### PR TITLE
Xtensa CS implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,25 +52,44 @@ jobs:
           command: check
           args: -Zbuild-std=core --examples --manifest-path=${{ matrix.chip }}-hal/Cargo.toml --target=xtensa-${{ matrix.chip }}-none-elf
 
-  clippy:
-    name: Clippy
+  clippy-riscv:
+    name: Run clippy on RISC-V builds
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        chip: [esp32, esp32c3, esp32s2, esp32s3]
+        toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          default: true
+          target: riscv32imc-unknown-none-elf
+          toolchain: ${{ matrix.toolchain }}
           components: clippy
+          default: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          # I find `clippy::too-many-arguments` to be rather rather arbitrary.
-          # As for `clippy::module-inception`... don't tell me what to do ;)
-          args: --manifest-path=${{ matrix.chip }}-hal/Cargo.toml -- --no-deps -D warnings --A clippy::too-many-arguments --A clippy::module-inception
+          args: --manifest-path=esp32c3-hal/Cargo.toml --target=riscv32imc-unknown-none-elf -- --no-deps -D warnings --A clippy::too-many-arguments --A clippy::module-inception
+        
+  clippy-xtensa:
+    name: Run clippy on Xtensa builds
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chip: [esp32, esp32s2, esp32s3]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: esp-rs/xtensa-toolchain@v1.2
+        with:
+          default: true
+          ldproxy: false
+          buildtargets: ${{ matrix.chip }}
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -Zbuild-std=core --manifest-path=${{ matrix.chip }}-hal/Cargo.toml --target=xtensa-${{ matrix.chip }}-none-elf -- --no-deps -D warnings --A clippy::too-many-arguments --A clippy::module-inception

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -46,18 +46,18 @@ esp32s2_pac = { package = "esp32s2", git = "https://github.com/esp-rs/esp-pacs.g
 esp32s3_pac = { package = "esp32s3", git = "https://github.com/esp-rs/esp-pacs.git", branch = "with_source", optional = true }
 
 [features]
-esp32   = ["esp32_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "smartled"]
-esp32c3 = ["esp32c3_pac/rt", "risc_v", "single_core", "smartled"]
-esp32s2 = ["esp32s2_pac/rt", "xtensa", "single_core", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "smartled"]
-esp32s3 = ["esp32s3_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "smartled"]
+esp32   = ["esp32_pac/rt", "xtensa",   "multicore", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "smartled"]
+esp32c3 = ["esp32c3_pac/rt", "risc_v", "unicore", "smartled"]
+esp32s2 = ["esp32s2_pac/rt", "xtensa", "unicore", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "smartled"]
+esp32s3 = ["esp32s3_pac/rt", "xtensa",   "multicore", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "smartled"]
 
 # Architecture (should not be enabled directly, but instead by a PAC's feature)
 risc_v = ["riscv", "riscv-atomic-emulation-trap"]
 xtensa = ["procmacros/rtc_slow"]
 
 # Core Count (should not be enabled directly, but instead by a PAC's feature)
-single_core = []
-dual_core   = ["lock_api"]
+unicore = []
+multicore   = ["lock_api"]
 
 # To support `ufmt`
 ufmt = ["ufmt-write"]

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -19,6 +19,8 @@ nb             = "1.0"
 paste          = "1.0"
 procmacros     = { path = "../esp-hal-procmacros", package = "esp-hal-procmacros" }
 void           = { version = "1.0", default-features = false }
+critical-section = { version = "0.2.7",features = ["custom-impl"] }
+lock_api = { version = "0.4.7", optional = true }
 
 # RISC-V
 riscv                       = { version = "0.8", optional = true }
@@ -44,7 +46,7 @@ esp32s2_pac = { package = "esp32s2", git = "https://github.com/esp-rs/esp-pacs.g
 esp32s3_pac = { package = "esp32s3", git = "https://github.com/esp-rs/esp-pacs.git", branch = "with_source", optional = true }
 
 [features]
-esp32   = [  "esp32_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "smartled"]
+esp32   = ["esp32_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "smartled"]
 esp32c3 = ["esp32c3_pac/rt", "risc_v", "single_core", "smartled"]
 esp32s2 = ["esp32s2_pac/rt", "xtensa", "single_core", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "smartled"]
 esp32s3 = ["esp32s3_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "smartled"]
@@ -55,7 +57,7 @@ xtensa = ["procmacros/rtc_slow"]
 
 # Core Count (should not be enabled directly, but instead by a PAC's feature)
 single_core = []
-dual_core   = []
+dual_core   = ["lock_api"]
 
 # To support `ufmt`
 ufmt = ["ufmt-write"]

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -46,14 +46,12 @@ esp32s2_pac = { package = "esp32s2", git = "https://github.com/esp-rs/esp-pacs.g
 esp32s3_pac = { package = "esp32s3", git = "https://github.com/esp-rs/esp-pacs.git", branch = "with_source", optional = true }
 
 [features]
-esp32   = ["esp32_pac/rt", "xtensa",   "multicore", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "smartled"]
-esp32c3 = ["esp32c3_pac/rt", "risc_v", "unicore", "smartled"]
-esp32s2 = ["esp32s2_pac/rt", "xtensa", "unicore", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "smartled"]
-esp32s3 = ["esp32s3_pac/rt", "xtensa",   "multicore", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "smartled"]
+esp32   = ["esp32_pac/rt",   "multicore", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32", "procmacros/rtc_slow", "smartled"]
+esp32c3 = ["esp32c3_pac/rt", "unicore", "riscv", "riscv-atomic-emulation-trap", "smartled"]
+esp32s2 = ["esp32s2_pac/rt", "unicore", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "procmacros/rtc_slow", "smartled"] # TODO support xtensa atomic emulation
+esp32s3 = ["esp32s3_pac/rt", "multicore", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "procmacros/rtc_slow", "smartled"]
 
-# Architecture (should not be enabled directly, but instead by a PAC's feature)
-risc_v = ["riscv", "riscv-atomic-emulation-trap"]
-xtensa = ["procmacros/rtc_slow"]
+
 
 # Core Count (should not be enabled directly, but instead by a PAC's feature)
 unicore = []

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -19,7 +19,7 @@ nb             = "1.0"
 paste          = "1.0"
 procmacros     = { path = "../esp-hal-procmacros", package = "esp-hal-procmacros" }
 void           = { version = "1.0", default-features = false }
-critical-section = { version = "0.2.7",features = ["custom-impl"] }
+critical-section = { git = "https://github.com/embassy-rs/critical-section", features = ["token-u32"] }
 lock_api = { version = "0.4.7", optional = true }
 
 # RISC-V

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -58,9 +58,9 @@ pub fn enable(core: Cpu, interrupt: Interrupt, which: CpuInterrupt) {
         let cpu_interrupt_number = which as isize;
         let intr_map_base = match core {
             Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
-            #[cfg(feature = "dual_core")]
+            #[cfg(feature = "multicore")]
             Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
-            #[cfg(feature = "single_core")]
+            #[cfg(feature = "unicore")]
             Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
         };
         intr_map_base
@@ -75,9 +75,9 @@ pub fn disable(core: Cpu, interrupt: Interrupt) {
         let interrupt_number = interrupt as isize;
         let intr_map_base = match core {
             Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
-            #[cfg(feature = "dual_core")]
+            #[cfg(feature = "multicore")]
             Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
-            #[cfg(feature = "single_core")]
+            #[cfg(feature = "unicore")]
             Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
         };
         intr_map_base.offset(interrupt_number).write_volatile(0);
@@ -111,7 +111,7 @@ pub fn get_status(core: Cpu) -> u128 {
                         .bits() as u128)
                         << 64
             }
-            #[cfg(feature = "dual_core")]
+            #[cfg(feature = "multicore")]
             Cpu::AppCpu => {
                 ((*core1_interrupt_peripheral())
                     .app_intr_status_0
@@ -128,7 +128,7 @@ pub fn get_status(core: Cpu) -> u128 {
                         .bits() as u128)
                         << 64
             }
-            #[cfg(feature = "single_core")]
+            #[cfg(feature = "unicore")]
             Cpu::AppCpu => {
                 ((*core0_interrupt_peripheral())
                     .pro_intr_status_0

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -38,8 +38,8 @@ pub mod efuse;
 
 pub mod gpio;
 pub mod i2c;
-#[cfg_attr(feature = "risc_v", path = "interrupt/riscv.rs")]
-#[cfg_attr(feature = "xtensa", path = "interrupt/xtensa.rs")]
+#[cfg_attr(target_arch = "riscv32", path = "interrupt/riscv.rs")]
+#[cfg_attr(target_arch = "xtensa", path = "interrupt/xtensa.rs")]
 pub mod interrupt;
 pub mod prelude;
 pub mod pulse_control;

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -91,12 +91,16 @@ pub enum Cpu {
 }
 
 pub fn get_core() -> Cpu {
-    #[cfg(target_arch = "xtensa")]
+    #[cfg(all(target_arch = "xtensa", feature = "multicore"))]
     match ((xtensa_lx::get_processor_id() >> 13) & 1) != 0 {
         false => Cpu::ProCpu,
         true => Cpu::AppCpu,
     }
-    #[cfg(target_arch = "riscv32")] // TODO get hart_id
+    // #[cfg(all(target_arch = "riscv32", feature = "multicore"))]
+    // TODO get hart_id
+
+    // single core always has ProCpu only
+    #[cfg(feature = "unicore")]
     Cpu::ProCpu
 }
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -27,6 +27,9 @@ categories = [
 bare-metal     = "1.0"
 embedded-hal   = { version = "0.2",  features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
+fugit          = "0.3"
+nb             = "1.0"
+void           = { version = "1.0",  default-features = false }
 xtensa-lx      = { version = "0.7",  features = ["esp32s3"] }
 xtensa-lx-rt   = { version = "0.12", features = ["esp32s3"], optional = true }
 
@@ -39,10 +42,13 @@ embedded-graphics = "0.7"
 panic-halt        = "0.2"
 ssd1306           = "0.7"
 smart-leds        = "0.3"
-esp-println       = { version = "0.1.0", features = ["esp32s3"] }
+esp-println = { version = "0.2.0", features = ["esp32s3"] }
+critical-section = { git = "https://github.com/embassy-rs/critical-section" }
+
+[patch.crates-io]
+bare-metal     = { version = "1.0", git = "https://github.com/rust-embedded/bare-metal" }
 
 [features]
 default = ["rt"]
-eh1     = ["esp-hal-common/eh1"]
 rt      = ["xtensa-lx-rt/esp32s3"]
 ufmt    = ["esp-hal-common/ufmt"]


### PR DESCRIPTION
- CS implementation for single core using PS.INTLEVEL
- Added locking for dual core chips using a reetrant mutex. Reentrancy
  is important for nested critical sections.
- Renames `single_core` & `dual_core` features to `unicore` & `multicore` respectively
- CI: Run clippy on each chip so that `cfg(target_arch = "...")` paths are taken correctly
- Remove redundant features

## Questions

~~It's unclear what the INIT value for thread id should be, see the docs: https://docs.rs/lock_api/0.4.7/lock_api/trait.GetThreadId.html. I chose the first CPU as an init value, but perhaps this needs to be "not locked by either" value.~~