### PR TITLE
Feature/spi builder

### DIFF
--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -24,7 +24,7 @@ use esp32_hal::{
     gpio::IO,
     pac::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::{SpiBuilder, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,
@@ -55,17 +55,18 @@ fn main() -> ! {
     let mosi = io.pins.gpio23;
     let cs = io.pins.gpio22;
 
-    let mut spi = Spi::new(
+    let mut spi = SpiBuilder::new(
         peripherals.SPI2,
-        sclk,
-        mosi,
-        miso,
-        cs,
-        1000u32.kHz(),
-        SpiMode::Mode0,
         &mut system.peripheral_clock_control,
         &clocks,
-    );
+        sclk,
+    )
+    .frequency(1000u32.kHz())
+    .mode(SpiMode::Mode0)
+    .mosi(mosi)
+    .miso(miso)
+    .cs(cs)
+    .build();
 
     let mut delay = Delay::new(&clocks);
     writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();


### PR DESCRIPTION
Adds a builder interface for SPI peripherals. Takes required SPI parameters in the builders constructor as arguments (clocks, sck line, ...) and allows the user to specify the rest as needed. This allows for fine-grained control about which SPI lines to use or omit, and reduces the length of the argument list in the call to `new`.

The `Builder` is added as new struct to maintain compatibility with the previous, direct instantiation method.

Feedback is very welcome!