### PR TITLE
Add boot-default ClockConfig

### DIFF
--- a/esp-hal-common/.vscode/settings.json
+++ b/esp-hal-common/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-    "rust-analyzer.cargo.features": [],
+    "rust-analyzer.cargo.features": [
+        "esp32c3"
+    ],
     "rust-analyzer.cargo.allFeatures": false,
     "editor.formatOnSave": true,
     "rust-analyzer.checkOnSave.allTargets": false,
@@ -7,10 +9,15 @@
     "rust-analyzer.checkOnSave.overrideCommand": [
         "cargo",
         "check",
+        "--features",
+        "esp32c3",
         "--message-format=json",
         "-Z",
         "build-std=core",
-        "--examples"
+        "--target",
+        "riscv32imac-unknown-none-elf",
+        "--examples",
+        "--lib",
     ],
     "rust-analyzer.cargo.buildScripts.enable": false
 }

--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -1,0 +1,117 @@
+//! # Clock Control
+use fugit::MegahertzU32;
+
+use crate::system::SystemClockControl;
+
+/// Frozen clock frequencies
+///
+/// The existence of this value indicates that the clock configuration can no
+/// longer be changed
+pub struct Clocks {
+    _private: (),
+    pub cpu_clock: MegahertzU32,
+    pub apb_clock: MegahertzU32,
+    pub xtal_clock: MegahertzU32,
+    pub i2c_clock: MegahertzU32,
+    // TODO chip specific additional ones as needed
+}
+
+#[doc(hidden)]
+impl Clocks {
+    /// This should not be used in user code.
+    /// The whole point this exists is make it possible to have other crates
+    /// (i.e. esp-wifi) create `Clocks`
+    #[doc(hidden)]
+    pub fn from_raw_clocks(raw_clocks: RawClocks) -> Clocks {
+        Self {
+            _private: (),
+            cpu_clock: raw_clocks.cpu_clock,
+            apb_clock: raw_clocks.apb_clock,
+            xtal_clock: raw_clocks.xtal_clock,
+            i2c_clock: raw_clocks.i2c_clock,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct RawClocks {
+    pub cpu_clock: MegahertzU32,
+    pub apb_clock: MegahertzU32,
+    pub xtal_clock: MegahertzU32,
+    pub i2c_clock: MegahertzU32,
+    // TODO chip specific additional ones as needed
+}
+/// Used to configure the frequencies of the clocks present in the chip.
+///
+/// After setting all frequencies, call the freeze function to apply the
+/// configuration.
+pub struct ClockControl {
+    _private: (),
+    desired_rates: RawClocks,
+}
+
+impl ClockControl {
+    /// Use what is considered the default settings after boot.
+    #[cfg(feature = "esp32c3")]
+    #[allow(unused)]
+    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(40),
+            },
+        }
+    }
+
+    #[cfg(feature = "esp32")]
+    #[allow(unused)]
+    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(80),
+            },
+        }
+    }
+
+    #[cfg(feature = "esp32s2")]
+    #[allow(unused)]
+    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(80),
+            },
+        }
+    }
+
+    #[cfg(feature = "esp32s3")]
+    #[allow(unused)]
+    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(40),
+            },
+        }
+    }
+
+    /// Applies the clock configuration and returns a Clocks struct that
+    /// signifies that the clocks are frozen, and contains the frequencies
+    /// used. After this function is called, the clocks can not change
+    pub fn freeze(self) -> Clocks {
+        Clocks::from_raw_clocks(self.desired_rates)
+    }
+}

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -59,6 +59,9 @@ pub use timer::Timer;
 #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
 pub use usb_serial_jtag::UsbSerialJtag;
 
+pub mod clock;
+pub mod system;
+
 /// Enumeration of CPU cores
 /// The actual number of available cores depends on the target.
 pub enum Cpu {

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -14,3 +14,5 @@ pub use embedded_hal::{
     prelude::*,
 };
 pub use fugit::{ExtU32 as _, ExtU64 as _, RateExtU32 as _, RateExtU64 as _};
+
+pub use crate::system::SystemExt;

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -1,0 +1,104 @@
+//! System
+//!
+//! The SYSTEM/DPORT peripheral needs to be split into several logical parts.
+//!
+//! Example
+//! ```no_run
+//! let peripherals = Peripherals::take().unwrap();
+//! let system = peripherals.SYSTEM.split();
+//! let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+//! ```
+#[cfg(not(feature = "esp32"))]
+type SystemPeripheral = crate::pac::SYSTEM;
+#[cfg(feature = "esp32")]
+type SystemPeripheral = crate::pac::DPORT;
+
+/// Peripherals which can be enabled via [PeripheralClockControl]
+pub enum Peripheral {
+    Spi2,
+    Spi3,
+    I2cExt0,
+    #[cfg(not(feature = "esp32c3"))]
+    I2cExt1,
+    Rmt,
+}
+
+/// Controls the enablement of peripheral clocks.
+pub struct PeripheralClockControl {
+    _private: (),
+}
+
+impl PeripheralClockControl {
+    /// Enables and resets the given peripheral
+    pub fn enable(&mut self, peripheral: Peripheral) {
+        let system = unsafe { &*SystemPeripheral::PTR };
+
+        #[cfg(not(feature = "esp32"))]
+        let (perip_clk_en0, perip_rst_en0) = { (&system.perip_clk_en0, &system.perip_rst_en0) };
+        #[cfg(feature = "esp32")]
+        let (perip_clk_en0, perip_rst_en0) = { (&system.perip_clk_en, &system.perip_rst_en) };
+
+        match peripheral {
+            Peripheral::Spi2 => {
+                perip_clk_en0.modify(|_, w| w.spi2_clk_en().set_bit());
+                perip_rst_en0.modify(|_, w| w.spi2_rst().clear_bit());
+            }
+            Peripheral::Spi3 => {
+                perip_clk_en0.modify(|_, w| w.spi3_clk_en().set_bit());
+                perip_rst_en0.modify(|_, w| w.spi3_rst().clear_bit());
+            }
+            #[cfg(feature = "esp32")]
+            Peripheral::I2cExt0 => {
+                perip_clk_en0.modify(|_, w| w.i2c0_ext0_clk_en().set_bit());
+                perip_rst_en0.modify(|_, w| w.i2c0_ext0_rst().clear_bit());
+            }
+            #[cfg(not(feature = "esp32"))]
+            Peripheral::I2cExt0 => {
+                perip_clk_en0.modify(|_, w| w.i2c_ext0_clk_en().set_bit());
+                perip_rst_en0.modify(|_, w| w.i2c_ext0_rst().clear_bit());
+            }
+            #[cfg(not(feature = "esp32c3"))]
+            Peripheral::I2cExt1 => {
+                perip_clk_en0.modify(|_, w| w.i2c_ext1_clk_en().set_bit());
+                perip_rst_en0.modify(|_, w| w.i2c_ext1_rst().clear_bit());
+            }
+            Peripheral::Rmt => {
+                perip_clk_en0.modify(|_, w| w.rmt_clk_en().set_bit());
+                perip_rst_en0.modify(|_, w| w.rmt_rst().clear_bit());
+            }
+        }
+    }
+}
+
+/// Controls the configuration of the chip's clocks.
+pub struct SystemClockControl {
+    _private: (),
+}
+
+/// The SYSTEM/DPORT splitted into it's different logical parts.
+pub struct SystemParts {
+    _private: (),
+    pub peripheral_clock_control: PeripheralClockControl,
+    pub clock_control: SystemClockControl,
+}
+
+/// Extension trait to split a SYSTEM/DPORT peripheral in independent logical
+/// parts
+pub trait SystemExt {
+    type Parts;
+
+    /// Splits the SYSTEM/DPORT peripheral into it's parts.
+    fn split(self) -> Self::Parts;
+}
+
+impl SystemExt for SystemPeripheral {
+    type Parts = SystemParts;
+
+    fn split(self) -> Self::Parts {
+        Self::Parts {
+            _private: (),
+            peripheral_clock_control: PeripheralClockControl { _private: () },
+            clock_control: SystemClockControl { _private: () },
+        }
+    }
+}

--- a/esp32-hal/examples/blinky.rs
+++ b/esp32-hal/examples/blinky.rs
@@ -1,13 +1,23 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Timer};
+use esp32_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Timer,
+};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
@@ -24,7 +34,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     loop {
         led.toggle().unwrap();

--- a/esp32-hal/examples/gpio_interrupt.rs
+++ b/esp32-hal/examples/gpio_interrupt.rs
@@ -4,6 +4,7 @@
 use core::{cell::RefCell, fmt::Write};
 
 use esp32_hal::{
+    clock::ClockControl,
     gpio::{Gpio0, IO},
     pac::{self, Peripherals, UART0},
     prelude::*,
@@ -31,6 +32,8 @@ static mut BUTTON: SpinLockMutex<RefCell<Option<Gpio0<Input<PullDown>>>>> =
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0);
@@ -62,7 +65,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     unsafe {
         xtensa_lx::interrupt::enable_mask(1 << 1);

--- a/esp32-hal/examples/i2c_display.rs
+++ b/esp32-hal/examples/i2c_display.rs
@@ -21,7 +21,16 @@ use embedded_graphics::{
     prelude::*,
     text::{Alignment, Text},
 };
-use esp32_hal::{gpio::IO, i2c::I2C, pac::Peripherals, prelude::*, RtcCntl, Serial, Timer};
+use esp32_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    i2c::I2C,
+    pac::Peripherals,
+    prelude::*,
+    RtcCntl,
+    Serial,
+    Timer,
+};
 use nb::block;
 use panic_halt as _;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
@@ -29,7 +38,9 @@ use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
@@ -50,7 +61,8 @@ fn main() -> ! {
         io.pins.gpio32,
         io.pins.gpio33,
         100u32.kHz(),
-        &mut peripherals.DPORT,
+        &mut system.peripheral_clock_control,
+        &clocks,
     )
     .unwrap();
 

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -18,13 +18,24 @@
 
 use core::fmt::Write;
 
-use esp32_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Serial, Timer};
+use esp32_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
@@ -49,10 +60,11 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         embedded_hal::spi::MODE_0,
-        &mut peripherals.DPORT,
+        &mut system.peripheral_clock_control,
+        &clocks,
     );
 
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     loop {
         let mut data = [0xde, 0xca, 0xfb, 0xad];

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub use embedded_hal as ehal;
 pub use esp_hal_common::{
+    clock,
     i2c,
     interrupt,
     pac,

--- a/esp32c3-hal/.vscode/settings.json
+++ b/esp32c3-hal/.vscode/settings.json
@@ -4,7 +4,6 @@
     "editor.formatOnSave": true,
     "rust-analyzer.checkOnSave.allTargets": false,
     "rust-analyzer.checkOnSave.allFeatures": false,
-    "rust-analyzer.cargo.runBuildScripts": false,
     "rust-analyzer.checkOnSave.overrideCommand": [
         "cargo",
         "check",
@@ -12,5 +11,6 @@
         "-Z",
         "build-std=core",
         "--examples"
-    ]
+    ],
+    "rust-analyzer.cargo.buildScripts.enable": false
 }

--- a/esp32c3-hal/examples/blinky.rs
+++ b/esp32c3-hal/examples/blinky.rs
@@ -1,13 +1,24 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Timer};
+use esp32c3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    system::SystemExt,
+    Delay,
+    RtcCntl,
+    Timer,
+};
 use panic_halt as _;
 use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
@@ -28,7 +39,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new(peripherals.SYSTIMER);
+    let mut delay = Delay::new(peripherals.SYSTIMER, &clocks);
 
     loop {
         led.toggle().unwrap();

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -5,6 +5,7 @@ use core::{cell::RefCell, fmt::Write};
 
 use bare_metal::Mutex;
 use esp32c3_hal::{
+    clock::ClockControl,
     gpio::{Gpio9, IO},
     pac::{self, Peripherals, UART0},
     prelude::*,
@@ -30,6 +31,8 @@ static mut BUTTON: Mutex<RefCell<Option<Gpio9<Input<PullDown>>>>> = Mutex::new(R
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
@@ -76,7 +79,7 @@ fn main() -> ! {
         riscv::interrupt::enable();
     }
 
-    let mut delay = Delay::new(peripherals.SYSTIMER);
+    let mut delay = Delay::new(peripherals.SYSTIMER, &clocks);
     loop {
         led.toggle().unwrap();
         delay.delay_ms(500u32);

--- a/esp32c3-hal/examples/i2c_display.rs
+++ b/esp32c3-hal/examples/i2c_display.rs
@@ -19,7 +19,15 @@ use embedded_graphics::{
     prelude::*,
     text::{Alignment, Text},
 };
-use esp32c3_hal::{gpio::IO, i2c::I2C, pac::Peripherals, prelude::*, RtcCntl, Timer};
+use esp32c3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    i2c::I2C,
+    pac::Peripherals,
+    prelude::*,
+    RtcCntl,
+    Timer,
+};
 use nb::block;
 use panic_halt as _;
 use riscv_rt::entry;
@@ -27,7 +35,9 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0);
@@ -48,7 +58,8 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut peripherals.SYSTEM,
+        &mut system.peripheral_clock_control,
+        &clocks,
     )
     .unwrap();
 

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -3,15 +3,25 @@
 
 use core::fmt::Write;
 
-use esp32c3_hal::{pac::Peripherals, prelude::*, Delay, RtcCntl, Timer, UsbSerialJtag};
+use esp32c3_hal::{
+    clock::ClockControl,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Timer,
+    UsbSerialJtag,
+};
 use panic_halt as _;
 use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut delay = Delay::new(peripherals.SYSTIMER);
+    let mut delay = Delay::new(peripherals.SYSTIMER, &clocks);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut timer1 = Timer::new(peripherals.TIMG1);

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -4,6 +4,7 @@ use core::arch::global_asm;
 
 pub use embedded_hal as ehal;
 pub use esp_hal_common::{
+    clock,
     i2c,
     interrupt,
     pac,
@@ -11,6 +12,7 @@ pub use esp_hal_common::{
     pulse_control,
     ram,
     spi,
+    system,
     utils,
     Cpu,
     Delay,

--- a/esp32s2-hal/examples/blinky.rs
+++ b/esp32s2-hal/examples/blinky.rs
@@ -1,13 +1,23 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Timer};
+use esp32s2_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Timer,
+};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
@@ -24,7 +34,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     loop {
         led.toggle().unwrap();

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -4,6 +4,7 @@
 use core::{cell::RefCell, fmt::Write};
 
 use esp32s2_hal::{
+    clock::ClockControl,
     gpio::{Gpio0, IO},
     pac::{self, Peripherals, UART0},
     prelude::*,
@@ -31,6 +32,8 @@ static mut BUTTON: CriticalSectionMutex<RefCell<Option<Gpio0<Input<PullDown>>>>>
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
@@ -61,7 +64,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     unsafe {
         xtensa_lx::interrupt::enable_mask(1 << 19);

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -21,7 +21,16 @@ use embedded_graphics::{
     prelude::*,
     text::{Alignment, Text},
 };
-use esp32s2_hal::{gpio::IO, i2c::I2C, pac::Peripherals, prelude::*, RtcCntl, Serial, Timer};
+use esp32s2_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    i2c::I2C,
+    pac::Peripherals,
+    prelude::*,
+    RtcCntl,
+    Serial,
+    Timer,
+};
 use nb::block;
 use panic_halt as _;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
@@ -29,7 +38,9 @@ use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
@@ -50,7 +61,8 @@ fn main() -> ! {
         io.pins.gpio35,
         io.pins.gpio36,
         100u32.kHz(),
-        &mut peripherals.SYSTEM,
+        &mut system.peripheral_clock_control,
+        &clocks,
     )
     .unwrap();
 

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -2,8 +2,8 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO36
-//! MISO    GPIO35
-//! MOSI    GPIO37
+//! MISO    GPIO37
+//! MOSI    GPIO35
 //! CS      GPIO34
 //!
 //! Depending on your target and the board you are using you have to change the
@@ -18,13 +18,24 @@
 
 use core::fmt::Write;
 
-use esp32s2_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Serial, Timer};
+use esp32s2_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
@@ -49,10 +60,11 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         embedded_hal::spi::MODE_0,
-        &mut peripherals.SYSTEM,
+        &mut system.peripheral_clock_control,
+        &clocks,
     );
 
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     loop {
         let mut data = [0xde, 0xca, 0xfb, 0xad];

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub use embedded_hal as ehal;
 pub use esp_hal_common::{
+    clock,
     i2c::{self, I2C},
     interrupt,
     pac,

--- a/esp32s3-hal/examples/blinky.rs
+++ b/esp32s3-hal/examples/blinky.rs
@@ -1,13 +1,23 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Timer};
+use esp32s3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Timer,
+};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
@@ -24,7 +34,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     loop {
         led.toggle().unwrap();

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -4,6 +4,7 @@
 use core::{cell::RefCell, fmt::Write};
 
 use esp32s3_hal::{
+    clock::ClockControl,
     gpio::{Gpio0, IO},
     pac::{self, Peripherals, UART0},
     prelude::*,
@@ -31,6 +32,8 @@ static mut BUTTON: SpinLockMutex<RefCell<Option<Gpio0<Input<PullDown>>>>> =
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
@@ -61,7 +64,7 @@ fn main() -> ! {
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     unsafe {
         xtensa_lx::interrupt::enable_mask(1 << 19);

--- a/esp32s3-hal/examples/i2c_display.rs
+++ b/esp32s3-hal/examples/i2c_display.rs
@@ -21,7 +21,16 @@ use embedded_graphics::{
     prelude::*,
     text::{Alignment, Text},
 };
-use esp32s3_hal::{gpio::IO, i2c::I2C, pac::Peripherals, prelude::*, RtcCntl, Serial, Timer};
+use esp32s3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    i2c::I2C,
+    pac::Peripherals,
+    prelude::*,
+    RtcCntl,
+    Serial,
+    Timer,
+};
 use nb::block;
 use panic_halt as _;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
@@ -29,7 +38,9 @@ use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut serial0 = Serial::new(peripherals.UART0).unwrap();
@@ -50,7 +61,8 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut peripherals.SYSTEM,
+        &mut system.peripheral_clock_control,
+        &clocks,
     )
     .unwrap();
 

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -18,13 +18,24 @@
 
 use core::fmt::Write;
 
-use esp32s3_hal::{gpio::IO, pac::Peripherals, prelude::*, Delay, RtcCntl, Serial, Timer};
+use esp32s3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
@@ -49,10 +60,11 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         embedded_hal::spi::MODE_0,
-        &mut peripherals.SYSTEM,
+        &mut system.peripheral_clock_control,
+        &clocks,
     );
 
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
 
     loop {
         let mut data = [0xde, 0xca, 0xfb, 0xad];

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -3,15 +3,25 @@
 
 use core::fmt::Write;
 
-use esp32s3_hal::{pac::Peripherals, prelude::*, Delay, RtcCntl, Timer, UsbSerialJtag};
+use esp32s3_hal::{
+    clock::ClockControl,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Timer,
+    UsbSerialJtag,
+};
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut delay = Delay::new();
+    let mut delay = Delay::new(&clocks);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0);
 

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub use embedded_hal as ehal;
 pub use esp_hal_common::{
+    clock,
     i2c,
     interrupt,
     pac,


### PR DESCRIPTION
This is the first part of #44 

While it doesn't allow you to change clock rates, yet it prepares for this by introducing `ClockControll::boot_defaults()`

- there is a `i2c_clock` which doesn't exist - it's because according to the TRM on ESP32 it's always 80MHz and it's not clear to me from where that is ... so, adding this for now seems to be the easiest solution - not ideal but should be okay for now
- the struct only contains clocks we actually use currently - if we need more, we should add them as needed
- also, this adds `system` which splits the SYSTEM/DPORT - currently only into `PeripheralClockControl` and `SystemClockControl`
- there is nothing yet for `SystemClockControl` - will be added once we actually allow to change clocks

I think this is an improvement in general - definitely more to come however - and I guess this contains enough changes for a single PR
