### PR TITLE
Fix `cargo run` for ESP32C3

### DIFF
--- a/esp32c3-hal/.cargo/config.toml
+++ b/esp32c3-hal/.cargo/config.toml
@@ -1,12 +1,12 @@
 [target.riscv32imc-unknown-none-elf]
-runner = "espflash --format direct-boot --monitor"
+runner = "espflash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x"
 ]
 
 # for testing: you can specify this target to see atomic emulation in action
 [target.riscv32imac-unknown-none-elf]
-runner = "espflash --format direct-boot --monitor"
+runner = "espflash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x"
 ]


### PR DESCRIPTION
We can conveniently `cd` into the chip specific HALs and run `cargo run --example EXAMPLE` - that broke for ESP32C3 when we changed it to default to use the 2nd stage bootloader. This fixes that 