### PR TITLE
Implement the embedded-hal Read trait for the RNG peripheral

### DIFF
--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -36,6 +36,7 @@ pub mod i2c;
 #[cfg_attr(feature = "esp32c3", path = "interrupt/riscv.rs")]
 pub mod interrupt;
 pub mod prelude;
+pub mod rng;
 #[cfg(not(feature = "esp32c3"))]
 pub mod rtc_cntl;
 pub mod serial;
@@ -46,6 +47,7 @@ pub use gpio::*;
 pub use interrupt::*;
 use procmacros;
 pub use procmacros::ram;
+pub use rng::Rng;
 #[cfg(not(feature = "esp32c3"))]
 pub use rtc_cntl::RtcCntl;
 pub use serial::Serial;

--- a/esp-hal-common/src/rng.rs
+++ b/esp-hal-common/src/rng.rs
@@ -1,17 +1,47 @@
+//! Random number generator driver
+
 use core::convert::Infallible;
 
 use embedded_hal::blocking::rng::Read;
 
 use crate::pac::RNG;
 
+/// Random Number Generator
+///
+/// It should be noted that there are certain pre-conditions which must be met
+/// in order for the RNG to produce *true* random numbers. The hardware RNG
+/// produces true random numbers under any of the following conditions:
+///
+/// - RF subsystem is enabled (i.e. Wi-Fi or Bluetooth are enabled).
+/// - An internal entropy source has been enabled by calling
+///   `bootloader_random_enable()` and not yet disabled by calling
+///   `bootloader_random_disable()`.
+/// - While the ESP-IDF Second stage bootloader is running. This is because the
+///   default ESP-IDF bootloader implementation calls
+///   `bootloader_random_enable()` when the bootloader starts, and
+///   `bootloader_random_disable()` before executing the app.
+///
+/// When any of these conditions are true, samples of physical noise are
+/// continuously mixed into the internal hardware RNG state to provide entropy.
+/// If none of the above conditions are true, the output of the RNG should be
+/// considered pseudo-random only.
+///
+/// For more information, please refer to the ESP-IDF documentation:  
+/// <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html>
 #[derive(Debug)]
 pub struct Rng {
     rng: RNG,
 }
 
 impl Rng {
+    /// Create a new random number generator instance
     pub fn new(rng: RNG) -> Self {
         Self { rng }
+    }
+
+    /// Return the raw interface to the underlying `Rng` instance
+    pub fn free(self) -> RNG {
+        self.rng
     }
 }
 

--- a/esp-hal-common/src/rng.rs
+++ b/esp-hal-common/src/rng.rs
@@ -1,0 +1,29 @@
+use core::convert::Infallible;
+
+use embedded_hal::blocking::rng::Read;
+
+use crate::pac::RNG;
+
+#[derive(Debug)]
+pub struct Rng {
+    rng: RNG,
+}
+
+impl Rng {
+    pub fn new(rng: RNG) -> Self {
+        Self { rng }
+    }
+}
+
+impl Read for Rng {
+    type Error = Infallible;
+
+    fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        for chunk in buffer.chunks_mut(4) {
+            let bytes = self.rng.data.read().bits().to_le_bytes();
+            chunk.copy_from_slice(&bytes[..chunk.len()]);
+        }
+
+        Ok(())
+    }
+}

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{i2c, pac, prelude, Delay, RtcCntl, Serial, Timer};
+pub use esp_hal_common::{i2c, pac, prelude, Delay, Rng, RtcCntl, Serial, Timer};
 
 pub use self::gpio::IO;
 

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{i2c, pac, prelude, Delay, Serial, Timer};
+pub use esp_hal_common::{i2c, pac, prelude, Delay, Rng, Serial, Timer};
 #[cfg(not(feature = "normalboot"))]
 use riscv_rt::pre_init;
 

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -7,6 +7,7 @@ pub use esp_hal_common::{
     prelude,
     ram,
     Delay,
+    Rng,
     RtcCntl,
     Serial,
     Timer,

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{i2c, pac, prelude, ram, Delay, RtcCntl, Serial, Timer};
+pub use esp_hal_common::{i2c, pac, prelude, ram, Delay, Rng, RtcCntl, Serial, Timer};
 
 pub use self::gpio::IO;
 


### PR DESCRIPTION
Simple peripheral, equally simple implementation. Did not include an example but did verify that it works as expected locally.