### PR TITLE
Put the `embedded-hal` alpha trait implementations behind a feature

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -13,7 +13,7 @@ license     = "MIT OR Apache-2.0"
 [dependencies]
 cfg-if         = "1.0"
 embedded-hal   = { version = "0.2", features = ["unproven"] }
-embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
+embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8", optional = true }
 fugit          = "0.3"
 nb             = "1.0"
 paste          = "1.0"
@@ -62,3 +62,6 @@ ufmt = ["ufmt-write"]
 
 # To use the external `smart_led` crate
 smartled = ["smart-leds-trait"]
+
+# Implement the `embedded-hal==1.0.0-alpha.x` traits
+eh1 = ["embedded-hal-1"]

--- a/esp-hal-common/src/delay.rs
+++ b/esp-hal-common/src/delay.rs
@@ -4,8 +4,6 @@
 //!
 //! [embedded-hal]: https://docs.rs/embedded-hal/latest/embedded_hal/
 
-use core::convert::Infallible;
-
 pub use self::delay::Delay;
 
 impl<T> embedded_hal::blocking::delay::DelayMs<T> for Delay
@@ -28,8 +26,9 @@ where
     }
 }
 
+#[cfg(feature = "eh1")]
 impl embedded_hal_1::delay::blocking::DelayUs for Delay {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
 
     fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
         self.delay(us);

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -523,10 +523,12 @@ macro_rules! impl_input {
             }
         }
 
+        #[cfg(feature = "eh1")]
         impl<MODE> embedded_hal_1::digital::ErrorType for $pxi<Input<MODE>> {
             type Error = Infallible;
         }
 
+        #[cfg(feature = "eh1")]
         impl<MODE> embedded_hal_1::digital::blocking::InputPin for $pxi<Input<MODE>> {
             fn is_high(&self) -> Result<bool, Self::Error> {
                 Ok(self.read_input() & (1 << $bit) != 0)
@@ -764,10 +766,12 @@ macro_rules! impl_output {
             }
         }
 
+        #[cfg(feature = "eh1")]
         impl<MODE> embedded_hal_1::digital::ErrorType for $pxi<Output<MODE>> {
             type Error = Infallible;
         }
 
+        #[cfg(feature = "eh1")]
         impl<MODE> embedded_hal_1::digital::blocking::OutputPin for $pxi<Output<MODE>> {
             fn set_low(&mut self) -> Result<(), Self::Error> {
                 self.write_output_clear(1 << $bit);
@@ -780,6 +784,7 @@ macro_rules! impl_output {
             }
         }
 
+        #[cfg(feature = "eh1")]
         impl<MODE> embedded_hal_1::digital::blocking::StatefulOutputPin for $pxi<Output<MODE>> {
             fn is_set_high(&self) -> Result<bool, Self::Error> {
                 Ok(self.read_output() & (1 << $bit) != 0)
@@ -790,6 +795,7 @@ macro_rules! impl_output {
             }
         }
 
+        #[cfg(feature = "eh1")]
         impl<MODE> embedded_hal_1::digital::blocking::ToggleableOutputPin for $pxi<Output<MODE>> {
             fn toggle(&mut self) -> Result<(), Self::Error> {
                 use embedded_hal_1::digital::blocking::{StatefulOutputPin as _, OutputPin as _};

--- a/esp-hal-common/src/i2c.rs
+++ b/esp-hal-common/src/i2c.rs
@@ -33,6 +33,7 @@ pub enum Error {
     CommandNrExceeded,
 }
 
+#[cfg(feature = "eh1")]
 impl embedded_hal_1::i2c::Error for Error {
     fn kind(&self) -> embedded_hal_1::i2c::ErrorKind {
         use embedded_hal_1::i2c::ErrorKind;
@@ -202,10 +203,12 @@ where
     }
 }
 
+#[cfg(feature = "eh1")]
 impl<T> embedded_hal_1::i2c::ErrorType for I2C<T> {
     type Error = Error;
 }
 
+#[cfg(feature = "eh1")]
 impl<T> embedded_hal_1::i2c::blocking::I2c for I2C<T>
 where
     T: Instance,

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -23,6 +23,7 @@ pub use nb;
 pub use crate::system::SystemExt;
 
 /// All traits required for using the 1.0.0-alpha.x release of embedded-hal
+#[cfg(feature = "eh1")]
 pub mod eh1 {
     pub use embedded_hal_1::{
         delay::blocking::DelayUs as _embedded_hal_delay_blocking_DelayUs,

--- a/esp-hal-common/src/serial.rs
+++ b/esp-hal-common/src/serial.rs
@@ -10,6 +10,7 @@ const UART_FIFO_SIZE: u16 = 128;
 #[derive(Debug)]
 pub enum Error {}
 
+#[cfg(feature = "eh1")]
 impl embedded_hal_1::serial::Error for Error {
     fn kind(&self) -> embedded_hal_1::serial::ErrorKind {
         embedded_hal_1::serial::ErrorKind::Other
@@ -245,10 +246,12 @@ where
     }
 }
 
+#[cfg(feature = "eh1")]
 impl<T> embedded_hal_1::serial::ErrorType for Serial<T> {
     type Error = Error;
 }
 
+#[cfg(feature = "eh1")]
 impl<T> embedded_hal_1::serial::nb::Read for Serial<T>
 where
     T: Instance,
@@ -258,6 +261,7 @@ where
     }
 }
 
+#[cfg(feature = "eh1")]
 impl<T> embedded_hal_1::serial::nb::Write for Serial<T>
 where
     T: Instance,

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -133,10 +133,12 @@ where
     }
 }
 
+#[cfg(feature = "eh1")]
 impl<T> embedded_hal_1::spi::ErrorType for Spi<T> {
     type Error = Infallible;
 }
 
+#[cfg(feature = "eh1")]
 impl<T> embedded_hal_1::spi::nb::FullDuplex for Spi<T>
 where
     T: Instance,

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -27,9 +27,6 @@ categories = [
 bare-metal     = "1.0"
 embedded-hal   = { version = "0.2",  features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
-fugit          = "0.3"
-nb             = "1.0"
-void           = { version = "1.0",  default-features = false }
 xtensa-lx      = { version = "0.7",  features = ["esp32"] }
 xtensa-lx-rt   = { version = "0.12", features = ["esp32"], optional = true }
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -43,5 +43,6 @@ smart-leds        = "0.3"
 [features]
 default   = ["rt"]
 bluetooth = []
+eh1       = ["esp-hal-common/eh1"]
 rt        = ["xtensa-lx-rt/esp32"]
 ufmt      = ["esp-hal-common/ufmt"]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -44,5 +44,6 @@ smart-leds        = "0.3"
 [features]
 default     = ["rt"]
 direct-boot = []
+eh1         = ["esp-hal-common/eh1"]
 rt          = ["riscv-rt"]
 ufmt        = ["esp-hal-common/ufmt"]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -27,12 +27,9 @@ categories = [
 bare-metal     = "1.0"
 embedded-hal   = { version = "0.2", features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
-fugit          = "0.3"
-nb             = "1.0"
 r0             = "1.0"
 riscv          = "0.8"
 riscv-rt       = { version = "0.8", optional = true }
-void           = { version = "1.0", default-features = false }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -42,5 +42,6 @@ smart-leds        = "0.3"
 
 [features]
 default = ["rt"]
+eh1     = ["esp-hal-common/eh1"]
 rt      = ["xtensa-lx-rt/esp32s2"]
 ufmt    = ["esp-hal-common/ufmt"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -27,9 +27,6 @@ categories = [
 bare-metal     = "1.0"
 embedded-hal   = { version = "0.2",  features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
-fugit          = "0.3"
-nb             = "1.0"
-void           = { version = "1.0",  default-features = false }
 xtensa-lx      = { version = "0.7",  features = ["esp32s2"] }
 xtensa-lx-rt   = { version = "0.12", features = ["esp32s2"], optional = true }
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -42,5 +42,6 @@ smart-leds        = "0.3"
 
 [features]
 default = ["rt"]
+eh1     = ["esp-hal-common/eh1"]
 rt      = ["xtensa-lx-rt/esp32s3"]
 ufmt    = ["esp-hal-common/ufmt"]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -27,9 +27,6 @@ categories = [
 bare-metal     = "1.0"
 embedded-hal   = { version = "0.2",  features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
-fugit          = "0.3"
-nb             = "1.0"
-void           = { version = "1.0",  default-features = false }
 xtensa-lx      = { version = "0.7",  features = ["esp32s3"] }
 xtensa-lx-rt   = { version = "0.12", features = ["esp32s3"], optional = true }
 


### PR DESCRIPTION
While the 0.2 and 1.0 releases can co-exist, if users are not utilizing the new release there's not much point in including it as a dependency.

Also removed some unused dependencies from the user-facing HAL crates.