### PR TITLE
Check for opt-level="z" in `build.rs`, provide feedback about dangers

### DIFF
--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -41,13 +41,14 @@ smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 
 [features]
-default     = ["rt", "vectored"]
-direct-boot = []
-eh1         = ["esp-hal-common/eh1"]
-rt          = ["riscv-rt"]
-smartled    = ["esp-hal-common/smartled"]
-ufmt        = ["esp-hal-common/ufmt"]
-vectored    = ["esp-hal-common/vectored"]
+default           = ["rt", "vectored"]
+direct-boot       = []
+eh1               = ["esp-hal-common/eh1"]
+rt                = ["riscv-rt"]
+smartled          = ["esp-hal-common/smartled"]
+ufmt              = ["esp-hal-common/ufmt"]
+vectored          = ["esp-hal-common/vectored"]
+allow-opt-level-z = []
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32c3-hal/build.rs
+++ b/esp32c3-hal/build.rs
@@ -78,7 +78,7 @@ fn add_defaults() {
 
 const OPT_LEVEL_Z_MSG: &str = r#"opt-level=z will produce broken 128-bit shifts (i.e. `1u128 << i`). The hal's interrupt handling relies on that operation, causing an 'attempt to subtract with overflow' panic if an enabled interrupt is triggered while using that opt-level.
 
-Please use `opt-level="s"` in lieu of "z", or alternatively enable `features = ["allow-opt-level-z"]` to supress this error. The latter option is only recommended if you:
+Please use `opt-level="s"` in lieu of "z", or alternatively enable `features = ["allow-opt-level-z"]` to suppress this error. The latter option is only recommended if you:
 
   * Do not use interrupts, and
   * Do not have any shifts of 128-bit integers (either u128 or i128) in your code

--- a/esp32c3-hal/build.rs
+++ b/esp32c3-hal/build.rs
@@ -76,11 +76,15 @@ fn add_defaults() {
     println!("cargo:rustc-link-search={}", out.display());
 }
 
-const OPT_LEVEL_Z_MSG: &str = r#"opt-level=z will produce broken interrupt handling code for this architecture, causing an 'attempt to subtract with overflow' panic if an enabled interrupt is triggered.
+const OPT_LEVEL_Z_MSG: &str = r#"opt-level=z will produce broken 128-bit shifts (i.e. `1u128 << i`). The hal's interrupt handling relies on that operation, causing an 'attempt to subtract with overflow' panic if an enabled interrupt is triggered while using that opt-level.
 
-Please use `opt-level="s"` in lieu of "z", or alternatively enable `features = ["allow-opt-level-z"]` to supress this error.
+Please use `opt-level="s"` in lieu of "z", or alternatively enable `features = ["allow-opt-level-z"]` to supress this error. The latter option is only recommended if you:
 
-For more information, see: https://github.com/esp-rs/esp-hal/issues/196
+  * Do not use interrupts, and
+  * Do not have any shifts of 128-bit integers (either u128 or i128) in your code
+
+See also: https://github.com/esp-rs/esp-hal/issues/196
+     and: https://github.com/llvm/llvm-project/issues/57988         
 "#;
 
 // Once a rust nightly has a fix for https://github.com/llvm/llvm-project/issues/57988 , consider:
@@ -94,7 +98,15 @@ fn check_opt_level() {
     match env::var_os("OPT_LEVEL") {
         Some(ref opt_level) => {
             if opt_level == "z" {
-                println!("cargo:warning={}", OPT_LEVEL_Z_MSG);
+                println!(
+                    "{}",
+                    OPT_LEVEL_Z_MSG
+                        .lines()
+                        .into_iter()
+                        .map(|l| format!("cargo:warning={l}"))
+                        .collect::<Vec<String>>()
+                        .join("\n")
+                );
                 exit(1);
             }
         }


### PR DESCRIPTION
With this change, trying to build with opt-level="z" produces a message that looks like this:

![image](https://user-images.githubusercontent.com/241129/192571729-88e12179-60c9-40b6-8cec-7fb645e64e87.png)

Mitigation for:

* https://github.com/esp-rs/esp-hal/issues/196
* https://github.com/llvm/llvm-project/issues/57988
