### PR TITLE
cpu_control::start_app_core improvements

### DIFF
--- a/esp-hal-common/src/cpu_control/esp32.rs
+++ b/esp-hal-common/src/cpu_control/esp32.rs
@@ -6,8 +6,10 @@ use xtensa_lx::set_stack_pointer;
 
 use crate::Cpu;
 
-static mut START_CORE1_FUNCTION: Option<&'static mut (dyn FnMut() -> () + 'static)> = None;
+static mut START_CORE1_FUNCTION: Option<&'static mut (dyn FnMut() + 'static)> = None;
 
+/// Will park the APP (second) core when dropped
+#[must_use]
 pub struct AppCoreGuard<'a> {
     phantom: PhantomData<&'a ()>,
 }
@@ -183,10 +185,11 @@ impl CpuControl {
     /// Start the APP (second) core
     ///
     /// The second core will start running the closure `entry`.
-    #[must_use]
+    ///
+    /// Dropping the returned guard will park the core.
     pub fn start_app_core<'a: 'b, 'b>(
         &mut self,
-        entry: &'a mut (dyn FnMut() -> () + 'a),
+        entry: &'a mut (dyn FnMut() + Send + 'a),
     ) -> Result<AppCoreGuard<'b>, Error> {
         let dport_control = crate::pac::DPORT::PTR;
         let dport_control = unsafe { &*dport_control };
@@ -205,7 +208,7 @@ impl CpuControl {
         self.enable_cache(Cpu::AppCpu);
 
         unsafe {
-            let entry_fn: &'static mut (dyn FnMut() -> () + 'static) = core::mem::transmute(entry);
+            let entry_fn: &'static mut (dyn FnMut() + 'static) = core::mem::transmute(entry);
             START_CORE1_FUNCTION = Some(entry_fn);
         }
 

--- a/esp-hal-common/src/cpu_control/esp32.rs
+++ b/esp-hal-common/src/cpu_control/esp32.rs
@@ -187,10 +187,10 @@ impl CpuControl {
     /// The second core will start running the closure `entry`.
     ///
     /// Dropping the returned guard will park the core.
-    pub fn start_app_core<'a: 'b, 'b>(
+    pub fn start_app_core(
         &mut self,
-        entry: &'a mut (dyn FnMut() + Send + 'a),
-    ) -> Result<AppCoreGuard<'b>, Error> {
+        entry: &mut (dyn FnMut() + Send),
+    ) -> Result<AppCoreGuard, Error> {
         let dport_control = crate::pac::DPORT::PTR;
         let dport_control = unsafe { &*dport_control };
 

--- a/esp-hal-common/src/cpu_control/esp32s3.rs
+++ b/esp-hal-common/src/cpu_control/esp32s3.rs
@@ -122,10 +122,10 @@ impl CpuControl {
     /// The second core will start running the closure `entry`.
     ///
     /// Dropping the returned guard will park the core.
-    pub fn start_app_core<'a: 'b, 'b>(
+    pub fn start_app_core(
         &mut self,
-        entry: &'a mut (dyn FnMut() + Send + 'a),
-    ) -> Result<AppCoreGuard<'b>, Error> {
+        entry: &mut (dyn FnMut() + Send),
+    ) -> Result<AppCoreGuard, Error> {
         let system_control = crate::pac::SYSTEM::PTR;
         let system_control = unsafe { &*system_control };
 


### PR DESCRIPTION
* add `Send` bound
* move `#[must_use]` to `AppCoreGuard`
* remove redundant `-> ()`
* document guard behaviour

The added `Send` bound is a breaking change but required for soundness.