### PR TITLE
Fix UART unlisten calls so they clear the interrupt enable

### DIFF
--- a/esp-hal-common/src/serial.rs
+++ b/esp-hal-common/src/serial.rs
@@ -361,7 +361,7 @@ where
         self.uart
             .register_block()
             .int_ena
-            .modify(|_, w| w.at_cmd_char_det_int_ena().set_bit());
+            .modify(|_, w| w.at_cmd_char_det_int_ena().clear_bit());
     }
 
     /// Listen for TX-DONE interrupts
@@ -377,7 +377,7 @@ where
         self.uart
             .register_block()
             .int_ena
-            .modify(|_, w| w.tx_done_int_ena().set_bit());
+            .modify(|_, w| w.tx_done_int_ena().clear_bit());
     }
 
     /// Listen for RX-FIFO-FULL interrupts
@@ -393,7 +393,7 @@ where
         self.uart
             .register_block()
             .int_ena
-            .modify(|_, w| w.rxfifo_full_int_ena().set_bit());
+            .modify(|_, w| w.rxfifo_full_int_ena().clear_bit());
     }
 
     /// Checks if AT-CMD interrupt is set


### PR DESCRIPTION
The interrupt unlisten methods on `esp_hal_common::serial::Instance` are setting the interrupt enable bit instead of clearing it, so they do the same thing as the interrupt listen methods.
Tested using an ESP32. Verified that if I run
```
uart0.listen_rx_fifo_full();
uart0.unlisten_rx_fifo_full();
```
I still get interrupts. With my change, I stop getting interrupts.