### PR TITLE
SPI: Add hardware CS

### DIFF
--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -396,7 +396,7 @@ mod ehal1 {
         }
 
         pub fn add_device<'a, CS: OutputPin>(&'a self, cs: CS) -> SpiBusDevice<'a, I, CS> {
-            SpiBusDevice { bus: self, cs }
+            SpiBusDevice::new(self, cs)
         }
     }
 


### PR DESCRIPTION
Removes a lot of generic arguments and hard-codes the `SpiBusController` and `SpiBusDevice` to work with the `Spi<T>` defined in the HAL instead. This allows us to access the `cs_signal()` trait function from `T: Instance`, which we need to connect/disconnect the CS I/O as appropriate.

Also it has recently been brought to my attention (in "Rust Embedded" on Matrix) that HALs aren't meant to implement `SpiDevice` unless they add some benefit over generic software implementations, so here we are. :)

For lack of a working ESP32 I cannot test this at the moment. Could someone please verify the CS lines work as expected?