### PR TITLE
Fix change detection of linker script on build files

### DIFF
--- a/esp32-hal/build.rs
+++ b/esp32-hal/build.rs
@@ -33,7 +33,7 @@ fn main() {
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=ld/memory.x");
 }
 
 fn generate_memory_extras() -> Vec<u8> {

--- a/esp32c3-hal/build.rs
+++ b/esp32c3-hal/build.rs
@@ -29,7 +29,7 @@ fn main() {
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=ld/memory.x");
 
     add_defaults();
 }
@@ -57,7 +57,7 @@ fn main() {
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=ld/memory.x");
 
     add_defaults();
 }

--- a/esp32s2-hal/build.rs
+++ b/esp32s2-hal/build.rs
@@ -27,5 +27,5 @@ fn main() {
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=ld/memory.x");
 }

--- a/esp32s3-hal/build.rs
+++ b/esp32s3-hal/build.rs
@@ -33,7 +33,7 @@ fn main() {
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=ld/memory.x");
 }
 
 #[cfg(feature = "direct-boot")]
@@ -69,5 +69,5 @@ fn main() {
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=ld/memory.x");
 }


### PR DESCRIPTION
In https://github.com/esp-rs/esp-hal/commit/7b59c9e76d42372fb74a4db0bff0394e3347e0f2 linker scripts have been moved in the `ld/` sub-folder for every target.

The change detection path in build.rs of every target hasn't been updated, resulting in the build script running at every code change, rather than only when there's a change in memory.x

This change allow to greatly reduce the compile time, by not running the build script after every changes. It also makes the cargo check (and rust-analyzer) provide instant feedback, rather than a 2-3 seconds delay.