### PR TITLE
Update `esp-hal-common` to use the newest PACs

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -43,11 +43,11 @@ ufmt-write = { version = "0.1.0", optional = true }
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature. We rename the PAC packages because we cannot
 # have dependencies and features with the same names.
-esp32   = { version = "0.13.0", optional = true }
-esp32c2 = { version = "0.2.0",  optional = true }
-esp32c3 = { version = "0.5.0",  optional = true }
-esp32s2 = { version = "0.3.0",  optional = true }
-esp32s3 = { version = "0.3.0",  optional = true }
+esp32   = { version = "0.14.0", features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.3.0",  features = ["critical-section"], optional = true }
+esp32c3 = { version = "0.6.0",  features = ["critical-section"], optional = true }
+esp32s2 = { version = "0.4.0",  features = ["critical-section"], optional = true }
+esp32s3 = { version = "0.4.0",  features = ["critical-section"], optional = true }
 
 [features]
 esp32   = ["esp32/rt"  , "procmacros/xtensa", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "critical-section/restore-state-u32", "lock_api"]

--- a/esp-hal-common/src/clocks_ll/esp32c2.rs
+++ b/esp-hal-common/src/clocks_ll/esp32c2.rs
@@ -172,5 +172,5 @@ pub(crate) fn esp32c2_rtc_apb_freq_update(apb_freq: ApbClock) {
 
     rtc_cntl
         .store5
-        .modify(|_, w| unsafe { w.rtc_scratch5().bits(value) });
+        .modify(|_, w| unsafe { w.scratch5().bits(value) });
 }

--- a/esp-hal-common/src/clocks_ll/esp32c3.rs
+++ b/esp-hal-common/src/clocks_ll/esp32c3.rs
@@ -232,5 +232,5 @@ pub(crate) fn esp32c3_rtc_apb_freq_update(apb_freq: ApbClock) {
 
     rtc_cntl
         .store5
-        .modify(|_, w| unsafe { w.rtc_scratch5().bits(value) });
+        .modify(|_, w| unsafe { w.scratch5().bits(value) });
 }

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -702,16 +702,16 @@ macro_rules! impl_input {
                 unsafe {
                     (&*GPIO::PTR).pin[$pin_num].modify(|_, w|
                         w
-                            .pin_int_ena().bits(crate::gpio_intr_enable(int_enable, nmi_enable))
-                            .pin_int_type().bits(event as u8)
-                            .pin_wakeup_enable().bit(wake_up_from_light_sleep)
+                            .int_ena().bits(crate::gpio_intr_enable(int_enable, nmi_enable))
+                            .int_type().bits(event as u8)
+                            .wakeup_enable().bit(wake_up_from_light_sleep)
                     );
                 }
             }
 
             fn unlisten(&mut self) {
                 unsafe { (&*GPIO::PTR).pin[$pin_num].modify(|_, w|
-                    w.pin_int_ena().bits(0).pin_int_type().bits(0).pin_int_ena().bits(0) );
+                    w.int_ena().bits(0).int_type().bits(0).int_ena().bits(0) );
                 }
             }
 
@@ -858,7 +858,7 @@ macro_rules! impl_output {
                 let iomux = unsafe { &*IO_MUX::PTR };
 
                 self.write_out_en_set(1 << $bit);
-                gpio.pin[$pin_num].modify(|_, w| w.pin_pad_driver().bit(open_drain));
+                gpio.pin[$pin_num].modify(|_, w| w.pad_driver().bit(open_drain));
 
                 gpio.func_out_sel_cfg[$pin_num]
                     .modify(|_, w| unsafe { w.out_sel().bits(OutputSignal::GPIO as OutputSignalType) });
@@ -941,7 +941,7 @@ macro_rules! impl_output {
             }
 
             fn enable_open_drain(&mut self, on: bool) -> &mut Self {
-                unsafe { &*GPIO::PTR }.pin[$pin_num].modify(|_, w| w.pin_pad_driver().bit(on));
+                unsafe { &*GPIO::PTR }.pin[$pin_num].modify(|_, w| w.pad_driver().bit(on));
                 self
             }
 
@@ -1234,7 +1234,7 @@ macro_rules! analog {
                         rtcio.enable_w1tc.write(|w| unsafe { w.enable_w1tc().bits(1 << $pin_num) });
 
                         // disable open drain
-                        rtcio.pin[$pin_num].modify(|_,w| w.pin_pad_driver().bit(false));
+                        rtcio.pin[$pin_num].modify(|_,w| w.pad_driver().bit(false));
 
                         paste! {
                             rtcio.$pin_reg.modify(|_,w| {

--- a/esp-hal-common/src/rtc/esp32c3.rs
+++ b/esp-hal-common/src/rtc/esp32c3.rs
@@ -237,7 +237,7 @@ fn rtc_sleep_pu() {
     rtc_cntl.dig_pwc.modify(|_, w| {
         w.lslp_mem_force_pu()
             .clear_bit()
-            .rtc_fastmem_force_lpu()
+            .fastmem_force_lpu()
             .clear_bit()
     });
 

--- a/esp-hal-common/src/rtc_cntl.rs
+++ b/esp-hal-common/src/rtc_cntl.rs
@@ -495,16 +495,10 @@ impl Rwdt {
 
         #[cfg(esp32)]
         rtc_cntl.int_ena.modify(|_, w| w.wdt_int_ena().set_bit());
-
-        #[cfg(esp32s2)]
+        #[cfg(not(esp32))]
         rtc_cntl
             .int_ena_rtc
             .modify(|_, w| w.wdt_int_ena().set_bit());
-
-        #[cfg(any(esp32c2, esp32c3, esp32s3))]
-        rtc_cntl
-            .int_ena_rtc
-            .modify(|_, w| w.rtc_wdt_int_ena().set_bit());
 
         self.set_write_protection(true);
     }
@@ -523,16 +517,10 @@ impl Rwdt {
 
         #[cfg(esp32)]
         rtc_cntl.int_ena.modify(|_, w| w.wdt_int_ena().clear_bit());
-
-        #[cfg(esp32s2)]
+        #[cfg(not(esp32))]
         rtc_cntl
             .int_ena_rtc
             .modify(|_, w| w.wdt_int_ena().clear_bit());
-
-        #[cfg(any(esp32c2, esp32c3, esp32s3))]
-        rtc_cntl
-            .int_ena_rtc
-            .modify(|_, w| w.rtc_wdt_int_ena().clear_bit());
 
         self.set_write_protection(true);
     }
@@ -544,14 +532,8 @@ impl Rwdt {
 
         #[cfg(esp32)]
         rtc_cntl.int_clr.write(|w| w.wdt_int_clr().set_bit());
-
-        #[cfg(esp32s2)]
+        #[cfg(not(esp32))]
         rtc_cntl.int_clr_rtc.write(|w| w.wdt_int_clr().set_bit());
-
-        #[cfg(any(esp32c2, esp32c3, esp32s3))]
-        rtc_cntl
-            .int_clr_rtc
-            .write(|w| w.rtc_wdt_int_clr().set_bit());
 
         self.set_write_protection(true);
     }
@@ -562,10 +544,8 @@ impl Rwdt {
         cfg_if::cfg_if! {
             if #[cfg(esp32)] {
                 rtc_cntl.int_st.read().wdt_int_st().bit_is_set()
-            } else if #[cfg(esp32s2)] {
+            } else {
                 rtc_cntl.int_st_rtc.read().wdt_int_st().bit_is_set()
-            } else if #[cfg(any(esp32c2, esp32c3, esp32s3))] {
-                rtc_cntl.int_st_rtc.read().rtc_wdt_int_st().bit_is_set()
             }
         }
     }

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -583,6 +583,7 @@ where
             .wdtconfig2
             .write(|w| unsafe { w.wdt_stg0_hold().bits(timeout_raw) });
 
+        #[cfg_attr(esp32, allow(unused_unsafe))]
         reg_block.wdtconfig0.write(|w| unsafe {
             w.wdt_en()
                 .bit(true)


### PR DESCRIPTION
I've overhauled the SVD generator, so there are a number of changes which make the SVDs more correct. More specifically I've also added the `SENS` peripheral to the ESP32-S3, so we can finally implement `ADC` for it.

There is also the chance of some regressions, but I've reviewed the changes the best I can and am reasonably confident we're in okay shape.

`svd2rust` now uses `critical-section` instead of `bare-metal` and `interrupt::free` so the new PACs do this as well. This unfortunately introduced a warning for the ESP32-C2/C3, however it has been fixed already so with the next release of `svd2rust` we can eliminate these.

I have not actually tested any examples on hardware yet which is why this is marked as draft. I'm going to test a bunch just to try and be reasonably sure I haven't horribly broken anything.