### PR TITLE
rtc: Disable Flashboot mode when disabling RTC Watchdog timer

### DIFF
--- a/esp-hal-common/src/rtc_cntl.rs
+++ b/esp-hal-common/src/rtc_cntl.rs
@@ -508,7 +508,7 @@ impl WatchdogDisable for Rwdt {
 
         self.set_write_protection(false);
 
-        rtc_cntl.wdtconfig0.modify(|_, w| w.wdt_en().clear_bit());
+        rtc_cntl.wdtconfig0.modify(|_, w| w.wdt_en().clear_bit().wdt_flashboot_mod_en().clear_bit());
 
         self.set_write_protection(true);
     }


### PR DESCRIPTION
## Summary 
This PR intends to fix a regression to Direct Boot support introduced on #134, which missed the inclusion of the routine for disabling the Flashboot mode.

## Testing
Booting `hello_world` example application with Direct Boot support

Closes #149 