### PR TITLE
[DRAFT] Support for RGBW leds

### DIFF
--- a/esp-hal-common/src/utils/mod.rs
+++ b/esp-hal-common/src/utils/mod.rs
@@ -5,6 +5,10 @@
 pub mod smart_leds_adapter;
 #[cfg(feature = "smartled")]
 pub use smart_leds_adapter::SmartLedsAdapter;
+#[cfg(feature = "smartled")]
+pub mod smart_leds_adapter_rgbw;
+#[cfg(feature = "smartled")]
+pub use smart_leds_adapter_rgbw::SmartLedsAdapterRGBW;
 
 // Re-export the macro that due to the macro_export configuration was already exported
 // in the root module (i.e., `esp-hal-common`)

--- a/esp-hal-common/src/utils/smart_leds_adapter_rgbw.rs
+++ b/esp-hal-common/src/utils/smart_leds_adapter_rgbw.rs
@@ -1,0 +1,86 @@
+use core::{marker::PhantomData, slice::IterMut};
+
+use smart_leds_trait::RGBA;
+
+use crate::{
+    pulse_control::{ConfiguredChannel, OutputChannel, RepeatMode},
+    utils::smart_leds_adapter::*,
+    OutputPin,
+};
+pub type RGBA8 = RGBA<u8>;
+
+#[macro_export]
+macro_rules! smartLedAdapterRGBW {
+    ($buffer_size: literal ) => {
+        SmartLedsAdapterRGBW::<_, _, { $buffer_size * 32 + 1 }>
+    };
+}
+
+pub struct SmartLedsAdapterRGBW<CHANNEL, PIN, const BUFFER_SIZE: usize> {
+    channel: CHANNEL,
+    rmt_buffer: [u32; BUFFER_SIZE],
+    _pin: PhantomData<PIN>,
+}
+
+impl<CHANNEL, PIN, const BUFFER_SIZE: usize> SmartLedsAdapterRGBW<CHANNEL, PIN, BUFFER_SIZE>
+where
+    CHANNEL: ConfiguredChannel,
+    PIN: OutputPin,
+{
+    pub fn new<UnconfiguredChannel>(
+        channel: UnconfiguredChannel,
+        pin: PIN,
+    ) -> SmartLedsAdapterRGBW<CHANNEL, PIN, BUFFER_SIZE>
+    where
+        UnconfiguredChannel: OutputChannel<CHANNEL>,
+    {
+        Self {
+            channel: SmartLedsAdapter::<CHANNEL, PIN, BUFFER_SIZE>::configure_channel(channel, pin),
+            rmt_buffer: [0; BUFFER_SIZE],
+            _pin: PhantomData,
+        }
+    }
+
+    fn convert_rgbw_to_pulse(
+        value: RGBA8,
+        mut_iter: &mut IterMut<u32>,
+    ) -> Result<(), LedAdapterError> {
+        SmartLedsAdapter::<CHANNEL, PIN, BUFFER_SIZE>::convert_rgb_channel_to_pulses(
+            value.g, mut_iter,
+        )?;
+        SmartLedsAdapter::<CHANNEL, PIN, BUFFER_SIZE>::convert_rgb_channel_to_pulses(
+            value.r, mut_iter,
+        )?;
+        SmartLedsAdapter::<CHANNEL, PIN, BUFFER_SIZE>::convert_rgb_channel_to_pulses(
+            value.b, mut_iter,
+        )?;
+        SmartLedsAdapter::<CHANNEL, PIN, BUFFER_SIZE>::convert_rgb_channel_to_pulses(
+            value.a, mut_iter,
+        )?;
+        Ok(())
+    }
+
+    // this is a duplicate of the smart_leds_adaptor implementation, except for the
+    // convert_rgbw_to_pulse function
+    pub fn write<T>(&mut self, iterator: T) -> Result<(), LedAdapterError>
+    where
+        T: Iterator<Item = RGBA8>,
+    {
+        let mut seq_iter = self.rmt_buffer.iter_mut();
+        for item in iterator {
+            SmartLedsAdapterRGBW::<CHANNEL, PIN, BUFFER_SIZE>::convert_rgbw_to_pulse(
+                item,
+                &mut seq_iter,
+            )?;
+        }
+        *seq_iter.next().ok_or(LedAdapterError::BufferSizeExceeded)? = 0;
+
+        match self
+            .channel
+            .send_pulse_sequence_raw(RepeatMode::SingleShot, &self.rmt_buffer)
+        {
+            Ok(_) => Ok(()),
+            Err(x) => Err(LedAdapterError::TransmissionError(x)),
+        }
+    }
+}


### PR DESCRIPTION
I've had some success modifying the `smart_leds_adapter` for RGBW. The implementation is identical to the existing adapter, just with three changes:
1. Use the `RGBA8` color type instead of `RGB8`
1. A buffer size of `32` instead of `24`, 
2. Apply the white component in the `convert_rgb_to_pulse` function.

I've tried to balance simplicity with code sharing, the only duplication is the write function, I couldn't think of a simple way to expose that.

If this is out of scope for the crate it would be greatly appreciated if the `smart_led_adapter.rs` change (or something similiar) made it through so that we can hook into the setup and pulse generation from other crates and benefit from any updates made here.

On a 'lighter' note, the rgbw variant is quite popular and the white channel provides some really beautiful colors when mixed with rgb.

![PXL_20221107_065533015](https://user-images.githubusercontent.com/25616826/200246570-5dfde44a-b8b5-4d1a-b848-a7cca220e793.jpg)