### PR TITLE
Add LEDC support for ESP32-C2

### DIFF
--- a/esp-hal-common/src/ledc/channel.rs
+++ b/esp-hal-common/src/ledc/channel.rs
@@ -31,9 +31,9 @@ pub enum Number {
     Channel3,
     Channel4,
     Channel5,
-    #[cfg(not(esp32c3))]
+    #[cfg(not(any(esp32c2, esp32c3)))]
     Channel6,
-    #[cfg(not(esp32c3))]
+    #[cfg(not(any(esp32c2, esp32c3)))]
     Channel7,
 }
 
@@ -373,14 +373,14 @@ where
                     self.output_pin
                         .connect_peripheral_to_output(OutputSignal::LEDC_LS_SIG5);
                 }
-                #[cfg(not(esp32c3))]
+                #[cfg(not(any(esp32c2, esp32c3)))]
                 Number::Channel6 => {
                     set_channel!(self, l, 6, timer_number);
                     update_channel!(self, 6);
                     self.output_pin
                         .connect_peripheral_to_output(OutputSignal::LEDC_LS_SIG6);
                 }
-                #[cfg(not(esp32c3))]
+                #[cfg(not(any(esp32c2, esp32c3)))]
                 Number::Channel7 => {
                     set_channel!(self, l, 7, timer_number);
                     update_channel!(self, 7);
@@ -404,9 +404,9 @@ where
             Number::Channel3 => set_duty!(self, l, 3, duty),
             Number::Channel4 => set_duty!(self, l, 4, duty),
             Number::Channel5 => set_duty!(self, l, 5, duty),
-            #[cfg(not(esp32c3))]
+            #[cfg(not(any(esp32c2, esp32c3)))]
             Number::Channel6 => set_duty!(self, l, 6, duty),
-            #[cfg(not(esp32c3))]
+            #[cfg(not(any(esp32c2, esp32c3)))]
             Number::Channel7 => set_duty!(self, l, 7, duty),
         };
     }

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -54,10 +54,9 @@ pub mod delay;
 pub mod dma;
 pub mod gpio;
 pub mod i2c;
-// FIXME: While the ESP32-C2 *does* have LEDC, it is not currently available in
-//        the SVD.
-#[cfg(not(esp32c2))]
 pub mod ledc;
+#[cfg(any(esp32s2, esp32s3))]
+pub mod otg_fs;
 pub mod prelude;
 #[cfg(not(esp32c2))]
 pub mod pulse_control;
@@ -90,9 +89,6 @@ pub mod efuse;
 #[cfg_attr(riscv, path = "interrupt/riscv.rs")]
 #[cfg_attr(xtensa, path = "interrupt/xtensa.rs")]
 pub mod interrupt;
-
-#[cfg(any(esp32s3, esp32s2))]
-pub mod otg_fs;
 
 /// Enumeration of CPU cores
 /// The actual number of available cores depends on the target.

--- a/esp32c2-hal/examples/ledc.rs
+++ b/esp32c2-hal/examples/ledc.rs
@@ -1,0 +1,70 @@
+//! Turns on LED with the option to change LED intensity depending on `duty`
+//! value. Possible values (`u32`) are in range 0..100.
+//!
+//! This assumes that a LED is connected to the pin assigned to `led`. (GPIO4)
+
+#![no_std]
+#![no_main]
+
+use esp32c2_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    ledc::{
+        channel::{self, ChannelIFace},
+        timer::{self, TimerIFace},
+        LSGlobalClkSource,
+        LowSpeed,
+        LEDC,
+    },
+    pac::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use riscv_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let led = io.pins.gpio4.into_push_pull_output();
+
+    let mut ledc = LEDC::new(
+        peripherals.LEDC,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
+    let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer2);
+
+    lstimer0
+        .configure(timer::config::Config {
+            duty: timer::config::Duty::Duty5Bit,
+            clock_source: timer::LSClockSource::APBClk,
+            frequency: 24u32.kHz(),
+        })
+        .unwrap();
+
+    let mut channel0 = ledc.get_channel(channel::Number::Channel0, led);
+    channel0
+        .configure(channel::config::Config {
+            timer: &lstimer0,
+            duty_pct: 90,
+        })
+        .unwrap();
+
+    loop {}
+}

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -10,6 +10,7 @@ pub use esp_hal_common::{
     gpio as gpio_types,
     i2c,
     interrupt,
+    ledc,
     macros,
     pac,
     prelude,


### PR DESCRIPTION
Turns out this peripheral was in the SVD after all (not sure why I thought it wasn't), it just needed some patching.