### PR TITLE
Fix embedded-hal 0.2.x SPI implementation

### DIFF
--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -203,7 +203,9 @@ where
     type Error = Infallible;
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        self.spi.write_bytes(words)
+        self.spi.write_bytes(words)?;
+        self.spi.flush()?;
+        Ok(())
     }
 }
 
@@ -592,6 +594,9 @@ pub trait Instance {
             // Wait for all chunks to complete except the last one.
             // The function is allowed to return before the bus is idle.
             // see [embedded-hal flushing](https://docs.rs/embedded-hal/1.0.0-alpha.8/embedded_hal/spi/blocking/index.html#flushing)
+            //
+            // THIS IS NOT TRUE FOR EH 0.2.X! MAKE SURE TO FLUSH IN EH 0.2.X TRAIT
+            // IMPLEMENTATIONS!
             if i < num_chunks {
                 while reg_block.cmd.read().usr().bit_is_set() {
                     // wait


### PR DESCRIPTION
While for embedded-hal 1.0.0 it's allowed to return before the operation is finished that is NOT true for embedded-hal 0.2.x

The implementation was missing a call to `flush`

This fixes #156

@AnthonyGrondin you might want to try this branch so we are sure it will actually fix #156 
