### PR TITLE
Update `rust-analzyer` configuration and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --examples --package=esp32c3-hal --target=riscv32imc-unknown-none-elf
+          args: --examples --manifest-path=esp32c3-hal/Cargo.toml --target=riscv32imc-unknown-none-elf
 
   check-xtensa:
     name: Check Xtensa Examples
@@ -41,15 +41,16 @@ jobs:
         chip: [esp32, esp32s2, esp32s3]
     steps:
       - uses: actions/checkout@v2
-      - uses: esp-rs/xtensa-toolchain@v1.1
+      - uses: esp-rs/xtensa-toolchain@v1.2
         with:
           default: true
           ldproxy: false
+          buildtargets: ${{ matrix.chip }}
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: -Zbuild-std=core --examples --package=${{ matrix.chip }}-hal --target=xtensa-${{ matrix.chip }}-none-elf
+          args: -Zbuild-std=core --examples --manifest-path=${{ matrix.chip }}-hal/Cargo.toml --target=xtensa-${{ matrix.chip }}-none-elf
 
   clippy:
     name: Clippy
@@ -72,4 +73,4 @@ jobs:
           command: clippy
           # I find `clippy::too-many-arguments` to be rather rather arbitrary.
           # As for `clippy::module-inception`... don't tell me what to do ;)
-          args: --package=${{ matrix.chip }}-hal -- --no-deps -D warnings --A clippy::too-many-arguments --A clippy::module-inception
+          args: --manifest-path=${{ matrix.chip }}-hal/Cargo.toml -- --no-deps -D warnings --A clippy::too-many-arguments --A clippy::module-inception

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,35 @@
 {
-    "rust-analyzer.cargo.features": [
-        "esp32c3"
-    ],
     "editor.formatOnSave": true,
-    "rust-analyzer.checkOnSave.allTargets": false
+
+    "rust-analyzer.cargo.buildScripts.enable": true,
+    "rust-analyzer.cargo.noDefaultFeatures": true,
+
+    "rust-analyzer.checkOnSave.allTargets": false,
+
+    "rust-analyzer.imports.granularity.enforce": true,
+    "rust-analyzer.imports.granularity.group": "crate",
+
+    "rust-analyzer.procMacro.attributes.enable": false,
+    "rust-analyzer.procMacro.enable": true,
+
+    // -----------------------------------------------------------------------
+    // Since we have to handle multiple toolchains AND multiple targets, we
+    // we need to give Rust Analyzer some directions.
+    //
+    // Enable ONE target and linked project based on which chip you are
+    // developing for. This will propagate to the `esp-hal-common` crate too,
+    // as it is a dependency. Changing target/project requires reloading
+    // Rust Analyzer.
+
+    // "rust-analyzer.cargo.target": "xtensa-esp32-none-elf",
+    "rust-analyzer.cargo.target": "riscv32imc-unknown-none-elf",
+    // "rust-analyzer.cargo.target": "xtensa-esp32s2-none-elf",
+    // "rust-analyzer.cargo.target": "xtensa-esp32s3-none-elf",
+
+    "rust-analyzer.linkedProjects": [
+        // "esp32-hal/Cargo.toml",
+        "esp32c3-hal/Cargo.toml",
+        // "esp32s2-hal/Cargo.toml",
+        // "esp32s3-hal/Cargo.toml",
+    ],
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,0 @@
-[workspace]
-members = [
-    "esp-hal-common",
-    "esp32-hal",
-    "esp32c3-hal",
-    "esp32s2-hal",
-    "esp32s3-hal"
-]


### PR DESCRIPTION
This takes all packages out of a workspace and instead instructs `rust-analyzer` to only build for one target/project at a time. This is based off of the `embassy` config and resolved a number of issues I was having (mostly with `esp-hal-common`).

The downside is that you need to change the configuration and restart the `rust-analyzer` server whenever you want to target a new chip, but this is just a minor inconvenience really.

I've also updated the CI to reflect the above changes, and to use the newest version of the `xtensa-toolchain` action which saves us nearly a minute in our CI run.

@bjoernQ please let me know what you think of this, and if it feels like a suitable enough workflow for you.