### PR TITLE
Begin implementing the embedded-hal alpha traits

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -11,13 +11,14 @@ repository  = "https://github.com/esp-rs/esp-hal"
 license     = "MIT OR Apache-2.0"
 
 [dependencies]
-cfg-if       = "1.0"
-embedded-hal = { version = "0.2", features = ["unproven"] }
-fugit        = "0.3"
-nb           = "1.0"
-paste        = "1.0"
-procmacros   = { path = "../esp-hal-procmacros", package = "esp-hal-procmacros" }
-void         = { version = "1.0", default-features = false }
+cfg-if         = "1.0"
+embedded-hal   = { version = "0.2", features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
+fugit          = "0.3"
+nb             = "1.0"
+paste          = "1.0"
+procmacros     = { path = "../esp-hal-procmacros", package = "esp-hal-procmacros" }
+void           = { version = "1.0", default-features = false }
 
 # RISC-V
 riscv                       = { version = "0.8", optional = true }
@@ -32,7 +33,6 @@ ufmt-write = { version = "0.1", optional = true }
 
 # Smart-LED (e.g., WS2812/SK68XX) support
 smart-leds-trait = { version = "0.2.1", optional = true }
-
 
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a

--- a/esp-hal-common/src/delay.rs
+++ b/esp-hal-common/src/delay.rs
@@ -4,27 +4,37 @@
 //!
 //! [embedded-hal]: https://docs.rs/embedded-hal/latest/embedded_hal/
 
-use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use core::convert::Infallible;
 
 pub use self::delay::Delay;
 
-impl<T> DelayMs<T> for Delay
+impl<T> embedded_hal::blocking::delay::DelayMs<T> for Delay
 where
     T: Into<u32>,
 {
     fn delay_ms(&mut self, ms: T) {
         for _ in 0..ms.into() {
-            self.delay_us(1000u32);
+            self.delay(1000u32);
         }
     }
 }
 
-impl<T> DelayUs<T> for Delay
+impl<T> embedded_hal::blocking::delay::DelayUs<T> for Delay
 where
     T: Into<u32>,
 {
     fn delay_us(&mut self, us: T) {
         self.delay(us.into());
+    }
+}
+
+impl embedded_hal_1::delay::blocking::DelayUs for Delay {
+    type Error = Infallible;
+
+    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+        self.delay(us);
+
+        Ok(())
     }
 }
 
@@ -65,7 +75,6 @@ mod delay {
 
 #[cfg(not(feature = "esp32c3"))]
 mod delay {
-
     use fugit::HertzU64;
 
     use crate::clock::Clocks;

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -4,15 +4,56 @@
 //! drivers implemented in this crate.
 
 pub use embedded_hal::{
-    blocking::delay::{DelayMs as _, DelayUs as _},
     digital::v2::{
-        InputPin as _,
-        OutputPin as _,
-        StatefulOutputPin as _,
-        ToggleableOutputPin as _,
+        InputPin as _embedded_hal_digital_v2_InputPin,
+        OutputPin as _embedded_hal_digital_v2_OutputPin,
+        StatefulOutputPin as _embedded_hal_digital_v2_StatefulOutputPin,
+        ToggleableOutputPin as _embedded_hal_digital_v2_ToggleableOutputPin,
     },
     prelude::*,
 };
-pub use fugit::{ExtU32 as _, ExtU64 as _, RateExtU32 as _, RateExtU64 as _};
+pub use fugit::{
+    ExtU32 as _fugit_ExtU32,
+    ExtU64 as _fugit_ExtU64,
+    RateExtU32 as _fugit_RateExtU32,
+    RateExtU64 as _fugit_RateExtU64,
+};
+pub use nb;
 
 pub use crate::system::SystemExt;
+
+/// All traits required for using the 1.0.0-alpha.x release of embedded-hal
+pub mod eh1 {
+    pub use embedded_hal_1::{
+        delay::blocking::DelayUs as _embedded_hal_delay_blocking_DelayUs,
+        digital::blocking::{
+            InputPin as _embedded_hal_digital_blocking_InputPin,
+            OutputPin as _embedded_hal_digital_blocking_OutputPin,
+            StatefulOutputPin as _embedded_hal_digital_blocking_StatefulOutputPin,
+            ToggleableOutputPin as _embedded_hal_digital_blocking_ToggleableOutputPin,
+        },
+        i2c::blocking::I2c as _embedded_hal_i2c_blocking_I2c,
+        serial::nb::{
+            Read as _embedded_hal_serial_nb_Read,
+            Write as _embedded_hal_serial_nb_Write,
+        },
+        spi::{
+            blocking::{
+                SpiBus as _embedded_hal_spi_blocking_SpiBus,
+                SpiBusFlush as _embedded_hal_spi_blocking_SpiBusFlush,
+                SpiBusRead as _embedded_hal_spi_blocking_SpiBusRead,
+                SpiBusWrite as _embedded_hal_spi_blocking_SpiBusWrite,
+            },
+            nb::FullDuplex as _embedded_hal_spi_nb_FullDuplex,
+        },
+    };
+    pub use fugit::{
+        ExtU32 as _fugit_ExtU32,
+        ExtU64 as _fugit_ExtU64,
+        RateExtU32 as _fugit_RateExtU32,
+        RateExtU64 as _fugit_RateExtU64,
+    };
+    pub use nb;
+
+    pub use crate::system::SystemExt;
+}

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -24,13 +24,14 @@ categories = [
 ]
 
 [dependencies]
-bare-metal   = "1.0"
-embedded-hal = { version = "0.2",  features = ["unproven"] }
-fugit        = "0.3"
-nb           = "1.0"
-void         = { version = "1.0",  default-features = false }
-xtensa-lx    = { version = "0.7",  features = ["esp32"] }
-xtensa-lx-rt = { version = "0.11", features = ["esp32"], optional = true }
+bare-metal     = "1.0"
+embedded-hal   = { version = "0.2",  features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
+fugit          = "0.3"
+nb             = "1.0"
+void           = { version = "1.0",  default-features = false }
+xtensa-lx      = { version = "0.7",  features = ["esp32"] }
+xtensa-lx-rt   = { version = "0.11", features = ["esp32"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -23,6 +23,7 @@ use esp32_hal::{
     gpio::IO,
     pac::Peripherals,
     prelude::*,
+    spi::{Spi, SpiMode},
     Delay,
     RtcCntl,
     Serial,
@@ -52,14 +53,14 @@ fn main() -> ! {
     let mosi = io.pins.gpio23;
     let cs = io.pins.gpio22;
 
-    let mut spi = esp32_hal::spi::Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
         miso,
         cs,
         100u32.kHz(),
-        embedded_hal::spi::MODE_0,
+        SpiMode::Mode0,
         &mut system.peripheral_clock_control,
         &clocks,
     );

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -24,14 +24,15 @@ categories = [
 ]
 
 [dependencies]
-bare-metal   = "1.0"
-embedded-hal = { version = "0.2", features = ["unproven"] }
-fugit        = "0.3"
-nb           = "1.0"
-r0           = "1.0"
-riscv        = "0.8"
-riscv-rt     = { version = "0.8", optional = true }
-void         = { version = "1.0", default-features = false }
+bare-metal     = "1.0"
+embedded-hal   = { version = "0.2", features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
+fugit          = "0.3"
+nb             = "1.0"
+r0             = "1.0"
+riscv          = "0.8"
+riscv-rt       = { version = "0.8", optional = true }
+void           = { version = "1.0", default-features = false }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -23,6 +23,7 @@ use esp32c3_hal::{
     gpio::IO,
     pac::Peripherals,
     prelude::*,
+    spi::{Spi, SpiMode},
     Delay,
     RtcCntl,
     Serial,
@@ -55,14 +56,14 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let mut spi = esp32c3_hal::spi::Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
         miso,
         cs,
         100u32.kHz(),
-        embedded_hal::spi::MODE_0,
+        SpiMode::Mode0,
         &mut system.peripheral_clock_control,
         &clocks,
     );

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -24,13 +24,14 @@ categories = [
 ]
 
 [dependencies]
-bare-metal   = "1.0"
-embedded-hal = { version = "0.2",  features = ["unproven"] }
-fugit        = "0.3"
-nb           = "1.0"
-void         = { version = "1.0",  default-features = false }
-xtensa-lx    = { version = "0.7",  features = ["esp32s2"] }
-xtensa-lx-rt = { version = "0.11", features = ["esp32s2"], optional = true }
+bare-metal     = "1.0"
+embedded-hal   = { version = "0.2",  features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
+fugit          = "0.3"
+nb             = "1.0"
+void           = { version = "1.0",  default-features = false }
+xtensa-lx      = { version = "0.7",  features = ["esp32s2"] }
+xtensa-lx-rt   = { version = "0.11", features = ["esp32s2"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -23,6 +23,7 @@ use esp32s2_hal::{
     gpio::IO,
     pac::Peripherals,
     prelude::*,
+    spi::{Spi, SpiMode},
     Delay,
     RtcCntl,
     Serial,
@@ -52,14 +53,14 @@ fn main() -> ! {
     let mosi = io.pins.gpio35;
     let cs = io.pins.gpio34;
 
-    let mut spi = esp32s2_hal::spi::Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
         miso,
         cs,
         100u32.kHz(),
-        embedded_hal::spi::MODE_0,
+        SpiMode::Mode0,
         &mut system.peripheral_clock_control,
         &clocks,
     );

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -24,13 +24,14 @@ categories = [
 ]
 
 [dependencies]
-bare-metal   = "1.0"
-embedded-hal = { version = "0.2",  features = ["unproven"] }
-fugit        = "0.3"
-nb           = "1.0"
-void         = { version = "1.0",  default-features = false }
-xtensa-lx    = { version = "0.7",  features = ["esp32s3"] }
-xtensa-lx-rt = { version = "0.11", features = ["esp32s3"], optional = true }
+bare-metal     = "1.0"
+embedded-hal   = { version = "0.2",  features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
+fugit          = "0.3"
+nb             = "1.0"
+void           = { version = "1.0",  default-features = false }
+xtensa-lx      = { version = "0.7",  features = ["esp32s3"] }
+xtensa-lx-rt   = { version = "0.11", features = ["esp32s3"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -23,6 +23,7 @@ use esp32s3_hal::{
     gpio::IO,
     pac::Peripherals,
     prelude::*,
+    spi::{Spi, SpiMode},
     Delay,
     RtcCntl,
     Serial,
@@ -52,14 +53,14 @@ fn main() -> ! {
     let mosi = io.pins.gpio13;
     let cs = io.pins.gpio10;
 
-    let mut spi = esp32s3_hal::spi::Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
         miso,
         cs,
         100u32.kHz(),
-        embedded_hal::spi::MODE_0,
+        SpiMode::Mode0,
         &mut system.peripheral_clock_control,
         &clocks,
     );


### PR DESCRIPTION
This is not exhaustive, but covers the traits which are analogous to those already implemented. It's possible for the `0.2.x` and `1.0.0-alpha.x` releases to co-exist, as the user can control which set of traits are imported via the prelude.

This has had some minimal level of testing, but I was not very thorough. Most of the functionality is identical to what we previously had so it should all work in theory. These traits are not currently being used in any examples, just to avoid additional changes. We can decide how we want to handle this at some other point I figure.

Implemented:

- `embedded_hal::delay::blocking::DelayUs`
- `embedded_hal::digital::blocking::InputPin`
- `embedded_hal::digital::blocking::OutputPin`
- `embedded_hal::digital::blocking::StatefulOutputPin`
- `embedded_hal::digital::blocking::ToggleableOutputPin`
- `embedded_hal::i2c::blocking::I2c`
- `embedded_hal::serial::nb::Read`
- `embedded_hal::serial::nb::Write`
- `embedded_hal::spi::nb::FullDuplex`

Not Implemented:

- `embedded_hal::digital::blocking::IoPin`
- `embedded_hal::serial::blocking::Write`
- `embedded_hal::spi::blocking::SpiBus`
- `embedded_hal::spi::blocking::SpiBusFlush`
- `embedded_hal::spi::blocking::SpiBusRead`
- `embedded_hal::spi::blocking::SpiBusWrite`

For compatibility reasons I've created the `esp_hal_common::spi::SpiMode` enum, as we were not actually using the data encoded in the enums provided by the two versions of `embedded-hal` and they are obviously different types. Let me know how you feel about this, I wasn't really sure how else to accomplish this.

If you feel anything is missing please let me know and I'll add it in. I'll likely deal with the unimplemented traits in a separate PR at some point.