### PR TITLE
Introduce optional ufmt support

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -25,6 +25,9 @@ riscv-atomic-emulation-trap = { version = "0.1", optional = true }
 # Xtensa
 xtensa-lx = { version = "0.6", optional = true }
 
+# Part of `ufmt` containing only `uWrite` trait
+ufmt-write = { version = "0.1", optional = true }
+
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature. We rename the PAC packages because we cannot
@@ -47,3 +50,6 @@ xtensa = ["procmacros/rtc_slow", "xtensa-lx/esp32"]
 # Core Count (should not be enabled directly, but instead by a PAC's feature)
 single_core = []
 dual_core   = []
+
+# To support `ufmt`
+ufmt = ["ufmt-write"]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -43,3 +43,4 @@ embedded-graphics = "0.7.1"
 [features]
 default = ["rt"]
 rt      = ["xtensa-lx-rt"]
+ufmt    = ["esp-hal-common/ufmt"]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -48,4 +48,5 @@ embedded-graphics = "0.7.1"
 [features]
 default = ["rt"]
 rt      = ["riscv-rt"]
+ufmt    = ["esp-hal-common/ufmt"]
 normalboot = []

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -43,3 +43,4 @@ embedded-graphics = "0.7.1"
 [features]
 default = ["rt"]
 rt      = ["xtensa-lx-rt"]
+ufmt    = ["esp-hal-common/ufmt"]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -43,3 +43,4 @@ embedded-graphics = "0.7.1"
 [features]
 default = ["rt"]
 rt      = ["xtensa-lx-rt"]
+ufmt    = ["esp-hal-common/ufmt"]


### PR DESCRIPTION
Subj
This implementation, while lacking most of core's fmt capabilities, provides optimized for size implementation that allows minimal viable formatting

I also took liberty to expose writing as common function to allow user to use, if he would need.
let me know if you want to hide it.