### PR TITLE
add/correct docs for gpio::OutputSignal and add PWM output signal to ESP32-S3

### DIFF
--- a/esp-hal-common/src/gpio/esp32c2.rs
+++ b/esp-hal-common/src/gpio/esp32c2.rs
@@ -5,6 +5,7 @@ pub const INPUT_SIGNAL_MAX: u8 = 100;
 pub const ONE_INPUT: u8 = 0x1e;
 pub const ZERO_INPUT: u8 = 0x1f;
 
+/// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum InputSignal {
@@ -43,6 +44,7 @@ pub enum InputSignal {
     SIG_FUNC_100  = 100,
 }
 
+/// Peripheral output signals for the GPIO mux
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum OutputSignal {

--- a/esp-hal-common/src/gpio/esp32c3.rs
+++ b/esp-hal-common/src/gpio/esp32c3.rs
@@ -5,6 +5,7 @@ pub const INPUT_SIGNAL_MAX: u8 = 100;
 pub const ONE_INPUT: u8 = 0x1e;
 pub const ZERO_INPUT: u8 = 0x1f;
 
+/// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum InputSignal {
@@ -52,6 +53,7 @@ pub enum InputSignal {
     SIG_FUNC_100     = 100,
 }
 
+/// Peripheral output signals for the GPIO mux
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum OutputSignal {

--- a/esp-hal-common/src/gpio/esp32s2.rs
+++ b/esp-hal-common/src/gpio/esp32s2.rs
@@ -69,7 +69,7 @@ pub enum InputSignal {
     PCMCLK            = 204,
 }
 
-/// Peripheral input signals for the GPIO mux
+/// Peripheral output signals for the GPIO mux
 #[allow(non_camel_case_types)]
 #[derive(PartialEq, Copy, Clone)]
 pub enum OutputSignal {

--- a/esp-hal-common/src/gpio/esp32s3.rs
+++ b/esp-hal-common/src/gpio/esp32s3.rs
@@ -102,7 +102,7 @@ pub enum InputSignal {
     PCMCLK            = 189,
 }
 
-/// Peripheral input signals for the GPIO mux
+/// Peripheral output signals for the GPIO mux
 #[allow(non_camel_case_types)]
 #[derive(PartialEq, Copy, Clone)]
 pub enum OutputSignal {
@@ -200,6 +200,18 @@ pub enum OutputSignal {
     SUBSPID6        = 157,
     SUBSPID7        = 158,
     SUBSPIDQS       = 159,
+    PWM0_0A         = 160,
+    PWM0_0B         = 161,
+    PWM0_1A         = 162,
+    PWM0_1B         = 163,
+    PWM0_2A         = 164,
+    PWM0_2B         = 165,
+    PWM1_0A         = 166,
+    PWM1_0B         = 167,
+    PWM1_1A         = 168,
+    PWM1_1B         = 169,
+    PWM1_2A         = 170,
+    PWM1_2B         = 171,
     SDIO_TOHOST_INT = 177,
     PCMFSYNC        = 194,
     PCMCLK          = 195,


### PR DESCRIPTION
Since `OutputSignal` is not marked `non_exhaustive` this is technically a breaking change