### PR TITLE
embedded-hal SpiDevice on all esp32 variants

### DIFF
--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -1,7 +1,8 @@
 //! # Serial Peripheral Interface
 //!
-//! There are multiple ways to use SPI, depending on your needs. Regardles of which way you choose,
-//! you must first create an SPI instance with [`Spi::new`].
+//! There are multiple ways to use SPI, depending on your needs. Regardles of
+//! which way you choose, you must first create an SPI instance with
+//! [`Spi::new`].
 //!
 //! ```rust
 //! let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -25,23 +26,26 @@
 //!
 //! ## Exclusive access to the SPI bus
 //!
-//! If all you want to do is to communicate to a single device, and you initiate transactions
-//! yourself, there are a number of ways to achieve this:
+//! If all you want to do is to communicate to a single device, and you initiate
+//! transactions yourself, there are a number of ways to achieve this:
 //!
-//! - Use the [`FullDuplex`](embedded_hal::spi::FullDuplex) trait to read/write single bytes at a
-//!   time,
-//! - Use the [`SpiBus`](embedded_hal_1::spi::blocking::SpiBus) trait (requires the "eh1" feature)
-//!   and its associated functions to initiate transactions with simultaneous reads and writes, or
+//! - Use the [`FullDuplex`](embedded_hal::spi::FullDuplex) trait to read/write
+//!   single bytes at a time,
+//! - Use the [`SpiBus`](embedded_hal_1::spi::blocking::SpiBus) trait (requires
+//!   the "eh1" feature) and its associated functions to initiate transactions
+//!   with simultaneous reads and writes, or
 //! - Use the [`SpiBusWrite`](embedded_hal_1::spi::blocking::SpiBusWrite) and
-//!   [`SpiBusRead`](embedded_hal_1::spi::blocking::SpiBusRead) traits (requires the "eh1" feature)
-//!   and their associated functions to read or write mutiple bytes at a time.
+//!   [`SpiBusRead`](embedded_hal_1::spi::blocking::SpiBusRead) traits (requires
+//!   the "eh1" feature) and their associated functions to read or write mutiple
+//!   bytes at a time.
 //!
 //!
 //! ## Shared SPI access
 //!
-//! If you have multiple devices on the same SPI bus that each have their own CS line, you may want
-//! to have a look at the [`SpiBusController`] and [`SpiBusDevice`] implemented here. These give
-//! exclusive access to the underlying SPI bus by means of a Mutex. This ensures that device
+//! If you have multiple devices on the same SPI bus that each have their own CS
+//! line, you may want to have a look at the [`SpiBusController`] and
+//! [`SpiBusDevice`] implemented here. These give exclusive access to the
+//! underlying SPI bus by means of a Mutex. This ensures that device
 //! transactions do not interfere with each other.
 
 use core::convert::Infallible;
@@ -360,100 +364,112 @@ mod ehal1 {
         }
     }
 
-    use xtensa_lx::mutex::Mutex;
-    use xtensa_lx::mutex::SpinLockMutex;
-    use core::cell::RefCell;
-    use embedded_hal_1::spi;
-    use embedded_hal_1::spi::ErrorType;
-    use embedded_hal_1::spi::blocking::SpiDevice;
-    use embedded_hal_1::digital::blocking::OutputPin;
+    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
+    pub use xtensa_spi_device::*;
 
-    /// SPI bus controller.
-    ///
-    /// Has exclusive access to an SPI bus, which is managed via a `Mutex`. Used as basis for the
-    /// [`SpiBusDevice`] implementation. Note that the wrapped [`RefCell`] is used solely to
-    /// achieve interior mutability.
-    pub struct SpiBusController<B: SpiBus + ErrorType> {
-        lock: SpinLockMutex<RefCell<B>>,
-    }
+    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
+    mod xtensa_spi_device {
+        use super::*;
+        use core::cell::RefCell;
 
-    impl<B: SpiBus + ErrorType> SpiBusController<B> {
-        /// Create a new controller from an SPI bus instance.
+        use embedded_hal_1::{
+            digital::blocking::OutputPin,
+            spi::{self, blocking::SpiDevice, ErrorType},
+        };
+        use xtensa_lx::mutex::{Mutex, SpinLockMutex};
+
+        /// SPI bus controller.
         ///
-        /// Takes ownership of the SPI bus in the process. Afterwards, the SPI bus can only be
-        /// accessed via instances of [`SpiBusDevice`].
-        pub fn from_spi(bus: B) -> Self {
-            SpiBusController {
-                lock: SpinLockMutex::new(RefCell::new(bus)),
+        /// Has exclusive access to an SPI bus, which is managed via a `Mutex`. Used as basis for
+        /// the [`SpiBusDevice`] implementation. Note that the wrapped [`RefCell`] is used solely
+        /// to achieve interior mutability.
+        pub struct SpiBusController<B: SpiBus + ErrorType> {
+            lock: SpinLockMutex<RefCell<B>>,
+        }
+
+        impl<B: SpiBus + ErrorType> SpiBusController<B> {
+            /// Create a new controller from an SPI bus instance.
+            ///
+            /// Takes ownership of the SPI bus in the process. Afterwards, the SPI bus can only be
+            /// accessed via instances of [`SpiBusDevice`].
+            pub fn from_spi(bus: B) -> Self {
+                SpiBusController {
+                    lock: SpinLockMutex::new(RefCell::new(bus)),
+                }
             }
         }
-    }
 
-    impl<B> ErrorType for SpiBusController<B>
-    where
-        B: SpiBus + ErrorType,
-    {
-        type Error = spi::ErrorKind;
-    }
+        impl<B> ErrorType for SpiBusController<B>
+        where
+            B: SpiBus + ErrorType,
+        {
+            type Error = spi::ErrorKind;
+        }
 
-    /// An SPI device on a shared SPI bus.
-    ///
-    /// Provides device specific access on a shared SPI bus. Enables attaching multiple SPI devices
-    /// to the same bus, each with its own CS line, and performing safe transfers on them.
-    pub struct SpiBusDevice<'a, B, CS>
-    where
-        B: SpiBus + ErrorType,
-        CS: OutputPin,
-    {
-        bus: &'a SpiBusController<B>,
-        cs: CS,
-    }
+        /// An SPI device on a shared SPI bus.
+        ///
+        /// Provides device specific access on a shared SPI bus. Enables attaching multiple SPI
+        /// devices to the same bus, each with its own CS line, and performing safe transfers on
+        /// them.
+        pub struct SpiBusDevice<'a, B, CS>
+        where
+            B: SpiBus + ErrorType,
+            CS: OutputPin,
+        {
+            bus: &'a SpiBusController<B>,
+            cs: CS,
+        }
 
-    impl<'a, B, CS> SpiBusDevice<'a, B, CS>
-    where
-        B: SpiBus + ErrorType,
-        CS: OutputPin,
-    {
-        pub fn new(bus: &'a SpiBusController<B>, cs: CS) -> Self {
-            SpiBusDevice {
-                bus,
-                cs,
+        impl<'a, B, CS> SpiBusDevice<'a, B, CS>
+        where
+            B: SpiBus + ErrorType,
+            CS: OutputPin,
+        {
+            pub fn new(bus: &'a SpiBusController<B>, cs: CS) -> Self {
+                SpiBusDevice { bus, cs }
             }
         }
-    }
 
-    impl<'a, B, CS> ErrorType for SpiBusDevice<'a, B, CS>
-    where
-        B: SpiBus + ErrorType,
-        CS: OutputPin,
-    {
-        type Error = spi::ErrorKind;
-    }
+        impl<'a, B, CS> ErrorType for SpiBusDevice<'a, B, CS>
+        where
+            B: SpiBus + ErrorType,
+            CS: OutputPin,
+        {
+            type Error = spi::ErrorKind;
+        }
 
-    impl<B, CS> SpiDevice for SpiBusDevice<'_, B, CS>
-    where
-        B: SpiBus + ErrorType,
-        CS: OutputPin,
-    {
-        type Bus = B;
+        impl<B, CS> SpiDevice for SpiBusDevice<'_, B, CS>
+        where
+            B: SpiBus + ErrorType,
+            CS: OutputPin,
+        {
+            type Bus = B;
 
-        fn transaction<R>(&mut self, f: impl FnOnce(&mut Self::Bus) -> Result<R, <Self::Bus as ErrorType>::Error>) -> Result<R, Self::Error> {
-            (&self.bus.lock).lock(|bus| {
-                let mut bus = bus.borrow_mut();
-                self.cs.set_low().map_err(|_| spi::ErrorKind::ChipSelectFault)?;
+            fn transaction<R>(
+                &mut self,
+                f: impl FnOnce(&mut Self::Bus) -> Result<R, <Self::Bus as ErrorType>::Error>,
+            ) -> Result<R, Self::Error> {
+                (&self.bus.lock).lock(|bus| {
+                    let mut bus = bus.borrow_mut();
+                    self.cs
+                        .set_low()
+                        .map_err(|_| spi::ErrorKind::ChipSelectFault)?;
 
-                // We postpone handling these errors until AFTER we raised CS again, so the bus is
-                // free (Or we die trying if CS errors).
-                let f_res = f(&mut bus);
-                let flush_res = bus.flush();
+                    // We postpone handling these errors until AFTER we raised CS again, so the bus
+                    // is free (Or we die trying if CS errors).
+                    let f_res = f(&mut bus);
+                    let flush_res = bus.flush();
 
-                self.cs.set_high().map_err(|_| spi::ErrorKind::ChipSelectFault)?;
+                    self.cs
+                        .set_high()
+                        .map_err(|_| spi::ErrorKind::ChipSelectFault)?;
 
-                let f_res = f_res.map_err(|_| spi::ErrorKind::Other)?;
-                flush_res.map_err(|_| spi::ErrorKind::Other)?;
+                    let f_res = f_res.map_err(|_| spi::ErrorKind::Other)?;
+                    flush_res.map_err(|_| spi::ErrorKind::Other)?;
 
-                Ok(f_res)
-            })
+                    Ok(f_res)
+                })
+            }
         }
     }
 }

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -344,6 +344,7 @@ mod ehal1 {
     use embedded_hal_1::spi::ErrorType;
     use embedded_hal_1::spi::blocking::SpiDevice;
     use embedded_hal_1::digital::blocking::OutputPin;
+    //use esp_hal_common::gpio::OutputPin;
 
     /// An SPI device on a shared SPI bus.
     ///
@@ -387,19 +388,20 @@ mod ehal1 {
         cs: CS,
     }
 
-    //impl<'a, B, M, CS> SpiBusDevice<'a, B, M, CS>
-    //where
-    //    B: SpiBus + ErrorType,
-    //    M: Mutex<Data=RefCell<B>>,
-    //    CS: OutputPin,
-    //{
-    //    pub fn new(bus: M, cs: CS) -> Self {
-    //        let cs = cs.into_push_pull_output();
-    //        SpiBusDevice {
-    //            bus,
-    //            cs,
-    //        }
-    //}
+    impl<'a, B, M, CS> SpiBusDevice<'a, B, M, CS>
+    where
+        B: SpiBus + ErrorType,
+        M: Mutex<Data=RefCell<B>>,
+        CS: OutputPin,
+    {
+        pub fn new(bus: &'a mut M, cs: CS) -> Self {
+            //let cs = cs.set_to_push_pull_output();
+            SpiBusDevice {
+                bus,
+                cs,
+            }
+        }
+    }
 
     impl<'a, B, M, CS> ErrorType for SpiBusDevice<'a, B, M, CS>
     where

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -397,6 +397,13 @@ mod ehal1 {
                     lock: SpinLockMutex::new(RefCell::new(bus)),
                 }
             }
+
+            pub fn add_device<'a, CS: OutputPin>(&'a self, cs: CS) -> SpiBusDevice<'a, B, CS> {
+                SpiBusDevice {
+                    bus: self,
+                    cs,
+                }
+            }
         }
 
         impl<B> ErrorType for SpiBusController<B>

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -1,8 +1,7 @@
 //! # Serial Peripheral Interface
 //!
-//! There are multiple ways to use SPI, depending on your needs. Regardles of
-//! which way you choose, you must first create an SPI instance with
-//! [`Spi::new`].
+//! There are multiple ways to use SPI, depending on your needs. Regardless of which way you
+//! choose, you must first create an SPI instance with [`Spi::new`].
 //!
 //! ```rust
 //! let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -26,26 +25,23 @@
 //!
 //! ## Exclusive access to the SPI bus
 //!
-//! If all you want to do is to communicate to a single device, and you initiate
-//! transactions yourself, there are a number of ways to achieve this:
+//! If all you want to do is to communicate to a single device, and you initiate transactions
+//! yourself, there are a number of ways to achieve this:
 //!
-//! - Use the [`FullDuplex`](embedded_hal::spi::FullDuplex) trait to read/write
-//!   single bytes at a time,
-//! - Use the [`SpiBus`](embedded_hal_1::spi::blocking::SpiBus) trait (requires
-//!   the "eh1" feature) and its associated functions to initiate transactions
-//!   with simultaneous reads and writes, or
+//! - Use the [`FullDuplex`](embedded_hal::spi::FullDuplex) trait to read/write single bytes at a
+//!   time,
+//! - Use the [`SpiBus`](embedded_hal_1::spi::blocking::SpiBus) trait (requires the "eh1" feature)
+//!   and its associated functions to initiate transactions with simultaneous reads and writes, or
 //! - Use the [`SpiBusWrite`](embedded_hal_1::spi::blocking::SpiBusWrite) and
-//!   [`SpiBusRead`](embedded_hal_1::spi::blocking::SpiBusRead) traits (requires
-//!   the "eh1" feature) and their associated functions to read or write mutiple
-//!   bytes at a time.
+//!   [`SpiBusRead`](embedded_hal_1::spi::blocking::SpiBusRead) traits (requires the "eh1" feature)
+//!   and their associated functions to read or write mutiple bytes at a time.
 //!
 //!
 //! ## Shared SPI access
 //!
-//! If you have multiple devices on the same SPI bus that each have their own CS
-//! line, you may want to have a look at the [`SpiBusController`] and
-//! [`SpiBusDevice`] implemented here. These give exclusive access to the
-//! underlying SPI bus by means of a Mutex. This ensures that device
+//! If you have multiple devices on the same SPI bus that each have their own CS line, you may want
+//! to have a look at the [`SpiBusController`] and [`SpiBusDevice`] implemented here. These give
+//! exclusive access to the underlying SPI bus by means of a Mutex. This ensures that device
 //! transactions do not interfere with each other.
 
 use core::convert::Infallible;

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -1,7 +1,8 @@
 //! # Serial Peripheral Interface
-//! To construct the SPI instances, use the `Spi::new` functions.
 //!
-//! ## Initialisation example
+//! There are multiple ways to use SPI, depending on your needs. Regardles of which way you choose,
+//! you must first create an SPI instance with [`Spi::new`].
+//!
 //! ```rust
 //! let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 //! let sclk = io.pins.gpio12;
@@ -21,6 +22,27 @@
 //!     &mut clocks,
 //! );
 //! ```
+//!
+//! ## Exclusive access to the SPI bus
+//!
+//! If all you want to do is to communicate to a single device, and you initiate transactions
+//! yourself, there are a number of ways to achieve this:
+//!
+//! - Use the [`FullDuplex`](embedded_hal::spi::FullDuplex) trait to read/write single bytes at a
+//!   time,
+//! - Use the [`SpiBus`](embedded_hal_1::spi::blocking::SpiBus) trait (requires the "eh1" feature)
+//!   and its associated functions to initiate transactions with simultaneous reads and writes, or
+//! - Use the [`SpiBusWrite`](embedded_hal_1::spi::blocking::SpiBusWrite) and
+//!   [`SpiBusRead`](embedded_hal_1::spi::blocking::SpiBusRead) traits (requires the "eh1" feature)
+//!   and their associated functions to read or write mutiple bytes at a time.
+//!
+//!
+//! ## Shared SPI access
+//!
+//! If you have multiple devices on the same SPI bus that each have their own CS line, you may want
+//! to have a look at the [`SpiBusController`] and [`SpiBusDevice`] implemented here. These give
+//! exclusive access to the underlying SPI bus by means of a Mutex. This ensures that device
+//! transactions do not interfere with each other.
 
 use core::convert::Infallible;
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -59,3 +59,7 @@ required-features = ["smartled"]
 [[example]]
 name = "spi_eh1_loopback"
 required-features = ["eh1"]
+
+[[example]]
+name = "spi_eh1_device_loopback"
+required-features = ["eh1"]

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -31,7 +31,7 @@ use esp32_hal::{
     Rtc,
     Serial,
 };
-use panic_halt as _;
+use esp_backtrace as _;
 use xtensa_lx_rt::entry;
 
 use embedded_hal_1::spi::blocking::SpiDevice;

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -1,0 +1,135 @@
+//! SPI loopback test
+//!
+//! Folowing pins are used:
+//! SCLK    GPIO19
+//! MISO    GPIO25
+//! MOSI    GPIO23
+//! CS      GPIO22
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! This example transfers data via SPI.
+//! Connect MISO and MOSI pins to see the outgoing data is read as incoming
+//! data.
+
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+
+use esp32_hal::{
+    clock::ClockControl,
+    pac::Peripherals,
+    prelude::*,
+    Delay,
+    RtcCntl,
+    Serial,
+    Timer,
+};
+use panic_halt as _;
+use xtensa_lx_rt::entry;
+
+use xtensa_lx::mutex::SpinLockMutex;
+use core::cell::RefCell;
+use embedded_hal_1::spi::blocking::SpiDevice;
+use esp32_hal::{
+    gpio::IO,
+    spi::{Spi, SpiMode, SpiBusDevice},
+};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut timer0 = Timer::new(peripherals.TIMG0, clocks.apb_clock);
+    let mut serial0 = Serial::new(peripherals.UART0).unwrap();
+
+    timer0.disable();
+    rtc_cntl.set_wdt_global_enable(false);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio19;
+    let miso = io.pins.gpio25;
+    let mosi = io.pins.gpio23;
+    let cs = io.pins.gpio22;
+    let cs = cs.into_push_pull_output();
+
+    let mut spi = Spi::new(
+        peripherals.SPI2,
+        sclk,
+        Some(mosi),
+        Some(miso),
+        None,
+        1000u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+    let mut mutex_spi = SpinLockMutex::new(RefCell::new(spi));
+    let spi_device = SpiBusDevice::new(&mut mutex_spi, cs);
+
+    let mut delay = Delay::new(&clocks);
+    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
+
+    loop {
+        // --- Symmetric transfer (Read as much as we write) ---
+        write!(serial0, "Starting symmetric transfer...").unwrap();
+        let write = [0xde, 0xad, 0xbe, 0xef];
+        let mut read: [u8; 4] = [0x00u8; 4];
+
+        spi_device.transaction(|bus| {
+            bus.transfer(&mut read[..], &write[..])
+        }).unwrap();
+        assert_eq!(write, read);
+        writeln!(serial0, " SUCCESS").unwrap();
+        delay.delay_ms(250u32);
+
+
+        //// --- Asymmetric transfer (Read more than we write) ---
+        //write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
+        //let mut read: [u8; 4] = [0x00; 4];
+
+        //SpiBus::transfer(&mut spi, &mut read[0..2], &write[..]).expect("Asymmetric transfer failed");
+        //assert_eq!(write[0], read[0]);
+        //assert_eq!(read[2], 0x00u8);
+        //writeln!(serial0, " SUCCESS").unwrap();
+        //delay.delay_ms(250u32);
+
+
+        //// --- Symmetric transfer with huge buffer ---
+        //// Only your RAM is the limit!
+        //write!(serial0, "Starting huge transfer...").unwrap();
+        //let mut write = [0x55u8; 4096];
+        //for byte in 0..write.len() {
+        //    write[byte] = byte as u8;
+        //}
+        //let mut read = [0x00u8; 4096];
+
+        //SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Huge transfer failed");
+        //assert_eq!(write, read);
+        //writeln!(serial0, " SUCCESS").unwrap();
+        //delay.delay_ms(250u32);
+
+
+        //// --- Symmetric transfer with huge buffer in-place (No additional allocation needed) ---
+        //write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        //let mut write = [0x55u8; 4096];
+        //for byte in 0..write.len() {
+        //    write[byte] = byte as u8;
+        //}
+
+        //SpiBus::transfer_in_place(&mut spi, &mut write[..]).expect("Huge transfer failed");
+        //for byte in 0..write.len() {
+        //    assert_eq!(write[byte], byte as u8);
+        //}
+        //writeln!(serial0, " SUCCESS").unwrap();
+        //delay.delay_ms(250u32);
+    }
+}
+

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -58,3 +58,7 @@ required-features = ["smartled"]
 [[example]]
 name = "spi_eh1_loopback"
 required-features = ["eh1"]
+
+[[example]]
+name = "spi_eh1_device_loopback"
+required-features = ["eh1"]

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -1,12 +1,12 @@
 //! SPI loopback test
 //!
 //! Folowing pins are used:
-//! SCLK    GPIO19
-//! MISO    GPIO25
-//! MOSI    GPIO23
-//! CS 1    GPIO12
-//! CS 2    GPIO13
-//! CS 3    GPIO14
+//! SCLK    GPIO6
+//! MISO    GPIO2
+//! MOSI    GPIO7
+//! CS 1    GPIO3
+//! CS 2    GPIO4
+//! CS 3    GPIO4
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -20,7 +20,7 @@
 
 use core::fmt::Write;
 
-use esp32_hal::{
+use esp32c3_hal::{
     clock::ClockControl,
     gpio::IO,
     pac::Peripherals,
@@ -46,16 +46,21 @@ fn main() -> ! {
     // the RTC WDT, and the TIMG WDTs.
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt = timer_group0.wdt;
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
     let mut serial0 = Serial::new(peripherals.UART0);
 
-    wdt.disable();
+    rtc.swd.disable();
     rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio19;
-    let miso = io.pins.gpio25;
-    let mosi = io.pins.gpio23;
+    let sclk = io.pins.gpio6;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio7;
 
     let spi_controller = SpiBusController::from_spi(Spi::new_no_cs(
         peripherals.SPI2,
@@ -67,9 +72,9 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
         &clocks,
     ));
-    let mut spi_device_1 = spi_controller.add_device(io.pins.gpio12);
-    let mut spi_device_2 = spi_controller.add_device(io.pins.gpio13);
-    let mut spi_device_3 = spi_controller.add_device(io.pins.gpio14);
+    let mut spi_device_1 = spi_controller.add_device(io.pins.gpio3);
+    let mut spi_device_2 = spi_controller.add_device(io.pins.gpio4);
+    let mut spi_device_3 = spi_controller.add_device(io.pins.gpio5);
 
     let mut delay = Delay::new(&clocks);
     writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -32,14 +32,14 @@ use esp32c3_hal::{
     Serial,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
+use riscv_rt::entry;
 
 use embedded_hal_1::spi::blocking::SpiDevice;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
-    let mut system = peripherals.DPORT.split();
+    let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -6,7 +6,7 @@
 //! MOSI    GPIO7
 //! CS 1    GPIO3
 //! CS 2    GPIO4
-//! CS 3    GPIO4
+//! CS 3    GPIO5
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -31,7 +31,7 @@ use esp32c3_hal::{
     Rtc,
     Serial,
 };
-use panic_halt as _;
+use esp_backtrace as _;
 use xtensa_lx_rt::entry;
 
 use embedded_hal_1::spi::blocking::SpiDevice;

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -57,3 +57,7 @@ required-features = ["smartled"]
 [[example]]
 name = "spi_eh1_loopback"
 required-features = ["eh1"]
+
+[[example]]
+name = "spi_eh1_device_loopback"
+required-features = ["eh1"]

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -1,12 +1,12 @@
 //! SPI loopback test
 //!
 //! Folowing pins are used:
-//! SCLK    GPIO19
-//! MISO    GPIO25
-//! MOSI    GPIO23
-//! CS 1    GPIO12
-//! CS 2    GPIO13
-//! CS 3    GPIO14
+//! SCLK    GPIO36
+//! MISO    GPIO37
+//! MOSI    GPIO35
+//! CS 1    GPIO1
+//! CS 2    GPIO2
+//! CS 3    GPIO3
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -20,7 +20,7 @@
 
 use core::fmt::Write;
 
-use esp32_hal::{
+use esp32s2_hal::{
     clock::ClockControl,
     gpio::IO,
     pac::Peripherals,
@@ -39,7 +39,7 @@ use embedded_hal_1::spi::blocking::SpiDevice;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
-    let mut system = peripherals.DPORT.split();
+    let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
@@ -53,9 +53,9 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio19;
-    let miso = io.pins.gpio25;
-    let mosi = io.pins.gpio23;
+    let sclk = io.pins.gpio36;
+    let miso = io.pins.gpio37;
+    let mosi = io.pins.gpio35;
 
     let spi_controller = SpiBusController::from_spi(Spi::new_no_cs(
         peripherals.SPI2,
@@ -67,9 +67,9 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
         &clocks,
     ));
-    let mut spi_device_1 = spi_controller.add_device(io.pins.gpio12);
-    let mut spi_device_2 = spi_controller.add_device(io.pins.gpio13);
-    let mut spi_device_3 = spi_controller.add_device(io.pins.gpio14);
+    let mut spi_device_1 = spi_controller.add_device(io.pins.gpio1);
+    let mut spi_device_2 = spi_controller.add_device(io.pins.gpio2);
+    let mut spi_device_3 = spi_controller.add_device(io.pins.gpio3);
 
     let mut delay = Delay::new(&clocks);
     writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -31,7 +31,7 @@ use esp32s2_hal::{
     Rtc,
     Serial,
 };
-use panic_halt as _;
+use esp_backtrace as _;
 use xtensa_lx_rt::entry;
 
 use embedded_hal_1::spi::blocking::SpiDevice;

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -60,3 +60,7 @@ required-features = ["smartled"]
 [[example]]
 name = "spi_eh1_loopback"
 required-features = ["eh1"]
+
+[[example]]
+name = "spi_eh1_device_loopback"
+required-features = ["eh1"]

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -31,7 +31,7 @@ use esp32s3_hal::{
     Rtc,
     Serial,
 };
-use panic_halt as _;
+use esp_backtrace as _;
 use xtensa_lx_rt::entry;
 
 use embedded_hal_1::spi::blocking::SpiDevice;

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -1,12 +1,12 @@
 //! SPI loopback test
 //!
 //! Folowing pins are used:
-//! SCLK    GPIO19
-//! MISO    GPIO25
-//! MOSI    GPIO23
-//! CS 1    GPIO12
-//! CS 2    GPIO13
-//! CS 3    GPIO14
+//! SCLK    GPIO12
+//! MISO    GPIO11
+//! MOSI    GPIO13
+//! CS 1    GPIO4
+//! CS 2    GPIO5
+//! CS 3    GPIO6
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -20,7 +20,7 @@
 
 use core::fmt::Write;
 
-use esp32_hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     gpio::IO,
     pac::Peripherals,
@@ -39,7 +39,7 @@ use embedded_hal_1::spi::blocking::SpiDevice;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
-    let mut system = peripherals.DPORT.split();
+    let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
@@ -53,9 +53,9 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio19;
-    let miso = io.pins.gpio25;
-    let mosi = io.pins.gpio23;
+    let sclk = io.pins.gpio12;
+    let miso = io.pins.gpio11;
+    let mosi = io.pins.gpio13;
 
     let spi_controller = SpiBusController::from_spi(Spi::new_no_cs(
         peripherals.SPI2,
@@ -67,9 +67,9 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
         &clocks,
     ));
-    let mut spi_device_1 = spi_controller.add_device(io.pins.gpio12);
-    let mut spi_device_2 = spi_controller.add_device(io.pins.gpio13);
-    let mut spi_device_3 = spi_controller.add_device(io.pins.gpio14);
+    let mut spi_device_1 = spi_controller.add_device(io.pins.gpio4);
+    let mut spi_device_2 = spi_controller.add_device(io.pins.gpio5);
+    let mut spi_device_3 = spi_controller.add_device(io.pins.gpio6);
 
     let mut delay = Delay::new(&clocks);
     writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();


### PR DESCRIPTION
Hello,

this is a WIP to implement the `SpiDevice` trait from embedded HAL on the esp32. It is currently based on the contents of #101, hence the many duplicate commits.

I'm mainly putting this up here to discuss some strange errors that I get during building my example code. Can someone here please explain to me what these mean? I can't seem to make any sense out of what the compiler tells me...

Here's the error:

```
error[E0277]: the trait bound `SpinLockMutex<RefCell<esp32_hal::spi::Spi<esp32_hal::esp32::SPI2>>>: Mutex` is not satisfied
   --> examples/spi_eh1_device_loopback.rs:75:40
    |
75  |     let spi_device = SpiBusDevice::new(&mut mutex_spi, cs);
    |                      ----------------- ^^^^^^^^^^^^^^ the trait `Mutex` is not implemented for `SpinLockMutex<RefCell<esp32_hal::spi::Spi<esp32_hal::esp32::SPI2>>>`
    |                      |
    |                      required by a bound introduced by this call
    |
    = help: the following implementations were found:
              <&SpinLockMutex<T> as Mutex>
note: required by a bound in `SpiBusDevice::<'a, B, M, CS>::new`
   --> /var/home/ahartmann/repos/mt/playground/esp-hal/esp-hal-common/src/spi.rs:322:12
    |
322 |         M: Mutex<Data=RefCell<B>>,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SpiBusDevice::<'a, B, M, CS>::new`

```

To me this sounds as if `SpinLockMutex` doesn't implement the `xtensa_lx::mutex::Mutex` trait. Looking in the docs I see that `Mutex` is in fact implemented for `&SpinLockMutex<T>`, a reference to a SpinLockMutex. But I don't get how this works: Why does rust claim that the Mutex here is a value and not a reference? I'm creating it as `mut` value in the example, but I'm passing it to the code as `&mut`, which should be a mutable reference, or not?
