### PR TITLE
No longer alias the PAC package names

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -40,18 +40,16 @@ critical-section = "1.0.0"
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature. We rename the PAC packages because we cannot
 # have dependencies and features with the same names.
-# NOTE: If we ever raise our MSRV to 1.60.0+ we can use the optional
-#       dependency syntax in the features instead of aliasing these packages.
-esp32_pac   = { package = "esp32",   version = "0.13.0", optional = true }
-esp32c3_pac = { package = "esp32c3", version = "0.5.0",  optional = true }
-esp32s2_pac = { package = "esp32s2", version = "0.3.0",  optional = true }
-esp32s3_pac = { package = "esp32s3", version = "0.3.0",  optional = true }
+esp32   = { version = "0.13.0", optional = true }
+esp32c3 = { version = "0.5.0",  optional = true }
+esp32s2 = { version = "0.3.0",  optional = true }
+esp32s3 = { version = "0.3.0",  optional = true }
 
 [features]
-esp32   = ["esp32_pac/rt"  , "procmacros/xtensa", "multi_core" , "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "critical-section/restore-state-u32"]
-esp32c3 = ["esp32c3_pac/rt", "procmacros/riscv" , "single_core", "riscv", "riscv-atomic-emulation-trap",      "critical-section/restore-state-u8"]
-esp32s2 = ["esp32s2_pac/rt", "procmacros/xtensa", "single_core", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "critical-section/restore-state-u32"]
-esp32s3 = ["esp32s3_pac/rt", "procmacros/xtensa", "multi_core" , "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "critical-section/restore-state-u32"]
+esp32   = ["esp32/rt"  , "procmacros/xtensa", "multi_core" , "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "critical-section/restore-state-u32"]
+esp32c3 = ["esp32c3/rt", "procmacros/riscv" , "single_core", "riscv", "riscv-atomic-emulation-trap",      "critical-section/restore-state-u8"]
+esp32s2 = ["esp32s2/rt", "procmacros/xtensa", "single_core", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "critical-section/restore-state-u32"]
+esp32s3 = ["esp32s3/rt", "procmacros/xtensa", "multi_core" , "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "critical-section/restore-state-u32"]
 
 # Core Count (should not be enabled directly, but instead by a PAC's feature)
 single_core = []

--- a/esp-hal-common/src/analog/adc/esp32s2.rs
+++ b/esp-hal-common/src/analog/adc/esp32s2.rs
@@ -1,11 +1,10 @@
 use core::marker::PhantomData;
 
 use embedded_hal::adc::{Channel, OneShot};
-use esp32s2_pac::APB_SARADC;
 
 use crate::{
     analog::{ADC1, ADC2},
-    pac::SENS,
+    pac::{APB_SARADC, SENS},
 };
 
 /// The sampling/readout resolution of the ADC

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -20,13 +20,13 @@
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 
 #[cfg(feature = "esp32")]
-pub use esp32_pac as pac;
+pub use esp32 as pac;
 #[cfg(feature = "esp32c3")]
-pub use esp32c3_pac as pac;
+pub use esp32c3 as pac;
 #[cfg(feature = "esp32s2")]
-pub use esp32s2_pac as pac;
+pub use esp32s2 as pac;
 #[cfg(feature = "esp32s3")]
-pub use esp32s3_pac as pac;
+pub use esp32s3 as pac;
 
 pub mod delay;
 


### PR DESCRIPTION
I don't know why I thought you couldn't have feature names which match optional packages, but I guess you can 😅 