### PR TITLE
procmacros: Replace `then_some`

### DIFF
--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -225,7 +225,7 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
     };
 
     let context_call =
-        (f.sig.inputs.len() == 1).then_some(Ident::new("context", proc_macro2::Span::call_site()));
+        (f.sig.inputs.len() == 1).then(|| Ident::new("context", proc_macro2::Span::call_site()));
 
     quote!(
         #(#cfgs)*


### PR DESCRIPTION
which was just [recently stabilized in rust 1.62.0][1] and hence raises
the MSRV to 1.62.0 for all HALs. Use `bool::then` instead, which takes a
closure instead of a parameter but has the same effect otherwise and is
available [since rust 1.50.0][2].

Fixes #131 

[1]: https://github.com/rust-lang/rust/pull/96628
[2]: https://doc.rust-lang.org/stable/std/primitive.bool.html#method.then