### PR TITLE
Add more configuration symbols and simplify the build script

### DIFF
--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -12,40 +12,90 @@ fn main() {
         n => panic!("Exactly 1 chip must be enabled via its Cargo feature, {n} provided"),
     }
 
-    // Configuration symbol for the enabled chip
-    if esp32 {
-        println!("cargo:rustc-cfg=esp32");
+    // Define all required configuration symbols for the enabled chip.
+    //
+    // When adding a new device, at the bare minimum the following symbols MUST be
+    // defined:
+    //   - the name of the device
+    //   - the architecture ('riscv' or 'xtensa')
+    //   - the core count ('single_core' or 'multi_core')
+    //
+    // Additionally, the following symbols MAY be defined if present:
+    //   - 'dac'
+    //   - 'gdma'
+    //   - 'i2c1'
+    //   - 'pdma'
+    //   - 'rmt'
+    //   - 'spi3'
+    //   - 'systimer'
+    //   - 'timg1'
+    //   - 'uart2'
+    //   - 'usb_otg'
+    //   - 'usb_serial_jtag'
+    //
+    // New symbols can be added as needed, but please be sure to update both this
+    // comment and the required vectors below.
+    let symbols = if esp32 {
+        vec![
+            "esp32",
+            "xtensa",
+            "multi_core",
+            "dac",
+            "i2c1",
+            "pdma",
+            "rmt",
+            "spi3",
+            "timg1",
+            "uart2",
+        ]
     } else if esp32c2 {
-        println!("cargo:rustc-cfg=esp32c2");
+        vec!["esp32c2", "riscv", "single_core", "gdma", "systimer"]
     } else if esp32c3 {
-        println!("cargo:rustc-cfg=esp32c3");
+        vec![
+            "esp32c3",
+            "riscv",
+            "single_core",
+            "gdma",
+            "rmt",
+            "spi3",
+            "systimer",
+            "timg1",
+            "usb_serial_jtag",
+        ]
     } else if esp32s2 {
-        println!("cargo:rustc-cfg=esp32s2");
+        vec![
+            "esp32s2",
+            "xtensa",
+            "single_core",
+            "dac",
+            "i2c1",
+            "pdma",
+            "rmt",
+            "spi3",
+            "systimer",
+            "timg1",
+            "usb_otg",
+        ]
     } else if esp32s3 {
-        println!("cargo:rustc-cfg=esp32s3");
-    }
-
-    // Configuration symbol for the architecture of the enabled chip
-    if esp32c2 || esp32c3 {
-        println!("cargo:rustc-cfg=riscv");
+        vec![
+            "esp32s3",
+            "xtensa",
+            "multi_core",
+            "gdma",
+            "i2c1",
+            "rmt",
+            "spi3",
+            "systimer",
+            "timg1",
+            "uart2",
+            "usb_otg",
+            "usb_serial_jtag",
+        ]
     } else {
-        println!("cargo:rustc-cfg=xtensa");
-    }
+        unreachable!(); // We've already confirmed exactly one chip was selected
+    };
 
-    // Inject a configuration symbol to state the core count of the enabled chip
-    if esp32c2 || esp32c3 || esp32s2 {
-        println!("cargo:rustc-cfg=single_core");
-    } else {
-        println!("cargo:rustc-cfg=multi_core");
-    }
-
-    // Configuration symbol for the SYSTIMER peripheral
-    if esp32c2 || esp32c3 || esp32s2 || esp32s3 {
-        println!("cargo:rustc-cfg=has_systimer");
-    }
-
-    // Configuration symbol for the USB_SERIAL_JTAG peripheral
-    if esp32c3 || esp32s3 {
-        println!("cargo:rustc-cfg=has_usb_serial_jtag");
+    for symbol in symbols {
+        println!("cargo:rustc-cfg={symbol}");
     }
 }

--- a/esp-hal-common/src/analog/mod.rs
+++ b/esp-hal-common/src/analog/mod.rs
@@ -4,7 +4,7 @@
 #[cfg_attr(esp32s2, path = "adc/xtensa.rs")]
 #[cfg_attr(esp32s3, path = "adc/xtensa.rs")]
 pub mod adc;
-#[cfg(not(any(esp32c2, esp32c3, esp32s3)))]
+#[cfg(dac)]
 pub mod dac;
 
 cfg_if::cfg_if! {

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -4,10 +4,9 @@ use core::{marker::PhantomData, sync::atomic::compiler_fence};
 
 use private::*;
 
-#[cfg(any(esp32c2, esp32c3, esp32s3))]
+#[cfg(gdma)]
 pub mod gdma;
-
-#[cfg(any(esp32, esp32s2))]
+#[cfg(pdma)]
 pub mod pdma;
 
 /// DMA Errors
@@ -20,7 +19,7 @@ pub enum DmaError {
 }
 
 /// DMA Priorities
-#[cfg(any(esp32c2, esp32c3, esp32s3))]
+#[cfg(gdma)]
 #[derive(Clone, Copy)]
 pub enum DmaPriority {
     Priority0 = 0,
@@ -37,7 +36,7 @@ pub enum DmaPriority {
 
 /// DMA Priorities
 /// The values need to match the TRM
-#[cfg(any(esp32, esp32s2))]
+#[cfg(pdma)]
 #[derive(Clone, Copy)]
 pub enum DmaPriority {
     Priority0 = 0,
@@ -45,49 +44,26 @@ pub enum DmaPriority {
 
 /// DMA capable peripherals
 /// The values need to match the TRM
-#[cfg(esp32c2)]
-#[derive(Clone, Copy)]
-pub enum DmaPeripheral {
-    Spi2 = 0,
-    Sha  = 7,
-}
-
-/// DMA capable peripherals
-/// The values need to match the TRM
-#[cfg(esp32c3)]
-#[derive(Clone, Copy)]
-pub enum DmaPeripheral {
-    Spi2  = 0,
-    Uhci0 = 2,
-    I2s   = 3,
-    Aes   = 6,
-    Sha   = 7,
-    Adc   = 8,
-}
-
-/// DMA capable peripherals
-/// The values need to match the TRM
-#[cfg(any(esp32, esp32s2))]
-#[derive(Clone, Copy)]
-pub enum DmaPeripheral {
-    Spi2 = 0,
-    Spi3 = 1,
-}
-
-/// DMA capable peripherals
-/// The values need to match the TRM
-#[cfg(esp32s3)]
 #[derive(Clone, Copy)]
 pub enum DmaPeripheral {
     Spi2   = 0,
+    #[cfg(any(pdma, esp32s3))]
     Spi3   = 1,
+    #[cfg(any(esp32c3, esp32s3))]
     Uhci0  = 2,
+    #[cfg(any(esp32c3, esp32s3))]
     I2s0   = 3,
+    #[cfg(esp32s3)]
     I2s1   = 4,
+    #[cfg(esp32s3)]
     LcdCam = 5,
+    #[cfg(any(esp32c3, esp32s3))]
     Aes    = 6,
+    #[cfg(gdma)]
     Sha    = 7,
+    #[cfg(any(esp32c3, esp32s3))]
     Adc    = 8,
+    #[cfg(esp32s3)]
     Rmt    = 9,
 }
 

--- a/esp-hal-common/src/embassy.rs
+++ b/esp-hal-common/src/embassy.rs
@@ -5,17 +5,11 @@ use embassy_time::driver::{AlarmHandle, Driver};
 use crate::clock::Clocks;
 
 #[cfg_attr(
-    all(
-        has_systimer,
-        feature = "embassy-time-systick",
-    ),
+    all(systimer, feature = "embassy-time-systick",),
     path = "embassy/time_driver_systimer.rs"
 )]
 #[cfg_attr(
-    all(
-        feature = "embassy-time-timg",
-        any(feature = "esp32", feature = "esp32s3", feature = "esp32s2")
-    ),
+    all(feature = "embassy-time-timg", any(esp32, esp32s2, esp32s3)),
     path = "embassy/time_driver_timg.rs"
 )]
 mod time_driver;

--- a/esp-hal-common/src/i2c.rs
+++ b/esp-hal-common/src/i2c.rs
@@ -310,7 +310,7 @@ fn enable_peripheral<T: Instance>(i2c: &T, peripheral_clock_control: &mut Periph
     // enable peripheral
     match i2c.i2c_number() {
         0 => peripheral_clock_control.enable(crate::system::Peripheral::I2cExt0),
-        #[cfg(not(any(esp32c2, esp32c3)))]
+        #[cfg(i2c1)]
         1 => peripheral_clock_control.enable(crate::system::Peripheral::I2cExt1),
         _ => unreachable!(), // will never happen
     }
@@ -364,7 +364,7 @@ pub trait Instance {
 
         // Reset entire peripheral (also resets fifo)
         self.reset();
-        
+
         Ok(())
     }
 
@@ -466,8 +466,8 @@ pub trait Instance {
         // In the "worst" case, we will subtract 13, make sure the result will still be
         // correct
 
-        // FIXME since we always set the filter threshold to 7 we don't need conditional code here
-        // once that changes we need the conditional code here
+        // FIXME since we always set the filter threshold to 7 we don't need conditional
+        // code here once that changes we need the conditional code here
         scl_high -= 7 + 6;
 
         // if (filter_cfg_en) {
@@ -1042,11 +1042,11 @@ pub trait Instance {
                 .txfifo_wm_int_raw()
                 .bit_is_set()
             {}
-            
+
             self.register_block()
                 .int_clr
                 .write(|w| w.txfifo_wm_int_clr().set_bit());
-            
+
             while !self
                 .register_block()
                 .int_raw
@@ -1261,7 +1261,7 @@ impl Instance for crate::pac::I2C0 {
     }
 }
 
-#[cfg(not(any(esp32c2, esp32c3)))]
+#[cfg(i2c1)]
 impl Instance for crate::pac::I2C1 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -33,9 +33,9 @@ pub use esp32s2 as pac;
 pub use esp32s3 as pac;
 pub use procmacros as macros;
 
-#[cfg(not(esp32c2))]
+#[cfg(rmt)]
 pub use self::pulse_control::PulseControl;
-#[cfg(has_usb_serial_jtag)]
+#[cfg(usb_serial_jtag)]
 pub use self::usb_serial_jtag::UsbSerialJtag;
 pub use self::{
     delay::Delay,
@@ -52,13 +52,15 @@ pub mod analog;
 pub mod clock;
 pub mod delay;
 pub mod dma;
+#[cfg(feature = "embassy")]
+pub mod embassy;
 pub mod gpio;
 pub mod i2c;
 pub mod ledc;
-#[cfg(any(esp32s2, esp32s3))]
+#[cfg(usb_otg)]
 pub mod otg_fs;
 pub mod prelude;
-#[cfg(not(esp32c2))]
+#[cfg(rmt)]
 pub mod pulse_control;
 pub mod rng;
 pub mod rom;
@@ -66,21 +68,18 @@ pub mod rtc_cntl;
 pub mod serial;
 pub mod spi;
 pub mod system;
-#[cfg(has_systimer)]
+#[cfg(systimer)]
 pub mod systimer;
 pub mod timer;
-#[cfg(has_usb_serial_jtag)]
+#[cfg(usb_serial_jtag)]
 pub mod usb_serial_jtag;
-#[cfg(not(esp32c2))]
+#[cfg(rmt)]
 pub mod utils;
 
 #[cfg_attr(esp32, path = "cpu_control/esp32.rs")]
 #[cfg_attr(any(esp32c2, esp32c3, esp32s2), path = "cpu_control/none.rs")]
 #[cfg_attr(esp32s3, path = "cpu_control/esp32s3.rs")]
 pub mod cpu_control;
-
-#[cfg(feature = "embassy")]
-pub mod embassy;
 
 #[cfg_attr(esp32, path = "efuse/esp32.rs")]
 #[cfg_attr(esp32c2, path = "efuse/esp32c2.rs")]

--- a/esp-hal-common/src/serial.rs
+++ b/esp-hal-common/src/serial.rs
@@ -1,7 +1,7 @@
 //! UART driver
 
 use self::config::Config;
-#[cfg(any(esp32, esp32s3))]
+#[cfg(uart2)]
 use crate::pac::UART2;
 use crate::{
     clock::Clocks,
@@ -742,7 +742,7 @@ impl Instance for UART1 {
     }
 }
 
-#[cfg(any(esp32, esp32s3))]
+#[cfg(uart2)]
 impl Instance for UART2 {
     #[inline(always)]
     fn register_block(&self) -> &RegisterBlock {

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -16,12 +16,12 @@ type SystemPeripheral = crate::pac::DPORT;
 /// Peripherals which can be enabled via [PeripheralClockControl]
 pub enum Peripheral {
     Spi2,
-    #[cfg(not(esp32c2))]
+    #[cfg(spi3)]
     Spi3,
     I2cExt0,
-    #[cfg(not(any(esp32c2, esp32c3)))]
+    #[cfg(i2c1)]
     I2cExt1,
-    #[cfg(not(esp32c2))]
+    #[cfg(rmt)]
     Rmt,
     Ledc,
     #[cfg(any(esp32, esp32s3))]
@@ -30,11 +30,11 @@ pub enum Peripheral {
     Mcpwm1,
     #[cfg(any(esp32c2, esp32c3))]
     ApbSarAdc,
-    #[cfg(any(esp32c2, esp32c3, esp32s3))]
+    #[cfg(gdma)]
     Gdma,
-    #[cfg(any(esp32, esp32s2))]
+    #[cfg(pdma)]
     Dma,
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(usb_otg)]
     Usb,
 }
 
@@ -61,7 +61,7 @@ impl PeripheralClockControl {
                 perip_clk_en0.modify(|_, w| w.spi2_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.spi2_rst().clear_bit());
             }
-            #[cfg(not(esp32c2))]
+            #[cfg(spi3)]
             Peripheral::Spi3 => {
                 perip_clk_en0.modify(|_, w| w.spi3_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.spi3_rst().clear_bit());
@@ -76,12 +76,12 @@ impl PeripheralClockControl {
                 perip_clk_en0.modify(|_, w| w.i2c_ext0_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2c_ext0_rst().clear_bit());
             }
-            #[cfg(not(any(esp32c2, esp32c3)))]
+            #[cfg(i2c1)]
             Peripheral::I2cExt1 => {
                 perip_clk_en0.modify(|_, w| w.i2c_ext1_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2c_ext1_rst().clear_bit());
             }
-            #[cfg(not(esp32c2))]
+            #[cfg(rmt)]
             Peripheral::Rmt => {
                 perip_clk_en0.modify(|_, w| w.rmt_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.rmt_rst().clear_bit());
@@ -105,7 +105,7 @@ impl PeripheralClockControl {
                 perip_clk_en0.modify(|_, w| w.apb_saradc_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.apb_saradc_rst().clear_bit());
             }
-            #[cfg(any(any(esp32c2, esp32c3, esp32s3)))]
+            #[cfg(gdma)]
             Peripheral::Gdma => {
                 perip_clk_en1.modify(|_, w| w.dma_clk_en().set_bit());
                 perip_rst_en1.modify(|_, w| w.dma_rst().clear_bit());
@@ -122,7 +122,7 @@ impl PeripheralClockControl {
                 perip_clk_en0.modify(|_, w| w.spi3_dma_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.spi3_dma_rst().clear_bit());
             }
-            #[cfg(any(esp32s2, esp32s3))]
+            #[cfg(usb_otg)]
             Peripheral::Usb => {
                 perip_clk_en0.modify(|_, w| w.usb_clk_en().set_bit());
                 perip_rst_en0.modify(|_, w| w.usb_rst().clear_bit());
@@ -142,7 +142,7 @@ pub struct CpuControl {
 }
 
 /// Dummy DMA peripheral.
-#[cfg(any(esp32, esp32s2))]
+#[cfg(pdma)]
 pub struct Dma {
     _private: (),
 }
@@ -153,7 +153,7 @@ pub struct SystemParts {
     pub peripheral_clock_control: PeripheralClockControl,
     pub clock_control: SystemClockControl,
     pub cpu_control: CpuControl,
-    #[cfg(any(esp32, esp32s2))]
+    #[cfg(pdma)]
     pub dma: Dma,
 }
 
@@ -175,7 +175,7 @@ impl SystemExt for SystemPeripheral {
             peripheral_clock_control: PeripheralClockControl { _private: () },
             clock_control: SystemClockControl { _private: () },
             cpu_control: CpuControl { _private: () },
-            #[cfg(any(esp32, esp32s2))]
+            #[cfg(pdma)]
             dma: Dma { _private: () },
         }
     }

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -12,7 +12,7 @@ use embedded_hal::{
 use fugit::{HertzU32, MicrosDurationU64};
 use void::Void;
 
-#[cfg(not(esp32c2))]
+#[cfg(timg1)]
 use crate::pac::TIMG1;
 use crate::{
     clock::Clocks,
@@ -50,7 +50,7 @@ impl TimerGroupInstance for TIMG0 {
     }
 }
 
-#[cfg(not(esp32c2))]
+#[cfg(timg1)]
 impl TimerGroupInstance for TIMG1 {
     #[inline(always)]
     fn register_block() -> *const RegisterBlock {


### PR DESCRIPTION
I've added a number of new symbols here to hopefully make our code a bit easier to reason about. I've also changed our approach in the build script, where each chip just defines all of its symbols now. I think this will be easier to maintain.

I was careful when changing the `#[cfg]`s but it's always possible I've made a mistake, so @MabezDev @bjoernQ please double check my work if you could! I've also consolidated the `DmaPeripheral` enums, and again while I've already checked this please review it.

Not sure how many more symbols we can pull out right now, but if I've missed anything let me know!