### PR TITLE
gpio: Impl From<>

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -833,6 +833,14 @@ macro_rules! impl_output {
             }
         }
 
+        impl_from!($pxi, Input<Floating>, into_floating_input);
+        impl_from!($pxi, Input<PullUp>, into_pull_up_input);
+        impl_from!($pxi, Input<PullDown>, into_pull_down_input);
+        impl_from!($pxi, Output<PushPull>, into_push_pull_output);
+        impl_from!($pxi, Output<OpenDrain>, into_open_drain_output);
+        impl_from!($pxi, Alternate<AF1>, into_alternate_1);
+        impl_from!($pxi, Alternate<AF2>, into_alternate_2);
+
         impl<MODE> $pxi<MODE> {
             pub fn into_pull_up_input(self) -> $pxi<Input<PullUp>> {
                 self.init_input(false, true);
@@ -1088,6 +1096,18 @@ macro_rules! impl_interrupt_status_register_access {
 
 #[doc(hidden)]
 #[macro_export]
+macro_rules! impl_from {
+    ($pxi:ident, $mode:ty, $function:ident) => {
+        impl From<$pxi<Unknown>> for $pxi<$mode> {
+            fn from(pin: $pxi<Unknown>) -> $pxi<$mode> {
+                pin.$function()
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! gpio {
     (
         $gpio_function:ident,
@@ -1240,6 +1260,8 @@ macro_rules! analog {
                     $pxi { _mode: PhantomData }
                 }
             }
+
+            impl_from!($pxi, Analog, into_analog);
         )+
     }
 }
@@ -1272,6 +1294,8 @@ macro_rules! analog {
                     $pxi { _mode: PhantomData }
                 }
             }
+
+            impl_from!($pxi, Analog, into_analog);
         )+
     }
 }
@@ -1281,6 +1305,7 @@ pub use gpio;
 pub use impl_errata36;
 pub use impl_gpio_register_access;
 pub use impl_input;
+pub use impl_from;
 pub use impl_interrupt_status_register_access;
 pub use impl_output;
 pub use impl_output_wrap;


### PR DESCRIPTION
When setting up peripherals, I like to have a function that initialize most of the low-level stuff that returns a struct with all the set up peripherals and pins. That allows for example to have a BSP that is easy to swap with another one since you can do this in another module.
When defining the struct, you're already describing the pins and the mode they are into; thus, having to use the `gpio.into_<mode>()` functions is redundant since you're already putting the pins into your peripherals or return struct that is typed.
This PR allows to only use `gpio.into()`, so there is only one place you have to set up the type of your pin for initialization,

Example of usage:
```rust
struct Init {
    dac: dac::DAC1,
    pins: Pins,
}

struct Pins {
    switch: gpio::Gpio17<Input<PullDown>>,
}

fn init_hw() -> Init {
    // Basic setup there...

    // Setup pins
    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
    let audio_out = io.pins.gpio25.into();
    let switch = io.pins.gpio17.into();

    // Setup the DAC
    let analog = peripherals.SENS.split();
    let dac = dac::DAC1::dac(analog.dac1, audio_out).unwrap();

    Init {
        dac,
        pins: Pins {
            switch,
        }
    }
```

Also I'm not really satisfied with having to use multiple call to `impl_from` for each mode instead of having a repeating macro but I'm not really sure how to use it since it's a nested macro and I'm getting not really clear errors.