### PR TITLE
Add uninit section to bl and mv linker scripts to match db

### DIFF
--- a/esp32c3-hal/ld/bl-riscv-link.x
+++ b/esp32c3-hal/ld/bl-riscv-link.x
@@ -153,6 +153,15 @@ SECTIONS
     _ebss = .;
   } > REGION_BSS
 
+  .uninit (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __suninit = .;
+    *(.uninit .uninit.*);
+    . = ALIGN(4);
+    __euninit = .;
+  } > REGION_BSS
+
   /* fictitious region that represents the memory available for the heap */
   .heap (NOLOAD) :
   {

--- a/esp32c3-hal/ld/mb-riscv-link.x
+++ b/esp32c3-hal/ld/mb-riscv-link.x
@@ -90,6 +90,15 @@ SECTIONS
     _ebss = .;
   } > REGION_BSS
 
+  .uninit (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __suninit = .;
+    *(.uninit .uninit.*);
+    . = ALIGN(4);
+    __euninit = .;
+  } > REGION_BSS
+
   /* fictitious region that represents the memory available for the heap */
   .heap (NOLOAD) :
   {


### PR DESCRIPTION
Probably should have done this as part of #175
This PR adds the .uninit section to the linker script for both bootloader modes to mirror the one provided by the cortex-m crate and match what is currently present in the direct-boot linker script.
The only user of this section that I know of is defmt-rtt.