### PR TITLE
ESP32-C3: Add driver for RTC Watchdog Timer (RWDT)

### DIFF
--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -118,9 +118,9 @@ impl ClockControl {
         // we will take care then
         let xtal_freq = clocks_ll::XtalFrequency::RtcXtalFreq40M;
         let pll_freq = match cpu_clock_speed {
-            CpuClock::Clock80MHz => clocks_ll::PllFequency::Pll320MHz,
-            CpuClock::Clock160MHz => clocks_ll::PllFequency::Pll320MHz,
-            CpuClock::Clock240MHz => clocks_ll::PllFequency::Pll480MHz,
+            CpuClock::Clock80MHz => clocks_ll::PllFrequency::Pll320MHz,
+            CpuClock::Clock160MHz => clocks_ll::PllFrequency::Pll320MHz,
+            CpuClock::Clock240MHz => clocks_ll::PllFrequency::Pll480MHz,
         };
 
         clocks_ll::esp32_rtc_update_to_xtal(xtal_freq, 1);

--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -1,5 +1,5 @@
 //! # Clock Control
-use fugit::MegahertzU32;
+use fugit::HertzU32;
 
 use crate::system::SystemClockControl;
 
@@ -10,7 +10,7 @@ use crate::system::SystemClockControl;
 mod clocks_ll;
 
 pub trait Clock {
-    fn frequency(&self) -> MegahertzU32;
+    fn frequency(&self) -> HertzU32;
 
     fn mhz(&self) -> u32 {
         self.frequency().to_MHz()
@@ -32,12 +32,12 @@ pub enum CpuClock {
 
 #[allow(dead_code)]
 impl Clock for CpuClock {
-    fn frequency(&self) -> MegahertzU32 {
+    fn frequency(&self) -> HertzU32 {
         match self {
-            CpuClock::Clock80MHz => MegahertzU32::MHz(80),
-            CpuClock::Clock160MHz => MegahertzU32::MHz(160),
+            CpuClock::Clock80MHz => HertzU32::MHz(80),
+            CpuClock::Clock160MHz => HertzU32::MHz(160),
             #[cfg(not(feature = "esp32c3"))]
-            CpuClock::Clock240MHz => MegahertzU32::MHz(240),
+            CpuClock::Clock240MHz => HertzU32::MHz(240),
         }
     }
 }
@@ -56,16 +56,16 @@ pub(crate) enum XtalClock {
 }
 
 impl Clock for XtalClock {
-    fn frequency(&self) -> MegahertzU32 {
+    fn frequency(&self) -> HertzU32 {
         match self {
-            XtalClock::RtcXtalFreq40M => MegahertzU32::MHz(40),
+            XtalClock::RtcXtalFreq40M => HertzU32::MHz(40),
             #[cfg(feature = "esp32")]
-            XtalClock::RtcXtalFreq26M => MegahertzU32::MHz(26),
+            XtalClock::RtcXtalFreq26M => HertzU32::MHz(26),
             #[cfg(feature = "esp32")]
-            XtalClock::RtcXtalFreq24M => MegahertzU32::MHz(24),
+            XtalClock::RtcXtalFreq24M => HertzU32::MHz(24),
             #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
-            XtalClock::RtcXtalFreq32M => MegahertzU32::MHz(32),
-            XtalClock::RtcXtalFreqOther(mhz) => MegahertzU32::MHz(*mhz),
+            XtalClock::RtcXtalFreq32M => HertzU32::MHz(32),
+            XtalClock::RtcXtalFreqOther(mhz) => HertzU32::MHz(*mhz),
         }
     }
 }
@@ -85,10 +85,10 @@ pub(crate) enum ApbClock {
 }
 
 impl Clock for ApbClock {
-    fn frequency(&self) -> MegahertzU32 {
+    fn frequency(&self) -> HertzU32 {
         match self {
-            ApbClock::ApbFreq80MHz => MegahertzU32::MHz(80),
-            ApbClock::ApbFreqOther(mhz) => MegahertzU32::MHz(*mhz),
+            ApbClock::ApbFreq80MHz => HertzU32::MHz(80),
+            ApbClock::ApbFreqOther(mhz) => HertzU32::MHz(*mhz),
         }
     }
 }
@@ -99,10 +99,10 @@ impl Clock for ApbClock {
 /// longer be changed
 pub struct Clocks {
     _private: (),
-    pub cpu_clock: MegahertzU32,
-    pub apb_clock: MegahertzU32,
-    pub xtal_clock: MegahertzU32,
-    pub i2c_clock: MegahertzU32,
+    pub cpu_clock: HertzU32,
+    pub apb_clock: HertzU32,
+    pub xtal_clock: HertzU32,
+    pub i2c_clock: HertzU32,
     // TODO chip specific additional ones as needed
 }
 
@@ -125,10 +125,10 @@ impl Clocks {
 
 #[doc(hidden)]
 pub struct RawClocks {
-    pub cpu_clock: MegahertzU32,
-    pub apb_clock: MegahertzU32,
-    pub xtal_clock: MegahertzU32,
-    pub i2c_clock: MegahertzU32,
+    pub cpu_clock: HertzU32,
+    pub apb_clock: HertzU32,
+    pub xtal_clock: HertzU32,
+    pub i2c_clock: HertzU32,
     // TODO chip specific additional ones as needed
 }
 /// Used to configure the frequencies of the clocks present in the chip.
@@ -157,10 +157,10 @@ impl ClockControl {
         ClockControl {
             _private: (),
             desired_rates: RawClocks {
-                cpu_clock: MegahertzU32::MHz(80),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(80),
+                cpu_clock: HertzU32::MHz(80),
+                apb_clock: HertzU32::MHz(80),
+                xtal_clock: HertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(80),
             },
         }
     }
@@ -186,9 +186,9 @@ impl ClockControl {
             _private: (),
             desired_rates: RawClocks {
                 cpu_clock: cpu_clock_speed.frequency(),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(40),
+                apb_clock: HertzU32::MHz(80),
+                xtal_clock: HertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -202,10 +202,10 @@ impl ClockControl {
         ClockControl {
             _private: (),
             desired_rates: RawClocks {
-                cpu_clock: MegahertzU32::MHz(80),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(40),
+                cpu_clock: HertzU32::MHz(80),
+                apb_clock: HertzU32::MHz(80),
+                xtal_clock: HertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -235,7 +235,7 @@ impl ClockControl {
                 cpu_clock: cpu_clock_speed.frequency(),
                 apb_clock: apb_freq.frequency(),
                 xtal_clock: xtal_freq.frequency(),
-                i2c_clock: MegahertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -249,10 +249,10 @@ impl ClockControl {
         ClockControl {
             _private: (),
             desired_rates: RawClocks {
-                cpu_clock: MegahertzU32::MHz(80),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(80),
+                cpu_clock: HertzU32::MHz(80),
+                apb_clock: HertzU32::MHz(80),
+                xtal_clock: HertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(80),
             },
         }
     }
@@ -266,9 +266,9 @@ impl ClockControl {
             _private: (),
             desired_rates: RawClocks {
                 cpu_clock: cpu_clock_speed.frequency(),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(40),
+                apb_clock: HertzU32::MHz(80),
+                xtal_clock: HertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -282,10 +282,10 @@ impl ClockControl {
         ClockControl {
             _private: (),
             desired_rates: RawClocks {
-                cpu_clock: MegahertzU32::MHz(80),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(40),
+                cpu_clock: HertzU32::MHz(80),
+                apb_clock: HertzU32::MHz(80),
+                xtal_clock: HertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -299,9 +299,9 @@ impl ClockControl {
             _private: (),
             desired_rates: RawClocks {
                 cpu_clock: cpu_clock_speed.frequency(),
-                apb_clock: MegahertzU32::MHz(80),
-                xtal_clock: MegahertzU32::MHz(40),
-                i2c_clock: MegahertzU32::MHz(40),
+                apb_clock: HertzU32::MHz(80),
+                xtal_clock: HertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(40),
             },
         }
     }

--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -159,13 +159,20 @@ impl ClockControl {
     /// Configure the CPU clock speed.
     #[allow(unused)]
     pub fn configure(clock_control: SystemClockControl, cpu_clock_speed: CpuClock) -> ClockControl {
-        clocks_ll::set_cpu_clock(cpu_clock_speed);
+        let apb_freq = clocks_ll::ApbFrequency::ApbFreq80MHz;
+        let xtal_freq = clocks_ll::XtalFrequency::RtcXtalFreq40M;
+        let pll_freq = clocks_ll::PllFrequency::Pll480MHz;
+
+        clocks_ll::esp32c3_rtc_bbpll_enable();
+        clocks_ll::esp32c3_rtc_bbpll_configure(xtal_freq, pll_freq);
+        clocks_ll::esp32c3_rtc_freq_to_pll_mhz(cpu_clock_speed);
+        clocks_ll::esp32c3_rtc_apb_freq_update(apb_freq);
 
         ClockControl {
             _private: (),
             desired_rates: RawClocks {
                 cpu_clock: cpu_clock_speed.frequency(),
-                apb_clock: MegahertzU32::MHz(80),
+                apb_clock: MegahertzU32::MHz(apb_freq.mhz()),
                 xtal_clock: MegahertzU32::MHz(40),
                 i2c_clock: MegahertzU32::MHz(40),
             },

--- a/esp-hal-common/src/clocks_ll/esp32.rs
+++ b/esp-hal-common/src/clocks_ll/esp32.rs
@@ -58,12 +58,12 @@ impl XtalFrequency {
 
 #[allow(unused)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PllFequency {
+pub(crate) enum PllFrequency {
     Pll320MHz,
     Pll480MHz,
 }
 
-pub(crate) fn esp32_rtc_bbpll_configure(xtal_freq: XtalFrequency, pll_freq: PllFequency) {
+pub(crate) fn esp32_rtc_bbpll_configure(xtal_freq: XtalFrequency, pll_freq: PllFrequency) {
     let efuse = unsafe { &*crate::pac::EFUSE::ptr() };
     let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
 
@@ -82,7 +82,7 @@ pub(crate) fn esp32_rtc_bbpll_configure(xtal_freq: XtalFrequency, pll_freq: PllF
         let i2c_bbpll_div_7_0: u32;
         let i2c_bbpll_dcur: u32;
 
-        if pll_freq == PllFequency::Pll320MHz {
+        if pll_freq == PllFrequency::Pll320MHz {
             // Raise the voltage, if needed
             rtc_cntl
                 .reg

--- a/esp-hal-common/src/clocks_ll/esp32c3.rs
+++ b/esp-hal-common/src/clocks_ll/esp32c3.rs
@@ -1,20 +1,280 @@
+use paste::paste;
+
 use crate::clock::CpuClock;
 
-pub(crate) fn set_cpu_clock(cpu_clock_speed: CpuClock) {
-    let system_control = unsafe { &*crate::pac::SYSTEM::PTR };
+use crate::rom::{ets_update_cpu_frequency, regi2c_ctrl_write_reg, regi2c_ctrl_write_reg_mask};
+use crate::{regi2c_write, regi2c_write_mask};
+
+const MHZ: u32 = 1_000_000;
+
+const I2C_BBPLL: u32 = 0x66;
+const I2C_BBPLL_HOSTID: u32 = 0;
+
+const I2C_BBPLL_MODE_HF: u32 = 4;
+
+const I2C_BBPLL_OC_REF_DIV: u32 = 2;
+const I2C_BBPLL_OC_DCHGP_LSB: u32 = 4;
+const I2C_BBPLL_OC_DIV_7_0: u32 = 3;
+
+const I2C_BBPLL_OC_DR1: u32 = 5;
+const I2C_BBPLL_OC_DR1_MSB: u32 = 2;
+const I2C_BBPLL_OC_DR1_LSB: u32 = 0;
+
+const I2C_BBPLL_OC_DR3: u32 = 5;
+const I2C_BBPLL_OC_DR3_MSB: u32 = 6;
+const I2C_BBPLL_OC_DR3_LSB: u32 = 4;
+
+const I2C_BBPLL_OC_DCUR: u32 = 6;
+
+const I2C_BBPLL_OC_VCO_DBIAS: u32 = 9;
+const I2C_BBPLL_OC_VCO_DBIAS_MSB: u32 = 1;
+const I2C_BBPLL_OC_VCO_DBIAS_LSB: u32 = 0;
+
+const I2C_BBPLL_OC_DHREF_SEL: u32 = 6;
+const I2C_BBPLL_OC_DHREF_SEL_MSB: u32 = 5;
+const I2C_BBPLL_OC_DHREF_SEL_LSB: u32 = 4;
+
+const I2C_BBPLL_OC_DLREF_SEL: u32 = 6;
+const I2C_BBPLL_OC_DLREF_SEL_MSB: u32 = 7;
+const I2C_BBPLL_OC_DLREF_SEL_LSB: u32 = 6;
+
+const I2C_MST_ANA_CONF0_REG: u32 = 0x6000_e040;
+const I2C_MST_BBPLL_STOP_FORCE_HIGH: u32 = 1 << 3;
+const I2C_MST_BBPLL_STOP_FORCE_LOW: u32 = 1 << 2;
+
+#[allow(unused)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum XtalFrequency {
+    RtcXtalFreq40M,
+    RtcXtalFreq32M,
+    RtcXtalFreqOther(u32),
+}
+
+impl XtalFrequency {
+    pub(crate) fn mhz(&self) -> u32 {
+        match self {
+            XtalFrequency::RtcXtalFreq40M => 40,
+            XtalFrequency::RtcXtalFreq32M => 32,
+            XtalFrequency::RtcXtalFreqOther(mhz) => *mhz,
+        }
+    }
+}
+
+#[allow(unused)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PllFrequency {
+    Pll320MHz,
+    Pll480MHz,
+}
+
+#[allow(unused)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApbFrequency {
+    ApbFreq80MHz,
+    ApbFreqOther(u32),
+}
+
+impl ApbFrequency {
+    pub(crate) fn mhz(&self) -> u32 {
+        match self {
+            ApbFrequency::ApbFreq80MHz => 80,
+            ApbFrequency::ApbFreqOther(mhz) => *mhz,
+        }
+    }
+
+    fn hz(&self) -> u32 {
+        self.mhz() * MHZ
+    }
+}
+
+pub(crate) fn esp32c3_rtc_bbpll_configure(xtal_freq: XtalFrequency, pll_freq: PllFrequency) {
+    let system = unsafe { &*crate::pac::SYSTEM::ptr() };
+
+    unsafe {
+        let div_ref: u32;
+        let div7_0: u32;
+        let dr1: u32;
+        let dr3: u32;
+        let dchgp: u32;
+        let dcur: u32;
+        let dbias: u32;
+        let i2c_bbpll_lref: u32;
+        let i2c_bbpll_div_7_0: u32;
+        let i2c_bbpll_dcur: u32;
+
+        let clear_reg_mask = |reg, mask: u32| {
+            (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask)
+        };
+        let set_reg_mask = |reg, mask: u32| {
+            (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask)
+        };
+
+        clear_reg_mask(I2C_MST_ANA_CONF0_REG, I2C_MST_BBPLL_STOP_FORCE_HIGH);
+        set_reg_mask(I2C_MST_ANA_CONF0_REG, I2C_MST_BBPLL_STOP_FORCE_LOW);
+
+        if pll_freq == PllFrequency::Pll480MHz {
+            // Set this register to let the digital part know 480M PLL is used
+            system
+                .cpu_per_conf
+                .modify(|_, w| w.pll_freq_sel().set_bit());
+
+            // Configure 480M PLL
+            match xtal_freq {
+                XtalFrequency::RtcXtalFreq40M => {
+                    div_ref = 0;
+                    div7_0 = 8;
+                    dr1 = 0;
+                    dr3 = 0;
+                    dchgp = 5;
+                    dcur = 3;
+                    dbias = 2;
+                }
+
+                XtalFrequency::RtcXtalFreq32M => {
+                    div_ref = 1;
+                    div7_0 = 26;
+                    dr1 = 1;
+                    dr3 = 1;
+                    dchgp = 4;
+                    dcur = 0;
+                    dbias = 2;
+                }
+
+                XtalFrequency::RtcXtalFreqOther(_) => {
+                    div_ref = 0;
+                    div7_0 = 8;
+                    dr1 = 0;
+                    dr3 = 0;
+                    dchgp = 5;
+                    dcur = 3;
+                    dbias = 2;
+                }
+            }
+
+            regi2c_write!(I2C_BBPLL, I2C_BBPLL_MODE_HF, 0x6b);
+        } else {
+            // Clear this register to let the digital part know 320M PLL is used
+            system
+                .cpu_per_conf
+                .modify(|_, w| w.pll_freq_sel().clear_bit());
+
+            // Configure 320M PLL
+            match xtal_freq {
+                XtalFrequency::RtcXtalFreq40M => {
+                    div_ref = 0;
+                    div7_0 = 4;
+                    dr1 = 0;
+                    dr3 = 0;
+                    dchgp = 5;
+                    dcur = 3;
+                    dbias = 2;
+                }
+
+                XtalFrequency::RtcXtalFreq32M => {
+                    div_ref = 1;
+                    div7_0 = 6;
+                    dr1 = 0;
+                    dr3 = 0;
+                    dchgp = 5;
+                    dcur = 3;
+                    dbias = 2;
+                }
+
+                XtalFrequency::RtcXtalFreqOther(_) => {
+                    div_ref = 0;
+                    div7_0 = 4;
+                    dr1 = 0;
+                    dr3 = 0;
+                    dchgp = 5;
+                    dcur = 3;
+                    dbias = 2;
+                }
+            }
+
+            regi2c_write!(I2C_BBPLL, I2C_BBPLL_MODE_HF, 0x69);
+        }
+
+        i2c_bbpll_lref = (dchgp << I2C_BBPLL_OC_DCHGP_LSB) | div_ref;
+        i2c_bbpll_div_7_0 = div7_0;
+        i2c_bbpll_dcur =
+            (2 << I2C_BBPLL_OC_DLREF_SEL_LSB) | (1 << I2C_BBPLL_OC_DHREF_SEL_LSB) | dcur;
+
+        regi2c_write!(I2C_BBPLL, I2C_BBPLL_OC_REF_DIV, i2c_bbpll_lref);
+
+        regi2c_write!(I2C_BBPLL, I2C_BBPLL_OC_DIV_7_0, i2c_bbpll_div_7_0);
+
+        regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_DR1, dr1);
+
+        regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_DR3, dr3);
+
+        regi2c_write!(I2C_BBPLL, I2C_BBPLL_OC_DCUR, i2c_bbpll_dcur);
+
+        regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_VCO_DBIAS, dbias);
+
+        regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_DHREF_SEL, 2);
+
+        regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_DLREF_SEL, 1);
+    }
+}
+
+pub(crate) fn esp32c3_rtc_bbpll_enable() {
+    let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
+
+    rtc_cntl.options0.modify(|_, w| {
+        w.bb_i2c_force_pd()
+            .clear_bit()
+            .bbpll_force_pd()
+            .clear_bit()
+            .bbpll_i2c_force_pd()
+            .clear_bit()
+    });
+}
+
+pub(crate) fn esp32c3_rtc_update_to_xtal(freq: XtalFrequency, _div: u32) {
+    let system_control = unsafe { &*crate::pac::SYSTEM::ptr() };
+
+    unsafe {
+        ets_update_cpu_frequency(freq.mhz());
+        // Set divider from XTAL to APB clock. Need to set divider to 1 (reg. value 0) first.
+        system_control.sysclk_conf.modify(|_, w| {
+            w.pre_div_cnt()
+                .bits(0)
+                .pre_div_cnt()
+                .bits((_div - 1) as u16)
+        });
+
+        // No need to adjust the REF_TICK
+
+        // Switch clock source
+        system_control
+            .sysclk_conf
+            .modify(|_, w| w.soc_clk_sel().bits(0));
+    }
+}
+
+pub(crate) fn esp32c3_rtc_freq_to_pll_mhz(cpu_clock_speed: CpuClock) {
+    let system_control = unsafe { &*crate::pac::SYSTEM::ptr() };
 
     unsafe {
         system_control
             .sysclk_conf
-            .modify(|_, w| w.soc_clk_sel().bits(1));
+            .modify(|_, w| w.pre_div_cnt().bits(0).soc_clk_sel().bits(1));
         system_control.cpu_per_conf.modify(|_, w| {
-            w.pll_freq_sel()
-                .set_bit()
-                .cpuperiod_sel()
-                .bits(match cpu_clock_speed {
-                    CpuClock::Clock80MHz => 0,
-                    CpuClock::Clock160MHz => 1,
-                })
+            w.cpuperiod_sel().bits(match cpu_clock_speed {
+                CpuClock::Clock80MHz => 0,
+                CpuClock::Clock160MHz => 1,
+            })
         });
+        ets_update_cpu_frequency(cpu_clock_speed.mhz());
     }
+}
+
+pub(crate) fn esp32c3_rtc_apb_freq_update(apb_freq: ApbFrequency) {
+    let rtc_cntl = unsafe { &*crate::pac::RTC_CNTL::ptr() };
+    let value = ((apb_freq.hz() >> 12) & u16::MAX as u32)
+        | (((apb_freq.hz() >> 12) & u16::MAX as u32) << 16);
+
+    rtc_cntl
+        .store5
+        .modify(|_, w| unsafe { w.rtc_scratch5().bits(value) });
 }

--- a/esp-hal-common/src/efuse/esp32.rs
+++ b/esp-hal-common/src/efuse/esp32.rs
@@ -73,7 +73,7 @@ impl Efuse {
     ///
     /// Note that the actual clock may be lower, depending on the current power
     /// configuration of the chip, clock source, and other settings.
-    pub fn get_max_cpu_fequency() -> HertzU32 {
+    pub fn get_max_cpu_frequency() -> HertzU32 {
         let efuse = unsafe { &*EFUSE::ptr() };
 
         let has_rating = efuse.blk0_rdata3.read().rd_chip_cpu_freq_rated().bit();

--- a/esp-hal-common/src/efuse/esp32c3.rs
+++ b/esp-hal-common/src/efuse/esp32c3.rs
@@ -53,4 +53,10 @@ impl Efuse {
             % 2)
             != 0
     }
+
+    /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
+    pub fn get_rwdt_multiplier() -> u8 {
+        let efuse = unsafe { &*EFUSE::ptr() };
+        efuse.rd_repeat_data1.read().wdt_delay_sel().bits()
+    }
 }

--- a/esp-hal-common/src/efuse/esp32s2.rs
+++ b/esp-hal-common/src/efuse/esp32s2.rs
@@ -53,4 +53,10 @@ impl Efuse {
             % 2)
             != 0
     }
+
+    /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
+    pub fn get_rwdt_multiplier() -> u8 {
+        let efuse = unsafe { &*EFUSE::ptr() };
+        efuse.rd_repeat_data1.read().wdt_delay_sel().bits()
+    }
 }

--- a/esp-hal-common/src/efuse/esp32s3.rs
+++ b/esp-hal-common/src/efuse/esp32s3.rs
@@ -53,4 +53,10 @@ impl Efuse {
             % 2)
             != 0
     }
+
+    /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
+    pub fn get_rwdt_multiplier() -> u8 {
+        let efuse = unsafe { &*EFUSE::ptr() };
+        efuse.rd_repeat_data1.read().wdt_delay_sel().bits()
+    }
 }

--- a/esp-hal-common/src/ledc/timer.rs
+++ b/esp-hal-common/src/ledc/timer.rs
@@ -1,4 +1,4 @@
-use fugit::MegahertzU32;
+use fugit::HertzU32;
 
 #[cfg(feature = "esp32")]
 use super::HighSpeed;
@@ -101,7 +101,7 @@ impl TimerSpeed for HighSpeed {
 /// Interface for Timers
 pub trait TimerIFace<S: TimerSpeed> {
     /// Return the frequency of the timer
-    fn get_freq(&self) -> Option<MegahertzU32>;
+    fn get_freq(&self) -> Option<HertzU32>;
 
     /// Configure the timer
     fn configure(&mut self, config: config::Config<S::ClockSourceType>) -> Result<(), Error>;
@@ -119,7 +119,7 @@ pub trait TimerIFace<S: TimerSpeed> {
 /// Interface for HW configuration of timer
 pub trait TimerHW<S: TimerSpeed> {
     /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<MegahertzU32>;
+    fn get_freq_hw(&self) -> Option<HertzU32>;
 
     /// Configure the HW for the timer
     fn configure_hw(&self, divisor: u32);
@@ -144,7 +144,7 @@ where
     Timer<'a, S>: TimerHW<S>,
 {
     /// Return the frequency of the timer
-    fn get_freq(&self) -> Option<MegahertzU32> {
+    fn get_freq(&self) -> Option<HertzU32> {
         self.get_freq_hw()
     }
 
@@ -216,7 +216,7 @@ impl<'a, S: TimerSpeed> Timer<'a, S> {
 /// Timer HW implementation for LowSpeed timers
 impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
     /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<MegahertzU32> {
+    fn get_freq_hw(&self) -> Option<fugit::HertzU32> {
         self.clock_source.map(|cs| match cs {
             LSClockSource::APBClk => self.clock_control_config.apb_clock,
         })
@@ -365,7 +365,7 @@ impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
 /// Timer HW implementation for HighSpeed timers
 impl<'a> TimerHW<HighSpeed> for Timer<'a, HighSpeed> {
     /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<MegahertzU32> {
+    fn get_freq_hw(&self) -> Option<HertzU32> {
         self.clock_source.map(|cs| match cs {
             // TODO RefTick HSClockSource::RefTick => self.clock_control_config.apb_clock,
             HSClockSource::APBClk => self.clock_control_config.apb_clock,

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -44,6 +44,7 @@ pub mod ledc;
 pub mod prelude;
 pub mod pulse_control;
 pub mod rng;
+pub mod rom;
 pub mod rtc_cntl;
 pub mod serial;
 pub mod spi;

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -59,7 +59,7 @@ pub use interrupt::*;
 pub use procmacros as macros;
 pub use pulse_control::PulseControl;
 pub use rng::Rng;
-pub use rtc_cntl::RtcCntl;
+pub use rtc_cntl::{Rtc, Rwdt};
 pub use serial::Serial;
 pub use spi::Spi;
 pub use timer::Timer;

--- a/esp-hal-common/src/rom.rs
+++ b/esp-hal-common/src/rom.rs
@@ -1,0 +1,121 @@
+pub use paste::paste;
+
+/// Pauses execution for us microseconds
+#[inline(always)]
+pub unsafe fn esp_rom_delay_us(us: u32) {
+    #[cfg(feature = "esp32")]
+    const ESP_ROM_DELAY_US: u32 = 0x4000_8534;
+    #[cfg(feature = "esp32s2")]
+    const ESP_ROM_DELAY_US: u32 = 0x4000_d888;
+    #[cfg(feature = "esp32s3")]
+    const ESP_ROM_DELAY_US: u32 = 0x4000_0600;
+    #[cfg(feature = "esp32c3")]
+    const ESP_ROM_DELAY_US: u32 = 0x4000_0050;
+
+    // cast to usize is just needed because of the way we run clippy in CI
+    let fn_esp_rom_delay_us: fn(us: u32) = core::mem::transmute(ESP_ROM_DELAY_US as usize);
+
+    fn_esp_rom_delay_us(us);
+}
+
+#[inline(always)]
+/// Set the real CPU ticks per us to the ets, so that ets_delay_us
+/// will be accurate. Call this function when CPU frequency is changed.
+pub unsafe fn ets_update_cpu_frequency(ticks_per_us: u32) {
+    #[cfg(feature = "esp32")]
+    const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x4000_8550;
+    #[cfg(feature = "esp32s2")]
+    const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x4000_d8a4;
+    #[cfg(feature = "esp32s3")]
+    const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x4004_3164;
+    #[cfg(feature = "esp32c3")]
+    const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x4000_0588;
+
+    // cast to usize is just needed because of the way we run clippy in CI
+    let rom_ets_update_cpu_frequency: fn(ticks_per_us: u32) =
+        core::mem::transmute(ETS_UPDATE_CPU_FREQUENCY as usize);
+
+    rom_ets_update_cpu_frequency(ticks_per_us);
+}
+
+#[inline(always)]
+pub unsafe fn regi2c_ctrl_write_reg(block: u32, block_hostid: u32, reg_add: u32, indata: u32) {
+    #[cfg(feature = "esp32")]
+    const ROM_I2C_WRITEREG: u32 = 0x4000_41a4;
+    #[cfg(feature = "esp32s2")]
+    const ROM_I2C_WRITEREG: u32 = 0x4000_a9a8;
+    #[cfg(feature = "esp32s3")]
+    const ROM_I2C_WRITEREG: u32 = 0x4000_5d60;
+    #[cfg(feature = "esp32c3")]
+    const ROM_I2C_WRITEREG: u32 = 0x4000_195c;
+
+    // cast to usize is just needed because of the way we run clippy in CI
+    let i2c_write_reg_raw: fn(block: u32, block_hostid: u32, reg_add: u32, indata: u32) -> i32 =
+        core::mem::transmute(ROM_I2C_WRITEREG as usize);
+
+    i2c_write_reg_raw(block, block_hostid, reg_add, indata);
+}
+
+#[macro_export]
+macro_rules! regi2c_write {
+    ( $block: ident, $reg_add: ident, $indata: expr ) => {
+        paste! {
+            regi2c_ctrl_write_reg($block,
+                [<$block _HOSTID>],
+                $reg_add,
+                $indata);
+        }
+    };
+}
+
+#[inline(always)]
+pub unsafe fn regi2c_ctrl_write_reg_mask(
+    block: u32,
+    block_hostid: u32,
+    reg_add: u32,
+    reg_add_msb: u32,
+    reg_add_lsb: u32,
+    indata: u32,
+) {
+    #[cfg(feature = "esp32")]
+    const ROM_I2C_WRITEREG_MASK: u32 = 0x4000_41fc;
+    #[cfg(feature = "esp32s2")]
+    const ROM_I2C_WRITEREG_MASK: u32 = 0x4000_aa00;
+    #[cfg(feature = "esp32s3")]
+    const ROM_I2C_WRITEREG_MASK: u32 = 0x4000_5d6c;
+    #[cfg(feature = "esp32c3")]
+    const ROM_I2C_WRITEREG_MASK: u32 = 0x4000_1960;
+
+    // cast to usize is just needed because of the way we run clippy in CI
+    let i2c_write_reg_mask_raw: fn(
+        block: u32,
+        block_hostid: u32,
+        reg_add: u32,
+        reg_add_msb: u32,
+        reg_add_lsb: u32,
+        indata: u32,
+    ) -> i32 = core::mem::transmute(ROM_I2C_WRITEREG_MASK as usize);
+
+    i2c_write_reg_mask_raw(
+        block,
+        block_hostid,
+        reg_add,
+        reg_add_msb,
+        reg_add_lsb,
+        indata,
+    );
+}
+
+#[macro_export]
+macro_rules! regi2c_write_mask {
+    ( $block: ident, $reg_add: ident, $indata: expr ) => {
+        paste! {
+            regi2c_ctrl_write_reg_mask($block,
+                [<$block _HOSTID>],
+                $reg_add,
+                [<$reg_add _MSB>],
+                [<$reg_add _LSB>],
+                $indata);
+        }
+    };
+}

--- a/esp-hal-common/src/rtc/esp32.rs
+++ b/esp-hal-common/src/rtc/esp32.rs
@@ -1,0 +1,28 @@
+use crate::{clock::XtalClock, pac::RTC_CNTL};
+
+use crate::rtc_cntl::{RtcCalSel, RtcClock, RtcFastClock, RtcSlowClock};
+
+pub(crate) fn init() {}
+
+pub(crate) fn configure_clock() {
+    assert!(matches!(
+        RtcClock::get_xtal_freq(),
+        XtalClock::RtcXtalFreq40M
+    ));
+
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
+
+    let cal_val = loop {
+        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRtc);
+
+        let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
+        if res != 0 {
+            break res;
+        }
+    };
+
+    unsafe {
+        let rtc_cntl = &*RTC_CNTL::ptr();
+        rtc_cntl.store1.write(|w| w.bits(cal_val));
+    }
+}

--- a/esp-hal-common/src/rtc/esp32c3.rs
+++ b/esp-hal-common/src/rtc/esp32c3.rs
@@ -1,0 +1,256 @@
+use paste::paste;
+
+use crate::{
+    clock::XtalClock, pac::APB_CTRL, pac::EXTMEM, pac::RTC_CNTL, pac::SPI0, pac::SPI1, pac::SYSTEM,
+};
+
+use crate::rtc_cntl::{RtcCalSel, RtcClock, RtcFastClock, RtcSlowClock};
+
+use crate::regi2c_write_mask;
+use crate::rom::regi2c_ctrl_write_reg_mask;
+
+const I2C_DIG_REG: u32 = 0x6d;
+const I2C_DIG_REG_HOSTID: u32 = 0;
+
+const I2C_ULP: u32 = 0x61;
+const I2C_ULP_HOSTID: u32 = 0;
+
+const I2C_DIG_REG_XPD_RTC_REG: u32 = 13;
+const I2C_DIG_REG_XPD_RTC_REG_MSB: u32 = 2;
+const I2C_DIG_REG_XPD_RTC_REG_LSB: u32 = 2;
+
+const I2C_DIG_REG_XPD_DIG_REG: u32 = 13;
+const I2C_DIG_REG_XPD_DIG_REG_MSB: u32 = 3;
+const I2C_DIG_REG_XPD_DIG_REG_LSB: u32 = 3;
+
+const I2C_ULP_IR_FORCE_XPD_CK: u32 = 0;
+const I2C_ULP_IR_FORCE_XPD_CK_MSB: u32 = 2;
+const I2C_ULP_IR_FORCE_XPD_CK_LSB: u32 = 2;
+
+pub(crate) fn init() {
+    let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+
+    unsafe {
+        regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_XPD_DIG_REG, 0);
+
+        regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_XPD_RTC_REG, 0);
+    }
+
+    rtc_cntl.ana_conf.modify(|_, w| w.pvtmon_pu().clear_bit());
+
+    unsafe {
+        rtc_cntl
+            .timer1
+            .modify(|_, w| w.pll_buf_wait().bits(20u8).ck8m_wait().bits(20u8));
+        rtc_cntl.timer5.modify(|_, w| w.min_slp_val().bits(2u8));
+
+        // Set default powerup & wait time
+        rtc_cntl.timer3.modify(|_, w| {
+            w.wifi_powerup_timer()
+                .bits(1u8)
+                .wifi_wait_timer()
+                .bits(1u16)
+                .bt_powerup_timer()
+                .bits(1u8)
+                .bt_wait_timer()
+                .bits(1u16)
+        });
+        rtc_cntl.timer4.modify(|_, w| {
+            w.cpu_top_powerup_timer()
+                .bits(1u8)
+                .cpu_top_wait_timer()
+                .bits(1u16)
+                .dg_wrap_powerup_timer()
+                .bits(1u8)
+                .dg_wrap_wait_timer()
+                .bits(1u16)
+        });
+        rtc_cntl.timer6.modify(|_, w| {
+            w.dg_peri_powerup_timer()
+                .bits(1u8)
+                .dg_peri_wait_timer()
+                .bits(1u16)
+        });
+    }
+
+    calibrate_ocode();
+
+    set_rtc_dig_dbias();
+
+    clock_control_init();
+
+    power_control_init();
+
+    unsafe {
+        rtc_cntl.int_ena_rtc.write(|w| w.bits(0));
+        rtc_cntl.int_clr_rtc.write(|w| w.bits(u32::MAX));
+
+        regi2c_write_mask!(I2C_ULP, I2C_ULP_IR_FORCE_XPD_CK, 0);
+    }
+}
+
+pub(crate) fn configure_clock() {
+    assert!(matches!(
+        RtcClock::get_xtal_freq(),
+        XtalClock::RtcXtalFreq40M
+    ));
+
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
+
+    let cal_val = loop {
+        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRtc);
+
+        let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
+        if res != 0 {
+            break res;
+        }
+    };
+
+    unsafe {
+        let rtc_cntl = &*RTC_CNTL::ptr();
+        rtc_cntl.store1.write(|w| w.bits(cal_val));
+    }
+}
+
+fn calibrate_ocode() {}
+
+fn set_rtc_dig_dbias() {}
+
+/// Perform clock control related initialization
+fn clock_control_init() {
+    let extmem = unsafe { &*EXTMEM::ptr() };
+    let spi_mem_0 = unsafe { &*SPI0::ptr() };
+    let spi_mem_1 = unsafe { &*SPI1::ptr() };
+
+    // Clear CMMU clock force on
+    extmem
+        .cache_mmu_power_ctrl
+        .modify(|_, w| w.cache_mmu_mem_force_on().clear_bit());
+
+    // Clear tag clock force on
+    extmem
+        .icache_tag_power_ctrl
+        .modify(|_, w| w.icache_tag_mem_force_on().clear_bit());
+
+    // Clear register clock force on
+    spi_mem_0.clock_gate.modify(|_, w| w.clk_en().clear_bit());
+    spi_mem_1.clock_gate.modify(|_, w| w.clk_en().clear_bit());
+}
+
+/// Perform power control related initialization
+fn power_control_init() {
+    let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+    let system = unsafe { &*SYSTEM::ptr() };
+    rtc_cntl
+        .clk_conf
+        .modify(|_, w| w.ck8m_force_pu().clear_bit());
+
+    // Cancel XTAL force PU if no need to force power up
+    // Cannot cancel XTAL force PU if PLL is force power on
+    rtc_cntl
+        .options0
+        .modify(|_, w| w.xtl_force_pu().clear_bit());
+
+    // Force PD APLL
+    rtc_cntl.ana_conf.modify(|_, w| {
+        w.plla_force_pu()
+            .clear_bit()
+            .plla_force_pd()
+            .set_bit()
+            // Open SAR_I2C protect function to avoid SAR_I2C
+            // Reset when rtc_ldo is low.
+            .reset_por_force_pd()
+            .clear_bit()
+    });
+
+    // Cancel BBPLL force PU if setting no force power up
+    rtc_cntl.options0.modify(|_, w| {
+        w.bbpll_force_pu()
+            .clear_bit()
+            .bbpll_i2c_force_pu()
+            .clear_bit()
+            .bb_i2c_force_pu()
+            .clear_bit()
+    });
+    rtc_cntl.rtc_cntl.modify(|_, w| {
+        w.regulator_force_pu()
+            .clear_bit()
+            .dboost_force_pu()
+            .clear_bit()
+            .dboost_force_pd()
+            .set_bit()
+    });
+
+    // If this mask is enabled, all soc memories cannot enter power down mode.
+    // We should control soc memory power down mode from RTC,
+    // so we will not touch this register any more.
+    system
+        .mem_pd_mask
+        .modify(|_, w| w.lslp_mem_pd_mask().clear_bit());
+
+    rtc_sleep_pu();
+
+    rtc_cntl.dig_pwc.modify(|_, w| {
+        w.dg_wrap_force_pu()
+            .clear_bit()
+            .wifi_force_pu()
+            .clear_bit()
+            .bt_force_pu()
+            .clear_bit()
+            .cpu_top_force_pu()
+            .clear_bit()
+            .dg_peri_force_pu()
+            .clear_bit()
+    });
+    rtc_cntl.dig_iso.modify(|_, w| {
+        w.dg_wrap_force_noiso()
+            .clear_bit()
+            .wifi_force_noiso()
+            .clear_bit()
+            .bt_force_noiso()
+            .clear_bit()
+            .cpu_top_force_noiso()
+            .clear_bit()
+            .dg_peri_force_noiso()
+            .clear_bit()
+    });
+
+    // Cancel digital PADS force no iso
+    system
+        .cpu_per_conf
+        .modify(|_, w| w.cpu_wait_mode_force_on().clear_bit());
+
+    // If SYSTEM_CPU_WAIT_MODE_FORCE_ON == 0,
+    // the CPU clock will be closed when CPU enter WAITI mode.
+    rtc_cntl.dig_iso.modify(|_, w| {
+        w.dg_pad_force_unhold()
+            .clear_bit()
+            .dg_pad_force_noiso()
+            .clear_bit()
+    });
+}
+
+/// Configure whether certain peripherals are powered down in deep sleep
+fn rtc_sleep_pu() {
+    let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+    let apb_ctrl = unsafe { &*APB_CTRL::ptr() };
+
+    rtc_cntl.dig_pwc.modify(|_, w| {
+        w.lslp_mem_force_pu()
+            .clear_bit()
+            .rtc_fastmem_force_lpu()
+            .clear_bit()
+    });
+
+    apb_ctrl.front_end_mem_pd.modify(|_, w| {
+        w.dc_mem_force_pu()
+            .clear_bit()
+            .pbus_mem_force_pu()
+            .clear_bit()
+            .agc_mem_force_pu()
+            .clear_bit()
+    });
+    apb_ctrl
+        .mem_power_up
+        .modify(|_, w| unsafe { w.sram_power_up().bits(0u8).rom_power_up().bits(0u8) });
+}

--- a/esp-hal-common/src/rtc/esp32s2.rs
+++ b/esp-hal-common/src/rtc/esp32s2.rs
@@ -1,0 +1,28 @@
+use crate::{clock::XtalClock, pac::RTC_CNTL};
+
+use crate::rtc_cntl::{RtcCalSel, RtcClock, RtcFastClock, RtcSlowClock};
+
+pub(crate) fn init() {}
+
+pub(crate) fn configure_clock() {
+    assert!(matches!(
+        RtcClock::get_xtal_freq(),
+        XtalClock::RtcXtalFreq40M
+    ));
+
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
+
+    let cal_val = loop {
+        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRtc);
+
+        let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
+        if res != 0 {
+            break res;
+        }
+    };
+
+    unsafe {
+        let rtc_cntl = &*RTC_CNTL::ptr();
+        rtc_cntl.store1.write(|w| w.bits(cal_val));
+    }
+}

--- a/esp-hal-common/src/rtc/esp32s3.rs
+++ b/esp-hal-common/src/rtc/esp32s3.rs
@@ -1,0 +1,28 @@
+use crate::{clock::XtalClock, pac::RTC_CNTL};
+
+use crate::rtc_cntl::{RtcCalSel, RtcClock, RtcFastClock, RtcSlowClock};
+
+pub(crate) fn init() {}
+
+pub(crate) fn configure_clock() {
+    assert!(matches!(
+        RtcClock::get_xtal_freq(),
+        XtalClock::RtcXtalFreq40M
+    ));
+
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
+
+    let cal_val = loop {
+        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRtc);
+
+        let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
+        if res != 0 {
+            break res;
+        }
+    };
+
+    unsafe {
+        let rtc_cntl = &*RTC_CNTL::ptr();
+        rtc_cntl.store1.write(|w| w.bits(cal_val));
+    }
+}

--- a/esp-hal-common/src/rtc_cntl.rs
+++ b/esp-hal-common/src/rtc_cntl.rs
@@ -1,46 +1,608 @@
-use crate::pac::RTC_CNTL;
+use fugit::{HertzU32, MicrosDurationU64};
 
-pub struct RtcCntl {
-    rtc_cntl: RTC_CNTL,
+use embedded_hal::watchdog::{Watchdog, WatchdogDisable, WatchdogEnable};
+
+use crate::{clock::Clock, clock::XtalClock, pac::RTC_CNTL, pac::TIMG0};
+
+#[cfg(not(feature = "esp32"))]
+use crate::efuse::Efuse;
+
+use crate::rom::esp_rom_delay_us;
+
+#[cfg_attr(feature = "esp32", path = "rtc/esp32.rs")]
+#[cfg_attr(feature = "esp32s2", path = "rtc/esp32s2.rs")]
+#[cfg_attr(feature = "esp32s3", path = "rtc/esp32s3.rs")]
+#[cfg_attr(feature = "esp32c3", path = "rtc/esp32c3.rs")]
+mod rtc;
+
+#[allow(unused)]
+#[derive(Debug, Clone, Copy)]
+/// RTC SLOW_CLK frequency values
+pub(crate) enum RtcFastClock {
+    /// Main XTAL, divided by 4
+    RtcFastClockXtalD4 = 0,
+    /// Internal fast RC oscillator
+    RtcFastClock8m = 1,
 }
 
-impl RtcCntl {
+impl Clock for RtcFastClock {
+    fn frequency(&self) -> HertzU32 {
+        match self {
+            RtcFastClock::RtcFastClockXtalD4 => HertzU32::Hz(40_000_000 / 4),
+            #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+            RtcFastClock::RtcFastClock8m => HertzU32::Hz(8_500_000),
+            #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+            RtcFastClock::RtcFastClock8m => HertzU32::Hz(17_500_000),
+        }
+    }
+}
+
+#[allow(unused)]
+#[derive(Debug, Clone, Copy)]
+/// RTC SLOW_CLK frequency values
+pub(crate) enum RtcSlowClock {
+    /// Internal slow RC oscillator
+    RtcSlowClockRtc = 0,
+    /// External 32 KHz XTAL
+    RtcSlowClock32kXtal = 1,
+    /// Internal fast RC oscillator, divided by 256
+    RtcSlowClock8mD256 = 2,
+}
+
+impl Clock for RtcSlowClock {
+    fn frequency(&self) -> HertzU32 {
+        match self {
+            #[cfg(feature = "esp32")]
+            RtcSlowClock::RtcSlowClockRtc => HertzU32::Hz(150_000),
+            #[cfg(feature = "esp32s2")]
+            RtcSlowClock::RtcSlowClockRtc => HertzU32::Hz(90_000),
+            #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+            RtcSlowClock::RtcSlowClockRtc => HertzU32::Hz(136_000),
+            RtcSlowClock::RtcSlowClock32kXtal => HertzU32::Hz(32768),
+            #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+            RtcSlowClock::RtcSlowClock8mD256 => HertzU32::Hz(8_500_000 / 256),
+            #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+            RtcSlowClock::RtcSlowClock8mD256 => HertzU32::Hz(17_500_000 / 256),
+        }
+    }
+}
+
+#[allow(unused)]
+#[derive(Debug, Clone, Copy)]
+/// Clock source to be calibrated using rtc_clk_cal function
+pub(crate) enum RtcCalSel {
+    /// Currently selected RTC SLOW_CLK
+    RtcCalRtcMux = 0,
+    /// Internal 8 MHz RC oscillator, divided by 256
+    RtcCal8mD256 = 1,
+    /// External 32 KHz XTAL
+    RtcCal32kXtal = 2,
+    #[cfg(not(feature = "esp32"))]
+    /// Internal 150 KHz RC oscillator
+    RtcCalInternalOsc = 3,
+}
+
+pub struct Rtc {
+    _inner: RTC_CNTL,
+    pub rwdt: Rwdt,
+    #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+    pub swd: Swd,
+}
+
+impl Rtc {
     pub fn new(rtc_cntl: RTC_CNTL) -> Self {
-        Self { rtc_cntl }
+        rtc::init();
+        rtc::configure_clock();
+
+        Self {
+            _inner: rtc_cntl,
+            rwdt: Rwdt::default(),
+            #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+            swd: Swd::new(),
+        }
+    }
+}
+
+/// RTC Watchdog Timer
+pub struct RtcClock;
+/// RTC Watchdog Timer driver
+impl RtcClock {
+    const CAL_FRACT: u32 = 19;
+
+    /// Get main XTAL frequency
+    /// This is the value stored in RTC register RTC_XTAL_FREQ_REG by the bootloader, as passed to
+    /// rtc_clk_init function.
+    fn get_xtal_freq() -> XtalClock {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+        let xtal_freq_reg = rtc_cntl.store4.read().bits();
+
+        // Values of RTC_XTAL_FREQ_REG and RTC_APB_FREQ_REG are stored as two copies in
+        // lower and upper 16-bit halves. These are the routines to work with such a
+        // representation.
+        let clk_val_is_valid = |val| {
+            (val & 0xffffu32) == ((val >> 16u32) & 0xffffu32) && val != 0u32 && val != u32::MAX
+        };
+        let reg_val_to_clk_val = |val| val & u16::MAX as u32;
+
+        if !clk_val_is_valid(xtal_freq_reg) {
+            return XtalClock::RtcXtalFreq40M;
+        }
+
+        match reg_val_to_clk_val(xtal_freq_reg) {
+            40 => XtalClock::RtcXtalFreq40M,
+            #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+            32 => XtalClock::RtcXtalFreq32M,
+            #[cfg(feature = "esp32")]
+            26 => XtalClock::RtcXtalFreq26M,
+            #[cfg(feature = "esp32")]
+            24 => XtalClock::RtcXtalFreq24M,
+            other => XtalClock::RtcXtalFreqOther(other),
+        }
+    }
+
+    /// Get the RTC_SLOW_CLK source
+    fn get_slow_freq() -> RtcSlowClock {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+        let slow_freq = rtc_cntl.clk_conf.read().ana_clk_rtc_sel().bits();
+        match slow_freq {
+            0 => RtcSlowClock::RtcSlowClockRtc,
+            1 => RtcSlowClock::RtcSlowClock32kXtal,
+            2 => RtcSlowClock::RtcSlowClock8mD256,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Select source for RTC_SLOW_CLK
+    fn set_slow_freq(slow_freq: RtcSlowClock) {
+        unsafe {
+            let rtc_cntl = &*RTC_CNTL::ptr();
+            rtc_cntl.clk_conf.modify(|_, w| {
+                w.ana_clk_rtc_sel()
+                    .bits(slow_freq as u8)
+                    // Why we need to connect this clock to digital?
+                    // Or maybe this clock should be connected to digital when
+                    // XTAL 32k clock is enabled instead?
+                    .dig_xtal32k_en()
+                    .bit(match slow_freq {
+                        RtcSlowClock::RtcSlowClock32kXtal => true,
+                        _ => false,
+                    })
+                    // The clk_8m_d256 will be closed when rtc_state in SLEEP,
+                    // so if the slow_clk is 8md256, clk_8m must be force power on
+                    .ck8m_force_pu()
+                    .bit(match slow_freq {
+                        RtcSlowClock::RtcSlowClock8mD256 => true,
+                        _ => false,
+                    })
+            });
+
+            esp_rom_delay_us(300u32);
+        };
+    }
+
+    /// Select source for RTC_FAST_CLK
+    fn set_fast_freq(fast_freq: RtcFastClock) {
+        unsafe {
+            let rtc_cntl = &*RTC_CNTL::ptr();
+            rtc_cntl.clk_conf.modify(|_, w| {
+                w.fast_clk_rtc_sel().bit(match fast_freq {
+                    RtcFastClock::RtcFastClock8m => true,
+                    RtcFastClock::RtcFastClockXtalD4 => false,
+                })
+            });
+
+            esp_rom_delay_us(3u32);
+        };
+    }
+
+    fn calibrate_internal(cal_clk: RtcCalSel, slowclk_cycles: u32) -> u32 {
+        // Except for ESP32, choosing RTC_CAL_RTC_MUX results in calibration of
+        // the 150k RTC clock (90k on ESP32-S2) regardless of the currently selected SLOW_CLK.
+        // On the ESP32, it uses the currently selected SLOW_CLK.
+        // The following code emulates ESP32 behavior for the other chips:
+
+        #[cfg(not(feature = "esp32"))]
+        let cal_clk = match cal_clk {
+            RtcCalSel::RtcCalRtcMux => match RtcClock::get_slow_freq() {
+                RtcSlowClock::RtcSlowClock32kXtal => RtcCalSel::RtcCal32kXtal,
+                RtcSlowClock::RtcSlowClock8mD256 => RtcCalSel::RtcCal8mD256,
+                _ => cal_clk,
+            },
+            RtcCalSel::RtcCalInternalOsc => RtcCalSel::RtcCalRtcMux,
+            _ => cal_clk,
+        };
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+        let timg0 = unsafe { &*TIMG0::ptr() };
+
+        // Enable requested clock (150k clock is always on)
+        let dig_32k_xtal_enabled = rtc_cntl.clk_conf.read().dig_xtal32k_en().bit_is_set();
+
+        if matches!(cal_clk, RtcCalSel::RtcCal32kXtal) && !dig_32k_xtal_enabled {
+            rtc_cntl
+                .clk_conf
+                .modify(|_, w| w.dig_xtal32k_en().set_bit());
+        }
+
+        if matches!(cal_clk, RtcCalSel::RtcCal8mD256) {
+            rtc_cntl
+                .clk_conf
+                .modify(|_, w| w.dig_clk8m_d256_en().set_bit());
+        }
+
+        // There may be another calibration process already running during we
+        // call this function, so we should wait the last process is done.
+        #[cfg(not(feature = "esp32"))]
+        if timg0
+            .rtccalicfg
+            .read()
+            .rtc_cali_start_cycling()
+            .bit_is_set()
+        {
+            // Set a small timeout threshold to accelerate the generation of timeout.
+            // The internal circuit will be reset when the timeout occurs and will not affect the next calibration.
+            timg0
+                .rtccalicfg2
+                .modify(|_, w| unsafe { w.rtc_cali_timeout_thres().bits(1) });
+
+            while timg0.rtccalicfg.read().rtc_cali_rdy().bit_is_clear()
+                && timg0.rtccalicfg2.read().rtc_cali_timeout().bit_is_clear()
+            {}
+        }
+
+        // Prepare calibration
+        timg0.rtccalicfg.modify(|_, w| unsafe {
+            w.rtc_cali_clk_sel()
+                .bits(cal_clk as u8)
+                .rtc_cali_start_cycling()
+                .clear_bit()
+                .rtc_cali_max()
+                .bits(slowclk_cycles as u16)
+        });
+
+        // Figure out how long to wait for calibration to finish
+        // Set timeout reg and expect time delay
+        let expected_freq = match cal_clk {
+            RtcCalSel::RtcCal32kXtal => {
+                #[cfg(not(feature = "esp32"))]
+                timg0.rtccalicfg2.modify(|_, w| unsafe {
+                    w.rtc_cali_timeout_thres().bits(slowclk_cycles << 12)
+                });
+                RtcSlowClock::RtcSlowClock32kXtal
+            }
+            RtcCalSel::RtcCal8mD256 => {
+                #[cfg(not(feature = "esp32"))]
+                timg0.rtccalicfg2.modify(|_, w| unsafe {
+                    w.rtc_cali_timeout_thres().bits(slowclk_cycles << 12)
+                });
+                RtcSlowClock::RtcSlowClock8mD256
+            }
+            _ => {
+                #[cfg(not(feature = "esp32"))]
+                timg0.rtccalicfg2.modify(|_, w| unsafe {
+                    w.rtc_cali_timeout_thres().bits(slowclk_cycles << 10)
+                });
+                RtcSlowClock::RtcSlowClockRtc
+            }
+        };
+
+        let us_time_estimate = HertzU32::MHz(slowclk_cycles) / expected_freq.frequency();
+
+        // Start calibration
+        timg0
+            .rtccalicfg
+            .modify(|_, w| w.rtc_cali_start().clear_bit().rtc_cali_start().set_bit());
+
+        // Wait for calibration to finish up to another us_time_estimate
+        unsafe {
+            esp_rom_delay_us(us_time_estimate);
+        }
+
+        #[cfg(feature = "esp32")]
+        let mut timeout_us = us_time_estimate;
+
+        let cal_val = loop {
+            if timg0.rtccalicfg.read().rtc_cali_rdy().bit_is_set() {
+                break timg0.rtccalicfg1.read().rtc_cali_value().bits();
+            }
+
+            #[cfg(not(feature = "esp32"))]
+            if timg0.rtccalicfg2.read().rtc_cali_timeout().bit_is_set() {
+                // Timed out waiting for calibration
+                break 0;
+            }
+
+            #[cfg(feature = "esp32")]
+            if timeout_us > 0 {
+                timeout_us -= 1;
+                unsafe {
+                    esp_rom_delay_us(1);
+                }
+            } else {
+                // Timed out waiting for calibration
+                break 0;
+            }
+        };
+
+        timg0
+            .rtccalicfg
+            .modify(|_, w| w.rtc_cali_start().clear_bit());
+        rtc_cntl
+            .clk_conf
+            .modify(|_, w| w.dig_xtal32k_en().bit(dig_32k_xtal_enabled));
+
+        if matches!(cal_clk, RtcCalSel::RtcCal8mD256) {
+            rtc_cntl
+                .clk_conf
+                .modify(|_, w| w.dig_clk8m_d256_en().clear_bit());
+        }
+
+        cal_val
+    }
+
+    /// Measure RTC slow clock's period, based on main XTAL frequency
+    ///
+    /// This function will time out and return 0 if the time for the given number
+    /// of cycles to be counted exceeds the expected time twice. This may happen if
+    /// 32k XTAL is being calibrated, but the oscillator has not started up (due to
+    /// incorrect loading capacitance, board design issue, or lack of 32 XTAL on board).
+    fn calibrate(cal_clk: RtcCalSel, slowclk_cycles: u32) -> u32 {
+        let xtal_freq = RtcClock::get_xtal_freq();
+        let xtal_cycles = RtcClock::calibrate_internal(cal_clk, slowclk_cycles) as u64;
+        let divider = xtal_freq.mhz() as u64 * slowclk_cycles as u64;
+        let period_64 = ((xtal_cycles << RtcClock::CAL_FRACT) + divider / 2u64 - 1u64) / divider;
+
+        (period_64 & u32::MAX as u64) as u32
+    }
+
+    /// Calculate the necessary RTC_SLOW_CLK cycles to complete 1 millisecond.
+    fn cycles_to_1ms() -> u16 {
+        let period_13q19 = RtcClock::calibrate(
+            match RtcClock::get_slow_freq() {
+                RtcSlowClock::RtcSlowClockRtc => RtcCalSel::RtcCalRtcMux,
+                RtcSlowClock::RtcSlowClock32kXtal => RtcCalSel::RtcCal32kXtal,
+                RtcSlowClock::RtcSlowClock8mD256 => RtcCalSel::RtcCal8mD256,
+            },
+            1024,
+        );
+
+        let q_to_float = |val| (val as f32) / ((1 << RtcClock::CAL_FRACT) as f32);
+        let period = q_to_float(period_13q19);
+
+        (1000f32 / period) as u16
+    }
+}
+
+/// Behavior of the RWDT stage if it times out
+#[allow(unused)]
+#[derive(Debug, Clone, Copy)]
+enum RwdtStageAction {
+    RwdtStageActionOff = 0,
+    RwdtStageActionInterrupt = 1,
+    RwdtStageActionResetCpu = 2,
+    RwdtStageActionResetSystem = 3,
+    RwdtStageActionResetRtc = 4,
+}
+
+/// RTC Watchdog Timer
+pub struct Rwdt {
+    stg0_action: RwdtStageAction,
+    stg1_action: RwdtStageAction,
+    stg2_action: RwdtStageAction,
+    stg3_action: RwdtStageAction,
+}
+
+impl Default for Rwdt {
+    fn default() -> Self {
+        Self {
+            stg0_action: RwdtStageAction::RwdtStageActionResetRtc,
+            stg1_action: RwdtStageAction::RwdtStageActionOff,
+            stg2_action: RwdtStageAction::RwdtStageActionOff,
+            stg3_action: RwdtStageAction::RwdtStageActionOff,
+        }
+    }
+}
+
+/// RTC Watchdog Timer driver
+impl Rwdt {
+    pub fn listen(&mut self) {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+
+        self.stg0_action = RwdtStageAction::RwdtStageActionInterrupt;
+
+        self.set_write_protection(false);
+
+        // Configure STAGE0 to trigger an interrupt upon expiration
+        rtc_cntl
+            .wdtconfig0
+            .modify(|_, w| unsafe { w.wdt_stg0().bits(self.stg0_action as u8) });
+
+        #[cfg(feature = "esp32")]
+        rtc_cntl.int_ena.modify(|_, w| w.wdt_int_ena().set_bit());
+
+        #[cfg(feature = "esp32s2")]
+        rtc_cntl
+            .int_ena_rtc
+            .modify(|_, w| w.wdt_int_ena().set_bit());
+
+        #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+        rtc_cntl
+            .int_ena_rtc
+            .modify(|_, w| w.rtc_wdt_int_ena().set_bit());
+
+        self.set_write_protection(true);
+    }
+
+    pub fn unlisten(&mut self) {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+
+        self.stg0_action = RwdtStageAction::RwdtStageActionResetRtc;
+
+        self.set_write_protection(false);
+
+        // Configure STAGE0 to reset the main system and the RTC upon expiration.
+        rtc_cntl
+            .wdtconfig0
+            .modify(|_, w| unsafe { w.wdt_stg0().bits(self.stg0_action as u8) });
+
+        #[cfg(feature = "esp32")]
+        rtc_cntl.int_ena.modify(|_, w| w.wdt_int_ena().clear_bit());
+
+        #[cfg(feature = "esp32s2")]
+        rtc_cntl
+            .int_ena_rtc
+            .modify(|_, w| w.wdt_int_ena().clear_bit());
+
+        #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+        rtc_cntl
+            .int_ena_rtc
+            .modify(|_, w| w.rtc_wdt_int_ena().clear_bit());
+
+        self.set_write_protection(true);
+    }
+
+    pub fn clear_interrupt(&mut self) {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+
+        self.set_write_protection(false);
+
+        #[cfg(feature = "esp32")]
+        rtc_cntl.int_clr.write(|w| w.wdt_int_clr().set_bit());
+
+        #[cfg(feature = "esp32s2")]
+        rtc_cntl.int_clr_rtc.write(|w| w.wdt_int_clr().set_bit());
+
+        #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+        rtc_cntl
+            .int_clr_rtc
+            .write(|w| w.rtc_wdt_int_clr().set_bit());
+
+        self.set_write_protection(true);
+    }
+
+    pub fn is_interrupt_set(&self) -> bool {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "esp32")] {
+                rtc_cntl.int_st.read().wdt_int_st().bit_is_set()
+            } else if #[cfg(feature = "esp32s2")] {
+                rtc_cntl.int_st_rtc.read().wdt_int_st().bit_is_set()
+            } else if #[cfg(any(feature = "esp32c3", feature = "esp32s3"))] {
+                rtc_cntl.int_st_rtc.read().rtc_wdt_int_st().bit_is_set()
+            }
+        }
     }
 
     /// Enable/disable write protection for WDT registers
-    fn set_wdt_write_protection(&mut self, enable: bool) {
+    fn set_write_protection(&mut self, enable: bool) {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
         let wkey = if enable { 0u32 } else { 0x50D8_3AA1 };
-        self.rtc_cntl.wdtwprotect.write(|w| unsafe { w.bits(wkey) });
+
+        rtc_cntl.wdtwprotect.write(|w| unsafe { w.bits(wkey) });
+    }
+}
+
+impl WatchdogDisable for Rwdt {
+    fn disable(&mut self) {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+
+        self.set_write_protection(false);
+
+        rtc_cntl.wdtconfig0.modify(|_, w| w.wdt_en().clear_bit());
+
+        self.set_write_protection(true);
+    }
+}
+
+impl WatchdogEnable for Rwdt {
+    type Time = MicrosDurationU64;
+
+    fn start<T>(&mut self, period: T)
+    where
+        T: Into<Self::Time>,
+    {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+        let timeout_raw = (period.into().to_millis() * (RtcClock::cycles_to_1ms() as u64)) as u32;
+
+        self.set_write_protection(false);
+
+        unsafe {
+            #[cfg(feature = "esp32")]
+            rtc_cntl
+                .wdtconfig1
+                .modify(|_, w| w.wdt_stg0_hold().bits(timeout_raw));
+
+            #[cfg(not(feature = "esp32"))]
+            rtc_cntl.wdtconfig1.modify(|_, w| {
+                w.wdt_stg0_hold()
+                    .bits(timeout_raw >> (1 + Efuse::get_rwdt_multiplier()))
+            });
+
+            rtc_cntl.wdtconfig0.modify(|_, w| {
+                w.wdt_stg0()
+                    .bits(self.stg0_action as u8)
+                    .wdt_cpu_reset_length()
+                    .bits(7)
+                    .wdt_sys_reset_length()
+                    .bits(7)
+                    .wdt_stg1()
+                    .bits(self.stg1_action as u8)
+                    .wdt_stg2()
+                    .bits(self.stg2_action as u8)
+                    .wdt_stg3()
+                    .bits(self.stg3_action as u8)
+                    .wdt_en()
+                    .set_bit()
+            });
+        }
+
+        self.set_write_protection(true);
+    }
+}
+
+impl Watchdog for Rwdt {
+    fn feed(&mut self) {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+
+        self.set_write_protection(false);
+
+        rtc_cntl.wdtfeed.write(|w| unsafe { w.bits(1) });
+
+        self.set_write_protection(true);
+    }
+}
+
+#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+/// Super Watchdog
+pub struct Swd;
+
+#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+/// Super Watchdog driver
+impl Swd {
+    pub fn new() -> Self {
+        Self
     }
 
-    /// Global switch for RTC_CNTL watchdog functionality
-    pub fn set_wdt_global_enable(&mut self, enable: bool) {
-        self.set_wdt_write_protection(false);
-        self.rtc_cntl
-            .wdtconfig0
-            .modify(|_, w| w.wdt_en().bit(enable).wdt_flashboot_mod_en().clear_bit());
-        self.set_wdt_write_protection(true);
-    }
-
-    #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
-    pub fn set_super_wdt_enable(&mut self, enable: bool) {
-        self.set_swd_write_protection(false);
-
-        self.rtc_cntl
-            .swd_conf
-            .write(|w| w.swd_auto_feed_en().bit(!enable));
-
-        self.set_swd_write_protection(true);
-    }
-
-    #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
-    fn set_swd_write_protection(&mut self, enable: bool) {
+    /// Enable/disable write protection for WDT registers
+    fn set_write_protection(&mut self, enable: bool) {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
         let wkey = if enable { 0u32 } else { 0x8F1D_312A };
 
-        self.rtc_cntl
+        rtc_cntl
             .swd_wprotect
             .write(|w| unsafe { w.swd_wkey().bits(wkey) });
+    }
+}
+
+#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+impl WatchdogDisable for Swd {
+    fn disable(&mut self) {
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+
+        self.set_write_protection(false);
+
+        rtc_cntl.swd_conf.write(|w| w.swd_auto_feed_en().set_bit());
+
+        self.set_write_protection(true);
     }
 }

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -6,7 +6,7 @@ use embedded_hal::{
     timer::{Cancel, CountDown, Periodic},
     watchdog::{Watchdog, WatchdogDisable, WatchdogEnable},
 };
-use fugit::{MegahertzU32, MicrosDurationU64};
+use fugit::{HertzU32, MicrosDurationU64};
 use void::Void;
 
 use crate::{
@@ -86,7 +86,7 @@ where
 /// General-purpose timer
 pub struct Timer<T> {
     timg: T,
-    apb_clk_freq: MegahertzU32,
+    apb_clk_freq: HertzU32,
 }
 
 /// Timer driver
@@ -95,7 +95,7 @@ where
     T: Instance,
 {
     /// Create a new timer instance
-    pub fn new(timg: T, apb_clk_freq: MegahertzU32) -> Self {
+    pub fn new(timg: T, apb_clk_freq: HertzU32) -> Self {
         // TODO: this currently assumes APB_CLK is being used, as we don't yet have a
         //       way to select the XTAL_CLK.
         Self { timg, apb_clk_freq }
@@ -438,12 +438,12 @@ where
 fn timeout_to_ticks<T, F>(timeout: T, clock: F, divider: u32) -> u64
 where
     T: Into<MicrosDurationU64>,
-    F: Into<MegahertzU32>,
+    F: Into<HertzU32>,
 {
     let timeout: MicrosDurationU64 = timeout.into();
     let micros = timeout.to_micros();
 
-    let clock: MegahertzU32 = clock.into();
+    let clock: HertzU32 = clock.into();
 
     // TODO can we get this to not use doubles/floats
     let period = 1_000_000f64 / (clock.to_Hz() as f64 / divider as f64); // micros

--- a/esp32-hal/examples/adc.rs
+++ b/esp32-hal/examples/adc.rs
@@ -13,7 +13,7 @@ use esp32_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use esp_println::println;
 use panic_halt as _;
@@ -27,11 +27,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut pin25 = io.pins.gpio25.into_analog();

--- a/esp32-hal/examples/advanced_serial.rs
+++ b/esp32-hal/examples/advanced_serial.rs
@@ -17,7 +17,7 @@ use esp32_hal::{
     },
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use esp_println::println;
@@ -33,11 +33,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32-hal/examples/blinky.rs
+++ b/esp32-hal/examples/blinky.rs
@@ -12,7 +12,7 @@ use esp32_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx_rt::entry;
@@ -25,11 +25,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/dac.rs
+++ b/esp32-hal/examples/dac.rs
@@ -13,7 +13,7 @@ use esp32_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx_rt::entry;
@@ -26,11 +26,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin25 = io.pins.gpio25.into_analog();

--- a/esp32-hal/examples/gpio_interrupt.rs
+++ b/esp32-hal/examples/gpio_interrupt.rs
@@ -18,7 +18,7 @@ use esp32_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx::mutex::{Mutex, SpinLockMutex};
@@ -36,11 +36,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/hello_rgb.rs
+++ b/esp32-hal/examples/hello_rgb.rs
@@ -21,7 +21,7 @@ use esp32_hal::{
     utils::{smartLedAdapter, SmartLedsAdapter},
     Delay,
     PulseControl,
-    RtcCntl,
+    Rtc,
     IO,
 };
 #[allow(unused_imports)]
@@ -40,14 +40,14 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Configure RMT peripheral globally
     let pulse = PulseControl::new(peripherals.RMT, &mut system.peripheral_clock_control).unwrap();

--- a/esp32-hal/examples/hello_world.rs
+++ b/esp32-hal/examples/hello_world.rs
@@ -11,7 +11,7 @@ use esp32_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -28,11 +28,11 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32-hal/examples/i2c_display.rs
+++ b/esp32-hal/examples/i2c_display.rs
@@ -28,7 +28,7 @@ use esp32_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -46,11 +46,11 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32-hal/examples/ledc.rs
+++ b/esp32-hal/examples/ledc.rs
@@ -20,7 +20,7 @@ use esp32_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -35,11 +35,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32-hal/examples/multicore.rs
+++ b/esp32-hal/examples/multicore.rs
@@ -13,7 +13,7 @@ use esp32_hal::{
     prelude::*,
     timer::{Timer, Timer0, TimerGroup},
     CpuControl,
-    RtcCntl,
+    Rtc,
 };
 use esp_println::println;
 use nb::block;
@@ -35,12 +35,12 @@ fn main() -> ! {
     let mut timer1 = timer_group1.timer0;
     let mut wdt1 = timer_group1.wdt;
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt0.disable();
     wdt1.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
     timer1.start(500u64.millis());

--- a/esp32-hal/examples/read_efuse.rs
+++ b/esp32-hal/examples/read_efuse.rs
@@ -12,7 +12,7 @@ use esp32_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -27,11 +27,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     writeln!(serial0, "MAC address {:02x?}", Efuse::get_mac_address()).unwrap();
     writeln!(serial0, "Core Count {}", Efuse::get_core_count()).unwrap();

--- a/esp32-hal/examples/read_efuse.rs
+++ b/esp32-hal/examples/read_efuse.rs
@@ -42,7 +42,12 @@ fn main() -> ! {
     )
     .unwrap();
     writeln!(serial0, "Chip type {:?}", Efuse::get_chip_type()).unwrap();
-    writeln!(serial0, "Max CPU clock {:?}", Efuse::get_max_cpu_fequency()).unwrap();
+    writeln!(
+        serial0,
+        "Max CPU clock {:?}",
+        Efuse::get_max_cpu_frequency()
+    )
+    .unwrap();
     writeln!(
         serial0,
         "Flash Encryption {:?}",

--- a/esp32-hal/examples/serial_interrupts.rs
+++ b/esp32-hal/examples/serial_interrupts.rs
@@ -14,7 +14,7 @@ use esp32_hal::{
     prelude::*,
     serial::config::AtCmdConfig,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -40,12 +40,12 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt0.disable();
     wdt1.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30);

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -26,7 +26,7 @@ use esp32_hal::{
     spi::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -40,13 +40,13 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio19;

--- a/esp32-hal/examples/timer_interrupt.rs
+++ b/esp32-hal/examples/timer_interrupt.rs
@@ -14,7 +14,7 @@ use esp32_hal::{
     pac::{self, Peripherals, TIMG0, TIMG1, UART0},
     prelude::*,
     timer::{Timer, Timer0, Timer1, TimerGroup},
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -50,12 +50,12 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     let serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt0.disable();
     wdt1.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     interrupt::enable(pac::Interrupt::TG0_T0_LEVEL, Priority::Priority2).unwrap();
     interrupt::enable(pac::Interrupt::TG0_T1_LEVEL, Priority::Priority2).unwrap();

--- a/esp32-hal/examples/watchdog.rs
+++ b/esp32-hal/examples/watchdog.rs
@@ -12,7 +12,7 @@ use esp32_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -29,9 +29,9 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     wdt.start(2u64.secs());
     timer0.start(1u64.secs());

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -21,7 +21,7 @@ pub use esp_hal_common::{
     Delay,
     PulseControl,
     Rng,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 

--- a/esp32c3-hal/examples/adc.rs
+++ b/esp32c3-hal/examples/adc.rs
@@ -15,7 +15,7 @@ use esp32c3_hal::{
     system::SystemExt,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use esp_println::println;
 use panic_halt as _;
@@ -29,14 +29,14 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
 
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -15,7 +15,7 @@ use esp32c3_hal::{
         TxRxPins,
     },
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
     IO,
 };
@@ -30,7 +30,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
@@ -38,8 +38,8 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/blinky.rs
+++ b/esp32c3-hal/examples/blinky.rs
@@ -13,7 +13,7 @@ use esp32c3_hal::{
     system::SystemExt,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use riscv_rt::entry;
@@ -26,14 +26,14 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
 
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -18,7 +18,7 @@ use esp32c3_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use riscv_rt::entry;
@@ -33,14 +33,14 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
 
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -20,7 +20,7 @@ use esp32c3_hal::{
     utils::{smartLedAdapter, SmartLedsAdapter},
     Delay,
     PulseControl,
-    RtcCntl,
+    Rtc,
     IO,
 };
 #[allow(unused_imports)]
@@ -39,14 +39,14 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Disable watchdogs
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
 
     // Configure RMT peripheral globally

--- a/esp32c3-hal/examples/hello_world.rs
+++ b/esp32c3-hal/examples/hello_world.rs
@@ -11,7 +11,7 @@ use esp32c3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -24,7 +24,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
@@ -33,8 +33,8 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/i2c_display.rs
+++ b/esp32c3-hal/examples/i2c_display.rs
@@ -26,7 +26,7 @@ use esp32c3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
 };
 use nb::block;
 use panic_halt as _;
@@ -39,7 +39,7 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
@@ -47,8 +47,8 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/ledc.rs
+++ b/esp32c3-hal/examples/ledc.rs
@@ -19,7 +19,7 @@ use esp32c3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
 };
 use esp_println;
 use panic_halt as _;
@@ -31,7 +31,7 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let _timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
@@ -39,8 +39,8 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/read_efuse.rs
+++ b/esp32c3-hal/examples/read_efuse.rs
@@ -12,7 +12,7 @@ use esp32c3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -24,7 +24,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
@@ -32,8 +32,8 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/rtc_watchdog.rs
+++ b/esp32c3-hal/examples/rtc_watchdog.rs
@@ -1,0 +1,69 @@
+//! This demos the RTC Watchdog Timer (RWDT).
+//! The RWDT is initially configured to trigger an interrupt after a given timeout.
+//! Then, upon expiration, the RWDT is restarted and then reconfigured to reset both the main
+//! system and the RTC.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use bare_metal::Mutex;
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    interrupt,
+    pac::{self, Peripherals},
+    prelude::*,
+    Rtc,
+};
+use esp_hal_common::Rwdt;
+use panic_halt as _;
+use riscv_rt::entry;
+
+static mut RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    interrupt::enable(pac::Interrupt::RTC_CORE, interrupt::Priority::Priority1).unwrap();
+
+    riscv::interrupt::free(|_cs| unsafe {
+        RWDT.get_mut().replace(Some(rtc.rwdt));
+    });
+
+    unsafe {
+        riscv::interrupt::enable();
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn RTC_CORE() {
+    riscv::interrupt::free(|cs| unsafe {
+        esp_println::println!("RWDT Interrupt");
+
+        let mut rwdt = RWDT.borrow(*cs).borrow_mut();
+        let rwdt = rwdt.as_mut().unwrap();
+
+        rwdt.clear_interrupt();
+
+        esp_println::println!("Restarting in 5 seconds...");
+
+        rwdt.start(5000u64.millis());
+        rwdt.unlisten();
+    });
+}

--- a/esp32c3-hal/examples/serial_interrupts.rs
+++ b/esp32c3-hal/examples/serial_interrupts.rs
@@ -16,7 +16,7 @@ use esp32c3_hal::{
     serial::config::AtCmdConfig,
     timer::TimerGroup,
     Cpu,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -31,7 +31,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
@@ -40,8 +40,8 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -26,7 +26,7 @@ use esp32c3_hal::{
     spi::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -40,7 +40,7 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
@@ -48,8 +48,8 @@ fn main() -> ! {
 
     let mut serial0 = Serial::new(peripherals.UART0);
 
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -15,7 +15,7 @@ use esp32c3_hal::{
     systimer::{Alarm, SystemTimer, Target},
     timer::TimerGroup,
     Cpu,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use riscv_rt::entry;
@@ -32,14 +32,14 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
 
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/timer_interrupt.rs
+++ b/esp32c3-hal/examples/timer_interrupt.rs
@@ -14,7 +14,7 @@ use esp32c3_hal::{
     pac::{self, Peripherals, TIMG0, TIMG1},
     prelude::*,
     timer::{Timer, Timer0, TimerGroup},
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use riscv_rt::entry;
@@ -30,7 +30,7 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
@@ -38,8 +38,8 @@ fn main() -> ! {
     let mut timer1 = timer_group1.timer0;
     let mut wdt1 = timer_group1.wdt;
 
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -14,7 +14,7 @@ use esp32c3_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     UsbSerialJtag,
 };
 use panic_halt as _;
@@ -27,15 +27,15 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut delay = Delay::new(&clocks);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
 

--- a/esp32c3-hal/examples/watchdog.rs
+++ b/esp32c3-hal/examples/watchdog.rs
@@ -8,12 +8,7 @@
 use core::fmt::Write;
 
 use esp32c3_hal::{
-    clock::ClockControl,
-    pac::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    RtcCntl,
-    Serial,
+    clock::ClockControl, pac::Peripherals, prelude::*, timer::TimerGroup, Rtc, Serial,
 };
 use nb::block;
 use panic_halt as _;
@@ -25,7 +20,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
@@ -34,8 +29,8 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.swd.disable();
+    rtc.rwdt.disable();
     wdt0.start(2u64.secs());
     wdt1.disable();
 

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -24,7 +24,7 @@ pub use esp_hal_common::{
     Delay,
     PulseControl,
     Rng,
-    RtcCntl,
+    Rtc,
     Serial,
     UsbSerialJtag,
 };

--- a/esp32s2-hal/examples/adc.rs
+++ b/esp32s2-hal/examples/adc.rs
@@ -13,7 +13,7 @@ use esp32s2_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use esp_println::println;
 use panic_halt as _;
@@ -27,11 +27,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut pin3 = io.pins.gpio3.into_analog();

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -18,7 +18,7 @@ use esp32s2_hal::{
     },
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use esp_println::println;
@@ -33,11 +33,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32s2-hal/examples/blinky.rs
+++ b/esp32s2-hal/examples/blinky.rs
@@ -12,7 +12,7 @@ use esp32s2_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx_rt::entry;
@@ -25,11 +25,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Set GPIO4 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s2-hal/examples/dac.rs
+++ b/esp32s2-hal/examples/dac.rs
@@ -13,7 +13,7 @@ use esp32s2_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx_rt::entry;
@@ -26,11 +26,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin17 = io.pins.gpio17.into_analog();

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -18,7 +18,7 @@ use esp32s2_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx::mutex::{CriticalSectionMutex, Mutex};
@@ -36,11 +36,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -19,7 +19,7 @@ use esp32s2_hal::{
     utils::{smartLedAdapter, SmartLedsAdapter},
     Delay,
     PulseControl,
-    RtcCntl,
+    Rtc,
     IO,
 };
 #[allow(unused_imports)]
@@ -38,14 +38,14 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Configure RMT peripheral globally
     let pulse = PulseControl::new(peripherals.RMT, &mut system.peripheral_clock_control).unwrap();

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -11,7 +11,7 @@ use esp32s2_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -27,12 +27,12 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -28,7 +28,7 @@ use esp32s2_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -46,11 +46,11 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -19,7 +19,7 @@ use esp32s2_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use esp_println;
@@ -36,11 +36,11 @@ fn main() -> ! {
     let _timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let _serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32s2-hal/examples/read_efuse.rs
+++ b/esp32s2-hal/examples/read_efuse.rs
@@ -12,7 +12,7 @@ use esp32s2_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -27,11 +27,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
     writeln!(serial0, "MAC address {:02x?}", Efuse::get_mac_address()).unwrap();
     writeln!(
         serial0,

--- a/esp32s2-hal/examples/serial_interrupts.rs
+++ b/esp32s2-hal/examples/serial_interrupts.rs
@@ -14,7 +14,7 @@ use esp32s2_hal::{
     prelude::*,
     serial::config::AtCmdConfig,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -40,12 +40,12 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt0.disable();
     wdt1.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30);

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -26,7 +26,7 @@ use esp32s2_hal::{
     spi::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -40,13 +40,13 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio36;

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -15,7 +15,7 @@ use esp32s2_hal::{
     systimer::{Alarm, SystemTimer, Target},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx::mutex::{CriticalSectionMutex, Mutex};
@@ -36,11 +36,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -14,7 +14,7 @@ use esp32s2_hal::{
     pac::{self, Peripherals, TIMG0, TIMG1, UART0},
     prelude::*,
     timer::{Timer, Timer0, Timer1, TimerGroup},
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -50,12 +50,12 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     let serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt0.disable();
     wdt1.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     interrupt::enable(pac::Interrupt::TG0_T0_LEVEL, Priority::Priority2).unwrap();
     interrupt::enable(pac::Interrupt::TG0_T1_LEVEL, Priority::Priority2).unwrap();

--- a/esp32s2-hal/examples/watchdog.rs
+++ b/esp32s2-hal/examples/watchdog.rs
@@ -12,7 +12,7 @@ use esp32s2_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -28,11 +28,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.start(2u64.secs());
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -21,7 +21,7 @@ pub use esp_hal_common::{
     Delay,
     PulseControl,
     Rng,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 

--- a/esp32s3-hal/examples/advanced_serial.rs
+++ b/esp32s3-hal/examples/advanced_serial.rs
@@ -18,7 +18,7 @@ use esp32s3_hal::{
     },
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use esp_println::println;
@@ -33,11 +33,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32s3-hal/examples/blinky.rs
+++ b/esp32s3-hal/examples/blinky.rs
@@ -12,7 +12,7 @@ use esp32s3_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx_rt::entry;
@@ -25,11 +25,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Set GPIO4 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -18,7 +18,7 @@ use esp32s3_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx::mutex::{Mutex, SpinLockMutex};
@@ -36,11 +36,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s3-hal/examples/hello_rgb.rs
+++ b/esp32s3-hal/examples/hello_rgb.rs
@@ -20,7 +20,7 @@ use esp32s3_hal::{
     utils::{smartLedAdapter, SmartLedsAdapter},
     Delay,
     PulseControl,
-    RtcCntl,
+    Rtc,
     IO,
 };
 #[allow(unused_imports)]
@@ -39,14 +39,14 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     // Configure RMT peripheral globally
     let pulse = PulseControl::new(

--- a/esp32s3-hal/examples/hello_world.rs
+++ b/esp32s3-hal/examples/hello_world.rs
@@ -11,7 +11,7 @@ use esp32s3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -27,12 +27,12 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32s3-hal/examples/i2c_display.rs
+++ b/esp32s3-hal/examples/i2c_display.rs
@@ -28,7 +28,7 @@ use esp32s3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -46,11 +46,11 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/ledc.rs
+++ b/esp32s3-hal/examples/ledc.rs
@@ -19,7 +19,7 @@ use esp32s3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use esp_println;
@@ -36,11 +36,11 @@ fn main() -> ! {
     let _timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let mut _serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32s3-hal/examples/multicore.rs
+++ b/esp32s3-hal/examples/multicore.rs
@@ -13,7 +13,7 @@ use esp32s3_hal::{
     prelude::*,
     timer::{Timer, Timer0, TimerGroup},
     CpuControl,
-    RtcCntl,
+    Rtc,
 };
 use esp_println::println;
 use nb::block;
@@ -35,12 +35,12 @@ fn main() -> ! {
     let mut timer1 = timer_group1.timer0;
     let mut wdt1 = timer_group1.wdt;
 
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt0.disable();
     wdt1.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
     timer1.start(500u64.millis());

--- a/esp32s3-hal/examples/read_efuse.rs
+++ b/esp32s3-hal/examples/read_efuse.rs
@@ -12,7 +12,7 @@ use esp32s3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -27,11 +27,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
     writeln!(serial0, "MAC address {:02x?}", Efuse::get_mac_address()).unwrap();
     writeln!(
         serial0,

--- a/esp32s3-hal/examples/serial_interrupts.rs
+++ b/esp32s3-hal/examples/serial_interrupts.rs
@@ -14,7 +14,7 @@ use esp32s3_hal::{
     prelude::*,
     serial::config::AtCmdConfig,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -40,12 +40,12 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     let mut serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt0.disable();
     wdt1.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30);

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -26,7 +26,7 @@ use esp32s3_hal::{
     spi::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -40,13 +40,13 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
     let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio12;

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -15,7 +15,7 @@ use esp32s3_hal::{
     systimer::{Alarm, SystemTimer, Target},
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
 };
 use panic_halt as _;
 use xtensa_lx::mutex::{Mutex, SpinLockMutex};
@@ -36,11 +36,11 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32s3-hal/examples/timer_interrupt.rs
+++ b/esp32s3-hal/examples/timer_interrupt.rs
@@ -14,7 +14,7 @@ use esp32s3_hal::{
     pac::{self, Peripherals, TIMG0, TIMG1, UART0},
     prelude::*,
     timer::{Timer, Timer0, Timer1, TimerGroup},
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use panic_halt as _;
@@ -50,12 +50,12 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     let serial0 = Serial::new(peripherals.UART0);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt0.disable();
     wdt1.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     interrupt::enable(pac::Interrupt::TG0_T0_LEVEL, Priority::Priority2).unwrap();
     interrupt::enable(pac::Interrupt::TG0_T1_LEVEL, Priority::Priority2).unwrap();

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -13,7 +13,7 @@ use esp32s3_hal::{
     prelude::*,
     timer::TimerGroup,
     Delay,
-    RtcCntl,
+    Rtc,
     UsbSerialJtag,
 };
 use panic_halt as _;
@@ -26,13 +26,13 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut delay = Delay::new(&clocks);
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     loop {
         writeln!(UsbSerialJtag, "Hello world!").ok();

--- a/esp32s3-hal/examples/watchdog.rs
+++ b/esp32s3-hal/examples/watchdog.rs
@@ -12,7 +12,7 @@ use esp32s3_hal::{
     pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    RtcCntl,
+    Rtc,
     Serial,
 };
 use nb::block;
@@ -28,11 +28,11 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.start(2u64.secs());
-    rtc_cntl.set_wdt_global_enable(false);
+    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -25,7 +25,7 @@ pub use esp_hal_common::{
     Delay,
     PulseControl,
     Rng,
-    RtcCntl,
+    Rtc,
     Serial,
     UsbSerialJtag,
 };


### PR DESCRIPTION
## Summary
This PR intends to add support for the **RTC Watchdog Timer** peripheral.

The RTC driver has been extended with clock configuration capabilities, for both the RTC Fast Clock and RTC Slow Clock. During the RTC initialization, the current implementation takes some shortcuts:
- Skip O-Code calibration
- Skip voltage bias configuration
- Skip power down behavior of some peripherals during deep sleep

**Assumptions**:
- Default RTC Slow Clock: Internal 136 kHz RC oscillator
- Default RTC Fast Clock: Internal 17.5 MHz RC oscillator

## Testing
RWDT was validated by running the `rtc_watchdog` example application on the **ESP32-C3-DevKitM-1** development board.