### PR TITLE
Implement DAC support for ESP32/ESP32-S2

### DIFF
--- a/esp-hal-common/src/analog/dac.rs
+++ b/esp-hal-common/src/analog/dac.rs
@@ -1,0 +1,127 @@
+use crate::pac::{RTCIO, SENS};
+
+pub trait DAC {
+    fn write(&mut self, value: u8);
+}
+
+#[doc(hidden)]
+pub trait DAC1Impl {
+    fn set_power(self) -> Self
+    where
+        Self: Sized,
+    {
+        #[cfg(feature = "esp32s2")]
+        {
+            let sensors = unsafe { &*SENS::ptr() };
+            sensors
+                .sar_dac_ctrl1
+                .modify(|_, w| w.dac_clkgate_en().set_bit());
+        }
+
+        let rtcio = unsafe { &*RTCIO::ptr() };
+
+        rtcio.pad_dac1.modify(|_, w| {
+            w.pdac1_dac_xpd_force().set_bit();
+            w.pdac1_xpd_dac().set_bit()
+        });
+
+        self
+    }
+
+    fn write(&mut self, value: u8) {
+        let rtcio = unsafe { &*RTCIO::ptr() };
+
+        let sensors = unsafe { &*SENS::ptr() };
+        sensors
+            .sar_dac_ctrl2
+            .modify(|_, w| w.dac_cw_en1().clear_bit());
+
+        rtcio
+            .pad_dac1
+            .modify(|_, w| unsafe { w.pdac1_dac().bits(value) });
+    }
+}
+
+#[doc(hidden)]
+pub trait DAC2Impl {
+    fn set_power(self) -> Self
+    where
+        Self: Sized,
+    {
+        #[cfg(feature = "esp32s2")]
+        {
+            let sensors = unsafe { &*SENS::ptr() };
+            sensors
+                .sar_dac_ctrl1
+                .modify(|_, w| w.dac_clkgate_en().set_bit());
+        }
+
+        let rtcio = unsafe { &*RTCIO::ptr() };
+
+        rtcio.pad_dac2.modify(|_, w| {
+            w.pdac2_dac_xpd_force().set_bit();
+            w.pdac2_xpd_dac().set_bit()
+        });
+
+        self
+    }
+
+    fn write(&mut self, value: u8) {
+        let rtcio = unsafe { &*RTCIO::ptr() };
+
+        let sensors = unsafe { &*SENS::ptr() };
+        sensors
+            .sar_dac_ctrl2
+            .modify(|_, w| w.dac_cw_en2().clear_bit());
+
+        rtcio
+            .pad_dac2
+            .modify(|_, w| unsafe { w.pdac2_dac().bits(value) });
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_dac {
+    ($($number:literal => $gpio:ident,)+) => {
+        use core::marker::PhantomData;
+        use crate::gpio;
+
+        $(
+            paste! {
+                pub use esp_hal_common::analog::dac::[<DAC $number Impl>];
+
+                /// DAC channel
+                pub struct [<DAC $number>] {
+                    _private: PhantomData<()>,
+                }
+
+                impl [<DAC $number Impl>] for [<DAC $number>] {}
+
+                impl [<DAC $number>] {
+                    /// Constructs a new DAC instance
+                    pub fn dac(
+                        _dac: esp_hal_common::analog::[<DAC $number>],
+                        _pin: gpio::$gpio<esp_hal_common::Analog>,
+                    ) -> Result<Self, ()> {
+                        let dac = Self {
+                            _private: PhantomData,
+                        }
+                        .set_power();
+                        Ok(dac)
+                    }
+
+                    /// Write the given value
+                    ///
+                    /// For each DAC channel, the output analog voltage can be calculated as follows:
+                    /// DACn_OUT = VDD3P3_RTC * PDACn_DAC/256
+                    pub fn write(&mut self, value: u8) {
+                        [<DAC $number Impl>]::write(self, value)
+                    }
+                }
+            }
+        )+
+    };
+}
+
+pub use impl_dac;

--- a/esp-hal-common/src/analog/mod.rs
+++ b/esp-hal-common/src/analog/mod.rs
@@ -1,0 +1,55 @@
+#[cfg(not(any(feature = "esp32c3", feature = "esp32s3")))]
+pub mod dac;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+        use core::marker::PhantomData;
+
+        use crate::pac::SENS;
+
+        pub struct ADC1 {
+            _private: PhantomData<()>,
+        }
+        pub struct ADC2 {
+            _private: PhantomData<()>,
+        }
+
+        pub struct DAC1 {
+            _private: PhantomData<()>,
+        }
+
+        pub struct DAC2 {
+            _private: PhantomData<()>,
+        }
+
+        pub struct AvailableAnalog {
+            pub adc1: ADC1,
+            pub adc2: ADC2,
+            pub dac1: DAC1,
+            pub dac2: DAC2,
+        }
+
+        pub trait SensExt {
+            fn split(self) -> AvailableAnalog;
+        }
+
+        impl SensExt for SENS {
+            fn split(self) -> AvailableAnalog {
+                AvailableAnalog {
+                    adc1: ADC1 {
+                        _private: PhantomData,
+                    },
+                    adc2: ADC2 {
+                        _private: PhantomData,
+                    },
+                    dac1: DAC1 {
+                        _private: PhantomData,
+                    },
+                    dac2: DAC2 {
+                        _private: PhantomData,
+                    },
+                }
+            }
+        }
+    }
+}

--- a/esp-hal-common/src/efuse/esp32.rs
+++ b/esp-hal-common/src/efuse/esp32.rs
@@ -1,5 +1,4 @@
 //! Reading of eFuses
-//! 
 
 use fugit::{HertzU32, RateExtU32};
 

--- a/esp-hal-common/src/efuse/esp32c3.rs
+++ b/esp-hal-common/src/efuse/esp32c3.rs
@@ -1,5 +1,4 @@
 //! Reading of eFuses
-//! 
 
 use crate::pac::EFUSE;
 

--- a/esp-hal-common/src/efuse/esp32s2.rs
+++ b/esp-hal-common/src/efuse/esp32s2.rs
@@ -1,5 +1,4 @@
 //! Reading of eFuses
-//! 
 
 use crate::pac::EFUSE;
 

--- a/esp-hal-common/src/efuse/esp32s3.rs
+++ b/esp-hal-common/src/efuse/esp32s3.rs
@@ -1,5 +1,4 @@
 //! Reading of eFuses
-//! 
 
 use crate::pac::EFUSE;
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1144,6 +1144,73 @@ macro_rules! gpio {
     };
 }
 
+#[doc(hidden)]
+pub fn enable_iomux_clk_gate() {
+    #[cfg(feature = "esp32s2")]
+    {
+        use crate::pac::SENS;
+        let sensors = unsafe { &*SENS::ptr() };
+        sensors
+            .sar_io_mux_conf
+            .modify(|_, w| w.iomux_clk_gate_en().set_bit());
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! analog {
+    ([
+        $($pxi:ident: ($pin_num:expr, $pin_reg:ident, $hold: ident, $mux_sel:ident,
+            $fun_sel:ident, $fun_ie:ident, $slp_ie:ident, $slp_sel:ident
+            $(, $rue:ident, $rde:ident, $drv:ident, $slp_oe:ident)?),)+
+    ]) => {
+        $(
+            impl<MODE> $pxi<MODE> {
+                pub fn into_analog(mut self) -> $pxi<Analog> {
+                    $(
+                        use crate::pac::RTCIO;
+                        let rtcio = unsafe{ &*RTCIO::ptr() };
+
+                        $crate::gpio::enable_iomux_clk_gate();
+
+                        // disable input
+                        rtcio.$pin_reg.modify(|_,w| w.$fun_ie().bit(false));
+
+                        // disable output
+                        rtcio.enable_w1tc.write(|w| unsafe { w.enable_w1tc().bits(1 << $pin_num) });
+                        // ESP32-S2 rtcio.rtc_gpio_enable_w1tc.write(|w| unsafe { w.reg_rtcio_reg_gpio_enable_w1tc().bits(1 << $pin_num) });
+                        //rtcio.rtc_gpio_enable_w1tc.write(|w| unsafe { w.rtc_gpio_enable_w1tc().bits(1 << $pin_num) });
+
+                        // disable open drain
+                        rtcio.pin[$pin_num].modify(|_,w| w.pin_pad_driver().bit(false));
+                        //rtcio.rtc_gpio_pin[$pin_num].modify(|_,w| w.gpio_pin0_pad_driver().bit(false));
+
+                        rtcio.$pin_reg.modify(|_,w| {
+                            w.$fun_ie().clear_bit();
+
+                            // Connect pin to analog / RTC module instead of standard GPIO
+                            w.$mux_sel().set_bit();
+
+                            // Select function "RTC function 1" (GPIO) for analog use
+                            unsafe { w.$fun_sel().bits(0b00) }
+                        });
+
+                        // Disable pull-up and pull-down resistors on the pin, if it has them
+                        rtcio.$pin_reg.modify(|_,w| {
+                            w
+                            .$rue().bit(false)
+                            .$rde().bit(false)
+                        });
+                    )?
+
+                    $pxi { _mode: PhantomData }
+                }
+            }
+        )+
+    }
+}
+
+pub use analog;
 pub use gpio;
 pub use impl_errata36;
 pub use impl_gpio_register_access;

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -71,10 +71,12 @@ pub mod systimer;
 pub mod clock;
 pub mod system;
 
+pub mod analog;
+
 /// Enumeration of CPU cores
 /// The actual number of available cores depends on the target.
 pub enum Cpu {
-    /// The fist core
+    /// The first core
     ProCpu = 0,
     /// The second core
     AppCpu,

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -20,6 +20,8 @@ pub use fugit::{
 };
 pub use nb;
 
+#[cfg(any(feature = "esp32", feature = "esp32s2"))]
+pub use crate::analog::SensExt;
 pub use crate::system::SystemExt;
 
 /// All traits required for using the 1.0.0-alpha.x release of embedded-hal

--- a/esp32-hal/examples/dac.rs
+++ b/esp32-hal/examples/dac.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
     let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32-hal/examples/dac.rs
+++ b/esp32-hal/examples/dac.rs
@@ -1,0 +1,56 @@
+//! This example shows how to use the DAC on PIN 25 and 26
+//! You can connect an LED (with a suitable resistor) or check the changing
+//! voltage using a voltmeter on those pins.
+
+#![no_std]
+#![no_main]
+
+use esp32_hal::{
+    clock::ClockControl,
+    dac,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Timer,
+};
+use panic_halt as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let pin25 = io.pins.gpio25.into_analog();
+    let pin26 = io.pins.gpio26.into_analog();
+
+    // Create DAC instances
+    let analog = peripherals.SENS.split();
+    let mut dac1 = dac::DAC1::dac(analog.dac1, pin25).unwrap();
+    let mut dac2 = dac::DAC2::dac(analog.dac2, pin26).unwrap();
+
+    let mut delay = Delay::new(&clocks);
+
+    let mut voltage_dac1: u8 = 200;
+    let mut voltage_dac2: u8 = 255;
+    loop {
+        // Change voltage on the pins using write function
+        voltage_dac1 = voltage_dac1.wrapping_add(1);
+        dac1.write(voltage_dac1);
+
+        voltage_dac2 = voltage_dac2.wrapping_sub(1);
+        dac2.write(voltage_dac2);
+        delay.delay_ms(50u32);
+    }
+}

--- a/esp32-hal/src/dac.rs
+++ b/esp32-hal/src/dac.rs
@@ -1,0 +1,10 @@
+//! Digital to analog (DAC) conversion.
+//!
+//! This module provides functions for controling two digital to
+//! analog converters, available on ESP32: `DAC1` and `DAC2`.
+//!
+//! The DAC1 is available on the GPIO pin 25, and DAC2 on pin 26.
+
+use esp_hal_common::{impl_dac, paste};
+
+impl_dac!(1 => Gpio25, 2 => Gpio26,);

--- a/esp32-hal/src/gpio.rs
+++ b/esp32-hal/src/gpio.rs
@@ -53,3 +53,24 @@ gpio! {
     Gpio38: (gpio38, 38, gpio38, Input, 0, Bank1, None),
     Gpio39: (gpio39, 39, gpio39, Input, 0, Bank1, None),
 }
+
+analog! {[
+    Gpio36: (0,  sensor_pads,  sense1_hold, sense1_mux_sel, sense1_fun_sel, sense1_fun_ie, sense1_slp_ie, sense1_slp_sel ),
+    Gpio37: (1,  sensor_pads,  sense2_hold, sense2_mux_sel, sense2_fun_sel, sense2_fun_ie, sense2_slp_ie, sense2_slp_sel ),
+    Gpio38: (2,  sensor_pads,  sense3_hold, sense3_mux_sel, sense3_fun_sel, sense3_fun_ie, sense3_slp_ie, sense3_slp_sel ),
+    Gpio39: (3,  sensor_pads,  sense4_hold, sense4_mux_sel, sense4_fun_sel, sense4_fun_ie, sense4_slp_ie, sense4_slp_sel ),
+    Gpio34: (4,  adc_pad,      adc1_hold,   adc1_mux_sel,   adc1_fun_sel,   adc1_fun_ie,   adc1_slp_ie,   adc1_slp_sel   ),
+    Gpio35: (5,  adc_pad,      adc2_hold,   adc2_mux_sel,   adc2_fun_sel,   adc1_fun_ie,   adc1_slp_ie,   adc1_slp_sel   ),
+    Gpio25: (6,  pad_dac1,     pdac1_hold,  pdac1_mux_sel,  pdac1_fun_sel,  pdac1_fun_ie,  pdac1_slp_ie,  pdac1_slp_sel,  pdac1_rue, pdac1_rde, pdac1_drv, pdac1_slp_oe),
+    Gpio26: (7,  pad_dac2,     pdac2_hold,  pdac2_mux_sel,  pdac2_fun_sel,  pdac2_fun_ie,  pdac2_slp_ie,  pdac2_slp_sel,  pdac2_rue, pdac2_rde, pdac2_drv, pdac2_slp_oe),
+    Gpio33: (8,  xtal_32k_pad, x32n_hold,   x32n_mux_sel,   x32n_fun_sel,   x32n_fun_ie,   x32n_slp_ie,   x32n_slp_sel,   x32n_rue,  x32n_rde,  x32n_drv,  x32n_slp_oe),
+    Gpio32: (9,  xtal_32k_pad, x32p_hold,   x32p_mux_sel,   x32p_fun_sel,   x32p_fun_ie,   x32p_slp_ie,   x32p_slp_sel,   x32p_rue,  x32p_rde,  x32p_drv,  x32p_slp_oe),
+    Gpio4:  (10, touch_pad0,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio0:  (11, touch_pad1,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio2:  (12, touch_pad2,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio15: (13, touch_pad3,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio13: (14, touch_pad4,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio12: (15, touch_pad5,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio14: (16, touch_pad6,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio27: (17, touch_pad7,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+]}

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -24,6 +24,7 @@ pub use esp_hal_common::{
 
 pub use self::gpio::IO;
 
+pub mod dac;
 pub mod gpio;
 
 #[no_mangle]

--- a/esp32s2-hal/examples/dac.rs
+++ b/esp32s2-hal/examples/dac.rs
@@ -1,0 +1,56 @@
+//! This example shows how to use the DAC on PIN 17 and 18
+//! You can connect an LED (with a suitable resistor) or check the changing
+//! voltage using a voltmeter on those pins.
+
+#![no_std]
+#![no_main]
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    dac,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Timer,
+};
+use panic_halt as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let pin17 = io.pins.gpio17.into_analog();
+    let pin18 = io.pins.gpio18.into_analog();
+
+    // Create DAC instances
+    let analog = peripherals.SENS.split();
+    let mut dac1 = dac::DAC1::dac(analog.dac1, pin17).unwrap();
+    let mut dac2 = dac::DAC2::dac(analog.dac2, pin18).unwrap();
+
+    let mut delay = Delay::new(&clocks);
+
+    let mut voltage_dac1: u8 = 200;
+    let mut voltage_dac2: u8 = 255;
+    loop {
+        // Change voltage on the pins using write function
+        voltage_dac1 = voltage_dac1.wrapping_add(1);
+        dac1.write(voltage_dac1);
+
+        voltage_dac2 = voltage_dac2.wrapping_sub(1);
+        dac2.write(voltage_dac2);
+        delay.delay_ms(50u32);
+    }
+}

--- a/esp32s2-hal/examples/dac.rs
+++ b/esp32s2-hal/examples/dac.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut timer0 = Timer::new(peripherals.TIMG0);
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32s2-hal/src/dac.rs
+++ b/esp32s2-hal/src/dac.rs
@@ -1,0 +1,10 @@
+//! Digital to analog (DAC) conversion.
+//!
+//! This module provides functions for controling two digital to
+//! analog converters, available on ESP32-S2: `DAC1` and `DAC2`.
+//!
+//! The DAC1 is available on the GPIO pin 17, and DAC2 on pin 18.
+
+use esp_hal_common::{impl_dac, paste};
+
+impl_dac!(1 => Gpio17, 2 => Gpio18,);

--- a/esp32s2-hal/src/gpio.rs
+++ b/esp32s2-hal/src/gpio.rs
@@ -58,3 +58,9 @@ gpio! {
     Gpio45: (gpio45, 45, gpio45, IO,    0, Bank1, None),
     Gpio46: (gpio46, 46, gpio46, IO,Input, Bank1, None),
 }
+
+// TODO other analog capable gpios - see https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s2/rtc_io_periph.c
+analog! {[
+    Gpio17: (17,  pad_dac1,     pdac1_hold,  pdac1_mux_sel,  pdac1_fun_sel,  pdac1_fun_ie,  pdac1_slp_ie,  pdac1_slp_sel,  pdac1_rue, pdac1_rde, pdac1_drv, pdac1_slp_oe),
+    Gpio18: (18,  pad_dac2,     pdac2_hold,  pdac2_mux_sel,  pdac2_fun_sel,  pdac2_fun_ie,  pdac2_slp_ie,  pdac2_slp_sel,  pdac2_rue, pdac2_rde, pdac2_drv, pdac2_slp_oe),
+]}

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -25,6 +25,7 @@ pub use esp_hal_common::{
 
 pub use self::gpio::IO;
 
+pub mod dac;
 pub mod gpio;
 
 #[no_mangle]

--- a/esp32s3-hal/src/gpio.rs
+++ b/esp32s3-hal/src/gpio.rs
@@ -63,3 +63,5 @@ gpio! {
     Gpio47: (gpio47, 47, gpio[47], IO,    0, Bank1, None),
     Gpio48: (gpio48, 48, gpio[48], IO,    0, Bank1, None),
 }
+
+// TODO add analog capable gpios - see https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s3/rtc_io_periph.c


### PR DESCRIPTION
This adds support for the two DACs on ESP32 and ESP32-S2.

Like the driver in the deprecated ESP32-HAL this doesn't include support for advanced functionality (like the CW generator or DMA etc.)
