### PR TITLE
SPI-DMA for ESP32

### DIFF
--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -1,426 +1,20 @@
 //! Direct Memory Access
 
-use core::{marker::PhantomData, sync::atomic::compiler_fence};
-
-use crate::system::{Peripheral, PeripheralClockControl};
-
-/// DMA Errors
-#[derive(Debug, Clone, Copy)]
-pub enum DmaError {
-    InvalidAlignment,
-    OutOfDescriptors,
-    InvalidDescriptorSize,
-    DescriptorError,
-}
-
-/// DMA Priorities
-pub enum DmaPriority {
-    Priority0  = 0,
-    Priority1  = 1,
-    Priority2  = 2,
-    Priority3  = 3,
-    Priority4  = 4,
-    Priority5  = 5,
-    Priority6  = 6,
-    Priority7  = 7,
-    Priority8  = 8,
-    Priority9  = 9,
-    Priority10 = 10,
-    Priority11 = 11,
-    Priority12 = 12,
-    Priority13 = 13,
-    Priority14 = 14,
-    Priority15 = 15,
-}
-
-enum Owner {
-    Cpu = 0,
-    Dma = 1,
-}
-
-impl From<u32> for Owner {
-    fn from(value: u32) -> Self {
-        match value {
-            0 => Owner::Cpu,
-            _ => Owner::Dma,
-        }
-    }
-}
-
-trait DmaLinkedListDw0 {
-    fn set_size(&mut self, len: u16);
-    fn get_size(&mut self) -> u16;
-    fn set_length(&mut self, len: u16);
-    fn get_length(&mut self) -> u16;
-    fn set_err_eof(&mut self, err_eof: bool);
-    fn get_err_eof(&mut self) -> bool;
-    fn set_suc_eof(&mut self, suc_eof: bool);
-    fn get_suc_eof(&mut self) -> bool;
-    fn set_owner(&mut self, owner: Owner);
-    fn get_owner(&mut self) -> Owner;
-}
-
-impl DmaLinkedListDw0 for &mut u32 {
-    fn set_size(&mut self, len: u16) {
-        let mask = 0b111111111111;
-        let bit_s = 0;
-        **self = (**self & !(mask << bit_s)) | (len as u32) << bit_s;
-    }
-
-    fn get_size(&mut self) -> u16 {
-        let mask = 0b111111111111;
-        let bit_s = 0;
-        ((**self & (mask << bit_s)) >> bit_s) as u16
-    }
-
-    fn set_length(&mut self, len: u16) {
-        let mask = 0b111111111111;
-        let bit_s = 12;
-        **self = (**self & !(mask << bit_s)) | (len as u32) << bit_s;
-    }
-
-    fn get_length(&mut self) -> u16 {
-        let mask = 0b111111111111;
-        let bit_s = 12;
-        ((**self & (mask << bit_s)) >> bit_s) as u16
-    }
-
-    fn set_err_eof(&mut self, err_eof: bool) {
-        let mask = 0b1;
-        let bit_s = 28;
-        **self = (**self & !(mask << bit_s)) | (err_eof as u32) << bit_s;
-    }
-
-    fn get_err_eof(&mut self) -> bool {
-        let mask = 0b1;
-        let bit_s = 28;
-        ((**self & (mask << bit_s)) >> bit_s) != 0
-    }
-
-    fn set_suc_eof(&mut self, suc_eof: bool) {
-        let mask = 0b1;
-        let bit_s = 30;
-        **self = (**self & !(mask << bit_s)) | (suc_eof as u32) << bit_s;
-    }
-
-    fn get_suc_eof(&mut self) -> bool {
-        let mask = 0b1;
-        let bit_s = 30;
-        ((**self & (mask << bit_s)) >> bit_s) != 0
-    }
-
-    fn set_owner(&mut self, owner: Owner) {
-        let mask = 0b1;
-        let bit_s = 31;
-        **self = (**self & !(mask << bit_s)) | (owner as u32) << bit_s;
-    }
-
-    fn get_owner(&mut self) -> Owner {
-        let mask = 0b1;
-        let bit_s = 31;
-        ((**self & (mask << bit_s)) >> bit_s).into()
-    }
-}
-
-/// DMA capable peripherals
-pub enum DmaPeripheral {
-    Spi2  = 0,
-    Uhci0 = 2,
-    I2s   = 3,
-    Aes   = 6,
-    Sha   = 7,
-    Adc   = 8,
-}
-
-/// DMA Rx
-///
-/// The functions here are not meant to be used outside the HAL and will be
-/// hidden/inaccessible in future.
-pub trait Rx {
-    fn init(&mut self, burst_mode: bool, priority: DmaPriority);
-    fn prepare_transfer(
-        &mut self,
-        peri: DmaPeripheral,
-        data: *mut u8,
-        len: usize,
-    ) -> Result<(), DmaError>;
-    fn is_done(&mut self) -> bool;
-}
-
-pub(crate) trait RxChannel<R>
-where
-    R: RegisterAccess,
-{
-    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
-        R::set_in_burstmode(burst_mode);
-        R::set_in_priority(priority);
-    }
-
-    fn prepare_transfer(
-        &mut self,
-        descriptors: &mut [u32],
-        peri: DmaPeripheral,
-        data: *mut u8,
-        len: usize,
-    ) -> Result<(), DmaError> {
-        for descr in descriptors.iter_mut() {
-            *descr = 0;
-        }
-
-        compiler_fence(core::sync::atomic::Ordering::SeqCst);
-
-        let mut processed = 0;
-        let mut descr = 0;
-        loop {
-            let chunk_size = usize::min(4092, len - processed);
-            let last = processed + chunk_size >= len;
-
-            descriptors[descr + 1] = data as u32 + processed as u32;
-
-            let mut dw0 = &mut descriptors[descr];
-
-            dw0.set_suc_eof(last);
-            dw0.set_owner(Owner::Dma);
-            dw0.set_size(chunk_size as u16); // align to 32 bits?
-            dw0.set_length(0); // actual size of the data!?
-
-            if !last {
-                descriptors[descr + 2] = (&descriptors[descr + 3]) as *const _ as *const () as u32;
-            } else {
-                descriptors[descr + 2] = 0;
-            }
-
-            processed += chunk_size;
-            descr += 3;
-
-            if processed >= len {
-                break;
-            }
-        }
-
-        R::clear_in_interrupts();
-        R::reset_in();
-        R::set_in_descriptors(descriptors.as_ptr() as u32);
-        R::set_in_peripheral(peri as u8);
-        R::start_in();
-
-        if R::has_in_descriptor_error() {
-            return Err(DmaError::DescriptorError);
-        }
-
-        Ok(())
-    }
-
-    fn is_done(&mut self) -> bool {
-        R::is_in_done()
-    }
-}
-
-pub(crate) struct ChannelRx<'a, T, R>
-where
-    T: RxChannel<R>,
-    R: RegisterAccess,
-{
-    descriptors: &'a mut [u32],
-    burst_mode: bool,
-    rx_impl: T,
-    _phantom: PhantomData<R>,
-}
-
-impl<'a, T, R> Rx for ChannelRx<'a, T, R>
-where
-    T: RxChannel<R>,
-    R: RegisterAccess,
-{
-    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
-        self.rx_impl.init(burst_mode, priority);
-    }
-
-    fn prepare_transfer(
-        &mut self,
-        peri: DmaPeripheral,
-        data: *mut u8,
-        len: usize,
-    ) -> Result<(), DmaError> {
-        if self.descriptors.len() % 3 != 0 {
-            return Err(DmaError::InvalidDescriptorSize);
-        }
-
-        if self.descriptors.len() / 3 < len / 4092 {
-            return Err(DmaError::OutOfDescriptors);
-        }
-
-        if self.burst_mode && (len % 4 != 0 || data as u32 % 4 != 0) {
-            return Err(DmaError::InvalidAlignment);
-        }
-
-        self.rx_impl
-            .prepare_transfer(self.descriptors, peri, data, len)?;
-        Ok(())
-    }
-
-    fn is_done(&mut self) -> bool {
-        self.rx_impl.is_done()
-    }
-}
-
-/// DMA Tx
-///
-/// The functions here are not meant to be used outside the HAL and will be
-/// hidden/inaccessible in future.
-pub trait Tx {
-    fn init(&mut self, burst_mode: bool, priority: DmaPriority);
-    fn prepare_transfer(
-        &mut self,
-        peri: DmaPeripheral,
-        data: *const u8,
-        len: usize,
-    ) -> Result<(), DmaError>;
-    fn is_done(&mut self) -> bool;
-}
-
-pub(crate) trait TxChannel<R>
-where
-    R: RegisterAccess,
-{
-    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
-        R::set_out_burstmode(burst_mode);
-        R::set_out_priority(priority);
-    }
-
-    fn prepare_transfer(
-        &mut self,
-        descriptors: &mut [u32],
-        peri: DmaPeripheral,
-        data: *const u8,
-        len: usize,
-    ) -> Result<(), DmaError> {
-        for descr in descriptors.iter_mut() {
-            *descr = 0;
-        }
-
-        compiler_fence(core::sync::atomic::Ordering::SeqCst);
-
-        let mut processed = 0;
-        let mut descr = 0;
-        loop {
-            let chunk_size = usize::min(4092, len - processed);
-            let last = processed + chunk_size >= len;
-
-            descriptors[descr + 1] = data as u32 + processed as u32;
-
-            let mut dw0 = &mut descriptors[descr];
-
-            dw0.set_suc_eof(last);
-            dw0.set_owner(Owner::Dma);
-            dw0.set_size(chunk_size as u16); // align to 32 bits?
-            dw0.set_length(chunk_size as u16); // actual size of the data!?
-
-            if !last {
-                descriptors[descr + 2] = (&descriptors[descr + 3]) as *const _ as *const () as u32;
-            } else {
-                descriptors[descr + 2] = 0;
-            }
-
-            processed += chunk_size;
-            descr += 3;
-
-            if processed >= len {
-                break;
-            }
-        }
-
-        R::clear_out_interrupts();
-        R::reset_out();
-        R::set_out_descriptors(descriptors.as_ptr() as u32);
-        R::set_out_peripheral(peri as u8);
-        R::start_out();
-
-        if R::has_out_descriptor_error() {
-            return Err(DmaError::DescriptorError);
-        }
-
-        Ok(())
-    }
-
-    fn is_done(&mut self) -> bool {
-        R::is_out_done()
-    }
-}
-
-pub(crate) struct ChannelTx<'a, T, R>
-where
-    T: TxChannel<R>,
-    R: RegisterAccess,
-{
-    descriptors: &'a mut [u32],
-    #[allow(unused)]
-    burst_mode: bool,
-    tx_impl: T,
-    _phantom: PhantomData<R>,
-}
-
-impl<'a, T, R> Tx for ChannelTx<'a, T, R>
-where
-    T: TxChannel<R>,
-    R: RegisterAccess,
-{
-    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
-        self.tx_impl.init(burst_mode, priority);
-    }
-
-    fn prepare_transfer(
-        &mut self,
-        peri: DmaPeripheral,
-        data: *const u8,
-        len: usize,
-    ) -> Result<(), DmaError> {
-        if self.descriptors.len() % 3 != 0 {
-            return Err(DmaError::InvalidDescriptorSize);
-        }
-
-        if self.descriptors.len() / 3 < len / 4092 {
-            return Err(DmaError::OutOfDescriptors);
-        }
-
-        self.tx_impl
-            .prepare_transfer(self.descriptors, peri, data, len)?;
-
-        Ok(())
-    }
-
-    fn is_done(&mut self) -> bool {
-        self.tx_impl.is_done()
-    }
-}
-
-pub(crate) trait RegisterAccess {
-    fn set_out_burstmode(burst_mode: bool);
-    fn set_out_priority(priority: DmaPriority);
-    fn clear_out_interrupts();
-    fn reset_out();
-    fn set_out_descriptors(address: u32);
-    fn has_out_descriptor_error() -> bool;
-    fn set_out_peripheral(peripheral: u8);
-    fn start_out();
-    fn is_out_done() -> bool;
-    fn set_in_burstmode(burst_mode: bool);
-    fn set_in_priority(priority: DmaPriority);
-    fn clear_in_interrupts();
-    fn reset_in();
-    fn set_in_descriptors(address: u32);
-    fn has_in_descriptor_error() -> bool;
-    fn set_in_peripheral(peripheral: u8);
-    fn start_in();
-    fn is_in_done() -> bool;
-}
+use crate::{
+    dma::gdma::private::*,
+    system::{Peripheral, PeripheralClockControl},
+};
 
 macro_rules! ImplChannel {
     ($num: literal) => {
         paste::paste! {
-            pub(crate) struct [<Channel $num>] {}
+            pub struct [<Channel $num>] {}
 
             impl RegisterAccess for [<Channel $num>] {
+                fn init_channel() {
+                    // nothing special to be done here
+                }
+
                 fn set_out_burstmode(burst_mode: bool) {
                     let dma = unsafe { &*crate::pac::DMA::PTR };
 
@@ -564,80 +158,80 @@ macro_rules! ImplChannel {
                 }
             }
 
-            pub(crate) struct [<Channel $num TxImpl>] {}
+            pub struct [<Channel $num TxImpl>] {}
 
             impl<'a> TxChannel<[<Channel $num>]> for [<Channel $num TxImpl>] {}
 
-            pub(crate) struct [<Channel $num RxImpl>] {}
+            pub struct [<Channel $num RxImpl>] {}
 
             impl<'a> RxChannel<[<Channel $num>]> for [<Channel $num RxImpl>] {}
 
-            /// Create the Tx half of the DMA channel
-            pub struct [<TxCreator $num>] {
+            pub struct [<ChannelCreator $num>] {
             }
 
-            impl [<TxCreator $num>] {
-                pub fn get<'a>(
+            impl [<ChannelCreator $num>] {
+                pub fn configure<'a>(
                     self,
-                    descriptors: &'a mut [u32],
                     burst_mode: bool,
+                    tx_descriptors: &'a mut [u32],
+                    rx_descriptors: &'a mut [u32],
                     priority: DmaPriority,
-                ) -> impl Tx + 'a {
+                ) -> Channel<ChannelTx<[<Channel $num TxImpl>], [<Channel $num>]>, ChannelRx<[<Channel $num RxImpl>], [<Channel $num>]>, [<SuitablePeripheral $num>]> {
                     let mut tx_impl = [<Channel $num TxImpl>] {};
                     tx_impl.init(burst_mode, priority);
 
-                    ChannelTx {
-                        descriptors,
+                    let tx_channel = ChannelTx {
+                        descriptors: tx_descriptors,
                         burst_mode,
                         tx_impl: tx_impl,
                         _phantom: PhantomData::default(),
-                    }
-                }
-            }
+                    };
 
-            /// Create the Rx half of the DMA channel
-            pub struct [<RxCreator $num>] {
-            }
-
-            impl [<RxCreator $num>] {
-                pub fn get<'a>(
-                    self,
-                    descriptors: &'a mut [u32],
-                    burst_mode: bool,
-                    priority: DmaPriority,
-                ) -> impl Rx + 'a {
                     let mut rx_impl = [<Channel $num RxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
-                    ChannelRx {
-                        descriptors,
+                    let rx_channel = ChannelRx {
+                        descriptors: rx_descriptors,
                         burst_mode,
                         rx_impl: rx_impl,
+                        _phantom: PhantomData::default(),
+                    };
+
+                    Channel {
+                        tx: tx_channel,
+                        rx: rx_channel,
                         _phantom: PhantomData::default(),
                     }
                 }
             }
+
+            pub struct [<SuitablePeripheral $num>] {}
+            impl PeripheralMarker for [<SuitablePeripheral $num>] {}
+
+            // with GDMA every channel can be used for any peripheral
+            impl SpiPeripheral for [<SuitablePeripheral $num>] {}
+            impl Spi2Peripheral for [<SuitablePeripheral $num>] {}
         }
     };
 }
 
-ImplChannel!(0);
-ImplChannel!(1);
-ImplChannel!(2);
+/// Crate private implementatin details
+pub(crate) mod private {
+    use crate::dma::{private::*, *};
 
-/// DMA Channel
-pub struct Channel<TX, RX> {
-    pub tx: TX,
-    pub rx: RX,
+    ImplChannel!(0);
+    ImplChannel!(1);
+    ImplChannel!(2);    
 }
 
 /// GDMA Peripheral
+/// 
 /// This offers the available DMA channels.
 pub struct Gdma {
     _inner: crate::pac::DMA,
-    pub channel0: Channel<TxCreator0, RxCreator0>,
-    pub channel1: Channel<TxCreator1, RxCreator1>,
-    pub channel2: Channel<TxCreator2, RxCreator2>,
+    pub channel0: ChannelCreator0,
+    pub channel1: ChannelCreator1,
+    pub channel2: ChannelCreator2,
 }
 
 impl Gdma {
@@ -653,32 +247,9 @@ impl Gdma {
 
         Gdma {
             _inner: dma,
-            channel0: Channel {
-                rx: RxCreator0 {},
-                tx: TxCreator0 {},
-            },
-            channel1: Channel {
-                rx: RxCreator1 {},
-                tx: TxCreator1 {},
-            },
-            channel2: Channel {
-                rx: RxCreator2 {},
-                tx: TxCreator2 {},
-            },
+            channel0: ChannelCreator0 {},
+            channel1: ChannelCreator1 {},
+            channel2: ChannelCreator2 {},
         }
     }
-}
-
-/// Trait to be implemented for an in progress dma transfer.
-#[allow(drop_bounds)]
-pub trait DmaTransfer<B, T>: Drop {
-    /// Wait for the transfer to finish.
-    fn wait(self) -> (B, T);
-}
-
-/// Trait to be implemented for an in progress dma transfer.
-#[allow(drop_bounds)]
-pub trait DmaTransferRxTx<BR, BT, T>: Drop {
-    /// Wait for the transfer to finish.
-    fn wait(self) -> (BR, BT, T);
 }

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -1,2 +1,512 @@
+//! Direct Memory Access Commons
+
+use core::{marker::PhantomData, sync::atomic::compiler_fence};
+
+use private::*;
+
 #[cfg(esp32c3)]
 pub mod gdma;
+
+#[cfg(esp32)]
+pub mod pdma;
+
+/// DMA Errors
+#[derive(Debug, Clone, Copy)]
+pub enum DmaError {
+    InvalidAlignment,
+    OutOfDescriptors,
+    InvalidDescriptorSize,
+    DescriptorError,
+}
+
+/// DMA Priorities
+#[cfg(any(esp32c3, esp32s3))]
+#[derive(Clone, Copy)]
+pub enum DmaPriority {
+    Priority0  = 0,
+    Priority1  = 1,
+    Priority2  = 2,
+    Priority3  = 3,
+    Priority4  = 4,
+    Priority5  = 5,
+    Priority6  = 6,
+    Priority7  = 7,
+    Priority8  = 8,
+    Priority9  = 9,
+    Priority10 = 10,
+    Priority11 = 11,
+    Priority12 = 12,
+    Priority13 = 13,
+    Priority14 = 14,
+    Priority15 = 15,
+}
+
+/// DMA Priorities
+#[cfg(any(esp32, esp32s2))]
+#[derive(Clone, Copy)]
+pub enum DmaPriority {
+    Priority0 = 0,
+}
+
+/// DMA capable peripherals
+/// The values need to match the TRM
+#[cfg(esp32c3)]
+#[derive(Clone, Copy)]
+pub enum DmaPeripheral {
+    Spi2  = 0,
+    Uhci0 = 2,
+    I2s   = 3,
+    Aes   = 6,
+    Sha   = 7,
+    Adc   = 8,
+}
+
+/// DMA capable peripherals
+#[cfg(esp32)]
+#[derive(Clone, Copy)]
+pub enum DmaPeripheral {
+    Spi2 = 0,
+    Spi3 = 1,
+}
+
+enum Owner {
+    Cpu = 0,
+    Dma = 1,
+}
+
+impl From<u32> for Owner {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => Owner::Cpu,
+            _ => Owner::Dma,
+        }
+    }
+}
+
+trait DmaLinkedListDw0 {
+    fn set_size(&mut self, len: u16);
+    fn get_size(&mut self) -> u16;
+    fn set_length(&mut self, len: u16);
+    fn get_length(&mut self) -> u16;
+    fn set_err_eof(&mut self, err_eof: bool);
+    #[cfg(not(esp32))]
+    fn get_err_eof(&mut self) -> bool;
+    #[cfg(not(esp32))]
+    fn set_suc_eof(&mut self, suc_eof: bool);
+    fn get_suc_eof(&mut self) -> bool;
+    fn set_owner(&mut self, owner: Owner);
+    fn get_owner(&mut self) -> Owner;
+}
+
+impl DmaLinkedListDw0 for &mut u32 {
+    fn set_size(&mut self, len: u16) {
+        let mask = 0b111111111111;
+        let bit_s = 0;
+        **self = (**self & !(mask << bit_s)) | (len as u32) << bit_s;
+    }
+
+    fn get_size(&mut self) -> u16 {
+        let mask = 0b111111111111;
+        let bit_s = 0;
+        ((**self & (mask << bit_s)) >> bit_s) as u16
+    }
+
+    fn set_length(&mut self, len: u16) {
+        let mask = 0b111111111111;
+        let bit_s = 12;
+        **self = (**self & !(mask << bit_s)) | (len as u32) << bit_s;
+    }
+
+    fn get_length(&mut self) -> u16 {
+        let mask = 0b111111111111;
+        let bit_s = 12;
+        ((**self & (mask << bit_s)) >> bit_s) as u16
+    }
+
+    fn set_err_eof(&mut self, err_eof: bool) {
+        let mask = 0b1;
+        let bit_s = 28;
+        **self = (**self & !(mask << bit_s)) | (err_eof as u32) << bit_s;
+    }
+
+    #[cfg(not(esp32))]
+    fn get_err_eof(&mut self) -> bool {
+        let mask = 0b1;
+        let bit_s = 28;
+        ((**self & (mask << bit_s)) >> bit_s) != 0
+    }
+
+    #[cfg(not(esp32))]
+    fn set_suc_eof(&mut self, suc_eof: bool) {
+        let mask = 0b1;
+        let bit_s = 30;
+        **self = (**self & !(mask << bit_s)) | (suc_eof as u32) << bit_s;
+    }
+
+    fn get_suc_eof(&mut self) -> bool {
+        let mask = 0b1;
+        let bit_s = 30;
+        ((**self & (mask << bit_s)) >> bit_s) != 0
+    }
+
+    fn set_owner(&mut self, owner: Owner) {
+        let mask = 0b1;
+        let bit_s = 31;
+        **self = (**self & !(mask << bit_s)) | (owner as u32) << bit_s;
+    }
+
+    fn get_owner(&mut self) -> Owner {
+        let mask = 0b1;
+        let bit_s = 31;
+        ((**self & (mask << bit_s)) >> bit_s).into()
+    }
+}
+
+/// Crate private implementatin details
+pub(crate) mod private {
+    use super::*;
+
+    pub trait PeripheralMarker {}
+
+    /// Marks channels as useable for SPI
+    pub trait SpiPeripheral: PeripheralMarker {}
+
+    /// Marks channels as useable for SPI2
+    pub trait Spi2Peripheral: SpiPeripheral + PeripheralMarker {}
+
+    /// Marks channels as useable for SPI3
+    #[cfg(esp32)]
+    pub trait Spi3Peripheral: SpiPeripheral + PeripheralMarker {}
+
+    /// DMA Rx
+    ///
+    /// The functions here are not meant to be used outside the HAL and will be
+    /// hidden/inaccessible in future.
+    pub trait Rx {
+        fn init(&mut self, burst_mode: bool, priority: DmaPriority);
+
+        fn init_channel(&mut self);
+
+        fn prepare_transfer(
+            &mut self,
+            peri: DmaPeripheral,
+            data: *mut u8,
+            len: usize,
+        ) -> Result<(), DmaError>;
+
+        fn is_done(&mut self) -> bool;
+    }
+
+    pub trait RxChannel<R>
+    where
+        R: RegisterAccess,
+    {
+        fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+            R::set_in_burstmode(burst_mode);
+            R::set_in_priority(priority);
+        }
+
+        fn prepare_transfer(
+            &mut self,
+            descriptors: &mut [u32],
+            peri: DmaPeripheral,
+            data: *mut u8,
+            len: usize,
+        ) -> Result<(), DmaError> {
+            for descr in descriptors.iter_mut() {
+                *descr = 0;
+            }
+
+            compiler_fence(core::sync::atomic::Ordering::SeqCst);
+
+            let mut processed = 0;
+            let mut descr = 0;
+            loop {
+                let chunk_size = usize::min(4092, len - processed);
+                let last = processed + chunk_size >= len;
+
+                descriptors[descr + 1] = data as u32 + processed as u32;
+
+                let mut dw0 = &mut descriptors[descr];
+
+                #[cfg(not(esp32))]
+                dw0.set_suc_eof(last);
+
+                dw0.set_owner(Owner::Dma);
+                dw0.set_size(chunk_size as u16); // align to 32 bits?
+                dw0.set_length(0); // actual size of the data!?
+
+                if !last {
+                    descriptors[descr + 2] =
+                        (&descriptors[descr + 3]) as *const _ as *const () as u32;
+                } else {
+                    descriptors[descr + 2] = 0;
+                }
+
+                processed += chunk_size;
+                descr += 3;
+
+                if processed >= len {
+                    break;
+                }
+            }
+
+            R::clear_in_interrupts();
+            R::reset_in();
+            R::set_in_descriptors(descriptors.as_ptr() as u32);
+            R::set_in_peripheral(peri as u8);
+            R::start_in();
+
+            if R::has_in_descriptor_error() {
+                return Err(DmaError::DescriptorError);
+            }
+
+            Ok(())
+        }
+
+        fn is_done(&mut self) -> bool {
+            R::is_in_done()
+        }
+    }
+
+    pub struct ChannelRx<'a, T, R>
+    where
+        T: RxChannel<R>,
+        R: RegisterAccess,
+    {
+        pub descriptors: &'a mut [u32],
+        pub burst_mode: bool,
+        pub rx_impl: T,
+        pub _phantom: PhantomData<R>,
+    }
+
+    impl<'a, T, R> Rx for ChannelRx<'a, T, R>
+    where
+        T: RxChannel<R>,
+        R: RegisterAccess,
+    {
+        fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+            self.rx_impl.init(burst_mode, priority);
+        }
+
+        fn prepare_transfer(
+            &mut self,
+            peri: DmaPeripheral,
+            data: *mut u8,
+            len: usize,
+        ) -> Result<(), DmaError> {
+            if self.descriptors.len() % 3 != 0 {
+                return Err(DmaError::InvalidDescriptorSize);
+            }
+
+            if self.descriptors.len() / 3 < len / 4092 {
+                return Err(DmaError::OutOfDescriptors);
+            }
+
+            if self.burst_mode && (len % 4 != 0 || data as u32 % 4 != 0) {
+                return Err(DmaError::InvalidAlignment);
+            }
+
+            self.rx_impl
+                .prepare_transfer(self.descriptors, peri, data, len)?;
+            Ok(())
+        }
+
+        fn is_done(&mut self) -> bool {
+            self.rx_impl.is_done()
+        }
+
+        fn init_channel(&mut self) {
+            R::init_channel();
+        }
+    }
+
+    /// DMA Tx
+    ///
+    /// The functions here are not meant to be used outside the HAL and will be
+    /// hidden/inaccessible in future.
+    pub trait Tx {
+        fn init(&mut self, burst_mode: bool, priority: DmaPriority);
+
+        fn init_channel(&mut self);
+
+        fn prepare_transfer(
+            &mut self,
+            peri: DmaPeripheral,
+            data: *const u8,
+            len: usize,
+        ) -> Result<(), DmaError>;
+
+        fn is_done(&mut self) -> bool;
+    }
+
+    pub trait TxChannel<R>
+    where
+        R: RegisterAccess,
+    {
+        fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+            R::set_out_burstmode(burst_mode);
+            R::set_out_priority(priority);
+        }
+
+        fn prepare_transfer(
+            &mut self,
+            descriptors: &mut [u32],
+            peri: DmaPeripheral,
+            data: *const u8,
+            len: usize,
+        ) -> Result<(), DmaError> {
+            for descr in descriptors.iter_mut() {
+                *descr = 0;
+            }
+
+            compiler_fence(core::sync::atomic::Ordering::SeqCst);
+
+            let mut processed = 0;
+            let mut descr = 0;
+            loop {
+                let chunk_size = usize::min(4092, len - processed);
+                let last = processed + chunk_size >= len;
+
+                descriptors[descr + 1] = data as u32 + processed as u32;
+
+                let mut dw0 = &mut descriptors[descr];
+
+                #[cfg(not(esp32))]
+                dw0.set_suc_eof(last);
+
+                dw0.set_owner(Owner::Dma);
+                dw0.set_size(chunk_size as u16); // align to 32 bits?
+                dw0.set_length(chunk_size as u16); // actual size of the data!?
+
+                if !last {
+                    descriptors[descr + 2] =
+                        (&descriptors[descr + 3]) as *const _ as *const () as u32;
+                } else {
+                    descriptors[descr + 2] = 0;
+                }
+
+                processed += chunk_size;
+                descr += 3;
+
+                if processed >= len {
+                    break;
+                }
+            }
+
+            R::clear_out_interrupts();
+            R::reset_out();
+            R::set_out_descriptors(descriptors.as_ptr() as u32);
+            R::set_out_peripheral(peri as u8);
+            R::start_out();
+
+            if R::has_out_descriptor_error() {
+                return Err(DmaError::DescriptorError);
+            }
+
+            Ok(())
+        }
+
+        fn is_done(&mut self) -> bool {
+            R::is_out_done()
+        }
+    }
+
+    pub struct ChannelTx<'a, T, R>
+    where
+        T: TxChannel<R>,
+        R: RegisterAccess,
+    {
+        pub descriptors: &'a mut [u32],
+        #[allow(unused)]
+        pub burst_mode: bool,
+        pub tx_impl: T,
+        pub _phantom: PhantomData<R>,
+    }
+
+    impl<'a, T, R> Tx for ChannelTx<'a, T, R>
+    where
+        T: TxChannel<R>,
+        R: RegisterAccess,
+    {
+        fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+            self.tx_impl.init(burst_mode, priority);
+        }
+
+        fn init_channel(&mut self) {
+            R::init_channel();
+        }
+
+        fn prepare_transfer(
+            &mut self,
+            peri: DmaPeripheral,
+            data: *const u8,
+            len: usize,
+        ) -> Result<(), DmaError> {
+            if self.descriptors.len() % 3 != 0 {
+                return Err(DmaError::InvalidDescriptorSize);
+            }
+
+            if self.descriptors.len() / 3 < len / 4092 {
+                return Err(DmaError::OutOfDescriptors);
+            }
+
+            self.tx_impl
+                .prepare_transfer(self.descriptors, peri, data, len)?;
+
+            Ok(())
+        }
+
+        fn is_done(&mut self) -> bool {
+            self.tx_impl.is_done()
+        }
+    }
+
+    pub trait RegisterAccess {
+        fn init_channel();
+        fn set_out_burstmode(burst_mode: bool);
+        fn set_out_priority(priority: DmaPriority);
+        fn clear_out_interrupts();
+        fn reset_out();
+        fn set_out_descriptors(address: u32);
+        fn has_out_descriptor_error() -> bool;
+        fn set_out_peripheral(peripheral: u8);
+        fn start_out();
+        fn is_out_done() -> bool;
+        fn set_in_burstmode(burst_mode: bool);
+        fn set_in_priority(priority: DmaPriority);
+        fn clear_in_interrupts();
+        fn reset_in();
+        fn set_in_descriptors(address: u32);
+        fn has_in_descriptor_error() -> bool;
+        fn set_in_peripheral(peripheral: u8);
+        fn start_in();
+        fn is_in_done() -> bool;
+    }
+}
+
+/// DMA Channel
+pub struct Channel<TX, RX, P>
+where
+    TX: Tx,
+    RX: Rx,
+    P: PeripheralMarker,
+{
+    pub(crate) tx: TX,
+    pub(crate) rx: RX,
+    _phantom: PhantomData<P>,
+}
+
+/// Trait to be implemented for an in progress dma transfer.
+#[allow(drop_bounds)]
+pub trait DmaTransfer<B, T>: Drop {
+    /// Wait for the transfer to finish.
+    fn wait(self) -> (B, T);
+}
+
+/// Trait to be implemented for an in progress dma transfer.
+#[allow(drop_bounds)]
+pub trait DmaTransferRxTx<BR, BT, T>: Drop {
+    /// Wait for the transfer to finish.
+    fn wait(self) -> (BR, BT, T);
+}

--- a/esp-hal-common/src/dma/pdma.rs
+++ b/esp-hal-common/src/dma/pdma.rs
@@ -1,0 +1,234 @@
+//! Direct Memory Access
+
+use crate::{
+    dma::pdma::private::*,
+    system::{Peripheral, PeripheralClockControl},
+};
+
+macro_rules! ImplSpiChannel {
+    ($num: literal) => {
+        paste::paste! {
+            pub struct [<Spi $num DmaChannel>] {}
+
+            impl RegisterAccess for [<Spi $num DmaChannel>] {
+                fn init_channel() {
+                    // (only) on ESP32 we need to configure DPORT for the SPI DMA channels
+                    let dport = unsafe { &*crate::pac::DPORT::PTR };
+
+                    match $num {
+                        2 => {
+                            dport
+                            .spi_dma_chan_sel
+                            .modify(|_, w| w.spi2_dma_chan_sel().variant(1));
+                        },
+                        3 => {
+                            dport
+                            .spi_dma_chan_sel
+                            .modify(|_, w| w.spi3_dma_chan_sel().variant(2));
+                        },
+                        _ => panic!("Only SPI2 and SPI3 supported"),
+                    }
+                }
+
+                fn set_out_burstmode(burst_mode: bool) {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_conf
+                        .modify(|_, w| w.outdscr_burst_en().bit(burst_mode));
+                }
+
+                fn set_out_priority(_priority: DmaPriority) {}
+
+                fn clear_out_interrupts() {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_int_clr.write(|w| {
+                        w.out_done_int_clr()
+                            .set_bit()
+                            .out_eof_int_clr()
+                            .set_bit()
+                            .out_total_eof_int_clr()
+                            .set_bit()
+                            .outlink_dscr_error_int_clr()
+                            .set_bit()
+                    });
+                }
+
+                fn reset_out() {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_conf.modify(|_, w| w.out_rst().set_bit());
+                    spi.dma_conf.modify(|_, w| w.out_rst().clear_bit());
+                }
+
+                fn set_out_descriptors(address: u32) {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_out_link
+                        .modify(|_, w| unsafe { w.outlink_addr().bits(address) });
+                }
+
+                fn has_out_descriptor_error() -> bool {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_int_raw.read().outlink_dscr_error_int_raw().bit()
+                }
+
+                fn set_out_peripheral(_peripheral: u8) {
+                    // no-op
+                }
+
+                fn start_out() {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_out_link.modify(|_, w| w.outlink_start().set_bit());
+                }
+
+                fn is_out_done() -> bool {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_int_raw.read().out_done_int_raw().bit()
+                }
+
+                fn set_in_burstmode(burst_mode: bool) {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_conf
+                        .modify(|_, w| w.indscr_burst_en().bit(burst_mode));
+                }
+
+                fn set_in_priority(_priority: DmaPriority) {}
+
+                fn clear_in_interrupts() {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_int_clr.write(|w| {
+                        w.in_done_int_clr()
+                            .set_bit()
+                            .in_err_eof_int_clr()
+                            .set_bit()
+                            .in_suc_eof_int_clr()
+                            .set_bit()
+                            .inlink_dscr_error_int_clr()
+                            .set_bit()
+                    });
+                }
+
+                fn reset_in() {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_conf.modify(|_, w| w.in_rst().set_bit());
+                    spi.dma_conf.modify(|_, w| w.in_rst().clear_bit());
+                }
+
+                fn set_in_descriptors(address: u32) {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_in_link
+                        .modify(|_, w| unsafe { w.inlink_addr().bits(address) });
+                }
+
+                fn has_in_descriptor_error() -> bool {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_int_raw.read().inlink_dscr_error_int_raw().bit()
+                }
+
+                fn set_in_peripheral(_peripheral: u8) {
+                    // no-op
+                }
+
+                fn start_in() {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_in_link.modify(|_, w| w.inlink_start().set_bit());
+                }
+
+                fn is_in_done() -> bool {
+                    let spi = unsafe { &*crate::pac::[<SPI $num>]::PTR };
+                    spi.dma_int_raw.read().in_done_int_raw().bit()
+                }
+            }
+
+            pub struct [<Spi $num DmaChannelTxImpl>] {}
+
+            impl<'a> TxChannel<[<Spi $num DmaChannel>]> for [<Spi $num DmaChannelTxImpl>] {}
+
+            pub struct [<Spi $num DmaChannelRxImpl>] {}
+
+            impl<'a> RxChannel<[<Spi $num DmaChannel>]> for [<Spi $num DmaChannelRxImpl>] {}
+
+            pub struct [<Spi $num DmaChannelCreator>] {}
+
+            impl [<Spi $num DmaChannelCreator>] {
+                pub fn configure<'a>(
+                    self,
+                    burst_mode: bool,
+                    tx_descriptors: &'a mut [u32],
+                    rx_descriptors: &'a mut [u32],
+                    priority: DmaPriority,
+                ) -> Channel<
+                    ChannelTx<[<Spi $num DmaChannelTxImpl>], [<Spi $num DmaChannel>]>,
+                    ChannelRx<[<Spi $num DmaChannelRxImpl>], [<Spi $num DmaChannel>]>,
+                    [<Spi $num DmaSuitablePeripheral>],
+                > {
+                    let mut tx_impl = [<Spi $num DmaChannelTxImpl>] {};
+                    tx_impl.init(burst_mode, priority);
+
+                    let tx_channel = ChannelTx {
+                        descriptors: tx_descriptors,
+                        burst_mode,
+                        tx_impl: tx_impl,
+                        _phantom: PhantomData::default(),
+                    };
+
+                    let mut rx_impl = [<Spi $num DmaChannelRxImpl>] {};
+                    rx_impl.init(burst_mode, priority);
+
+                    let rx_channel = ChannelRx {
+                        descriptors: rx_descriptors,
+                        burst_mode,
+                        rx_impl: rx_impl,
+                        _phantom: PhantomData::default(),
+                    };
+
+                    Channel {
+                        tx: tx_channel,
+                        rx: rx_channel,
+                        _phantom: PhantomData::default(),
+                    }
+                }
+            }
+        }
+    };
+}
+
+/// Crate private implementatin details
+pub(crate) mod private {
+    use crate::dma::{private::*, *};
+
+    pub struct Spi2DmaSuitablePeripheral {}
+    impl PeripheralMarker for Spi2DmaSuitablePeripheral {}
+    impl SpiPeripheral for Spi2DmaSuitablePeripheral {}
+    impl Spi2Peripheral for Spi2DmaSuitablePeripheral {}
+
+    pub struct Spi3DmaSuitablePeripheral {}
+    impl PeripheralMarker for Spi3DmaSuitablePeripheral {}
+    impl SpiPeripheral for Spi3DmaSuitablePeripheral {}
+    impl Spi3Peripheral for Spi3DmaSuitablePeripheral {}
+
+    ImplSpiChannel!(2);
+    ImplSpiChannel!(3);
+}
+
+/// DMA Peripheral
+/// 
+/// This offers the available DMA channels.
+pub struct Dma {
+    _inner: crate::system::Dma,
+    pub spi2channel: Spi2DmaChannelCreator,
+    pub spi3channel: Spi3DmaChannelCreator,
+}
+
+impl Dma {
+    /// Create a DMA instance.
+    pub fn new(
+        dma: crate::system::Dma,
+        peripheral_clock_control: &mut PeripheralClockControl,
+    ) -> Dma {
+        peripheral_clock_control.enable(Peripheral::Dma);
+
+        Dma {
+            _inner: dma,
+            spi2channel: Spi2DmaChannelCreator {},
+            spi3channel: Spi3DmaChannelCreator {},
+        }
+    }
+}

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -90,6 +90,7 @@ pub mod efuse;
 #[cfg_attr(xtensa, path = "interrupt/xtensa.rs")]
 pub mod interrupt;
 
+#[cfg(any(esp32c3, esp32))]
 pub mod dma;
 
 /// Enumeration of CPU cores

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -28,6 +28,8 @@ pub enum Peripheral {
     ApbSarAdc,
     #[cfg(esp32c3)]
     Gdma,
+    #[cfg(esp32)]
+    Dma,
 }
 
 /// Controls the enablement of peripheral clocks.
@@ -92,6 +94,11 @@ impl PeripheralClockControl {
                 perip_clk_en1.modify(|_, w| w.dma_clk_en().set_bit());
                 perip_rst_en1.modify(|_, w| w.dma_rst().clear_bit());
             }
+            #[cfg(esp32)]
+            Peripheral::Dma => {
+                perip_clk_en0.modify(|_, w| w.spi_dma_clk_en().set_bit());
+                perip_rst_en0.modify(|_, w| w.spi_dma_rst().clear_bit());
+            }
         }
     }
 }
@@ -106,12 +113,20 @@ pub struct CpuControl {
     _private: (),
 }
 
+/// Controls the configuration of the chip's clocks.
+#[cfg(esp32)]
+pub struct Dma {
+    _private: (),
+}
+
 /// The SYSTEM/DPORT splitted into it's different logical parts.
 pub struct SystemParts {
     _private: (),
     pub peripheral_clock_control: PeripheralClockControl,
     pub clock_control: SystemClockControl,
     pub cpu_control: CpuControl,
+    #[cfg(esp32)]
+    pub dma: Dma,
 }
 
 /// Extension trait to split a SYSTEM/DPORT peripheral in independent logical
@@ -132,6 +147,8 @@ impl SystemExt for SystemPeripheral {
             peripheral_clock_control: PeripheralClockControl { _private: () },
             clock_control: SystemClockControl { _private: () },
             cpu_control: CpuControl { _private: () },
+            #[cfg(esp32)]
+            dma: Dma { _private: () },
         }
     }
 }

--- a/esp32-hal/examples/adc.rs
+++ b/esp32-hal/examples/adc.rs
@@ -39,7 +39,8 @@ fn main() -> ! {
     let analog = peripherals.SENS.split();
 
     let mut adc2_config = AdcConfig::new();
-    let mut pin25 = adc2_config.enable_pin(io.pins.gpio25.into_analog(), Attenuation::Attenuation11dB);
+    let mut pin25 =
+        adc2_config.enable_pin(io.pins.gpio25.into_analog(), Attenuation::Attenuation11dB);
     let mut adc2 = ADC::<ADC2>::adc(analog.adc2, adc2_config).unwrap();
 
     let mut delay = Delay::new(&clocks);

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -4,6 +4,8 @@ pub use embedded_hal as ehal;
 pub use esp_hal_common::{
     clock,
     cpu_control::CpuControl,
+    dma,
+    dma::pdma,
     efuse,
     gpio as gpio_types,
     i2c,

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -5,6 +5,7 @@ use core::arch::global_asm;
 pub use embedded_hal as ehal;
 pub use esp_hal_common::{
     clock,
+    dma,
     dma::gdma,
     efuse,
     gpio as gpio_types,


### PR DESCRIPTION
This adds DMA for ESP32. In this PR it is only available for SPI

Since DMA on ESP32/ESP32-S2 is fundamentally different from the GDMA found on later chips this is much more code than I wished for.

I hope that after this implementing support for ESP32-S2 should be much easier. We'll see.
