### PR TITLE
common/gpio: Allow disconnecting IO from peripheral

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -140,6 +140,10 @@ pub trait InputPin: Pin {
         force_via_gpio_mux: bool,
     ) -> &mut Self;
 
+    /// Remove a connected `signal` from this input pin.
+    ///
+    /// Clears the entry in the GPIO matrix / IO mux that associates this input pin with the given
+    /// [input `signal`](`InputSignal`). Any other connected signals remain intact.
     fn disconnect_input_from_peripheral(&mut self, signal: InputSignal) -> &mut Self;
 }
 
@@ -175,6 +179,11 @@ pub trait OutputPin: Pin {
         force_via_gpio_mux: bool,
     ) -> &mut Self;
 
+    /// Remove this output pin from a connected [signal](`InputSignal`).
+    ///
+    /// Clears the entry in the GPIO matrix / IO mux that associates this output pin with a
+    /// previously connected [signal](`InputSignal`). Any other outputs connected to the signal
+    /// remain intact.
     fn disconnect_peripheral_from_output(&mut self) -> &mut Self;
 
     fn internal_pull_up(&mut self, on: bool) -> &mut Self;

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -173,6 +173,8 @@ pub trait OutputPin: Pin {
         force_via_gpio_mux: bool,
     ) -> &mut Self;
 
+    fn disconnect_peripheral_from_output(&mut self) -> &mut Self;
+
     fn internal_pull_up(&mut self, on: bool) -> &mut Self;
 
     fn internal_pull_down(&mut self, on: bool) -> &mut Self;
@@ -971,6 +973,19 @@ macro_rules! impl_output {
                         .inv_sel().bit(invert)
                         .oen_sel().bit(enable_from_gpio)
                         .oen_inv_sel().bit(invert_enable)
+                });
+
+                self
+            }
+
+            fn disconnect_peripheral_from_output(
+                &mut self,
+            ) -> &mut Self {
+                // Reset this GPIO to plain GPIO
+                self.set_alternate_function(AlternateFunction::Function2);
+
+                unsafe { &*GPIO::PTR }.func_out_sel_cfg[$pin_num].modify(|_, w| unsafe {
+                    w.out_sel().bits(OutputSignal::GPIO as OutputSignalType)
                 });
 
                 self

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -650,7 +650,7 @@ macro_rules! impl_input {
 
             fn disconnect_input_from_peripheral(&mut self, signal: InputSignal) -> &mut Self {
                 // Reset this GPIO to plain GPIO
-                self.set_alternate_function(AlternateFunction::Function2);
+                self.set_alternate_function(AlternateFunction::$gpio_function);
 
                 unsafe { &*GPIO::PTR }.func_in_sel_cfg[signal as usize].modify(|_, w| unsafe {
                     w.sel().clear_bit()
@@ -1004,7 +1004,7 @@ macro_rules! impl_output {
                 &mut self,
             ) -> &mut Self {
                 // Reset this GPIO to plain GPIO
-                self.set_alternate_function(AlternateFunction::Function2);
+                self.set_alternate_function(AlternateFunction::$gpio_function);
 
                 unsafe { &*GPIO::PTR }.func_out_sel_cfg[$pin_num].modify(|_, w| unsafe {
                     w.out_sel().bits(OutputSignal::GPIO as OutputSignalType)

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -139,6 +139,8 @@ pub trait InputPin: Pin {
         invert: bool,
         force_via_gpio_mux: bool,
     ) -> &mut Self;
+
+    fn disconnect_input_from_peripheral(&mut self, signal: InputSignal) -> &mut Self;
 }
 
 pub trait OutputPin: Pin {
@@ -634,6 +636,17 @@ macro_rules! impl_input {
                             .bits($pin_num)
                     });
                 }
+                self
+            }
+
+            fn disconnect_input_from_peripheral(&mut self, signal: InputSignal) -> &mut Self {
+                // Reset this GPIO to plain GPIO
+                self.set_alternate_function(AlternateFunction::Function2);
+
+                unsafe { &*GPIO::PTR }.func_in_sel_cfg[signal as usize].modify(|_, w| unsafe {
+                    w.sel().clear_bit()
+                });
+
                 self
             }
         }


### PR DESCRIPTION
This is a work-in-progress that enables disconnecting IOs from peripherals they were previously associated with.

It is currently implemented only for output signals because I'm not quite sure yet if I got it right at all. I'm looking forward to your feedback!


## Why?

I need this personally for a project I'm currently working on, in order to replicate some existing C code that performs half-duplex UART with a shared IO line for RX and TX.

Another, probably more obvious and cool application comes with the `SpiDevice` trait from embedded hal 1.0.0-alpha.8. Here, disconnecting peripherals allows us to share the SPI bus, and have the CS line controlled by hardware by connecting it to CS before we start the transactions, and disconnecting it afterwards.

In #100, @jrmoulton already implements the bit where the CS line is selectively connected before a transaction. This is the "missing" bit to have the CS line controlled by hardware on a shared bus.