### PR TITLE
Prepare for updated wifi drivers

### DIFF
--- a/esp32-hal/build.rs
+++ b/esp32-hal/build.rs
@@ -29,6 +29,11 @@ fn main() {
         .write_all(&memory_extras)
         .unwrap();
 
+    File::create(out.join("link-esp32.x"))
+        .unwrap()
+        .write_all(include_bytes!("ld/link-esp32.x"))
+        .unwrap();
+
     println!("cargo:rustc-link-search={}", out.display());
 
     // Only re-run the build script when memory.x is changed,

--- a/esp32-hal/ld/link-esp32.x
+++ b/esp32-hal/ld/link-esp32.x
@@ -1,0 +1,84 @@
+
+/* before memory.x to allow override */
+ENTRY(Reset)
+
+INCLUDE memory.x
+
+/* after memory.x to allow override */
+PROVIDE(__pre_init = DefaultPreInit);
+PROVIDE(__zero_bss = default_mem_hook);
+PROVIDE(__init_data = default_mem_hook);
+
+INCLUDE exception.x
+
+SECTIONS {
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    . = ALIGN (4);
+    _text_start = ABSOLUTE(.);
+    . = ALIGN (4);
+    *(.literal .text .literal.* .text.*)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } > ROTEXT
+
+  .rodata : ALIGN(4)
+  {
+    _rodata_start = ABSOLUTE(.);
+    . = ALIGN (4);
+    *(.rodata .rodata.*)
+    _rodata_end = ABSOLUTE(.);
+  } > RODATA
+
+  .rodata.wifi :
+  {
+    . = ALIGN(4);
+    *( .rodata_wlog_*.* )
+  } > RODATA AT > RODATA
+
+  .data : ALIGN(4)
+  {
+    _data_start = ABSOLUTE(.);
+    . = ALIGN (4);
+    *(.data .data.*)
+    _data_end = ABSOLUTE(.);
+  } > RWDATA AT > RODATA
+
+  /* LMA of .data */
+  _sidata = LOADADDR(.data);
+
+  .bss (NOLOAD) : ALIGN(4)
+  {
+    _bss_start = ABSOLUTE(.);
+    . = ALIGN (4);
+    *(.bss .bss.* COMMON)
+    _bss_end = ABSOLUTE(.);
+  } > RWDATA
+
+  .noinit (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    *(.noinit .noinit.*)
+  } > RWDATA
+
+  .rwtext : ALIGN(4)
+  {
+    . = ALIGN (4);
+    *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
+  } > RWTEXT
+
+ /* must be last segment using RWTEXT */
+  .text_heap_start (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN (4);
+    _text_heap_start = ABSOLUTE(.);
+  } > RWTEXT
+
+ /* must be last segment using RWDATA */
+  .heap_start (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN (4);
+    _heap_start = ABSOLUTE(.);
+  } > RWDATA
+}

--- a/esp32-hal/ld/linkall.x
+++ b/esp32-hal/ld/linkall.x
@@ -1,2 +1,2 @@
-INCLUDE "link.x"
+INCLUDE "link-esp32.x"
 INCLUDE "hal-defaults.x"

--- a/esp32-hal/ld/memory.x
+++ b/esp32-hal/ld/memory.x
@@ -155,6 +155,9 @@ SECTIONS {
     . = ALIGN(4);
     *( .wifi0iram  .wifi0iram.*)
     *( .wifirxiram  .wifirxiram.*)
+    *( .wifislprxiram  .wifislprxiram.*)
+    *( .wifislpiram  .wifislpiram.*)
+    *( .phyiram  .phyiram.*)
     *( .iram1  .iram1.*)
   } > RWTEXT AT > RODATA
 


### PR DESCRIPTION
In order to use the latest wifi drivers (see https://github.com/esp-rs/esp-wifi/issues/52) we need some changes to the ESP32 linker scripts.

When not linking the wifi drivers nothing should change with this
