### PR TITLE
Optimize the ESP32-S3 linker script

### DIFF
--- a/esp32s3-hal/ld/esp32s3.x
+++ b/esp32s3-hal/ld/esp32s3.x
@@ -71,7 +71,7 @@ SECTIONS {
     /*  Create an empty gap as big as .rwtext section - 32k (SRAM0) 
      *  because SRAM1 is available on the data bus and instruction bus 
      */
-    . = MAX(SIZEOF(.rwtext), 32k) - 32k + VECTORS_SIZE + RESERVE_ICACHES;
+    . = MAX(SIZEOF(.rwtext) + RESERVE_ICACHE + VECTORS_SIZE, 32k) - 32k;
 
     /* Prepare the alignment of the section above. */
     . = ALIGN(4);

--- a/esp32s3-hal/ld/esp32s3.x
+++ b/esp32s3-hal/ld/esp32s3.x
@@ -1,6 +1,5 @@
-
 /* before memory.x to allow override */
-ENTRY(Reset)
+ENTRY(ESP32Reset)
 
 INCLUDE memory.x
 
@@ -53,7 +52,6 @@ SECTIONS {
     _rodata_end = ABSOLUTE(.);
   } > RODATA
 
-
   .rwtext : ALIGN(4)
   {
     . = ALIGN (4);
@@ -70,15 +68,13 @@ SECTIONS {
 
     . = ALIGN(ALIGNOF(.rwtext));
 
-    /* Create an empty gap as big as .text section */
-
-    . = SIZEOF(.rwtext);
-
-    /* Prepare the alignment of the section above. Few bytes (0x20) must be
-     * added for the mapping header.
+    /*  Create an empty gap as big as .rwtext section - 32k (SRAM0) 
+     *  because SRAM1 is available on the data bus and instruction bus 
      */
+    . = MAX(SIZEOF(.rwtext), 32k) - 32k + VECTORS_SIZE + RESERVE_ICACHES;
 
-    . = ALIGN(0x10000) + 0x20;
+    /* Prepare the alignment of the section above. */
+    . = ALIGN(4);
     _rwdata_reserved_start = .;
   } > RWDATA
 

--- a/esp32s3-hal/ld/memory.x
+++ b/esp32s3-hal/ld/memory.x
@@ -2,7 +2,7 @@
 ENTRY(ESP32Reset)
 
 /* reserved for ICACHE */
-RESERVE_ICACHES = 0x8000;
+RESERVE_ICACHE = 0x8000;
 
 /* reserved at the start of the RTC memories for use by the ULP processor */
 RESERVE_RTC_FAST = 0;
@@ -22,16 +22,16 @@ VECTORS_SIZE = 0x400;
  memory, but can only be used after app starts.
 
  D cache use the memory from high address, so when it's configured to 16K/32K, the region
- 0x3FCF000 ~ (3FD00000 - DATA_CACHE_SIZE) should be available. This region is not used as
+ 0x3FCF0000 ~ (3FD00000 - DATA_CACHE_SIZE) should be available. This region is not used as
  static memory, leaving to the heap.
 */
 MEMORY
 {
-  vectors_seg ( RX )     : ORIGIN = 0x40370000 + RESERVE_ICACHES, len =  1k
-  iram_seg ( RX )        : ORIGIN = 0x40370000 + RESERVE_ICACHES + VECTORS_SIZE, len = 328k - VECTORS_SIZE - RESERVE_ICACHES
-  dram_seg ( RW )        : ORIGIN = 0x3FC80000 + RESERVE_ICACHES + VECTORS_SIZE, len = 328k - VECTORS_SIZE - RESERVE_ICACHES
+  vectors_seg ( RX )     : ORIGIN = 0x40370000 + RESERVE_ICACHE, len = VECTORS_SIZE
+  iram_seg ( RX )        : ORIGIN = 0x40370000 + RESERVE_ICACHE + VECTORS_SIZE, len = 328k - VECTORS_SIZE - RESERVE_ICACHE
+  dram_seg ( RW )        : ORIGIN = 0x3FC88000 , len = 328k 
 
-  reserved_for_boot_seg  : ORIGIN = 0x3FFDC200, len = 144k /* reserved for static ROM usage; can be used for heap */
+  reserved_for_boot_seg  : ORIGIN = 0x3FCDC700, len = 0xB000 /* reserved for static ROM usage; can be used for heap */
 
   /* external flash 
      The 0x20 offset is a convenience for the app binary image generation.

--- a/esp32s3-hal/ld/memory.x
+++ b/esp32s3-hal/ld/memory.x
@@ -29,7 +29,7 @@ MEMORY
 {
   vectors_seg ( RX )     : ORIGIN = 0x40370000 + RESERVE_ICACHE, len = VECTORS_SIZE
   iram_seg ( RX )        : ORIGIN = 0x40370000 + RESERVE_ICACHE + VECTORS_SIZE, len = 328k - VECTORS_SIZE - RESERVE_ICACHE
-  dram_seg ( RW )        : ORIGIN = 0x3FC88000 , len = 328k 
+  dram_seg ( RW )        : ORIGIN = 0x3FC88000 , len = 345856 
 
   reserved_for_boot_seg  : ORIGIN = 0x3FCDC700, len = 0xB000 /* reserved for static ROM usage; can be used for heap */
 

--- a/esp32s3-hal/ld/memory.x
+++ b/esp32s3-hal/ld/memory.x
@@ -1,8 +1,8 @@
 /* override entry point */
 ENTRY(ESP32Reset)
 
-/* reserved at the start of DRAM */
-RESERVE_DRAM = 0x8000;
+/* reserved for ICACHE */
+RESERVE_ICACHES = 0x8000;
 
 /* reserved at the start of the RTC memories for use by the ULP processor */
 RESERVE_RTC_FAST = 0;
@@ -11,14 +11,27 @@ RESERVE_RTC_SLOW = 0;
 /* define stack size for both cores */
 STACK_SIZE = 8k;
 
-/* Specify main memory areas */
+VECTORS_SIZE = 0x400;
+
+/* Specify main memory areas
+
+ 40370000 <- IRAM/Icache -> 40378000 <- D/IRAM (I) -> 403E0000
+                            3FC88000 <- D/IRAM (D) -> 3FCF0000 <- DRAM/DCache -> 3FD00000
+
+ Startup code uses the IRAM from 0x403B9000 to 0x403E0000, which is not available for static
+ memory, but can only be used after app starts.
+
+ D cache use the memory from high address, so when it's configured to 16K/32K, the region
+ 0x3FCF000 ~ (3FD00000 - DATA_CACHE_SIZE) should be available. This region is not used as
+ static memory, leaving to the heap.
+*/
 MEMORY
 {
-  vectors_seg ( RX )     : ORIGIN = 0x40370000 + RESERVE_DRAM, len =  1k
-  iram_seg ( RX )        : ORIGIN = 0x40370400 + RESERVE_DRAM, len = 328k - 0x400
+  vectors_seg ( RX )     : ORIGIN = 0x40370000 + RESERVE_ICACHES, len =  1k
+  iram_seg ( RX )        : ORIGIN = 0x40370000 + RESERVE_ICACHES + VECTORS_SIZE, len = 328k - VECTORS_SIZE - RESERVE_ICACHES
+  dram_seg ( RW )        : ORIGIN = 0x3FC80000 + RESERVE_ICACHES + VECTORS_SIZE, len = 328k - VECTORS_SIZE - RESERVE_ICACHES
 
-  dram_seg ( RW )        : ORIGIN = 0x3FC80000 + RESERVE_DRAM, len = 328k - RESERVE_DRAM
-  reserved_for_boot_seg  : ORIGIN = 0x3FFDC200, len = 144k /* ???? SRAM1; reserved for static ROM usage; can be used for heap */
+  reserved_for_boot_seg  : ORIGIN = 0x3FFDC200, len = 144k /* reserved for static ROM usage; can be used for heap */
 
   /* external flash 
      The 0x20 offset is a convenience for the app binary image generation.


### PR DESCRIPTION
Fixes #162 

Turned out we already took care of the overlapping - we just wasted 32k of RAM which should now be avoided.
