### PR TITLE
ESP32-S2: Fix broken reference in documentation

### DIFF
--- a/esp32s2-hal/ld/memory.x
+++ b/esp32s2-hal/ld/memory.x
@@ -1,7 +1,7 @@
 /* This memory map assumes the flash cache is on; 
    the blocks used are excluded from the various memory ranges 
    
-   see: https://github.com/espressif/esp-idf/blob/master/components/soc/src/esp32/soc_memory_layout.c
+   see: https://github.com/espressif/esp-idf/blob/5b1189570025ba027f2ff6c2d91f6ffff3809cc2/components/heap/port/esp32s2/memory_layout.c
    for details
    */
 


### PR DESCRIPTION
## Summary
This PR is a complement to #153, which missed a file from the ESP32-S2 implementation.

## Testing
Not applicable.