### PR TITLE
Fix ESP32-C3 builds on latest nightlies

### DIFF
--- a/esp32c3-hal/ld/bl-riscv-link.x
+++ b/esp32c3-hal/ld/bl-riscv-link.x
@@ -59,8 +59,8 @@ SECTIONS
     KEEP(*(.init));
     KEEP(*(.init.rust));
     . = ALIGN(4);
-    (*(.trap));
-    (*(.trap.rust));
+    KEEP(*(.trap));
+    KEEP(*(.trap.rust));
 
     *(.text .text.*);
     _etext = .;

--- a/esp32c3-hal/ld/db-riscv-link.x
+++ b/esp32c3-hal/ld/db-riscv-link.x
@@ -52,8 +52,8 @@ SECTIONS
     KEEP(*(.init));
     KEEP(*(.init.rust));
     . = ALIGN(4);
-    (*(.trap));
-    (*(.trap.rust));
+    KEEP(*(.trap));
+    KEEP(*(.trap.rust));
 
     *(.text .text.*);
     _etext = .;


### PR DESCRIPTION
With recent nightlies there is a linker error like this:
```
  = note: rust-lld: error: C:\projects\esp\esp-hal\esp32c3-hal\target\riscv32imc-unknown-none-elf\debug\build\esp32c3-hal-8b9b1d88afc70fd1\out\bl-riscv-link.x:62: expected filename pattern
          >>>     (*(.trap));
          >>>     ^
```

This should fix it
