### PR TITLE
Basic DMA for ESP32-C3

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -23,6 +23,7 @@ nb               = "1.0.0"
 paste            = "=1.0.8"
 procmacros       = { version = "0.1.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 void             = { version = "1.0.2", default-features = false }
+embedded-dma     = "0.2.0"
 
 # RISC-V
 riscv                       = { version = "0.8.0", optional = true }

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -1,0 +1,684 @@
+//! Direct Memory Access
+
+use core::{marker::PhantomData, sync::atomic::compiler_fence};
+
+use crate::system::{Peripheral, PeripheralClockControl};
+
+/// DMA Errors
+#[derive(Debug, Clone, Copy)]
+pub enum DmaError {
+    InvalidAlignment,
+    OutOfDescriptors,
+    InvalidDescriptorSize,
+    DescriptorError,
+}
+
+/// DMA Priorities
+pub enum DmaPriority {
+    Priority0  = 0,
+    Priority1  = 1,
+    Priority2  = 2,
+    Priority3  = 3,
+    Priority4  = 4,
+    Priority5  = 5,
+    Priority6  = 6,
+    Priority7  = 7,
+    Priority8  = 8,
+    Priority9  = 9,
+    Priority10 = 10,
+    Priority11 = 11,
+    Priority12 = 12,
+    Priority13 = 13,
+    Priority14 = 14,
+    Priority15 = 15,
+}
+
+enum Owner {
+    Cpu = 0,
+    Dma = 1,
+}
+
+impl From<u32> for Owner {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => Owner::Cpu,
+            _ => Owner::Dma,
+        }
+    }
+}
+
+trait DmaLinkedListDw0 {
+    fn set_size(&mut self, len: u16);
+    fn get_size(&mut self) -> u16;
+    fn set_length(&mut self, len: u16);
+    fn get_length(&mut self) -> u16;
+    fn set_err_eof(&mut self, err_eof: bool);
+    fn get_err_eof(&mut self) -> bool;
+    fn set_suc_eof(&mut self, suc_eof: bool);
+    fn get_suc_eof(&mut self) -> bool;
+    fn set_owner(&mut self, owner: Owner);
+    fn get_owner(&mut self) -> Owner;
+}
+
+impl DmaLinkedListDw0 for &mut u32 {
+    fn set_size(&mut self, len: u16) {
+        let mask = 0b111111111111;
+        let bit_s = 0;
+        **self = (**self & !(mask << bit_s)) | (len as u32) << bit_s;
+    }
+
+    fn get_size(&mut self) -> u16 {
+        let mask = 0b111111111111;
+        let bit_s = 0;
+        ((**self & (mask << bit_s)) >> bit_s) as u16
+    }
+
+    fn set_length(&mut self, len: u16) {
+        let mask = 0b111111111111;
+        let bit_s = 12;
+        **self = (**self & !(mask << bit_s)) | (len as u32) << bit_s;
+    }
+
+    fn get_length(&mut self) -> u16 {
+        let mask = 0b111111111111;
+        let bit_s = 12;
+        ((**self & (mask << bit_s)) >> bit_s) as u16
+    }
+
+    fn set_err_eof(&mut self, err_eof: bool) {
+        let mask = 0b1;
+        let bit_s = 28;
+        **self = (**self & !(mask << bit_s)) | (err_eof as u32) << bit_s;
+    }
+
+    fn get_err_eof(&mut self) -> bool {
+        let mask = 0b1;
+        let bit_s = 28;
+        ((**self & (mask << bit_s)) >> bit_s) != 0
+    }
+
+    fn set_suc_eof(&mut self, suc_eof: bool) {
+        let mask = 0b1;
+        let bit_s = 30;
+        **self = (**self & !(mask << bit_s)) | (suc_eof as u32) << bit_s;
+    }
+
+    fn get_suc_eof(&mut self) -> bool {
+        let mask = 0b1;
+        let bit_s = 30;
+        ((**self & (mask << bit_s)) >> bit_s) != 0
+    }
+
+    fn set_owner(&mut self, owner: Owner) {
+        let mask = 0b1;
+        let bit_s = 31;
+        **self = (**self & !(mask << bit_s)) | (owner as u32) << bit_s;
+    }
+
+    fn get_owner(&mut self) -> Owner {
+        let mask = 0b1;
+        let bit_s = 31;
+        ((**self & (mask << bit_s)) >> bit_s).into()
+    }
+}
+
+/// DMA capable peripherals
+pub enum DmaPeripheral {
+    Spi2  = 0,
+    Uhci0 = 2,
+    I2s   = 3,
+    Aes   = 6,
+    Sha   = 7,
+    Adc   = 8,
+}
+
+/// DMA Rx
+///
+/// The functions here are not meant to be used outside the HAL and will be
+/// hidden/inaccessible in future.
+pub trait Rx {
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority);
+    fn prepare_transfer(
+        &mut self,
+        peri: DmaPeripheral,
+        data: *mut u8,
+        len: usize,
+    ) -> Result<(), DmaError>;
+    fn is_done(&mut self) -> bool;
+}
+
+pub(crate) trait RxChannel<R>
+where
+    R: RegisterAccess,
+{
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+        R::set_in_burstmode(burst_mode);
+        R::set_in_priority(priority);
+    }
+
+    fn prepare_transfer(
+        &mut self,
+        descriptors: &mut [u32],
+        peri: DmaPeripheral,
+        data: *mut u8,
+        len: usize,
+    ) -> Result<(), DmaError> {
+        for descr in descriptors.iter_mut() {
+            *descr = 0;
+        }
+
+        compiler_fence(core::sync::atomic::Ordering::SeqCst);
+
+        let mut processed = 0;
+        let mut descr = 0;
+        loop {
+            let chunk_size = usize::min(4092, len - processed);
+            let last = processed + chunk_size >= len;
+
+            descriptors[descr + 1] = data as u32 + processed as u32;
+
+            let mut dw0 = &mut descriptors[descr];
+
+            dw0.set_suc_eof(last);
+            dw0.set_owner(Owner::Dma);
+            dw0.set_size(chunk_size as u16); // align to 32 bits?
+            dw0.set_length(0); // actual size of the data!?
+
+            if !last {
+                descriptors[descr + 2] = (&descriptors[descr + 3]) as *const _ as *const () as u32;
+            } else {
+                descriptors[descr + 2] = 0;
+            }
+
+            processed += chunk_size;
+            descr += 3;
+
+            if processed >= len {
+                break;
+            }
+        }
+
+        R::clear_in_interrupts();
+        R::reset_in();
+        R::set_in_descriptors(descriptors.as_ptr() as u32);
+        R::set_in_peripheral(peri as u8);
+        R::start_in();
+
+        if R::has_in_descriptor_error() {
+            return Err(DmaError::DescriptorError);
+        }
+
+        Ok(())
+    }
+
+    fn is_done(&mut self) -> bool {
+        R::is_in_done()
+    }
+}
+
+pub(crate) struct ChannelRx<'a, T, R>
+where
+    T: RxChannel<R>,
+    R: RegisterAccess,
+{
+    descriptors: &'a mut [u32],
+    burst_mode: bool,
+    rx_impl: T,
+    _phantom: PhantomData<R>,
+}
+
+impl<'a, T, R> Rx for ChannelRx<'a, T, R>
+where
+    T: RxChannel<R>,
+    R: RegisterAccess,
+{
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+        self.rx_impl.init(burst_mode, priority);
+    }
+
+    fn prepare_transfer(
+        &mut self,
+        peri: DmaPeripheral,
+        data: *mut u8,
+        len: usize,
+    ) -> Result<(), DmaError> {
+        if self.descriptors.len() % 3 != 0 {
+            return Err(DmaError::InvalidDescriptorSize);
+        }
+
+        if self.descriptors.len() / 3 < len / 4092 {
+            return Err(DmaError::OutOfDescriptors);
+        }
+
+        if self.burst_mode && (len % 4 != 0 || data as u32 % 4 != 0) {
+            return Err(DmaError::InvalidAlignment);
+        }
+
+        self.rx_impl
+            .prepare_transfer(self.descriptors, peri, data, len)?;
+        Ok(())
+    }
+
+    fn is_done(&mut self) -> bool {
+        self.rx_impl.is_done()
+    }
+}
+
+/// DMA Tx
+///
+/// The functions here are not meant to be used outside the HAL and will be
+/// hidden/inaccessible in future.
+pub trait Tx {
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority);
+    fn prepare_transfer(
+        &mut self,
+        peri: DmaPeripheral,
+        data: *const u8,
+        len: usize,
+    ) -> Result<(), DmaError>;
+    fn is_done(&mut self) -> bool;
+}
+
+pub(crate) trait TxChannel<R>
+where
+    R: RegisterAccess,
+{
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+        R::set_out_burstmode(burst_mode);
+        R::set_out_priority(priority);
+    }
+
+    fn prepare_transfer(
+        &mut self,
+        descriptors: &mut [u32],
+        peri: DmaPeripheral,
+        data: *const u8,
+        len: usize,
+    ) -> Result<(), DmaError> {
+        for descr in descriptors.iter_mut() {
+            *descr = 0;
+        }
+
+        compiler_fence(core::sync::atomic::Ordering::SeqCst);
+
+        let mut processed = 0;
+        let mut descr = 0;
+        loop {
+            let chunk_size = usize::min(4092, len - processed);
+            let last = processed + chunk_size >= len;
+
+            descriptors[descr + 1] = data as u32 + processed as u32;
+
+            let mut dw0 = &mut descriptors[descr];
+
+            dw0.set_suc_eof(last);
+            dw0.set_owner(Owner::Dma);
+            dw0.set_size(chunk_size as u16); // align to 32 bits?
+            dw0.set_length(chunk_size as u16); // actual size of the data!?
+
+            if !last {
+                descriptors[descr + 2] = (&descriptors[descr + 3]) as *const _ as *const () as u32;
+            } else {
+                descriptors[descr + 2] = 0;
+            }
+
+            processed += chunk_size;
+            descr += 3;
+
+            if processed >= len {
+                break;
+            }
+        }
+
+        R::clear_out_interrupts();
+        R::reset_out();
+        R::set_out_descriptors(descriptors.as_ptr() as u32);
+        R::set_out_peripheral(peri as u8);
+        R::start_out();
+
+        if R::has_out_descriptor_error() {
+            return Err(DmaError::DescriptorError);
+        }
+
+        Ok(())
+    }
+
+    fn is_done(&mut self) -> bool {
+        R::is_out_done()
+    }
+}
+
+pub(crate) struct ChannelTx<'a, T, R>
+where
+    T: TxChannel<R>,
+    R: RegisterAccess,
+{
+    descriptors: &'a mut [u32],
+    #[allow(unused)]
+    burst_mode: bool,
+    tx_impl: T,
+    _phantom: PhantomData<R>,
+}
+
+impl<'a, T, R> Tx for ChannelTx<'a, T, R>
+where
+    T: TxChannel<R>,
+    R: RegisterAccess,
+{
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+        self.tx_impl.init(burst_mode, priority);
+    }
+
+    fn prepare_transfer(
+        &mut self,
+        peri: DmaPeripheral,
+        data: *const u8,
+        len: usize,
+    ) -> Result<(), DmaError> {
+        if self.descriptors.len() % 3 != 0 {
+            return Err(DmaError::InvalidDescriptorSize);
+        }
+
+        if self.descriptors.len() / 3 < len / 4092 {
+            return Err(DmaError::OutOfDescriptors);
+        }
+
+        self.tx_impl
+            .prepare_transfer(self.descriptors, peri, data, len)?;
+
+        Ok(())
+    }
+
+    fn is_done(&mut self) -> bool {
+        self.tx_impl.is_done()
+    }
+}
+
+pub(crate) trait RegisterAccess {
+    fn set_out_burstmode(burst_mode: bool);
+    fn set_out_priority(priority: DmaPriority);
+    fn clear_out_interrupts();
+    fn reset_out();
+    fn set_out_descriptors(address: u32);
+    fn has_out_descriptor_error() -> bool;
+    fn set_out_peripheral(peripheral: u8);
+    fn start_out();
+    fn is_out_done() -> bool;
+    fn set_in_burstmode(burst_mode: bool);
+    fn set_in_priority(priority: DmaPriority);
+    fn clear_in_interrupts();
+    fn reset_in();
+    fn set_in_descriptors(address: u32);
+    fn has_in_descriptor_error() -> bool;
+    fn set_in_peripheral(peripheral: u8);
+    fn start_in();
+    fn is_in_done() -> bool;
+}
+
+macro_rules! ImplChannel {
+    ($num: literal) => {
+        paste::paste! {
+            pub(crate) struct [<Channel $num>] {}
+
+            impl RegisterAccess for [<Channel $num>] {
+                fn set_out_burstmode(burst_mode: bool) {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+
+                    dma.[<out_conf0_ch $num>].modify(|_,w| {
+                        w.[<out_data_burst_en_ch $num>]().bit(burst_mode)
+                            .[<outdscr_burst_en_ch $num>]().bit(burst_mode)
+                    });
+                }
+
+                fn set_out_priority(priority: DmaPriority) {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+
+                    dma.[<out_pri_ch $num>].write(|w| {
+                        w.[<tx_pri_ch $num>]().variant(priority as u8)
+                    });
+                }
+
+                fn clear_out_interrupts() {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+
+                    dma.[<int_clr_ch $num>].write(|w| {
+                        w.[<out_eof_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<out_dscr_err_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<out_done_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<out_total_eof_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<outfifo_ovf_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<outfifo_udf_ch $num _int_clr>]()
+                            .set_bit()
+                    });
+                }
+
+                fn reset_out() {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<out_conf0_ch $num>].modify(|_, w| w.[<out_rst_ch $num>]().set_bit());
+                    dma.[<out_conf0_ch $num>].modify(|_, w| w.[<out_rst_ch $num>]().clear_bit());
+                }
+
+                fn set_out_descriptors(address: u32) {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<out_link_ch $num>]
+                        .modify(|_, w| unsafe { w.[<outlink_addr_ch $num>]().bits(address) });
+                }
+
+                fn has_out_descriptor_error() -> bool {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<int_raw_ch $num>].read().[<out_dscr_err_ch $num _int_raw>]().bit()
+                }
+
+                fn set_out_peripheral(peripheral: u8) {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<out_peri_sel_ch $num>]
+                        .modify(|_, w| w.[<peri_out_sel_ch $num>]().variant(peripheral));
+                }
+
+                fn start_out() {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<out_link_ch $num>]
+                        .modify(|_, w| w.[<outlink_start_ch $num>]().set_bit());
+                }
+
+                fn is_out_done() -> bool {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<int_raw_ch $num>].read().[<out_total_eof_ch $num _int_raw>]().bit()
+                }
+
+                fn set_in_burstmode(burst_mode: bool) {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+
+                    dma.[<in_conf0_ch $num>].modify(|_,w| {
+                        w.[<in_data_burst_en_ch $num>]().bit(burst_mode)
+                            .[<indscr_burst_en_ch $num>]().bit(burst_mode)
+                    });
+                }
+
+                fn set_in_priority(priority: DmaPriority) {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+
+                    dma.[<in_pri_ch $num>].write(|w| {
+                        w.[<rx_pri_ch $num>]().variant(priority as u8)
+                    });
+                }
+
+                fn clear_in_interrupts() {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+
+                    dma.[<int_clr_ch $num>].write(|w| {
+                        w.[<in_suc_eof_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<in_err_eof_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<in_dscr_err_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<in_dscr_empty_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<in_done_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<infifo_ovf_ch $num _int_clr>]()
+                            .set_bit()
+                            .[<infifo_udf_ch $num _int_clr>]()
+                            .set_bit()
+                    });
+                }
+
+                fn reset_in() {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<in_conf0_ch $num>].modify(|_, w| w.[<in_rst_ch $num>]().set_bit());
+                    dma.[<in_conf0_ch $num>].modify(|_, w| w.[<in_rst_ch $num>]().clear_bit());
+                }
+
+                fn set_in_descriptors(address: u32) {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<in_link_ch $num>]
+                        .modify(|_, w| unsafe { w.[<inlink_addr_ch $num>]().bits(address) });
+                }
+
+                fn has_in_descriptor_error() -> bool {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<int_raw_ch $num>].read().[<in_dscr_err_ch $num _int_raw>]().bit()
+                }
+
+                fn set_in_peripheral(peripheral: u8) {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<in_peri_sel_ch $num>]
+                        .modify(|_, w| w.[<peri_in_sel_ch $num>]().variant(peripheral));
+                }
+
+                fn start_in() {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<in_link_ch $num>]
+                        .modify(|_, w| w.[<inlink_start_ch $num>]().set_bit());
+                }
+
+                fn is_in_done() -> bool {
+                    let dma = unsafe { &*crate::pac::DMA::PTR };
+                    dma.[<int_raw_ch $num>].read().[<in_suc_eof_ch $num _int_raw>]().bit()
+                }
+            }
+
+            pub(crate) struct [<Channel $num TxImpl>] {}
+
+            impl<'a> TxChannel<[<Channel $num>]> for [<Channel $num TxImpl>] {}
+
+            pub(crate) struct [<Channel $num RxImpl>] {}
+
+            impl<'a> RxChannel<[<Channel $num>]> for [<Channel $num RxImpl>] {}
+
+            /// Create the Tx half of the DMA channel
+            pub struct [<TxCreator $num>] {
+            }
+
+            impl [<TxCreator $num>] {
+                pub fn get<'a>(
+                    self,
+                    descriptors: &'a mut [u32],
+                    burst_mode: bool,
+                    priority: DmaPriority,
+                ) -> impl Tx + 'a {
+                    let mut tx_impl = [<Channel $num TxImpl>] {};
+                    tx_impl.init(burst_mode, priority);
+
+                    ChannelTx {
+                        descriptors,
+                        burst_mode,
+                        tx_impl: tx_impl,
+                        _phantom: PhantomData::default(),
+                    }
+                }
+            }
+
+            /// Create the Rx half of the DMA channel
+            pub struct [<RxCreator $num>] {
+            }
+
+            impl [<RxCreator $num>] {
+                pub fn get<'a>(
+                    self,
+                    descriptors: &'a mut [u32],
+                    burst_mode: bool,
+                    priority: DmaPriority,
+                ) -> impl Rx + 'a {
+                    let mut rx_impl = [<Channel $num RxImpl>] {};
+                    rx_impl.init(burst_mode, priority);
+
+                    ChannelRx {
+                        descriptors,
+                        burst_mode,
+                        rx_impl: rx_impl,
+                        _phantom: PhantomData::default(),
+                    }
+                }
+            }
+        }
+    };
+}
+
+ImplChannel!(0);
+ImplChannel!(1);
+ImplChannel!(2);
+
+/// DMA Channel
+pub struct Channel<TX, RX> {
+    pub tx: TX,
+    pub rx: RX,
+}
+
+/// GDMA Peripheral
+/// This offers the available DMA channels.
+pub struct Gdma {
+    _inner: crate::pac::DMA,
+    pub channel0: Channel<TxCreator0, RxCreator0>,
+    pub channel1: Channel<TxCreator1, RxCreator1>,
+    pub channel2: Channel<TxCreator2, RxCreator2>,
+}
+
+impl Gdma {
+    /// Create a DMA instance.
+    pub fn new(
+        dma: crate::pac::DMA,
+        peripheral_clock_control: &mut PeripheralClockControl,
+    ) -> Gdma {
+        peripheral_clock_control.enable(Peripheral::Gdma);
+        dma.misc_conf.modify(|_, w| w.ahbm_rst_inter().set_bit());
+        dma.misc_conf.modify(|_, w| w.ahbm_rst_inter().clear_bit());
+        dma.misc_conf.modify(|_, w| w.clk_en().set_bit());
+
+        Gdma {
+            _inner: dma,
+            channel0: Channel {
+                rx: RxCreator0 {},
+                tx: TxCreator0 {},
+            },
+            channel1: Channel {
+                rx: RxCreator1 {},
+                tx: TxCreator1 {},
+            },
+            channel2: Channel {
+                rx: RxCreator2 {},
+                tx: TxCreator2 {},
+            },
+        }
+    }
+}
+
+/// Trait to be implemented for an in progress dma transfer.
+#[allow(drop_bounds)]
+pub trait DmaTransfer<B, T>: Drop {
+    /// Wait for the transfer to finish.
+    fn wait(self) -> (B, T);
+}
+
+/// Trait to be implemented for an in progress dma transfer.
+#[allow(drop_bounds)]
+pub trait DmaTransferRxTx<BR, BT, T>: Drop {
+    /// Wait for the transfer to finish.
+    fn wait(self) -> (BR, BT, T);
+}

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(esp32c3)]
+pub mod gdma;

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -79,6 +79,8 @@ pub mod efuse;
 #[cfg_attr(xtensa, path = "interrupt/xtensa.rs")]
 pub mod interrupt;
 
+pub mod dma;
+
 /// Enumeration of CPU cores
 /// The actual number of available cores depends on the target.
 pub enum Cpu {

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -24,6 +24,8 @@ pub enum Peripheral {
     Ledc,
     #[cfg(esp32c3)]
     ApbSarAdc,
+    #[cfg(esp32c3)]
+    Gdma,
 }
 
 /// Controls the enablement of peripheral clocks.
@@ -40,6 +42,9 @@ impl PeripheralClockControl {
         let (perip_clk_en0, perip_rst_en0) = { (&system.perip_clk_en0, &system.perip_rst_en0) };
         #[cfg(esp32)]
         let (perip_clk_en0, perip_rst_en0) = { (&system.perip_clk_en, &system.perip_rst_en) };
+
+        #[cfg(esp32c3)]
+        let (perip_clk_en1, perip_rst_en1) = { (&system.perip_clk_en1, &system.perip_rst_en1) };
 
         match peripheral {
             Peripheral::Spi2 => {
@@ -77,6 +82,11 @@ impl PeripheralClockControl {
             Peripheral::ApbSarAdc => {
                 perip_clk_en0.modify(|_, w| w.apb_saradc_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.apb_saradc_rst().clear_bit());
+            }
+            #[cfg(esp32c3)]
+            Peripheral::Gdma => {
+                perip_clk_en1.modify(|_, w| w.dma_clk_en().set_bit());
+                perip_rst_en1.modify(|_, w| w.dma_rst().clear_bit());
             }
         }
     }

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -1,0 +1,124 @@
+//! SPI loopback test using DMA
+//!
+//! Folowing pins are used:
+//! SCLK    GPIO6
+//! MISO    GPIO2
+//! MOSI    GPIO7
+//! CS      GPIO10
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! This example transfers data via SPI.
+//! Connect MISO and MOSI pins to see the outgoing data is read as incoming
+//! data.
+
+#![no_std]
+#![no_main]
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    gdma::{DmaPriority, DmaTransferRxTx, Gdma},
+    gpio::IO,
+    pac::Peripherals,
+    prelude::*,
+    spi::{Spi, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+use riscv_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio6;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio7;
+    let cs = io.pins.gpio10;
+
+    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma_channel = dma.channel0;
+
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let mut spi = Spi::new(
+        peripherals.SPI2,
+        sclk,
+        mosi,
+        miso,
+        cs,
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_tx_rx_dma(
+        dma_channel
+            .tx
+            .get(&mut descriptors, false, DmaPriority::Priority0),
+        dma_channel
+            .rx
+            .get(&mut rx_descriptors, false, DmaPriority::Priority0),
+    );
+
+    let mut delay = Delay::new(&clocks);
+
+    // DMA buffer require a static life-time
+    let mut send = buffer1();
+    let mut receive = buffer2();
+    let mut i = 0;
+
+    for (i, v) in send.iter_mut().enumerate() {
+        *v = (i % 255) as u8;
+    }
+
+    loop {
+        send[0] = i;
+        send[send.len() - 1] = i;
+        i = i.wrapping_add(1);
+
+        let transfer = spi.dma_transfer(send, receive).unwrap();
+        // here we could do something else while DMA transfer is in progress
+        // the buffers and spi is moved into the transfer and we can get it back via
+        // `wait`
+        (receive, send, spi) = transfer.wait();
+        println!(
+            "{:x?} .. {:x?}",
+            &receive[..10],
+            &receive[receive.len() - 10..]
+        );
+
+        delay.delay_ms(250u32);
+    }
+}
+
+fn buffer1() -> &'static mut [u8; 32000] {
+    static mut BUFFER: [u8; 32000] = [0u8; 32000];
+    unsafe { &mut BUFFER }
+}
+
+fn buffer2() -> &'static mut [u8; 32000] {
+    static mut BUFFER: [u8; 32000] = [0u8; 32000];
+    unsafe { &mut BUFFER }
+}

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -5,6 +5,7 @@ use core::arch::global_asm;
 pub use embedded_hal as ehal;
 pub use esp_hal_common::{
     clock,
+    dma::gdma,
     efuse,
     gpio as gpio_types,
     i2c,


### PR DESCRIPTION
This adds basic DMA functionality for ESP32-C3

There is still a lot to improve here but I'd like to get this in to see if is a general fit and as a base for exploring how to implement DMA for the other supported chips - especially ESP32 and ESP32-S2 are very different in regards to DMA.

This includes DMA support for SPI. The DMA API is similar to the STM32F1XX implementation - it's unfortunately a bit hard to use but that it seems to be the only possible way to implement DMA in a safe and sound way. Maybe we find ways to improve the ease-of-use while keeping it memory safe.

Other than most HALs it also implements the SPI traits from EH with DMA. Most HALs don't do that since those are blocking and it doesn't make sense for them. For us however it enables single SPI transactions of up to 32k (in contrast for 64 bytes without DMA). Because those APIs are blocking, they should be safe and sound.

As said this PR doesn't aim for perfection - I'm sure we need to change a lot of things to make this work for the other chips - so I don't want to waste effort in polishing something that will get changed anyway (for now - at some point of time we will polish things here).

The PR is not exactly small but I think an implementation of DMA without at least one peripheral supporting it doesn't make any sense.
