### PR TITLE
Inject configuration symbols in build script, simplify cfg gating

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -17,6 +17,7 @@ critical-section = "1.1.0"
 embedded-hal     = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1   = { package = "embedded-hal", version = "=1.0.0-alpha.8", optional = true }
 fugit            = "0.3.6"
+lock_api         = { version = "0.4.8", optional = true }
 nb               = "1.0.0"
 paste            = "=1.0.8"
 procmacros       = { version = "0.1.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
@@ -46,14 +47,10 @@ esp32s2 = { version = "0.3.0",  optional = true }
 esp32s3 = { version = "0.3.0",  optional = true }
 
 [features]
-esp32   = ["esp32/rt"  , "procmacros/xtensa", "multi_core" , "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "critical-section/restore-state-u32"]
-esp32c3 = ["esp32c3/rt", "procmacros/riscv" , "single_core", "riscv", "riscv-atomic-emulation-trap",      "critical-section/restore-state-u8"]
-esp32s2 = ["esp32s2/rt", "procmacros/xtensa", "single_core", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "critical-section/restore-state-u32"]
-esp32s3 = ["esp32s3/rt", "procmacros/xtensa", "multi_core" , "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "critical-section/restore-state-u32"]
-
-# Core Count (should not be enabled directly, but instead by a PAC's feature)
-single_core = []
-multi_core  = []
+esp32   = ["esp32/rt"  , "procmacros/xtensa", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "critical-section/restore-state-u32", "lock_api"]
+esp32c3 = ["esp32c3/rt", "procmacros/riscv" , "riscv", "riscv-atomic-emulation-trap",      "critical-section/restore-state-u8"]
+esp32s2 = ["esp32s2/rt", "procmacros/xtensa", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "critical-section/restore-state-u32"]
+esp32s3 = ["esp32s3/rt", "procmacros/xtensa", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "critical-section/restore-state-u32", "lock_api"]
 
 # Implement the `embedded-hal==1.0.0-alpha.x` traits
 eh1 = ["embedded-hal-1"]

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -1,12 +1,24 @@
 fn main() {
-    let chip_features = [
-        cfg!(feature = "esp32"),
-        cfg!(feature = "esp32c3"),
-        cfg!(feature = "esp32s2"),
-        cfg!(feature = "esp32s3"),
-    ];
+    let esp32 = cfg!(feature = "esp32");
+    let esp32c3 = cfg!(feature = "esp32c3");
+    let esp32s2 = cfg!(feature = "esp32s2");
+    let esp32s3 = cfg!(feature = "esp32s3");
 
-    if chip_features.iter().filter(|&&f| f).count() != 1 {
-        panic!("Exactly one chip must be enabled via its cargo feature");
+    // Ensure that exactly one chip has been specified
+    let chip_features = [esp32, esp32c3, esp32s2, esp32s3];
+    match chip_features.iter().filter(|&&f| f).count() {
+        1 => {}
+        n => panic!("Exactly 1 chip must be enabled via its Cargo feature, {n} provided"),
+    }
+
+    // Inject a configuration symbol for the enabled chip
+    if esp32 {
+        println!("cargo:rustc-cfg=esp32");
+    } else if esp32c3 {
+        println!("cargo:rustc-cfg=esp32c3");
+    } else if esp32s2 {
+        println!("cargo:rustc-cfg=esp32s2");
+    } else if esp32s3 {
+        println!("cargo:rustc-cfg=esp32s3");
     }
 }

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -21,4 +21,18 @@ fn main() {
     } else if esp32s3 {
         println!("cargo:rustc-cfg=esp32s3");
     }
+
+    // Inject a configuration symbol for the architecture of the enabled chip
+    if esp32c3 {
+        println!("cargo:rustc-cfg=riscv");
+    } else {
+        println!("cargo:rustc-cfg=xtensa");
+    }
+
+    // Inject a configuration symbol to state the core count of the enabled chip
+    if esp32c3 || esp32s2 {
+        println!("cargo:rustc-cfg=single_core");
+    } else {
+        println!("cargo:rustc-cfg=multi_core");
+    }
 }

--- a/esp-hal-common/src/analog/dac.rs
+++ b/esp-hal-common/src/analog/dac.rs
@@ -10,7 +10,7 @@ pub trait DAC1Impl {
     where
         Self: Sized,
     {
-        #[cfg(feature = "esp32s2")]
+        #[cfg(esp32s2)]
         {
             let sensors = unsafe { &*SENS::ptr() };
             sensors
@@ -48,7 +48,7 @@ pub trait DAC2Impl {
     where
         Self: Sized,
     {
-        #[cfg(feature = "esp32s2")]
+        #[cfg(esp32s2)]
         {
             let sensors = unsafe { &*SENS::ptr() };
             sensors

--- a/esp-hal-common/src/analog/mod.rs
+++ b/esp-hal-common/src/analog/mod.rs
@@ -1,13 +1,13 @@
-#[cfg_attr(feature = "esp32", path = "adc/esp32.rs")]
-#[cfg_attr(feature = "esp32s2", path = "adc/esp32s2.rs")]
-#[cfg_attr(feature = "esp32s3", path = "adc/esp32s3.rs")]
-#[cfg_attr(feature = "esp32c3", path = "adc/esp32c3.rs")]
+#[cfg_attr(esp32, path = "adc/esp32.rs")]
+#[cfg_attr(esp32s2, path = "adc/esp32s2.rs")]
+#[cfg_attr(esp32s3, path = "adc/esp32s3.rs")]
+#[cfg_attr(esp32c3, path = "adc/esp32c3.rs")]
 pub mod adc;
-#[cfg(not(any(feature = "esp32c3", feature = "esp32s3")))]
+#[cfg(not(any(esp32c3, esp32s3)))]
 pub mod dac;
 
 cfg_if::cfg_if! {
-    if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+    if #[cfg(any(esp32, esp32s2))] {
         use core::marker::PhantomData;
 
         use crate::pac::SENS;
@@ -61,7 +61,7 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "esp32c3")] {
+    if #[cfg(esp32c3)] {
         use core::marker::PhantomData;
 
         use crate::pac::APB_SARADC;

--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -3,10 +3,10 @@ use fugit::HertzU32;
 
 use crate::system::SystemClockControl;
 
-#[cfg_attr(feature = "esp32", path = "clocks_ll/esp32.rs")]
-#[cfg_attr(feature = "esp32c3", path = "clocks_ll/esp32c3.rs")]
-#[cfg_attr(feature = "esp32s2", path = "clocks_ll/esp32s2.rs")]
-#[cfg_attr(feature = "esp32s3", path = "clocks_ll/esp32s3.rs")]
+#[cfg_attr(esp32, path = "clocks_ll/esp32.rs")]
+#[cfg_attr(esp32c3, path = "clocks_ll/esp32c3.rs")]
+#[cfg_attr(esp32s2, path = "clocks_ll/esp32s2.rs")]
+#[cfg_attr(esp32s3, path = "clocks_ll/esp32s3.rs")]
 mod clocks_ll;
 
 pub trait Clock {
@@ -26,7 +26,7 @@ pub trait Clock {
 pub enum CpuClock {
     Clock80MHz,
     Clock160MHz,
-    #[cfg(not(feature = "esp32c3"))]
+    #[cfg(not(esp32c3))]
     Clock240MHz,
 }
 
@@ -36,7 +36,7 @@ impl Clock for CpuClock {
         match self {
             CpuClock::Clock80MHz => HertzU32::MHz(80),
             CpuClock::Clock160MHz => HertzU32::MHz(160),
-            #[cfg(not(feature = "esp32c3"))]
+            #[cfg(not(esp32c3))]
             CpuClock::Clock240MHz => HertzU32::MHz(240),
         }
     }
@@ -46,11 +46,11 @@ impl Clock for CpuClock {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum XtalClock {
     RtcXtalFreq40M,
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     RtcXtalFreq26M,
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     RtcXtalFreq24M,
-    #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+    #[cfg(any(esp32c3, esp32s3))]
     RtcXtalFreq32M,
     RtcXtalFreqOther(u32),
 }
@@ -59,11 +59,11 @@ impl Clock for XtalClock {
     fn frequency(&self) -> HertzU32 {
         match self {
             XtalClock::RtcXtalFreq40M => HertzU32::MHz(40),
-            #[cfg(feature = "esp32")]
+            #[cfg(esp32)]
             XtalClock::RtcXtalFreq26M => HertzU32::MHz(26),
-            #[cfg(feature = "esp32")]
+            #[cfg(esp32)]
             XtalClock::RtcXtalFreq24M => HertzU32::MHz(24),
-            #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+            #[cfg(any(esp32c3, esp32s3))]
             XtalClock::RtcXtalFreq32M => HertzU32::MHz(32),
             XtalClock::RtcXtalFreqOther(mhz) => HertzU32::MHz(*mhz),
         }
@@ -149,7 +149,7 @@ impl ClockControl {
     }
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 impl ClockControl {
     /// Use what is considered the default settings after boot.
     #[allow(unused)]
@@ -194,7 +194,7 @@ impl ClockControl {
     }
 }
 
-#[cfg(feature = "esp32c3")]
+#[cfg(esp32c3)]
 impl ClockControl {
     /// Use what is considered the default settings after boot.
     #[allow(unused)]
@@ -241,7 +241,7 @@ impl ClockControl {
     }
 }
 
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 impl ClockControl {
     /// Use what is considered the default settings after boot.
     #[allow(unused)]
@@ -274,7 +274,7 @@ impl ClockControl {
     }
 }
 
-#[cfg(feature = "esp32s3")]
+#[cfg(esp32s3)]
 impl ClockControl {
     /// Use what is considered the default settings after boot.
     #[allow(unused)]

--- a/esp-hal-common/src/delay.rs
+++ b/esp-hal-common/src/delay.rs
@@ -37,7 +37,7 @@ impl embedded_hal_1::delay::blocking::DelayUs for Delay {
     }
 }
 
-#[cfg(feature = "esp32c3")]
+#[cfg(esp32c3)]
 mod delay {
     use fugit::HertzU64;
 
@@ -72,7 +72,7 @@ mod delay {
     }
 }
 
-#[cfg(not(feature = "esp32c3"))]
+#[cfg(not(esp32c3))]
 mod delay {
     use fugit::HertzU64;
 

--- a/esp-hal-common/src/delay.rs
+++ b/esp-hal-common/src/delay.rs
@@ -37,7 +37,7 @@ impl embedded_hal_1::delay::blocking::DelayUs for Delay {
     }
 }
 
-#[cfg(esp32c3)]
+#[cfg(riscv)]
 mod delay {
     use fugit::HertzU64;
 
@@ -72,7 +72,7 @@ mod delay {
     }
 }
 
-#[cfg(not(esp32c3))]
+#[cfg(xtensa)]
 mod delay {
     use fugit::HertzU64;
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -10,10 +10,10 @@ pub use paste::paste;
 use crate::pac::GPIO;
 
 #[doc(hidden)]
-#[cfg_attr(feature = "esp32", path = "gpio/esp32.rs")]
-#[cfg_attr(feature = "esp32c3", path = "gpio/esp32c3.rs")]
-#[cfg_attr(feature = "esp32s2", path = "gpio/esp32s2.rs")]
-#[cfg_attr(feature = "esp32s3", path = "gpio/esp32s3.rs")]
+#[cfg_attr(esp32, path = "gpio/esp32.rs")]
+#[cfg_attr(esp32c3, path = "gpio/esp32c3.rs")]
+#[cfg_attr(esp32s2, path = "gpio/esp32s2.rs")]
+#[cfg_attr(esp32s3, path = "gpio/esp32s3.rs")]
 pub mod types;
 
 #[derive(Copy, Clone)]
@@ -230,7 +230,7 @@ impl InteruptStatusRegisterAccess for SingleCoreInteruptStatusRegisterAccess {
 // interrupt enable bit see
 // https://github.com/espressif/esp-idf/blob/c04803e88b871a4044da152dfb3699cf47354d18/components/hal/esp32s3/include/hal/gpio_ll.h#L32
 // Treating it as SingleCore in the gpio macro makes this work.
-#[cfg(not(any(feature = "esp32c3", feature = "esp32s2", feature = "esp32s3")))]
+#[cfg(not(any(esp32c3, esp32s2, esp32s3)))]
 impl InteruptStatusRegisterAccess for DualCoreInteruptStatusRegisterAccess {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
@@ -334,7 +334,7 @@ impl BankGpioRegisterAccess for Bank0GpioRegisterAccess {
 }
 
 #[doc(hidden)]
-#[cfg(not(feature = "esp32c3"))]
+#[cfg(not(esp32c3))]
 impl BankGpioRegisterAccess for Bank1GpioRegisterAccess {
     fn write_out_en_clear(word: u32) {
         unsafe { &*GPIO::PTR }
@@ -1103,7 +1103,7 @@ macro_rules! impl_from {
                 pin.$function()
             }
         }
-    }
+    };
 }
 
 #[doc(hidden)]
@@ -1196,7 +1196,7 @@ macro_rules! gpio {
 
 #[doc(hidden)]
 pub fn enable_iomux_clk_gate() {
-    #[cfg(feature = "esp32s2")]
+    #[cfg(esp32s2)]
     {
         use crate::pac::SENS;
         let sensors = unsafe { &*SENS::ptr() };
@@ -1206,7 +1206,7 @@ pub fn enable_iomux_clk_gate() {
     }
 }
 
-#[cfg(not(feature = "esp32c3"))]
+#[cfg(not(esp32c3))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! analog {
@@ -1266,7 +1266,7 @@ macro_rules! analog {
     }
 }
 
-#[cfg(feature = "esp32c3")]
+#[cfg(esp32c3)]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! analog {
@@ -1303,9 +1303,9 @@ macro_rules! analog {
 pub use analog;
 pub use gpio;
 pub use impl_errata36;
+pub use impl_from;
 pub use impl_gpio_register_access;
 pub use impl_input;
-pub use impl_from;
 pub use impl_interrupt_status_register_access;
 pub use impl_output;
 pub use impl_output_wrap;

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -155,27 +155,27 @@ pub fn get_status(core: Cpu) -> u128 {
     }
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 unsafe fn core0_interrupt_peripheral() -> *const crate::pac::dport::RegisterBlock {
     crate::pac::DPORT::PTR
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 unsafe fn core1_interrupt_peripheral() -> *const crate::pac::dport::RegisterBlock {
     crate::pac::DPORT::PTR
 }
 
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 unsafe fn core0_interrupt_peripheral() -> *const crate::pac::interrupt::RegisterBlock {
     crate::pac::INTERRUPT::PTR
 }
 
-#[cfg(feature = "esp32s3")]
+#[cfg(esp32s3)]
 unsafe fn core0_interrupt_peripheral() -> *const crate::pac::interrupt_core0::RegisterBlock {
     crate::pac::INTERRUPT_CORE0::PTR
 }
 
-#[cfg(feature = "esp32s3")]
+#[cfg(esp32s3)]
 unsafe fn core1_interrupt_peripheral() -> *const crate::pac::interrupt_core1::RegisterBlock {
     crate::pac::INTERRUPT_CORE1::PTR
 }
@@ -433,7 +433,7 @@ mod vectored {
         }
     }
 
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     mod chip_specific {
         use super::*;
         pub const INTERRUPT_EDGE: u128 =
@@ -455,7 +455,7 @@ mod vectored {
         }
     }
 
-    #[cfg(feature = "esp32s2")]
+    #[cfg(esp32s2)]
     mod chip_specific {
         use super::*;
         pub const INTERRUPT_EDGE: u128 =
@@ -480,7 +480,7 @@ mod vectored {
         }
     }
 
-    #[cfg(feature = "esp32s3")]
+    #[cfg(esp32s3)]
     mod chip_specific {
         use super::*;
         pub const INTERRUPT_EDGE: u128 = 0;

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -65,9 +65,9 @@ pub unsafe fn map(core: Cpu, interrupt: Interrupt, which: CpuInterrupt) {
     let cpu_interrupt_number = which as isize;
     let intr_map_base = match core {
         Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
-        #[cfg(feature = "multi_core")]
+        #[cfg(multi_core)]
         Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
-        #[cfg(feature = "single_core")]
+        #[cfg(single_core)]
         Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
     };
     intr_map_base
@@ -81,9 +81,9 @@ pub fn disable(core: Cpu, interrupt: Interrupt) {
         let interrupt_number = interrupt as isize;
         let intr_map_base = match core {
             Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
-            #[cfg(feature = "multi_core")]
+            #[cfg(multi_core)]
             Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
-            #[cfg(feature = "single_core")]
+            #[cfg(single_core)]
             Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
         };
         intr_map_base.offset(interrupt_number).write_volatile(0);
@@ -117,7 +117,7 @@ pub fn get_status(core: Cpu) -> u128 {
                         .bits() as u128)
                         << 64
             }
-            #[cfg(feature = "multi_core")]
+            #[cfg(multi_core)]
             Cpu::AppCpu => {
                 ((*core1_interrupt_peripheral())
                     .app_intr_status_0
@@ -134,7 +134,7 @@ pub fn get_status(core: Cpu) -> u128 {
                         .bits() as u128)
                         << 64
             }
-            #[cfg(feature = "single_core")]
+            #[cfg(single_core)]
             Cpu::AppCpu => {
                 ((*core0_interrupt_peripheral())
                     .pro_intr_status_0
@@ -256,9 +256,9 @@ mod vectored {
         unsafe {
             let intr_map_base = match core {
                 Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
-                #[cfg(feature = "multi_core")]
+                #[cfg(multi_core)]
                 Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
-                #[cfg(feature = "single_core")]
+                #[cfg(single_core)]
                 Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
             };
 

--- a/esp-hal-common/src/ledc/channel.rs
+++ b/esp-hal-common/src/ledc/channel.rs
@@ -1,6 +1,6 @@
 use paste::paste;
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 use super::HighSpeed;
 use super::{
     timer::{TimerIFace, TimerSpeed},
@@ -31,9 +31,9 @@ pub enum Number {
     Channel3,
     Channel4,
     Channel5,
-    #[cfg(not(feature = "esp32c3"))]
+    #[cfg(not(esp32c3))]
     Channel6,
-    #[cfg(not(feature = "esp32c3"))]
+    #[cfg(not(esp32c3))]
     Channel7,
 }
 
@@ -134,7 +134,7 @@ where
     }
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 /// Macro to configure channel parameters in hw
 macro_rules! set_channel {
     ($self: ident, $speed: ident, $num: literal, $timer_number: ident) => {
@@ -163,7 +163,7 @@ macro_rules! set_channel {
     };
 }
 
-#[cfg(not(feature = "esp32"))]
+#[cfg(not(esp32))]
 /// Macro to configure channel parameters in hw
 macro_rules! set_channel {
     ($self: ident, $speed: ident, $num: literal, $timer_number: ident) => {
@@ -192,7 +192,7 @@ macro_rules! set_channel {
     };
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 /// Macro to set duty parameters in hw
 macro_rules! set_duty {
     ($self: ident, $speed: ident, $num: literal, $duty: ident) => {
@@ -204,7 +204,7 @@ macro_rules! set_duty {
     };
 }
 
-#[cfg(not(feature = "esp32"))]
+#[cfg(not(esp32))]
 /// Macro to set duty parameters in hw
 macro_rules! set_duty {
     ($self: ident, $speed: ident, $num: literal, $duty: ident) => {
@@ -216,7 +216,7 @@ macro_rules! set_duty {
     };
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 /// Macro to update channel configuration (only for LowSpeed channels)
 macro_rules! update_channel {
     ($self: ident, $num: literal) => {
@@ -228,7 +228,7 @@ macro_rules! update_channel {
     };
 }
 
-#[cfg(not(feature = "esp32"))]
+#[cfg(not(esp32))]
 /// Macro to update channel configuration (only for LowSpeed channels)
 macro_rules! update_channel {
     ($self: ident, $num: literal) => {
@@ -240,7 +240,7 @@ macro_rules! update_channel {
     };
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 /// Channel HW interface for HighSpeed channels
 impl<'a, O> ChannelHW<O> for Channel<'a, HighSpeed, O>
 where
@@ -373,14 +373,14 @@ where
                     self.output_pin
                         .connect_peripheral_to_output(OutputSignal::LEDC_LS_SIG5);
                 }
-                #[cfg(not(feature = "esp32c3"))]
+                #[cfg(not(esp32c3))]
                 Number::Channel6 => {
                     set_channel!(self, l, 6, timer_number);
                     update_channel!(self, 6);
                     self.output_pin
                         .connect_peripheral_to_output(OutputSignal::LEDC_LS_SIG6);
                 }
-                #[cfg(not(feature = "esp32c3"))]
+                #[cfg(not(esp32c3))]
                 Number::Channel7 => {
                     set_channel!(self, l, 7, timer_number);
                     update_channel!(self, 7);
@@ -404,9 +404,9 @@ where
             Number::Channel3 => set_duty!(self, l, 3, duty),
             Number::Channel4 => set_duty!(self, l, 4, duty),
             Number::Channel5 => set_duty!(self, l, 5, duty),
-            #[cfg(not(feature = "esp32c3"))]
+            #[cfg(not(esp32c3))]
             Number::Channel6 => set_duty!(self, l, 6, duty),
-            #[cfg(not(feature = "esp32c3"))]
+            #[cfg(not(esp32c3))]
             Number::Channel7 => set_duty!(self, l, 7, duty),
         };
     }

--- a/esp-hal-common/src/ledc/mod.rs
+++ b/esp-hal-common/src/ledc/mod.rs
@@ -90,7 +90,7 @@ pub struct LEDC<'a> {
     clock_control_config: &'a Clocks,
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 /// Used to specify HighSpeed Timer/Channel
 pub struct HighSpeed {}
 
@@ -99,14 +99,18 @@ pub struct LowSpeed {}
 
 pub trait Speed {}
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 impl Speed for HighSpeed {}
 
 impl Speed for LowSpeed {}
 
 impl<'a> LEDC<'a> {
     /// Return a new LEDC
-    pub fn new(_instance: crate::pac::LEDC, clock_control_config: &'a Clocks, system: &mut PeripheralClockControl) -> Self {
+    pub fn new(
+        _instance: crate::pac::LEDC,
+        clock_control_config: &'a Clocks,
+        system: &mut PeripheralClockControl,
+    ) -> Self {
         system.enable(Peripheral::Ledc);
 
         let ledc = unsafe { &*crate::pac::LEDC::ptr() };
@@ -118,13 +122,13 @@ impl<'a> LEDC<'a> {
     }
 
     /// Set global slow clock source
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     pub fn set_global_slow_clock(&mut self, _clock_source: LSGlobalClkSource) {
         self.ledc.conf.write(|w| w.apb_clk_sel().set_bit());
         self.ledc.lstimer0_conf.modify(|_, w| w.para_up().set_bit());
     }
 
-    #[cfg(not(feature = "esp32"))]
+    #[cfg(not(esp32))]
     /// Set global slow clock source
     pub fn set_global_slow_clock(&mut self, clock_source: LSGlobalClkSource) {
         match clock_source {

--- a/esp-hal-common/src/ledc/timer.rs
+++ b/esp-hal-common/src/ledc/timer.rs
@@ -1,6 +1,6 @@
 use fugit::HertzU32;
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 use super::HighSpeed;
 use super::{LowSpeed, Speed};
 use crate::{clock::Clocks, pac::ledc};
@@ -14,7 +14,7 @@ pub enum Error {
     Divisor,
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 /// Clock source for HS Timers
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum HSClockSource {
@@ -59,17 +59,17 @@ pub mod config {
         Duty12Bit,
         Duty13Bit,
         Duty14Bit,
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         Duty15Bit,
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         Duty16Bit,
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         Duty17Bit,
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         Duty18Bit,
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         Duty19Bit,
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         Duty20Bit,
     }
 
@@ -92,7 +92,7 @@ impl TimerSpeed for LowSpeed {
     type ClockSourceType = LSClockSource;
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 /// Timer source type for HighSpeed timers
 impl TimerSpeed for HighSpeed {
     type ClockSourceType = HSClockSource;
@@ -223,7 +223,7 @@ impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
         })
     }
 
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     /// Configure the HW for the timer
     fn configure_hw(&self, divisor: u32) {
         let duty = self.duty.unwrap() as u8;
@@ -281,7 +281,7 @@ impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
         };
     }
 
-    #[cfg(not(feature = "esp32"))]
+    #[cfg(not(esp32))]
     /// Configure the HW for the timer
     fn configure_hw(&self, divisor: u32) {
         let duty = self.duty.unwrap() as u8;
@@ -339,7 +339,7 @@ impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
         };
     }
 
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     /// Update the timer in HW
     fn update_hw(&self) {
         match self.number {
@@ -350,7 +350,7 @@ impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
         };
     }
 
-    #[cfg(not(feature = "esp32"))]
+    #[cfg(not(esp32))]
     /// Update the timer in HW
     fn update_hw(&self) {
         match self.number {
@@ -362,7 +362,7 @@ impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
     }
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 /// Timer HW implementation for HighSpeed timers
 impl<'a> TimerHW<HighSpeed> for Timer<'a, HighSpeed> {
     /// Get the current source timer frequency from the HW

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -17,29 +17,29 @@
 //! [esp32s3-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32s3-hal
 
 #![no_std]
-#![cfg_attr(not(feature = "esp32c3"), feature(asm_experimental_arch))]
+#![cfg_attr(not(esp32c3), feature(asm_experimental_arch))]
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 pub use esp32 as pac;
-#[cfg(feature = "esp32c3")]
+#[cfg(esp32c3)]
 pub use esp32c3 as pac;
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 pub use esp32s2 as pac;
-#[cfg(feature = "esp32s3")]
+#[cfg(esp32s3)]
 pub use esp32s3 as pac;
 
 pub mod delay;
 
-#[cfg_attr(feature = "esp32", path = "efuse/esp32.rs")]
-#[cfg_attr(feature = "esp32c3", path = "efuse/esp32c3.rs")]
-#[cfg_attr(feature = "esp32s2", path = "efuse/esp32s2.rs")]
-#[cfg_attr(feature = "esp32s3", path = "efuse/esp32s3.rs")]
+#[cfg_attr(esp32, path = "efuse/esp32.rs")]
+#[cfg_attr(esp32c3, path = "efuse/esp32c3.rs")]
+#[cfg_attr(esp32s2, path = "efuse/esp32s2.rs")]
+#[cfg_attr(esp32s3, path = "efuse/esp32s3.rs")]
 pub mod efuse;
 
 pub mod gpio;
 pub mod i2c;
-#[cfg_attr(feature = "esp32c3", path = "interrupt/riscv.rs")]
-#[cfg_attr(not(feature = "esp32c3"), path = "interrupt/xtensa.rs")]
+#[cfg_attr(esp32c3, path = "interrupt/riscv.rs")]
+#[cfg_attr(not(esp32c3), path = "interrupt/xtensa.rs")]
 pub mod interrupt;
 pub mod ledc;
 pub mod prelude;
@@ -50,7 +50,7 @@ pub mod rtc_cntl;
 pub mod serial;
 pub mod spi;
 pub mod timer;
-#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+#[cfg(any(esp32c3, esp32s3))]
 pub mod usb_serial_jtag;
 pub mod utils;
 
@@ -64,9 +64,9 @@ pub use rtc_cntl::{Rtc, Rwdt};
 pub use serial::Serial;
 pub use spi::Spi;
 pub use timer::Timer;
-#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+#[cfg(any(esp32c3, esp32s3))]
 pub use usb_serial_jtag::UsbSerialJtag;
-#[cfg(any(feature = "esp32c3", feature = "esp32s3", feature = "esp32s2"))]
+#[cfg(any(esp32c3, esp32s3, esp32s2))]
 pub mod systimer;
 
 pub mod clock;
@@ -74,10 +74,10 @@ pub mod system;
 
 pub mod analog;
 
-#[cfg_attr(feature = "esp32", path = "cpu_control/esp32.rs")]
-#[cfg_attr(feature = "esp32c3", path = "cpu_control/none.rs")]
-#[cfg_attr(feature = "esp32s2", path = "cpu_control/none.rs")]
-#[cfg_attr(feature = "esp32s3", path = "cpu_control/esp32s3.rs")]
+#[cfg_attr(esp32, path = "cpu_control/esp32.rs")]
+#[cfg_attr(esp32c3, path = "cpu_control/none.rs")]
+#[cfg_attr(esp32s2, path = "cpu_control/none.rs")]
+#[cfg_attr(esp32s3, path = "cpu_control/esp32s3.rs")]
 pub mod cpu_control;
 
 /// Enumeration of CPU cores
@@ -90,13 +90,13 @@ pub enum Cpu {
 }
 
 pub fn get_core() -> Cpu {
-    #[cfg(all(not(feature = "esp32c3"), feature = "multi_core"))]
+    #[cfg(all(not(esp32c3), feature = "multi_core"))]
     match ((xtensa_lx::get_processor_id() >> 13) & 1) != 0 {
         false => Cpu::ProCpu,
         true => Cpu::AppCpu,
     }
 
-    // #[cfg(all(feature = "esp32c3", feature = "multi_core"))]
+    // #[cfg(all(esp32c3, feature = "multi_core"))]
     // TODO get hart_id
 
     // single core always has ProCpu only
@@ -109,7 +109,7 @@ mod critical_section_impl {
 
     critical_section::set_impl!(CriticalSection);
 
-    #[cfg(not(feature = "esp32c3"))]
+    #[cfg(not(esp32c3))]
     mod xtensa {
 
         unsafe impl critical_section::Impl for super::CriticalSection {
@@ -140,7 +140,7 @@ mod critical_section_impl {
         }
     }
 
-    #[cfg(feature = "esp32c3")]
+    #[cfg(esp32c3)]
     mod riscv {
         unsafe impl critical_section::Impl for super::CriticalSection {
             unsafe fn acquire() -> critical_section::RawRestoreState {

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -27,20 +27,27 @@ pub use esp32c3 as pac;
 pub use esp32s2 as pac;
 #[cfg(esp32s3)]
 pub use esp32s3 as pac;
+pub use procmacros as macros;
 
+#[cfg(any(esp32c3, esp32s3))]
+pub use self::usb_serial_jtag::UsbSerialJtag;
+pub use self::{
+    delay::Delay,
+    gpio::*,
+    interrupt::*,
+    pulse_control::PulseControl,
+    rng::Rng,
+    rtc_cntl::{Rtc, Rwdt},
+    serial::Serial,
+    spi::Spi,
+    timer::Timer,
+};
+
+pub mod analog;
+pub mod clock;
 pub mod delay;
-
-#[cfg_attr(esp32, path = "efuse/esp32.rs")]
-#[cfg_attr(esp32c3, path = "efuse/esp32c3.rs")]
-#[cfg_attr(esp32s2, path = "efuse/esp32s2.rs")]
-#[cfg_attr(esp32s3, path = "efuse/esp32s3.rs")]
-pub mod efuse;
-
 pub mod gpio;
 pub mod i2c;
-#[cfg_attr(riscv, path = "interrupt/riscv.rs")]
-#[cfg_attr(xtensa, path = "interrupt/xtensa.rs")]
-pub mod interrupt;
 pub mod ledc;
 pub mod prelude;
 pub mod pulse_control;
@@ -49,36 +56,28 @@ pub mod rom;
 pub mod rtc_cntl;
 pub mod serial;
 pub mod spi;
+pub mod system;
+#[cfg(any(esp32c3, esp32s3, esp32s2))]
+pub mod systimer;
 pub mod timer;
 #[cfg(any(esp32c3, esp32s3))]
 pub mod usb_serial_jtag;
 pub mod utils;
 
-pub use delay::Delay;
-pub use gpio::*;
-pub use interrupt::*;
-pub use procmacros as macros;
-pub use pulse_control::PulseControl;
-pub use rng::Rng;
-pub use rtc_cntl::{Rtc, Rwdt};
-pub use serial::Serial;
-pub use spi::Spi;
-pub use timer::Timer;
-#[cfg(any(esp32c3, esp32s3))]
-pub use usb_serial_jtag::UsbSerialJtag;
-#[cfg(any(esp32c3, esp32s3, esp32s2))]
-pub mod systimer;
-
-pub mod clock;
-pub mod system;
-
-pub mod analog;
-
 #[cfg_attr(esp32, path = "cpu_control/esp32.rs")]
-#[cfg_attr(esp32c3, path = "cpu_control/none.rs")]
-#[cfg_attr(esp32s2, path = "cpu_control/none.rs")]
+#[cfg_attr(any(esp32c3, esp32s2), path = "cpu_control/none.rs")]
 #[cfg_attr(esp32s3, path = "cpu_control/esp32s3.rs")]
 pub mod cpu_control;
+
+#[cfg_attr(esp32, path = "efuse/esp32.rs")]
+#[cfg_attr(esp32c3, path = "efuse/esp32c3.rs")]
+#[cfg_attr(esp32s2, path = "efuse/esp32s2.rs")]
+#[cfg_attr(esp32s3, path = "efuse/esp32s3.rs")]
+pub mod efuse;
+
+#[cfg_attr(riscv, path = "interrupt/riscv.rs")]
+#[cfg_attr(xtensa, path = "interrupt/xtensa.rs")]
+pub mod interrupt;
 
 /// Enumeration of CPU cores
 /// The actual number of available cores depends on the target.

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -20,7 +20,7 @@ pub use fugit::{
 };
 pub use nb;
 
-#[cfg(any(feature = "esp32", feature = "esp32s2"))]
+#[cfg(any(esp32, esp32s2))]
 pub use crate::analog::SensExt;
 pub use crate::system::SystemExt;
 

--- a/esp-hal-common/src/pulse_control.rs
+++ b/esp-hal-common/src/pulse_control.rs
@@ -119,14 +119,14 @@ pub enum RepeatMode {
     /// Send sequence once
     SingleShot,
     /// Send sequence N times (`N < (2^10)`)
-    #[cfg(not(feature = "esp32"))]
+    #[cfg(not(esp32))]
     RepeatNtimes(u16),
     /// Repeat sequence until stopped by additional function call
     Forever,
 }
 
 /// Specify the clock source for the RMT peripheral
-#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+#[cfg(any(esp32c3, esp32s3))]
 #[derive(Debug, Copy, Clone)]
 pub enum ClockSource {
     /// Application-level clock
@@ -139,7 +139,7 @@ pub enum ClockSource {
 
 /// Specify the clock source for the RMT peripheral on the ESP32 and ESP32-S3
 /// variants
-#[cfg(any(feature = "esp32s2", feature = "esp32"))]
+#[cfg(any(esp32s2, esp32))]
 #[derive(Debug, Copy, Clone)]
 pub enum ClockSource {
     /// Reference Tick (usually configured to 1 us)
@@ -150,19 +150,19 @@ pub enum ClockSource {
 
 // Specifies how many entries we can store in the RAM section that is allocated
 // to the RMT channel
-#[cfg(any(feature = "esp32s2", feature = "esp32"))]
+#[cfg(any(esp32s2, esp32))]
 const CHANNEL_RAM_SIZE: u8 = 64;
-#[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+#[cfg(any(esp32c3, esp32s3))]
 const CHANNEL_RAM_SIZE: u8 = 48;
 
 // Specifies where the RMT RAM section starts for the particular ESP32 variant
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 const RMT_RAM_START: usize = 0x3f416400;
-#[cfg(feature = "esp32c3")]
+#[cfg(esp32c3)]
 const RMT_RAM_START: usize = 0x60016400;
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 const RMT_RAM_START: usize = 0x3ff56800;
-#[cfg(feature = "esp32s3")]
+#[cfg(esp32s3)]
 const RMT_RAM_START: usize = 0x60016800;
 
 /// Object representing the state of one pulse code per ESP32-C3 TRM
@@ -229,7 +229,7 @@ pub trait OutputChannel {
 
     /// Set the clock source (for the ESP32-S2 abd ESP32 this can be done on a
     /// channel level)
-    #[cfg(any(feature = "esp32s2", feature = "esp32"))]
+    #[cfg(any(esp32s2, esp32))]
     fn set_clock_source(&mut self, source: ClockSource) -> &mut Self;
 
     /// Assign a pin that should be driven by this channel
@@ -278,7 +278,7 @@ macro_rules! channel_instance {
                 let mut channel = $cxi { mem_offset: 0 };
 
                 cfg_if::cfg_if! {
-                    if #[cfg(any(feature = "esp32c3", feature = "esp32s3"))] {
+                    if #[cfg(any(esp32c3, esp32s3))] {
                         // Apply default configuration
                         unsafe { &*RMT::PTR }.ch_tx_conf0[$num].modify(|_, w| unsafe {
                             // Configure memory block size
@@ -301,7 +301,7 @@ macro_rules! channel_instance {
                     }
                 };
 
-                #[cfg(feature = "esp32")]
+                #[cfg(esp32)]
                 conf0!($num).modify(|_, w|
                     // Enable clock
                     w.clk_en()
@@ -367,7 +367,7 @@ macro_rules! output_channel {
             #[inline(always)]
             fn set_idle_output_level(&mut self, level: bool) -> &mut Self {
                 cfg_if::cfg_if! {
-                    if #[cfg(any(feature = "esp32c3", feature = "esp32s3"))] {
+                    if #[cfg(any(esp32c3, esp32s3))] {
                         unsafe { &*RMT::PTR }
                             .ch_tx_conf0[$num]
                             .modify(|_, w| w.idle_out_lv().bit(level));
@@ -384,7 +384,7 @@ macro_rules! output_channel {
             #[inline(always)]
             fn set_idle_output(&mut self, state: bool) -> &mut Self {
                 cfg_if::cfg_if! {
-                    if #[cfg(any(feature = "esp32c3", feature = "esp32s3"))] {
+                    if #[cfg(any(esp32c3, esp32s3))] {
                         unsafe { &*RMT::PTR }
                             .ch_tx_conf0[$num]
                             .modify(|_, w| w.idle_out_en().bit(state));
@@ -401,7 +401,7 @@ macro_rules! output_channel {
             #[inline(always)]
             fn set_channel_divider(&mut self, divider: u8) -> &mut Self {
                 cfg_if::cfg_if! {
-                    if #[cfg(any(feature = "esp32c3", feature = "esp32s3"))] {
+                    if #[cfg(any(esp32c3, esp32s3))] {
                         unsafe { &*RMT::PTR }
                             .ch_tx_conf0[$num]
                             .modify(|_, w| unsafe { w.div_cnt().bits(divider) });
@@ -418,7 +418,7 @@ macro_rules! output_channel {
             #[inline(always)]
             fn set_carrier_modulation(&mut self, state: bool) -> &mut Self {
                 cfg_if::cfg_if! {
-                    if #[cfg(any(feature = "esp32c3", feature = "esp32s3"))] {
+                    if #[cfg(any(esp32c3, esp32s3))] {
                         unsafe { &*RMT::PTR }
                             .ch_tx_conf0[$num]
                             .modify(|_, w| w.carrier_en().bit(state));
@@ -433,7 +433,7 @@ macro_rules! output_channel {
 
             /// Set the clock source (for the ESP32-S2 and ESP32 this can be done on a
             /// channel level)
-            #[cfg(any(feature = "esp32s2", feature = "esp32"))]
+            #[cfg(any(esp32s2, esp32))]
             #[inline(always)]
             fn set_clock_source(&mut self, source: ClockSource) -> &mut Self {
                 let bit_value = match source {
@@ -489,7 +489,7 @@ macro_rules! output_channel {
             ) -> Result<(), TransmissionError> {
                 // Check for any configuration error states
                 match repeat_mode {
-                    #[cfg(not(feature = "esp32"))]
+                    #[cfg(not(esp32))]
                     RepeatMode::RepeatNtimes(val) => {
                         if val >= 1024 {
                             return Err(TransmissionError::RepetitionOverflow);
@@ -508,7 +508,7 @@ macro_rules! output_channel {
 
                 // Depending on the variant, other registers have to be used here
                 cfg_if::cfg_if! {
-                    if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+                    if #[cfg(any(esp32, esp32s2))] {
                         let conf_reg = & conf1!($num);
                     } else {
                         let conf_reg = & unsafe{ &*RMT::PTR }.ch_tx_conf0[$num];
@@ -518,7 +518,7 @@ macro_rules! output_channel {
                 // The ESP32 does not support loop/count modes, as such we have to
                 // only configure a subset of registers
                 cfg_if::cfg_if! {
-                    if #[cfg(feature = "esp32")] {
+                    if #[cfg(esp32)] {
                         // Configure counting mode and repetitions
                         unsafe { &*RMT::PTR }.ch_tx_lim[$num].modify(|_, w| unsafe {
                             // Set the interrupt threshold for sent pulse codes to
@@ -552,7 +552,7 @@ macro_rules! output_channel {
                     }
                 }
 
-                #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+                #[cfg(any(esp32c3, esp32s3))]
                 conf_reg.modify(|_, w| {
                     // Set config update bit
                     w.conf_update().set_bit()
@@ -591,7 +591,7 @@ macro_rules! output_channel {
                 // having concurrency issues)
                 // Depending on the variant, other registers have to be used here
                 cfg_if::cfg_if! {
-                    if #[cfg(feature = "esp32")] {
+                    if #[cfg(esp32)] {
                         unsafe { &*RMT::PTR }.int_clr.write(|w| {
                             // The ESP32 variant does not have the loop functionality
                             paste!(
@@ -603,7 +603,7 @@ macro_rules! output_channel {
                                     .set_bit()
                             )
                         });
-                    } else if #[cfg(feature = "esp32s2")] {
+                    } else if #[cfg(esp32s2)] {
                         unsafe { &*RMT::PTR }.int_clr.write(|w| {
                             paste!(
                                 w.[<ch $num _tx_end_int_clr>]()
@@ -633,14 +633,14 @@ macro_rules! output_channel {
                 }
 
                 // always enable tx wrap
-                #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+                #[cfg(any(esp32c3, esp32s3))]
                 unsafe { &*RMT::PTR }.ch_tx_conf0[$num].modify(|_, w| {
                     w.mem_tx_wrap_en()
                         .set_bit()
                 });
 
                 // apply configuration updates
-                #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+                #[cfg(any(esp32c3, esp32s3))]
                 unsafe { &*RMT::PTR }.ch_tx_conf0[$num].modify(|_, w| {
                     w.conf_update()
                         .set_bit()
@@ -648,7 +648,7 @@ macro_rules! output_channel {
 
                 // Depending on the variant, other registers have to be used here
                 cfg_if::cfg_if! {
-                    if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+                    if #[cfg(any(esp32, esp32s2))] {
                         conf1!($num).modify(|_, w| w.tx_start().set_bit());
                     } else {
                         unsafe{ &*RMT::PTR }.ch_tx_conf0[$num].modify(|_, w| w.tx_start().set_bit());
@@ -665,14 +665,14 @@ macro_rules! output_channel {
                         match (
                             unsafe { interrupts.ch_tx_end_int_raw($num).bit() },
                             // The ESP32 variant does not support the loop functionality
-                            #[cfg(not(feature = "esp32"))]
+                            #[cfg(not(esp32))]
                             unsafe {interrupts.ch_tx_loop_int_raw($num).bit()},
-                            #[cfg(feature = "esp32")]
+                            #[cfg(esp32)]
                             false,
                             // The C3/S3 have a slightly different interrupt naming scheme
-                            #[cfg(any(feature = "esp32", feature= "esp32s2"))]
+                            #[cfg(any(esp32, feature= "esp32s2"))]
                             unsafe { interrupts.ch_err_int_raw($num).bit() },
-                            #[cfg(any(feature = "esp32c3", feature= "esp32s3"))]
+                            #[cfg(any(esp32c3, feature= "esp32s3"))]
                             unsafe { interrupts.ch_tx_err_int_raw($num).bit() },
                             unsafe { interrupts.ch_tx_thr_event_int_raw($num).bit() },
                         ) {
@@ -700,14 +700,14 @@ macro_rules! output_channel {
                                 return Err(TransmissionError::Failure(
                                     unsafe { interrupts.ch_tx_end_int_raw($num).bit() },
                                     // The ESP32 variant does not support the loop functionality
-                                    #[cfg(not(feature = "esp32"))]
+                                    #[cfg(not(esp32))]
                                     unsafe {interrupts.ch_tx_loop_int_raw($num).bit()},
-                                    #[cfg(feature = "esp32")]
+                                    #[cfg(esp32)]
                                     false,
                                     // The C3/S3 have a slightly different interrupt naming scheme
-                                    #[cfg(any(feature = "esp32", feature= "esp32s2"))]
+                                    #[cfg(any(esp32, feature= "esp32s2"))]
                                     unsafe { interrupts.ch_err_int_raw($num).bit() },
-                                    #[cfg(any(feature = "esp32c3", feature= "esp32s3"))]
+                                    #[cfg(any(esp32c3, feature= "esp32s3"))]
                                     unsafe { interrupts.ch_tx_err_int_raw($num).bit() },
                                     unsafe { interrupts.ch_tx_thr_event_int_raw($num).bit() },
                                 ))
@@ -725,12 +725,12 @@ macro_rules! output_channel {
             /// previously a sequence was sent with `RepeatMode::Forever`.
             fn stop_transmission(&self) {
                 cfg_if::cfg_if! {
-                    if #[cfg(any(feature = "esp32c3", feature = "esp32s3"))] {
+                    if #[cfg(any(esp32c3, esp32s3))] {
                         unsafe { &*RMT::PTR }
                             .ch_tx_conf0[$num]
                             .modify(|_, w| w.tx_stop().set_bit());
                     }
-                    else if #[cfg(feature = "esp32s2")] {
+                    else if #[cfg(esp32s2)] {
                         conf1!($num)
                             .modify(|_, w| w.tx_stop().set_bit());
                     }
@@ -742,7 +742,7 @@ macro_rules! output_channel {
     };
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 macro_rules! conf0 {
     ($channel: literal) => {
         match $channel {
@@ -759,7 +759,7 @@ macro_rules! conf0 {
     };
 }
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 macro_rules! conf1 {
     ($channel: literal) => {
         match $channel {
@@ -776,7 +776,7 @@ macro_rules! conf1 {
     };
 }
 
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 macro_rules! conf0 {
     ($channel: literal) => {
         match $channel {
@@ -789,7 +789,7 @@ macro_rules! conf0 {
     };
 }
 
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 macro_rules! conf1 {
     ($channel: literal) => {
         match $channel {
@@ -822,7 +822,7 @@ macro_rules! rmt {
 
     impl PulseControl {
         /// Create a new pulse controller instance
-        #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+        #[cfg(any(esp32c3, esp32s3))]
         pub fn new(
             instance: RMT,
             peripheral_clock_control: &mut PeripheralClockControl,
@@ -846,7 +846,7 @@ macro_rules! rmt {
         }
 
         /// Create a new pulse controller instance
-        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        #[cfg(any(esp32, esp32s2))]
         pub fn new(
             instance: RMT,
             peripheral_clock_control: &mut PeripheralClockControl,
@@ -882,7 +882,7 @@ macro_rules! rmt {
         /// clock is calculated as follows:
         ///
         /// divider = absolute_part + 1 + (fractional_part_a / fractional_part_b)
-        #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+        #[cfg(any(esp32c3, esp32s3))]
         fn config_global(
             &self,
             clk_source: ClockSource,
@@ -941,7 +941,7 @@ macro_rules! rmt {
         }
 
         /// Assign the global (peripheral-wide) configuration.
-        #[cfg(any(feature = "esp32s2", feature = "esp32"))]
+        #[cfg(any(esp32s2, esp32))]
         fn config_global(&self) -> Result<(), SetupError> {
             // TODO: Confirm that the selected clock source is enabled in the
             // system / rtc_cntl peripheral? Particularly relevant for clock sources
@@ -949,7 +949,7 @@ macro_rules! rmt {
             // addressed!
 
             cfg_if::cfg_if! {
-                if #[cfg(feature = "esp32")] {
+                if #[cfg(esp32)] {
                     // Configure peripheral
                     self.reg.apb_conf.modify(|_, w|
                         // Disable FIFO mode
@@ -998,14 +998,14 @@ macro_rules! rmt {
  };
 }
 
-#[cfg(feature = "esp32c3")]
+#[cfg(esp32c3)]
 rmt!(
     sys_conf,
     (0, Channel0, channel0, OutputSignal::RMT_SIG_0),
     (1, Channel1, channel1, OutputSignal::RMT_SIG_1),
 );
 
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 rmt!(
     apb_conf,
     (0, Channel0, channel0, OutputSignal::RMT_SIG_OUT0),
@@ -1014,7 +1014,7 @@ rmt!(
     (3, Channel3, channel3, OutputSignal::RMT_SIG_OUT3),
 );
 
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 rmt!(
     apb_conf,
     (0, Channel0, channel0, OutputSignal::RMT_SIG_0),
@@ -1027,7 +1027,7 @@ rmt!(
     (7, Channel7, channel7, OutputSignal::RMT_SIG_7),
 );
 
-#[cfg(feature = "esp32s3")]
+#[cfg(esp32s3)]
 rmt!(
     sys_conf,
     (0, Channel0, channel0, OutputSignal::RMT_SIG_OUT0),

--- a/esp-hal-common/src/rom.rs
+++ b/esp-hal-common/src/rom.rs
@@ -3,13 +3,13 @@ pub use paste::paste;
 /// Pauses execution for us microseconds
 #[inline(always)]
 pub unsafe fn esp_rom_delay_us(us: u32) {
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     const ESP_ROM_DELAY_US: u32 = 0x4000_8534;
-    #[cfg(feature = "esp32s2")]
+    #[cfg(esp32s2)]
     const ESP_ROM_DELAY_US: u32 = 0x4000_d888;
-    #[cfg(feature = "esp32s3")]
+    #[cfg(esp32s3)]
     const ESP_ROM_DELAY_US: u32 = 0x4000_0600;
-    #[cfg(feature = "esp32c3")]
+    #[cfg(esp32c3)]
     const ESP_ROM_DELAY_US: u32 = 0x4000_0050;
 
     // cast to usize is just needed because of the way we run clippy in CI
@@ -22,13 +22,13 @@ pub unsafe fn esp_rom_delay_us(us: u32) {
 /// Set the real CPU ticks per us to the ets, so that ets_delay_us
 /// will be accurate. Call this function when CPU frequency is changed.
 pub unsafe fn ets_update_cpu_frequency(ticks_per_us: u32) {
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x4000_8550;
-    #[cfg(feature = "esp32s2")]
+    #[cfg(esp32s2)]
     const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x4000_d8a4;
-    #[cfg(feature = "esp32s3")]
+    #[cfg(esp32s3)]
     const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x4004_3164;
-    #[cfg(feature = "esp32c3")]
+    #[cfg(esp32c3)]
     const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x4000_0588;
 
     // cast to usize is just needed because of the way we run clippy in CI
@@ -40,13 +40,13 @@ pub unsafe fn ets_update_cpu_frequency(ticks_per_us: u32) {
 
 #[inline(always)]
 pub unsafe fn regi2c_ctrl_write_reg(block: u32, block_hostid: u32, reg_add: u32, indata: u32) {
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     const ROM_I2C_WRITEREG: u32 = 0x4000_41a4;
-    #[cfg(feature = "esp32s2")]
+    #[cfg(esp32s2)]
     const ROM_I2C_WRITEREG: u32 = 0x4000_a9a8;
-    #[cfg(feature = "esp32s3")]
+    #[cfg(esp32s3)]
     const ROM_I2C_WRITEREG: u32 = 0x4000_5d60;
-    #[cfg(feature = "esp32c3")]
+    #[cfg(esp32c3)]
     const ROM_I2C_WRITEREG: u32 = 0x4000_195c;
 
     // cast to usize is just needed because of the way we run clippy in CI
@@ -77,13 +77,13 @@ pub unsafe fn regi2c_ctrl_write_reg_mask(
     reg_add_lsb: u32,
     indata: u32,
 ) {
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     const ROM_I2C_WRITEREG_MASK: u32 = 0x4000_41fc;
-    #[cfg(feature = "esp32s2")]
+    #[cfg(esp32s2)]
     const ROM_I2C_WRITEREG_MASK: u32 = 0x4000_aa00;
-    #[cfg(feature = "esp32s3")]
+    #[cfg(esp32s3)]
     const ROM_I2C_WRITEREG_MASK: u32 = 0x4000_5d6c;
-    #[cfg(feature = "esp32c3")]
+    #[cfg(esp32c3)]
     const ROM_I2C_WRITEREG_MASK: u32 = 0x4000_1960;
 
     // cast to usize is just needed because of the way we run clippy in CI

--- a/esp-hal-common/src/serial.rs
+++ b/esp-hal-common/src/serial.rs
@@ -1,7 +1,7 @@
 //! UART driver
 
 use self::config::Config;
-#[cfg(any(feature = "esp32", feature = "esp32s3"))]
+#[cfg(any(esp32, esp32s3))]
 use crate::pac::UART2;
 use crate::{
     clock::Clocks,
@@ -296,7 +296,7 @@ where
 
     /// Configures the AT-CMD detection settings.
     pub fn set_at_cmd(&mut self, config: config::AtCmdConfig) {
-        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        #[cfg(not(any(esp32, esp32s2)))]
         self.uart
             .register_block()
             .clk_conf
@@ -330,7 +330,7 @@ where
                 .write(|w| unsafe { w.rx_gap_tout().bits(gap_timeout.into()) });
         }
 
-        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        #[cfg(not(any(esp32, esp32s2)))]
         self.uart
             .register_block()
             .clk_conf
@@ -339,7 +339,7 @@ where
 
     /// Configures the RX-FIFO threshold
     pub fn set_rx_fifo_full_threshold(&mut self, threshold: u16) {
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         let threshold: u8 = threshold as u8;
 
         self.uart
@@ -476,7 +476,7 @@ where
         let offset = 0;
 
         // on ESP32-S2 we need to use PeriBus2 to read the FIFO
-        #[cfg(feature = "esp32s2")]
+        #[cfg(esp32s2)]
         let offset = 0x20c00000;
 
         if self.uart.get_rx_fifo_count() > 0 {
@@ -495,7 +495,7 @@ where
     /// Change the number of stop bits
     pub fn change_stop_bits(&mut self, stop_bits: config::StopBits) -> &mut Self {
         // workaround for hardware issue, when UART stop bit set as 2-bit mode.
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         if stop_bits == config::StopBits::STOP2 {
             self.uart
                 .register_block()
@@ -518,7 +518,7 @@ where
                 .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8) });
         }
 
-        #[cfg(not(feature = "esp32"))]
+        #[cfg(not(esp32))]
         self.uart
             .register_block()
             .conf0
@@ -551,7 +551,7 @@ where
         self
     }
 
-    #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+    #[cfg(any(esp32c3, esp32s3))]
     fn change_baud(&self, baudrate: u32, clocks: &Clocks) {
         // we force the clock source to be APB and don't use the decimal part of the
         // divider
@@ -584,7 +584,7 @@ where
             .write(|w| unsafe { w.clkdiv().bits(divider).frag().bits(0) });
     }
 
-    #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+    #[cfg(any(esp32, esp32s2))]
     fn change_baud(&self, baudrate: u32, clocks: &Clocks) {
         // we force the clock source to be APB and don't use the decimal part of the
         // divider
@@ -670,18 +670,18 @@ pub trait Instance {
     }
 
     fn is_tx_idle(&self) -> bool {
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         let idle = self.register_block().status.read().st_utx_out().bits() == 0x0u8;
-        #[cfg(not(feature = "esp32"))]
+        #[cfg(not(esp32))]
         let idle = self.register_block().fsm_status.read().st_utx_out().bits() == 0x0u8;
 
         idle
     }
 
     fn is_rx_idle(&self) -> bool {
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         let idle = self.register_block().status.read().st_urx_out().bits() == 0x0u8;
-        #[cfg(not(feature = "esp32"))]
+        #[cfg(not(esp32))]
         let idle = self.register_block().fsm_status.read().st_urx_out().bits() == 0x0u8;
 
         idle
@@ -742,7 +742,7 @@ impl Instance for UART1 {
     }
 }
 
-#[cfg(any(feature = "esp32", feature = "esp32s3"))]
+#[cfg(any(esp32, esp32s3))]
 impl Instance for UART2 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -62,9 +62,9 @@ use crate::{
 };
 
 /// The size of the FIFO buffer for SPI
-#[cfg(not(feature = "esp32s2"))]
+#[cfg(not(esp32s2))]
 const FIFO_SIZE: usize = 64;
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 const FIFO_SIZE: usize = 72;
 /// Padding byte for empty write transfers
 const EMPTY_WRITE_PAD: u8 = 0x00u8;
@@ -504,7 +504,7 @@ pub trait Instance {
                 .clear_bit()
         });
 
-        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        #[cfg(not(any(esp32, esp32s2)))]
         reg_block.clk_gate.modify(|_, w| {
             w.clk_en()
                 .set_bit()
@@ -516,7 +516,7 @@ pub trait Instance {
 
         reg_block.ctrl.write(|w| unsafe { w.bits(0) });
 
-        #[cfg(not(feature = "esp32"))]
+        #[cfg(not(esp32))]
         reg_block.misc.write(|w| unsafe { w.bits(0) });
 
         reg_block.slave.write(|w| unsafe { w.bits(0) });
@@ -605,7 +605,7 @@ pub trait Instance {
             .write(|w| unsafe { w.bits(reg_val) });
     }
 
-    #[cfg(not(feature = "esp32"))]
+    #[cfg(not(esp32))]
     fn set_data_mode(&mut self, data_mode: SpiMode) -> &mut Self {
         let reg_block = self.register_block();
 
@@ -630,7 +630,7 @@ pub trait Instance {
         self
     }
 
-    #[cfg(feature = "esp32")]
+    #[cfg(esp32)]
     fn set_data_mode(&mut self, data_mode: SpiMode) -> &mut Self {
         let reg_block = self.register_block();
 
@@ -801,7 +801,7 @@ pub trait Instance {
         Ok(words)
     }
 
-    #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+    #[cfg(not(any(esp32, esp32s2)))]
     fn update(&self) {
         let reg_block = self.register_block();
 
@@ -812,7 +812,7 @@ pub trait Instance {
         }
     }
 
-    #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+    #[cfg(any(esp32, esp32s2))]
     fn update(&self) {
         // not need/available on ESP32/ESP32S2
     }
@@ -820,12 +820,12 @@ pub trait Instance {
     fn configure_datalen(&self, len: u32) {
         let reg_block = self.register_block();
 
-        #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+        #[cfg(any(esp32c3, esp32s3))]
         reg_block
             .ms_dlen
             .write(|w| unsafe { w.ms_data_bitlen().bits(len - 1) });
 
-        #[cfg(not(any(feature = "esp32c3", feature = "esp32s3")))]
+        #[cfg(not(any(esp32c3, esp32s3)))]
         {
             reg_block
                 .mosi_dlen
@@ -838,7 +838,7 @@ pub trait Instance {
     }
 }
 
-#[cfg(any(feature = "esp32c3"))]
+#[cfg(any(esp32c3))]
 impl Instance for crate::pac::SPI2 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {
@@ -871,7 +871,7 @@ impl Instance for crate::pac::SPI2 {
     }
 }
 
-#[cfg(any(feature = "esp32"))]
+#[cfg(any(esp32))]
 impl Instance for crate::pac::SPI2 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {
@@ -904,7 +904,7 @@ impl Instance for crate::pac::SPI2 {
     }
 }
 
-#[cfg(any(feature = "esp32"))]
+#[cfg(any(esp32))]
 impl Instance for crate::pac::SPI3 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {
@@ -937,7 +937,7 @@ impl Instance for crate::pac::SPI3 {
     }
 }
 
-#[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+#[cfg(any(esp32s2, esp32s3))]
 impl Instance for crate::pac::SPI2 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {
@@ -970,7 +970,7 @@ impl Instance for crate::pac::SPI2 {
     }
 }
 
-#[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+#[cfg(any(esp32s2, esp32s3))]
 impl Instance for crate::pac::SPI3 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -8,9 +8,9 @@
 //! let system = peripherals.SYSTEM.split();
 //! let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 //! ```
-#[cfg(not(feature = "esp32"))]
+#[cfg(not(esp32))]
 type SystemPeripheral = crate::pac::SYSTEM;
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 type SystemPeripheral = crate::pac::DPORT;
 
 /// Peripherals which can be enabled via [PeripheralClockControl]
@@ -18,11 +18,11 @@ pub enum Peripheral {
     Spi2,
     Spi3,
     I2cExt0,
-    #[cfg(not(feature = "esp32c3"))]
+    #[cfg(not(esp32c3))]
     I2cExt1,
     Rmt,
     Ledc,
-    #[cfg(feature = "esp32c3")]
+    #[cfg(esp32c3)]
     ApbSarAdc,
 }
 
@@ -36,9 +36,9 @@ impl PeripheralClockControl {
     pub fn enable(&mut self, peripheral: Peripheral) {
         let system = unsafe { &*SystemPeripheral::PTR };
 
-        #[cfg(not(feature = "esp32"))]
+        #[cfg(not(esp32))]
         let (perip_clk_en0, perip_rst_en0) = { (&system.perip_clk_en0, &system.perip_rst_en0) };
-        #[cfg(feature = "esp32")]
+        #[cfg(esp32)]
         let (perip_clk_en0, perip_rst_en0) = { (&system.perip_clk_en, &system.perip_rst_en) };
 
         match peripheral {
@@ -50,17 +50,17 @@ impl PeripheralClockControl {
                 perip_clk_en0.modify(|_, w| w.spi3_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.spi3_rst().clear_bit());
             }
-            #[cfg(feature = "esp32")]
+            #[cfg(esp32)]
             Peripheral::I2cExt0 => {
                 perip_clk_en0.modify(|_, w| w.i2c0_ext0_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2c0_ext0_rst().clear_bit());
             }
-            #[cfg(not(feature = "esp32"))]
+            #[cfg(not(esp32))]
             Peripheral::I2cExt0 => {
                 perip_clk_en0.modify(|_, w| w.i2c_ext0_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2c_ext0_rst().clear_bit());
             }
-            #[cfg(not(feature = "esp32c3"))]
+            #[cfg(not(esp32c3))]
             Peripheral::I2cExt1 => {
                 perip_clk_en0.modify(|_, w| w.i2c_ext1_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2c_ext1_rst().clear_bit());
@@ -73,7 +73,7 @@ impl PeripheralClockControl {
                 perip_clk_en0.modify(|_, w| w.ledc_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.ledc_rst().clear_bit());
             }
-            #[cfg(feature = "esp32c3")]
+            #[cfg(esp32c3)]
             Peripheral::ApbSarAdc => {
                 perip_clk_en0.modify(|_, w| w.apb_saradc_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.apb_saradc_rst().clear_bit());

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -23,9 +23,9 @@ pub struct SystemTimer {
 }
 
 impl SystemTimer {
-    #[cfg(feature = "esp32s2")]
+    #[cfg(esp32s2)]
     pub const TICKS_PER_SECOND: u64 = 80_000_000; // TODO this can change when we have support for changing APB frequency
-    #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+    #[cfg(any(esp32c3, esp32s3))]
     pub const TICKS_PER_SECOND: u64 = 16_000_000;
 
     pub fn new(p: SYSTIMER) -> Self {
@@ -132,10 +132,10 @@ impl<T, const CHANNEL: u8> Alarm<T, CHANNEL> {
                 _ => unreachable!(),
             };
 
-            #[cfg(feature = "esp32s2")]
+            #[cfg(esp32s2)]
             systimer.step.write(|w| w.timer_xtal_step().bits(0x1)); // run at XTAL freq, not 80 * XTAL freq
 
-            #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+            #[cfg(any(esp32c3, esp32s3))]
             {
                 tconf.write(|w| w.target0_timer_unit_sel().clear_bit()); // default, use unit 0
                 systimer
@@ -145,7 +145,7 @@ impl<T, const CHANNEL: u8> Alarm<T, CHANNEL> {
 
             conf(tconf, hi, lo);
 
-            #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+            #[cfg(any(esp32c3, esp32s3))]
             {
                 match CHANNEL {
                     0 => {
@@ -170,7 +170,7 @@ impl<T, const CHANNEL: u8> Alarm<T, CHANNEL> {
                 });
             }
 
-            #[cfg(feature = "esp32s2")]
+            #[cfg(esp32s2)]
             tconf.modify(|_r, w| match CHANNEL {
                 0 => w.target0_work_en().set_bit(),
                 1 => w.target0_work_en().set_bit(),

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -29,7 +29,7 @@ where
     T: TimerGroupInstance,
 {
     pub timer0: Timer<Timer0<T>>,
-    #[cfg(not(feature = "esp32c3"))]
+    #[cfg(not(esp32c3))]
     pub timer1: Timer<Timer1<T>>,
     pub wdt: Wdt<T>,
 }
@@ -64,7 +64,7 @@ where
             clocks.apb_clock,
         );
 
-        #[cfg(not(feature = "esp32c3"))]
+        #[cfg(not(esp32c3))]
         let timer1 = Timer::new(
             Timer1 {
                 phantom: PhantomData::default(),
@@ -76,7 +76,7 @@ where
 
         Self {
             timer0,
-            #[cfg(not(feature = "esp32c3"))]
+            #[cfg(not(esp32c3))]
             timer1,
             wdt,
         }
@@ -242,7 +242,7 @@ where
         let reg_block = unsafe { &*TG::register_block() };
 
         // always use level interrupt
-        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        #[cfg(any(esp32, esp32s2))]
         reg_block.t0config.modify(|_, w| w.level_int_en().set_bit());
 
         reg_block
@@ -298,13 +298,13 @@ where
     }
 }
 
-#[cfg(not(feature = "esp32c3"))]
+#[cfg(not(esp32c3))]
 pub struct Timer1<TG> {
     phantom: PhantomData<TG>,
 }
 
 /// Timer peripheral instance
-#[cfg(not(feature = "esp32c3"))]
+#[cfg(not(esp32c3))]
 impl<TG> Instance for Timer1<TG>
 where
     TG: TimerGroupInstance,
@@ -379,7 +379,7 @@ where
         let reg_block = unsafe { &*TG::register_block() };
 
         // always use level interrupt
-        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        #[cfg(any(esp32, esp32s2))]
         reg_block.t1config.modify(|_, w| w.level_int_en().set_bit());
 
         reg_block
@@ -597,7 +597,7 @@ where
                 .bits(0)
         });
 
-        #[cfg(feature = "esp32c3")]
+        #[cfg(esp32c3)]
         reg_block
             .wdtconfig0
             .modify(|_, w| w.wdt_conf_update_en().set_bit());

--- a/esp-hal-common/src/utils/smart_leds_adapter.rs
+++ b/esp-hal-common/src/utils/smart_leds_adapter.rs
@@ -16,7 +16,7 @@ use core::{marker::PhantomData, slice::IterMut};
 use fugit::NanosDuration;
 use smart_leds_trait::{SmartLedsWrite, RGB8};
 
-#[cfg(any(feature = "esp32", feature = "esp32s2"))]
+#[cfg(any(esp32, esp32s2))]
 use crate::pulse_control::ClockSource;
 use crate::{
     gpio::OutputPin,
@@ -28,13 +28,13 @@ use crate::{
 //
 // TODO: Factor in clock configuration, this needs to be revisited once #24 and
 // #44 have been addressed.
-#[cfg(feature = "esp32c3")]
+#[cfg(esp32c3)]
 const SOURCE_CLK_FREQ: u32 = 40_000_000;
-#[cfg(feature = "esp32s2")]
+#[cfg(esp32s2)]
 const SOURCE_CLK_FREQ: u32 = 40_000_000;
-#[cfg(feature = "esp32")]
+#[cfg(esp32)]
 const SOURCE_CLK_FREQ: u32 = 40_000_000;
-#[cfg(feature = "esp32s3")]
+#[cfg(esp32s3)]
 const SOURCE_CLK_FREQ: u32 = 40_000_000;
 
 const SK68XX_CODE_PERIOD: u32 = 1200;
@@ -94,14 +94,14 @@ where
 {
     /// Create a new adapter object that drives the pin using the RMT channel.
     pub fn new(mut channel: CHANNEL, pin: PIN) -> SmartLedsAdapter<CHANNEL, PIN, BUFFER_SIZE> {
-        #[cfg(any(feature = "esp32c3", feature = "esp32s3"))]
+        #[cfg(any(esp32c3, esp32s3))]
         channel
             .set_idle_output_level(false)
             .set_carrier_modulation(false)
             .set_channel_divider(1)
             .set_idle_output(true);
 
-        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        #[cfg(any(esp32, esp32s2))]
         channel
             .set_idle_output_level(false)
             .set_carrier_modulation(false)


### PR DESCRIPTION
The `esp-hal-common` build script now injects the following configuration symbols depending on which chip's Cargo feature is activated:

- Chip: `#[cfg(esp32)]`, `#[cfg(esp32c3)]`, `#[cfg(esp32s2)]`, `#[cfg(esp32s3)]`
- Architecture: `#[cfg(riscv)]`, `#[cfg(xtensa)]`
- Core count: `#[cfg(single_core)]`, `#[cfg(multi_core)]`

cfg gates are updated as necessary, I just used Ye Olde Search-and-Replace. As a side effect the `single_core` and `multi_core` features have been eliminated; this is for the best as they were not intended for use by users anyway.

While I was doing this I discovered that the multi-core implementation of Critical Sections was broken, and that it was gated behind a non-existent feature; this has been fixed.

I also just organized the `lib.rs` file because it was a bit of a mess.