### PR TITLE
SpiDevice trait on the esp32c3

### DIFF
--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -21,9 +21,9 @@
 //!     &mut clocks,
 //! );
 //! ```
-
 #[cfg(all(feature = "eh1", feature = "esp32c3"))]
-use core::{cell::RefCell, convert::Infallible};
+use core::cell::RefCell;
+use core::convert::Infallible;
 
 use fugit::HertzU32;
 #[cfg(all(feature = "eh1", feature = "esp32c3"))]


### PR DESCRIPTION
Right now this is very untested. This does compile and run but currently has not been tested while running interrupts.
And it seems that I need to find a way to clear the previous CS pin before setting the new one (I can see on the oscilloscope that both CS pins are being driven at the same time), there are a few traits that are still unimplemented and this only has support for the esp32c3 right now. 