### PR TITLE
rtc: Add RWDT examples for ESP32, ESP32-S2 and ESP32-S3

### DIFF
--- a/esp32-hal/examples/rtc_watchdog.rs
+++ b/esp32-hal/examples/rtc_watchdog.rs
@@ -1,0 +1,66 @@
+//! This demos the RTC Watchdog Timer (RWDT).
+//! The RWDT is initially configured to trigger an interrupt after a given
+//! timeout. Then, upon expiration, the RWDT is restarted and then reconfigured
+//! to reset both the main system and the RTC.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use esp32_hal::{
+    clock::ClockControl,
+    interrupt,
+    pac::{self, Peripherals},
+    prelude::*,
+    Rtc,
+    Rwdt,
+};
+use panic_halt as _;
+use xtensa_lx::mutex::{CriticalSectionMutex, Mutex};
+use xtensa_lx_rt::entry;
+
+static mut RWDT: CriticalSectionMutex<RefCell<Option<Rwdt>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.DPORT.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timer
+    rtc.rwdt.disable();
+
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    interrupt::enable(pac::Interrupt::RTC_CORE, interrupt::Priority::Priority1).unwrap();
+
+    unsafe {
+        (&RWDT).lock(|data| (*data).replace(Some(rtc.rwdt)));
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn RTC_CORE() {
+    unsafe {
+        (&RWDT).lock(|data| {
+            esp_println::println!("RWDT Interrupt");
+
+            let mut rwdt = data.borrow_mut();
+            let rwdt = rwdt.as_mut().unwrap();
+
+            rwdt.clear_interrupt();
+
+            esp_println::println!("Restarting in 5 seconds...");
+
+            rwdt.start(5000u64.millis());
+            rwdt.unlisten();
+        });
+    }
+}

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -22,6 +22,7 @@ pub use esp_hal_common::{
     PulseControl,
     Rng,
     Rtc,
+    Rwdt,
     Serial,
 };
 

--- a/esp32c3-hal/examples/rtc_watchdog.rs
+++ b/esp32c3-hal/examples/rtc_watchdog.rs
@@ -15,9 +15,8 @@ use esp32c3_hal::{
     interrupt,
     pac::{self, Peripherals},
     prelude::*,
-    Rtc,
+    Rtc, Rwdt,
 };
-use esp_hal_common::Rwdt;
 use panic_halt as _;
 use riscv_rt::entry;
 

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -4,28 +4,8 @@ use core::arch::global_asm;
 
 pub use embedded_hal as ehal;
 pub use esp_hal_common::{
-    clock,
-    efuse,
-    gpio as gpio_types,
-    i2c,
-    interrupt,
-    ledc,
-    macros,
-    pac,
-    prelude,
-    pulse_control,
-    serial,
-    spi,
-    system,
-    systimer,
-    timer,
-    utils,
-    Cpu,
-    Delay,
-    PulseControl,
-    Rng,
-    Rtc,
-    Serial,
+    clock, efuse, gpio as gpio_types, i2c, interrupt, ledc, macros, pac, prelude, pulse_control,
+    serial, spi, system, systimer, timer, utils, Cpu, Delay, PulseControl, Rng, Rtc, Rwdt, Serial,
     UsbSerialJtag,
 };
 #[cfg(feature = "direct-boot")]

--- a/esp32s2-hal/examples/rtc_watchdog.rs
+++ b/esp32s2-hal/examples/rtc_watchdog.rs
@@ -1,0 +1,66 @@
+//! This demos the RTC Watchdog Timer (RWDT).
+//! The RWDT is initially configured to trigger an interrupt after a given
+//! timeout. Then, upon expiration, the RWDT is restarted and then reconfigured
+//! to reset both the main system and the RTC.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    interrupt,
+    pac::{self, Peripherals},
+    prelude::*,
+    Rtc,
+    Rwdt,
+};
+use panic_halt as _;
+use xtensa_lx::mutex::{CriticalSectionMutex, Mutex};
+use xtensa_lx_rt::entry;
+
+static mut RWDT: CriticalSectionMutex<RefCell<Option<Rwdt>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timer
+    rtc.rwdt.disable();
+
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    interrupt::enable(pac::Interrupt::RTC_CORE, interrupt::Priority::Priority1).unwrap();
+
+    unsafe {
+        (&RWDT).lock(|data| (*data).replace(Some(rtc.rwdt)));
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn RTC_CORE() {
+    unsafe {
+        (&RWDT).lock(|data| {
+            esp_println::println!("RWDT Interrupt");
+
+            let mut rwdt = data.borrow_mut();
+            let rwdt = rwdt.as_mut().unwrap();
+
+            rwdt.clear_interrupt();
+
+            esp_println::println!("Restarting in 5 seconds...");
+
+            rwdt.start(5000u64.millis());
+            rwdt.unlisten();
+        });
+    }
+}

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -22,6 +22,7 @@ pub use esp_hal_common::{
     PulseControl,
     Rng,
     Rtc,
+    Rwdt,
     Serial,
 };
 

--- a/esp32s3-hal/examples/rtc_watchdog.rs
+++ b/esp32s3-hal/examples/rtc_watchdog.rs
@@ -1,0 +1,67 @@
+//! This demos the RTC Watchdog Timer (RWDT).
+//! The RWDT is initially configured to trigger an interrupt after a given
+//! timeout. Then, upon expiration, the RWDT is restarted and then reconfigured
+//! to reset both the main system and the RTC.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    interrupt,
+    pac::{self, Peripherals},
+    prelude::*,
+    Rtc,
+    Rwdt,
+};
+use panic_halt as _;
+use xtensa_lx::mutex::{CriticalSectionMutex, Mutex};
+use xtensa_lx_rt::entry;
+
+static mut RWDT: CriticalSectionMutex<RefCell<Option<Rwdt>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    interrupt::enable(pac::Interrupt::RTC_CORE, interrupt::Priority::Priority1).unwrap();
+
+    unsafe {
+        (&RWDT).lock(|data| (*data).replace(Some(rtc.rwdt)));
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn RTC_CORE() {
+    unsafe {
+        (&RWDT).lock(|data| {
+            esp_println::println!("RWDT Interrupt");
+
+            let mut rwdt = data.borrow_mut();
+            let rwdt = rwdt.as_mut().unwrap();
+
+            rwdt.clear_interrupt();
+
+            esp_println::println!("Restarting in 5 seconds...");
+
+            rwdt.start(5000u64.millis());
+            rwdt.unlisten();
+        });
+    }
+}

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -26,6 +26,7 @@ pub use esp_hal_common::{
     PulseControl,
     Rng,
     Rtc,
+    Rwdt,
     Serial,
     UsbSerialJtag,
 };


### PR DESCRIPTION
## Summary
This PR intends to complement #134 with an example of RWDT operation on the remaining chips:
- **ESP32**
- **ESP32-S2**
- **ESP32-S3**

## Testing
**RWDT** was validated by running the `rtc_watchdog` example application on the following development boards:
- **ESP32-Ethernet-Kit**
- **ESP32-S2-DevKitC-1**
- **ESP32-S3-DevKitC-1**