### PR TITLE
crate: update riscv dependency crate to v0.9.0

### DIFF
--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -30,7 +30,7 @@ embedded-hal-1   = { version = "=1.0.0-alpha.9", optional = true, package = "emb
 embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32c3"], path = "../esp-hal-common" }
 r0               = "1.0.0"
-riscv            = "0.8.0"
+riscv            = "0.9.0"
 riscv-rt         = { version = "0.9.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
The `riscv` crate has introduced several fixes which newer users would take advantage of (https://github.com/rust-embedded/riscv/pull/112)