### PR TITLE
Update xtensa-lx-rt, fix interrupt related examples

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -26,7 +26,7 @@ riscv-atomic-emulation-trap = { version = "0.1", optional = true }
 xtensa-lx = { version = "0.6", optional = true }
 
 # Xtensa Runtime
-xtensa-lx-rt = { version = "0.10.0", optional = true }
+xtensa-lx-rt = { version = "0.11.0", optional = true }
 
 # Part of `ufmt` containing only `uWrite` trait
 ufmt-write = { version = "0.1", optional = true }

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -29,7 +29,7 @@ embedded-hal = { version = "0.2", features = ["unproven"] }
 nb           = "1.0"
 void         = { version = "1.0", default-features = false }
 xtensa-lx    = { version = "0.6.0", features = ["esp32"] }
-xtensa-lx-rt = { version = "0.10.0", features = ["esp32"], optional = true }
+xtensa-lx-rt = { version = "0.11.0", features = ["esp32"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32-hal/examples/gpio_interrupt.rs
+++ b/esp32-hal/examples/gpio_interrupt.rs
@@ -65,7 +65,9 @@ fn main() -> ! {
     let mut delay = Delay::new();
 
     unsafe {
-        xtensa_lx::interrupt::enable();
+        xtensa_lx::interrupt::enable_mask(
+            1 << 1
+        );
     }
 
     loop {

--- a/esp32-hal/examples/timer_interrupt.rs
+++ b/esp32-hal/examples/timer_interrupt.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     interrupt::enable(
         Cpu::ProCpu,
         pac::Interrupt::TG1_T0_LEVEL,
-        interrupt::CpuInterrupt::Interrupt24LevelPriority4,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
     );
     timer1.start(100_000_000u64);
     timer1.listen();
@@ -62,10 +62,10 @@ fn main() -> ! {
     unsafe {
         xtensa_lx::interrupt::disable();
         xtensa_lx::interrupt::enable_mask(
-            xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask(),
+            1 << 20,
         );
         xtensa_lx::interrupt::enable_mask(
-            xtensa_lx_rt::interrupt::CpuInterruptLevel::Level4.mask(),
+            1 << 23,
         );
     }
 
@@ -98,18 +98,18 @@ pub fn level2_interrupt() {
 }
 
 #[no_mangle]
-pub fn level4_interrupt() {
+pub fn level3_interrupt() {
     unsafe {
         (&SERIAL).lock(|data| {
             let mut serial = data.borrow_mut();
             let serial = serial.as_mut().unwrap();
-            writeln!(serial, "Interrupt Level 4").ok();
+            writeln!(serial, "Interrupt Level 3").ok();
         });
     }
 
     interrupt::clear(
         Cpu::ProCpu,
-        interrupt::CpuInterrupt::Interrupt24LevelPriority4,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
     );
 
     unsafe {

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -29,7 +29,7 @@ embedded-hal = { version = "0.2", features = ["unproven"] }
 nb           = "1.0"
 void         = { version = "1.0", default-features = false }
 xtensa-lx    = { version = "0.6.0", features = ["esp32"] } # FIXME
-xtensa-lx-rt = { version = "0.10.0", features = ["esp32s2"], optional = true }
+xtensa-lx-rt = { version = "0.11.0", features = ["esp32s2"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
 
     unsafe {
         xtensa_lx::interrupt::enable_mask(
-            xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask(),
+            1 << 19,
         );
     }
 

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     interrupt::enable(
         Cpu::ProCpu,
         pac::Interrupt::TG1_T0_LEVEL,
-        interrupt::CpuInterrupt::Interrupt24LevelPriority4,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
     );
     timer1.start(100_000_000u64);
     timer1.listen();
@@ -62,10 +62,10 @@ fn main() -> ! {
     unsafe {
         xtensa_lx::interrupt::disable();
         xtensa_lx::interrupt::enable_mask(
-            xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask(),
+            1 << 20,
         );
         xtensa_lx::interrupt::enable_mask(
-            xtensa_lx_rt::interrupt::CpuInterruptLevel::Level4.mask(),
+            1 << 23,
         );
     }
 
@@ -98,18 +98,18 @@ pub fn level2_interrupt() {
 }
 
 #[no_mangle]
-pub fn level4_interrupt() {
+pub fn level3_interrupt() {
     unsafe {
         (&SERIAL).lock(|data| {
             let mut serial = data.borrow_mut();
             let serial = serial.as_mut().unwrap();
-            writeln!(serial, "Interrupt Level 4").ok();
+            writeln!(serial, "Interrupt Level 3").ok();
         });
     }
 
     interrupt::clear(
         Cpu::ProCpu,
-        interrupt::CpuInterrupt::Interrupt24LevelPriority4,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
     );
 
     unsafe {

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -29,7 +29,7 @@ embedded-hal = { version = "0.2", features = ["unproven"] }
 nb           = "1.0"
 void         = { version = "1.0", default-features = false }
 xtensa-lx    = { version = "0.6.0", features = ["esp32"] } # FIXME
-xtensa-lx-rt = { version = "0.10.0", features = ["esp32s3"], optional = true }
+xtensa-lx-rt = { version = "0.11.0", features = ["esp32s3"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
 
     unsafe {
         xtensa_lx::interrupt::enable_mask(
-            xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask(),
+            1 << 19,
         );
     }
 

--- a/esp32s3-hal/examples/timer_interrupt.rs
+++ b/esp32s3-hal/examples/timer_interrupt.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     interrupt::enable(
         Cpu::ProCpu,
         pac::Interrupt::TG1_T0_LEVEL,
-        interrupt::CpuInterrupt::Interrupt24LevelPriority4,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
     );
     timer1.start(100_000_000u64);
     timer1.listen();
@@ -62,10 +62,10 @@ fn main() -> ! {
     unsafe {
         xtensa_lx::interrupt::disable();
         xtensa_lx::interrupt::enable_mask(
-            xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask(),
+            1 << 20,
         );
         xtensa_lx::interrupt::enable_mask(
-            xtensa_lx_rt::interrupt::CpuInterruptLevel::Level4.mask(),
+            1 << 23,
         );
     }
 
@@ -98,18 +98,18 @@ pub fn level2_interrupt() {
 }
 
 #[no_mangle]
-pub fn level4_interrupt() {
+pub fn level3_interrupt() {
     unsafe {
         (&SERIAL).lock(|data| {
             let mut serial = data.borrow_mut();
             let serial = serial.as_mut().unwrap();
-            writeln!(serial, "Interrupt Level 4").ok();
+            writeln!(serial, "Interrupt Level 3").ok();
         });
     }
 
     interrupt::clear(
         Cpu::ProCpu,
-        interrupt::CpuInterrupt::Interrupt24LevelPriority4,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
     );
 
     unsafe {


### PR DESCRIPTION
- update xtensa-lx-rt to 0.11.0
- fix the Xtensa interrupt related examples (only enable the used interrupts - not all interrupts for that priority, don't use interrupt levels > 3 since they are not meant to be implemented in high level languages)
