### PR TITLE
doc: add `#[doc(inline)]` to esp-hal-common re-exports

### DIFF
--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
+#[doc(inline)]
 pub use esp_hal_common::{
     clock,
     cpu_control::CpuControl,

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -3,6 +3,7 @@
 use core::arch::global_asm;
 
 pub use embedded_hal as ehal;
+#[doc(inline)]
 pub use esp_hal_common::{
     clock,
     dma::{self, gdma},

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -6,6 +6,7 @@ use core::arch::{asm, global_asm};
 use core::mem::size_of;
 
 pub use embedded_hal as ehal;
+#[doc(inline)]
 pub use esp_hal_common::{
     clock,
     dma,

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub use embedded_hal as ehal;
+#[doc(inline)]
 pub use esp_hal_common::{
     clock,
     dma,

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature = "direct-boot", feature(asm_experimental_arch))]
 
 pub use embedded_hal as ehal;
+#[doc(inline)]
 pub use esp_hal_common::{
     clock,
     cpu_control::CpuControl,


### PR DESCRIPTION
This PR makes the documents more accessible. Since esp-hal-common shouldn't be used directly, it's probably okay to inline it.