### PR TITLE
SPI: Implement more SPI traits from embedded-hal 1.0.0-alpha.8

### DIFF
--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -556,7 +556,7 @@ pub trait Instance {
     // FIXME: See below.
     fn write_bytes(&mut self, words: &[u8]) -> Result<(), Infallible> {
         let reg_block = self.register_block();
-        let num_chuncks = words.len() / FIFO_SIZE;
+        let num_chunks = words.len() / FIFO_SIZE;
 
         // The fifo has a limited fixed size, so the data must be chunked and then transmitted
         for (i, chunk) in words.chunks(FIFO_SIZE).enumerate() {
@@ -573,7 +573,6 @@ pub trait Instance {
                     // why.
                     FIFO_SIZE / 4,
                 );
-                //fifo_ptr = fifo_ptr.offset(transfer_num_words as isize);
             }
 
             self.update();
@@ -583,7 +582,7 @@ pub trait Instance {
             // Wait for all chunks to complete except the last one.
             // The function is allowed to return before the bus is idle.
             // see [embedded-hal flushing](https://docs.rs/embedded-hal/1.0.0-alpha.8/embedded_hal/spi/blocking/index.html#flushing)
-            if i < num_chuncks {
+            if i < num_chunks {
                 while reg_block.cmd.read().usr().bit_is_set() {
                     // wait
                 }

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -37,6 +37,8 @@ use fugit::HertzU32;
 const FIFO_SIZE: usize = 64;
 #[cfg(feature = "esp32s2")]
 const FIFO_SIZE: usize = 72;
+/// Padding byte for empty write transfers
+const EMPTY_WRITE_PAD: u8 = 0x00u8;
 
 #[derive(Debug, Clone, Copy)]
 pub enum SpiMode {
@@ -211,7 +213,6 @@ mod ehal1 {
     use embedded_hal_1::spi::blocking::{SpiBus, SpiBusFlush, SpiBusRead, SpiBusWrite};
     use embedded_hal_1::spi::nb::FullDuplex;
 
-    const EMPTY_WRITE_PAD: u8 = 0x00u8;
 
     impl<T> embedded_hal_1::spi::ErrorType for Spi<T> {
         type Error = Infallible;
@@ -597,7 +598,7 @@ pub trait Instance {
     /// If you want to read the response to something you have written before, consider using
     /// [`transfer`] instead.
     fn read_bytes(&mut self, words: &mut [u8]) -> Result<(), Infallible> {
-        let empty_array = [EMPTY_WRITE_STUFFING; FIFO_SIZE];
+        let empty_array = [EMPTY_WRITE_PAD; FIFO_SIZE];
 
         for chunk in words.chunks_mut(FIFO_SIZE) {
             self.write_bytes(&empty_array[0..chunk.len()])?;

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -203,41 +203,47 @@ where
 }
 
 #[cfg(feature = "eh1")]
-impl<T> embedded_hal_1::spi::ErrorType for Spi<T> {
-    type Error = Infallible;
-}
+pub use ehal1::*;
 
 #[cfg(feature = "eh1")]
-impl<T> embedded_hal_1::spi::nb::FullDuplex for Spi<T>
-where
-    T: Instance,
-{
-    fn read(&mut self) -> nb::Result<u8, Self::Error> {
-        self.spi.read_byte()
+mod ehal1 {
+    use super::*;
+    use embedded_hal_1::spi::nb::FullDuplex;
+    use embedded_hal_1::spi::blocking::{SpiBus, SpiBusWrite, SpiBusRead, SpiBusFlush};
+
+    impl<T> embedded_hal_1::spi::ErrorType for Spi<T> {
+        type Error = Infallible;
     }
 
-    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
-        self.spi.write_byte(word)
-    }
-}
+    impl<T> FullDuplex for Spi<T>
+    where
+        T: Instance,
+    {
+        fn read(&mut self) -> nb::Result<u8, Self::Error> {
+            self.spi.read_byte()
+        }
 
-#[cfg(feature = "eh1")]
-impl<T> embedded_hal_1::spi::blocking::SpiBusWrite for Spi<T>
-where
-    T: Instance,
-{
-    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        self.spi.send_bytes(words)
+        fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+            self.spi.write_byte(word)
+        }
     }
-}
 
-#[cfg(feature = "eh1")]
-impl<T> embedded_hal_1::spi::blocking::SpiBusFlush for Spi<T>
-where
-    T: Instance,
-{
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        self.spi.flush()
+    impl<T> SpiBusWrite for Spi<T>
+    where
+        T: Instance,
+    {
+        fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+            self.spi.send_bytes(words)
+        }
+    }
+
+    impl<T> SpiBusFlush for Spi<T>
+    where
+        T: Instance,
+    {
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            self.spi.flush()
+        }
     }
 }
 

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -454,12 +454,7 @@ pub trait Instance {
     }
 
     fn write_bytes(&mut self, words: &[u8]) -> Result<(), Infallible> {
-        let mut words_mut = [0u8; 256];
-        words_mut[0..words.len()].clone_from_slice(&words[0..words.len()]);
-
-        self.transfer(&mut words_mut[0..words.len()])?;
-
-        Ok(())
+        self.send_bytes(words)
     }
 
     fn send_bytes(&mut self, words: &[u8]) -> Result<(), Infallible> {

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -33,9 +33,10 @@ use core::convert::Infallible;
 use fugit::HertzU32;
 
 /// The size of the FIFO buffer for SPI
+#[cfg(not(feature = "esp32s2"))]
 const FIFO_SIZE: usize = 64;
-/// Empty byte to write out on SPI while reading
-const EMPTY_WRITE_STUFFING: u8 = 0u8;
+#[cfg(feature = "esp32s2")]
+const FIFO_SIZE: usize = 72;
 
 #[derive(Debug, Clone, Copy)]
 pub enum SpiMode {

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -588,18 +588,9 @@ pub trait Instance {
 
         for chunk in words.chunks_mut(FIFO_SIZE) {
             // Beginning of reception buffer
-            let mut fifo_ptr = reg_block.w0.as_ptr();
-            for index in (0..chunk.len()).step_by(4) {
-                let reg_val = unsafe { *fifo_ptr };
-                let bytes = reg_val.to_le_bytes();
-
-                let len = usize::min(chunk.len(), index + 4) - index;
-                chunk[index..(index + len)].clone_from_slice(&bytes[0..len]);
-
-                unsafe {
-                    fifo_ptr = fifo_ptr.offset(1);
-                };
-            }
+            let fifo_ptr = reg_block.w0.as_ptr() as *const u8;
+            let raw_slice = unsafe { core::slice::from_raw_parts::<u8>(fifo_ptr, chunk.len()) };
+            chunk.copy_from_slice(raw_slice);
         }
 
         Ok(())

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -66,10 +66,8 @@ where
         sck.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.sclk_signal());
 
-        if let Some(mut mosi) = mosi {
-            mosi.set_to_push_pull_output()
-                .connect_peripheral_to_output(spi.mosi_signal());
-        }
+        mosi.set_to_push_pull_output()
+            .connect_peripheral_to_output(spi.mosi_signal());
 
         miso.set_to_input()
             .connect_input_to_peripheral(spi.miso_signal());

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -527,6 +527,14 @@ pub trait Instance {
         }
         Ok(())
     }
+
+    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Infallible> {
+        for chunk in words.chunks_mut(FIFO_SIZE) {
+            self.send_bytes(chunk)?;
+            self.flush()?;
+            self.read_bytes(chunk)?;
+        }
+
         Ok(words)
     }
 

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -23,9 +23,7 @@
 //! ```
 
 use core::convert::Infallible;
-
 use fugit::HertzU32;
-
 use crate::{
     clock::Clocks,
     pac::spi2::RegisterBlock,
@@ -37,6 +35,7 @@ use crate::{
 
 /// The size of the FIFO buffer for SPI
 const FIFO_SIZE: usize = 64;
+const EMPTY_WRITE_PAD: u8 = 0x00u8;
 
 #[derive(Debug, Clone, Copy)]
 pub enum SpiMode {
@@ -69,8 +68,10 @@ where
         sck.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.sclk_signal());
 
-        mosi.set_to_push_pull_output()
-            .connect_peripheral_to_output(spi.mosi_signal());
+        if let Some(mut mosi) = mosi {
+            mosi.set_to_push_pull_output()
+                .connect_peripheral_to_output(spi.mosi_signal());
+        }
 
         miso.set_to_input()
             .connect_input_to_peripheral(spi.miso_signal());

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -34,7 +34,6 @@ use fugit::HertzU32;
 
 /// The size of the FIFO buffer for SPI
 const FIFO_SIZE: usize = 64;
-const EMPTY_WRITE_PAD: u8 = 0x00u8;
 
 #[derive(Debug, Clone, Copy)]
 pub enum SpiMode {
@@ -210,6 +209,8 @@ mod ehal1 {
     use super::*;
     use embedded_hal_1::spi::blocking::{SpiBus, SpiBusFlush, SpiBusRead, SpiBusWrite};
     use embedded_hal_1::spi::nb::FullDuplex;
+
+    const EMPTY_WRITE_PAD: u8 = 0x00u8;
 
     impl<T> embedded_hal_1::spi::ErrorType for Spi<T> {
         type Error = Infallible;

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -35,6 +35,9 @@ use crate::{
     OutputPin,
 };
 
+/// The size of the FIFO buffer for SPI
+const FIFO_SIZE: usize = 64;
+
 #[derive(Debug, Clone, Copy)]
 pub enum SpiMode {
     Mode0,
@@ -461,11 +464,10 @@ pub trait Instance {
 
     fn send_bytes(&mut self, words: &[u8]) -> Result<(), Infallible> {
         let reg_block = self.register_block();
-        let num_chuncks = words.len() / 64;
+        let num_chuncks = words.len() / FIFO_SIZE;
 
-        // The fifo has a total of 16 32 bit registers (64 bytes) so the data
-        // must be chunked and then transmitted
-        for (i, chunk) in words.chunks(64).enumerate() {
+        // The fifo has a limited fixed size, so the data must be chunken and then transmitted
+        for (i, chunk) in words.chunks(FIFO_SIZE).enumerate() {
             self.configure_datalen(chunk.len() as u32 * 8);
 
             let mut fifo_ptr = reg_block.w0.as_ptr();

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -54,3 +54,7 @@ vectored = ["esp-hal-common/vectored"]
 [[example]]
 name              = "hello_rgb"
 required-features = ["smartled"]
+
+[[example]]
+name = "spi_eh1_loopback"
+required-features = ["eh1"]

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -18,9 +18,7 @@
 
 use core::fmt::Write;
 
-use embedded_hal_1::spi::blocking::{
-    SpiBus, SpiBusWrite, SpiBusRead, SpiBusFlush,
-};
+use embedded_hal_1::spi::blocking::SpiBus;
 use esp32_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -72,6 +70,7 @@ fn main() -> ! {
     writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
 
     loop {
+        // --- Symmetric transfer (Read as much as we write) ---
         write!(serial0, "Starting symmetric transfer...").unwrap();
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
@@ -82,7 +81,8 @@ fn main() -> ! {
         delay.delay_ms(250u32);
 
 
-        write!(serial0, "Starting assymetric transfer (read > write)...").unwrap();
+        // --- Asymmetric transfer (Read more than we write) ---
+        write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
         let mut read: [u8; 4] = [0x00; 4];
 
         SpiBus::transfer(&mut spi, &mut read[0..2], &write[..]).expect("Asymmetric transfer failed");
@@ -92,17 +92,32 @@ fn main() -> ! {
         delay.delay_ms(250u32);
 
 
+        // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
         write!(serial0, "Starting huge transfer...").unwrap();
-        let mut write = [0x55u8; 256];
+        let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
         }
-        let mut read = [0x00u8; 256];
+        let mut read = [0x00u8; 4096];
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Huge transfer failed");
-        //SpiBus::transfer_in_place(&mut spi, &mut write[..]).expect("Huge transfer failed");
         assert_eq!(write, read);
+        writeln!(serial0, " SUCCESS").unwrap();
+        delay.delay_ms(250u32);
+
+
+        // --- Symmetric transfer with huge buffer in-place (No additional allocation needed) ---
+        write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        let mut write = [0x55u8; 4096];
+        for byte in 0..write.len() {
+            write[byte] = byte as u8;
+        }
+
+        SpiBus::transfer_in_place(&mut spi, &mut write[..]).expect("Huge transfer failed");
+        for byte in 0..write.len() {
+            assert_eq!(write[byte], byte as u8);
+        }
         writeln!(serial0, " SUCCESS").unwrap();
         delay.delay_ms(250u32);
     }

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -30,15 +30,12 @@ use esp32_hal::{
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
-#[cfg(feature = "eh1")]
 use embedded_hal_1::spi::blocking::SpiBus;
-#[cfg(feature = "eh1")]
 use esp32_hal::{
     gpio::IO,
     spi::{Spi, SpiMode},
 };
 
-#[cfg(feature = "eh1")]
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
@@ -129,26 +126,3 @@ fn main() -> ! {
     }
 }
 
-#[cfg(not(feature = "eh1"))]
-#[entry]
-fn main() -> ! {
-
-    let peripherals = Peripherals::take().unwrap();
-    let system = peripherals.DPORT.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
-    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
-    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
-
-    timer0.disable();
-    rtc_cntl.set_wdt_global_enable(false);
-    let mut delay = Delay::new(&clocks);
-
-    loop {
-        writeln!(serial0, "This example requires the 'eh1' feature flag!").unwrap();
-        delay.delay_ms(1000u32);
-    }
-}

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -1,0 +1,94 @@
+//! SPI loopback test
+//!
+//! Folowing pins are used:
+//! SCLK    GPIO19
+//! MISO    GPIO25
+//! MOSI    GPIO23
+//! CS      GPIO22
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! This example transfers data via SPI.
+//! Connect MISO and MOSI pins to see the outgoing data is read as incoming
+//! data.
+
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+
+use embedded_hal_1::spi::blocking::{
+    SpiBus, SpiBusWrite, SpiBusRead, SpiBusFlush,
+};
+use esp32_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    spi::{Spi, SpiMode},
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
+use panic_halt as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
+    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio19;
+    let miso = io.pins.gpio25;
+    let mosi = io.pins.gpio23;
+    let cs = io.pins.gpio22;
+
+    let mut spi = Spi::new(
+        peripherals.SPI2,
+        sclk,
+        Some(mosi),
+        Some(miso),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        write!(serial0, "Starting symmetric transfer...").unwrap();
+        let write = [0xde, 0xad, 0xbe, 0xef];
+        let mut read: [u8; 4] = [0x00u8; 4];
+
+        SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Symmetric transfer failed");
+        assert_eq!(write, read);
+        writeln!(serial0, " SUCCESS").unwrap();
+        delay.delay_ms(250u32);
+
+
+        write!(serial0, "Starting assymetric transfer (read > write)...").unwrap();
+        let mut read: [u8; 4] = [0x00; 4];
+
+        SpiBus::transfer(&mut spi, &mut read[0..2], &write[..]).expect("Asymmetric transfer failed");
+        assert_eq!(write[0], read[0]);
+        assert_eq!(read[2], 0x00u8);
+        writeln!(serial0, " SUCCESS").unwrap();
+        delay.delay_ms(250u32);
+
+    }
+}

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -62,13 +62,14 @@ fn main() -> ! {
         Some(mosi),
         Some(miso),
         Some(cs),
-        100u32.kHz(),
+        1000u32.kHz(),
         SpiMode::Mode0,
         &mut system.peripheral_clock_control,
         &clocks,
     );
 
     let mut delay = Delay::new(&clocks);
+    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
 
     loop {
         write!(serial0, "Starting symmetric transfer...").unwrap();
@@ -90,5 +91,19 @@ fn main() -> ! {
         writeln!(serial0, " SUCCESS").unwrap();
         delay.delay_ms(250u32);
 
+
+        // Only your RAM is the limit!
+        write!(serial0, "Starting huge transfer...").unwrap();
+        let mut write = [0x55u8; 256];
+        for byte in 0..write.len() {
+            write[byte] = byte as u8;
+        }
+        let mut read = [0x00u8; 256];
+
+        SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Huge transfer failed");
+        //SpiBus::transfer_in_place(&mut spi, &mut write[..]).expect("Huge transfer failed");
+        assert_eq!(write, read);
+        writeln!(serial0, " SUCCESS").unwrap();
+        delay.delay_ms(250u32);
     }
 }

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -18,13 +18,10 @@
 
 use core::fmt::Write;
 
-use embedded_hal_1::spi::blocking::SpiBus;
 use esp32_hal::{
     clock::ClockControl,
-    gpio::IO,
     pac::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
     Delay,
     RtcCntl,
     Serial,
@@ -33,6 +30,15 @@ use esp32_hal::{
 use panic_halt as _;
 use xtensa_lx_rt::entry;
 
+#[cfg(feature = "eh1")]
+use embedded_hal_1::spi::blocking::SpiBus;
+#[cfg(feature = "eh1")]
+use esp32_hal::{
+    gpio::IO,
+    spi::{Spi, SpiMode},
+};
+
+#[cfg(feature = "eh1")]
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
@@ -120,5 +126,29 @@ fn main() -> ! {
         }
         writeln!(serial0, " SUCCESS").unwrap();
         delay.delay_ms(250u32);
+    }
+}
+
+#[cfg(not(feature = "eh1"))]
+#[entry]
+fn main() -> ! {
+
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
+    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        writeln!(serial0, "This example requires the 'eh1' feature flag!").unwrap();
+        delay.delay_ms(1000u32);
     }
 }

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -26,7 +26,7 @@ use esp32_hal::{
     spi::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -42,13 +42,13 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio19;

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -54,3 +54,7 @@ vectored = ["esp-hal-common/vectored"]
 [[example]]
 name              = "hello_rgb"
 required-features = ["smartled"]
+
+[[example]]
+name = "spi_eh1_loopback"
+required-features = ["eh1"]

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -26,7 +26,7 @@ use esp32c3_hal::{
     spi::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -42,7 +42,7 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
@@ -50,8 +50,8 @@ fn main() -> ! {
 
     let mut serial0 = Serial::new(peripherals.UART0);
 
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -52,3 +52,7 @@ vectored = ["esp-hal-common/vectored"]
 [[example]]
 name              = "hello_rgb"
 required-features = ["smartled"]
+
+[[example]]
+name = "spi_eh1_loopback"
+required-features = ["eh1"]

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -1,10 +1,10 @@
 //! SPI loopback test
 //!
 //! Folowing pins are used:
-//! SCLK    GPIO19
-//! MISO    GPIO25
-//! MOSI    GPIO23
-//! CS      GPIO22
+//! SCLK    GPIO36
+//! MISO    GPIO37
+//! MOSI    GPIO35
+//! CS      GPIO34
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -18,7 +18,7 @@
 
 use core::fmt::Write;
 
-use esp32_hal::{
+use esp32s2_hal::{
     clock::ClockControl,
     gpio::IO,
     pac::Peripherals,
@@ -37,7 +37,7 @@ use embedded_hal_1::spi::blocking::SpiBus;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
-    let mut system = peripherals.DPORT.split();
+    let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
@@ -51,10 +51,10 @@ fn main() -> ! {
     rtc_cntl.set_wdt_global_enable(false);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio19;
-    let miso = io.pins.gpio25;
-    let mosi = io.pins.gpio23;
-    let cs = io.pins.gpio22;
+    let sclk = io.pins.gpio36;
+    let miso = io.pins.gpio37;
+    let mosi = io.pins.gpio35;
+    let cs = io.pins.gpio34;
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -26,7 +26,7 @@ use esp32s2_hal::{
     spi::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -42,13 +42,13 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio36;

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -54,3 +54,7 @@ vectored = ["esp-hal-common/vectored"]
 [[example]]
 name              = "hello_rgb"
 required-features = ["smartled"]
+
+[[example]]
+name = "spi_eh1_loopback"
+required-features = ["eh1"]

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -1,10 +1,10 @@
 //! SPI loopback test
 //!
 //! Folowing pins are used:
-//! SCLK    GPIO19
-//! MISO    GPIO25
-//! MOSI    GPIO23
-//! CS      GPIO22
+//! SCLK    GPIO12
+//! MISO    GPIO11
+//! MOSI    GPIO13
+//! CS      GPIO10
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -18,7 +18,7 @@
 
 use core::fmt::Write;
 
-use esp32_hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     gpio::IO,
     pac::Peripherals,
@@ -37,7 +37,7 @@ use embedded_hal_1::spi::blocking::SpiBus;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
-    let mut system = peripherals.DPORT.split();
+    let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
@@ -51,10 +51,10 @@ fn main() -> ! {
     rtc_cntl.set_wdt_global_enable(false);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio19;
-    let miso = io.pins.gpio25;
-    let mosi = io.pins.gpio23;
-    let cs = io.pins.gpio22;
+    let sclk = io.pins.gpio12;
+    let miso = io.pins.gpio11;
+    let mosi = io.pins.gpio13;
+    let cs = io.pins.gpio10;
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -26,7 +26,7 @@ use esp32s3_hal::{
     spi::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -42,13 +42,13 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio12;


### PR DESCRIPTION
Hi,

as the title suggests, this PR implements the `SpiBusWrite` and `SpiBus` traits from the latest `embedded-hal` alpha release as [documented here](https://docs.rs/embedded-hal/1.0.0-alpha.8/embedded_hal/spi/blocking/index.html).

I'm putting this up here in case someone is interested in having a preliminary look. Things that I'd still like to implement:

- [x] Consistent naming
  Currently we have `send_bytes` and `write_bytes`, both doing the same thing really, what should I do with that?
- [ ] A generic `SpiDevice` trait so we can share the `SpiBus` when we want to
  Ideally this goes in tandem with some sort of marker trait that prohibits creating a `SpiDevice` from a `SpiBus` that has a `CS` pin associated? Or maybe we make the `SpiDevice` the default and drop the `CS` from the bus entirely?
- [ ] Proper error types
  While the code is in fact infallible (apart from the `unsafe` parts of course), I think it would be nice to have e.g. a `ReadOnly` and `WriteOnly` that is returned when writing without `mosi` and reading without `miso`, respectively. I guess these could be enforced at compile time with more types and abstractions, but tbh these abstractions make me all fuzzy in the head... Or should we keep the current behavior where nothing happens?
- [x] Add more fun use cases to the example
- [x] Find out why there is a 2 ms gap between consecutive transfers when using `SpiBus::transfer` with buffers much bigger than the 64 bytes SPI FIFO
- [x] Fix `transfer_in_place` (currently broken)


I only have an ESP32 here for testing, so I'm looking forward to get some feedback from anyone who cares to test this on other ESP32 boards/chips. I have implemented a new test `esp32-hal/examples/spi_eh1_loopback.rs` that performs a very simple demo as of currently.