### PR TITLE
Add a minimal driver for the USB_SERIAL_JTAG peripheral

### DIFF
--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -40,6 +40,8 @@ pub mod rtc_cntl;
 pub mod serial;
 pub mod spi;
 pub mod timer;
+#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+pub mod usb_serial_jtag;
 
 pub use delay::Delay;
 pub use gpio::*;
@@ -52,6 +54,8 @@ pub use rtc_cntl::RtcCntl;
 pub use serial::Serial;
 pub use spi::Spi;
 pub use timer::Timer;
+#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+pub use usb_serial_jtag::UsbSerialJtag;
 
 /// Enumeration of CPU cores
 /// The actual number of available cores depends on the target.

--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -1,0 +1,34 @@
+#[cfg(feature = "esp32c3")]
+const USB_SERIAL_JTAG_FIFO_REG: usize = 0x6004_3000;
+#[cfg(feature = "esp32c3")]
+const USB_SERIAL_JTAG_CONF_REG: usize = 0x6004_3004;
+
+#[cfg(feature = "esp32s3")]
+const USB_SERIAL_JTAG_FIFO_REG: usize = 0x6003_8000;
+#[cfg(feature = "esp32s3")]
+const USB_SERIAL_JTAG_CONF_REG: usize = 0x6003_8004;
+
+pub struct UsbSerialJtag;
+
+impl core::fmt::Write for UsbSerialJtag {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        unsafe {
+            let fifo = USB_SERIAL_JTAG_FIFO_REG as *mut u32;
+            let conf = USB_SERIAL_JTAG_CONF_REG as *mut u32;
+
+            // TODO: 64 byte chunks max
+            for chunk in s.as_bytes().chunks(32) {
+                for &b in chunk {
+                    fifo.write_volatile(b as u32);
+                }
+                conf.write_volatile(0b001);
+
+                while conf.read_volatile() & 0b011 == 0b000 {
+                    // wait
+                }
+            }
+
+            core::fmt::Result::Ok(())
+        }
+    }
+}

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -1,0 +1,29 @@
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+
+use esp32c3_hal::{pac::Peripherals, prelude::*, Delay, RtcCntl, Timer, UsbSerialJtag};
+use panic_halt as _;
+use riscv_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+
+    let mut delay = Delay::new(peripherals.SYSTIMER);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut timer1 = Timer::new(peripherals.TIMG1);
+
+    // Disable watchdog timers
+    rtc_cntl.set_super_wdt_enable(false);
+    rtc_cntl.set_wdt_enable(false);
+    timer0.disable();
+    timer1.disable();
+
+    loop {
+        writeln!(UsbSerialJtag, "Hello world!").ok();
+        delay.delay_ms(500u32);
+    }
+}

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -3,16 +3,27 @@
 use core::arch::global_asm;
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{i2c, pac, prelude, spi, Delay, Rng, Serial, Timer};
+pub use esp_hal_common::{
+    i2c,
+    interrupt,
+    pac,
+    prelude,
+    ram,
+    spi,
+    Cpu,
+    Delay,
+    Rng,
+    Serial,
+    Timer,
+    UsbSerialJtag,
+};
 #[cfg(feature = "direct-boot")]
 use riscv_rt::pre_init;
 
+pub use self::{gpio::IO, rtc_cntl::RtcCntl};
+
 pub mod gpio;
 pub mod rtc_cntl;
-
-pub use esp_hal_common::{interrupt, ram, Cpu};
-
-pub use self::{gpio::IO, rtc_cntl::RtcCntl};
 
 extern "C" {
     // Boundaries of the .iram section

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+
+use esp32s3_hal::{pac::Peripherals, prelude::*, Delay, RtcCntl, Timer, UsbSerialJtag};
+use panic_halt as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+
+    let mut delay = Delay::new();
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut timer0 = Timer::new(peripherals.TIMG0);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    loop {
+        writeln!(UsbSerialJtag, "Hello world!").ok();
+        delay.delay_ms(500u32);
+    }
+}

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -1,13 +1,26 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{i2c, pac, prelude, ram, spi, Delay, Rng, RtcCntl, Serial, Timer};
+pub use esp_hal_common::{
+    i2c,
+    interrupt,
+    pac,
+    prelude,
+    ram,
+    spi,
+    usb_serial_jtag,
+    Cpu,
+    Delay,
+    Rng,
+    RtcCntl,
+    Serial,
+    Timer,
+    UsbSerialJtag,
+};
 
 pub use self::gpio::IO;
 
 pub mod gpio;
-
-pub use esp_hal_common::{interrupt, Cpu};
 
 #[no_mangle]
 extern "C" fn DefaultHandler(_level: u32, _interrupt: pac::Interrupt) {}


### PR DESCRIPTION
This is basically taken directly from `esp-println`, and simply implements `core::fmt::Write`. Added some examples as well (though they're almost identical to the existing `hello_world` examples). Test on the C3 and S3.