### PR TITLE
Pin version of paste to fix build errors

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -18,7 +18,7 @@ embedded-hal     = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1   = { package = "embedded-hal", version = "=1.0.0-alpha.8", optional = true }
 fugit            = "0.3.6"
 nb               = "1.0.0"
-paste            = "1.0.8"
+paste            = "=1.0.8"
 procmacros       = { path = "../esp-hal-procmacros", package = "esp-hal-procmacros" }
 void             = { version = "1.0.2", default-features = false }
 


### PR DESCRIPTION
A few hours ago, the `paste` crate got a seemingly semver compatible update: https://crates.io/crates/paste/1.0.9

For us this causes a lot of trouble and failing builds. For now, this pins the `paste` crate to version 1.0.8

I don't see an easy way to fix things for 1.0.9 - let's see if there will be a 1.0.10 fixing that or if we need to come up with something.

For now, this should fix things

However, I guess that the already published HALs will be broken now - needs to be verified