### PR TITLE
[esp32c3] SYSTIMER peripheral

### DIFF
--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -58,6 +58,8 @@ pub use spi::Spi;
 pub use timer::Timer;
 #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
 pub use usb_serial_jtag::UsbSerialJtag;
+#[cfg(feature = "esp32c3")]
+pub mod systimer;
 
 pub mod clock;
 pub mod system;

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -58,7 +58,7 @@ pub use spi::Spi;
 pub use timer::Timer;
 #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
 pub use usb_serial_jtag::UsbSerialJtag;
-#[cfg(feature = "esp32c3")]
+#[cfg(any(feature = "esp32c3", feature = "esp32s3", feature = "esp32s2"))]
 pub mod systimer;
 
 pub mod clock;

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -65,7 +65,8 @@ pub struct Alarm<MODE, const CHANNEL: u8> {
     _pd: PhantomData<MODE>,
 }
 
-impl<const CHANNEL: u8> Alarm<Target, CHANNEL> {
+impl<T, const CHANNEL: u8> Alarm<T, CHANNEL> {
+    // private constructor
     fn new() -> Self {
         Self { _pd: PhantomData }
     }
@@ -95,7 +96,9 @@ impl<const CHANNEL: u8> Alarm<Target, CHANNEL> {
             _ => unreachable!(),
         }
     }
+}
 
+impl<const CHANNEL: u8> Alarm<Target, CHANNEL> {
     pub fn set_target(&self, timestamp: u64) {
         unsafe {
             let systimer = &*SYSTIMER::ptr();

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -1,6 +1,6 @@
 use core::{intrinsics::transmute, marker::PhantomData};
 
-use esp32c3_pac::{
+use crate::pac::{
     generic::Reg,
     systimer::{
         comp0_load::COMP0_LOAD_SPEC,
@@ -8,9 +8,8 @@ use esp32c3_pac::{
         target0_hi::TARGET0_HI_SPEC,
         target0_lo::TARGET0_LO_SPEC,
     },
+    SYSTIMER,
 };
-
-use crate::pac::SYSTIMER;
 
 // TODO this only handles unit0 of the systimer
 

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -1,0 +1,171 @@
+use core::{intrinsics::transmute, marker::PhantomData};
+
+use esp32c3_pac::{
+    generic::Reg,
+    systimer::{
+        comp0_load::COMP0_LOAD_SPEC,
+        target0_conf::TARGET0_CONF_SPEC,
+        target0_hi::TARGET0_HI_SPEC,
+        target0_lo::TARGET0_LO_SPEC,
+    },
+};
+
+use crate::pac::SYSTIMER;
+
+// TODO this only handles unit0 of the systimer
+
+#[derive(Debug)]
+pub struct SystemTimer {
+    inner: SYSTIMER,
+    alrm0: Option<Alarm<Target, 0>>,
+    alrm1: Option<Alarm<Target, 1>>,
+    alrm2: Option<Alarm<Target, 2>>,
+}
+
+impl SystemTimer {
+    pub fn new(p: SYSTIMER) -> Self {
+        // TODO enable
+        Self {
+            inner: p,
+            alrm0: Some(Alarm::new()),
+            alrm1: Some(Alarm::new()),
+            alrm2: Some(Alarm::new()),
+        }
+    }
+
+    // TODO use fugit types
+    pub fn now(&self) -> u64 {
+        self.inner
+            .unit0_op
+            .write(|w| w.timer_unit0_update().set_bit());
+
+        while !self
+            .inner
+            .unit0_op
+            .read()
+            .timer_unit0_value_valid()
+            .bit_is_set()
+        {}
+
+        let value_lo = self.inner.unit0_value_lo.read().bits();
+        let value_hi = self.inner.unit0_value_hi.read().bits();
+
+        ((value_hi as u64) << 32) | value_lo as u64
+    }
+
+    pub fn alarm0(&mut self) -> Option<Alarm<Target, 0>> {
+        self.alrm0.take()
+    }
+
+    pub fn alarm1(&mut self) -> Option<Alarm<Target, 1>> {
+        self.alrm1.take()
+    }
+
+    pub fn alarm2(&mut self) -> Option<Alarm<Target, 2>> {
+        self.alrm2.take()
+    }
+}
+
+#[derive(Debug)]
+pub struct Target;
+// pub struct Periodic; // TODO
+
+#[derive(Debug)]
+pub struct Alarm<MODE, const CHANNEL: u8> {
+    _pd: PhantomData<MODE>,
+}
+
+impl<const CHANNEL: u8> Alarm<Target, CHANNEL> {
+    fn new() -> Self {
+        Self { _pd: PhantomData }
+    }
+
+    pub fn enable_interrupt(&self) {
+        let systimer = unsafe { &*SYSTIMER::ptr() };
+        match CHANNEL {
+            0 => systimer
+                .int_ena
+                .modify(|_, w| w.target0_int_ena().set_bit()),
+            1 => systimer
+                .int_ena
+                .modify(|_, w| w.target1_int_ena().set_bit()),
+            2 => systimer
+                .int_ena
+                .modify(|_, w| w.target2_int_ena().set_bit()),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn clear_interrupt(&self) {
+        let systimer = unsafe { &*SYSTIMER::ptr() };
+        match CHANNEL {
+            0 => systimer.int_clr.write(|w| w.target0_int_clr().set_bit()),
+            1 => systimer.int_clr.write(|w| w.target1_int_clr().set_bit()),
+            2 => systimer.int_clr.write(|w| w.target2_int_clr().set_bit()),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn set_target(&self, timestamp: u64) {
+        unsafe {
+            let systimer = &*SYSTIMER::ptr();
+            let (tconf, hi, lo, comp): (
+                &Reg<TARGET0_CONF_SPEC>,
+                &Reg<TARGET0_HI_SPEC>,
+                &Reg<TARGET0_LO_SPEC>,
+                &Reg<COMP0_LOAD_SPEC>,
+            ) = match CHANNEL {
+                0 => (
+                    &systimer.target0_conf,
+                    &systimer.target0_hi,
+                    &systimer.target0_lo,
+                    &systimer.comp0_load,
+                ),
+                1 => (
+                    transmute(&systimer.target1_conf),
+                    transmute(&systimer.target1_hi),
+                    transmute(&systimer.target1_lo),
+                    transmute(&systimer.comp1_load),
+                ),
+                2 => (
+                    transmute(&systimer.target2_conf),
+                    transmute(&systimer.target2_hi),
+                    transmute(&systimer.target2_lo),
+                    transmute(&systimer.comp2_load),
+                ),
+                _ => unreachable!(),
+            };
+
+            tconf.write(|w| {
+                w.target0_timer_unit_sel()
+                    .clear_bit()
+                    .target0_period_mode()
+                    .clear_bit()
+            });
+
+            hi.write(|w| w.timer_target0_hi().bits((timestamp >> 32) as u32));
+            lo.write(|w| w.timer_target0_lo().bits((timestamp & 0xFFFF_FFFF) as u32));
+
+            comp.write(|w| w.timer_comp0_load().set_bit());
+
+            systimer.conf.modify(|_r, w| match CHANNEL {
+                0 => w
+                    .target0_work_en()
+                    .set_bit()
+                    .timer_unit0_core0_stall_en()
+                    .clear_bit(),
+                1 => w
+                    .target1_work_en()
+                    .set_bit()
+                    .timer_unit0_core0_stall_en()
+                    .clear_bit(),
+                2 => w
+                    .target2_work_en()
+                    .set_bit()
+                    .timer_unit0_core0_stall_en()
+                    .clear_bit(),
+                _ => unreachable!(),
+            });
+        }
+    }
+}

--- a/esp32c3-hal/examples/blinky.rs
+++ b/esp32c3-hal/examples/blinky.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new(peripherals.SYSTIMER, &clocks);
+    let mut delay = Delay::new(&clocks);
 
     loop {
         led.toggle().unwrap();

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -79,7 +79,7 @@ fn main() -> ! {
         riscv::interrupt::enable();
     }
 
-    let mut delay = Delay::new(peripherals.SYSTIMER, &clocks);
+    let mut delay = Delay::new(&clocks);
     loop {
         led.toggle().unwrap();
         delay.delay_ms(500u32);

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new(peripherals.SYSTIMER, &clocks);
+    let mut delay = Delay::new(&clocks);
 
     let mut color = Hsv {
         hue: 0,

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -67,7 +67,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    let mut delay = Delay::new(peripherals.SYSTIMER, &clocks);
+    let mut delay = Delay::new(&clocks);
 
     loop {
         let mut data = [0xde, 0xca, 0xfb, 0xad];

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -42,19 +42,19 @@ fn main() -> ! {
 
     writeln!(serial0, "SYSTIMER Demo start!").ok();
 
-    let mut syst = SystemTimer::new(peripherals.SYSTIMER);
+    let syst = SystemTimer::new(peripherals.SYSTIMER);
 
-    writeln!(serial0, "SYSTIMER Current value = {}", syst.now()).ok();
+    writeln!(serial0, "SYSTIMER Current value = {}", SystemTimer::now()).ok();
 
-    let alarm0 = syst.alarm0().unwrap();
+    let alarm0 = syst.alarm0;
     alarm0.set_target(40_000_000);
     alarm0.enable_interrupt();
 
-    let alarm1 = syst.alarm1().unwrap();
+    let alarm1 = syst.alarm1;
     alarm1.set_target(41_111_111);
     alarm1.enable_interrupt();
 
-    let alarm2 = syst.alarm2().unwrap();
+    let alarm2 = syst.alarm2;
     alarm2.set_target(42_222_222 * 2);
     alarm2.enable_interrupt();
 
@@ -123,7 +123,7 @@ pub fn interrupt1() {
     riscv::interrupt::free(|cs| unsafe {
         let mut serial = SERIAL.borrow(*cs).borrow_mut();
         let serial = serial.as_mut().unwrap();
-        writeln!(serial, "Interrupt 1").ok();
+        writeln!(serial, "Interrupt 1 = {}", SystemTimer::now()).ok();
 
         let mut alarm = ALARM0.borrow(*cs).borrow_mut();
         let alarm = alarm.as_mut().unwrap();
@@ -138,7 +138,7 @@ pub fn interrupt2() {
     riscv::interrupt::free(|cs| unsafe {
         let mut serial = SERIAL.borrow(*cs).borrow_mut();
         let serial = serial.as_mut().unwrap();
-        writeln!(serial, "Interrupt 2").ok();
+        writeln!(serial, "Interrupt 2 = {}", SystemTimer::now()).ok();
 
         let mut alarm = ALARM1.borrow(*cs).borrow_mut();
         let alarm = alarm.as_mut().unwrap();
@@ -153,7 +153,7 @@ pub fn interrupt3() {
     riscv::interrupt::free(|cs| unsafe {
         let mut serial = SERIAL.borrow(*cs).borrow_mut();
         let serial = serial.as_mut().unwrap();
-        writeln!(serial, "Interrupt 3").ok();
+        writeln!(serial, "Interrupt 3 = {}", SystemTimer::now()).ok();
 
         let mut alarm = ALARM2.borrow(*cs).borrow_mut();
         let alarm = alarm.as_mut().unwrap();

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -1,0 +1,164 @@
+#![no_std]
+#![no_main]
+
+use core::{cell::RefCell, fmt::Write};
+
+use bare_metal::Mutex;
+use esp32c3_hal::{
+    pac::{self, Peripherals, UART0},
+    prelude::*,
+    RtcCntl,
+    Serial,
+    Timer,
+};
+use esp_hal_common::{
+    interrupt::{self},
+    systimer::{Alarm, SystemTimer, Target},
+    Cpu,
+};
+use panic_halt as _;
+use riscv_rt::entry;
+
+static mut SERIAL: Mutex<RefCell<Option<Serial<UART0>>>> = Mutex::new(RefCell::new(None));
+static mut ALARM0: Mutex<RefCell<Option<Alarm<Target, 0>>>> = Mutex::new(RefCell::new(None));
+static mut ALARM1: Mutex<RefCell<Option<Alarm<Target, 1>>>> = Mutex::new(RefCell::new(None));
+static mut ALARM2: Mutex<RefCell<Option<Alarm<Target, 2>>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut timer1 = Timer::new(peripherals.TIMG1);
+    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+
+    rtc_cntl.set_super_wdt_enable(false);
+    rtc_cntl.set_wdt_enable(false);
+    timer0.disable();
+    timer1.disable();
+
+    writeln!(serial0, "SYSTIMER Demo start!").ok();
+
+    let mut syst = SystemTimer::new(peripherals.SYSTIMER);
+
+    writeln!(serial0, "SYSTIMER Current value = {}", syst.now()).ok();
+
+    let alarm0 = syst.alarm0().unwrap();
+    alarm0.set_target(40_000_000);
+    alarm0.enable_interrupt();
+
+    let alarm1 = syst.alarm1().unwrap();
+    alarm1.set_target(41_111_111);
+    alarm1.enable_interrupt();
+
+    let alarm2 = syst.alarm2().unwrap();
+    alarm2.set_target(42_222_222 * 2);
+    alarm2.enable_interrupt();
+
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET0,
+        interrupt::CpuInterrupt::Interrupt1,
+    );
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET1,
+        interrupt::CpuInterrupt::Interrupt2,
+    );
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET2,
+        interrupt::CpuInterrupt::Interrupt3,
+    );
+    interrupt::set_kind(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt1,
+        interrupt::InterruptKind::Level,
+    );
+    interrupt::set_kind(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt2,
+        interrupt::InterruptKind::Level,
+    );
+    interrupt::set_kind(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt3,
+        interrupt::InterruptKind::Level,
+    );
+    interrupt::set_priority(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt1,
+        interrupt::Priority::Priority1,
+    );
+    interrupt::set_priority(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt2,
+        interrupt::Priority::Priority1,
+    );
+    interrupt::set_priority(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt3,
+        interrupt::Priority::Priority1,
+    );
+
+    riscv::interrupt::free(|_cs| unsafe {
+        SERIAL.get_mut().replace(Some(serial0));
+        ALARM0.get_mut().replace(Some(alarm0));
+        ALARM1.get_mut().replace(Some(alarm1));
+        ALARM2.get_mut().replace(Some(alarm2));
+    });
+
+    unsafe {
+        riscv::interrupt::enable();
+    }
+
+    loop {}
+}
+
+#[no_mangle]
+pub fn interrupt1() {
+    riscv::interrupt::free(|cs| unsafe {
+        let mut serial = SERIAL.borrow(*cs).borrow_mut();
+        let serial = serial.as_mut().unwrap();
+        writeln!(serial, "Interrupt 1").ok();
+
+        let mut alarm = ALARM0.borrow(*cs).borrow_mut();
+        let alarm = alarm.as_mut().unwrap();
+
+        interrupt::clear(Cpu::ProCpu, interrupt::CpuInterrupt::Interrupt1);
+        alarm.clear_interrupt();
+    });
+}
+
+#[no_mangle]
+pub fn interrupt2() {
+    riscv::interrupt::free(|cs| unsafe {
+        let mut serial = SERIAL.borrow(*cs).borrow_mut();
+        let serial = serial.as_mut().unwrap();
+        writeln!(serial, "Interrupt 2").ok();
+
+        let mut alarm = ALARM1.borrow(*cs).borrow_mut();
+        let alarm = alarm.as_mut().unwrap();
+
+        interrupt::clear(Cpu::ProCpu, interrupt::CpuInterrupt::Interrupt2);
+        alarm.clear_interrupt();
+    });
+}
+
+#[no_mangle]
+pub fn interrupt3() {
+    riscv::interrupt::free(|cs| unsafe {
+        let mut serial = SERIAL.borrow(*cs).borrow_mut();
+        let serial = serial.as_mut().unwrap();
+        writeln!(serial, "Interrupt 3").ok();
+
+        let mut alarm = ALARM2.borrow(*cs).borrow_mut();
+        let alarm = alarm.as_mut().unwrap();
+
+        interrupt::clear(Cpu::ProCpu, interrupt::CpuInterrupt::Interrupt3);
+        alarm.clear_interrupt();
+    });
+}

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -21,7 +21,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut delay = Delay::new(peripherals.SYSTIMER, &clocks);
+    let mut delay = Delay::new(&clocks);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut timer1 = Timer::new(peripherals.TIMG1);

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -13,6 +13,7 @@ pub use esp_hal_common::{
     ram,
     spi,
     system,
+    systimer,
     utils,
     Cpu,
     Delay,

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -1,0 +1,173 @@
+#![no_std]
+#![no_main]
+
+use core::{cell::RefCell, fmt::Write};
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    pac::{self, Peripherals, UART0},
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
+use esp_hal_common::{
+    interrupt,
+    Cpu,
+    systimer::{SystemTimer, Alarm, Target}
+};
+use panic_halt as _;
+use xtensa_lx::mutex::{Mutex, CriticalSectionMutex};
+use xtensa_lx_rt::entry;
+
+static mut SERIAL: CriticalSectionMutex<RefCell<Option<Serial<UART0>>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+static mut ALARM0: CriticalSectionMutex<RefCell<Option<Alarm<Target, 0>>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+static mut ALARM1: CriticalSectionMutex<RefCell<Option<Alarm<Target, 1>>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+static mut ALARM2: CriticalSectionMutex<RefCell<Option<Alarm<Target, 2>>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let syst = SystemTimer::new(peripherals.SYSTIMER);
+
+    let now = SystemTimer::now();
+
+    writeln!(serial0, "Now: {}", now).ok();
+
+    let alarm0 = syst.alarm0;
+    alarm0.set_target(40_000_0000);
+    alarm0.enable_interrupt();
+
+    let alarm1 = syst.alarm1;
+    alarm1.set_target(41_111_1110);
+    alarm1.enable_interrupt();
+
+    let alarm2 = syst.alarm2;
+    alarm2.set_target(42_222_2220 * 2);
+    alarm2.enable_interrupt();
+
+    unsafe {
+        (&SERIAL).lock(|data| (*data).replace(Some(serial0)));
+        (&ALARM0).lock(|data| (*data).replace(Some(alarm0)));
+        (&ALARM1).lock(|data| (*data).replace(Some(alarm1)));
+        (&ALARM2).lock(|data| (*data).replace(Some(alarm2)));
+    }
+
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET0,
+        interrupt::CpuInterrupt::Interrupt0LevelPriority1,
+    );
+
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET1,
+        interrupt::CpuInterrupt::Interrupt19LevelPriority2,
+    );
+
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET2,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
+    );
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    unsafe {
+        xtensa_lx::interrupt::enable_mask(1 << 19 | 1 << 0 | 1 << 23 );
+    }
+
+    loop {
+        delay.delay_ms(500u32);
+    }
+}
+
+#[no_mangle]
+pub fn level1_interrupt() {
+    unsafe {
+        (&SERIAL).lock(|data| {
+            let mut serial = data.borrow_mut();
+            let serial = serial.as_mut().unwrap();
+            writeln!(serial, "Interrupt lvl1 (alarm0)").ok();
+        });
+    }
+
+    interrupt::clear(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt0LevelPriority1,
+    );
+
+    unsafe { 
+        (&ALARM0).lock(|data| {
+            let mut alarm = data.borrow_mut();
+            let alarm = alarm.as_mut().unwrap();
+            alarm.clear_interrupt();
+        });
+    }
+}
+
+#[no_mangle]
+pub fn level2_interrupt() {
+    unsafe {
+        (&SERIAL).lock(|data| {
+            let mut serial = data.borrow_mut();
+            let serial = serial.as_mut().unwrap();
+            writeln!(serial, "Interrupt lvl2 (alarm1)").ok();
+        });
+    }
+
+    interrupt::clear(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt19LevelPriority2,
+    );
+
+    unsafe { 
+        (&ALARM1).lock(|data| {
+            let mut alarm = data.borrow_mut();
+            let alarm = alarm.as_mut().unwrap();
+            alarm.clear_interrupt();
+        });
+    }
+}
+
+#[no_mangle]
+pub fn level3_interrupt() {
+    unsafe {
+        (&SERIAL).lock(|data| {
+            let mut serial = data.borrow_mut();
+            let serial = serial.as_mut().unwrap();
+            writeln!(serial, "Interrupt lvl3 (alarm2)").ok();
+        });
+    }
+
+    interrupt::clear(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
+    );
+
+    unsafe { 
+        (&ALARM2).lock(|data| {
+            let mut alarm = data.borrow_mut();
+            let alarm = alarm.as_mut().unwrap();
+            alarm.clear_interrupt();
+        });
+    }
+}

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -1,0 +1,169 @@
+#![no_std]
+#![no_main]
+
+use core::{cell::RefCell, fmt::Write};
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    pac::{self, Peripherals, UART0},
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
+use esp_hal_common::{
+    interrupt,
+    Cpu,
+    systimer::{SystemTimer, Alarm, Target}
+};
+use panic_halt as _;
+use xtensa_lx::mutex::{Mutex, SpinLockMutex};
+use xtensa_lx_rt::entry;
+
+static mut SERIAL: SpinLockMutex<RefCell<Option<Serial<UART0>>>> =
+    SpinLockMutex::new(RefCell::new(None));
+static mut ALARM0: SpinLockMutex<RefCell<Option<Alarm<Target, 0>>>> =
+    SpinLockMutex::new(RefCell::new(None));
+static mut ALARM1: SpinLockMutex<RefCell<Option<Alarm<Target, 1>>>> =
+    SpinLockMutex::new(RefCell::new(None));
+static mut ALARM2: SpinLockMutex<RefCell<Option<Alarm<Target, 2>>>> =
+    SpinLockMutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let serial0 = Serial::new(peripherals.UART0).unwrap();
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let syst = SystemTimer::new(peripherals.SYSTIMER);
+
+    let alarm0 = syst.alarm0;
+    alarm0.set_target(40_000_000);
+    alarm0.enable_interrupt();
+
+    let alarm1 = syst.alarm1;
+    alarm1.set_target(41_111_111);
+    alarm1.enable_interrupt();
+
+    let alarm2 = syst.alarm2;
+    alarm2.set_target(42_222_222 * 2);
+    alarm2.enable_interrupt();
+
+    unsafe {
+        (&SERIAL).lock(|data| (*data).replace(Some(serial0)));
+        (&ALARM0).lock(|data| (*data).replace(Some(alarm0)));
+        (&ALARM1).lock(|data| (*data).replace(Some(alarm1)));
+        (&ALARM2).lock(|data| (*data).replace(Some(alarm2)));
+    }
+
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET0,
+        interrupt::CpuInterrupt::Interrupt0LevelPriority1,
+    );
+
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET1,
+        interrupt::CpuInterrupt::Interrupt19LevelPriority2,
+    );
+
+    interrupt::enable(
+        Cpu::ProCpu,
+        pac::Interrupt::SYSTIMER_TARGET2,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
+    );
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    unsafe {
+        xtensa_lx::interrupt::enable_mask(1 << 19 | 1 << 0 | 1 << 23 );
+    }
+
+    loop {
+        delay.delay_ms(500u32);
+    }
+}
+
+#[no_mangle]
+pub fn level1_interrupt() {
+    unsafe {
+        (&SERIAL).lock(|data| {
+            let mut serial = data.borrow_mut();
+            let serial = serial.as_mut().unwrap();
+            writeln!(serial, "Interrupt lvl1 (alarm0)").ok();
+        });
+    }
+
+    interrupt::clear(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt0LevelPriority1,
+    );
+
+    unsafe { 
+        (&ALARM0).lock(|data| {
+            let mut alarm = data.borrow_mut();
+            let alarm = alarm.as_mut().unwrap();
+            alarm.clear_interrupt();
+        });
+    }
+}
+
+#[no_mangle]
+pub fn level2_interrupt() {
+    unsafe {
+        (&SERIAL).lock(|data| {
+            let mut serial = data.borrow_mut();
+            let serial = serial.as_mut().unwrap();
+            writeln!(serial, "Interrupt lvl2 (alarm1)").ok();
+        });
+    }
+
+    interrupt::clear(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt19LevelPriority2,
+    );
+
+    unsafe { 
+        (&ALARM1).lock(|data| {
+            let mut alarm = data.borrow_mut();
+            let alarm = alarm.as_mut().unwrap();
+            alarm.clear_interrupt();
+        });
+    }
+}
+
+#[no_mangle]
+pub fn level3_interrupt() {
+    unsafe {
+        (&SERIAL).lock(|data| {
+            let mut serial = data.borrow_mut();
+            let serial = serial.as_mut().unwrap();
+            writeln!(serial, "Interrupt lvl3 (alarm2)").ok();
+        });
+    }
+
+    interrupt::clear(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt23LevelPriority3,
+    );
+
+    unsafe { 
+        (&ALARM2).lock(|data| {
+            let mut alarm = data.borrow_mut();
+            let alarm = alarm.as_mut().unwrap();
+            alarm.clear_interrupt();
+        });
+    }
+}

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -10,6 +10,7 @@ pub use esp_hal_common::{
     pulse_control,
     ram,
     spi,
+    systimer,
     usb_serial_jtag,
     utils,
     Cpu,


### PR DESCRIPTION
Opening in draft form early to bikeshed the API.

Limitations of this implementation:

- Period alarms are not supported
- Only unit0 of the systimer is used

This is a key part of embassy integration, so I thought I'd upstream this early :).

## TODO

- [ ] Implement Delay on Alarm<Target>
  -  [x] ~~Make `delay::Delay` take an alarm instead of the whole SYSTIMER~~
- [ ] Periodic (might not get to this in this PR)
  -  Implement e-h timer traits on Alarm<Periodic>