### PR TITLE
Add some config options to the UART driver

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1246,6 +1246,156 @@ macro_rules! analog {
     }
 }
 
+#[doc(hidden)]
+/// A "No-Pin" used internally for convenience.
+pub struct NoPin<MODE> {
+    _mode: PhantomData<MODE>,
+}
+
+impl<MODE> NoPin<Input<MODE>> {}
+
+impl<MODE> NoPin<Output<MODE>> {}
+
+impl<MODE> Pin for NoPin<MODE> {
+    fn number(&self) -> u8 {
+        unreachable!()
+    }
+
+    fn sleep_mode(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn set_alternate_function(&mut self, _alternate: AlternateFunction) -> &mut Self {
+        unreachable!()
+    }
+
+    fn listen_with_options(
+        &mut self,
+        _event: Event,
+        _int_enable: bool,
+        _nmi_enable: bool,
+        _wake_up_from_light_sleep: bool,
+    ) {
+        unreachable!()
+    }
+
+    fn unlisten(&mut self) {
+        unreachable!()
+    }
+
+    fn clear_interrupt(&mut self) {
+        unreachable!()
+    }
+
+    fn is_pcore_interrupt_set(&self) -> bool {
+        unreachable!()
+    }
+
+    fn is_pcore_non_maskable_interrupt_set(&self) -> bool {
+        unreachable!()
+    }
+
+    fn is_acore_interrupt_set(&self) -> bool {
+        unreachable!()
+    }
+
+    fn is_acore_non_maskable_interrupt_set(&self) -> bool {
+        unreachable!()
+    }
+
+    fn enable_hold(&mut self, _on: bool) {
+        unreachable!()
+    }
+}
+
+impl<MODE> OutputPin for NoPin<MODE> {
+    type OutputSignal = OutputSignal;
+
+    fn set_to_open_drain_output(&mut self) -> &mut Self {
+        unreachable!()
+    }
+
+    fn set_to_push_pull_output(&mut self) -> &mut Self {
+        unreachable!()
+    }
+
+    fn enable_output(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn set_output_high(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn set_drive_strength(&mut self, _strength: DriveStrength) -> &mut Self {
+        unreachable!()
+    }
+
+    fn enable_open_drain(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn enable_output_in_sleep_mode(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn internal_pull_up_in_sleep_mode(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn internal_pull_down_in_sleep_mode(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn connect_peripheral_to_output_with_options(
+        &mut self,
+        _signal: Self::OutputSignal,
+        _invert: bool,
+        _invert_enable: bool,
+        _enable_from_gpio: bool,
+        _force_via_gpio_mux: bool,
+    ) -> &mut Self {
+        unreachable!()
+    }
+
+    fn internal_pull_up(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn internal_pull_down(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+}
+
+impl<MODE> InputPin for NoPin<MODE> {
+    type InputSignal = InputSignal;
+
+    fn set_to_input(&mut self) -> &mut Self {
+        unreachable!()
+    }
+
+    fn enable_input(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn enable_input_in_sleep_mode(&mut self, _on: bool) -> &mut Self {
+        unreachable!()
+    }
+
+    fn is_input_high(&self) -> bool {
+        unreachable!()
+    }
+
+    fn connect_input_to_peripheral_with_options(
+        &mut self,
+        _signal: Self::InputSignal,
+        _invert: bool,
+        _force_via_gpio_mux: bool,
+    ) -> &mut Self {
+        unreachable!()
+    }
+}
+
 pub use analog;
 pub use gpio;
 pub use impl_errata36;
@@ -1255,4 +1405,4 @@ pub use impl_interrupt_status_register_access;
 pub use impl_output;
 pub use impl_output_wrap;
 
-use self::types::InputSignal;
+use self::types::{InputSignal, OutputSignal};

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -121,8 +121,6 @@ pub trait Pin {
 }
 
 pub trait InputPin: Pin {
-    type InputSignal;
-
     fn set_to_input(&mut self) -> &mut Self;
 
     fn enable_input(&mut self, on: bool) -> &mut Self;
@@ -131,21 +129,19 @@ pub trait InputPin: Pin {
 
     fn is_input_high(&self) -> bool;
 
-    fn connect_input_to_peripheral(&mut self, signal: Self::InputSignal) -> &mut Self {
+    fn connect_input_to_peripheral(&mut self, signal: InputSignal) -> &mut Self {
         self.connect_input_to_peripheral_with_options(signal, false, false)
     }
 
     fn connect_input_to_peripheral_with_options(
         &mut self,
-        signal: Self::InputSignal,
+        signal: InputSignal,
         invert: bool,
         force_via_gpio_mux: bool,
     ) -> &mut Self;
 }
 
 pub trait OutputPin: Pin {
-    type OutputSignal;
-
     fn set_to_open_drain_output(&mut self) -> &mut Self;
 
     fn set_to_push_pull_output(&mut self) -> &mut Self;
@@ -164,13 +160,13 @@ pub trait OutputPin: Pin {
 
     fn internal_pull_down_in_sleep_mode(&mut self, on: bool) -> &mut Self;
 
-    fn connect_peripheral_to_output(&mut self, signal: Self::OutputSignal) -> &mut Self {
+    fn connect_peripheral_to_output(&mut self, signal: OutputSignal) -> &mut Self {
         self.connect_peripheral_to_output_with_options(signal, false, false, false, false)
     }
 
     fn connect_peripheral_to_output_with_options(
         &mut self,
-        signal: Self::OutputSignal,
+        signal: OutputSignal,
         invert: bool,
         invert_enable: bool,
         enable_from_gpio: bool,
@@ -576,8 +572,6 @@ macro_rules! impl_input {
         }
 
         impl<MODE> InputPin for $pxi<MODE> {
-            type InputSignal = $input_signal;
-
             fn set_to_input(&mut self) -> &mut Self {
                 self.init_input(false, false);
                 self
@@ -607,7 +601,7 @@ macro_rules! impl_input {
 
             fn connect_input_to_peripheral_with_options(
                 &mut self,
-                signal: Self::InputSignal,
+                signal: InputSignal,
                 invert: bool,
                 force_via_gpio_mux: bool,
             ) -> &mut Self {
@@ -616,7 +610,7 @@ macro_rules! impl_input {
                 } else {
                     match signal {
                         $( $(
-                            Self::InputSignal::$af_signal => AlternateFunction::$af,
+                            InputSignal::$af_signal => AlternateFunction::$af,
                         )* )?
                         _ => AlternateFunction::$gpio_function
                     }
@@ -875,8 +869,6 @@ macro_rules! impl_output {
         }
 
         impl<MODE> OutputPin for $pxi<MODE> {
-            type OutputSignal = $output_signal;
-
             fn set_to_open_drain_output(&mut self) -> &mut Self {
                 self.init_output(AlternateFunction::$gpio_function, true);
                 self
@@ -948,7 +940,7 @@ macro_rules! impl_output {
 
             fn connect_peripheral_to_output_with_options(
                 &mut self,
-                signal: Self::OutputSignal,
+                signal: OutputSignal,
                 invert: bool,
                 invert_enable: bool,
                 enable_from_gpio: bool,
@@ -959,7 +951,7 @@ macro_rules! impl_output {
                 } else {
                     match signal {
                         $( $(
-                            Self::OutputSignal::$af_signal => AlternateFunction::$af,
+                            OutputSignal::$af_signal => AlternateFunction::$af,
                         )* )?
                         _ => AlternateFunction::$gpio_function
                     }
@@ -1243,156 +1235,6 @@ macro_rules! analog {
                 }
             }
         )+
-    }
-}
-
-#[doc(hidden)]
-/// A "No-Pin" used internally for convenience.
-pub struct NoPin<MODE> {
-    _mode: PhantomData<MODE>,
-}
-
-impl<MODE> NoPin<Input<MODE>> {}
-
-impl<MODE> NoPin<Output<MODE>> {}
-
-impl<MODE> Pin for NoPin<MODE> {
-    fn number(&self) -> u8 {
-        unreachable!()
-    }
-
-    fn sleep_mode(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn set_alternate_function(&mut self, _alternate: AlternateFunction) -> &mut Self {
-        unreachable!()
-    }
-
-    fn listen_with_options(
-        &mut self,
-        _event: Event,
-        _int_enable: bool,
-        _nmi_enable: bool,
-        _wake_up_from_light_sleep: bool,
-    ) {
-        unreachable!()
-    }
-
-    fn unlisten(&mut self) {
-        unreachable!()
-    }
-
-    fn clear_interrupt(&mut self) {
-        unreachable!()
-    }
-
-    fn is_pcore_interrupt_set(&self) -> bool {
-        unreachable!()
-    }
-
-    fn is_pcore_non_maskable_interrupt_set(&self) -> bool {
-        unreachable!()
-    }
-
-    fn is_acore_interrupt_set(&self) -> bool {
-        unreachable!()
-    }
-
-    fn is_acore_non_maskable_interrupt_set(&self) -> bool {
-        unreachable!()
-    }
-
-    fn enable_hold(&mut self, _on: bool) {
-        unreachable!()
-    }
-}
-
-impl<MODE> OutputPin for NoPin<MODE> {
-    type OutputSignal = OutputSignal;
-
-    fn set_to_open_drain_output(&mut self) -> &mut Self {
-        unreachable!()
-    }
-
-    fn set_to_push_pull_output(&mut self) -> &mut Self {
-        unreachable!()
-    }
-
-    fn enable_output(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn set_output_high(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn set_drive_strength(&mut self, _strength: DriveStrength) -> &mut Self {
-        unreachable!()
-    }
-
-    fn enable_open_drain(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn enable_output_in_sleep_mode(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn internal_pull_up_in_sleep_mode(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn internal_pull_down_in_sleep_mode(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn connect_peripheral_to_output_with_options(
-        &mut self,
-        _signal: Self::OutputSignal,
-        _invert: bool,
-        _invert_enable: bool,
-        _enable_from_gpio: bool,
-        _force_via_gpio_mux: bool,
-    ) -> &mut Self {
-        unreachable!()
-    }
-
-    fn internal_pull_up(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn internal_pull_down(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-}
-
-impl<MODE> InputPin for NoPin<MODE> {
-    type InputSignal = InputSignal;
-
-    fn set_to_input(&mut self) -> &mut Self {
-        unreachable!()
-    }
-
-    fn enable_input(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn enable_input_in_sleep_mode(&mut self, _on: bool) -> &mut Self {
-        unreachable!()
-    }
-
-    fn is_input_high(&self) -> bool {
-        unreachable!()
-    }
-
-    fn connect_input_to_peripheral_with_options(
-        &mut self,
-        _signal: Self::InputSignal,
-        _invert: bool,
-        _force_via_gpio_mux: bool,
-    ) -> &mut Self {
-        unreachable!()
     }
 }
 

--- a/esp-hal-common/src/i2c.rs
+++ b/esp-hal-common/src/i2c.rs
@@ -272,10 +272,7 @@ where
     /// Create a new I2C instance
     /// This will enable the peripheral but the peripheral won't get
     /// automatically disabled when this gets dropped.
-    pub fn new<
-        SDA: OutputPin<OutputSignal = OutputSignal> + InputPin<InputSignal = InputSignal>,
-        SCL: OutputPin<OutputSignal = OutputSignal> + InputPin<InputSignal = InputSignal>,
-    >(
+    pub fn new<SDA: OutputPin + InputPin, SCL: OutputPin + InputPin>(
         i2c: T,
         mut sda: SDA,
         mut scl: SCL,

--- a/esp-hal-common/src/pulse_control.rs
+++ b/esp-hal-common/src/pulse_control.rs
@@ -237,10 +237,7 @@ pub trait OutputChannel {
     /// (Note that we only take a reference here, so the ownership remains with
     /// the calling entity. The configured pin thus can be re-configured
     /// independently.)
-    fn assign_pin<RmtPin: OutputPin<OutputSignal = OutputSignal>>(
-        &mut self,
-        pin: RmtPin,
-    ) -> &mut Self;
+    fn assign_pin<RmtPin: OutputPin>(&mut self, pin: RmtPin) -> &mut Self;
 
     /// Send a pulse sequence in a blocking fashion
     fn send_pulse_sequence<const N: usize>(
@@ -457,7 +454,7 @@ macro_rules! output_channel {
             }
 
             /// Assign a pin that should be driven by this channel
-            fn assign_pin<RmtPin: OutputPin<OutputSignal = OutputSignal>>(
+            fn assign_pin<RmtPin: OutputPin >(
                 &mut self,
                 mut pin: RmtPin,
             ) -> &mut Self {

--- a/esp-hal-common/src/serial.rs
+++ b/esp-hal-common/src/serial.rs
@@ -1,14 +1,146 @@
 //! UART driver
 
+use self::config::Config;
 #[cfg(any(feature = "esp32", feature = "esp32s3"))]
 use crate::pac::UART2;
-use crate::pac::{uart0::RegisterBlock, UART0, UART1};
+use crate::{
+    clock::Clocks,
+    pac::{
+        uart0::{fifo::FIFO_SPEC, RegisterBlock},
+        UART0,
+        UART1,
+    },
+    types::{InputSignal, OutputSignal},
+    Floating,
+    Input,
+    InputPin,
+    NoPin,
+    Output,
+    OutputPin,
+};
 
 const UART_FIFO_SIZE: u16 = 128;
 
 /// Custom serial error type
 #[derive(Debug)]
 pub enum Error {}
+
+/// UART configuration
+pub mod config {
+    /// Number of data bits
+    #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+    pub enum DataBits {
+        DataBits5 = 0,
+        DataBits6 = 1,
+        DataBits7 = 2,
+        DataBits8 = 3,
+    }
+
+    /// Parity check
+    #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+    pub enum Parity {
+        ParityNone,
+        ParityEven,
+        ParityOdd,
+    }
+
+    /// Number of stop bits
+    #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+    pub enum StopBits {
+        /// 1 stop bit
+        STOP1   = 1,
+        /// 1.5 stop bits
+        STOP1P5 = 2,
+        /// 2 stop bits
+        STOP2   = 3,
+    }
+
+    /// UART configuration
+    #[derive(Debug, Copy, Clone)]
+    pub struct Config {
+        pub baudrate: u32,
+        pub data_bits: DataBits,
+        pub parity: Parity,
+        pub stop_bits: StopBits,
+    }
+
+    impl Config {
+        pub fn baudrate(mut self, baudrate: u32) -> Self {
+            self.baudrate = baudrate;
+            self
+        }
+
+        pub fn parity_none(mut self) -> Self {
+            self.parity = Parity::ParityNone;
+            self
+        }
+
+        pub fn parity_even(mut self) -> Self {
+            self.parity = Parity::ParityEven;
+            self
+        }
+
+        pub fn parity_odd(mut self) -> Self {
+            self.parity = Parity::ParityOdd;
+            self
+        }
+
+        pub fn data_bits(mut self, data_bits: DataBits) -> Self {
+            self.data_bits = data_bits;
+            self
+        }
+
+        pub fn stop_bits(mut self, stop_bits: StopBits) -> Self {
+            self.stop_bits = stop_bits;
+            self
+        }
+    }
+
+    impl Default for Config {
+        fn default() -> Config {
+            Config {
+                baudrate: 115_200,
+                data_bits: DataBits::DataBits8,
+                parity: Parity::ParityNone,
+                stop_bits: StopBits::STOP1,
+            }
+        }
+    }
+}
+
+/// Pins used by the UART interface
+pub struct Pins<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> {
+    pub tx: Option<TX>,
+    pub rx: Option<RX>,
+    pub cts: Option<CTS>,
+    pub rts: Option<RTS>,
+}
+
+impl<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> Pins<TX, RX, CTS, RTS> {
+    pub fn new(tx: TX, rx: RX, cts: CTS, rts: RTS) -> Pins<TX, RX, CTS, RTS> {
+        Pins {
+            tx: Some(tx),
+            rx: Some(rx),
+            cts: Some(cts),
+            rts: Some(rts),
+        }
+    }
+}
+
+impl<TX: OutputPin, RX: InputPin> Pins<TX, RX, NoPin<Input<Floating>>, NoPin<Output<Floating>>> {
+    pub fn new_tx_rx(
+        tx: TX,
+        rx: RX,
+    ) -> Pins<TX, RX, NoPin<Input<Floating>>, NoPin<Output<Floating>>> {
+        let pins: Pins<TX, RX, NoPin<Input<Floating>>, NoPin<Output<Floating>>> = Pins {
+            tx: Some(tx),
+            rx: Some(rx),
+            cts: None,
+            rts: None,
+        };
+        pins
+    }
+}
 
 #[cfg(feature = "eh1")]
 impl embedded_hal_1::serial::Error for Error {
@@ -26,7 +158,35 @@ impl<T> Serial<T>
 where
     T: Instance,
 {
-    /// Create a new UART instance
+    /// Create a new UART instance with defaults
+    pub fn new_with_config<
+        TX: OutputPin<OutputSignal = OutputSignal>,
+        RX: InputPin<InputSignal = InputSignal>,
+        CTS: InputPin<InputSignal = InputSignal>,
+        RTS: OutputPin<OutputSignal = OutputSignal>,
+    >(
+        uart: T,
+        config: Option<Config>,
+        pins: Option<Pins<TX, RX, CTS, RTS>>,
+        clocks: &Clocks,
+    ) -> Result<Self, Error> {
+        let mut serial = Serial { uart };
+        serial.uart.disable_rx_interrupts();
+        serial.uart.disable_tx_interrupts();
+
+        serial.uart.configure_pins(pins);
+
+        config.map(|config| {
+            serial.change_data_bits(config.data_bits);
+            serial.change_parity(config.parity);
+            serial.change_stop_bits(config.stop_bits);
+            serial.change_baud(config.baudrate, clocks);
+        });
+
+        Ok(serial)
+    }
+
+    /// Create a new UART instance with defaults
     pub fn new(uart: T) -> Result<Self, Error> {
         let mut serial = Serial { uart };
         serial.uart.disable_rx_interrupts();
@@ -68,19 +228,134 @@ where
     }
 
     fn read_byte(&mut self) -> nb::Result<u8, Error> {
+        #[allow(unused_variables)]
+        let offset = 0;
+
+        // on ESP32-S2 we need to use PeriBus2 to read the FIFO
+        #[cfg(feature = "esp32s2")]
+        let offset = 0x20c00000;
+
         if self.uart.get_rx_fifo_count() > 0 {
-            let value = self
-                .uart
-                .register_block()
-                .fifo
-                .read()
-                .rxfifo_rd_byte()
-                .bits();
+            let value = unsafe {
+                let fifo = (self.uart.register_block().fifo.as_ptr() as *mut u8).offset(offset)
+                    as *mut crate::pac::generic::Reg<FIFO_SPEC>;
+                (*fifo).read().rxfifo_rd_byte().bits()
+            };
 
             Ok(value)
         } else {
             Err(nb::Error::WouldBlock)
         }
+    }
+
+    /// Change the number of stop bits
+    pub fn change_stop_bits(&mut self, stop_bits: config::StopBits) -> &mut Self {
+        // workaround for hardware issue, when UART stop bit set as 2-bit mode.
+        #[cfg(feature = "esp32")]
+        if stop_bits == config::StopBits::STOP2 {
+            self.uart
+                .register_block()
+                .rs485_conf
+                .modify(|_, w| w.dl1_en().bit(true));
+
+            self.uart
+                .register_block()
+                .conf0
+                .modify(|_, w| unsafe { w.stop_bit_num().bits(1) });
+        } else {
+            self.uart
+                .register_block()
+                .rs485_conf
+                .modify(|_, w| w.dl1_en().bit(false));
+
+            self.uart
+                .register_block()
+                .conf0
+                .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8) });
+        }
+
+        #[cfg(not(feature = "esp32"))]
+        self.uart
+            .register_block()
+            .conf0
+            .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8) });
+
+        self
+    }
+
+    /// Change the number of data bits
+    fn change_data_bits(&mut self, data_bits: config::DataBits) -> &mut Self {
+        self.uart
+            .register_block()
+            .conf0
+            .modify(|_, w| unsafe { w.bit_num().bits(data_bits as u8) });
+
+        self
+    }
+
+    /// Change the type of parity checking
+    fn change_parity(&mut self, parity: config::Parity) -> &mut Self {
+        self.uart
+            .register_block()
+            .conf0
+            .modify(|_, w| match parity {
+                config::Parity::ParityNone => w.parity_en().clear_bit(),
+                config::Parity::ParityEven => w.parity_en().set_bit().parity().clear_bit(),
+                config::Parity::ParityOdd => w.parity_en().set_bit().parity().set_bit(),
+            });
+
+        self
+    }
+
+    #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+    fn change_baud(&self, baudrate: u32, clocks: &Clocks) {
+        // we force the clock source to be APB and don't use the decimal part of the
+        // divider
+        let clk = clocks.apb_clock.to_Hz();
+        let max_div = 0b1111_1111_1111 - 1;
+        let clk_div = ((clk) + (max_div * baudrate) - 1) / (max_div * baudrate);
+
+        self.uart.register_block().clk_conf.write(|w| unsafe {
+            w.sclk_sel()
+                .bits(1) // APB
+                .sclk_div_a()
+                .bits(0)
+                .sclk_div_b()
+                .bits(0)
+                .sclk_div_num()
+                .bits(clk_div as u8 - 1)
+                .rx_sclk_en()
+                .bit(true)
+                .tx_sclk_en()
+                .bit(true)
+        });
+
+        let clk = clk / clk_div;
+        let divider = clk / baudrate;
+        let divider = divider as u16;
+
+        self.uart
+            .register_block()
+            .clkdiv
+            .write(|w| unsafe { w.clkdiv().bits(divider).frag().bits(0) });
+    }
+
+    #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+    fn change_baud(&self, baudrate: u32, clocks: &Clocks) {
+        // we force the clock source to be APB and don't use the decimal part of the
+        // divider
+        let clk = clocks.apb_clock.to_Hz();
+
+        self.uart
+            .register_block()
+            .conf0
+            .modify(|_, w| w.tick_ref_always_on().bit(true));
+        let divider = clk / baudrate;
+
+        self.uart
+            .register_block()
+            .clkdiv
+            .write(|w| unsafe { w.clkdiv().bits(divider).frag().bits(0) });
     }
 }
 
@@ -167,12 +442,78 @@ pub trait Instance {
 
         idle
     }
+
+    fn configure_pins<
+        TX: OutputPin<OutputSignal = OutputSignal>,
+        RX: InputPin<InputSignal = InputSignal>,
+        CTS: InputPin<InputSignal = InputSignal>,
+        RTS: OutputPin<OutputSignal = OutputSignal>,
+    >(
+        &self,
+        pins: Option<Pins<TX, RX, CTS, RTS>>,
+    ) {
+        if pins.is_some() {
+            let pins = pins.unwrap();
+
+            if pins.tx.is_some() {
+                pins.tx
+                    .unwrap()
+                    .set_to_push_pull_output()
+                    .connect_peripheral_to_output(self.tx_signal());
+            }
+
+            if pins.rx.is_some() {
+                pins.rx
+                    .unwrap()
+                    .set_to_input()
+                    .connect_input_to_peripheral(self.rx_signal());
+            }
+
+            if pins.cts.is_some() {
+                pins.cts
+                    .unwrap()
+                    .set_to_input()
+                    .connect_input_to_peripheral(self.cts_signal());
+            }
+
+            if pins.rts.is_some() {
+                pins.rts
+                    .unwrap()
+                    .set_to_push_pull_output()
+                    .connect_peripheral_to_output(self.rts_signal());
+            }
+        }
+    }
+
+    fn tx_signal(&self) -> OutputSignal;
+
+    fn rx_signal(&self) -> InputSignal;
+
+    fn cts_signal(&self) -> InputSignal;
+
+    fn rts_signal(&self) -> OutputSignal;
 }
 
 impl Instance for UART0 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {
         self
+    }
+
+    fn tx_signal(&self) -> OutputSignal {
+        OutputSignal::U0TXD
+    }
+
+    fn rx_signal(&self) -> InputSignal {
+        InputSignal::U0RXD
+    }
+
+    fn cts_signal(&self) -> InputSignal {
+        InputSignal::U0CTS
+    }
+
+    fn rts_signal(&self) -> OutputSignal {
+        OutputSignal::U0RTS
     }
 }
 
@@ -181,6 +522,22 @@ impl Instance for UART1 {
     fn register_block(&self) -> &RegisterBlock {
         self
     }
+
+    fn tx_signal(&self) -> OutputSignal {
+        OutputSignal::U1TXD
+    }
+
+    fn rx_signal(&self) -> InputSignal {
+        InputSignal::U1RXD
+    }
+
+    fn cts_signal(&self) -> InputSignal {
+        InputSignal::U1CTS
+    }
+
+    fn rts_signal(&self) -> OutputSignal {
+        OutputSignal::U1RTS
+    }
 }
 
 #[cfg(any(feature = "esp32", feature = "esp32s3"))]
@@ -188,6 +545,22 @@ impl Instance for UART2 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {
         self
+    }
+
+    fn tx_signal(&self) -> OutputSignal {
+        OutputSignal::U2TXD
+    }
+
+    fn rx_signal(&self) -> InputSignal {
+        InputSignal::U2RXD
+    }
+
+    fn cts_signal(&self) -> InputSignal {
+        InputSignal::U2CTS
+    }
+
+    fn rts_signal(&self) -> OutputSignal {
+        OutputSignal::U2RTS
     }
 }
 

--- a/esp-hal-common/src/serial.rs
+++ b/esp-hal-common/src/serial.rs
@@ -105,7 +105,6 @@ pub mod config {
 }
 
 /// Pins used by the UART interface
-
 pub trait UartPins {
     fn configure_pins(
         &mut self,
@@ -116,6 +115,7 @@ pub trait UartPins {
     );
 }
 
+/// All pins offered by UART
 pub struct AllPins<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> {
     pub tx: Option<TX>,
     pub rx: Option<RX>,
@@ -123,6 +123,7 @@ pub struct AllPins<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> {
     pub rts: Option<RTS>,
 }
 
+/// Tx and Rx pins
 impl<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> AllPins<TX, RX, CTS, RTS> {
     pub fn new(tx: TX, rx: RX, cts: CTS, rts: RTS) -> AllPins<TX, RX, CTS, RTS> {
         AllPins {
@@ -219,7 +220,7 @@ where
         config: Option<Config>,
         mut pins: Option<P>,
         clocks: &Clocks,
-    ) -> Result<Self, Error>
+    ) -> Self
     where
         P: UartPins,
     {
@@ -243,16 +244,16 @@ where
             serial.change_baud(config.baudrate, clocks);
         });
 
-        Ok(serial)
+        serial
     }
 
     /// Create a new UART instance with defaults
-    pub fn new(uart: T) -> Result<Self, Error> {
+    pub fn new(uart: T) -> Self {
         let mut serial = Serial { uart };
         serial.uart.disable_rx_interrupts();
         serial.uart.disable_tx_interrupts();
 
-        Ok(serial)
+        serial
     }
 
     /// Return the raw interface to the underlying UART instance

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -52,12 +52,7 @@ where
     T: Instance,
 {
     /// Constructs an SPI instance in 8bit dataframe mode.
-    pub fn new<
-        SCK: OutputPin<OutputSignal = OutputSignal>,
-        MOSI: OutputPin<OutputSignal = OutputSignal>,
-        MISO: InputPin<InputSignal = InputSignal>,
-        CS: OutputPin<OutputSignal = OutputSignal>,
-    >(
+    pub fn new<SCK: OutputPin, MOSI: OutputPin, MISO: InputPin, CS: OutputPin>(
         spi: T,
         mut sck: SCK,
         mut mosi: MOSI,

--- a/esp-hal-common/src/utils/smart_leds_adapter.rs
+++ b/esp-hal-common/src/utils/smart_leds_adapter.rs
@@ -19,7 +19,7 @@ use smart_leds_trait::{SmartLedsWrite, RGB8};
 #[cfg(any(feature = "esp32", feature = "esp32s2"))]
 use crate::pulse_control::ClockSource;
 use crate::{
-    gpio::{types::OutputSignal, OutputPin},
+    gpio::OutputPin,
     pulse_control::{OutputChannel, PulseCode, RepeatMode, TransmissionError},
 };
 
@@ -90,7 +90,7 @@ pub struct SmartLedsAdapter<CHANNEL, PIN, const BUFFER_SIZE: usize> {
 impl<CHANNEL, PIN, const BUFFER_SIZE: usize> SmartLedsAdapter<CHANNEL, PIN, BUFFER_SIZE>
 where
     CHANNEL: OutputChannel,
-    PIN: OutputPin<OutputSignal = OutputSignal>,
+    PIN: OutputPin,
 {
     /// Create a new adapter object that drives the pin using the RMT channel.
     pub fn new(mut channel: CHANNEL, pin: PIN) -> SmartLedsAdapter<CHANNEL, PIN, BUFFER_SIZE> {
@@ -166,7 +166,7 @@ impl<CHANNEL, PIN, const BUFFER_SIZE: usize> SmartLedsWrite
     for SmartLedsAdapter<CHANNEL, PIN, BUFFER_SIZE>
 where
     CHANNEL: OutputChannel,
-    PIN: OutputPin<OutputSignal = OutputSignal>,
+    PIN: OutputPin,
 {
     type Error = LedAdapterError;
     type Color = RGB8;

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -40,7 +40,7 @@ embedded-graphics = "0.7"
 panic-halt        = "0.2"
 ssd1306           = "0.7"
 smart-leds        = "0.3"
-esp-println       = { version = "0.1.0", features = ["esp32"] }
+esp-println       = { version = "0.2.0", features = ["esp32"] }
 
 [features]
 default   = ["rt"]

--- a/esp32-hal/examples/advanced_serial.rs
+++ b/esp32-hal/examples/advanced_serial.rs
@@ -51,8 +51,7 @@ fn main() -> ! {
         io.pins.gpio17.into_floating_input(),
     );
 
-    let mut serial1 =
-        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks).unwrap();
+    let mut serial1 = Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32-hal/examples/advanced_serial.rs
+++ b/esp32-hal/examples/advanced_serial.rs
@@ -1,0 +1,71 @@
+//! This shows how to configure UART
+//! You can short the TX and RX pin and see it reads what was written.
+//! Additionally you can connect a logic analzyer to TX and see how the changes
+//! of the configuration change the output signal.
+
+#![no_std]
+#![no_main]
+
+use esp32_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    serial::{
+        config::{Config, DataBits, Parity, StopBits},
+        Pins,
+    },
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
+use esp_println::println;
+use nb::block;
+use panic_halt as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let config = Config {
+        baudrate: 115200,
+        data_bits: DataBits::DataBits8,
+        parity: Parity::ParityNone,
+        stop_bits: StopBits::STOP1,
+    };
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let pins = Pins::new_tx_rx(
+        io.pins.gpio16.into_push_pull_output(),
+        io.pins.gpio17.into_floating_input(),
+    );
+
+    let mut serial1 =
+        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks).unwrap();
+
+    let mut delay = Delay::new(&clocks);
+
+    println!("Start");
+    loop {
+        serial1.write(0x42).ok();
+        let read = block!(serial1.read());
+
+        match read {
+            Ok(read) => println!("Read {:02x}", read),
+            Err(err) => println!("Error {:?}", err),
+        }
+
+        delay.delay_ms(250u32);
+    }
+}

--- a/esp32-hal/examples/advanced_serial.rs
+++ b/esp32-hal/examples/advanced_serial.rs
@@ -13,7 +13,7 @@ use esp32_hal::{
     prelude::*,
     serial::{
         config::{Config, DataBits, Parity, StopBits},
-        Pins,
+        TxRxPins,
     },
     Delay,
     RtcCntl,
@@ -46,7 +46,7 @@ fn main() -> ! {
     };
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pins = Pins::new_tx_rx(
+    let pins = TxRxPins::new_tx_rx(
         io.pins.gpio16.into_push_pull_output(),
         io.pins.gpio17.into_floating_input(),
     );

--- a/esp32-hal/examples/gpio_interrupt.rs
+++ b/esp32-hal/examples/gpio_interrupt.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
 
     // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32-hal/examples/hello_world.rs
+++ b/esp32-hal/examples/hello_world.rs
@@ -15,7 +15,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32-hal/examples/i2c_display.rs
+++ b/esp32-hal/examples/i2c_display.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer

--- a/esp32-hal/examples/ram.rs
+++ b/esp32-hal/examples/ram.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT flash boot protection
     timer0.disable();

--- a/esp32-hal/examples/read_efuse.rs
+++ b/esp32-hal/examples/read_efuse.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     // the RTC WDT, and the TIMG WDTs.
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     timer0.disable();
     rtc_cntl.set_wdt_global_enable(false);

--- a/esp32-hal/examples/timer_interrupt.rs
+++ b/esp32-hal/examples/timer_interrupt.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -12,6 +12,7 @@ pub use esp_hal_common::{
     prelude,
     pulse_control,
     ram,
+    serial,
     spi,
     utils,
     Cpu,
@@ -32,11 +33,6 @@ pub mod gpio;
 /// Common module for analog functions
 pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SensExt};
-}
-
-/// Serial Configuration
-pub mod serial {
-    pub use esp_hal_common::serial::*;
 }
 
 #[no_mangle]

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -34,6 +34,11 @@ pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SensExt};
 }
 
+/// Serial Configuration
+pub mod serial {
+    pub use esp_hal_common::serial::*;
+}
+
 #[no_mangle]
 extern "C" fn DefaultHandler(_level: u32, _interrupt: pac::Interrupt) {}
 

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -40,7 +40,7 @@ embedded-graphics = "0.7"
 panic-halt        = "0.2"
 ssd1306           = "0.7"
 smart-leds        = "0.3"
-esp-println       = { version = "0.1.0", features = ["esp32c3"] }
+esp-println       = { version = "0.2.0", features = ["esp32c3"] }
 
 [features]
 default     = ["rt"]

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -12,7 +12,7 @@ use esp32c3_hal::{
     prelude::*,
     serial::{
         config::{Config, DataBits, Parity, StopBits},
-        Pins,
+        TxRxPins,
     },
     RtcCntl,
     Serial,
@@ -48,7 +48,7 @@ fn main() -> ! {
     };
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pins = Pins::new_tx_rx(
+    let pins = TxRxPins::new_tx_rx(
         io.pins.gpio1.into_push_pull_output(),
         io.pins.gpio2.into_floating_input(),
     );

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -53,8 +53,7 @@ fn main() -> ! {
         io.pins.gpio2.into_floating_input(),
     );
 
-    let mut serial1 =
-        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks).unwrap();
+    let mut serial1 = Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks);
 
     timer0.start(250u64.millis());
 

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -1,0 +1,73 @@
+//! This shows how to configure UART
+//! You can short the TX and RX pin and see it reads what was written.
+//! Additionally you can connect a logic analzyer to TX and see how the changes
+//! of the configuration change the output signal.
+
+#![no_std]
+#![no_main]
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    pac::Peripherals,
+    prelude::*,
+    serial::{
+        config::{Config, DataBits, Parity, StopBits},
+        Pins,
+    },
+    RtcCntl,
+    Serial,
+    Timer,
+    IO,
+};
+use esp_println::println;
+use nb::block;
+use panic_halt as _;
+use riscv_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
+    let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
+
+    // Disable watchdog timers
+    rtc_cntl.set_super_wdt_enable(false);
+    rtc_cntl.set_wdt_enable(false);
+    timer0.disable();
+    timer1.disable();
+
+    let config = Config {
+        baudrate: 115200,
+        data_bits: DataBits::DataBits8,
+        parity: Parity::ParityNone,
+        stop_bits: StopBits::STOP1,
+    };
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let pins = Pins::new_tx_rx(
+        io.pins.gpio1.into_push_pull_output(),
+        io.pins.gpio2.into_floating_input(),
+    );
+
+    let mut serial1 =
+        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks).unwrap();
+
+    timer0.start(250u64.millis());
+
+    println!("Start");
+    loop {
+        serial1.write(0x42).ok();
+        let read = block!(serial1.read());
+
+        match read {
+            Ok(read) => println!("Read {:02x}", read),
+            Err(err) => println!("Error {:?}", err),
+        }
+
+        block!(timer0.wait()).unwrap();
+    }
+}

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
 
     rtc_cntl.set_super_wdt_enable(false);
     rtc_cntl.set_wdt_enable(false);

--- a/esp32c3-hal/examples/hello_world.rs
+++ b/esp32c3-hal/examples/hello_world.rs
@@ -15,7 +15,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
 

--- a/esp32c3-hal/examples/ram.rs
+++ b/esp32c3-hal/examples/ram.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT flash boot protection
     timer0.disable();

--- a/esp32c3-hal/examples/read_efuse.rs
+++ b/esp32c3-hal/examples/read_efuse.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
 

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     rtc_cntl.set_super_wdt_enable(false);
     rtc_cntl.set_wdt_enable(false);

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     rtc_cntl.set_super_wdt_enable(false);
     rtc_cntl.set_wdt_enable(false);

--- a/esp32c3-hal/examples/timer_interrupt.rs
+++ b/esp32c3-hal/examples/timer_interrupt.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
 
     rtc_cntl.set_super_wdt_enable(false);
     rtc_cntl.set_wdt_enable(false);

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -13,6 +13,7 @@ pub use esp_hal_common::{
     prelude,
     pulse_control,
     ram,
+    serial,
     spi,
     system,
     systimer,
@@ -37,11 +38,6 @@ pub mod rtc_cntl;
 /// Common module for analog functions
 pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
-}
-
-/// Serial Configuration
-pub mod serial {
-    pub use esp_hal_common::serial::*;
 }
 
 extern "C" {

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -39,6 +39,11 @@ pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
 }
 
+/// Serial Configuration
+pub mod serial {
+    pub use esp_hal_common::serial::*;
+}
+
 extern "C" {
     // Boundaries of the .iram section
     static mut _srwtext: u32;

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -39,7 +39,7 @@ embedded-graphics = "0.7"
 panic-halt        = "0.2"
 ssd1306           = "0.7"
 smart-leds        = "0.3"
-esp-println       = { version = "0.1.0", features = ["esp32s2"] }
+esp-println       = { version = "0.2.0", features = ["esp32s2"] }
 
 [features]
 default = ["rt"]

--- a/esp32s2-hal/examples/adc.rs
+++ b/esp32s2-hal/examples/adc.rs
@@ -1,8 +1,6 @@
 //! Connect a potentiometer to PIN3 and see the read values change when
 //! rotating the shaft. Alternatively you could also connect the PIN to GND or
 //! 3V3 to see the maximum and minimum raw values read.
-//!
-//! THIS CURRENTLY DOESN'T WORK IN DEBUG BUILDS! THIS NEEDS TO GET FIGURED OUT!
 
 #![no_std]
 #![no_main]

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -1,0 +1,73 @@
+//! This shows how to configure UART
+//! You can short the TX and RX pin and see it reads what was written.
+//! Additionally you can connect a logic analzyer to TX and see how the changes
+//! of the configuration change the output signal.
+//! 
+//! THIS CURRENTLY DOESN'T WORK IN DEBUG BUILDS! THIS NEEDS TO GET FIGURED OUT!
+
+#![no_std]
+#![no_main]
+
+use embedded_hal_1::nb::block;
+use esp32s2_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    serial::{
+        config::{Config, DataBits, Parity, StopBits},
+        Pins,
+    },
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
+use esp_println::println;
+use panic_halt as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let config = Config {
+        baudrate: 115200,
+        data_bits: DataBits::DataBits8,
+        parity: Parity::ParityNone,
+        stop_bits: StopBits::STOP1,
+    };
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let pins = Pins::new_tx_rx(
+        io.pins.gpio1.into_push_pull_output(),
+        io.pins.gpio2.into_floating_input(),
+    );
+
+    let mut serial1 =
+        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks).unwrap();
+
+    let mut delay = Delay::new(&clocks);
+
+    println!("Start");
+    loop {
+        serial1.write(0x42).ok();
+        let read = block!(serial1.read());
+
+        match read {
+            Ok(read) => println!("Read {:02x}", read),
+            Err(err) => println!("Error {:?}", err),
+        }
+
+        delay.delay_ms(250u32);
+    }
+}

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -14,7 +14,7 @@ use esp32s2_hal::{
     prelude::*,
     serial::{
         config::{Config, DataBits, Parity, StopBits},
-        Pins,
+        TxRxPins,
     },
     Delay,
     RtcCntl,
@@ -46,7 +46,7 @@ fn main() -> ! {
     };
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pins = Pins::new_tx_rx(
+    let pins = TxRxPins::new_tx_rx(
         io.pins.gpio1.into_push_pull_output(),
         io.pins.gpio2.into_floating_input(),
     );

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -51,8 +51,7 @@ fn main() -> ! {
         io.pins.gpio2.into_floating_input(),
     );
 
-    let mut serial1 =
-        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks).unwrap();
+    let mut serial1 = Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -2,8 +2,6 @@
 //! You can short the TX and RX pin and see it reads what was written.
 //! Additionally you can connect a logic analzyer to TX and see how the changes
 //! of the configuration change the output signal.
-//! 
-//! THIS CURRENTLY DOESN'T WORK IN DEBUG BUILDS! THIS NEEDS TO GET FIGURED OUT!
 
 #![no_std]
 #![no_main]

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -16,7 +16,7 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT flash boot protection
     timer0.disable();

--- a/esp32s2-hal/examples/read_efuse.rs
+++ b/esp32s2-hal/examples/read_efuse.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     // the RTC WDT, and the TIMG WDTs.
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     timer0.disable();
     rtc_cntl.set_wdt_global_enable(false);

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -36,7 +36,7 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -11,6 +11,7 @@ pub use esp_hal_common::{
     prelude,
     pulse_control,
     ram,
+    serial,
     spi,
     systimer,
     utils,
@@ -32,11 +33,6 @@ pub mod gpio;
 /// Common module for analog functions
 pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SensExt};
-}
-
-/// Serial Configuration
-pub mod serial {
-    pub use esp_hal_common::serial::*;
 }
 
 #[no_mangle]

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -34,6 +34,11 @@ pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SensExt};
 }
 
+/// Serial Configuration
+pub mod serial {
+    pub use esp_hal_common::serial::*;
+}
+
 #[no_mangle]
 extern "C" fn DefaultHandler(_level: u32, _interrupt: pac::Interrupt) {}
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -39,7 +39,7 @@ embedded-graphics = "0.7"
 panic-halt        = "0.2"
 ssd1306           = "0.7"
 smart-leds        = "0.3"
-esp-println       = { version = "0.1.0", features = ["esp32s3"] }
+esp-println       = { version = "0.2.0", features = ["esp32s3"] }
 
 [features]
 default = ["rt"]

--- a/esp32s3-hal/examples/advanced_serial.rs
+++ b/esp32s3-hal/examples/advanced_serial.rs
@@ -1,0 +1,71 @@
+//! This shows how to configure UART
+//! You can short the TX and RX pin and see it reads what was written.
+//! Additionally you can connect a logic analzyer to TX and see how the changes
+//! of the configuration change the output signal.
+
+#![no_std]
+#![no_main]
+
+use embedded_hal_1::nb::block;
+use esp32s3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    serial::{
+        config::{Config, DataBits, Parity, StopBits},
+        Pins,
+    },
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
+use esp_println::println;
+use panic_halt as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let config = Config {
+        baudrate: 115200,
+        data_bits: DataBits::DataBits8,
+        parity: Parity::ParityNone,
+        stop_bits: StopBits::STOP1,
+    };
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let pins = Pins::new_tx_rx(
+        io.pins.gpio1.into_push_pull_output(),
+        io.pins.gpio2.into_floating_input(),
+    );
+
+    let mut serial1 =
+        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks).unwrap();
+
+    let mut delay = Delay::new(&clocks);
+
+    println!("Start");
+    loop {
+        serial1.write(0x42).ok();
+        let read = block!(serial1.read());
+
+        match read {
+            Ok(read) => println!("Read {:02x}", read),
+            Err(err) => println!("Error {:?}", err),
+        }
+
+        delay.delay_ms(250u32);
+    }
+}

--- a/esp32s3-hal/examples/advanced_serial.rs
+++ b/esp32s3-hal/examples/advanced_serial.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
     );
 
     let mut serial1 =
-        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks).unwrap();
+        Serial::new_with_config(peripherals.UART1, Some(config), Some(pins), &clocks);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32s3-hal/examples/advanced_serial.rs
+++ b/esp32s3-hal/examples/advanced_serial.rs
@@ -14,7 +14,7 @@ use esp32s3_hal::{
     prelude::*,
     serial::{
         config::{Config, DataBits, Parity, StopBits},
-        Pins,
+        TxRxPins,
     },
     Delay,
     RtcCntl,
@@ -46,7 +46,7 @@ fn main() -> ! {
     };
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pins = Pins::new_tx_rx(
+    let pins = TxRxPins::new_tx_rx(
         io.pins.gpio1.into_push_pull_output(),
         io.pins.gpio2.into_floating_input(),
     );

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();

--- a/esp32s3-hal/examples/hello_world.rs
+++ b/esp32s3-hal/examples/hello_world.rs
@@ -16,7 +16,7 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();

--- a/esp32s3-hal/examples/i2c_display.rs
+++ b/esp32s3-hal/examples/i2c_display.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer

--- a/esp32s3-hal/examples/ram.rs
+++ b/esp32s3-hal/examples/ram.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT flash boot protection
     timer0.disable();

--- a/esp32s3-hal/examples/read_efuse.rs
+++ b/esp32s3-hal/examples/read_efuse.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     // the RTC WDT, and the TIMG WDTs.
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+    let mut serial0 = Serial::new(peripherals.UART0);
 
     timer0.disable();
     rtc_cntl.set_wdt_global_enable(false);

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -36,7 +36,7 @@ fn main() -> ! {
 
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     timer0.disable();

--- a/esp32s3-hal/examples/timer_interrupt.rs
+++ b/esp32s3-hal/examples/timer_interrupt.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     // Disable the TIMG watchdog timer.
     let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
     let mut timer1 = Timer::new(peripherals.TIMG1, clocks.apb_clock);
-    let serial0 = Serial::new(peripherals.UART0).unwrap();
+    let serial0 = Serial::new(peripherals.UART0);
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -30,6 +30,11 @@ pub use self::gpio::IO;
 
 pub mod gpio;
 
+/// Serial Configuration
+pub mod serial {
+    pub use esp_hal_common::serial::*;
+}
+
 #[no_mangle]
 extern "C" fn DefaultHandler(_level: u32, _interrupt: pac::Interrupt) {}
 

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -12,6 +12,7 @@ pub use esp_hal_common::{
     prelude,
     pulse_control,
     ram,
+    serial,
     spi,
     systimer,
     usb_serial_jtag,
@@ -29,11 +30,6 @@ pub use esp_hal_common::{
 pub use self::gpio::IO;
 
 pub mod gpio;
-
-/// Serial Configuration
-pub mod serial {
-    pub use esp_hal_common::serial::*;
-}
 
 #[no_mangle]
 extern "C" fn DefaultHandler(_level: u32, _interrupt: pac::Interrupt) {}


### PR DESCRIPTION
This implement configuring the UART / serial driver and adds examples to show how to do that.

Additionally reading never worked on ESP32-S2 - this is fixed now