### PR TITLE
Disable RWDT watchdog after Startup

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -20,6 +20,7 @@ void                        = { version = "1.0", default-features = false }
 xtensa-lx                   = { version = "0.6.0", optional = true }
 xtensa-lx-rt                = { version = "0.9.0", optional = true }
 procmacros                  = { path = "../esp-hal-procmacros", package = "esp-hal-procmacros" }
+cfg-if                      = "1.0.0"
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -35,6 +35,8 @@ pub mod gpio;
 #[cfg_attr(feature = "esp32c3", path = "interrupt/riscv.rs")]
 pub mod interrupt;
 pub mod prelude;
+#[cfg(not(feature = "esp32c3"))]
+pub mod rtc_cntl;
 pub mod serial;
 pub mod timer;
 
@@ -43,6 +45,8 @@ pub use gpio::*;
 pub use interrupt::*;
 use procmacros;
 pub use procmacros::ram;
+#[cfg(not(feature = "esp32c3"))]
+pub use rtc_cntl::RtcCntl;
 pub use serial::Serial;
 pub use timer::Timer;
 

--- a/esp-hal-common/src/rtc_cntl.rs
+++ b/esp-hal-common/src/rtc_cntl.rs
@@ -13,16 +13,34 @@ impl RtcCntl {
     fn set_wdt_write_protection(&mut self, enable: bool) {
         let wkey = if enable { 0u32 } else { 0x50D8_3AA1 };
 
-        self.rtc_cntl.wdtwprotect.write(|w| unsafe { w.bits(wkey) });
+        // FIXME: To be removed once the ESP32-S3 SVD
+        //        register naming is aligned!
+        cfg_if::cfg_if! {
+            if #[cfg(any(feature = "esp32s3"))] {
+                let register = &self.rtc_cntl.rtc_wdtwprotect;
+            } else {
+                let register = &self.rtc_cntl.wdtwprotect;
+            }
+        }
+
+        register.write(|w| unsafe { w.bits(wkey) });
     }
 
     /// Global switch for RTC_CNTL watchdog functionality
     pub fn set_wdt_global_enable(&mut self, enable: bool) {
         self.set_wdt_write_protection(false);
 
-        self.rtc_cntl
-            .wdtconfig0
-            .modify(|_, w| w.wdt_en().bit(enable).wdt_flashboot_mod_en().clear_bit());
+        // FIXME: To be removed once the ESP32-S3 SVD
+        //        register naming is aligned!
+        cfg_if::cfg_if! {
+            if #[cfg(any(feature = "esp32s3"))] {
+                let register = &self.rtc_cntl.rtc_wdtconfig0;
+            } else {
+                let register = &self.rtc_cntl.wdtconfig0;
+            }
+        }
+
+        register.modify(|_, w| w.wdt_en().bit(enable).wdt_flashboot_mod_en().clear_bit());
 
         self.set_wdt_write_protection(true);
     }

--- a/esp-hal-common/src/rtc_cntl.rs
+++ b/esp-hal-common/src/rtc_cntl.rs
@@ -1,0 +1,29 @@
+use crate::pac::RTC_CNTL;
+
+pub struct RtcCntl {
+    rtc_cntl: RTC_CNTL,
+}
+
+impl RtcCntl {
+    pub fn new(rtc_cntl: RTC_CNTL) -> Self {
+        Self { rtc_cntl }
+    }
+
+    /// Enable/disable write protection for WDT registers
+    fn set_wdt_write_protection(&mut self, enable: bool) {
+        let wkey = if enable { 0u32 } else { 0x50D8_3AA1 };
+
+        self.rtc_cntl.wdtwprotect.write(|w| unsafe { w.bits(wkey) });
+    }
+
+    /// Global switch for RTC_CNTL watchdog functionality
+    pub fn set_wdt_global_enable(&mut self, enable: bool) {
+        self.set_wdt_write_protection(false);
+
+        self.rtc_cntl
+            .wdtconfig0
+            .modify(|_, w| w.wdt_en().bit(enable).wdt_flashboot_mod_en().clear_bit());
+
+        self.set_wdt_write_protection(true);
+    }
+}

--- a/esp32-hal/examples/blinky.rs
+++ b/esp32-hal/examples/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, Timer};
+use esp32_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Timer};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
@@ -9,10 +9,12 @@ use xtensa_lx_rt::entry;
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
-    // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/gpio_interrupt.rs
+++ b/esp32-hal/examples/gpio_interrupt.rs
@@ -8,6 +8,7 @@ use esp32_hal::{
     pac::{self, Peripherals, UART0},
     prelude::*,
     Delay,
+    RtcCntl,
     Serial,
     Timer,
 };
@@ -34,8 +35,11 @@ fn main() -> ! {
     // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/hello_world.rs
+++ b/esp32-hal/examples/hello_world.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Write;
 
-use esp32_hal::{pac::Peripherals, prelude::*, Serial, Timer};
+use esp32_hal::{pac::Peripherals, prelude::*, RtcCntl, Serial, Timer};
 use nb::block;
 use panic_halt as _;
 use xtensa_lx_rt::entry;
@@ -14,9 +14,11 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
-    // Disable watchdog timer
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     timer0.start(10_000_000u64);
 

--- a/esp32-hal/examples/ram.rs
+++ b/esp32-hal/examples/ram.rs
@@ -7,7 +7,6 @@ use esp32_hal::{
     pac::{Peripherals, UART0},
     prelude::*,
     ram,
-    RtcCntl,
     Serial,
     Timer,
 };
@@ -30,11 +29,11 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    // Disable MWDT flash boot protection
     timer0.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    // The RWDT flash boot protection remains enabled and it being triggered is part
+    // of the example
 
     timer0.start(10_000_000u64);
 

--- a/esp32-hal/examples/ram.rs
+++ b/esp32-hal/examples/ram.rs
@@ -7,6 +7,7 @@ use esp32_hal::{
     pac::{Peripherals, UART0},
     prelude::*,
     ram,
+    RtcCntl,
     Serial,
     Timer,
 };
@@ -29,9 +30,11 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
-    // Disable watchdog timer
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     timer0.start(10_000_000u64);
 

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{pac, prelude, Delay, Serial, Timer};
+pub use esp_hal_common::{pac, prelude, Delay, RtcCntl, Serial, Timer};
 
 pub use self::gpio::IO;
 

--- a/esp32c3-hal/examples/blinky.rs
+++ b/esp32c3-hal/examples/blinky.rs
@@ -11,7 +11,7 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut timer1 = Timer::new(peripherals.TIMG1);
 

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut timer1 = Timer::new(peripherals.TIMG1);
     let serial0 = Serial::new(peripherals.UART0).unwrap();

--- a/esp32c3-hal/examples/hello_world.rs
+++ b/esp32c3-hal/examples/hello_world.rs
@@ -12,7 +12,7 @@ use riscv_rt::entry;
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
-    let rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut timer1 = Timer::new(peripherals.TIMG1);

--- a/esp32c3-hal/examples/ram.rs
+++ b/esp32c3-hal/examples/ram.rs
@@ -29,9 +29,10 @@ fn main() -> ! {
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
 
-    // don't disable WDTs ... we actually want it getting triggered in this example
-
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    // The RWDT flash boot protection remains enabled and it being triggered is part
+    // of the example
 
     timer0.start(10_000_000u64);
 

--- a/esp32c3-hal/examples/ram.rs
+++ b/esp32c3-hal/examples/ram.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
 
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    // Disable MWDT flash boot protection
     timer0.disable();
     // The RWDT flash boot protection remains enabled and it being triggered is part
     // of the example

--- a/esp32c3-hal/src/rtc_cntl.rs
+++ b/esp32c3-hal/src/rtc_cntl.rs
@@ -9,7 +9,7 @@ impl RtcCntl {
         Self { rtc_cntl }
     }
 
-    pub fn set_super_wdt_enable(&self, enable: bool) {
+    pub fn set_super_wdt_enable(&mut self, enable: bool) {
         self.set_swd_write_protection(false);
 
         self.rtc_cntl
@@ -19,7 +19,7 @@ impl RtcCntl {
         self.set_swd_write_protection(true);
     }
 
-    fn set_swd_write_protection(&self, enable: bool) {
+    fn set_swd_write_protection(&mut self, enable: bool) {
         let wkey = if enable { 0u32 } else { 0x8F1D_312A };
 
         self.rtc_cntl
@@ -27,7 +27,7 @@ impl RtcCntl {
             .write(|w| unsafe { w.swd_wkey().bits(wkey) });
     }
 
-    pub fn set_wdt_enable(&self, enable: bool) {
+    pub fn set_wdt_enable(&mut self, enable: bool) {
         self.set_wdt_write_protection(false);
 
         if !enable {
@@ -41,7 +41,7 @@ impl RtcCntl {
         self.set_wdt_write_protection(true);
     }
 
-    fn set_wdt_write_protection(&self, enable: bool) {
+    fn set_wdt_write_protection(&mut self, enable: bool) {
         let wkey = if enable { 0u32 } else { 0x50D8_3AA1 };
 
         self.rtc_cntl

--- a/esp32s2-hal/examples/blinky.rs
+++ b/esp32s2-hal/examples/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, Timer};
+use esp32s2_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Timer};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
@@ -9,10 +9,12 @@ use xtensa_lx_rt::entry;
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
-    // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     // Set GPIO4 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -8,6 +8,7 @@ use esp32s2_hal::{
     pac::{self, Peripherals, UART0},
     prelude::*,
     Delay,
+    RtcCntl,
     Serial,
     Timer,
 };
@@ -31,11 +32,13 @@ static mut BUTTON: CriticalSectionMutex<RefCell<Option<Gpio0<Input<PullDown>>>>>
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
-    // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let serial0 = Serial::new(peripherals.UART0).unwrap();
 
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     // Set GPIO4 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Write;
 
-use esp32s2_hal::{pac::Peripherals, prelude::*, Serial, Timer};
+use esp32s2_hal::{pac::Peripherals, prelude::*, RtcCntl, Serial, Timer};
 use nb::block;
 use panic_halt as _;
 use xtensa_lx_rt::entry;
@@ -13,10 +13,12 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
 
-    // Disable watchdog timer
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     timer0.start(40_000_000u64);
 

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -7,7 +7,6 @@ use esp32s2_hal::{
     pac::{Peripherals, UART0},
     prelude::*,
     ram,
-    RtcCntl,
     Serial,
     Timer,
 };
@@ -29,12 +28,12 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
 
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    // Disable MWDT flash boot protection
     timer0.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    // The RWDT flash boot protection remains enabled and it being triggered is part
+    // of the example
 
     timer0.start(10_000_000u64);
 

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -7,6 +7,7 @@ use esp32s2_hal::{
     pac::{Peripherals, UART0},
     prelude::*,
     ram,
+    RtcCntl,
     Serial,
     Timer,
 };
@@ -28,10 +29,12 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
 
-    // Disable watchdog timer
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     timer0.start(10_000_000u64);
 

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{pac, prelude, ram, Delay, Serial, Timer};
+pub use esp_hal_common::{pac, prelude, ram, Delay, RtcCntl, Serial, Timer};
 
 pub use self::gpio::IO;
 

--- a/esp32s3-hal/examples/blinky.rs
+++ b/esp32s3-hal/examples/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, Timer};
+use esp32s3_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Timer};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
@@ -9,10 +9,12 @@ use xtensa_lx_rt::entry;
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
-    // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     // Set GPIO4 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -8,6 +8,7 @@ use esp32s3_hal::{
     pac::{self, Peripherals, UART0},
     prelude::*,
     Delay,
+    RtcCntl,
     Serial,
     Timer,
 };
@@ -31,11 +32,13 @@ static mut BUTTON: SpinLockMutex<RefCell<Option<Gpio0<Input<PullDown>>>>> =
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
-    // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let serial0 = Serial::new(peripherals.UART0).unwrap();
 
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     // Set GPIO4 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s3-hal/examples/hello_world.rs
+++ b/esp32s3-hal/examples/hello_world.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Write;
 
-use esp32s3_hal::{pac::Peripherals, prelude::*, Serial, Timer};
+use esp32s3_hal::{pac::Peripherals, prelude::*, RtcCntl, Serial, Timer};
 use nb::block;
 use panic_halt as _;
 use xtensa_lx_rt::entry;
@@ -13,10 +13,12 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
 
-    // Disable watchdog timer
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     timer0.start(40_000_000u64);
 

--- a/esp32s3-hal/examples/ram.rs
+++ b/esp32s3-hal/examples/ram.rs
@@ -7,7 +7,6 @@ use esp32s3_hal::{
     pac::{Peripherals, UART0},
     prelude::*,
     ram,
-    RtcCntl,
     Serial,
     Timer,
 };
@@ -29,12 +28,12 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
 
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    // Disable MWDT flash boot protection
     timer0.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    // The RWDT flash boot protection remains enabled and it being triggered is part
+    // of the example
 
     timer0.start(10_000_000u64);
 

--- a/esp32s3-hal/examples/ram.rs
+++ b/esp32s3-hal/examples/ram.rs
@@ -7,6 +7,7 @@ use esp32s3_hal::{
     pac::{Peripherals, UART0},
     prelude::*,
     ram,
+    RtcCntl,
     Serial,
     Timer,
 };
@@ -28,10 +29,12 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
 
-    // Disable watchdog timer
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
 
     timer0.start(10_000_000u64);
 

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{pac, prelude, ram, Delay, Serial, Timer};
+pub use esp_hal_common::{pac, prelude, ram, Delay, RtcCntl, Serial, Timer};
 
 pub use self::gpio::IO;
 


### PR DESCRIPTION
- Add a simple implementation of the peripheral `RTC_CNTL` to allow for the disabling of the RWDT flash boot protection after startup.
- This prevents the SoCs to reset after a few seconds. Already existed for C3, now for all SoCs.
- Also updated the mutability assumptions for ESP32-C3 in that context (we write to registers, so should be `mut`).
- When implementing proper support for `RTC_CNTL`, it might be possible to integrate the differences of the C3 variant  (e.g., additional super watchdog) into a shared implementation, but as part of this PR it's left separated.
- Related SVD Issue: https://github.com/espressif/svd/issues/20, PR can be simplified with SVD fixed
- Tested with `hello_world` example on all 4 variants.