### PR TITLE
MCPWM MVP implementation

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -54,7 +54,7 @@ esp32   = { version = "0.16.0", features = ["critical-section"], optional = true
 esp32c2 = { version = "0.5.1",  features = ["critical-section"], optional = true }
 esp32c3 = { version = "0.8.1",  features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.6.0",  features = ["critical-section"], optional = true }
-esp32s3 = { version = "0.9.0",  features = ["critical-section"], optional = true }
+esp32s3 = { version = "0.10.0",  features = ["critical-section"], optional = true }
 
 [features]
 esp32   = ["esp32/rt"  , "procmacros/xtensa", "xtensa-lx-rt/esp32",   "xtensa-lx/esp32",   "critical-section/restore-state-u32", "lock_api"]

--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -113,6 +113,8 @@ pub struct Clocks {
     pub apb_clock: HertzU32,
     pub xtal_clock: HertzU32,
     pub i2c_clock: HertzU32,
+    #[cfg(esp32)]
+    pub pwm_clock: HertzU32,
     #[cfg(esp32s3)]
     pub crypto_pwm_clock: HertzU32,
     // TODO chip specific additional ones as needed
@@ -131,6 +133,8 @@ impl Clocks {
             apb_clock: raw_clocks.apb_clock,
             xtal_clock: raw_clocks.xtal_clock,
             i2c_clock: raw_clocks.i2c_clock,
+            #[cfg(esp32)]
+            pwm_clock: raw_clocks.pwm_clock,
             #[cfg(esp32s3)]
             crypto_pwm_clock: raw_clocks.crypto_pwm_clock,
         }
@@ -143,6 +147,8 @@ pub struct RawClocks {
     pub apb_clock: HertzU32,
     pub xtal_clock: HertzU32,
     pub i2c_clock: HertzU32,
+    #[cfg(esp32)]
+    pub pwm_clock: HertzU32,
     #[cfg(esp32s3)]
     pub crypto_pwm_clock: HertzU32,
     // TODO chip specific additional ones as needed
@@ -178,6 +184,7 @@ impl ClockControl {
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
                 i2c_clock: HertzU32::MHz(80),
+                pwm_clock: HertzU32::MHz(160),
             },
         }
     }
@@ -206,6 +213,10 @@ impl ClockControl {
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
                 i2c_clock: HertzU32::MHz(40),
+                // The docs are unclear here. pwm_clock seems to be tied to clocks.apb_clock
+                // while simultaneously being fixed at 160 MHz.
+                // Testing showed 160 MHz to be correct for current clock configurations.
+                pwm_clock: HertzU32::MHz(160),
             },
         }
     }
@@ -350,7 +361,6 @@ impl ClockControl {
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
                 i2c_clock: HertzU32::MHz(40),
-                #[cfg(esp32s3)]
                 crypto_pwm_clock: HertzU32::MHz(160),
             },
         }
@@ -368,7 +378,6 @@ impl ClockControl {
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
                 i2c_clock: HertzU32::MHz(40),
-                #[cfg(esp32s3)]
                 crypto_pwm_clock: HertzU32::MHz(160),
             },
         }

--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -113,6 +113,8 @@ pub struct Clocks {
     pub apb_clock: HertzU32,
     pub xtal_clock: HertzU32,
     pub i2c_clock: HertzU32,
+    #[cfg(esp32s3)]
+    pub crypto_pwm_clock: HertzU32,
     // TODO chip specific additional ones as needed
 }
 
@@ -129,6 +131,8 @@ impl Clocks {
             apb_clock: raw_clocks.apb_clock,
             xtal_clock: raw_clocks.xtal_clock,
             i2c_clock: raw_clocks.i2c_clock,
+            #[cfg(esp32s3)]
+            crypto_pwm_clock: raw_clocks.crypto_pwm_clock,
         }
     }
 }
@@ -139,6 +143,8 @@ pub struct RawClocks {
     pub apb_clock: HertzU32,
     pub xtal_clock: HertzU32,
     pub i2c_clock: HertzU32,
+    #[cfg(esp32s3)]
+    pub crypto_pwm_clock: HertzU32,
     // TODO chip specific additional ones as needed
 }
 
@@ -344,6 +350,8 @@ impl ClockControl {
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
                 i2c_clock: HertzU32::MHz(40),
+                #[cfg(esp32s3)]
+                crypto_pwm_clock: HertzU32::MHz(160),
             },
         }
     }
@@ -360,6 +368,8 @@ impl ClockControl {
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
                 i2c_clock: HertzU32::MHz(40),
+                #[cfg(esp32s3)]
+                crypto_pwm_clock: HertzU32::MHz(160),
             },
         }
     }

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -62,6 +62,8 @@ pub mod i2c;
 pub mod i2s;
 
 pub mod ledc;
+#[cfg(any(esp32, esp32s3))]
+pub mod mcpwm;
 #[cfg(usb_otg)]
 pub mod otg_fs;
 pub mod prelude;

--- a/esp-hal-common/src/mcpwm/mod.rs
+++ b/esp-hal-common/src/mcpwm/mod.rs
@@ -1,3 +1,62 @@
+//! MCPWM (Motor Control Pulse Width Modulator) peripheral
+//!
+//! # Peripheral capabilities:
+//! * PWM Timers 0, 1 and 2
+//!     * Every PWM timer has a dedicated 8-bit clock prescaler.
+//!     * The 16-bit counter in the PWM timer can work in count-up mode,
+//!       count-down mode or count-up-down mode.
+//!     * A hardware sync or software sync can trigger a reload on the PWM timer
+//!       with a phase register (Not yet implemented)
+//! * PWM Operators 0, 1 and 2
+//!     * Every PWM operator has two PWM outputs: PWMxA and PWMxB. They can work
+//!       independently, in symmetric and asymmetric configuration.
+//!     * Software, asynchronously override control of PWM signals.
+//!     * Configurable dead-time on rising and falling edges; each set up
+//!       independently. (Not yet implemented)
+//!     * All events can trigger CPU interrupts. (Not yet implemented)
+//!     * Modulating of PWM output by high-frequency carrier signals, useful
+//!       when gate drivers are insulated with a transformer. (Not yet
+//!       implemented)
+//!     * Period, time stamps and important control registers have shadow
+//!       registers with flexible updating methods.
+//! * Fault Detection Module (Not yet implemented)
+//! * Capture Module (Not yet implemented)
+//!
+//! # Example
+//! Uses timer0 and operator0 of the MCPWM0 peripheral to output a 50% duty
+//! signal at 20 kHz. The signal will be output to the pin assigned to `pin`.
+//!
+//! ```
+//! # use esp_hal_common::{mcpwm, prelude::*};
+//! use mcpwm::{operator::PwmPinConfig, timer::PwmWorkingMode, PeripheralClockConfig, MCPWM};
+//!
+//! // initialize peripheral
+//! let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40u32.MHz()).unwrap();
+//! let mut mcpwm = MCPWM::new(
+//!     peripherals.PWM0,
+//!     clock_cfg,
+//!     &mut system.peripheral_clock_control,
+//! );
+//!
+//! // connect operator0 to timer0
+//! mcpwm.operator0.set_timer(&mcpwm.timer0);
+//! // connect operator0 to pin
+//! let mut pwm_pin = mcpwm
+//!     .operator0
+//!     .with_pin_a(pin, PwmPinConfig::UP_ACTIVE_HIGH);
+//!
+//! // start timer with timestamp values in the range of 0..=99 and a frequency of 20 kHz
+//! let timer_clock_cfg = clock_cfg
+//!     .timer_clock_with_frequency(99, PwmWorkingMode::Increase, 20u32.kHz())
+//!     .unwrap();
+//! mcpwm.timer0.start(timer_clock_cfg);
+//!
+//! // pin will be high 50% of the time
+//! pwm_pin.set_timestamp(50);
+//! ```
+
+#![deny(missing_docs)]
+
 use core::marker::PhantomData;
 
 use fugit::HertzU32;
@@ -10,26 +69,34 @@ use crate::{
     types::OutputSignal,
 };
 
+/// MCPWM operators
 pub mod operator;
+/// MCPWM timers
 pub mod timer;
 
+/// The MCPWM peripheral
 #[non_exhaustive]
-pub struct MCPWM<'a, PWM> {
-    pub peripheral_clock: PeripheralClockConfig<'a>,
+pub struct MCPWM<PWM> {
+    /// Timer0
     pub timer0: Timer<0, PWM>,
+    /// Timer1
     pub timer1: Timer<1, PWM>,
+    /// Timer2
     pub timer2: Timer<2, PWM>,
+    /// Operator0
     pub operator0: Operator<0, PWM>,
+    /// Operator1
     pub operator1: Operator<1, PWM>,
+    /// Operator2
     pub operator2: Operator<2, PWM>,
 }
 
-impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
+impl<PWM: PwmPeripheral> MCPWM<PWM> {
     /// `pwm_clk = clocks.crypto_pwm_clock / (prescaler + 1)`
     // clocks.crypto_pwm_clock normally is 160 MHz
     pub fn new(
         peripheral: PWM,
-        peripheral_clock: PeripheralClockConfig<'a>,
+        peripheral_clock: PeripheralClockConfig,
         system: &mut PeripheralClockControl,
     ) -> Self {
         let _ = peripheral;
@@ -45,7 +112,6 @@ impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
         block.clk.write(|w| w.en().set_bit());
 
         MCPWM {
-            peripheral_clock,
             timer0: Timer::new(),
             timer1: Timer::new(),
             timer2: Timer::new(),
@@ -56,6 +122,7 @@ impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
     }
 }
 
+/// Clock configuration of the MCPWM peripheral
 #[derive(Copy, Clone)]
 pub struct PeripheralClockConfig<'a> {
     frequency: HertzU32,
@@ -64,6 +131,13 @@ pub struct PeripheralClockConfig<'a> {
 }
 
 impl<'a> PeripheralClockConfig<'a> {
+    /// Get a clock configuration with the given prescaler.
+    ///
+    /// With standard system clock configurations the input clock to the MCPWM
+    /// peripheral is `160 MHz`.
+    ///
+    /// The peripheral clock frequency is calculated as:
+    /// `peripheral_clock = input_clock / (prescaler + 1)`
     pub fn with_prescaler(clocks: &'a Clocks, prescaler: u8) -> Self {
         #[cfg(esp32)]
         let source_clock = clocks.pwm_clock;
@@ -77,6 +151,20 @@ impl<'a> PeripheralClockConfig<'a> {
         }
     }
 
+    /// Get a clock configuration with the given frequency.
+    ///
+    /// ### Note:
+    /// This will try to select an appropriate prescaler for the
+    /// [`PeripheralClockConfig::with_prescaler`] method.
+    /// If the calculated prescaler is not in the range `0..u8::MAX`
+    /// [`FrequencyError`] will be returned.
+    ///
+    /// With standard system clock configurations the input clock to the MCPWM
+    /// peripheral is `160 MHz`.
+    ///
+    /// Only divisors of the input clock (`160 Mhz / 1`, `160 Mhz / 2`, ...,
+    /// `160 Mhz / 256`) are representable exactly. Other target frequencies
+    /// will be rounded up to the next divisor.
     pub fn with_frequency(
         clocks: &'a Clocks,
         target_freq: HertzU32,
@@ -96,10 +184,23 @@ impl<'a> PeripheralClockConfig<'a> {
         Ok(Self::with_prescaler(clocks, prescaler as u8))
     }
 
+    /// Get the peripheral clock frequency.
+    ///
+    /// ### Note:
+    /// The actual value is rounded down to the nearest `u32` value
     pub fn frequency(&self) -> HertzU32 {
         self.frequency
     }
 
+    /// Get a timer clock configuration with the given prescaler.
+    ///
+    /// The resulting timer frequency depends of the chosen
+    /// [`timer::PwmWorkingMode`].
+    ///
+    /// #### `PwmWorkingMode::Increase` or `PwmWorkingMode::Decrease`
+    /// `timer_frequency = peripheral_clock / (prescaler + 1) / (period + 1)`
+    /// #### `PwmWorkingMode::UpDown`
+    /// `timer_frequency = peripheral_clock / (prescaler + 1) / (2 * period)`
     pub fn timer_clock_with_prescaler(
         &self,
         period: u16,
@@ -109,6 +210,15 @@ impl<'a> PeripheralClockConfig<'a> {
         timer::TimerClockConfig::with_prescaler(self, period, mode, prescaler)
     }
 
+    /// Get a timer clock configuration with the given frequency.
+    ///
+    /// ### Note:
+    /// This will try to select an appropriate prescaler for the timer.
+    /// If the calculated prescaler is not in the range `0..u8::MAX`
+    /// [`FrequencyError`] will be returned.
+    ///
+    /// See [`PeripheralClockConfig::timer_clock_with_prescaler`] for how the
+    /// frequency is calculated.
     pub fn timer_clock_with_frequency(
         &self,
         period: u16,
@@ -119,7 +229,9 @@ impl<'a> PeripheralClockConfig<'a> {
     }
 }
 
-#[derive(Debug)]
+/// Target frequency could not be set.
+/// Check how the frequency is calculated in the corresponding method docs.
+#[derive(Copy, Clone, Debug)]
 pub struct FrequencyError;
 
 /// A MCPWM peripheral

--- a/esp-hal-common/src/mcpwm/mod.rs
+++ b/esp-hal-common/src/mcpwm/mod.rs
@@ -81,10 +81,8 @@ impl<'a> PwmClock<'a> {
 
     #[cfg(esp32)]
     fn new(clocks: &'a Clocks, prescaler: u8) -> Self {
-        // TODO Docs are unclear here, need to test this
-
         PwmClock {
-            pwm_clock: clocks.apb_clock / (prescaler as u32 + 1),
+            pwm_clock: clocks.pwm_clock / (prescaler as u32 + 1),
             phantom: PhantomData,
         }
     }

--- a/esp-hal-common/src/mcpwm/mod.rs
+++ b/esp-hal-common/src/mcpwm/mod.rs
@@ -43,9 +43,6 @@ impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
         // enable clock
         block.clk.write(|w| w.en().set_bit());
 
-        // sync comparator updates when timer counter is equal to zero.
-        Self::set_comparator_update_method(block, 0b0001);
-
         MCPWM {
             pwm_clk: PwmClock::new(clocks, prescaler),
             timer0: Timer::new(),
@@ -55,50 +52,6 @@ impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
             operator1: Operator::new(),
             operator2: Operator::new(),
         }
-    }
-
-    #[cfg(esp32)]
-    fn set_comparator_update_method(block: &crate::pac::pwm0::RegisterBlock, bits: u8) {
-        block.gen0_stmp_cfg.write(|w| {
-            w.gen0_a_upmethod()
-                .variant(bits)
-                .gen0_b_upmethod()
-                .variant(bits)
-        });
-        block.gen1_stmp_cfg.write(|w| {
-            w.gen1_a_upmethod()
-                .variant(bits)
-                .gen1_b_upmethod()
-                .variant(bits)
-        });
-        block.gen2_stmp_cfg.write(|w| {
-            w.gen2_a_upmethod()
-                .variant(bits)
-                .gen2_b_upmethod()
-                .variant(bits)
-        });
-    }
-
-    #[cfg(esp32s3)]
-    fn set_comparator_update_method(block: &crate::pac::pwm0::RegisterBlock, bits: u8) {
-        block.cmpr0_cfg.write(|w| {
-            w.cmpr0_a_upmethod()
-                .variant(bits)
-                .cmpr0_b_upmethod()
-                .variant(bits)
-        });
-        block.cmpr1_cfg.write(|w| {
-            w.cmpr1_a_upmethod()
-                .variant(bits)
-                .cmpr1_b_upmethod()
-                .variant(bits)
-        });
-        block.cmpr2_cfg.write(|w| {
-            w.cmpr2_a_upmethod()
-                .variant(bits)
-                .cmpr2_b_upmethod()
-                .variant(bits)
-        });
     }
 }
 

--- a/esp-hal-common/src/mcpwm/mod.rs
+++ b/esp-hal-common/src/mcpwm/mod.rs
@@ -57,7 +57,7 @@
 
 #![deny(missing_docs)]
 
-use core::marker::PhantomData;
+use core::{marker::PhantomData, ops::Deref};
 
 use fugit::HertzU32;
 use operator::Operator;
@@ -103,13 +103,12 @@ impl<PWM: PwmPeripheral> MCPWM<PWM> {
 
         PWM::enable(system);
 
-        let block = unsafe { &*PWM::block() };
         // set prescaler
-        block
+        peripheral
             .clk_cfg
             .write(|w| w.clk_prescale().variant(peripheral_clock.prescaler));
         // enable clock
-        block.clk.write(|w| w.en().set_bit());
+        peripheral.clk.write(|w| w.en().set_bit());
 
         MCPWM {
             timer0: Timer::new(),
@@ -235,7 +234,7 @@ impl<'a> PeripheralClockConfig<'a> {
 pub struct FrequencyError;
 
 /// A MCPWM peripheral
-pub unsafe trait PwmPeripheral {
+pub unsafe trait PwmPeripheral: Deref<Target = crate::pac::pwm0::RegisterBlock> {
     /// Enable peripheral
     fn enable(system: &mut PeripheralClockControl);
     /// Get a pointer to the peripheral RegisterBlock

--- a/esp-hal-common/src/mcpwm/mod.rs
+++ b/esp-hal-common/src/mcpwm/mod.rs
@@ -13,18 +13,15 @@ use crate::{
 pub mod operator;
 pub mod timer;
 
-// TODO provide a getter
-pub struct PwmClock(HertzU32);
-
+#[non_exhaustive]
 pub struct MCPWM<'a, PWM> {
+    pub pwm_clk: PwmClock<'a>,
     pub timer0: Timer<0, PWM>,
     pub timer1: Timer<1, PWM>,
     pub timer2: Timer<2, PWM>,
     pub operator0: Operator<0, PWM>,
     pub operator1: Operator<1, PWM>,
     pub operator2: Operator<2, PWM>,
-    pub pwm_clk: PwmClock,
-    phantom: PhantomData<(&'a Clocks, PWM)>,
 }
 
 impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
@@ -49,30 +46,15 @@ impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
         // sync comparator updates when timer counter is equal to zero.
         Self::set_comparator_update_method(block, 0b0001);
 
-        #[cfg(esp32)]
-        // TODO Docs are unclear here, need to test this
-        let pwm_clk = PwmClock(clocks.apb_clock / (prescaler as u32 + 1));
-        #[cfg(esp32s3)]
-        let pwm_clk = PwmClock(clocks.crypto_pwm_clock / (prescaler as u32 + 1));
-
         MCPWM {
+            pwm_clk: PwmClock::new(clocks, prescaler),
             timer0: Timer::new(),
             timer1: Timer::new(),
             timer2: Timer::new(),
             operator0: Operator::new(),
             operator1: Operator::new(),
             operator2: Operator::new(),
-            pwm_clk,
-            phantom: PhantomData,
         }
-    }
-
-    pub fn timer_freq(&self, mode: timer::PwmWorkingMode, prescaler: u8, period: u16) -> HertzU32 {
-        let period = match mode {
-            timer::PwmWorkingMode::Increase | timer::PwmWorkingMode::Decrease => period as u32 + 1,
-            timer::PwmWorkingMode::UpDown => period as u32 * 2,
-        };
-        self.pwm_clk.0 / (prescaler as u32 + 1) / period
     }
 
     #[cfg(esp32)]
@@ -117,6 +99,49 @@ impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
                 .cmpr2_b_upmethod()
                 .variant(bits)
         });
+    }
+}
+
+pub struct PwmClock<'a> {
+    pwm_clock: HertzU32,
+    phantom: PhantomData<&'a Clocks>,
+}
+
+impl<'a> PwmClock<'a> {
+    pub fn clock_frequency(&self) -> HertzU32 {
+        self.pwm_clock
+    }
+
+    pub fn timer_frequency(
+        &self,
+        mode: timer::PwmWorkingMode,
+        prescaler: u8,
+        period: u16,
+    ) -> HertzU32 {
+        let period = match mode {
+            timer::PwmWorkingMode::Increase | timer::PwmWorkingMode::Decrease => period as u32 + 1,
+            // The reference manual seems to provide an incorrect formula for UpDown
+            timer::PwmWorkingMode::UpDown => period as u32 * 2,
+        };
+        self.pwm_clock / (prescaler as u32 + 1) / period
+    }
+
+    #[cfg(esp32)]
+    fn new(clocks: &'a Clocks, prescaler: u8) -> Self {
+        // TODO Docs are unclear here, need to test this
+
+        PwmClock {
+            pwm_clock: clocks.apb_clock / (prescaler as u32 + 1),
+            phantom: PhantomData,
+        }
+    }
+
+    #[cfg(esp32s3)]
+    fn new(clocks: &'a Clocks, prescaler: u8) -> Self {
+        PwmClock {
+            pwm_clock: clocks.crypto_pwm_clock / (prescaler as u32 + 1),
+            phantom: PhantomData,
+        }
     }
 }
 

--- a/esp-hal-common/src/mcpwm/mod.rs
+++ b/esp-hal-common/src/mcpwm/mod.rs
@@ -241,7 +241,7 @@ pub unsafe trait PwmPeripheral {
     /// Get a pointer to the peripheral RegisterBlock
     fn block() -> *const crate::pac::pwm0::RegisterBlock;
     /// Get operator GPIO mux output signal
-    fn output_signal<const O: u8, const IS_A: bool>() -> OutputSignal;
+    fn output_signal<const OP: u8, const IS_A: bool>() -> OutputSignal;
 }
 
 unsafe impl PwmPeripheral for crate::pac::PWM0 {
@@ -253,8 +253,8 @@ unsafe impl PwmPeripheral for crate::pac::PWM0 {
         Self::ptr()
     }
 
-    fn output_signal<const O: u8, const IS_A: bool>() -> OutputSignal {
-        match (O, IS_A) {
+    fn output_signal<const OP: u8, const IS_A: bool>() -> OutputSignal {
+        match (OP, IS_A) {
             (0, true) => OutputSignal::PWM0_0A,
             (1, true) => OutputSignal::PWM0_1A,
             (2, true) => OutputSignal::PWM0_1A,
@@ -275,8 +275,8 @@ unsafe impl PwmPeripheral for crate::pac::PWM1 {
         Self::ptr()
     }
 
-    fn output_signal<const O: u8, const IS_A: bool>() -> OutputSignal {
-        match (O, IS_A) {
+    fn output_signal<const OP: u8, const IS_A: bool>() -> OutputSignal {
+        match (OP, IS_A) {
             (0, true) => OutputSignal::PWM1_0A,
             (1, true) => OutputSignal::PWM1_1A,
             (2, true) => OutputSignal::PWM1_1A,

--- a/esp-hal-common/src/mcpwm/mod.rs
+++ b/esp-hal-common/src/mcpwm/mod.rs
@@ -1,0 +1,175 @@
+use core::marker::PhantomData;
+
+use fugit::HertzU32;
+use operator::Operator;
+use timer::Timer;
+
+use crate::{
+    clock::Clocks,
+    system::{Peripheral, PeripheralClockControl},
+    types::OutputSignal,
+};
+
+pub mod operator;
+pub mod timer;
+
+// TODO provide a getter
+pub struct PwmClock(HertzU32);
+
+pub struct MCPWM<'a, PWM> {
+    pub timer0: Timer<0, PWM>,
+    pub timer1: Timer<1, PWM>,
+    pub timer2: Timer<2, PWM>,
+    pub operator0: Operator<0, PWM>,
+    pub operator1: Operator<1, PWM>,
+    pub operator2: Operator<2, PWM>,
+    pub pwm_clk: PwmClock,
+    phantom: PhantomData<(&'a Clocks, PWM)>,
+}
+
+impl<'a, PWM: PwmPeripheral> MCPWM<'a, PWM> {
+    /// `pwm_clk = clocks.crypto_pwm_clock / (prescaler + 1)`
+    // clocks.crypto_pwm_clock normally is 160 MHz
+    pub fn new(
+        peripheral: PWM,
+        clocks: &'a Clocks,
+        prescaler: u8,
+        system: &mut PeripheralClockControl,
+    ) -> Self {
+        let _ = peripheral;
+
+        PWM::enable(system);
+
+        let block = unsafe { &*PWM::block() };
+        // set prescaler
+        block.clk_cfg.write(|w| w.clk_prescale().variant(prescaler));
+        // enable clock
+        block.clk.write(|w| w.en().set_bit());
+
+        // sync comparator updates when timer counter is equal to zero.
+        Self::set_comparator_update_method(block, 0b0001);
+
+        #[cfg(esp32)]
+        // TODO Docs are unclear here, need to test this
+        let pwm_clk = PwmClock(clocks.apb_clock / (prescaler as u32 + 1));
+        #[cfg(esp32s3)]
+        let pwm_clk = PwmClock(clocks.crypto_pwm_clock / (prescaler as u32 + 1));
+
+        MCPWM {
+            timer0: Timer::new(),
+            timer1: Timer::new(),
+            timer2: Timer::new(),
+            operator0: Operator::new(),
+            operator1: Operator::new(),
+            operator2: Operator::new(),
+            pwm_clk,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn timer_freq(&self, mode: timer::PwmWorkingMode, prescaler: u8, period: u16) -> HertzU32 {
+        let period = match mode {
+            timer::PwmWorkingMode::Increase | timer::PwmWorkingMode::Decrease => period as u32 + 1,
+            timer::PwmWorkingMode::UpDown => period as u32 * 2,
+        };
+        self.pwm_clk.0 / (prescaler as u32 + 1) / period
+    }
+
+    #[cfg(esp32)]
+    fn set_comparator_update_method(block: &crate::pac::pwm0::RegisterBlock, bits: u8) {
+        block.gen0_stmp_cfg.write(|w| {
+            w.gen0_a_upmethod()
+                .variant(bits)
+                .gen0_b_upmethod()
+                .variant(bits)
+        });
+        block.gen1_stmp_cfg.write(|w| {
+            w.gen1_a_upmethod()
+                .variant(bits)
+                .gen1_b_upmethod()
+                .variant(bits)
+        });
+        block.gen2_stmp_cfg.write(|w| {
+            w.gen2_a_upmethod()
+                .variant(bits)
+                .gen2_b_upmethod()
+                .variant(bits)
+        });
+    }
+
+    #[cfg(esp32s3)]
+    fn set_comparator_update_method(block: &crate::pac::pwm0::RegisterBlock, bits: u8) {
+        block.cmpr0_cfg.write(|w| {
+            w.cmpr0_a_upmethod()
+                .variant(bits)
+                .cmpr0_b_upmethod()
+                .variant(bits)
+        });
+        block.cmpr1_cfg.write(|w| {
+            w.cmpr1_a_upmethod()
+                .variant(bits)
+                .cmpr1_b_upmethod()
+                .variant(bits)
+        });
+        block.cmpr2_cfg.write(|w| {
+            w.cmpr2_a_upmethod()
+                .variant(bits)
+                .cmpr2_b_upmethod()
+                .variant(bits)
+        });
+    }
+}
+
+/// A MCPWM peripheral
+pub unsafe trait PwmPeripheral {
+    /// Enable peripheral
+    fn enable(system: &mut PeripheralClockControl);
+    /// Get a pointer to the peripheral RegisterBlock
+    fn block() -> *const crate::pac::pwm0::RegisterBlock;
+    /// Get operator GPIO mux output signal
+    fn output_signal<const O: u8, const IS_A: bool>() -> OutputSignal;
+}
+
+unsafe impl PwmPeripheral for crate::pac::PWM0 {
+    fn enable(system: &mut PeripheralClockControl) {
+        system.enable(Peripheral::Mcpwm0)
+    }
+
+    fn block() -> *const crate::pac::pwm0::RegisterBlock {
+        Self::ptr()
+    }
+
+    fn output_signal<const O: u8, const IS_A: bool>() -> OutputSignal {
+        match (O, IS_A) {
+            (0, true) => OutputSignal::PWM0_0A,
+            (1, true) => OutputSignal::PWM0_1A,
+            (2, true) => OutputSignal::PWM0_1A,
+            (0, false) => OutputSignal::PWM0_0B,
+            (1, false) => OutputSignal::PWM0_1B,
+            (2, false) => OutputSignal::PWM0_1B,
+            _ => unreachable!(),
+        }
+    }
+}
+
+unsafe impl PwmPeripheral for crate::pac::PWM1 {
+    fn enable(system: &mut PeripheralClockControl) {
+        system.enable(Peripheral::Mcpwm1)
+    }
+
+    fn block() -> *const crate::pac::pwm0::RegisterBlock {
+        Self::ptr()
+    }
+
+    fn output_signal<const O: u8, const IS_A: bool>() -> OutputSignal {
+        match (O, IS_A) {
+            (0, true) => OutputSignal::PWM1_0A,
+            (1, true) => OutputSignal::PWM1_1A,
+            (2, true) => OutputSignal::PWM1_1A,
+            (0, false) => OutputSignal::PWM1_0B,
+            (1, false) => OutputSignal::PWM1_1B,
+            (2, false) => OutputSignal::PWM1_1B,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/esp-hal-common/src/mcpwm/operator.rs
+++ b/esp-hal-common/src/mcpwm/operator.rs
@@ -34,6 +34,8 @@ impl<const OP: u8, PWM: PwmPeripheral> Operator<OP, PWM> {
     /// By default TIMER0 is used
     pub fn set_timer<const TIM: u8>(&mut self, timer: &Timer<TIM, PWM>) {
         let _ = timer;
+        // SAFETY:
+        // We only write to our OPERATORx_TIMERSEL register
         let block = unsafe { &*PWM::block() };
         block.operator_timersel.modify(|_, w| match OP {
             0 => w.operator0_timersel().variant(TIM),
@@ -109,7 +111,9 @@ pub struct PwmPin<Pin, PWM, const OP: u8, const IS_A: bool> {
     phantom: PhantomData<PWM>,
 }
 
-impl<Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<Pin, PWM, OP, IS_A> {
+impl<Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
+    PwmPin<Pin, PWM, OP, IS_A>
+{
     fn new(mut pin: Pin, config: PwmPinConfig<IS_A>) -> Self {
         let output_signal = PWM::output_signal::<OP, IS_A>();
         pin.enable_output(true)
@@ -126,7 +130,7 @@ impl<Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<
     /// Configure what actions should be taken on timing events
     pub fn set_actions(&mut self, value: PwmActions<IS_A>) {
         // SAFETY:
-        // We only grant access to our GENx_x register with the lifetime of &mut self
+        // We only write to our GENx_x register
         let block = unsafe { &*PWM::block() };
 
         let bits = value.0;
@@ -149,6 +153,8 @@ impl<Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<
     /// Set how a new timestamp syncs with the timer
     #[cfg(esp32)]
     pub fn set_update_method(&mut self, update_method: PwmUpdateMethod) {
+        // SAFETY:
+        // We only write to our GENx_x_UPMETHOD register
         let block = unsafe { &*PWM::block() };
         let bits = update_method.0;
         match (OP, IS_A) {
@@ -179,6 +185,8 @@ impl<Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<
     /// Set how a new timestamp syncs with the timer
     #[cfg(esp32s3)]
     pub fn set_update_method(&mut self, update_method: PwmUpdateMethod) {
+        // SAFETY:
+        // We only write to our GENx_x_UPMETHOD register
         let block = unsafe { &*PWM::block() };
         let bits = update_method.0;
         match (OP, IS_A) {
@@ -211,6 +219,8 @@ impl<Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<
     /// [`PwmUpdateMethod`].
     #[cfg(esp32)]
     pub fn set_timestamp(&mut self, value: u16) {
+        // SAFETY:
+        // We only write to our GENx_TSTMP_x register
         let block = unsafe { &*PWM::block() };
         match (OP, IS_A) {
             (0, true) => block.gen0_tstmp_a.write(|w| w.gen0_a().variant(value)),
@@ -230,6 +240,8 @@ impl<Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<
     /// [`PwmUpdateMethod`].
     #[cfg(esp32s3)]
     pub fn set_timestamp(&mut self, value: u16) {
+        // SAFETY:
+        // We only write to our GENx_TSTMP_x register
         let block = unsafe { &*PWM::block() };
         match (OP, IS_A) {
             (0, true) => block.cmpr0_value0.write(|w| w.cmpr0_a().variant(value)),

--- a/esp-hal-common/src/mcpwm/operator.rs
+++ b/esp-hal-common/src/mcpwm/operator.rs
@@ -21,8 +21,12 @@ pub struct Operator<const OP: u8, PWM> {
 
 impl<const OP: u8, PWM: PwmPeripheral> Operator<OP, PWM> {
     pub(super) fn new() -> Self {
-        // TODO maybe set timersel to 3 to disable?
-
+        // Side note:
+        // It would have been nice to deselect any timer reference on peripheral
+        // initialization.
+        // However experimentation (ESP32-S3) showed that writing `3` to timersel
+        // will not disable the timer reference but instead act as though `2` was
+        // written.
         Operator {
             phantom: PhantomData,
         }

--- a/esp-hal-common/src/mcpwm/operator.rs
+++ b/esp-hal-common/src/mcpwm/operator.rs
@@ -1,0 +1,201 @@
+use core::marker::PhantomData;
+
+use crate::{
+    mcpwm::{timer::Timer, PwmPeripheral},
+    OutputPin,
+};
+
+pub struct Operator<const O: u8, PWM> {
+    phantom: PhantomData<PWM>,
+}
+
+impl<const O: u8, PWM: PwmPeripheral> Operator<O, PWM> {
+    pub(super) fn new() -> Self {
+        // TODO maybe set timersel to 3 to disable?
+
+        Operator {
+            phantom: PhantomData,
+        }
+    }
+
+    /// Select which [`Timer`] is the timing reference for this operator
+    ///
+    /// ### Note:
+    /// By default TIMER0 is used
+    pub fn set_timer<const T: u8>(&mut self, timer: &Timer<T, PWM>) {
+        let _ = timer;
+        let block = unsafe { &*PWM::block() };
+        block.operator_timersel.modify(|_, w| match O {
+            0 => w.operator0_timersel().variant(T),
+            1 => w.operator1_timersel().variant(T),
+            2 => w.operator2_timersel().variant(T),
+            _ => {
+                unreachable!()
+            }
+        });
+    }
+
+    pub fn with_a_pin<Pin: OutputPin>(
+        self,
+        pin: Pin,
+        actions: PwmActions<true>,
+    ) -> PwmPin<Pin, PWM, O, true> {
+        let mut pin = PwmPin::new(pin);
+        pin.set_actions(actions);
+        pin
+    }
+    pub fn with_b_pin<Pin: OutputPin>(
+        self,
+        pin: Pin,
+        actions: PwmActions<false>,
+    ) -> PwmPin<Pin, PWM, O, false> {
+        let mut pin = PwmPin::new(pin);
+        pin.set_actions(actions);
+        pin
+    }
+    pub fn with_pins<PinA: OutputPin, PinB: OutputPin>(
+        self,
+        pin_a: PinA,
+        actions_a: PwmActions<true>,
+        pin_b: PinB,
+        actions_b: PwmActions<false>,
+    ) -> (PwmPin<PinA, PWM, O, true>, PwmPin<PinB, PWM, O, false>) {
+        let self2 = Self::new();
+        (
+            self.with_a_pin(pin_a, actions_a),
+            self2.with_b_pin(pin_b, actions_b),
+        )
+    }
+}
+
+pub struct PwmPin<Pin, PWM, const O: u8, const IS_A: bool> {
+    _pin: Pin,
+    phantom: PhantomData<PWM>,
+}
+
+impl<Pin: OutputPin, PWM: PwmPeripheral, const O: u8, const IS_A: bool> PwmPin<Pin, PWM, O, IS_A> {
+    fn new(mut pin: Pin) -> Self {
+        let output_signal = PWM::output_signal::<O, IS_A>();
+        pin.enable_output(true)
+            .connect_peripheral_to_output(output_signal);
+        PwmPin {
+            _pin: pin,
+            phantom: PhantomData,
+        }
+    }
+
+    // TODO mention that using A on B and vice versa is not supported
+    // TODO should this be public?
+    pub fn set_actions(&mut self, value: PwmActions<IS_A>) {
+        // SAFETY:
+        // We only grant access to our GENx_x register with the lifetime of &mut self
+        let block = unsafe { &*PWM::block() };
+
+        let bits = value.0;
+
+        // SAFETY:
+        // `bits` is a valid bit pattern
+        unsafe {
+            match (O, IS_A) {
+                (0, true) => block.gen0_a.write(|w| w.bits(bits)),
+                (1, true) => block.gen1_a.write(|w| w.bits(bits)),
+                (2, true) => block.gen2_a.write(|w| w.bits(bits)),
+                (0, false) => block.gen0_b.write(|w| w.bits(bits)),
+                (1, false) => block.gen1_b.write(|w| w.bits(bits)),
+                (2, false) => block.gen2_b.write(|w| w.bits(bits)),
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[cfg(esp32)]
+    pub fn set_timestamp(&mut self, value: u16) {
+        let block = unsafe { &*PWM::block() };
+        unsafe {
+            match (O, IS_A) {
+                (0, true) => &block.gen0_tstmp_a.write(|w| w.gen0_a().bits(value)),
+                (1, true) => &block.gen1_tstmp_a.write(|w| w.gen1_a().bits(value)),
+                (2, true) => &block.gen2_tstmp_a.write(|w| w.gen2_a().bits(value)),
+                (0, false) => &block.gen0_tstmp_b.write(|w| w.gen0_b().bits(value)),
+                (1, false) => &block.gen1_tstmp_b.write(|w| w.gen1_b().bits(value)),
+                (2, false) => &block.gen2_tstmp_b.write(|w| w.gen2_b().bits(value)),
+                _ => {
+                    unreachable!()
+                }
+            }
+        };
+    }
+
+    #[cfg(esp32s3)]
+    pub fn set_timestamp(&mut self, value: u16) {
+        let block = unsafe { &*PWM::block() };
+        unsafe {
+            match (O, IS_A) {
+                (0, true) => &block.cmpr0_value0.write(|w| w.cmpr0_a().bits(value)),
+                (1, true) => &block.cmpr1_value0.write(|w| w.cmpr1_a().bits(value)),
+                (2, true) => &block.cmpr2_value0.write(|w| w.cmpr2_a().bits(value)),
+                (0, false) => &block.cmpr0_value1.write(|w| w.cmpr0_b().bits(value)),
+                (1, false) => &block.cmpr1_value1.write(|w| w.cmpr1_b().bits(value)),
+                (2, false) => &block.cmpr2_value1.write(|w| w.cmpr2_b().bits(value)),
+                _ => {
+                    unreachable!()
+                }
+            }
+        };
+    }
+}
+
+#[repr(u32)]
+pub enum UpdateAction {
+    None    = 0,
+    SetLow  = 1,
+    SetHigh = 2,
+    Toggle  = 3,
+}
+
+pub struct PwmActions<const IS_A: bool>(u32);
+
+impl<const IS_A: bool> PwmActions<IS_A> {
+    pub const UP_ACTIVE_HIGH: Self = Self::empty()
+        .on_up_counting_timer_equals_zero(UpdateAction::SetHigh)
+        .on_up_counting_timer_equals_timestamp(UpdateAction::SetLow);
+
+    pub const UP_DOWN_ACTIVE_HIGH: Self = Self::empty()
+        .on_down_counting_timer_equals_timestamp(UpdateAction::SetHigh)
+        .on_up_counting_timer_equals_timestamp(UpdateAction::SetLow);
+
+    pub const fn empty() -> Self {
+        PwmActions(0)
+    }
+    pub const fn on_up_counting_timer_equals_zero(self, action: UpdateAction) -> Self {
+        self.with_value_at_offset(action as u32, 0)
+    }
+    pub const fn on_up_counting_timer_equals_period(self, action: UpdateAction) -> Self {
+        self.with_value_at_offset(action as u32, 2)
+    }
+    pub const fn on_up_counting_timer_equals_timestamp(self, action: UpdateAction) -> Self {
+        match IS_A {
+            true => self.with_value_at_offset(action as u32, 4),
+            false => self.with_value_at_offset(action as u32, 6),
+        }
+    }
+
+    pub const fn on_down_counting_timer_equals_zero(self, action: UpdateAction) -> Self {
+        self.with_value_at_offset(action as u32, 12)
+    }
+    pub const fn on_down_counting_timer_equals_period(self, action: UpdateAction) -> Self {
+        self.with_value_at_offset(action as u32, 14)
+    }
+    pub const fn on_down_counting_timer_equals_timestamp(self, action: UpdateAction) -> Self {
+        match IS_A {
+            true => self.with_value_at_offset(action as u32, 16),
+            false => self.with_value_at_offset(action as u32, 18),
+        }
+    }
+
+    const fn with_value_at_offset(self, value: u32, offset: u32) -> Self {
+        let mask = !(0b11 << offset);
+        let value = (self.0 & mask) | (value << offset);
+        PwmActions(value)
+    }
+}

--- a/esp-hal-common/src/mcpwm/timer.rs
+++ b/esp-hal-common/src/mcpwm/timer.rs
@@ -18,7 +18,7 @@ pub enum PwmWorkingMode {
     /// This is a combination of the two modes mentioned above. The PWM timer
     /// starts increasing from zero until the period value is reached. Then,
     /// the timer decreases back to zero. This pattern is then repeated. The
-    /// PWM period is the result of (the value of the period field × 2 + 1).
+    /// PWM period is the result of the value of the period field × 2.
     UpDown   = 3,
 }
 

--- a/esp-hal-common/src/mcpwm/timer.rs
+++ b/esp-hal-common/src/mcpwm/timer.rs
@@ -1,0 +1,148 @@
+use core::marker::PhantomData;
+
+use crate::mcpwm::PwmPeripheral;
+
+/// PWM working mode
+#[repr(u8)]
+pub enum PwmWorkingMode {
+    /// In this mode, the PWM timer increments from zero until reaching the
+    /// value configured in the period field. Once done, the PWM timer
+    /// returns to zero and starts increasing again. PWM period is equal to the
+    /// value of the period field + 1.
+    Increase = 1,
+    /// The PWM timer decrements to zero, starting from the value configured in
+    /// the period field. After reaching zero, it is set back to the period
+    /// value. Then it starts to decrement again. In this case, the PWM period
+    /// is also equal to the value of period field + 1.
+    Decrease = 2,
+    /// This is a combination of the two modes mentioned above. The PWM timer
+    /// starts increasing from zero until the period value is reached. Then,
+    /// the timer decreases back to zero. This pattern is then repeated. The
+    /// PWM period is the result of (the value of the period field × 2 + 1).
+    UpDown   = 3,
+}
+
+pub struct Timer<const T: u8, PWM> {
+    pub(super) phantom: PhantomData<PWM>,
+}
+
+impl<const T: u8, PWM: PwmPeripheral> Timer<T, PWM> {
+    pub(super) fn new() -> Self {
+        Timer {
+            phantom: PhantomData,
+        }
+    }
+
+    /// Set the prescaler, period and then the mode
+    ///
+    /// ### Note:
+    /// `prescaler` and `period` will be applied immediately.
+    /// If the timer is already running you might want to call [`stop`] first.
+    ///
+    /// Note also that the hardware supports writing these settings
+    /// in sync with certain timer events but this HAL does not expose these for
+    /// now.
+    pub fn start(&mut self, prescaler: u8, period: u16, mode: PwmWorkingMode) {
+        // write prescaler and period with immediate update method
+        unsafe {
+            self.cfg0().write(|w| {
+                w.timer0_prescale()
+                    .bits(prescaler)
+                    .timer0_period()
+                    .bits(period)
+                    .timer0_period_upmethod()
+                    .variant(0)
+            });
+        }
+
+        // set timer to continuously run and set the timer working mode
+        self.cfg1()
+            .write(|w| w.timer0_start().variant(2).timer0_mod().variant(mode as u8));
+    }
+
+    pub fn stop(&mut self) {
+        // freeze the timer
+        self.cfg1().write(|w| w.timer0_mod().variant(0));
+    }
+
+    pub fn status(&self) -> (u16, CounterDirection) {
+        let block = unsafe { &*PWM::block() };
+
+        match T {
+            0 => {
+                let reg = block.timer0_status.read();
+                (
+                    reg.timer0_value().bits(),
+                    reg.timer0_direction().bit_is_set().into(),
+                )
+            }
+            1 => {
+                let reg = block.timer1_status.read();
+                (
+                    reg.timer1_value().bits(),
+                    reg.timer1_direction().bit_is_set().into(),
+                )
+            }
+            2 => {
+                let reg = block.timer2_status.read();
+                (
+                    reg.timer2_value().bits(),
+                    reg.timer2_direction().bit_is_set().into(),
+                )
+            }
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+
+    fn cfg0(&mut self) -> &crate::pac::pwm0::TIMER0_CFG0 {
+        // SAFETY:
+        // We only grant access to our CFG0 register with the lifetime of &mut self
+        let block = unsafe { &*PWM::block() };
+
+        // SAFETY:
+        // The CFG0 registers are identical for all timers so we can pretend they're
+        // TIMER0_CFG0
+        match T {
+            0 => &block.timer0_cfg0,
+            1 => unsafe { &*(&block.timer1_cfg0 as *const _ as *const _) },
+            2 => unsafe { &*(&block.timer2_cfg0 as *const _ as *const _) },
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+    fn cfg1(&mut self) -> &crate::pac::pwm0::TIMER0_CFG1 {
+        // SAFETY:
+        // We only grant access to our CFG1 register with the lifetime of &mut self
+        let block = unsafe { &*PWM::block() };
+
+        // SAFETY:
+        // The CFG1 registers are identical for all timers so we can pretend they're
+        // TIMER0_CFG1
+        match T {
+            0 => &block.timer0_cfg1,
+            1 => unsafe { &*(&block.timer1_cfg1 as *const _ as *const _) },
+            2 => unsafe { &*(&block.timer2_cfg1 as *const _ as *const _) },
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum CounterDirection {
+    Increasing,
+    Decreasing,
+}
+
+impl From<bool> for CounterDirection {
+    fn from(bit: bool) -> Self {
+        match bit {
+            false => CounterDirection::Increasing,
+            true => CounterDirection::Decreasing,
+        }
+    }
+}

--- a/esp-hal-common/src/mcpwm/timer.rs
+++ b/esp-hal-common/src/mcpwm/timer.rs
@@ -67,22 +67,39 @@ impl<const TIM: u8, PWM: PwmPeripheral> Timer<TIM, PWM> {
         // We only write to our TIMERx_SYNC register
         let block = unsafe { &*PWM::block() };
 
-        // FIXME replace with safe API after https://github.com/esp-rs/esp-pacs/issues/57
         match TIM {
             0 => {
                 let sw = block.timer0_sync.read().sw().bit_is_set();
-                let bits = ((direction as u32) << 20) + ((phase as u32) << 4) + ((!sw as u32) << 1);
-                unsafe { block.timer0_sync.write(|w| w.bits(bits)) }
+                block.timer0_sync.write(|w| {
+                    w.timer0_phase_direction()
+                        .variant(direction as u8 != 0)
+                        .timer0_phase()
+                        .variant(phase)
+                        .sw()
+                        .variant(!sw)
+                });
             }
             1 => {
                 let sw = block.timer1_sync.read().sw().bit_is_set();
-                let bits = ((direction as u32) << 20) + ((phase as u32) << 4) + ((!sw as u32) << 1);
-                unsafe { block.timer1_sync.write(|w| w.bits(bits)) }
+                block.timer1_sync.write(|w| {
+                    w.timer1_phase_direction()
+                        .variant(direction as u8 != 0)
+                        .timer1_phase()
+                        .variant(phase)
+                        .sw()
+                        .variant(!sw)
+                });
             }
             2 => {
                 let sw = block.timer2_sync.read().sw().bit_is_set();
-                let bits = ((direction as u32) << 20) + ((phase as u32) << 4) + ((!sw as u32) << 1);
-                unsafe { block.timer2_sync.write(|w| w.bits(bits)) }
+                block.timer2_sync.write(|w| {
+                    w.timer2_phase_direction()
+                        .variant(direction as u8 != 0)
+                        .timer2_phase()
+                        .variant(phase)
+                        .sw()
+                        .variant(!sw)
+                });
             }
             _ => {
                 unreachable!()

--- a/esp-hal-common/src/mcpwm/timer.rs
+++ b/esp-hal-common/src/mcpwm/timer.rs
@@ -12,11 +12,11 @@ use crate::{
 /// Every timer of a particular [`MCPWM`](super::MCPWM) peripheral can be used
 /// as a timing reference for every
 /// [`Operator`](super::operator::Operator) of that peripheral
-pub struct Timer<const T: u8, PWM> {
+pub struct Timer<const TIM: u8, PWM> {
     pub(super) phantom: PhantomData<PWM>,
 }
 
-impl<const T: u8, PWM: PwmPeripheral> Timer<T, PWM> {
+impl<const TIM: u8, PWM: PwmPeripheral> Timer<TIM, PWM> {
     pub(super) fn new() -> Self {
         Timer {
             phantom: PhantomData,
@@ -63,7 +63,7 @@ impl<const T: u8, PWM: PwmPeripheral> Timer<T, PWM> {
     pub fn set_counter(&mut self, phase: u16) {
         // FIXME add phase_direction to SVD, then add CounterDirection as a parameter
         let block = unsafe { &*PWM::block() };
-        match T {
+        match TIM {
             0 => block.timer0_sync.modify(|r, w| {
                 w.timer0_phase()
                     .variant(phase as u32)
@@ -92,7 +92,7 @@ impl<const T: u8, PWM: PwmPeripheral> Timer<T, PWM> {
     pub fn status(&self) -> (u16, CounterDirection) {
         let block = unsafe { &*PWM::block() };
 
-        match T {
+        match TIM {
             0 => {
                 let reg = block.timer0_status.read();
                 (
@@ -128,7 +128,7 @@ impl<const T: u8, PWM: PwmPeripheral> Timer<T, PWM> {
         // SAFETY:
         // The CFG0 registers are identical for all timers so we can pretend they're
         // TIMER0_CFG0
-        match T {
+        match TIM {
             0 => &block.timer0_cfg0,
             1 => unsafe { &*(&block.timer1_cfg0 as *const _ as *const _) },
             2 => unsafe { &*(&block.timer2_cfg0 as *const _ as *const _) },
@@ -145,7 +145,7 @@ impl<const T: u8, PWM: PwmPeripheral> Timer<T, PWM> {
         // SAFETY:
         // The CFG1 registers are identical for all timers so we can pretend they're
         // TIMER0_CFG1
-        match T {
+        match TIM {
             0 => &block.timer0_cfg1,
             1 => unsafe { &*(&block.timer1_cfg1 as *const _ as *const _) },
             2 => unsafe { &*(&block.timer2_cfg1 as *const _ as *const _) },

--- a/esp-hal-common/src/mcpwm/timer.rs
+++ b/esp-hal-common/src/mcpwm/timer.rs
@@ -63,6 +63,8 @@ impl<const TIM: u8, PWM: PwmPeripheral> Timer<TIM, PWM> {
 
     /// Set the timer counter to the provided value
     pub fn set_counter(&mut self, phase: u16, direction: CounterDirection) {
+        // SAFETY:
+        // We only write to our TIMERx_SYNC register
         let block = unsafe { &*PWM::block() };
 
         // FIXME replace with safe API after https://github.com/esp-rs/esp-pacs/issues/57
@@ -90,6 +92,8 @@ impl<const TIM: u8, PWM: PwmPeripheral> Timer<TIM, PWM> {
 
     /// Read the counter value and counter direction of the timer
     pub fn status(&self) -> (u16, CounterDirection) {
+        // SAFETY:
+        // We only read from our TIMERx_STATUS register
         let block = unsafe { &*PWM::block() };
 
         match TIM {

--- a/esp32-hal/examples/mcpwm.rs
+++ b/esp32-hal/examples/mcpwm.rs
@@ -38,8 +38,7 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin = io.pins.gpio4;
 
-    // TODO check timing
-    // clocks.crypto_pwm_clock is 160 MHz
+    // clocks.pwm_clock is 160 MHz
     // with `prescaler = 3` pwm_clk will run at `160 MHz / (3 + 1) = 40 MHz`
     let mut mcpwm = MCPWM::new(
         peripherals.PWM0,

--- a/esp32-hal/examples/mcpwm.rs
+++ b/esp32-hal/examples/mcpwm.rs
@@ -9,7 +9,7 @@ use esp32_hal::{
     clock::ClockControl,
     gpio::IO,
     mcpwm::{
-        MCPWM,
+        {MCPWM, PeripheralClockConfig},
         operator::PwmPinConfig,
         timer::PwmWorkingMode,
     },
@@ -38,23 +38,24 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin = io.pins.gpio4;
 
-    // clocks.pwm_clock is 160 MHz
-    // with `prescaler = 3` pwm_clk will run at `160 MHz / (3 + 1) = 40 MHz`
+    // initialize peripheral
+    let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40u32.MHz()).unwrap();
     let mut mcpwm = MCPWM::new(
         peripherals.PWM0,
-        &clocks,
-        3,
+        clock_cfg,
         &mut system.peripheral_clock_control,
     );
 
-    // with `prescaler = 19` timer0 counter will run at `40 MHz / (19 + 1) = 2 MHz`
-    // with `period = 99` timer0 will run at `2 MHz / (99 + 1) = 20 kHz`
-    mcpwm.timer0.start(19, 99, PwmWorkingMode::Increase);
+    // connect operator0 to timer0
     mcpwm.operator0.set_timer(&mcpwm.timer0);
-
+    // connect operator0 to pin
     let mut pwm_pin = mcpwm
         .operator0
         .with_pin_a(pin, PwmPinConfig::UP_ACTIVE_HIGH);
+
+    // start timer with timestamp values in the range of 0..=99 and a frequency of 20 kHz
+    let timer_clock_cfg = clock_cfg.timer_clock_with_frequency(99, PwmWorkingMode::Increase, 20u32.kHz()).unwrap();
+    mcpwm.timer0.start(timer_clock_cfg);
 
     // pin will be high 50% of the time
     pwm_pin.set_timestamp(50);

--- a/esp32-hal/examples/mcpwm.rs
+++ b/esp32-hal/examples/mcpwm.rs
@@ -1,0 +1,64 @@
+//! Uses timer0 and operator0 of the MCPWM0 peripheral to output a 50% duty signal at 20 kHz.
+//!
+//! The signal will be output to the pin assigned to `pin`. (GPIO4)
+
+#![no_std]
+#![no_main]
+
+use esp32_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    mcpwm::{
+        MCPWM,
+        operator::PwmActions,
+        timer::PwmWorkingMode,
+    },
+    pac::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timer
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let pin = io.pins.gpio4;
+
+    // TODO check timing
+    // clocks.crypto_pwm_clock is 160 MHz
+    // with `prescaler = 3` pwm_clk will run at `160 MHz / (3 + 1) = 40 MHz`
+    let mut mcpwm = MCPWM::new(
+        peripherals.PWM0,
+        &clocks,
+        3,
+        &mut system.peripheral_clock_control,
+    );
+
+    // with `prescaler = 19` timer0 counter will run at `40 MHz / (19 + 1) = 2 MHz`
+    // with `period = 99` timer0 will run at `2 MHz / (99 + 1) = 20 kHz`
+    mcpwm.timer0.start(19, 99, PwmWorkingMode::Increase);
+    mcpwm.operator0.set_timer(&mcpwm.timer0);
+
+    let mut pwm_pin = mcpwm
+        .operator0
+        .with_a_pin(pin, PwmActions::UP_ACTIVE_HIGH);
+
+    // pin will be high 50% of the time
+    pwm_pin.set_timestamp(50);
+
+    loop {}
+}

--- a/esp32-hal/examples/mcpwm.rs
+++ b/esp32-hal/examples/mcpwm.rs
@@ -10,7 +10,7 @@ use esp32_hal::{
     gpio::IO,
     mcpwm::{
         MCPWM,
-        operator::PwmActions,
+        operator::PwmPinConfig,
         timer::PwmWorkingMode,
     },
     pac::Peripherals,
@@ -55,7 +55,7 @@ fn main() -> ! {
 
     let mut pwm_pin = mcpwm
         .operator0
-        .with_a_pin(pin, PwmActions::UP_ACTIVE_HIGH);
+        .with_pin_a(pin, PwmPinConfig::UP_ACTIVE_HIGH);
 
     // pin will be high 50% of the time
     pwm_pin.set_timestamp(50);

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -14,6 +14,7 @@ pub use esp_hal_common::{
     interrupt,
     ledc,
     macros,
+    mcpwm,
     pac,
     prelude,
     pulse_control,

--- a/esp32s3-hal/examples/mcpwm.rs
+++ b/esp32s3-hal/examples/mcpwm.rs
@@ -1,0 +1,63 @@
+//! Uses timer0 and operator0 of the MCPWM0 peripheral to output a 50% duty signal at 20 kHz.
+//!
+//! The signal will be output to the pin assigned to `pin`. (GPIO4)
+
+#![no_std]
+#![no_main]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    mcpwm::{
+        MCPWM,
+        operator::PwmActions,
+        timer::PwmWorkingMode,
+    },
+    pac::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timer
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let pin = io.pins.gpio4;
+
+    // clocks.crypto_pwm_clock is 160 MHz
+    // with `prescaler = 3` pwm_clk will run at `160 MHz / (3 + 1) = 40 MHz`
+    let mut mcpwm = MCPWM::new(
+        peripherals.PWM0,
+        &clocks,
+        3,
+        &mut system.peripheral_clock_control,
+    );
+
+    // with `prescaler = 19` timer0 counter will run at `40 MHz / (19 + 1) = 2 MHz`
+    // with `period = 99` timer0 will run at `2 MHz / (99 + 1) = 20 kHz`
+    mcpwm.timer0.start(19, 99, PwmWorkingMode::Increase);
+    mcpwm.operator0.set_timer(&mcpwm.timer0);
+
+    let mut pwm_pin = mcpwm
+        .operator0
+        .with_a_pin(pin, PwmActions::UP_ACTIVE_HIGH);
+
+    // pin will be high 50% of the time
+    pwm_pin.set_timestamp(50);
+
+    loop {}
+}

--- a/esp32s3-hal/examples/mcpwm.rs
+++ b/esp32s3-hal/examples/mcpwm.rs
@@ -10,7 +10,7 @@ use esp32s3_hal::{
     gpio::IO,
     mcpwm::{
         MCPWM,
-        operator::PwmActions,
+        operator::PwmPinConfig,
         timer::PwmWorkingMode,
     },
     pac::Peripherals,
@@ -54,7 +54,7 @@ fn main() -> ! {
 
     let mut pwm_pin = mcpwm
         .operator0
-        .with_a_pin(pin, PwmActions::UP_ACTIVE_HIGH);
+        .with_pin_a(pin, PwmPinConfig::UP_ACTIVE_HIGH);
 
     // pin will be high 50% of the time
     pwm_pin.set_timestamp(50);

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -15,6 +15,7 @@ pub use esp_hal_common::{
     interrupt,
     ledc,
     macros,
+    mcpwm,
     otg_fs,
     pac,
     prelude,


### PR DESCRIPTION
## Major things missing:

- [x] Need to resolve TODOs
- [x] Documentation
- [x] Test on ESP32 Hardware
- [x] Test on ESP32-S3 Hardware
- [ ] something else?

## Request for feedback:

### Are we allowed to copy text passages from the reference manuals for documentation? What about pictures?
The MCPWM peripheral is quite complex with lots of moving parts so adding some graphics might help.

### What are people thinking about the API design? 
I chose an implementation without looking much at the existing `LEDC` code or the ESP IDF API.
There might be some disconnect here.

Things I tried to consider were (in no particular order):
* compile errors over runtime errors
* "zero-cost"-ness
* use of const-generics with the option of using [adt_const_params](https://github.com/rust-lang/rust/issues/95174) at some later point
* ability to add more features later without major architectural changes
* discoverability

I'd love to have some feedback here whether these goal were accomplished and if other considerations were missed.

### What's the pwm period of a Count-Up-Down Mode timer?
~~The [docs ](https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf) mention:~~
~~> The PWM timer starts increasing from zero until the period value is reached. Then, the timer decreases back to zero. This pattern is then repeated. The PWM period is the result of (the value of the period field × 2 + 1)~~

~~Looking at the timing diagrams is seems to me that it would rather be `period field × 2`. Is that a mistake in the docs?~~

Doing some measurements confirmed that the docs indeed are wrong here the period is `period field × 2`