### PR TITLE
Enforce clippy lints in CI, miscellaneous cleanup and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,26 @@ jobs:
         with:
           command: check
           args: -Zbuild-std=core --examples --package=${{ matrix.chip }}-hal --target=xtensa-${{ matrix.chip }}-none-elf
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chip: [esp32, esp32c3, esp32s2, esp32s3]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          default: true
+          components: clippy
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          # I find `clippy::too-many-arguments` to be rather rather arbitrary.
+          # As for `clippy::module-inception`... don't tell me what to do ;)
+          args: --package=${{ matrix.chip }}-hal -- --no-deps -D warnings --A clippy::too-many-arguments --A clippy::module-inception

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -19,14 +19,12 @@ procmacros   = { path = "../esp-hal-procmacros", package = "esp-hal-procmacros" 
 void         = { version = "1.0", default-features = false }
 
 # RISC-V
-riscv                       = { version = "0.8.0", optional = true }
+riscv                       = { version = "0.8", optional = true }
 riscv-atomic-emulation-trap = { version = "0.1", optional = true }
 
 # Xtensa
-xtensa-lx = { version = "0.7.0", optional = true }
-
-# Xtensa Runtime
-xtensa-lx-rt = { version = "0.11.0", optional = true }
+xtensa-lx    = { version = "0.7",  optional = true }
+xtensa-lx-rt = { version = "0.11", optional = true }
 
 # Part of `ufmt` containing only `uWrite` trait
 ufmt-write = { version = "0.1", optional = true }
@@ -41,7 +39,7 @@ esp32s2_pac = { package = "esp32s2", git = "https://github.com/esp-rs/esp-pacs.g
 esp32s3_pac = { package = "esp32s3", git = "https://github.com/esp-rs/esp-pacs.git", branch = "with_source", optional = true }
 
 [features]
-esp32   = [  "esp32_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32", "xtensa-lx/esp32"]
+esp32   = [  "esp32_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32"]
 esp32c3 = ["esp32c3_pac/rt", "risc_v", "single_core"]
 esp32s2 = ["esp32s2_pac/rt", "xtensa", "single_core", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2"]
 esp32s3 = ["esp32s3_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3"]

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -107,13 +107,13 @@ pub trait Pin {
 
     fn clear_interrupt(&mut self);
 
-    fn is_pcore_interrupt_set(&mut self) -> bool;
+    fn is_pcore_interrupt_set(&self) -> bool;
 
-    fn is_pcore_non_maskable_interrupt_set(&mut self) -> bool;
+    fn is_pcore_non_maskable_interrupt_set(&self) -> bool;
 
-    fn is_acore_interrupt_set(&mut self) -> bool;
+    fn is_acore_interrupt_set(&self) -> bool;
 
-    fn is_acore_non_maskable_interrupt_set(&mut self) -> bool;
+    fn is_acore_non_maskable_interrupt_set(&self) -> bool;
 
     fn enable_hold(&mut self, on: bool);
 }
@@ -127,7 +127,7 @@ pub trait InputPin: Pin {
 
     fn enable_input_in_sleep_mode(&mut self, on: bool) -> &mut Self;
 
-    fn is_input_high(&mut self) -> bool;
+    fn is_input_high(&self) -> bool;
 
     fn connect_input_to_peripheral(&mut self, signal: Self::InputSignal) -> &mut Self {
         self.connect_input_to_peripheral_with_options(signal, false, false)
@@ -330,7 +330,7 @@ macro_rules! impl_input {
                 self
             }
 
-            fn is_input_high(&mut self) -> bool {
+            fn is_input_high(&self) -> bool {
                 unsafe { &*GPIO::ptr() }.$reg.read().$reader().bits() & (1 << $bit) != 0
             }
 
@@ -425,19 +425,19 @@ macro_rules! impl_input {
                     unsafe {w.bits(1 << $bit)})
             }
 
-            fn is_pcore_interrupt_set(&mut self) -> bool {
+            fn is_pcore_interrupt_set(&self) -> bool {
                 (unsafe {&*GPIO::ptr()}.$pcpu_int.read().bits() & (1 << $bit)) !=0
             }
 
-            fn is_pcore_non_maskable_interrupt_set(&mut self) -> bool {
+            fn is_pcore_non_maskable_interrupt_set(&self) -> bool {
                 (unsafe {&*GPIO::ptr()}.$pcpu_nmi.read().bits() & (1 << $bit)) !=0
             }
 
-            fn is_acore_interrupt_set(&mut self) -> bool {
+            fn is_acore_interrupt_set(&self) -> bool {
                 (unsafe {&*GPIO::ptr()}.$acpu_int.read().bits() & (1 << $bit)) !=0
             }
 
-            fn is_acore_non_maskable_interrupt_set(&mut self) -> bool {
+            fn is_acore_non_maskable_interrupt_set(&self) -> bool {
                 (unsafe {&*GPIO::ptr()}.$acpu_nmi.read().bits() & (1 << $bit)) !=0
             }
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -190,51 +190,57 @@ macro_rules! impl_errata36 {
     (pad_dac1, $pull_down:expr, $pull_up:expr) => {
         use crate::pac::RTCIO;
         let rtcio = unsafe { &*RTCIO::ptr() };
-        rtcio.pad_dac1.modify(|r,w| unsafe {
-            w.bits( r.bits() )
-                .pdac1_rue().bit($pull_up)
-                .pdac1_rde().bit($pull_down)
+        rtcio.pad_dac1.modify(|r, w| unsafe {
+            w.bits(r.bits())
+                .pdac1_rue()
+                .bit($pull_up)
+                .pdac1_rde()
+                .bit($pull_down)
         });
     };
 
     (pad_dac2, $pull_down:expr, $pull_up:expr) => {
         use crate::pac::RTCIO;
         let rtcio = unsafe { &*RTCIO::ptr() };
-        rtcio.pad_dac2.modify(|r,w| unsafe {
-            w.bits( r.bits() )
-                .pdac2_rue().bit($pull_up)
-                .pdac2_rde().bit($pull_down)
+        rtcio.pad_dac2.modify(|r, w| unsafe {
+            w.bits(r.bits())
+                .pdac2_rue()
+                .bit($pull_up)
+                .pdac2_rde()
+                .bit($pull_down)
         });
     };
 
     (xtal_32k_n, $pull_down:expr, $pull_up:expr) => {
         use crate::pac::RTCIO;
         let rtcio = unsafe { &*RTCIO::ptr() };
-        rtcio.xtal_32k_pad.modify(|r,w| unsafe {
-            w.bits( r.bits() )
-                .x32n_rue().bit($pull_up)
-                .x32n_rde().bit($pull_down)
+        rtcio.xtal_32k_pad.modify(|r, w| unsafe {
+            w.bits(r.bits())
+                .x32n_rue()
+                .bit($pull_up)
+                .x32n_rde()
+                .bit($pull_down)
         });
     };
 
     (xtal_32k_p, $pull_down:expr, $pull_up:expr) => {
         use crate::pac::RTCIO;
         let rtcio = unsafe { &*RTCIO::ptr() };
-        rtcio.xtal_32k_pad.modify(|r,w| unsafe {
-            w.bits( r.bits() )
-                .x32p_rue().bit($pull_up)
-                .x32p_rde().bit($pull_down)
+        rtcio.xtal_32k_pad.modify(|r, w| unsafe {
+            w.bits(r.bits())
+                .x32p_rue()
+                .bit($pull_up)
+                .x32p_rde()
+                .bit($pull_down)
         });
     };
 
     ($errata36:ident, $pull_down:expr, $pull_up:expr) => {
         use crate::pac::RTCIO;
         let rtcio = unsafe { &*RTCIO::ptr() };
-        rtcio.$errata36.modify(|r,w| unsafe {
-            w.bits( r.bits() )
-                .rue().bit($pull_up)
-                .rde().bit($pull_down)
-        });
+        rtcio
+            .$errata36
+            .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit($pull_up).rde().bit($pull_down) });
     };
 }
 
@@ -895,8 +901,8 @@ macro_rules! gpio {
 }
 
 pub use gpio;
+pub use impl_errata36;
 pub use impl_input;
 pub use impl_input_wrap;
 pub use impl_output;
 pub use impl_output_wrap;
-pub use impl_errata36;

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -289,11 +289,7 @@ pub unsafe extern "C" fn start_trap_rust_hal(trap_frame: *mut TrapFrame) {
 #[doc(hidden)]
 unsafe fn handle_exception(pc: usize, trap_frame: *mut TrapFrame) {
     let insn: usize = *(pc as *const _);
-    let needs_atomic_emulation = if (insn & 0b1111111) != 0b0101111 {
-        false
-    } else {
-        true
-    };
+    let needs_atomic_emulation = (insn & 0b1111111) == 0b0101111;
 
     if !needs_atomic_emulation {
         extern "C" {

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -1,5 +1,6 @@
-use crate::{pac::Interrupt, Cpu};
 use xtensa_lx_rt::exception::Context;
+
+use crate::{pac::Interrupt, Cpu};
 
 extern "C" {
     fn level1_interrupt(save_frame: &mut Context);

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -57,11 +57,11 @@ pub fn enable(core: Cpu, interrupt: Interrupt, which: CpuInterrupt) {
         let interrupt_number = interrupt as isize;
         let cpu_interrupt_number = which as isize;
         let intr_map_base = match core {
-            Cpu::ProCpu => (&*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
+            Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
             #[cfg(feature = "dual_core")]
-            Cpu::AppCpu => (&*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
+            Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
             #[cfg(feature = "single_core")]
-            Cpu::AppCpu => (&*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
+            Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
         };
         intr_map_base
             .offset(interrupt_number)
@@ -74,11 +74,11 @@ pub fn disable(core: Cpu, interrupt: Interrupt) {
     unsafe {
         let interrupt_number = interrupt as isize;
         let intr_map_base = match core {
-            Cpu::ProCpu => (&*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
+            Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
             #[cfg(feature = "dual_core")]
-            Cpu::AppCpu => (&*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
+            Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
             #[cfg(feature = "single_core")]
-            Cpu::AppCpu => (&*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
+            Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
         };
         intr_map_base.offset(interrupt_number).write_volatile(0);
     }
@@ -96,16 +96,16 @@ pub fn get_status(core: Cpu) -> u128 {
     unsafe {
         match core {
             Cpu::ProCpu => {
-                ((&*core0_interrupt_peripheral())
+                ((*core0_interrupt_peripheral())
                     .pro_intr_status_0
                     .read()
                     .bits() as u128)
-                    | ((&*core0_interrupt_peripheral())
+                    | ((*core0_interrupt_peripheral())
                         .pro_intr_status_1
                         .read()
                         .bits() as u128)
                         << 32
-                    | ((&*core0_interrupt_peripheral())
+                    | ((*core0_interrupt_peripheral())
                         .pro_intr_status_2
                         .read()
                         .bits() as u128)
@@ -113,16 +113,16 @@ pub fn get_status(core: Cpu) -> u128 {
             }
             #[cfg(feature = "dual_core")]
             Cpu::AppCpu => {
-                ((&*core1_interrupt_peripheral())
+                ((*core1_interrupt_peripheral())
                     .app_intr_status_0
                     .read()
                     .bits() as u128)
-                    | ((&*core1_interrupt_peripheral())
+                    | ((*core1_interrupt_peripheral())
                         .app_intr_status_1
                         .read()
                         .bits() as u128)
                         << 32
-                    | ((&*core1_interrupt_peripheral())
+                    | ((*core1_interrupt_peripheral())
                         .app_intr_status_2
                         .read()
                         .bits() as u128)
@@ -130,16 +130,16 @@ pub fn get_status(core: Cpu) -> u128 {
             }
             #[cfg(feature = "single_core")]
             Cpu::AppCpu => {
-                ((&*core0_interrupt_peripheral())
+                ((*core0_interrupt_peripheral())
                     .pro_intr_status_0
                     .read()
                     .bits() as u128)
-                    | ((&*core0_interrupt_peripheral())
+                    | ((*core0_interrupt_peripheral())
                         .pro_intr_status_1
                         .read()
                         .bits() as u128)
                         << 32
-                    | ((&*core0_interrupt_peripheral())
+                    | ((*core0_interrupt_peripheral())
                         .pro_intr_status_2
                         .read()
                         .bits() as u128)

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -46,7 +46,6 @@ pub mod usb_serial_jtag;
 pub use delay::Delay;
 pub use gpio::*;
 pub use interrupt::*;
-use procmacros;
 pub use procmacros::ram;
 pub use rng::Rng;
 #[cfg(not(feature = "esp32c3"))]

--- a/esp-hal-common/src/serial.rs
+++ b/esp-hal-common/src/serial.rs
@@ -104,7 +104,7 @@ pub trait Instance {
             .into()
     }
 
-    fn is_tx_idle(&mut self) -> bool {
+    fn is_tx_idle(&self) -> bool {
         #[cfg(feature = "esp32")]
         let idle = self.register_block().status.read().st_utx_out().bits() == 0x0u8;
         #[cfg(not(feature = "esp32"))]
@@ -113,7 +113,7 @@ pub trait Instance {
         idle
     }
 
-    fn is_rx_idle(&mut self) -> bool {
+    fn is_rx_idle(&self) -> bool {
         #[cfg(feature = "esp32")]
         let idle = self.register_block().status.read().st_urx_out().bits() == 0x0u8;
         #[cfg(not(feature = "esp32"))]

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -75,10 +75,8 @@ where
 
         spi.enable_peripheral(system);
 
-        let mut spi = Self { spi: spi };
-
+        let mut spi = Self { spi };
         spi.spi.setup(frequency);
-
         spi.spi.init();
         spi.spi.set_data_mode(mode);
 
@@ -207,9 +205,6 @@ pub trait Instance {
             */
 
             let mut pre: i32;
-            let n: i32;
-            let mut h: i32;
-            let l: i32;
             let mut bestn: i32 = -1;
             let mut bestpre: i32 = -1;
             let mut besterr: i32 = 0;
@@ -242,20 +237,20 @@ pub trait Instance {
                 }
             }
 
-            n = bestn;
+            let n: i32 = bestn;
             pre = bestpre as i32;
-            l = n;
+            let l: i32 = n;
 
             /* Effectively, this does:
             *   h = round((duty_cycle * n) / 256)
             */
 
-            h = (duty_cycle * n + 127) / 256;
+            let mut h: i32 = (duty_cycle * n + 127) / 256;
             if h <= 0 {
                 h = 1;
             }
 
-            reg_val = ((l as u32 - 1) << 0) |
+            reg_val = (l as u32 - 1) |
                     ((h as u32 - 1) << 6) |
                     ((n as u32 - 1) << 12) |
                     ((pre as u32 - 1) << 18);
@@ -353,7 +348,7 @@ pub trait Instance {
             let mut fifo_ptr = reg_block.w0.as_ptr();
             for chunk in chunk.chunks(4) {
                 let mut u32_as_bytes = [0u8; 4];
-                u32_as_bytes[0..(chunk.len())].clone_from_slice(&chunk);
+                u32_as_bytes[0..(chunk.len())].clone_from_slice(chunk);
                 let reg_val: u32 = u32::from_le_bytes(u32_as_bytes);
 
                 unsafe {

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -73,7 +73,7 @@ pub trait Instance {
             .modify(|_, w| w.t0_en().bit(state));
     }
 
-    fn is_counter_active(&mut self) -> bool {
+    fn is_counter_active(&self) -> bool {
         self.register_block().t0config.read().t0_en().bit_is_set()
     }
 
@@ -95,7 +95,7 @@ pub trait Instance {
             .modify(|_, w| w.t0_alarm_en().bit(state));
     }
 
-    fn is_alarm_active(&mut self) -> bool {
+    fn is_alarm_active(&self) -> bool {
         self.register_block()
             .t0config
             .read()

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-darling = "0.10"
+darling = "0.14"
 syn = {version = "1.0", features = ["extra-traits", "full"]}
 proc-macro-error = "1.0.4"
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -25,20 +25,20 @@ categories = [
 
 [dependencies]
 bare-metal   = "1.0"
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = { version = "0.2",  features = ["unproven"] }
 nb           = "1.0"
-void         = { version = "1.0", default-features = false }
-xtensa-lx    = { version = "0.7.0", features = ["esp32"] }
-xtensa-lx-rt = { version = "0.11.0", features = ["esp32"], optional = true }
+void         = { version = "1.0",  default-features = false }
+xtensa-lx    = { version = "0.7",  features = ["esp32"] }
+xtensa-lx-rt = { version = "0.11", features = ["esp32"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"
 features = ["esp32"]
 
 [dev-dependencies]
-panic-halt = "0.2"
-ssd1306 = "0.7.0"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.7"
+panic-halt        = "0.2"
+ssd1306           = "0.7"
 
 [features]
 default = ["rt"]

--- a/esp32-hal/examples/gpio_interrupt.rs
+++ b/esp32-hal/examples/gpio_interrupt.rs
@@ -65,9 +65,7 @@ fn main() -> ! {
     let mut delay = Delay::new();
 
     unsafe {
-        xtensa_lx::interrupt::enable_mask(
-            1 << 1
-        );
+        xtensa_lx::interrupt::enable_mask(1 << 1);
     }
 
     loop {

--- a/esp32-hal/examples/timer_interrupt.rs
+++ b/esp32-hal/examples/timer_interrupt.rs
@@ -61,12 +61,8 @@ fn main() -> ! {
 
     unsafe {
         xtensa_lx::interrupt::disable();
-        xtensa_lx::interrupt::enable_mask(
-            1 << 20,
-        );
-        xtensa_lx::interrupt::enable_mask(
-            1 << 23,
-        );
+        xtensa_lx::interrupt::enable_mask(1 << 20);
+        xtensa_lx::interrupt::enable_mask(1 << 23);
     }
 
     loop {}

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -1,13 +1,24 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
-pub use esp_hal_common::{i2c, pac, prelude, spi, Delay, Rng, RtcCntl, Serial, Timer};
+pub use esp_hal_common::{
+    i2c,
+    interrupt,
+    pac,
+    prelude,
+    ram,
+    spi,
+    Cpu,
+    Delay,
+    Rng,
+    RtcCntl,
+    Serial,
+    Timer,
+};
 
 pub use self::gpio::IO;
 
 pub mod gpio;
-
-pub use esp_hal_common::{interrupt, ram, Cpu};
 
 #[no_mangle]
 extern "C" fn DefaultHandler(_level: u32, _interrupt: pac::Interrupt) {}

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -24,23 +24,22 @@ categories = [
 ]
 
 [dependencies]
-bare-metal                  = "1.0"
-embedded-hal                = { version = "0.2", features = ["unproven"] }
-nb                          = "1.0"
-riscv                       = "0.8.0"
-riscv-rt                    = { version = "0.8.1", optional = true }
-void                        = { version = "1.0", default-features = false }
-r0                          = "1.0.0"
-riscv-atomic-emulation-trap = "0.1.0"
+bare-metal   = "1.0"
+embedded-hal = { version = "0.2", features = ["unproven"] }
+nb           = "1.0"
+r0           = "1.0.0"
+riscv        = "0.8.0"
+riscv-rt     = { version = "0.8", optional = true }
+void         = { version = "1.0", default-features = false }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"
 features = ["esp32c3"]
 
 [dev-dependencies]
-panic-halt = "0.2"
-ssd1306 = "0.7.0"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.7"
+panic-halt        = "0.2"
+ssd1306           = "0.7"
 
 [features]
 default     = ["rt"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -25,20 +25,20 @@ categories = [
 
 [dependencies]
 bare-metal   = "1.0"
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = { version = "0.2",  features = ["unproven"] }
 nb           = "1.0"
-void         = { version = "1.0", default-features = false }
-xtensa-lx    = { version = "0.7.0", features = ["esp32s2"] }
-xtensa-lx-rt = { version = "0.11.0", features = ["esp32s2"], optional = true }
+void         = { version = "1.0",  default-features = false }
+xtensa-lx    = { version = "0.7",  features = ["esp32s2"] }
+xtensa-lx-rt = { version = "0.11", features = ["esp32s2"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"
 features = ["esp32s2"]
 
 [dev-dependencies]
-panic-halt = "0.2"
-ssd1306 = "0.7.0"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.7"
+panic-halt        = "0.2"
+ssd1306           = "0.7"
 
 [features]
 default = ["rt"]

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -64,9 +64,7 @@ fn main() -> ! {
     let mut delay = Delay::new();
 
     unsafe {
-        xtensa_lx::interrupt::enable_mask(
-            1 << 19,
-        );
+        xtensa_lx::interrupt::enable_mask(1 << 19);
     }
 
     loop {

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -61,12 +61,8 @@ fn main() -> ! {
 
     unsafe {
         xtensa_lx::interrupt::disable();
-        xtensa_lx::interrupt::enable_mask(
-            1 << 20,
-        );
-        xtensa_lx::interrupt::enable_mask(
-            1 << 23,
-        );
+        xtensa_lx::interrupt::enable_mask(1 << 20);
+        xtensa_lx::interrupt::enable_mask(1 << 23);
     }
 
     loop {}

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -3,10 +3,12 @@
 pub use embedded_hal as ehal;
 pub use esp_hal_common::{
     i2c::{self, I2C},
+    interrupt,
     pac,
     prelude,
     ram,
     spi,
+    Cpu,
     Delay,
     Rng,
     RtcCntl,
@@ -17,8 +19,6 @@ pub use esp_hal_common::{
 pub use self::gpio::IO;
 
 pub mod gpio;
-
-pub use esp_hal_common::{interrupt, Cpu};
 
 #[no_mangle]
 extern "C" fn DefaultHandler(_level: u32, _interrupt: pac::Interrupt) {}

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -25,20 +25,20 @@ categories = [
 
 [dependencies]
 bare-metal   = "1.0"
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = { version = "0.2",  features = ["unproven"] }
 nb           = "1.0"
-void         = { version = "1.0", default-features = false }
-xtensa-lx    = { version = "0.7.0", features = ["esp32s3"] }
-xtensa-lx-rt = { version = "0.11.0", features = ["esp32s3"], optional = true }
+void         = { version = "1.0",  default-features = false }
+xtensa-lx    = { version = "0.7",  features = ["esp32s3"] }
+xtensa-lx-rt = { version = "0.11", features = ["esp32s3"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"
 features = ["esp32s3"]
 
 [dev-dependencies]
-panic-halt = "0.2"
-ssd1306 = "0.7.0"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.7"
+panic-halt        = "0.2"
+ssd1306           = "0.7"
 
 [features]
 default = ["rt"]

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -64,9 +64,7 @@ fn main() -> ! {
     let mut delay = Delay::new();
 
     unsafe {
-        xtensa_lx::interrupt::enable_mask(
-            1 << 19,
-        );
+        xtensa_lx::interrupt::enable_mask(1 << 19);
     }
 
     loop {

--- a/esp32s3-hal/examples/timer_interrupt.rs
+++ b/esp32s3-hal/examples/timer_interrupt.rs
@@ -61,12 +61,8 @@ fn main() -> ! {
 
     unsafe {
         xtensa_lx::interrupt::disable();
-        xtensa_lx::interrupt::enable_mask(
-            1 << 20,
-        );
-        xtensa_lx::interrupt::enable_mask(
-            1 << 23,
-        );
+        xtensa_lx::interrupt::enable_mask(1 << 20);
+        xtensa_lx::interrupt::enable_mask(1 << 23);
     }
 
     loop {}


### PR DESCRIPTION
Nothing too interesting here. Ran `rustfmt` on the repository, fixed a bunch of clippy warnings, and added a clippy job to the CI.