### PR TITLE
Use the correct AlternateFunction for GPIO

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -552,7 +552,7 @@ macro_rules! impl_input {
                 paste! {
                     iomux.$iomux_reg.modify(|_, w| unsafe {
                         w.mcu_sel()
-                            .bits(2)
+                            .bits(AlternateFunction::$gpio_function as u8)
                             .fun_ie()
                             .set_bit()
                             .fun_wpd()


### PR DESCRIPTION
Turned out that we pass the correct AlternateFunction to select GPIO into the GPIO macros but we never used it.

It was always correct for ESP32 and often didn't show up as a problem on other chips - however it didn't work for certain pins.

Fixes #136 
