### PR TITLE
Initial embassy support

### DIFF
--- a/.github/workflows/ci-async.yml
+++ b/.github/workflows/ci-async.yml
@@ -64,7 +64,7 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v2
-      - uses: esp-rs/xtensa-toolchain@v1.2
+      - uses: esp-rs/xtensa-toolchain@v1.4
         with:
           default: true
           ldproxy: false

--- a/.github/workflows/ci-async.yml
+++ b/.github/workflows/ci-async.yml
@@ -1,0 +1,76 @@
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+  workflow_dispatch:
+
+name: CI-Async
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Check Examples
+
+  check-async-riscv:
+    name: Check Async RISC-V Examples
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chip_features:
+          [
+            { chip: esp32c2, features: "embassy,embassy-time-systick" },
+            { chip: esp32c3, features: "embassy,embassy-time-systick" },
+          ]
+        toolchain: [nightly]
+        example:
+          [
+            "embassy_hello_world"
+          ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: riscv32imc-unknown-none-elf
+          toolchain: ${{ matrix.toolchain }}
+          default: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --example ${{ matrix.example }} --manifest-path=${{ matrix.chip_features.chip }}-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --features=${{ matrix.chip_features.features }}
+
+  check-async-xtensa:
+    name: Check Async Xtensa Examples
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chip_features:
+          [
+            { chip: esp32, features: "embassy,embassy-time-timg" },
+            { chip: esp32s2, features: "embassy,embassy-time-systick" },
+            { chip: esp32s2, features: "embassy,embassy-time-timg" },
+            { chip: esp32s3, features: "embassy,embassy-time-systick" },
+            { chip: esp32s3, features: "embassy,embassy-time-timg" },
+          ]
+        example:
+          [
+            "embassy_hello_world"
+          ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: esp-rs/xtensa-toolchain@v1.2
+        with:
+          default: true
+          ldproxy: false
+          buildtargets: ${{ matrix.chip_features.chip }}
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -Zbuild-std=core --example ${{ matrix.example }} --manifest-path=${{ matrix.chip_features.chip }}-hal/Cargo.toml --target=xtensa-${{ matrix.chip_features.chip }}-none-elf --features=${{ matrix.chip_features.features }}

--- a/.github/workflows/ci-async.yml
+++ b/.github/workflows/ci-async.yml
@@ -62,6 +62,8 @@ jobs:
           [
             "embassy_hello_world"
           ]
+    env:
+      RUSTFLAGS: "--cfg target_has_atomic=\"8\" --cfg target_has_atomic=\"16\" --cfg target_has_atomic=\"32\" --cfg target_has_atomic=\"ptr\""
     steps:
       - uses: actions/checkout@v2
       - uses: esp-rs/xtensa-toolchain@v1.4

--- a/.github/workflows/ci-async.yml
+++ b/.github/workflows/ci-async.yml
@@ -53,7 +53,7 @@ jobs:
         chip_features:
           [
             { chip: esp32, features: "embassy,embassy-time-timg" },
-            { chip: esp32s2, features: "embassy,embassy-time-systick" },
+            # { chip: esp32s2, features: "embassy,embassy-time-systick" }, # Removed for now, see esp32s2-hal/Cargo.toml
             { chip: esp32s2, features: "embassy,embassy-time-timg" },
             { chip: esp32s3, features: "embassy,embassy-time-systick" },
             { chip: esp32s3, features: "embassy,embassy-time-timg" },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
             { chip: esp32s3, features: "eh1,smartled,ufmt" },
             { chip: esp32s3, features: "direct-boot,eh1,smartled,ufmt" },
           ]
+    env:
+      RUSTFLAGS: "--cfg target_has_atomic=\"8\" --cfg target_has_atomic=\"16\" --cfg target_has_atomic=\"32\" --cfg target_has_atomic=\"ptr\""
     steps:
       - uses: actions/checkout@v2
       - uses: esp-rs/xtensa-toolchain@v1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v2
-      - uses: esp-rs/xtensa-toolchain@v1.2
+      - uses: esp-rs/xtensa-toolchain@v1.4
         with:
           default: true
           ldproxy: false

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -27,6 +27,11 @@ embedded-dma         = "0.2.0"
 esp-synopsys-usb-otg = { version = "0.3.1", optional = true, features = ["fs", "esp32sx"] }
 usb-device           = { version = "0.2.3", optional = true }
 
+# async
+embassy-sync       = { package = "embassy-sync", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", optional = true }
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", optional = true, features = ["nightly"] }
+embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+
 # RISC-V
 riscv                       = { version = "0.9.0", optional = true }
 riscv-atomic-emulation-trap = { version = "0.2.0", optional = true }
@@ -69,3 +74,10 @@ ufmt = ["ufmt-write"]
 
 # To use vectored interrupts (calling the handlers defined in the PAC)
 vectored = ["procmacros/interrupt"]
+
+# Implement the `embedded-hal-async==1.0.0-alpha.x` traits
+async = ["embedded-hal-async", "eh1", "embassy-sync"]
+embassy = ["embassy-time"]
+
+embassy-time-systick = []
+embassy-time-timg = []

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -28,7 +28,7 @@ esp-synopsys-usb-otg = { version = "0.3.1", optional = true, features = ["fs", "
 usb-device           = { version = "0.2.3", optional = true }
 
 # async
-embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
 embassy-sync       = { version = "0.1.0", optional = true }
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -28,9 +28,9 @@ esp-synopsys-usb-otg = { version = "0.3.1", optional = true, features = ["fs", "
 usb-device           = { version = "0.2.3", optional = true }
 
 # async
-embassy-sync       = { package = "embassy-sync", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", optional = true }
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", optional = true, features = ["nightly"] }
 embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embassy-sync       = { version = "0.1.0", optional = true }
+embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 # RISC-V
 riscv                       = { version = "0.9.0", optional = true }

--- a/esp-hal-common/src/embassy.rs
+++ b/esp-hal-common/src/embassy.rs
@@ -1,18 +1,36 @@
-
 use core::{cell::Cell, ptr};
+
 use embassy_time::driver::{AlarmHandle, Driver};
+
 use crate::clock::Clocks;
 
-#[cfg_attr(all(feature = "embassy-time-systick", any(feature = "esp32c3", feature = "esp32s3", feature = "esp32s2")), path = "embassy/time_driver_systimer.rs")]
-#[cfg_attr(all(feature = "embassy-time-timg", any(feature = "esp32", feature = "esp32s3", feature = "esp32s2")), path = "embassy/time_driver_timg.rs")]
+#[cfg_attr(
+    all(
+        feature = "embassy-time-systick",
+        any(
+            feature = "esp32c3",
+            feature = "esp32s3",
+            feature = "esp32s2",
+            feature = "esp32c2"
+        )
+    ),
+    path = "embassy/time_driver_systimer.rs"
+)]
+#[cfg_attr(
+    all(
+        feature = "embassy-time-timg",
+        any(feature = "esp32", feature = "esp32s3", feature = "esp32s2")
+    ),
+    path = "embassy/time_driver_timg.rs"
+)]
 mod time_driver;
 
 use time_driver::EmbassyTimer;
 
 pub fn init(clocks: &Clocks) {
     // TODO:
-    // In the future allow taking of &mut Peripheral when we move to the PeripheralRef way of driver initialization,
-    // see: https://github.com/esp-rs/esp-idf-hal/blob/5d1aea58cdda195e20d1489fcba8a8ecb6562d9a/src/peripheral.rs#L94
+    // In the future allow taking of &mut Peripheral when we move to the
+    // PeripheralRef way of driver initialization, see: https://github.com/esp-rs/esp-idf-hal/blob/5d1aea58cdda195e20d1489fcba8a8ecb6562d9a/src/peripheral.rs#L94
 
     EmbassyTimer::init(clocks);
 }

--- a/esp-hal-common/src/embassy.rs
+++ b/esp-hal-common/src/embassy.rs
@@ -91,7 +91,7 @@ impl Driver for EmbassyTimer {
         })
     }
 
-    fn set_alarm(&self, alarm: embassy_time::driver::AlarmHandle, timestamp: u64) {
+    fn set_alarm(&self, alarm: embassy_time::driver::AlarmHandle, timestamp: u64) -> bool {
         self.set_alarm(alarm, timestamp)
     }
 }

--- a/esp-hal-common/src/embassy.rs
+++ b/esp-hal-common/src/embassy.rs
@@ -6,13 +6,8 @@ use crate::clock::Clocks;
 
 #[cfg_attr(
     all(
+        has_systimer,
         feature = "embassy-time-systick",
-        any(
-            feature = "esp32c3",
-            feature = "esp32s3",
-            feature = "esp32s2",
-            feature = "esp32c2"
-        )
     ),
     path = "embassy/time_driver_systimer.rs"
 )]
@@ -64,8 +59,8 @@ impl Driver for EmbassyTimer {
     }
 
     unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {
-        return critical_section::with(|_cs| {
-            let alarms = self.alarms.borrow(_cs);
+        return critical_section::with(|cs| {
+            let alarms = self.alarms.borrow(cs);
             for i in 0..time_driver::ALARM_COUNT {
                 let c = alarms.get_unchecked(i);
                 if !c.allocated.get() {

--- a/esp-hal-common/src/embassy.rs
+++ b/esp-hal-common/src/embassy.rs
@@ -4,7 +4,7 @@ use embassy_time::driver::{AlarmHandle, Driver};
 use crate::clock::Clocks;
 
 #[cfg_attr(all(feature = "embassy-time-systick", any(feature = "esp32c3", feature = "esp32s3", feature = "esp32s2")), path = "embassy/time_driver_systimer.rs")]
-#[cfg_attr(all(feature = "embassy-time-timg", any(feature = "esp32", feature = "esp32s3", feature = "esp32s3")), path = "embassy/time_driver_timg.rs")]
+#[cfg_attr(all(feature = "embassy-time-timg", any(feature = "esp32", feature = "esp32s3", feature = "esp32s2")), path = "embassy/time_driver_timg.rs")]
 mod time_driver;
 
 use time_driver::EmbassyTimer;

--- a/esp-hal-common/src/embassy.rs
+++ b/esp-hal-common/src/embassy.rs
@@ -1,22 +1,20 @@
 
 use core::{cell::Cell, ptr};
 use embassy_time::driver::{AlarmHandle, Driver};
-use crate::{pac::Peripherals, clock::Clocks};
+use crate::clock::Clocks;
 
-#[cfg_attr(all(feature = "embassy-time-systick", any(feature = "esp32c3", feature = "esp32s3", feature = "esp32s3")), path = "embassy/time_driver_systimer.rs")]
+#[cfg_attr(all(feature = "embassy-time-systick", any(feature = "esp32c3", feature = "esp32s3", feature = "esp32s2")), path = "embassy/time_driver_systimer.rs")]
 #[cfg_attr(all(feature = "embassy-time-timg", any(feature = "esp32", feature = "esp32s3", feature = "esp32s3")), path = "embassy/time_driver_timg.rs")]
 mod time_driver;
 
 use time_driver::EmbassyTimer;
 
-pub fn init(clocks: &Clocks) -> Peripherals {
-    // Do this first, so that it panics if user is calling `init` a second time
-    // before doing anything important.
-    let peripherals = Peripherals::take().unwrap(); // TODO make new `Peripherals` without SYSTIMER as we use it in embassy
+pub fn init(clocks: &Clocks) {
+    // TODO:
+    // In the future allow taking of &mut Peripheral when we move to the PeripheralRef way of driver initialization,
+    // see: https://github.com/esp-rs/esp-idf-hal/blob/5d1aea58cdda195e20d1489fcba8a8ecb6562d9a/src/peripheral.rs#L94
 
     EmbassyTimer::init(clocks);
-
-    peripherals
 }
 
 pub struct AlarmState {

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -1,0 +1,103 @@
+use critical_section::{CriticalSection, Mutex};
+
+use super::AlarmState;
+use crate::{
+    pac,
+    systimer::{Alarm, SystemTimer, Target},
+};
+use crate::clock::Clocks;
+
+pub const ALARM_COUNT: usize = 3;
+
+pub struct EmbassyTimer {
+    pub alarms: Mutex<[AlarmState; ALARM_COUNT]>,
+    pub alarm0: Alarm<Target, 0>,
+    pub alarm1: Alarm<Target, 1>,
+    pub alarm2: Alarm<Target, 2>,
+}
+
+const ALARM_STATE_NONE: AlarmState = AlarmState::new();
+
+embassy_time::time_driver_impl!(static DRIVER: EmbassyTimer = EmbassyTimer {
+    alarms: Mutex::new([ALARM_STATE_NONE; ALARM_COUNT]),
+    alarm0: unsafe { Alarm::<_, 0>::conjure() },
+    alarm1: unsafe { Alarm::<_, 1>::conjure() },
+    alarm2: unsafe { Alarm::<_, 2>::conjure() },
+});
+
+impl EmbassyTimer {
+    pub(crate) fn now() -> u64 {
+        SystemTimer::now()
+    }
+
+    pub(crate) fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
+        let alarm = &self.alarms.borrow(cs)[n];
+        // safety:
+        // - we can ignore the possiblity of `f` being unset (null) because of the
+        //   safety contract of `allocate_alarm`.
+        // - other than that we only store valid function pointers into alarm.callback
+        let f: fn(*mut ()) = unsafe { core::mem::transmute(alarm.callback.get()) };
+        f(alarm.ctx.get());
+    }
+
+    fn on_interrupt(&self, id: u8) {
+        match id {
+            0 => self.alarm0.clear_interrupt(),
+            1 => self.alarm1.clear_interrupt(),
+            2 => self.alarm2.clear_interrupt(),
+            _ => unreachable!(),
+        };
+        critical_section::with(|cs| {
+            self.trigger_alarm(id as usize, cs);
+        })
+    }
+
+    pub(crate) fn init(_clocks: &Clocks) {
+        use crate::{interrupt, interrupt::Priority, macros::interrupt};
+
+        // TODO these priorities should probably be higher than 1...
+        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET0, Priority::Priority1).unwrap();
+        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET1, Priority::Priority1).unwrap();
+        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET2, Priority::Priority1).unwrap();
+
+        #[interrupt]
+        fn SYSTIMER_TARGET0() {
+            DRIVER.on_interrupt(0);
+        }
+        #[interrupt]
+        fn SYSTIMER_TARGET1() {
+            DRIVER.on_interrupt(1);
+        }
+        #[interrupt]
+        fn SYSTIMER_TARGET2() {
+            DRIVER.on_interrupt(2);
+        }
+    }
+
+    pub(crate) fn set_alarm(&self, alarm: embassy_time::driver::AlarmHandle, timestamp: u64) {
+        critical_section::with(|cs| {
+            let now = Self::now();
+            if timestamp < now {
+                self.trigger_alarm(alarm.id() as usize, cs);
+                return;
+            }
+            let alarm_state = unsafe { self.alarms.borrow(cs).get_unchecked(alarm.id() as usize) };
+            alarm_state.timestamp.set(timestamp);
+            match alarm.id() {
+                0 => {
+                    self.alarm0.set_target(timestamp);
+                    self.alarm0.enable_interrupt();
+                }
+                1 => {
+                    self.alarm1.set_target(timestamp);
+                    self.alarm1.enable_interrupt();
+                }
+                2 => {
+                    self.alarm2.set_target(timestamp);
+                    self.alarm2.enable_interrupt();
+                }
+                _ => panic!(),
+            }
+        })
+    }
+}

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -55,10 +55,9 @@ impl EmbassyTimer {
     pub(crate) fn init(_clocks: &Clocks) {
         use crate::{interrupt, interrupt::Priority, macros::interrupt};
 
-        // TODO these priorities should probably be higher than 1...
-        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET0, Priority::Priority1).unwrap();
-        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET1, Priority::Priority1).unwrap();
-        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET2, Priority::Priority1).unwrap();
+        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET0, Priority::max()).unwrap();
+        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET1, Priority::max()).unwrap();
+        interrupt::enable(pac::Interrupt::SYSTIMER_TARGET2, Priority::max()).unwrap();
 
         #[interrupt]
         fn SYSTIMER_TARGET0() {

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -2,10 +2,10 @@ use critical_section::{CriticalSection, Mutex};
 
 use super::AlarmState;
 use crate::{
+    clock::Clocks,
     pac,
     systimer::{Alarm, SystemTimer, Target},
 };
-use crate::clock::Clocks;
 
 pub const ALARM_COUNT: usize = 3;
 

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -58,7 +58,8 @@ impl EmbassyTimer {
 
         // TODO can we avoid this steal in the future...
         let mut tg = TimerGroup::new(unsafe { pac::Peripherals::steal().TIMG0 }, clocks);
-        // set divider to get a 1mhz clock. abp (80mhz) / 80 = 1mhz... // TODO assert abp clock is the source and its at the correct speed for the divider
+        // set divider to get a 1mhz clock. abp (80mhz) / 80 = 1mhz... // TODO assert
+        // abp clock is the source and its at the correct speed for the divider
         tg.timer0.set_divider(clocks.apb_clock.to_MHz() as u16);
         tg.timer1.set_divider(clocks.apb_clock.to_MHz() as u16);
 

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -1,0 +1,111 @@
+use core::cell::RefCell;
+
+use critical_section::{CriticalSection, Mutex};
+use embedded_hal::timer::CountDown;
+use pac::TIMG0;
+
+use super::AlarmState;
+use crate::{
+    clock::Clocks,
+    pac,
+    prelude::*,
+    timer::{Instance, Timer0, TimerGroup},
+    Timer,
+};
+
+pub const ALARM_COUNT: usize = 3;
+
+pub struct EmbassyTimer {
+    pub alarms: Mutex<[AlarmState; ALARM_COUNT]>,
+}
+
+const ALARM_STATE_NONE: AlarmState = AlarmState::new();
+
+static TG: Mutex<RefCell<Option<TimerGroup<TIMG0>>>> = Mutex::new(RefCell::new(None));
+
+embassy_time::time_driver_impl!(static DRIVER: EmbassyTimer = EmbassyTimer {
+    alarms: Mutex::new([ALARM_STATE_NONE; ALARM_COUNT]),
+});
+
+impl EmbassyTimer {
+    pub(crate) fn now() -> u64 {
+        critical_section::with(|cs| TG.borrow_ref(cs).as_ref().unwrap().timer0.now())
+    }
+
+    pub(crate) fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
+        let alarm = &self.alarms.borrow(cs)[n];
+        // safety:
+        // - we can ignore the possiblity of `f` being unset (null) because of the
+        //   safety contract of `allocate_alarm`.
+        // - other than that we only store valid function pointers into alarm.callback
+        let f: fn(*mut ()) = unsafe { core::mem::transmute(alarm.callback.get()) };
+        f(alarm.ctx.get());
+    }
+
+    fn on_interrupt(&self, id: u8) {
+        critical_section::with(|cs| {
+            let tg = TG.borrow_ref_mut(cs).as_mut().unwrap();
+            match id {
+                0 => tg.timer0.clear_interrupt(),
+                1 => tg.timer1.clear_interrupt(),
+                _ => unreachable!(),
+            };
+            self.trigger_alarm(id as usize, cs);
+        });
+    }
+
+    pub(crate) fn init(clocks: &Clocks) {
+        use crate::{interrupt, interrupt::Priority};
+
+        let tg = TimerGroup::new(unsafe { pac::Peripherals::steal().TIMG0 }, clocks);
+
+        critical_section::with(|cs| TG.borrow_ref_mut(cs).replace(tg));
+
+        // TODO these priorities should probably be higher than 1...
+        interrupt::enable(pac::Interrupt::TG0_T0_LEVEL, Priority::Priority1).unwrap();
+        interrupt::enable(pac::Interrupt::TG0_T1_LEVEL, Priority::Priority1).unwrap();
+
+        #[interrupt]
+        fn TG0_T0_LEVEL() {
+            DRIVER.on_interrupt(0);
+        }
+
+        #[interrupt]
+        fn TG0_T1_LEVEL() {
+            DRIVER.on_interrupt(1);
+        }
+    }
+
+    pub(crate) fn set_alarm(&self, alarm: embassy_time::driver::AlarmHandle, timestamp: u64) {
+        critical_section::with(|cs| {
+            let now = Self::now();
+            if timestamp < now {
+                self.trigger_alarm(alarm.id() as usize, cs);
+                return;
+            }
+            let alarm_state = unsafe { self.alarms.borrow(cs).get_unchecked(alarm.id() as usize) };
+            alarm_state.timestamp.set(timestamp);
+
+            let tg = TG.borrow_ref_mut(cs).as_mut().unwrap();
+            match alarm.id() {
+                0 => {
+                    tg.timer0.load_alarm_value(timestamp);
+                    tg.timer0.listen();
+                    tg.timer0.set_counter_decrementing(false);
+                    tg.timer0.set_auto_reload(false);
+                    tg.timer0.set_counter_active(true);
+                    tg.timer0.set_alarm_active(true);
+                }
+                1 => {
+                    tg.timer1.load_alarm_value(timestamp);
+                    tg.timer1.listen();
+                    tg.timer1.set_counter_decrementing(false);
+                    tg.timer1.set_auto_reload(false);
+                    tg.timer1.set_counter_active(true);
+                    tg.timer1.set_alarm_active(true);
+                }
+                _ => panic!(),
+            }
+        })
+    }
+}

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -65,9 +65,8 @@ impl EmbassyTimer {
 
         critical_section::with(|cs| TG.borrow_ref_mut(cs).replace(tg));
 
-        // TODO these priorities should probably be higher than 1...
-        interrupt::enable(pac::Interrupt::TG0_T0_LEVEL, Priority::Priority1).unwrap();
-        interrupt::enable(pac::Interrupt::TG0_T1_LEVEL, Priority::Priority1).unwrap();
+        interrupt::enable(pac::Interrupt::TG0_T0_LEVEL, Priority::max()).unwrap();
+        interrupt::enable(pac::Interrupt::TG0_T1_LEVEL, Priority::max()).unwrap();
 
         #[interrupt]
         fn TG0_T0_LEVEL() {

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -122,6 +122,16 @@ pub enum Priority {
     Priority15,
 }
 
+impl Priority {
+    pub fn max() -> Priority {
+        Priority::Priority15
+    }
+
+    pub fn min() -> Priority {
+        Priority::Priority1
+    }
+}
+
 /// Assign a peripheral interrupt to an CPU interrupt.
 ///
 /// Great care must be taken when using the `vectored` feature (enabled by
@@ -246,13 +256,13 @@ mod vectored {
 
     /// Get the interrupts configured for the core
     #[inline]
-    fn get_configured_interrupts(_core: Cpu, mut status: u128) -> [u128; 15] {
+    fn get_configured_interrupts(_core: Cpu, mut status: u128) -> [u128; 16] {
         unsafe {
             let intr = &*crate::pac::INTERRUPT_CORE0::PTR;
             let intr_map_base = intr.mac_intr_map.as_ptr();
             let intr_prio_base = intr.cpu_int_pri_0.as_ptr();
 
-            let mut prios = [0u128; 15];
+            let mut prios = [0u128; 16];
 
             while status != 0 {
                 let interrupt_nr = status.trailing_zeros();

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -205,6 +205,16 @@ mod vectored {
         Priority3,
     }
 
+    impl Priority {
+        pub fn max() -> Priority {
+            Priority::Priority3
+        }
+
+        pub fn min() -> Priority {
+            Priority::Priority1
+        }
+    }
+
     impl CpuInterrupt {
         #[inline]
         fn level(&self) -> Priority {
@@ -252,7 +262,7 @@ mod vectored {
 
     /// Get the interrupts configured for the core
     #[inline]
-    fn get_configured_interrupts(core: Cpu, mut status: u128) -> [u128; 7] {
+    fn get_configured_interrupts(core: Cpu, mut status: u128) -> [u128; 8] {
         unsafe {
             let intr_map_base = match core {
                 Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
@@ -262,7 +272,7 @@ mod vectored {
                 Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
             };
 
-            let mut levels = [0u128; 7];
+            let mut levels = [0u128; 8];
 
             while status != 0 {
                 let interrupt_nr = status.trailing_zeros();

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -79,6 +79,9 @@ pub mod utils;
 #[cfg_attr(esp32s3, path = "cpu_control/esp32s3.rs")]
 pub mod cpu_control;
 
+#[cfg(feature = "embassy")]
+pub mod embassy;
+
 #[cfg_attr(esp32, path = "efuse/esp32.rs")]
 #[cfg_attr(esp32c2, path = "efuse/esp32c2.rs")]
 #[cfg_attr(esp32c3, path = "efuse/esp32c3.rs")]

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -57,3 +57,6 @@ pub mod eh1 {
 
     pub use crate::system::SystemExt;
 }
+
+pub use crate::macros::*;
+pub use crate::timer::Instance;

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -58,5 +58,4 @@ pub mod eh1 {
     pub use crate::system::SystemExt;
 }
 
-pub use crate::macros::*;
-pub use crate::timer::Instance;
+pub use crate::{macros::*, timer::Instance};

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -217,7 +217,6 @@ impl<const CHANNEL: u8> Alarm<Periodic, CHANNEL> {
     }
 }
 
-
 impl<T> Alarm<T, 0> {
     pub const unsafe fn conjure() -> Self {
         Self { _pd: PhantomData }

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -216,3 +216,22 @@ impl<const CHANNEL: u8> Alarm<Periodic, CHANNEL> {
         Alarm { _pd: PhantomData }
     }
 }
+
+
+impl<T> Alarm<T, 0> {
+    pub const unsafe fn conjure() -> Self {
+        Self { _pd: PhantomData }
+    }
+}
+
+impl<T> Alarm<T, 1> {
+    pub const unsafe fn conjure() -> Self {
+        Self { _pd: PhantomData }
+    }
+}
+
+impl<T> Alarm<T, 2> {
+    pub const unsafe fn conjure() -> Self {
+        Self { _pd: PhantomData }
+    }
+}

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -78,18 +78,18 @@ impl<T, const CHANNEL: u8> Alarm<T, CHANNEL> {
         Self { _pd: PhantomData }
     }
 
-    pub fn enable_interrupt(&self) {
+    pub fn interrupt_enable(&self, val: bool) {
         let systimer = unsafe { &*SYSTIMER::ptr() };
         match CHANNEL {
             0 => systimer
                 .int_ena
-                .modify(|_, w| w.target0_int_ena().set_bit()),
+                .modify(|_, w| w.target0_int_ena().bit(val)),
             1 => systimer
                 .int_ena
-                .modify(|_, w| w.target1_int_ena().set_bit()),
+                .modify(|_, w| w.target1_int_ena().bit(val)),
             2 => systimer
                 .int_ena
-                .modify(|_, w| w.target2_int_ena().set_bit()),
+                .modify(|_, w| w.target2_int_ena().bit(val)),
             _ => unreachable!(),
         }
     }

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -130,8 +130,8 @@ where
     }
 
     /// Read current raw timer value in timer ticks
-    pub fn read_raw(&self) -> u64 {
-        self.timg.read_raw()
+    pub fn now(&self) -> u64 {
+        self.timg.now()
     }
 }
 
@@ -159,7 +159,7 @@ pub trait Instance {
 
     fn clear_interrupt(&mut self);
 
-    fn read_raw(&self) -> u64;
+    fn now(&self) -> u64;
 
     fn divider(&self) -> u32;
 
@@ -267,7 +267,7 @@ where
         reg_block.int_clr_timers.write(|w| w.t0_int_clr().set_bit());
     }
 
-    fn read_raw(&self) -> u64 {
+    fn now(&self) -> u64 {
         let reg_block = unsafe { &*TG::register_block() };
 
         reg_block.t0update.write(|w| unsafe { w.bits(0) });
@@ -404,7 +404,7 @@ where
         reg_block.int_clr_timers.write(|w| w.t1_int_clr().set_bit());
     }
 
-    fn read_raw(&self) -> u64 {
+    fn now(&self) -> u64 {
         let reg_block = unsafe { &*TG::register_block() };
 
         reg_block.t1update.write(|w| unsafe { w.bits(0) });

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -1,6 +1,9 @@
 //! General-purpose timers
 
-use core::{marker::PhantomData, ops::{Deref, DerefMut}};
+use core::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
 use embedded_hal::{
     timer::{Cancel, CountDown, Periodic},
@@ -110,20 +113,25 @@ where
     }
 }
 
-impl<T> Deref for Timer<T> where T: Instance {
+impl<T> Deref for Timer<T>
+where
+    T: Instance,
+{
     type Target = T;
-    
+
     fn deref(&self) -> &Self::Target {
         &self.timg
     }
 }
 
-impl<T> DerefMut for Timer<T> where T: Instance {
+impl<T> DerefMut for Timer<T>
+where
+    T: Instance,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.timg
     }
 }
-
 
 /// Timer peripheral instance
 pub trait Instance {
@@ -295,7 +303,9 @@ where
     fn set_divider(&mut self, divider: u16) {
         let reg_block = unsafe { &*TG::register_block() };
 
-        reg_block.t0config.modify(|_, w| unsafe { w.divider().bits(divider) })
+        reg_block
+            .t0config
+            .modify(|_, w| unsafe { w.divider().bits(divider) })
     }
 }
 
@@ -438,7 +448,9 @@ where
     fn set_divider(&mut self, divider: u16) {
         let reg_block = unsafe { &*TG::register_block() };
 
-        reg_block.t1config.modify(|_, w| unsafe { w.divider().bits(divider) })
+        reg_block
+            .t1config
+            .modify(|_, w| unsafe { w.divider().bits(divider) })
     }
 }
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -67,3 +67,7 @@ required-features = ["eh1"]
 [[example]]
 name              = "spi_eh1_device_loopback"
 required-features = ["eh1"]
+
+[[example]]
+name              = "embassy_hello_world"
+required-features = ["embassy"]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -31,6 +31,9 @@ embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32"], path = "../esp-hal-common" }
 xtensa-lx        = { version = "0.7.0",  features = ["esp32"] }
 xtensa-lx-rt     = { version = "0.13.0", features = ["esp32"], optional = true }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
+embedded-hal-async = { version = "0.1.0-alpha.1"}
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -48,6 +51,9 @@ rt        = ["xtensa-lx-rt/esp32"]
 smartled  = ["esp-hal-common/smartled"]
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
+async = ["esp-hal-common/async"]
+embassy = ["esp-hal-common/embassy"]
+embassy-time-timg = ["esp-hal-common/embassy-time-timg"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -31,10 +31,8 @@ embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32"], path = "../esp-hal-common" }
 xtensa-lx        = { version = "0.7.0",  features = ["esp32"] }
 xtensa-lx-rt     = { version = "0.13.0", features = ["esp32"], optional = true }
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
-embedded-hal-async = { version = "0.1.0-alpha.1"}
-static_cell        = "1.0.0"
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -43,6 +41,8 @@ esp-backtrace     = { version = "0.2.0", features = ["esp32", "panic-handler", "
 esp-println       = { version = "0.3.0", features = ["esp32"] }
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+static_cell       = "1.0.0"
 
 [features]
 default   = ["rt", "vectored"]
@@ -52,8 +52,8 @@ rt        = ["xtensa-lx-rt/esp32"]
 smartled  = ["esp-hal-common/smartled"]
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
-async = ["esp-hal-common/async"]
-embassy = ["esp-hal-common/embassy", "dep:embassy-executor"]
+async = ["esp-hal-common/async", "embedded-hal-async"]
+embassy = ["esp-hal-common/embassy"]
 embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
 
 [[example]]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -34,6 +34,7 @@ xtensa-lx-rt     = { version = "0.13.0", features = ["esp32"], optional = true }
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
 embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
 embedded-hal-async = { version = "0.1.0-alpha.1"}
+static_cell        = "1.0.0"
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -52,8 +53,8 @@ smartled  = ["esp-hal-common/smartled"]
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
 async = ["esp-hal-common/async"]
-embassy = ["esp-hal-common/embassy"]
-embassy-time-timg = ["esp-hal-common/embassy-time-timg"]
+embassy = ["esp-hal-common/embassy", "dep:embassy-executor"]
+embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -31,8 +31,8 @@ embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32"], path = "../esp-hal-common" }
 xtensa-lx        = { version = "0.7.0",  features = ["esp32"] }
 xtensa-lx-rt     = { version = "0.13.0", features = ["esp32"], optional = true }
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
 embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -41,7 +41,7 @@ esp-backtrace     = { version = "0.2.0", features = ["esp32", "panic-handler", "
 esp-println       = { version = "0.3.0", features = ["esp32"] }
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f945ccd5c4ef2af77230042dd4954e981ac", features = ["nightly", "integrated-timers"] }
 static_cell       = "1.0.0"
 
 [features]
@@ -54,7 +54,7 @@ ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
 async = ["esp-hal-common/async", "embedded-hal-async"]
 embassy = ["esp-hal-common/embassy"]
-embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
+embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -31,7 +31,7 @@ embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32"], path = "../esp-hal-common" }
 xtensa-lx        = { version = "0.7.0",  features = ["esp32"] }
 xtensa-lx-rt     = { version = "0.13.0", features = ["esp32"], optional = true }
-embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 [dev-dependencies]

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -18,7 +18,7 @@ use static_cell::StaticCell;
 async fn run1() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
-        Timer::after(Duration::from_millis(10_000)).await;
+        Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
@@ -26,7 +26,7 @@ async fn run1() {
 async fn run2() {
     loop {
         esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(30_000)).await;
+        Timer::after(Duration::from_millis(5_000)).await;
     }
 }
 

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -1,0 +1,60 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc, embassy,
+};
+use esp_backtrace as _;
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run1() {
+    loop {
+        esp_println::println!("Hello world from embassy using esp-hal-async!");
+        Timer::after(Duration::from_millis(10_000)).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run2() {
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(30_000)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[xtensa_lx_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = embassy::init();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run1()).ok();
+        spawner.spawn(run2()).ok();
+    });
+}

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -27,10 +27,12 @@ pub use esp_hal_common::{
     Rtc,
     Rwdt,
     Serial,
-    embassy,
 };
 
 pub use self::gpio::IO;
+
+#[cfg(feature = "embassy")]
+pub use esp_hal_common::embassy;
 
 pub mod adc;
 pub mod dac;

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -27,6 +27,7 @@ pub use esp_hal_common::{
     Rtc,
     Rwdt,
     Serial,
+    embassy,
 };
 
 pub use self::gpio::IO;

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -32,8 +32,8 @@ esp-hal-common   = { version = "0.2.0",  features = ["esp32c2"], path = "../esp-
 r0               = "1.0.0"
 riscv            = "0.9.0"
 riscv-rt         = { version = "0.9.0", optional = true }
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
 embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -41,8 +41,8 @@ embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.3.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.0", features = ["esp32c2"] }
 ssd1306           = "0.7.1"
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f945ccd5c4ef2af77230042dd4954e981ac", features = ["nightly", "integrated-timers"] }
 static_cell        = "1.0.0"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
 
 [features]
 default     = ["rt", "vectored"]
@@ -53,7 +53,7 @@ ufmt        = ["esp-hal-common/ufmt"]
 vectored    = ["esp-hal-common/vectored"]
 async = ["esp-hal-common/async", "embedded-hal-async"]
 embassy = ["esp-hal-common/embassy"]
-embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 
 [[example]]
 name              = "spi_eh1_loopback"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -32,6 +32,8 @@ esp-hal-common   = { version = "0.2.0",  features = ["esp32c2"], path = "../esp-
 r0               = "1.0.0"
 riscv            = "0.9.0"
 riscv-rt         = { version = "0.9.0", optional = true }
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -39,6 +41,8 @@ embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.3.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.0", features = ["esp32c2"] }
 ssd1306           = "0.7.1"
+static_cell        = "1.0.0"
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
 
 [features]
 default     = ["rt", "vectored"]
@@ -47,6 +51,9 @@ eh1         = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"
 rt          = ["riscv-rt"]
 ufmt        = ["esp-hal-common/ufmt"]
 vectored    = ["esp-hal-common/vectored"]
+async = ["esp-hal-common/async", "embedded-hal-async"]
+embassy = ["esp-hal-common/embassy"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
 
 [[example]]
 name              = "spi_eh1_loopback"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -32,7 +32,7 @@ esp-hal-common   = { version = "0.2.0",  features = ["esp32c2"], path = "../esp-
 r0               = "1.0.0"
 riscv            = "0.9.0"
 riscv-rt         = { version = "0.9.0", optional = true }
-embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 [dev-dependencies]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -62,3 +62,7 @@ required-features = ["eh1"]
 [[example]]
 name              = "spi_eh1_device_loopback"
 required-features = ["eh1"]
+
+[[example]]
+name              = "embassy_hello_world"
+required-features = ["embassy"]

--- a/esp32c2-hal/examples/embassy_hello_world.rs
+++ b/esp32c2-hal/examples/embassy_hello_world.rs
@@ -19,7 +19,7 @@ use static_cell::StaticCell;
 async fn run1() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
-        Timer::after(Duration::from_millis(10_000)).await;
+        Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
@@ -27,7 +27,7 @@ async fn run1() {
 async fn run2() {
     loop {
         esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(30_000)).await;
+        Timer::after(Duration::from_millis(5_000)).await;
     }
 }
 

--- a/esp32c2-hal/examples/embassy_hello_world.rs
+++ b/esp32c2-hal/examples/embassy_hello_world.rs
@@ -1,0 +1,58 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32c2_hal::{
+    clock::ClockControl,
+    embassy,
+    pac::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run1() {
+    loop {
+        esp_println::println!("Hello world from embassy using esp-hal-async!");
+        Timer::after(Duration::from_millis(10_000)).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run2() {
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(30_000)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[riscv_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take().unwrap();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    embassy::init(&clocks);
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run1()).ok();
+        spawner.spawn(run2()).ok();
+    });
+}

--- a/esp32c2-hal/examples/systimer.rs
+++ b/esp32c2-hal/examples/systimer.rs
@@ -47,15 +47,15 @@ fn main() -> ! {
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.Hz());
     alarm0.clear_interrupt();
-    alarm0.enable_interrupt();
+    alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.enable_interrupt();
+    alarm1.interrupt_enable(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.enable_interrupt();
+    alarm2.interrupt_enable(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -3,6 +3,8 @@
 use core::arch::global_asm;
 
 pub use embedded_hal as ehal;
+#[cfg(feature = "embassy")]
+pub use esp_hal_common::embassy;
 #[doc(inline)]
 pub use esp_hal_common::{
     clock,

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -33,13 +33,14 @@ esp-hal-common   = { version = "0.2.0",  features = ["esp32c3"], path = "../esp-
 r0               = "1.0.0"
 riscv            = "0.9.0"
 riscv-rt         = { version = "0.9.0", optional = true }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
+embedded-hal-async = { version = "0.1.0-alpha.1"}
+static_cell        = "1.0.0"
 
 [dev-dependencies]
 critical-section  = "1.1.0"
 embedded-graphics = "0.7.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
-embassy-sync       = { package = "embassy-sync", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957"}
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
 embedded-hal-async = { version = "0.1.0-alpha.1"}
 static_cell        = "1.0.0"
 esp-backtrace     = { version = "0.2.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
@@ -58,7 +59,7 @@ ufmt              = ["esp-hal-common/ufmt"]
 vectored          = ["esp-hal-common/vectored"]
 allow-opt-level-z = []
 async = ["esp-hal-common/async"]
-embassy = ["esp-hal-common/embassy"]
+embassy = ["esp-hal-common/embassy", "dep:embassy-executor"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
 
 [[example]]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -72,5 +72,9 @@ required-features = ["eh1"]
 name              = "spi_eh1_device_loopback"
 required-features = ["eh1"]
 
+[[example]]
+name              = "embassy_hello_world"
+required-features = ["embassy"]
+
 [profile.dev]
 opt-level = 1

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -33,20 +33,18 @@ esp-hal-common   = { version = "0.2.0",  features = ["esp32c3"], path = "../esp-
 r0               = "1.0.0"
 riscv            = "0.9.0"
 riscv-rt         = { version = "0.9.0", optional = true }
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
-embedded-hal-async = { version = "0.1.0-alpha.1"}
-static_cell        = "1.0.0"
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
 embedded-graphics = "0.7.1"
-embedded-hal-async = { version = "0.1.0-alpha.1"}
-static_cell        = "1.0.0"
 esp-backtrace     = { version = "0.2.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.0", features = ["esp32c3"] }
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
+static_cell        = "1.0.0"
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
 
 [features]
 default           = ["rt", "vectored"]
@@ -58,8 +56,8 @@ smartled          = ["esp-hal-common/smartled"]
 ufmt              = ["esp-hal-common/ufmt"]
 vectored          = ["esp-hal-common/vectored"]
 allow-opt-level-z = []
-async = ["esp-hal-common/async"]
-embassy = ["esp-hal-common/embassy", "dep:embassy-executor"]
+async = ["esp-hal-common/async", "embedded-hal-async"]
+embassy = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
 
 [[example]]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -37,6 +37,11 @@ riscv-rt         = { version = "0.9.0", optional = true }
 [dev-dependencies]
 critical-section  = "1.1.0"
 embedded-graphics = "0.7.1"
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+embassy-sync       = { package = "embassy-sync", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957"}
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
+embedded-hal-async = { version = "0.1.0-alpha.1"}
+static_cell        = "1.0.0"
 esp-backtrace     = { version = "0.2.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.0", features = ["esp32c3"] }
 smart-leds        = "0.3.0"
@@ -52,6 +57,9 @@ smartled          = ["esp-hal-common/smartled"]
 ufmt              = ["esp-hal-common/ufmt"]
 vectored          = ["esp-hal-common/vectored"]
 allow-opt-level-z = []
+async = ["esp-hal-common/async"]
+embassy = ["esp-hal-common/embassy"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -33,8 +33,8 @@ esp-hal-common   = { version = "0.2.0",  features = ["esp32c3"], path = "../esp-
 r0               = "1.0.0"
 riscv            = "0.9.0"
 riscv-rt         = { version = "0.9.0", optional = true }
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
-embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
+embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -43,8 +43,8 @@ esp-backtrace     = { version = "0.2.0", features = ["esp32c3", "panic-handler",
 esp-println       = { version = "0.3.0", features = ["esp32c3"] }
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f945ccd5c4ef2af77230042dd4954e981ac", features = ["nightly", "integrated-timers"] }
 static_cell        = "1.0.0"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
 
 [features]
 default           = ["rt", "vectored"]
@@ -58,7 +58,7 @@ vectored          = ["esp-hal-common/vectored"]
 allow-opt-level-z = []
 async = ["esp-hal-common/async", "embedded-hal-async"]
 embassy = ["esp-hal-common/embassy"]
-embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -1,0 +1,60 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc, embassy,
+};
+use esp_backtrace as _;
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run1() {
+    loop {
+        esp_println::println!("Hello world from embassy using esp-hal-async!");
+        Timer::after(Duration::from_millis(10_000)).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run2() {
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(30_000)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[riscv_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = embassy::init();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run1()).ok();
+        spawner.spawn(run2()).ok();
+    });
+}

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -18,7 +18,7 @@ use static_cell::StaticCell;
 async fn run1() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
-        Timer::after(Duration::from_millis(10_000)).await;
+        Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
@@ -26,7 +26,7 @@ async fn run1() {
 async fn run2() {
     loop {
         esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(30_000)).await;
+        Timer::after(Duration::from_millis(5_000)).await;
     }
 }
 

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -47,15 +47,15 @@ fn main() -> ! {
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.Hz());
     alarm0.clear_interrupt();
-    alarm0.enable_interrupt();
+    alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.enable_interrupt();
+    alarm1.interrupt_enable(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.enable_interrupt();
+    alarm2.interrupt_enable(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -34,6 +34,10 @@ pub use esp_hal_common::{
     Serial,
     UsbSerialJtag,
 };
+
+#[cfg(feature = "embassy")]
+pub use esp_hal_common::embassy;
+
 #[cfg(feature = "direct-boot")]
 use riscv_rt::pre_init;
 

--- a/esp32s2-hal/.cargo/config.toml
+++ b/esp32s2-hal/.cargo/config.toml
@@ -5,6 +5,15 @@ runner = "espflash --monitor"
 rustflags = [
   "-C", "link-arg=-nostartfiles",
   "-C", "link-arg=-Wl,-Tlinkall.x",
+
+  # enable the atomic codegen option for Xtensa
+  "-C", "target-feature=+s32c1i",
+
+  # tell the core library have atomics even though it's not specified in the target definition
+  "--cfg", 'target_has_atomic="8"',
+  "--cfg", 'target_has_atomic="16"',
+  "--cfg", 'target_has_atomic="32"',
+  "--cfg", 'target_has_atomic="ptr"',
 ]
 target = "xtensa-esp32s2-none-elf"
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -70,3 +70,7 @@ required-features = ["eh1"]
 [[example]]
 name              = "spi_eh1_device_loopback"
 required-features = ["eh1"]
+
+[[example]]
+name              = "embassy_hello_world"
+required-features = ["embassy"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -31,7 +31,7 @@ embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-lx        = { version = "0.7.0",  features = ["esp32s2"] }
 xtensa-lx-rt     = { version = "0.13.0", features = ["esp32s2"], optional = true }
-embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 xtensa-atomic-emulation-trap = { version = "0.2.0", features = ["esp32s2"] }
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -36,6 +36,7 @@ embassy-sync       = { package = "embassy-sync", git = "https://github.com/embas
 embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"] }
 embedded-hal-async = { version = "0.1.0-alpha.1"}
 static_cell        = "1.0.0"
+xtensa-atomic-emulation-trap = { version = "0.2.0", features = ["esp32s2"] }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -55,9 +56,9 @@ smartled  = ["esp-hal-common/smartled"]
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
 async = ["esp-hal-common/async"]
-embassy = ["esp-hal-common/embassy"]
-embassy-time-systick = ["esp-hal-common/embassy-time-systick"]
-embassy-time-timg = ["esp-hal-common/embassy-time-timg"]
+embassy = ["esp-hal-common/embassy", "embassy-executor"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
+embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -56,7 +56,10 @@ ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
 async = ["esp-hal-common/async", "embedded-hal-async"]
 embassy = ["esp-hal-common/embassy"]
-embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-1_000_000"] # TODO add 80_000_000 support to embassy time
+# FIXME:
+# - add 80_000_000 support to embassy time
+# - Fix https://github.com/esp-rs/esp-hal/issues/253
+# embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-1_000_000"] 
 embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -38,7 +38,7 @@ xtensa-atomic-emulation-trap = { version = "0.2.0", features = ["esp32s2"] }
 [dev-dependencies]
 critical-section  = "1.1.0"
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.2.0", features = ["esp32s2", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.2.0", features = ["esp32s2", "panic-handler", "print-uart"] }
 esp-println       = { version = "0.3.0", features = ["esp32s2"] }
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -31,8 +31,8 @@ embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-lx        = { version = "0.7.0",  features = ["esp32s2"] }
 xtensa-lx-rt     = { version = "0.13.0", features = ["esp32s2"], optional = true }
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
 embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 xtensa-atomic-emulation-trap = { version = "0.2.0", features = ["esp32s2"] }
 
 [dev-dependencies]
@@ -44,7 +44,7 @@ smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 usb-device        = { version = "0.2.3" }
 usbd-serial       = "0.1.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f945ccd5c4ef2af77230042dd4954e981ac", features = ["nightly", "integrated-timers"] }
 static_cell        = "1.0.0"
 
 [features]
@@ -56,8 +56,8 @@ ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
 async = ["esp-hal-common/async", "embedded-hal-async"]
 embassy = ["esp-hal-common/embassy"]
-embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
-embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-1_000_000"] # TODO add 80_000_000 support to embassy time
+embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -31,11 +31,8 @@ embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-lx        = { version = "0.7.0",  features = ["esp32s2"] }
 xtensa-lx-rt     = { version = "0.13.0", features = ["esp32s2"], optional = true }
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
-embassy-sync       = { package = "embassy-sync", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957"}
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"] }
-embedded-hal-async = { version = "0.1.0-alpha.1"}
-static_cell        = "1.0.0"
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
 xtensa-atomic-emulation-trap = { version = "0.2.0", features = ["esp32s2"] }
 
 [dev-dependencies]
@@ -47,6 +44,8 @@ smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 usb-device        = { version = "0.2.3" }
 usbd-serial       = "0.1.1"
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+static_cell        = "1.0.0"
 
 [features]
 default   = ["rt", "vectored"]
@@ -55,8 +54,8 @@ rt        = ["xtensa-lx-rt/esp32s2"]
 smartled  = ["esp-hal-common/smartled"]
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
-async = ["esp-hal-common/async"]
-embassy = ["esp-hal-common/embassy", "embassy-executor"]
+async = ["esp-hal-common/async", "embedded-hal-async"]
+embassy = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
 embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -31,6 +31,11 @@ embedded-hal-nb  = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common   = { version = "0.2.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-lx        = { version = "0.7.0",  features = ["esp32s2"] }
 xtensa-lx-rt     = { version = "0.13.0", features = ["esp32s2"], optional = true }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+embassy-sync       = { package = "embassy-sync", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957"}
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"] }
+embedded-hal-async = { version = "0.1.0-alpha.1"}
+static_cell        = "1.0.0"
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -49,6 +54,10 @@ rt        = ["xtensa-lx-rt/esp32s2"]
 smartled  = ["esp-hal-common/smartled"]
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
+async = ["esp-hal-common/async"]
+embassy = ["esp-hal-common/embassy"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick"]
+embassy-time-timg = ["esp-hal-common/embassy-time-timg"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s2-hal/examples/adc.rs
+++ b/esp32s2-hal/examples/adc.rs
@@ -55,3 +55,17 @@ fn main() -> ! {
         delay.delay_ms(1500u32);
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/adc.rs
+++ b/esp32s2-hal/examples/adc.rs
@@ -16,6 +16,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use esp_println::println;
 use xtensa_lx_rt::entry;
 

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -21,6 +21,7 @@ use esp32s2_hal::{
     Serial,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use esp_println::println;
 use nb::block;
 use xtensa_lx_rt::entry;

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -70,3 +70,17 @@ fn main() -> ! {
         delay.delay_ms(250u32);
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/blinky.rs
+++ b/esp32s2-hal/examples/blinky.rs
@@ -15,6 +15,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 #[entry]

--- a/esp32s2-hal/examples/blinky.rs
+++ b/esp32s2-hal/examples/blinky.rs
@@ -47,3 +47,17 @@ fn main() -> ! {
         delay.delay_ms(500u32);
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/clock_monitor.rs
+++ b/esp32s2-hal/examples/clock_monitor.rs
@@ -64,3 +64,17 @@ fn RTC_CORE() {
         rtc.rwdt.clear_interrupt();
     });
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/clock_monitor.rs
+++ b/esp32s2-hal/examples/clock_monitor.rs
@@ -16,6 +16,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use esp_println::println;
 use xtensa_lx_rt::entry;
 

--- a/esp32s2-hal/examples/dac.rs
+++ b/esp32s2-hal/examples/dac.rs
@@ -56,3 +56,17 @@ fn main() -> ! {
         delay.delay_ms(50u32);
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/dac.rs
+++ b/esp32s2-hal/examples/dac.rs
@@ -16,6 +16,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 #[entry]

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -5,7 +5,7 @@
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 
-use esp32c3_hal::{
+use esp32s2_hal::{
     clock::ClockControl,
     prelude::*,
     timer::TimerGroup,
@@ -32,7 +32,7 @@ async fn run2() {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[riscv_rt::entry]
+#[xtensa_lx_rt::entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take().unwrap();

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -12,6 +12,7 @@ use esp32s2_hal::{
     Rtc, embassy, pac::Peripherals,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use static_cell::StaticCell;
 
 #[embassy_executor::task]
@@ -47,7 +48,6 @@ fn main() -> ! {
     let mut wdt1 = timer_group1.wdt;
 
     // Disable watchdog timers
-    rtc.swd.disable();
     rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -59,3 +59,17 @@ fn main() -> ! {
         spawner.spawn(run2()).ok();
     });
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -19,7 +19,7 @@ use static_cell::StaticCell;
 async fn run1() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
-        Timer::after(Duration::from_millis(10_000)).await;
+        Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
@@ -27,7 +27,7 @@ async fn run1() {
 async fn run2() {
     loop {
         esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(30_000)).await;
+        Timer::after(Duration::from_millis(5_000)).await;
     }
 }
 

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -79,3 +79,17 @@ fn GPIO() {
             .clear_interrupt()
     });
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -22,6 +22,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 static BUTTON: Mutex<RefCell<Option<Gpio0<Input<PullDown>>>>> = Mutex::new(RefCell::new(None));

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -82,3 +82,17 @@ fn main() -> ! {
         }
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -24,6 +24,7 @@ use esp32s2_hal::{
 };
 #[allow(unused_imports)]
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use smart_leds::{
     brightness,
     gamma,

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -42,3 +42,17 @@ fn main() -> ! {
         block!(timer0.wait()).unwrap();
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -15,6 +15,7 @@ use esp32s2_hal::{
     Serial,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use nb::block;
 use xtensa_lx_rt::entry;
 

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -29,6 +29,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use nb::block;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 use xtensa_lx_rt::entry;

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -130,3 +130,17 @@ fn main() -> ! {
         block!(timer0.wait()).unwrap();
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -22,6 +22,8 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
+use esp_println;
 use xtensa_lx_rt::entry;
 
 #[entry]

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -71,3 +71,17 @@ fn main() -> ! {
 
     loop {}
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/pulse_control.rs
+++ b/esp32s2-hal/examples/pulse_control.rs
@@ -76,3 +76,17 @@ fn main() -> ! {
             .unwrap();
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/pulse_control.rs
+++ b/esp32s2-hal/examples/pulse_control.rs
@@ -16,6 +16,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 #[entry]

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -17,6 +17,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
+use xtensa_atomic_emulation_trap as _;
 use nb::block;
 use xtensa_lx_rt::entry;
 

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -97,3 +97,17 @@ fn function_in_ram() {
 fn function_in_rtc_ram() -> u32 {
     42
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/read_efuse.rs
+++ b/esp32s2-hal/examples/read_efuse.rs
@@ -35,3 +35,17 @@ fn main() -> ! {
 
     loop {}
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/read_efuse.rs
+++ b/esp32s2-hal/examples/read_efuse.rs
@@ -14,6 +14,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 #[entry]

--- a/esp32s2-hal/examples/rtc_watchdog.rs
+++ b/esp32s2-hal/examples/rtc_watchdog.rs
@@ -57,3 +57,17 @@ fn RTC_CORE() {
         rwdt.unlisten();
     });
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/rtc_watchdog.rs
+++ b/esp32s2-hal/examples/rtc_watchdog.rs
@@ -18,6 +18,7 @@ use esp32s2_hal::{
     Rwdt,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));

--- a/esp32s2-hal/examples/serial_interrupts.rs
+++ b/esp32s2-hal/examples/serial_interrupts.rs
@@ -93,3 +93,17 @@ fn UART0() {
         serial.reset_rx_fifo_full_interrupt();
     });
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/serial_interrupts.rs
+++ b/esp32s2-hal/examples/serial_interrupts.rs
@@ -19,6 +19,7 @@ use esp32s2_hal::{
     Serial,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use nb::block;
 use xtensa_lx_rt::entry;
 

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -148,3 +148,17 @@ fn main() -> ! {
         delay.delay_ms(250u32);
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -31,6 +31,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 #[entry]

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -120,3 +120,17 @@ fn main() -> ! {
         delay.delay_ms(250u32);
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -29,6 +29,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 #[entry]

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -74,3 +74,17 @@ fn main() -> ! {
         delay.delay_ms(250u32);
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -28,6 +28,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 #[entry]

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -29,6 +29,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
+use xtensa_atomic_emulation_trap as _;
 use esp_println::println;
 use xtensa_lx_rt::entry;
 

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -117,3 +117,17 @@ fn buffer2() -> &'static mut [u8; 32000] {
     static mut BUFFER: [u8; 32000] = [0u8; 32000];
     unsafe { &mut BUFFER }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -111,3 +111,17 @@ fn SYSTIMER_TARGET2() {
             .clear_interrupt()
     });
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -47,15 +47,15 @@ fn main() -> ! {
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.Hz());
-    alarm0.enable_interrupt();
+    alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.enable_interrupt();
+    alarm1.interrupt_enable(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.enable_interrupt();
+    alarm2.interrupt_enable(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -20,6 +20,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -19,6 +19,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
+use xtensa_atomic_emulation_trap as _;
 use xtensa_lx_rt::entry;
 
 static TIMER00: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -129,3 +129,17 @@ fn TG1_T1_LEVEL() {
         }
     });
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/examples/watchdog.rs
+++ b/esp32s2-hal/examples/watchdog.rs
@@ -8,6 +8,7 @@
 use esp32s2_hal::{clock::ClockControl, pac::Peripherals, prelude::*, timer::TimerGroup, Rtc};
 use esp_backtrace as _;
 use esp_println::println;
+use xtensa_atomic_emulation_trap as _;
 use nb::block;
 use xtensa_lx_rt::entry;
 

--- a/esp32s2-hal/examples/watchdog.rs
+++ b/esp32s2-hal/examples/watchdog.rs
@@ -34,3 +34,17 @@ fn main() -> ! {
         block!(timer0.wait()).unwrap();
     }
 }
+
+#[xtensa_lx_rt::exception]
+fn exception(cause: xtensa_lx_rt::exception::ExceptionCause, frame: xtensa_lx_rt::exception::Context) {
+    use esp_println::*;
+
+    println!("\n\nException occured {:?} {:x?}", cause, frame);
+    
+    let backtrace = esp_backtrace::arch::backtrace();
+    for b in backtrace.iter() {
+        if let Some(addr) = b {
+            println!("0x{:x}", addr)
+        }
+    }
+}

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -30,6 +30,9 @@ pub use esp_hal_common::{
     Serial,
 };
 
+#[cfg(feature = "embassy")]
+pub use esp_hal_common::embassy;
+
 pub use self::gpio::IO;
 
 pub mod adc;

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -33,8 +33,8 @@ esp-hal-common  = { version = "0.2.0",  features = ["esp32s3"], path = "../esp-h
 r0              = { version = "1.0.0",  optional = true }
 xtensa-lx       = { version = "0.7.0",  features = ["esp32s3"] }
 xtensa-lx-rt    = { version = "0.13.0", features = ["esp32s3"], optional = true }
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
 embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -45,7 +45,7 @@ smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 usb-device        = { version = "0.2.3" }
 usbd-serial       = "0.1.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f945ccd5c4ef2af77230042dd4954e981ac", features = ["nightly", "integrated-timers"] }
 static_cell        = "1.0.0"
 
 [features]
@@ -58,8 +58,8 @@ ufmt        = ["esp-hal-common/ufmt"]
 vectored    = ["esp-hal-common/vectored"]
 async = ["esp-hal-common/async", "embedded-hal-async"]
 embassy = ["esp-hal-common/embassy"]
-embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
-embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -33,6 +33,11 @@ esp-hal-common  = { version = "0.2.0",  features = ["esp32s3"], path = "../esp-h
 r0              = { version = "1.0.0",  optional = true }
 xtensa-lx       = { version = "0.7.0",  features = ["esp32s3"] }
 xtensa-lx-rt    = { version = "0.13.0", features = ["esp32s3"], optional = true }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+embassy-sync       = { package = "embassy-sync", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957"}
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
+embedded-hal-async = { version = "0.1.0-alpha.1"}
+static_cell        = "1.0.0"
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -52,6 +57,10 @@ rt          = ["xtensa-lx-rt/esp32s3"]
 smartled    = ["esp-hal-common/smartled"]
 ufmt        = ["esp-hal-common/ufmt"]
 vectored    = ["esp-hal-common/vectored"]
+async = ["esp-hal-common/async"]
+embassy = ["esp-hal-common/embassy"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick"]
+embassy-time-timg = ["esp-hal-common/embassy-time-timg"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -33,11 +33,8 @@ esp-hal-common  = { version = "0.2.0",  features = ["esp32s3"], path = "../esp-h
 r0              = { version = "1.0.0",  optional = true }
 xtensa-lx       = { version = "0.7.0",  features = ["esp32s3"] }
 xtensa-lx-rt    = { version = "0.13.0", features = ["esp32s3"], optional = true }
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
-embassy-sync       = { package = "embassy-sync", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957"}
-embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "tick-16mhz"] }
-embedded-hal-async = { version = "0.1.0-alpha.1"}
-static_cell        = "1.0.0"
+embassy-time       = { package = "embassy-time", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly"], optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.0"
@@ -48,6 +45,8 @@ smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 usb-device        = { version = "0.2.3" }
 usbd-serial       = "0.1.1"
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "92ed957", features = ["nightly", "integrated-timers"] }
+static_cell        = "1.0.0"
 
 [features]
 default     = ["rt", "vectored"]
@@ -57,8 +56,8 @@ rt          = ["xtensa-lx-rt/esp32s3"]
 smartled    = ["esp-hal-common/smartled"]
 ufmt        = ["esp-hal-common/ufmt"]
 vectored    = ["esp-hal-common/vectored"]
-async = ["esp-hal-common/async"]
-embassy = ["esp-hal-common/embassy", "dep:embassy-executor"]
+async = ["esp-hal-common/async", "embedded-hal-async"]
+embassy = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
 embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -58,9 +58,9 @@ smartled    = ["esp-hal-common/smartled"]
 ufmt        = ["esp-hal-common/ufmt"]
 vectored    = ["esp-hal-common/vectored"]
 async = ["esp-hal-common/async"]
-embassy = ["esp-hal-common/embassy"]
-embassy-time-systick = ["esp-hal-common/embassy-time-systick"]
-embassy-time-timg = ["esp-hal-common/embassy-time-timg"]
+embassy = ["esp-hal-common/embassy", "dep:embassy-executor"]
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-16mhz"]
+embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-1mhz"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -33,7 +33,7 @@ esp-hal-common  = { version = "0.2.0",  features = ["esp32s3"], path = "../esp-h
 r0              = { version = "1.0.0",  optional = true }
 xtensa-lx       = { version = "0.7.0",  features = ["esp32s3"] }
 xtensa-lx-rt    = { version = "0.13.0", features = ["esp32s3"], optional = true }
-embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 [dev-dependencies]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -72,3 +72,7 @@ required-features = ["eh1"]
 [[example]]
 name              = "spi_eh1_device_loopback"
 required-features = ["eh1"]
+
+[[example]]
+name              = "embassy_hello_world"
+required-features = ["embassy"]

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -18,7 +18,7 @@ use static_cell::StaticCell;
 async fn run1() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
-        Timer::after(Duration::from_millis(10_000)).await;
+        Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
@@ -26,7 +26,7 @@ async fn run1() {
 async fn run2() {
     loop {
         esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(30_000)).await;
+        Timer::after(Duration::from_millis(5_000)).await;
     }
 }
 

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -5,7 +5,7 @@
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 
-use esp32c3_hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     prelude::*,
     timer::TimerGroup,
@@ -32,7 +32,7 @@ async fn run2() {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[riscv_rt::entry]
+#[xtensa_lx_rt::entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take().unwrap();

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -46,15 +46,15 @@ fn main() -> ! {
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.Hz());
-    alarm0.enable_interrupt();
+    alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.enable_interrupt();
+    alarm1.interrupt_enable(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.enable_interrupt();
+    alarm2.interrupt_enable(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -35,7 +35,7 @@ pub use esp_hal_common::{
 };
 
 #[cfg(feature = "embassy")]
-use esp_hal_common::embassy;
+pub use esp_hal_common::embassy;
 
 pub use self::gpio::IO;
 

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -34,6 +34,9 @@ pub use esp_hal_common::{
     UsbSerialJtag,
 };
 
+#[cfg(feature = "embassy")]
+use esp_hal_common::embassy;
+
 pub use self::gpio::IO;
 
 pub mod adc;


### PR DESCRIPTION
The following features are now available in `esp-hal-common`:

- `async`, enables eh1, eha, and embassy-sync
-  `embassy`, enables embassy-time and the base time driver implementation
- `embassy-time-systick` & `embassy-time-timg` features add embassy driver support for either the systick or timg peripheral
  - Depending on the chip these features are also available on the chip specific hal

This PR also enables atomic emulation for the esp32s2 by default, the examples have been updated. I've also implemented Deref for the Timer wrapping structs to allow calling the underlying functions without boilerplate.

## Blocked on

- [x] Xtensa targets won't build because we need 1.65 release for GAT support in embedded-hal-async

## Unresolved issues

- [x] LoadStore exception with systimer timer on s2 - probably related to atomic emulation? - Moved to https://github.com/esp-rs/esp-hal/issues/253
- [x] git deps for embassy will stop us publishing new versions
- [x] CI needs to be reworked to test these new examples, we'll need nightly and the ability to supply some different features


Closes #231 
Closes #232 
