### PR TITLE
Disable `smartled` feature by default and update `xtensa-lx-rt` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --examples --manifest-path=esp32c3-hal/Cargo.toml --target=riscv32imc-unknown-none-elf
+          # The `hello_rgb` example requires the `smartled` feature to be enabled
+          args: --examples --manifest-path=esp32c3-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --features=smartled
 
   check-xtensa:
     name: Check Xtensa Examples
@@ -50,7 +51,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: -Zbuild-std=core --examples --manifest-path=${{ matrix.chip }}-hal/Cargo.toml --target=xtensa-${{ matrix.chip }}-none-elf
+          # The `hello_rgb` example requires the `smartled` feature to be enabled
+          args: -Zbuild-std=core --examples --manifest-path=${{ matrix.chip }}-hal/Cargo.toml --target=xtensa-${{ matrix.chip }}-none-elf --features=smartled
 
   clippy:
     name: Clippy

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -26,7 +26,7 @@ riscv-atomic-emulation-trap = { version = "0.1", optional = true }
 
 # Xtensa
 xtensa-lx    = { version = "0.7",  optional = true }
-xtensa-lx-rt = { version = "0.12", optional = true }
+xtensa-lx-rt = { version = "0.13", optional = true }
 
 # Part of `ufmt` containing only `uWrite` trait
 ufmt-write = { version = "0.1", optional = true }

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -47,10 +47,10 @@ esp32s2_pac = { package = "esp32s2", git = "https://github.com/esp-rs/esp-pacs.g
 esp32s3_pac = { package = "esp32s3", git = "https://github.com/esp-rs/esp-pacs.git", rev = "148dbb843cba3c311364aa994b8f3f773d15b04f", optional = true }
 
 [features]
-esp32   = [  "esp32_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "smartled"]
-esp32c3 = ["esp32c3_pac/rt", "risc_v", "single_core", "smartled"]
-esp32s2 = ["esp32s2_pac/rt", "xtensa", "single_core", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "smartled"]
-esp32s3 = ["esp32s3_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "smartled"]
+esp32   = [  "esp32_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32",     "xtensa-lx/esp32"]
+esp32c3 = ["esp32c3_pac/rt", "risc_v", "single_core"]
+esp32s2 = ["esp32s2_pac/rt", "xtensa", "single_core", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2"]
+esp32s3 = ["esp32s3_pac/rt", "xtensa",   "dual_core", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3"]
 
 # Architecture (should not be enabled directly, but instead by a PAC's feature)
 risc_v = ["riscv", "riscv-atomic-emulation-trap"]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -28,7 +28,7 @@ bare-metal     = "1.0"
 embedded-hal   = { version = "0.2",  features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
 xtensa-lx      = { version = "0.7",  features = ["esp32"] }
-xtensa-lx-rt   = { version = "0.12", features = ["esp32"], optional = true }
+xtensa-lx-rt   = { version = "0.13", features = ["esp32"], optional = true }
 nb             = "1.0.0"
 
 [dependencies.esp-hal-common]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -47,4 +47,9 @@ default   = ["rt"]
 bluetooth = []
 eh1       = ["esp-hal-common/eh1"]
 rt        = ["xtensa-lx-rt/esp32"]
+smartled  = ["esp-hal-common/smartled"]
 ufmt      = ["esp-hal-common/ufmt"]
+
+[[example]]
+name              = "hello_rgb"
+required-features = ["smartled"]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -47,4 +47,9 @@ default     = ["rt"]
 direct-boot = []
 eh1         = ["esp-hal-common/eh1"]
 rt          = ["riscv-rt"]
+smartled    = ["esp-hal-common/smartled"]
 ufmt        = ["esp-hal-common/ufmt"]
+
+[[example]]
+name              = "hello_rgb"
+required-features = ["smartled"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -42,7 +42,12 @@ smart-leds        = "0.3"
 esp-println       = { version = "0.2.0", features = ["esp32s2"] }
 
 [features]
-default = ["rt"]
-eh1     = ["esp-hal-common/eh1"]
-rt      = ["xtensa-lx-rt/esp32s2"]
-ufmt    = ["esp-hal-common/ufmt"]
+default   = ["rt"]
+eh1       = ["esp-hal-common/eh1"]
+rt        = ["xtensa-lx-rt/esp32s2"]
+smartled  = ["esp-hal-common/smartled"]
+ufmt      = ["esp-hal-common/ufmt"]
+
+[[example]]
+name              = "hello_rgb"
+required-features = ["smartled"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -28,7 +28,7 @@ bare-metal     = "1.0"
 embedded-hal   = { version = "0.2",  features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
 xtensa-lx      = { version = "0.7",  features = ["esp32s2"] }
-xtensa-lx-rt   = { version = "0.12", features = ["esp32s2"], optional = true }
+xtensa-lx-rt   = { version = "0.13", features = ["esp32s2"], optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -28,8 +28,8 @@ bare-metal     = "1.0"
 embedded-hal   = { version = "0.2",  features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.8" }
 xtensa-lx      = { version = "0.7",  features = ["esp32s3"] }
-xtensa-lx-rt   = { version = "0.12", features = ["esp32s3"], optional = true }
-r0             = { version = "1.0.0", optional = true }
+xtensa-lx-rt   = { version = "0.13", features = ["esp32s3"], optional = true }
+r0             = { version = "1.0", optional = true }
 
 [dependencies.esp-hal-common]
 path     = "../esp-hal-common"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -43,8 +43,13 @@ smart-leds        = "0.3"
 esp-println       = { version = "0.2.0", features = ["esp32s3"] }
 
 [features]
-default = ["rt"]
+default     = ["rt"]
 direct-boot = ["r0"]
-eh1     = ["esp-hal-common/eh1"]
-rt      = ["xtensa-lx-rt/esp32s3"]
-ufmt    = ["esp-hal-common/ufmt"]
+eh1         = ["esp-hal-common/eh1"]
+rt          = ["xtensa-lx-rt/esp32s3"]
+smartled    = ["esp-hal-common/smartled"]
+ufmt        = ["esp-hal-common/ufmt"]
+
+[[example]]
+name              = "hello_rgb"
+required-features = ["smartled"]


### PR DESCRIPTION
- Updated `xtensa-lx-rt` to the newest version (`0.13.0`)
- Disable the `smartled` feature in `esp-hal-common` and instead allow chip-specific HALs to optionally enable this
- Update the CI config to use `--features=smartled` so that the `hello_rgb` example still builds

Closes #105 