### PR TITLE
rtc: Add support for monitoring of XTAL clock

### DIFF
--- a/esp32-hal/examples/clock_monitor.rs
+++ b/esp32-hal/examples/clock_monitor.rs
@@ -1,0 +1,69 @@
+//! This demos a simple monitor for the XTAL frequency, by relying on a special
+//! feature of the TIMG0 (Timer Group 0). This feature counts the number of XTAL
+//! clock cycles within a given number of RTC_SLOW_CLK cycles.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use esp32_hal::{
+    clock::ClockControl,
+    interrupt,
+    pac::{self, Peripherals},
+    prelude::*,
+    Rtc,
+};
+use panic_halt as _;
+use xtensa_lx::mutex::{CriticalSectionMutex, Mutex};
+use xtensa_lx_rt::entry;
+
+static mut RTC: CriticalSectionMutex<RefCell<Option<Rtc>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timer
+    rtc.rwdt.disable();
+
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    esp_println::println!(
+        "{: <10} XTAL frequency: {} MHz",
+        "[Expected]",
+        clocks.xtal_clock.to_MHz()
+    );
+
+    interrupt::enable(pac::Interrupt::RTC_CORE, interrupt::Priority::Priority1).unwrap();
+
+    unsafe {
+        (&RTC).lock(|data| (*data).replace(Some(rtc)));
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn RTC_CORE() {
+    unsafe {
+        (&RTC).lock(|data| {
+            let mut rtc = data.borrow_mut();
+            let rtc = rtc.as_mut().unwrap();
+
+            esp_println::println!(
+                "{: <10} XTAL frequency: {} MHz",
+                "[Monitor]",
+                rtc.estimate_xtal_frequency()
+            );
+
+            rtc.rwdt.clear_interrupt();
+        });
+    }
+}

--- a/esp32c3-hal/examples/clock_monitor.rs
+++ b/esp32c3-hal/examples/clock_monitor.rs
@@ -1,0 +1,72 @@
+//! This demos a simple monitor for the XTAL frequency, by relying on a special feature of the
+//! TIMG0 (Timer Group 0). This feature counts the number of XTAL clock cycles within a given
+//! number of RTC_SLOW_CLK cycles.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use bare_metal::Mutex;
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    interrupt,
+    pac::{self, Peripherals},
+    prelude::*,
+    Rtc,
+};
+use panic_halt as _;
+use riscv_rt::entry;
+
+static mut RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    esp_println::println!(
+        "{: <10} XTAL frequency: {} MHz",
+        "[Expected]",
+        clocks.xtal_clock.to_MHz()
+    );
+
+    interrupt::enable(pac::Interrupt::RTC_CORE, interrupt::Priority::Priority1).unwrap();
+
+    riscv::interrupt::free(|_cs| unsafe {
+        RTC.get_mut().replace(Some(rtc));
+    });
+
+    unsafe {
+        riscv::interrupt::enable();
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn RTC_CORE() {
+    riscv::interrupt::free(|cs| unsafe {
+        let mut rtc = RTC.borrow(*cs).borrow_mut();
+        let rtc = rtc.as_mut().unwrap();
+
+        esp_println::println!(
+            "{: <10} XTAL frequency: {} MHz",
+            "[Monitor]",
+            rtc.estimate_xtal_frequency()
+        );
+
+        rtc.rwdt.clear_interrupt();
+    });
+}

--- a/esp32s2-hal/examples/clock_monitor.rs
+++ b/esp32s2-hal/examples/clock_monitor.rs
@@ -1,0 +1,69 @@
+//! This demos a simple monitor for the XTAL frequency, by relying on a special
+//! feature of the TIMG0 (Timer Group 0). This feature counts the number of XTAL
+//! clock cycles within a given number of RTC_SLOW_CLK cycles.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    interrupt,
+    pac::{self, Peripherals},
+    prelude::*,
+    Rtc,
+};
+use panic_halt as _;
+use xtensa_lx::mutex::{CriticalSectionMutex, Mutex};
+use xtensa_lx_rt::entry;
+
+static mut RTC: CriticalSectionMutex<RefCell<Option<Rtc>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timer
+    rtc.rwdt.disable();
+
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    esp_println::println!(
+        "{: <10} XTAL frequency: {} MHz",
+        "[Expected]",
+        clocks.xtal_clock.to_MHz()
+    );
+
+    interrupt::enable(pac::Interrupt::RTC_CORE, interrupt::Priority::Priority1).unwrap();
+
+    unsafe {
+        (&RTC).lock(|data| (*data).replace(Some(rtc)));
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn RTC_CORE() {
+    unsafe {
+        (&RTC).lock(|data| {
+            let mut rtc = data.borrow_mut();
+            let rtc = rtc.as_mut().unwrap();
+
+            esp_println::println!(
+                "{: <10} XTAL frequency: {} MHz",
+                "[Monitor]",
+                rtc.estimate_xtal_frequency()
+            );
+
+            rtc.rwdt.clear_interrupt();
+        });
+    }
+}

--- a/esp32s3-hal/examples/clock_monitor.rs
+++ b/esp32s3-hal/examples/clock_monitor.rs
@@ -1,0 +1,70 @@
+//! This demos a simple monitor for the XTAL frequency, by relying on a special
+//! feature of the TIMG0 (Timer Group 0). This feature counts the number of XTAL
+//! clock cycles within a given number of RTC_SLOW_CLK cycles.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    interrupt,
+    pac::{self, Peripherals},
+    prelude::*,
+    Rtc,
+};
+use panic_halt as _;
+use xtensa_lx::mutex::{CriticalSectionMutex, Mutex};
+use xtensa_lx_rt::entry;
+
+static mut RTC: CriticalSectionMutex<RefCell<Option<Rtc>>> =
+    CriticalSectionMutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    esp_println::println!(
+        "{: <10} XTAL frequency: {} MHz",
+        "[Expected]",
+        clocks.xtal_clock.to_MHz()
+    );
+
+    interrupt::enable(pac::Interrupt::RTC_CORE, interrupt::Priority::Priority1).unwrap();
+
+    unsafe {
+        (&RTC).lock(|data| (*data).replace(Some(rtc)));
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn RTC_CORE() {
+    unsafe {
+        (&RTC).lock(|data| {
+            let mut rtc = data.borrow_mut();
+            let rtc = rtc.as_mut().unwrap();
+
+            esp_println::println!(
+                "{: <10} XTAL frequency: {} MHz",
+                "[Monitor]",
+                rtc.estimate_xtal_frequency()
+            );
+
+            rtc.rwdt.clear_interrupt();
+        });
+    }
+}


### PR DESCRIPTION
## Summary
This PR intends to add a new RTC feature for monitoring the actual XTAL frequency by relying on a special feature of the Timer Group 0 (**TIMG0**), which counts the number of XTAL clock cycles within a given number of the cycles from the internal Slow RC Oscillator.

## Testing
The XTAL frequency monitoring feature was validated by running the `clock_monitor` example application on the following development boards:
- **ESP32-Ethernet-Kit**
- **ESP32-S2-DevKitC-1**
- **ESP32-S3-DevKitC-1**
- **ESP32-C3-DevKitM-1**

**Output:**
```
[Expected] XTAL frequency: 40 MHz
[Monitor]  XTAL frequency: 38 MHz
[Monitor]  XTAL frequency: 38 MHz
[Monitor]  XTAL frequency: 38 MHz
[Monitor]  XTAL frequency: 38 MHz
...
```