### PR TITLE
Use `esp_println` in favour of the Serial peripheral wherever possible

### DIFF
--- a/esp32-hal/examples/i2c_display.rs
+++ b/esp32-hal/examples/i2c_display.rs
@@ -10,8 +10,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use embedded_graphics::{
     mono_font::{
         ascii::{FONT_6X10, FONT_9X18_BOLD},
@@ -29,7 +27,6 @@ use esp32_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -45,7 +42,6 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
@@ -53,8 +49,6 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    writeln!(serial0, "Enabling peripheral!").unwrap();
 
     // Create a new peripheral object with the described wiring
     // and standard I2C clock speed
@@ -70,8 +64,6 @@ fn main() -> ! {
 
     // Start timer (5 second interval)
     timer0.start(5u64.secs());
-
-    writeln!(serial0, "Starting timer!").unwrap();
 
     // Initialize display
     let interface = I2CDisplayInterface::new(i2c);
@@ -90,8 +82,6 @@ fn main() -> ! {
         .build();
 
     loop {
-        writeln!(serial0, "In Loop!").unwrap();
-
         // Fill display bufffer with a centered text with two lines (and two text
         // styles)
         Text::with_alignment(

--- a/esp32-hal/examples/ledc.rs
+++ b/esp32-hal/examples/ledc.rs
@@ -6,8 +6,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -21,7 +19,6 @@ use esp32_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
 use xtensa_lx_rt::entry;
@@ -34,7 +31,6 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
@@ -44,10 +40,11 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    writeln!(serial0, "\nESP32 Started\n\n").unwrap();
-
-    let ledc = LEDC::new(peripherals.LEDC, &clocks, &mut system.peripheral_clock_control);
-
+    let ledc = LEDC::new(
+        peripherals.LEDC,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let mut hstimer0 = ledc.get_timer::<HighSpeed>(timer::Number::Timer0);
 
     hstimer0

--- a/esp32-hal/examples/pulse_control.rs
+++ b/esp32-hal/examples/pulse_control.rs
@@ -67,8 +67,6 @@ fn main() -> ! {
         };
     }
 
-    esp_println::println!("Start");
-
     loop {
         // Send sequence
         rmt_channel0

--- a/esp32-hal/examples/ram.rs
+++ b/esp32-hal/examples/ram.rs
@@ -8,17 +8,15 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32_hal::{
     clock::ClockControl,
     macros::ram,
-    pac::{Peripherals, UART0},
+    pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use nb::block;
 use xtensa_lx_rt::entry;
 
@@ -40,7 +38,6 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT flash boot protection
     wdt.disable();
@@ -49,23 +46,21 @@ fn main() -> ! {
 
     timer0.start(1u64.secs());
 
-    writeln!(
-        serial0,
+    println!(
         "IRAM function located at {:p}",
         function_in_ram as *const ()
-    )
-    .unwrap();
+    );
     unsafe {
-        writeln!(serial0, "SOME_INITED_DATA {:x?}", SOME_INITED_DATA).unwrap();
-        writeln!(serial0, "SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA).unwrap();
-        writeln!(serial0, "SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA).unwrap();
+        println!("SOME_INITED_DATA {:x?}", SOME_INITED_DATA);
+        println!("SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA);
+        println!("SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA);
 
         SOME_INITED_DATA[0] = 0xff;
         SOME_ZEROED_DATA[0] = 0xff;
 
-        writeln!(serial0, "SOME_INITED_DATA {:x?}", SOME_INITED_DATA).unwrap();
-        writeln!(serial0, "SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA).unwrap();
-        writeln!(serial0, "SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA).unwrap();
+        println!("SOME_INITED_DATA {:x?}", SOME_INITED_DATA);
+        println!("SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA);
+        println!("SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA);
 
         if SOME_UNINITED_DATA[0] != 0 {
             SOME_UNINITED_DATA[0] = 0;
@@ -76,27 +71,25 @@ fn main() -> ! {
             SOME_UNINITED_DATA[1] = 0;
         }
 
-        writeln!(serial0, "Counter {}", SOME_UNINITED_DATA[1]).unwrap();
+        println!("Counter {}", SOME_UNINITED_DATA[1]);
         SOME_UNINITED_DATA[1] += 1;
     }
 
-    writeln!(
-        serial0,
+    println!(
         "RTC_FAST function located at {:p}",
         function_in_rtc_ram as *const ()
-    )
-    .unwrap();
-    writeln!(serial0, "Result {}", function_in_rtc_ram()).unwrap();
+    );
+    println!("Result {}", function_in_rtc_ram());
 
     loop {
-        function_in_ram(&mut serial0);
+        function_in_ram();
         block!(timer0.wait()).unwrap();
     }
 }
 
 #[ram]
-fn function_in_ram(serial0: &mut Serial<UART0>) {
-    writeln!(serial0, "Hello world!").unwrap();
+fn function_in_ram() {
+    println!("Hello world!");
 }
 
 #[ram(rtc_fast)]

--- a/esp32-hal/examples/read_efuse.rs
+++ b/esp32-hal/examples/read_efuse.rs
@@ -4,8 +4,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32_hal::{
     clock::ClockControl,
     efuse::Efuse,
@@ -13,9 +11,9 @@ use esp32_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -26,34 +24,18 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
     rtc.rwdt.disable();
 
-    writeln!(serial0, "MAC address {:02x?}", Efuse::get_mac_address()).unwrap();
-    writeln!(serial0, "Core Count {}", Efuse::get_core_count()).unwrap();
-    writeln!(
-        serial0,
-        "Bluetooth enabled {}",
-        Efuse::is_bluetooth_enabled()
-    )
-    .unwrap();
-    writeln!(serial0, "Chip type {:?}", Efuse::get_chip_type()).unwrap();
-    writeln!(
-        serial0,
-        "Max CPU clock {:?}",
-        Efuse::get_max_cpu_frequency()
-    )
-    .unwrap();
-    writeln!(
-        serial0,
-        "Flash Encryption {:?}",
-        Efuse::get_flash_encryption()
-    )
-    .unwrap();
+    println!("MAC address {:02x?}", Efuse::get_mac_address());
+    println!("Core Count {}", Efuse::get_core_count());
+    println!("Bluetooth enabled {}", Efuse::is_bluetooth_enabled());
+    println!("Chip type {:?}", Efuse::get_chip_type());
+    println!("Max CPU clock {:?}", Efuse::get_max_cpu_frequency());
+    println!("Flash Encryption {:?}", Efuse::get_flash_encryption());
 
     loop {}
 }

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -16,8 +16,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use embedded_hal_1::spi::blocking::SpiBus;
 use esp32_hal::{
     clock::ClockControl,
@@ -28,9 +26,9 @@ use esp32_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::{print, println};
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -44,7 +42,6 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
     rtc.rwdt.disable();
@@ -68,33 +65,33 @@ fn main() -> ! {
     );
 
     let mut delay = Delay::new(&clocks);
-    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
+    println!("=== SPI example with embedded-hal-1 traits ===");
 
     loop {
         // --- Symmetric transfer (Read as much as we write) ---
-        write!(serial0, "Starting symmetric transfer...").unwrap();
+        print!("Starting symmetric transfer...");
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Symmetric transfer failed");
         assert_eq!(write, read);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Asymmetric transfer (Read more than we write) ---
-        write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
+        print!("Starting asymetric transfer (read > write)...");
         let mut read: [u8; 4] = [0x00; 4];
 
         SpiBus::transfer(&mut spi, &mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
         assert_eq!(write[0], read[0]);
         assert_eq!(read[2], 0x00u8);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
-        write!(serial0, "Starting huge transfer...").unwrap();
+        print!("Starting huge transfer...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -103,12 +100,12 @@ fn main() -> ! {
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Huge transfer failed");
         assert_eq!(write, read);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
-        write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        print!("Starting huge transfer (in-place)...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -118,7 +115,7 @@ fn main() -> ! {
         for byte in 0..write.len() {
             assert_eq!(write[byte], byte as u8);
         }
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
     }
 }

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -16,8 +16,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -27,9 +25,9 @@ use esp32_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -43,7 +41,6 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
     rtc.rwdt.disable();
@@ -71,7 +68,7 @@ fn main() -> ! {
     loop {
         let mut data = [0xde, 0xca, 0xfb, 0xad];
         spi.transfer(&mut data).unwrap();
-        writeln!(serial0, "{:x?}", data).ok();
+        println!("{:x?}", data);
 
         delay.delay_ms(250u32);
     }

--- a/esp32-hal/examples/watchdog.rs
+++ b/esp32-hal/examples/watchdog.rs
@@ -5,17 +5,9 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
-use esp32_hal::{
-    clock::ClockControl,
-    pac::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-    Serial,
-};
+use esp32_hal::{clock::ClockControl, pac::Peripherals, prelude::*, timer::TimerGroup, Rtc};
 use esp_backtrace as _;
+use esp_println::println;
 use nb::block;
 use xtensa_lx_rt::entry;
 
@@ -28,7 +20,6 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     rtc.rwdt.disable();
@@ -38,7 +29,7 @@ fn main() -> ! {
 
     loop {
         wdt.feed();
-        writeln!(serial0, "Hello world!").unwrap();
+        println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }
 }

--- a/esp32c3-hal/examples/ledc.rs
+++ b/esp32c3-hal/examples/ledc.rs
@@ -22,7 +22,6 @@ use esp32c3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_println;
 use riscv_rt::entry;
 
 #[entry]
@@ -33,7 +32,6 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let _timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
@@ -47,12 +45,12 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    esp_println::println!("\nESP32C3 Started\n\n");
-
-    let mut ledc = LEDC::new(peripherals.LEDC, &clocks, &mut system.peripheral_clock_control);
-
+    let mut ledc = LEDC::new(
+        peripherals.LEDC,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
-
     let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer2);
 
     lstimer0

--- a/esp32c3-hal/examples/pulse_control.rs
+++ b/esp32c3-hal/examples/pulse_control.rs
@@ -82,8 +82,6 @@ fn main() -> ! {
         };
     }
 
-    esp_println::println!("Start");
-
     loop {
         // Send sequence
         rmt_channel0

--- a/esp32c3-hal/examples/ram.rs
+++ b/esp32c3-hal/examples/ram.rs
@@ -8,17 +8,15 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32c3_hal::{
     clock::ClockControl,
     macros::ram,
-    pac::{Peripherals, UART0},
+    pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use nb::block;
 use riscv_rt::entry;
 
@@ -41,8 +39,6 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
 
-    let mut serial0 = Serial::new(peripherals.UART0);
-
     // Disable MWDT flash boot protection
     wdt0.disable();
     // The RWDT flash boot protection remains enabled and it being triggered is part
@@ -50,23 +46,21 @@ fn main() -> ! {
 
     timer0.start(1u64.secs());
 
-    writeln!(
-        serial0,
+    println!(
         "IRAM function located at {:p}",
         function_in_ram as *const ()
-    )
-    .unwrap();
+    );
     unsafe {
-        writeln!(serial0, "SOME_INITED_DATA {:x?}", SOME_INITED_DATA).unwrap();
-        writeln!(serial0, "SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA).unwrap();
-        writeln!(serial0, "SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA).unwrap();
+        println!("SOME_INITED_DATA {:x?}", SOME_INITED_DATA);
+        println!("SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA);
+        println!("SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA);
 
         SOME_INITED_DATA[0] = 0xff;
         SOME_ZEROED_DATA[0] = 0xff;
 
-        writeln!(serial0, "SOME_INITED_DATA {:x?}", SOME_INITED_DATA).unwrap();
-        writeln!(serial0, "SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA).unwrap();
-        writeln!(serial0, "SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA).unwrap();
+        println!("SOME_INITED_DATA {:x?}", SOME_INITED_DATA);
+        println!("SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA);
+        println!("SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA);
 
         if SOME_UNINITED_DATA[0] != 0 {
             SOME_UNINITED_DATA[0] = 0;
@@ -77,27 +71,25 @@ fn main() -> ! {
             SOME_UNINITED_DATA[1] = 0;
         }
 
-        writeln!(serial0, "Counter {}", SOME_UNINITED_DATA[1]).unwrap();
+        println!("Counter {}", SOME_UNINITED_DATA[1]);
         SOME_UNINITED_DATA[1] += 1;
     }
 
-    writeln!(
-        serial0,
+    println!(
         "RTC_FAST function located at {:p}",
         function_in_rtc_ram as *const ()
-    )
-    .unwrap();
-    writeln!(serial0, "Result {}", function_in_rtc_ram()).unwrap();
+    );
+    println!("Result {}", function_in_rtc_ram());
 
     loop {
-        function_in_ram(&mut serial0);
+        function_in_ram();
         block!(timer0.wait()).unwrap();
     }
 }
 
 #[ram]
-fn function_in_ram(serial0: &mut Serial<UART0>) {
-    writeln!(serial0, "Hello world!").unwrap();
+fn function_in_ram() {
+    println!("Hello world!");
 }
 
 #[ram(rtc_fast)]

--- a/esp32c3-hal/examples/read_efuse.rs
+++ b/esp32c3-hal/examples/read_efuse.rs
@@ -4,8 +4,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32c3_hal::{
     clock::ClockControl,
     efuse::Efuse,
@@ -13,9 +11,9 @@ use esp32c3_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use riscv_rt::entry;
 
 #[entry]
@@ -25,7 +23,6 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
@@ -37,13 +34,8 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
-    writeln!(serial0, "MAC address {:02x?}", Efuse::get_mac_address()).unwrap();
-    writeln!(
-        serial0,
-        "Flash Encryption {:?}",
-        Efuse::get_flash_encryption()
-    )
-    .unwrap();
+    println!("MAC address {:02x?}", Efuse::get_mac_address());
+    println!("Flash Encryption {:?}", Efuse::get_flash_encryption());
 
     loop {}
 }

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -18,8 +18,7 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
+use embedded_hal_1::spi::blocking::SpiDevice;
 use esp32c3_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -29,12 +28,10 @@ use esp32c3_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::{print, println};
 use riscv_rt::entry;
-
-use embedded_hal_1::spi::blocking::SpiDevice;
 
 #[entry]
 fn main() -> ! {
@@ -49,8 +46,6 @@ fn main() -> ! {
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
-
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     rtc.swd.disable();
     rtc.rwdt.disable();
@@ -77,11 +72,11 @@ fn main() -> ! {
     let mut spi_device_3 = spi_controller.add_device(io.pins.gpio5);
 
     let mut delay = Delay::new(&clocks);
-    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
+    println!("=== SPI example with embedded-hal-1 traits ===");
 
     loop {
         // --- Symmetric transfer (Read as much as we write) ---
-        write!(serial0, "Starting symmetric transfer...").unwrap();
+        print!("Starting symmetric transfer...");
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
@@ -89,11 +84,11 @@ fn main() -> ! {
         assert_eq!(write, read);
         spi_device_2.transfer(&mut read[..], &write[..]).unwrap();
         spi_device_3.transfer(&mut read[..], &write[..]).unwrap();
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Asymmetric transfer (Read more than we write) ---
-        write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
+        print!("Starting asymetric transfer (read > write)...");
         let mut read: [u8; 4] = [0x00; 4];
 
         spi_device_1
@@ -107,12 +102,12 @@ fn main() -> ! {
         spi_device_3
             .transfer(&mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
-        write!(serial0, "Starting huge transfer...").unwrap();
+        print!("Starting huge transfer...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -129,12 +124,12 @@ fn main() -> ! {
         spi_device_3
             .transfer(&mut read[..], &write[..])
             .expect("Huge transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
-        write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        print!("Starting huge transfer (in-place)...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -152,7 +147,7 @@ fn main() -> ! {
         spi_device_3
             .transfer_in_place(&mut write[..])
             .expect("Huge transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
     }
 }

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -16,8 +16,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use embedded_hal_1::spi::blocking::SpiBus;
 use esp32c3_hal::{
     clock::ClockControl,
@@ -28,9 +26,9 @@ use esp32c3_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::{print, println};
 use riscv_rt::entry;
 
 #[entry]
@@ -46,8 +44,6 @@ fn main() -> ! {
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
-
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     rtc.swd.disable();
     rtc.rwdt.disable();
@@ -73,33 +69,33 @@ fn main() -> ! {
     );
 
     let mut delay = Delay::new(&clocks);
-    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
+    println!("=== SPI example with embedded-hal-1 traits ===");
 
     loop {
         // --- Symmetric transfer (Read as much as we write) ---
-        write!(serial0, "Starting symmetric transfer...").unwrap();
+        print!("Starting symmetric transfer...");
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Symmetric transfer failed");
         assert_eq!(write, read);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Asymmetric transfer (Read more than we write) ---
-        write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
+        print!("Starting asymetric transfer (read > write)...");
         let mut read: [u8; 4] = [0x00; 4];
 
         SpiBus::transfer(&mut spi, &mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
         assert_eq!(write[0], read[0]);
         assert_eq!(read[2], 0x00u8);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
-        write!(serial0, "Starting huge transfer...").unwrap();
+        print!("Starting huge transfer...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -108,12 +104,12 @@ fn main() -> ! {
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Huge transfer failed");
         assert_eq!(write, read);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
-        write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        print!("Starting huge transfer (in-place)...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -123,7 +119,7 @@ fn main() -> ! {
         for byte in 0..write.len() {
             assert_eq!(write[byte], byte as u8);
         }
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
     }
 }

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -16,8 +16,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32c3_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -27,9 +25,9 @@ use esp32c3_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use riscv_rt::entry;
 
 #[entry]
@@ -45,8 +43,6 @@ fn main() -> ! {
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
-
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     rtc.swd.disable();
     rtc.rwdt.disable();
@@ -76,7 +72,7 @@ fn main() -> ! {
     loop {
         let mut data = [0xde, 0xca, 0xfb, 0xad];
         spi.transfer(&mut data).unwrap();
-        writeln!(serial0, "{:x?}", data).ok();
+        println!("{:x?}", data);
 
         delay.delay_ms(250u32);
     }

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -19,6 +19,7 @@ use esp32c3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use riscv_rt::entry;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
@@ -41,7 +42,7 @@ fn main() -> ! {
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 
-    esp_println::println!("SYSTIMER Current value = {}", SystemTimer::now());
+    println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.Hz());
@@ -77,7 +78,7 @@ fn main() -> ! {
 
 #[interrupt]
 fn SYSTIMER_TARGET0() {
-    esp_println::println!("Interrupt lvl1 (alarm0)");
+    println!("Interrupt lvl1 (alarm0)");
     critical_section::with(|cs| {
         ALARM0
             .borrow_ref_mut(cs)
@@ -89,7 +90,7 @@ fn SYSTIMER_TARGET0() {
 
 #[interrupt]
 fn SYSTIMER_TARGET1() {
-    esp_println::println!("Interrupt lvl2 (alarm1)");
+    println!("Interrupt lvl2 (alarm1)");
     critical_section::with(|cs| {
         ALARM1
             .borrow_ref_mut(cs)
@@ -101,7 +102,7 @@ fn SYSTIMER_TARGET1() {
 
 #[interrupt]
 fn SYSTIMER_TARGET2() {
-    esp_println::println!("Interrupt lvl2 (alarm2)");
+    println!("Interrupt lvl2 (alarm2)");
     critical_section::with(|cs| {
         ALARM2
             .borrow_ref_mut(cs)

--- a/esp32c3-hal/examples/watchdog.rs
+++ b/esp32c3-hal/examples/watchdog.rs
@@ -5,17 +5,9 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
-use esp32c3_hal::{
-    clock::ClockControl,
-    pac::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-    Serial,
-};
+use esp32c3_hal::{clock::ClockControl, pac::Peripherals, prelude::*, timer::TimerGroup, Rtc};
 use esp_backtrace as _;
+use esp_println::println;
 use nb::block;
 use riscv_rt::entry;
 
@@ -26,7 +18,6 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
@@ -43,7 +34,7 @@ fn main() -> ! {
 
     loop {
         wdt0.feed();
-        writeln!(serial0, "Hello world!").unwrap();
+        println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }
 }

--- a/esp32s2-hal/examples/clock_monitor.rs
+++ b/esp32s2-hal/examples/clock_monitor.rs
@@ -16,6 +16,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
@@ -34,7 +35,7 @@ fn main() -> ! {
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 
-    esp_println::println!(
+    println!(
         "{: <10} XTAL frequency: {} MHz",
         "[Expected]",
         clocks.xtal_clock.to_MHz()
@@ -53,7 +54,7 @@ fn RTC_CORE() {
         let mut rtc = RTC.borrow_ref_mut(cs);
         let rtc = rtc.as_mut().unwrap();
 
-        esp_println::println!(
+        println!(
             "{: <10} XTAL frequency: {} MHz",
             "[Monitor]",
             rtc.estimate_xtal_frequency()

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -10,8 +10,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use embedded_graphics::{
     mono_font::{
         ascii::{FONT_6X10, FONT_9X18_BOLD},
@@ -29,7 +27,6 @@ use esp32s2_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -45,7 +42,6 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
@@ -53,8 +49,6 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    writeln!(serial0, "Enabling peripheral!").unwrap();
 
     // Create a new peripheral object with the described wiring
     // and standard I2C clock speed
@@ -70,8 +64,6 @@ fn main() -> ! {
 
     // Start timer (5 second interval)
     timer0.start(5u64.secs());
-
-    writeln!(serial0, "Starting timer!").unwrap();
 
     // Initialize display
     let interface = I2CDisplayInterface::new(i2c);
@@ -90,8 +82,6 @@ fn main() -> ! {
         .build();
 
     loop {
-        writeln!(serial0, "In Loop!").unwrap();
-
         // Fill display bufffer with a centered text with two lines (and two text
         // styles)
         Text::with_alignment(

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -20,10 +20,8 @@ use esp32s2_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
-use esp_println;
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -33,9 +31,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let _timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let _serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
@@ -45,9 +41,11 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    esp_println::println!("\nESP32S2 Started\n\n");
-
-    let mut ledc = LEDC::new(peripherals.LEDC, &clocks, &mut system.peripheral_clock_control);
+    let mut ledc = LEDC::new(
+        peripherals.LEDC,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 

--- a/esp32s2-hal/examples/pulse_control.rs
+++ b/esp32s2-hal/examples/pulse_control.rs
@@ -68,8 +68,6 @@ fn main() -> ! {
         };
     }
 
-    esp_println::println!("Start");
-
     loop {
         // Send sequence
         rmt_channel0

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -8,17 +8,15 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32s2_hal::{
     clock::ClockControl,
     macros::ram,
-    pac::{Peripherals, UART0},
+    pac::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use nb::block;
 use xtensa_lx_rt::entry;
 
@@ -40,7 +38,6 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     // Disable MWDT flash boot protection
     wdt.disable();
@@ -49,23 +46,21 @@ fn main() -> ! {
 
     timer0.start(1u64.secs());
 
-    writeln!(
-        serial0,
+    println!(
         "IRAM function located at {:p}",
         function_in_ram as *const ()
-    )
-    .unwrap();
+    );
     unsafe {
-        writeln!(serial0, "SOME_INITED_DATA {:x?}", SOME_INITED_DATA).unwrap();
-        writeln!(serial0, "SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA).unwrap();
-        writeln!(serial0, "SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA).unwrap();
+        println!("SOME_INITED_DATA {:x?}", SOME_INITED_DATA);
+        println!("SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA);
+        println!("SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA);
 
         SOME_INITED_DATA[0] = 0xff;
         SOME_ZEROED_DATA[0] = 0xff;
 
-        writeln!(serial0, "SOME_INITED_DATA {:x?}", SOME_INITED_DATA).unwrap();
-        writeln!(serial0, "SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA).unwrap();
-        writeln!(serial0, "SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA).unwrap();
+        println!("SOME_INITED_DATA {:x?}", SOME_INITED_DATA);
+        println!("SOME_UNINITED_DATA {:x?}", SOME_UNINITED_DATA);
+        println!("SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA);
 
         if SOME_UNINITED_DATA[0] != 0 {
             SOME_UNINITED_DATA[0] = 0;
@@ -76,27 +71,25 @@ fn main() -> ! {
             SOME_UNINITED_DATA[1] = 0;
         }
 
-        writeln!(serial0, "Counter {}", SOME_UNINITED_DATA[1]).unwrap();
+        println!("Counter {}", SOME_UNINITED_DATA[1]);
         SOME_UNINITED_DATA[1] += 1;
     }
 
-    writeln!(
-        serial0,
+    println!(
         "RTC_FAST function located at {:p}",
         function_in_rtc_ram as *const ()
-    )
-    .unwrap();
-    writeln!(serial0, "Result {}", function_in_rtc_ram()).unwrap();
+    );
+    println!("Result {}", function_in_rtc_ram());
 
     loop {
-        function_in_ram(&mut serial0);
+        function_in_ram();
         block!(timer0.wait()).unwrap();
     }
 }
 
 #[ram]
-fn function_in_ram(serial0: &mut Serial<UART0>) {
-    writeln!(serial0, "Hello world!").unwrap();
+fn function_in_ram() {
+    println!("Hello world!");
 }
 
 #[ram(rtc_fast)]

--- a/esp32s2-hal/examples/read_efuse.rs
+++ b/esp32s2-hal/examples/read_efuse.rs
@@ -4,8 +4,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32s2_hal::{
     clock::ClockControl,
     efuse::Efuse,
@@ -13,9 +11,9 @@ use esp32s2_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -26,19 +24,13 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
     rtc.rwdt.disable();
-    writeln!(serial0, "MAC address {:02x?}", Efuse::get_mac_address()).unwrap();
-    writeln!(
-        serial0,
-        "Flash Encryption {:?}",
-        Efuse::get_flash_encryption()
-    )
-    .unwrap();
+    println!("MAC address {:02x?}", Efuse::get_mac_address());
+    println!("Flash Encryption {:?}", Efuse::get_flash_encryption());
 
     loop {}
 }

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -18,8 +18,7 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
+use embedded_hal_1::spi::blocking::SpiDevice;
 use esp32s2_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -29,12 +28,10 @@ use esp32s2_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::{print, println};
 use xtensa_lx_rt::entry;
-
-use embedded_hal_1::spi::blocking::SpiDevice;
 
 #[entry]
 fn main() -> ! {
@@ -47,7 +44,6 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
     rtc.rwdt.disable();
@@ -72,11 +68,11 @@ fn main() -> ! {
     let mut spi_device_3 = spi_controller.add_device(io.pins.gpio3);
 
     let mut delay = Delay::new(&clocks);
-    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
+    println!("=== SPI example with embedded-hal-1 traits ===");
 
     loop {
         // --- Symmetric transfer (Read as much as we write) ---
-        write!(serial0, "Starting symmetric transfer...").unwrap();
+        print!("Starting symmetric transfer...");
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
@@ -84,11 +80,11 @@ fn main() -> ! {
         assert_eq!(write, read);
         spi_device_2.transfer(&mut read[..], &write[..]).unwrap();
         spi_device_3.transfer(&mut read[..], &write[..]).unwrap();
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Asymmetric transfer (Read more than we write) ---
-        write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
+        print!("Starting asymetric transfer (read > write)...");
         let mut read: [u8; 4] = [0x00; 4];
 
         spi_device_1
@@ -102,12 +98,12 @@ fn main() -> ! {
         spi_device_3
             .transfer(&mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
-        write!(serial0, "Starting huge transfer...").unwrap();
+        print!("Starting huge transfer...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -124,12 +120,12 @@ fn main() -> ! {
         spi_device_3
             .transfer(&mut read[..], &write[..])
             .expect("Huge transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
-        write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        print!("Starting huge transfer (in-place)...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -147,7 +143,7 @@ fn main() -> ! {
         spi_device_3
             .transfer_in_place(&mut write[..])
             .expect("Huge transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
     }
 }

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -16,8 +16,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use embedded_hal_1::spi::blocking::SpiBus;
 use esp32s2_hal::{
     clock::ClockControl,
@@ -28,9 +26,9 @@ use esp32s2_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::{print, println};
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -44,7 +42,6 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
     rtc.rwdt.disable();
@@ -68,33 +65,33 @@ fn main() -> ! {
     );
 
     let mut delay = Delay::new(&clocks);
-    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
+    println!("=== SPI example with embedded-hal-1 traits ===");
 
     loop {
         // --- Symmetric transfer (Read as much as we write) ---
-        write!(serial0, "Starting symmetric transfer...").unwrap();
+        print!("Starting symmetric transfer...");
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Symmetric transfer failed");
         assert_eq!(write, read);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Asymmetric transfer (Read more than we write) ---
-        write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
+        print!("Starting asymetric transfer (read > write)...");
         let mut read: [u8; 4] = [0x00; 4];
 
         SpiBus::transfer(&mut spi, &mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
         assert_eq!(write[0], read[0]);
         assert_eq!(read[2], 0x00u8);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
-        write!(serial0, "Starting huge transfer...").unwrap();
+        print!("Starting huge transfer...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -103,12 +100,12 @@ fn main() -> ! {
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Huge transfer failed");
         assert_eq!(write, read);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
-        write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        print!("Starting huge transfer (in-place)...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -118,7 +115,7 @@ fn main() -> ! {
         for byte in 0..write.len() {
             assert_eq!(write[byte], byte as u8);
         }
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
     }
 }

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -16,8 +16,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32s2_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -27,9 +25,9 @@ use esp32s2_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -43,7 +41,6 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
     rtc.rwdt.disable();
@@ -71,7 +68,7 @@ fn main() -> ! {
     loop {
         let mut data = [0xde, 0xca, 0xfb, 0xad];
         spi.transfer(&mut data).unwrap();
-        writeln!(serial0, "{:x?}", data).ok();
+        println!("{:x?}", data);
 
         delay.delay_ms(250u32);
     }

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -13,12 +13,13 @@ use esp32s2_hal::{
     interrupt::Priority,
     pac::{self, Peripherals},
     prelude::*,
-    systimer::{Alarm, SystemTimer, Target, Periodic},
+    systimer::{Alarm, Periodic, SystemTimer, Target},
     timer::TimerGroup,
     Delay,
     Rtc,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
@@ -41,7 +42,7 @@ fn main() -> ! {
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 
-    esp_println::println!("SYSTIMER Current value = {}", SystemTimer::now());
+    println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.Hz());
@@ -76,7 +77,7 @@ fn main() -> ! {
 
 #[interrupt]
 fn SYSTIMER_TARGET0() {
-    esp_println::println!("Interrupt lvl1 (alarm0)");
+    println!("Interrupt lvl1 (alarm0)");
     critical_section::with(|cs| {
         ALARM0
             .borrow_ref_mut(cs)
@@ -88,7 +89,7 @@ fn SYSTIMER_TARGET0() {
 
 #[interrupt]
 fn SYSTIMER_TARGET1() {
-    esp_println::println!("Interrupt lvl3 (alarm1)");
+    println!("Interrupt lvl3 (alarm1)");
     critical_section::with(|cs| {
         ALARM1
             .borrow_ref_mut(cs)
@@ -100,7 +101,7 @@ fn SYSTIMER_TARGET1() {
 
 #[interrupt]
 fn SYSTIMER_TARGET2() {
-    esp_println::println!("Interrupt lvl3 (alarm2)");
+    println!("Interrupt lvl3 (alarm2)");
     critical_section::with(|cs| {
         ALARM2
             .borrow_ref_mut(cs)

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -18,6 +18,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 static TIMER00: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));
@@ -81,7 +82,7 @@ fn TG0_T0_LEVEL() {
         if timer.is_interrupt_set() {
             timer.clear_interrupt();
             timer.start(500u64.millis());
-            esp_println::println!("Interrupt Level 2 - Timer0");
+            println!("Interrupt Level 2 - Timer0");
         }
     });
 }
@@ -95,7 +96,7 @@ fn TG0_T1_LEVEL() {
         if timer.is_interrupt_set() {
             timer.clear_interrupt();
             timer.start(500u64.millis());
-            esp_println::println!("Interrupt Level 2 - Timer1");
+            println!("Interrupt Level 2 - Timer1");
         }
     });
 }
@@ -109,7 +110,7 @@ fn TG1_T0_LEVEL() {
         if timer.is_interrupt_set() {
             timer.clear_interrupt();
             timer.start(500u64.millis());
-            esp_println::println!("Interrupt Level 3 - Timer0");
+            println!("Interrupt Level 3 - Timer0");
         }
     });
 }
@@ -123,7 +124,7 @@ fn TG1_T1_LEVEL() {
         if timer.is_interrupt_set() {
             timer.clear_interrupt();
             timer.start(500u64.millis());
-            esp_println::println!("Interrupt Level 3 - Timer1");
+            println!("Interrupt Level 3 - Timer1");
         }
     });
 }

--- a/esp32s2-hal/examples/watchdog.rs
+++ b/esp32s2-hal/examples/watchdog.rs
@@ -5,17 +5,9 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
-use esp32s2_hal::{
-    clock::ClockControl,
-    pac::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-    Serial,
-};
+use esp32s2_hal::{clock::ClockControl, pac::Peripherals, prelude::*, timer::TimerGroup, Rtc};
 use esp_backtrace as _;
+use esp_println::println;
 use nb::block;
 use xtensa_lx_rt::entry;
 
@@ -29,7 +21,6 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.start(2u64.secs());
     rtc.rwdt.disable();
@@ -38,7 +29,7 @@ fn main() -> ! {
 
     loop {
         wdt.feed();
-        writeln!(serial0, "Hello world!").unwrap();
+        println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }
 }

--- a/esp32s3-hal/examples/clock_monitor.rs
+++ b/esp32s3-hal/examples/clock_monitor.rs
@@ -16,6 +16,7 @@ use esp32s3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
@@ -34,7 +35,7 @@ fn main() -> ! {
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 
-    esp_println::println!(
+    println!(
         "{: <10} XTAL frequency: {} MHz",
         "[Expected]",
         clocks.xtal_clock.to_MHz()
@@ -53,7 +54,7 @@ fn RTC_CORE() {
         let mut rtc = RTC.borrow_ref_mut(cs);
         let rtc = rtc.as_mut().unwrap();
 
-        esp_println::println!(
+        println!(
             "{: <10} XTAL frequency: {} MHz",
             "[Monitor]",
             rtc.estimate_xtal_frequency()

--- a/esp32s3-hal/examples/i2c_display.rs
+++ b/esp32s3-hal/examples/i2c_display.rs
@@ -10,8 +10,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use embedded_graphics::{
     mono_font::{
         ascii::{FONT_6X10, FONT_9X18_BOLD},
@@ -29,7 +27,6 @@ use esp32s3_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -45,7 +42,6 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
@@ -53,8 +49,6 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    writeln!(serial0, "Enabling peripheral!").unwrap();
 
     // Create a new peripheral object with the described wiring
     // and standard I2C clock speed
@@ -71,15 +65,11 @@ fn main() -> ! {
     // Start timer (5 second interval)
     timer0.start(5u64.secs());
 
-    writeln!(serial0, "Starting timer!").unwrap();
-
     // Initialize display
     let interface = I2CDisplayInterface::new(i2c);
     let mut display = Ssd1306::new(interface, DisplaySize128x64, DisplayRotation::Rotate0)
         .into_buffered_graphics_mode();
     display.init().unwrap();
-
-    writeln!(serial0, "Display initialized!").unwrap();
 
     // Specify different text styles
     let text_style = MonoTextStyleBuilder::new()
@@ -92,8 +82,6 @@ fn main() -> ! {
         .build();
 
     loop {
-        writeln!(serial0, "In Loop!").unwrap();
-
         // Fill display bufffer with a centered text with two lines (and two text
         // styles)
         Text::with_alignment(

--- a/esp32s3-hal/examples/ledc.rs
+++ b/esp32s3-hal/examples/ledc.rs
@@ -20,10 +20,8 @@ use esp32s3_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
-use esp_println;
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -33,9 +31,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let _timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut _serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable watchdog timer
@@ -45,9 +41,11 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    esp_println::println!("\nESP32S3 Started\n\n");
-
-    let mut ledc = LEDC::new(peripherals.LEDC, &clocks, &mut system.peripheral_clock_control);
+    let mut ledc = LEDC::new(
+        peripherals.LEDC,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 

--- a/esp32s3-hal/examples/pulse_control.rs
+++ b/esp32s3-hal/examples/pulse_control.rs
@@ -10,7 +10,7 @@ use esp32s3_hal::{
     gpio::IO,
     pac::Peripherals,
     prelude::*,
-    pulse_control::{ConfiguredChannel, ClockSource, OutputChannel, PulseCode, RepeatMode},
+    pulse_control::{ClockSource, ConfiguredChannel, OutputChannel, PulseCode, RepeatMode},
     timer::TimerGroup,
     PulseControl,
     Rtc,
@@ -75,8 +75,6 @@ fn main() -> ! {
             length2: 60u32.nanos(),
         };
     }
-
-    esp_println::println!("Start");
 
     loop {
         // Send sequence

--- a/esp32s3-hal/examples/read_efuse.rs
+++ b/esp32s3-hal/examples/read_efuse.rs
@@ -4,8 +4,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32s3_hal::{
     clock::ClockControl,
     efuse::Efuse,
@@ -13,9 +11,9 @@ use esp32s3_hal::{
     prelude::*,
     timer::TimerGroup,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -26,19 +24,13 @@ fn main() -> ! {
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
     rtc.rwdt.disable();
-    writeln!(serial0, "MAC address {:02x?}", Efuse::get_mac_address()).unwrap();
-    writeln!(
-        serial0,
-        "Flash Encryption {:?}",
-        Efuse::get_flash_encryption()
-    )
-    .unwrap();
+    println!("MAC address {:02x?}", Efuse::get_mac_address());
+    println!("Flash Encryption {:?}", Efuse::get_flash_encryption());
 
     loop {}
 }

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -18,8 +18,7 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
+use embedded_hal_1::spi::blocking::SpiDevice;
 use esp32s3_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -29,12 +28,10 @@ use esp32s3_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::{print, println};
 use xtensa_lx_rt::entry;
-
-use embedded_hal_1::spi::blocking::SpiDevice;
 
 #[entry]
 fn main() -> ! {
@@ -47,7 +44,6 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
     rtc.rwdt.disable();
@@ -72,11 +68,11 @@ fn main() -> ! {
     let mut spi_device_3 = spi_controller.add_device(io.pins.gpio6);
 
     let mut delay = Delay::new(&clocks);
-    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
+    println!("=== SPI example with embedded-hal-1 traits ===");
 
     loop {
         // --- Symmetric transfer (Read as much as we write) ---
-        write!(serial0, "Starting symmetric transfer...").unwrap();
+        print!("Starting symmetric transfer...");
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
@@ -84,11 +80,11 @@ fn main() -> ! {
         assert_eq!(write, read);
         spi_device_2.transfer(&mut read[..], &write[..]).unwrap();
         spi_device_3.transfer(&mut read[..], &write[..]).unwrap();
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Asymmetric transfer (Read more than we write) ---
-        write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
+        print!("Starting asymetric transfer (read > write)...");
         let mut read: [u8; 4] = [0x00; 4];
 
         spi_device_1
@@ -102,12 +98,12 @@ fn main() -> ! {
         spi_device_3
             .transfer(&mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
-        write!(serial0, "Starting huge transfer...").unwrap();
+        print!("Starting huge transfer...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -124,12 +120,12 @@ fn main() -> ! {
         spi_device_3
             .transfer(&mut read[..], &write[..])
             .expect("Huge transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
-        write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        print!("Starting huge transfer (in-place)...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -147,7 +143,7 @@ fn main() -> ! {
         spi_device_3
             .transfer_in_place(&mut write[..])
             .expect("Huge transfer failed");
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
     }
 }

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -16,8 +16,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use embedded_hal_1::spi::blocking::SpiBus;
 use esp32s3_hal::{
     clock::ClockControl,
@@ -28,9 +26,9 @@ use esp32s3_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::{print, println};
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -44,7 +42,6 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
     rtc.rwdt.disable();
@@ -68,33 +65,33 @@ fn main() -> ! {
     );
 
     let mut delay = Delay::new(&clocks);
-    writeln!(serial0, "=== SPI example with embedded-hal-1 traits ===").unwrap();
+    println!("=== SPI example with embedded-hal-1 traits ===");
 
     loop {
         // --- Symmetric transfer (Read as much as we write) ---
-        write!(serial0, "Starting symmetric transfer...").unwrap();
+        print!("Starting symmetric transfer...");
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Symmetric transfer failed");
         assert_eq!(write, read);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Asymmetric transfer (Read more than we write) ---
-        write!(serial0, "Starting asymetric transfer (read > write)...").unwrap();
+        print!("Starting asymetric transfer (read > write)...");
         let mut read: [u8; 4] = [0x00; 4];
 
         SpiBus::transfer(&mut spi, &mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
         assert_eq!(write[0], read[0]);
         assert_eq!(read[2], 0x00u8);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
-        write!(serial0, "Starting huge transfer...").unwrap();
+        print!("Starting huge transfer...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -103,12 +100,12 @@ fn main() -> ! {
 
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Huge transfer failed");
         assert_eq!(write, read);
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
-        write!(serial0, "Starting huge transfer (in-place)...").unwrap();
+        print!("Starting huge transfer (in-place)...");
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -118,7 +115,7 @@ fn main() -> ! {
         for byte in 0..write.len() {
             assert_eq!(write[byte], byte as u8);
         }
-        writeln!(serial0, " SUCCESS").unwrap();
+        println!(" SUCCESS");
         delay.delay_ms(250u32);
     }
 }

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -16,8 +16,6 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
 use esp32s3_hal::{
     clock::ClockControl,
     gpio::IO,
@@ -27,9 +25,9 @@ use esp32s3_hal::{
     timer::TimerGroup,
     Delay,
     Rtc,
-    Serial,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -43,7 +41,6 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt = timer_group0.wdt;
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.disable();
     rtc.rwdt.disable();
@@ -71,7 +68,7 @@ fn main() -> ! {
     loop {
         let mut data = [0xde, 0xca, 0xfb, 0xad];
         spi.transfer(&mut data).unwrap();
-        writeln!(serial0, "{:x?}", data).ok();
+        println!("{:x?}", data);
 
         delay.delay_ms(250u32);
     }

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -13,12 +13,13 @@ use esp32s3_hal::{
     interrupt::Priority,
     pac::{self, Peripherals},
     prelude::*,
-    systimer::{Alarm, SystemTimer, Target, Periodic},
+    systimer::{Alarm, Periodic, SystemTimer, Target},
     timer::TimerGroup,
     Delay,
     Rtc,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
@@ -41,7 +42,7 @@ fn main() -> ! {
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 
-    esp_println::println!("SYSTIMER Current value = {}", SystemTimer::now());
+    println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.Hz());
@@ -76,7 +77,7 @@ fn main() -> ! {
 
 #[interrupt]
 fn SYSTIMER_TARGET0() {
-    esp_println::println!("Interrupt lvl1 (alarm0)");
+    println!("Interrupt lvl1 (alarm0)");
     critical_section::with(|cs| {
         ALARM0
             .borrow_ref_mut(cs)
@@ -88,7 +89,7 @@ fn SYSTIMER_TARGET0() {
 
 #[interrupt]
 fn SYSTIMER_TARGET1() {
-    esp_println::println!("Interrupt lvl2 (alarm1)");
+    println!("Interrupt lvl2 (alarm1)");
     critical_section::with(|cs| {
         ALARM1
             .borrow_ref_mut(cs)
@@ -100,7 +101,7 @@ fn SYSTIMER_TARGET1() {
 
 #[interrupt]
 fn SYSTIMER_TARGET2() {
-    esp_println::println!("Interrupt lvl2 (alarm2)");
+    println!("Interrupt lvl2 (alarm2)");
     critical_section::with(|cs| {
         ALARM2
             .borrow_ref_mut(cs)

--- a/esp32s3-hal/examples/timer_interrupt.rs
+++ b/esp32s3-hal/examples/timer_interrupt.rs
@@ -18,6 +18,7 @@ use esp32s3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use xtensa_lx_rt::entry;
 
 static TIMER00: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));
@@ -81,7 +82,7 @@ fn TG0_T0_LEVEL() {
         if timer.is_interrupt_set() {
             timer.clear_interrupt();
             timer.start(500u64.millis());
-            esp_println::println!("Interrupt Level 2 - Timer0");
+            println!("Interrupt Level 2 - Timer0");
         }
     });
 }
@@ -95,7 +96,7 @@ fn TG0_T1_LEVEL() {
         if timer.is_interrupt_set() {
             timer.clear_interrupt();
             timer.start(500u64.millis());
-            esp_println::println!("Interrupt Level 2 - Timer1");
+            println!("Interrupt Level 2 - Timer1");
         }
     });
 }
@@ -109,7 +110,7 @@ fn TG1_T0_LEVEL() {
         if timer.is_interrupt_set() {
             timer.clear_interrupt();
             timer.start(500u64.millis());
-            esp_println::println!("Interrupt Level 3 - Timer0");
+            println!("Interrupt Level 3 - Timer0");
         }
     });
 }
@@ -123,7 +124,7 @@ fn TG1_T1_LEVEL() {
         if timer.is_interrupt_set() {
             timer.clear_interrupt();
             timer.start(500u64.millis());
-            esp_println::println!("Interrupt Level 3 - Timer1");
+            println!("Interrupt Level 3 - Timer1");
         }
     });
 }

--- a/esp32s3-hal/examples/watchdog.rs
+++ b/esp32s3-hal/examples/watchdog.rs
@@ -5,17 +5,9 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
-
-use esp32s3_hal::{
-    clock::ClockControl,
-    pac::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-    Serial,
-};
+use esp32s3_hal::{clock::ClockControl, pac::Peripherals, prelude::*, timer::TimerGroup, Rtc};
 use esp_backtrace as _;
+use esp_println::println;
 use nb::block;
 use xtensa_lx_rt::entry;
 
@@ -29,7 +21,6 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Serial::new(peripherals.UART0);
 
     wdt.start(2u64.secs());
     rtc.rwdt.disable();
@@ -38,7 +29,7 @@ fn main() -> ! {
 
     loop {
         wdt.feed();
-        writeln!(serial0, "Hello world!").unwrap();
+        println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }
 }


### PR DESCRIPTION
This is kind of a dumb PR, but I'm going to be changing the interface for the Serial peripheral driver eventually anyway so these were going to need changing regardless.

The examples `hello_world`, `advanced_serial`, and `serial_interrupts` examples still use the Serial peripheral driver, as they are more or less demonstrating it. Any remaining examples were updated to use `esp_println`, and some had their output removed altogether when it wasn't necessary or it did not otherwise add to the example.

Not really much to review here, but let me know if you have any comments.