### PR TITLE
CPU clock settings for ESP32 and ESP32-C3

### DIFF
--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -3,6 +3,42 @@ use fugit::MegahertzU32;
 
 use crate::system::SystemClockControl;
 
+#[cfg_attr(feature = "esp32", path = "clocks_ll/esp32.rs")]
+#[cfg_attr(feature = "esp32c3", path = "clocks_ll/esp32c3.rs")]
+#[cfg_attr(feature = "esp32s2", path = "clocks_ll/esp32s2.rs")]
+#[cfg_attr(feature = "esp32s3", path = "clocks_ll/esp32s3.rs")]
+mod clocks_ll;
+
+/// CPU clock speed
+#[derive(Debug, Clone, Copy)]
+pub enum CpuClock {
+    Clock80MHz,
+    Clock160MHz,
+    #[cfg(not(feature = "esp32c3"))]
+    Clock240MHz,
+}
+
+#[allow(dead_code)]
+impl CpuClock {
+    fn frequency(&self) -> MegahertzU32 {
+        match self {
+            CpuClock::Clock80MHz => MegahertzU32::MHz(80),
+            CpuClock::Clock160MHz => MegahertzU32::MHz(160),
+            #[cfg(not(feature = "esp32c3"))]
+            CpuClock::Clock240MHz => MegahertzU32::MHz(240),
+        }
+    }
+
+    fn mhz(&self) -> u32 {
+        match self {
+            CpuClock::Clock80MHz => 80,
+            CpuClock::Clock160MHz => 160,
+            #[cfg(not(feature = "esp32c3"))]
+            CpuClock::Clock240MHz => 240,
+        }
+    }
+}
+
 /// Frozen clock frequencies
 ///
 /// The existence of this value indicates that the clock configuration can no
@@ -51,67 +87,122 @@ pub struct ClockControl {
 }
 
 impl ClockControl {
-    /// Use what is considered the default settings after boot.
-    #[cfg(feature = "esp32c3")]
-    #[allow(unused)]
-    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
-        ClockControl {
-            _private: (),
-            desired_rates: RawClocks {
-                cpu_clock: MegahertzU32::MHz(80),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(40),
-            },
-        }
-    }
-
-    #[cfg(feature = "esp32")]
-    #[allow(unused)]
-    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
-        ClockControl {
-            _private: (),
-            desired_rates: RawClocks {
-                cpu_clock: MegahertzU32::MHz(80),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(80),
-            },
-        }
-    }
-
-    #[cfg(feature = "esp32s2")]
-    #[allow(unused)]
-    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
-        ClockControl {
-            _private: (),
-            desired_rates: RawClocks {
-                cpu_clock: MegahertzU32::MHz(80),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(80),
-            },
-        }
-    }
-
-    #[cfg(feature = "esp32s3")]
-    #[allow(unused)]
-    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
-        ClockControl {
-            _private: (),
-            desired_rates: RawClocks {
-                cpu_clock: MegahertzU32::MHz(80),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(40),
-            },
-        }
-    }
-
     /// Applies the clock configuration and returns a Clocks struct that
     /// signifies that the clocks are frozen, and contains the frequencies
     /// used. After this function is called, the clocks can not change
     pub fn freeze(self) -> Clocks {
         Clocks::from_raw_clocks(self.desired_rates)
+    }
+}
+
+#[cfg(feature = "esp32")]
+impl ClockControl {
+    /// Use what is considered the default settings after boot.
+    #[allow(unused)]
+    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(80),
+            },
+        }
+    }
+
+    /// Configure the CPU clock speed.
+    #[allow(unused)]
+    pub fn configure(clock_control: SystemClockControl, cpu_clock_speed: CpuClock) -> ClockControl {
+        // like NuttX use 40M hardcoded - if it turns out to be a problem
+        // we will take care then
+        let xtal_freq = clocks_ll::XtalFrequency::RtcXtalFreq40M;
+        let pll_freq = match cpu_clock_speed {
+            CpuClock::Clock80MHz => clocks_ll::PllFequency::Pll320MHz,
+            CpuClock::Clock160MHz => clocks_ll::PllFequency::Pll320MHz,
+            CpuClock::Clock240MHz => clocks_ll::PllFequency::Pll480MHz,
+        };
+
+        clocks_ll::esp32_rtc_update_to_xtal(xtal_freq, 1);
+        clocks_ll::esp32_rtc_bbpll_enable();
+        clocks_ll::esp32_rtc_bbpll_configure(xtal_freq, pll_freq);
+        clocks_ll::set_cpu_freq(cpu_clock_speed);
+
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: cpu_clock_speed.frequency(),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(40),
+            },
+        }
+    }
+}
+
+#[cfg(feature = "esp32c3")]
+impl ClockControl {
+    /// Use what is considered the default settings after boot.
+    #[allow(unused)]
+    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(40),
+            },
+        }
+    }
+
+    /// Configure the CPU clock speed.
+    #[allow(unused)]
+    pub fn configure(clock_control: SystemClockControl, cpu_clock_speed: CpuClock) -> ClockControl {
+        clocks_ll::set_cpu_clock(cpu_clock_speed);
+
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: cpu_clock_speed.frequency(),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(40),
+            },
+        }
+    }
+}
+
+#[cfg(feature = "esp32s2")]
+impl ClockControl {
+    /// Use what is considered the default settings after boot.
+    #[allow(unused)]
+    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(80),
+            },
+        }
+    }
+}
+
+#[cfg(feature = "esp32s3")]
+impl ClockControl {
+    /// Use what is considered the default settings after boot.
+    #[allow(unused)]
+    pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
+        ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(80),
+                xtal_clock: MegahertzU32::MHz(40),
+                i2c_clock: MegahertzU32::MHz(40),
+            },
+        }
     }
 }

--- a/esp-hal-common/src/clocks_ll/esp32.rs
+++ b/esp-hal-common/src/clocks_ll/esp32.rs
@@ -1,0 +1,381 @@
+use procmacros::ram;
+
+const REF_CLK_FREQ: u32 = 1000000;
+
+const MHZ: u32 = 1000000;
+const UINT16_MAX: u32 = 0xffff;
+
+const RTC_CNTL_DBIAS_1V10: u32 = 4;
+const RTC_CNTL_DBIAS_1V25: u32 = 7;
+
+const DIG_DBIAS_80M_160M: u32 = RTC_CNTL_DBIAS_1V10;
+const DIG_DBIAS_XTAL: u32 = RTC_CNTL_DBIAS_1V10;
+
+const I2C_BBPLL: u32 = 0x66;
+const I2C_BBPLL_HOSTID: u32 = 4;
+
+const I2C_BBPLL_IR_CAL_DELAY: u32 = 0;
+const I2C_BBPLL_IR_CAL_EXT_CAP: u32 = 1;
+const I2C_BBPLL_OC_ENB_FCAL: u32 = 4;
+const I2C_BBPLL_OC_ENB_VCON: u32 = 10;
+const I2C_BBPLL_BBADC_CAL_7_0: u32 = 12;
+
+const BBPLL_IR_CAL_DELAY_VAL: u32 = 0x18;
+const BBPLL_IR_CAL_EXT_CAP_VAL: u32 = 0x20;
+const BBPLL_OC_ENB_FCAL_VAL: u32 = 0x9a;
+const BBPLL_OC_ENB_VCON_VAL: u32 = 0x00;
+const BBPLL_BBADC_CAL_7_0_VAL: u32 = 0x00;
+
+const I2C_BBPLL_ENDIV5: u32 = 11;
+
+const BBPLL_ENDIV5_VAL_320M: u32 = 0x43;
+const BBPLL_BBADC_DSMP_VAL_320M: u32 = 0x84;
+const BBPLL_ENDIV5_VAL_480M: u32 = 0xc3;
+const BBPLL_BBADC_DSMP_VAL_480M: u32 = 0x74;
+
+const I2C_BBPLL_BBADC_DSMP: u32 = 9;
+const I2C_BBPLL_OC_LREF: u32 = 2;
+const I2C_BBPLL_OC_DIV_7_0: u32 = 3;
+const I2C_BBPLL_OC_DCUR: u32 = 5;
+
+#[allow(unused)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum XtalFrequency {
+    RtcXtalFreq40M,
+    RtcXtalFreq26M,
+    RtcXtalFreq24M,
+    RtcXtalFreqOther(u32),
+}
+
+impl XtalFrequency {
+    fn hz(&self) -> u32 {
+        match self {
+            XtalFrequency::RtcXtalFreq40M => 40_000_000,
+            XtalFrequency::RtcXtalFreq26M => 26_000_000,
+            XtalFrequency::RtcXtalFreq24M => 24_000_000,
+            XtalFrequency::RtcXtalFreqOther(mhz) => mhz * MHZ,
+        }
+    }
+}
+
+#[allow(unused)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PllFequency {
+    Pll320MHz,
+    Pll480MHz,
+}
+
+#[ram]
+pub(crate) fn esp32_rtc_bbpll_configure(xtal_freq: XtalFrequency, pll_freq: PllFequency) {
+    let efuse = unsafe { &*crate::pac::EFUSE::ptr() };
+    let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
+
+    unsafe {
+        let rtc_cntl_dbias_hp_volt: u32 =
+            RTC_CNTL_DBIAS_1V25 - efuse.blk0_rdata5.read().rd_vol_level_hp_inv().bits() as u32;
+        let dig_dbias_240_m: u32 = rtc_cntl_dbias_hp_volt;
+
+        let div_ref: u32;
+        let div7_0: u32;
+        let div10_8: u32;
+        let lref: u32;
+        let dcur: u32;
+        let bw: u32;
+        let i2c_bbpll_lref: u32;
+        let i2c_bbpll_div_7_0: u32;
+        let i2c_bbpll_dcur: u32;
+
+        if pll_freq == PllFequency::Pll320MHz {
+            // Raise the voltage, if needed
+            rtc_cntl
+                .reg
+                .modify(|_, w| w.dig_dbias_wak().variant(DIG_DBIAS_80M_160M as u8));
+
+            // Configure 320M PLL
+            match xtal_freq {
+                XtalFrequency::RtcXtalFreq40M => {
+                    div_ref = 0;
+                    div7_0 = 32;
+                    div10_8 = 0;
+                    lref = 0;
+                    dcur = 6;
+                    bw = 3;
+                }
+
+                XtalFrequency::RtcXtalFreq26M => {
+                    div_ref = 12;
+                    div7_0 = 224;
+                    div10_8 = 4;
+                    lref = 1;
+                    dcur = 0;
+                    bw = 1;
+                }
+
+                XtalFrequency::RtcXtalFreq24M => {
+                    div_ref = 11;
+                    div7_0 = 224;
+                    div10_8 = 4;
+                    lref = 1;
+                    dcur = 0;
+                    bw = 1;
+                }
+
+                XtalFrequency::RtcXtalFreqOther(_) => {
+                    div_ref = 12;
+                    div7_0 = 224;
+                    div10_8 = 4;
+                    lref = 0;
+                    dcur = 0;
+                    bw = 0;
+                }
+            }
+
+            i2c_writereg_rtc(
+                I2C_BBPLL,
+                I2C_BBPLL_HOSTID,
+                I2C_BBPLL_ENDIV5,
+                BBPLL_ENDIV5_VAL_320M,
+            );
+            i2c_writereg_rtc(
+                I2C_BBPLL,
+                I2C_BBPLL_HOSTID,
+                I2C_BBPLL_BBADC_DSMP,
+                BBPLL_BBADC_DSMP_VAL_320M,
+            );
+        } else {
+            // Raise the voltage
+            rtc_cntl
+                .reg
+                .modify(|_, w| w.dig_dbias_wak().variant(dig_dbias_240_m as u8));
+
+            // Configure 480M PLL
+            match xtal_freq {
+                XtalFrequency::RtcXtalFreq40M => {
+                    div_ref = 0;
+                    div7_0 = 28;
+                    div10_8 = 0;
+                    lref = 0;
+                    dcur = 6;
+                    bw = 3;
+                }
+
+                XtalFrequency::RtcXtalFreq26M => {
+                    div_ref = 12;
+                    div7_0 = 144;
+                    div10_8 = 4;
+                    lref = 1;
+                    dcur = 0;
+                    bw = 1;
+                }
+
+                XtalFrequency::RtcXtalFreq24M => {
+                    div_ref = 11;
+                    div7_0 = 144;
+                    div10_8 = 4;
+                    lref = 1;
+                    dcur = 0;
+                    bw = 1;
+                }
+
+                XtalFrequency::RtcXtalFreqOther(_) => {
+                    div_ref = 12;
+                    div7_0 = 224;
+                    div10_8 = 4;
+                    lref = 0;
+                    dcur = 0;
+                    bw = 0;
+                }
+            }
+
+            i2c_writereg_rtc(
+                I2C_BBPLL,
+                I2C_BBPLL_HOSTID,
+                I2C_BBPLL_ENDIV5,
+                BBPLL_ENDIV5_VAL_480M,
+            );
+
+            i2c_writereg_rtc(
+                I2C_BBPLL,
+                I2C_BBPLL_HOSTID,
+                I2C_BBPLL_BBADC_DSMP,
+                BBPLL_BBADC_DSMP_VAL_480M,
+            );
+        }
+
+        i2c_bbpll_lref = (lref << 7) | (div10_8 << 4) | (div_ref);
+        i2c_bbpll_div_7_0 = div7_0;
+        i2c_bbpll_dcur = (bw << 6) | dcur;
+        i2c_writereg_rtc(
+            I2C_BBPLL,
+            I2C_BBPLL_HOSTID,
+            I2C_BBPLL_OC_LREF,
+            i2c_bbpll_lref,
+        );
+
+        i2c_writereg_rtc(
+            I2C_BBPLL,
+            I2C_BBPLL_HOSTID,
+            I2C_BBPLL_OC_DIV_7_0,
+            i2c_bbpll_div_7_0,
+        );
+
+        i2c_writereg_rtc(
+            I2C_BBPLL,
+            I2C_BBPLL_HOSTID,
+            I2C_BBPLL_OC_DCUR,
+            i2c_bbpll_dcur,
+        );
+    }
+}
+
+#[ram]
+pub(crate) fn esp32_rtc_bbpll_enable() {
+    let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
+
+    unsafe {
+        rtc_cntl.options0.modify(|_, w| {
+            w.bias_i2c_force_pd()
+                .clear_bit()
+                .bb_i2c_force_pd()
+                .clear_bit()
+                .bbpll_force_pd()
+                .clear_bit()
+                .bbpll_i2c_force_pd()
+                .clear_bit()
+        });
+
+        // reset BBPLL configuration
+        i2c_writereg_rtc(
+            I2C_BBPLL,
+            I2C_BBPLL_HOSTID,
+            I2C_BBPLL_IR_CAL_DELAY,
+            BBPLL_IR_CAL_DELAY_VAL,
+        );
+        i2c_writereg_rtc(
+            I2C_BBPLL,
+            I2C_BBPLL_HOSTID,
+            I2C_BBPLL_IR_CAL_EXT_CAP,
+            BBPLL_IR_CAL_EXT_CAP_VAL,
+        );
+        i2c_writereg_rtc(
+            I2C_BBPLL,
+            I2C_BBPLL_HOSTID,
+            I2C_BBPLL_OC_ENB_FCAL,
+            BBPLL_OC_ENB_FCAL_VAL,
+        );
+        i2c_writereg_rtc(
+            I2C_BBPLL,
+            I2C_BBPLL_HOSTID,
+            I2C_BBPLL_OC_ENB_VCON,
+            BBPLL_OC_ENB_VCON_VAL,
+        );
+        i2c_writereg_rtc(
+            I2C_BBPLL,
+            I2C_BBPLL_HOSTID,
+            I2C_BBPLL_BBADC_CAL_7_0,
+            BBPLL_BBADC_CAL_7_0_VAL,
+        );
+    }
+}
+
+#[inline(always)]
+unsafe fn i2c_writereg_rtc(block: u32, block_hostid: u32, reg_add: u32, indata: u32) {
+    const ROM_I2C_WRITEREG: u32 = 0x400041a4;
+
+    // cast to usize is just needed because of the way we run clippy in CI
+    let rom_i2c_writereg: fn(block: u32, block_hostid: u32, reg_add: u32, indata: u32) -> i32 =
+        core::mem::transmute(ROM_I2C_WRITEREG as usize);
+
+    rom_i2c_writereg(block, block_hostid, reg_add, indata);
+}
+
+#[ram]
+pub(crate) fn esp32_rtc_update_to_xtal(freq: XtalFrequency, _div: u32) {
+    let apb_cntl = unsafe { &*crate::pac::APB_CTRL::ptr() };
+    let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
+
+    unsafe {
+        let value = (((freq.hz()) >> 12) & UINT16_MAX) | ((((freq.hz()) >> 12) & UINT16_MAX) << 16);
+        esp32_update_cpu_freq(freq.hz());
+        // set divider from XTAL to APB clock
+        apb_cntl.sysclk_conf.modify(|_, w| {
+            w.pre_div_cnt()
+                .bits(((freq.hz()) / REF_CLK_FREQ - 1) as u16)
+        });
+
+        // adjust ref_tick
+        apb_cntl.xtal_tick_conf.as_ptr().write_volatile(
+            ((freq.hz()) / REF_CLK_FREQ - 1) | apb_cntl.xtal_tick_conf.as_ptr().read_volatile(),
+        ); // TODO make it RW in SVD
+
+        // switch clock source
+        rtc_cntl.clk_conf.modify(|_, w| w.soc_clk_sel().xtal());
+        rtc_cntl
+            .store5
+            .modify(|_, w| w.scratch5().bits(value as u32));
+
+        // lower the voltage
+        rtc_cntl
+            .reg
+            .modify(|_, w| w.dig_dbias_wak().variant(DIG_DBIAS_XTAL as u8));
+    }
+}
+
+#[ram]
+pub(crate) fn set_cpu_freq(cpu_freq_mhz: crate::clock::CpuClock) {
+    let efuse = unsafe { &*crate::pac::EFUSE::ptr() };
+    let dport = unsafe { &*crate::pac::DPORT::ptr() };
+    let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
+
+    unsafe {
+        const RTC_CNTL_DBIAS_1V25: u32 = 7;
+
+        let rtc_cntl_dbias_hp_volt: u32 =
+            RTC_CNTL_DBIAS_1V25 - efuse.blk0_rdata5.read().rd_vol_level_hp_inv().bits() as u32;
+        let dig_dbias_240_m: u32 = rtc_cntl_dbias_hp_volt;
+
+        const CPU_80M: u32 = 0;
+        const CPU_160M: u32 = 1;
+        const CPU_240M: u32 = 2;
+
+        let mut dbias = DIG_DBIAS_80M_160M;
+        let per_conf;
+
+        match cpu_freq_mhz {
+            crate::clock::CpuClock::Clock160MHz => {
+                per_conf = CPU_160M;
+            }
+            crate::clock::CpuClock::Clock240MHz => {
+                dbias = dig_dbias_240_m;
+                per_conf = CPU_240M;
+            }
+            crate::clock::CpuClock::Clock80MHz => {
+                per_conf = CPU_80M;
+            }
+        }
+
+        let value = (((80 * MHZ) >> 12) & UINT16_MAX) | ((((80 * MHZ) >> 12) & UINT16_MAX) << 16);
+        dport
+            .cpu_per_conf
+            .write(|w| w.cpuperiod_sel().bits(per_conf as u8));
+        rtc_cntl
+            .reg
+            .modify(|_, w| w.dig_dbias_wak().variant(dbias as u8));
+        rtc_cntl.clk_conf.modify(|_, w| w.soc_clk_sel().pll());
+        rtc_cntl
+            .store5
+            .modify(|_, w| w.scratch5().bits(value as u32));
+
+        esp32_update_cpu_freq(cpu_freq_mhz.frequency().to_Hz());
+    }
+}
+
+/// Set the real CPU ticks per us to the ets, so that ets_delay_us
+/// will be accurate. Call this function when CPU frequency is changed.
+fn esp32_update_cpu_freq(ticks_per_us: u32) {
+    const G_TICKS_PER_US_PRO: u32 = 0x3ffe01e0;
+    unsafe {
+        // Update scale factors used by esp_rom_delay_us
+        *(G_TICKS_PER_US_PRO as *mut u32) = ticks_per_us;
+    }
+}

--- a/esp-hal-common/src/clocks_ll/esp32.rs
+++ b/esp-hal-common/src/clocks_ll/esp32.rs
@@ -1,5 +1,3 @@
-use procmacros::ram;
-
 const REF_CLK_FREQ: u32 = 1000000;
 
 const MHZ: u32 = 1000000;
@@ -65,7 +63,6 @@ pub(crate) enum PllFequency {
     Pll480MHz,
 }
 
-#[ram]
 pub(crate) fn esp32_rtc_bbpll_configure(xtal_freq: XtalFrequency, pll_freq: PllFequency) {
     let efuse = unsafe { &*crate::pac::EFUSE::ptr() };
     let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
@@ -228,7 +225,6 @@ pub(crate) fn esp32_rtc_bbpll_configure(xtal_freq: XtalFrequency, pll_freq: PllF
     }
 }
 
-#[ram]
 pub(crate) fn esp32_rtc_bbpll_enable() {
     let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
 
@@ -289,7 +285,6 @@ unsafe fn i2c_writereg_rtc(block: u32, block_hostid: u32, reg_add: u32, indata: 
     rom_i2c_writereg(block, block_hostid, reg_add, indata);
 }
 
-#[ram]
 pub(crate) fn esp32_rtc_update_to_xtal(freq: XtalFrequency, _div: u32) {
     let apb_cntl = unsafe { &*crate::pac::APB_CTRL::ptr() };
     let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
@@ -321,7 +316,6 @@ pub(crate) fn esp32_rtc_update_to_xtal(freq: XtalFrequency, _div: u32) {
     }
 }
 
-#[ram]
 pub(crate) fn set_cpu_freq(cpu_freq_mhz: crate::clock::CpuClock) {
     let efuse = unsafe { &*crate::pac::EFUSE::ptr() };
     let dport = unsafe { &*crate::pac::DPORT::ptr() };
@@ -376,6 +370,6 @@ fn esp32_update_cpu_freq(ticks_per_us: u32) {
     const G_TICKS_PER_US_PRO: u32 = 0x3ffe01e0;
     unsafe {
         // Update scale factors used by esp_rom_delay_us
-        *(G_TICKS_PER_US_PRO as *mut u32) = ticks_per_us;
+        (G_TICKS_PER_US_PRO as *mut u32).write_volatile(ticks_per_us);
     }
 }

--- a/esp-hal-common/src/clocks_ll/esp32c3.rs
+++ b/esp-hal-common/src/clocks_ll/esp32c3.rs
@@ -1,0 +1,20 @@
+use crate::clock::CpuClock;
+
+pub(crate) fn set_cpu_clock(cpu_clock_speed: CpuClock) {
+    let system_control = crate::pac::SYSTEM::PTR;
+
+    unsafe {
+        (&*system_control)
+            .sysclk_conf
+            .modify(|_, w| w.soc_clk_sel().bits(1));
+        (&*system_control).cpu_per_conf.modify(|_, w| {
+            w.pll_freq_sel()
+                .set_bit()
+                .cpuperiod_sel()
+                .bits(match cpu_clock_speed {
+                    CpuClock::Clock80MHz => 0,
+                    CpuClock::Clock160MHz => 1,
+                })
+        });
+    }
+}

--- a/esp-hal-common/src/clocks_ll/esp32s2.rs
+++ b/esp-hal-common/src/clocks_ll/esp32s2.rs
@@ -1,0 +1,1 @@
+// unused for now

--- a/esp-hal-common/src/clocks_ll/esp32s3.rs
+++ b/esp-hal-common/src/clocks_ll/esp32s3.rs
@@ -1,0 +1,1 @@
+// unused for now


### PR DESCRIPTION
This adds a way to configure the CPU clock for ESP32 and ESP32-C3 to 80,160 and for the ESP32 to 240 MHz.

Other chips will follow in separate PR(s)

Unfortunately, on the Xtensas we need a ROM function - maybe we can replace it someday but for now I think it's okay
Also, on ESP32 the code assumes 40MHz XTAL - it's the same thing that NuttX does so I guess it's fine for now and I we ever run into issues we can extend the code.

This is a non-breaking change.

I didn't add any examples for this since they would be pretty boring