### PR TITLE
Avoid potential linker error for ESP32-C2 and ESP32-C3

### DIFF
--- a/esp32c2-hal/ld/bl-riscv-link.x
+++ b/esp32c2-hal/ld/bl-riscv-link.x
@@ -58,6 +58,7 @@ SECTIONS
     /* point of the program. */
     KEEP(*(.init));
     KEEP(*(.init.rust));
+    KEEP(*(.text.abort));
     . = ALIGN(4);
     KEEP(*(.trap));
     KEEP(*(.trap.rust));

--- a/esp32c2-hal/ld/db-riscv-link.x
+++ b/esp32c2-hal/ld/db-riscv-link.x
@@ -51,6 +51,7 @@ SECTIONS
     /* point of the program. */
     KEEP(*(.init));
     KEEP(*(.init.rust));
+    KEEP(*(.text.abort));
     . = ALIGN(4);
     KEEP(*(.trap));
     KEEP(*(.trap.rust));

--- a/esp32c3-hal/ld/bl-riscv-link.x
+++ b/esp32c3-hal/ld/bl-riscv-link.x
@@ -58,6 +58,7 @@ SECTIONS
     /* point of the program. */
     KEEP(*(.init));
     KEEP(*(.init.rust));
+    KEEP(*(.text.abort));
     . = ALIGN(4);
     KEEP(*(.trap));
     KEEP(*(.trap.rust));

--- a/esp32c3-hal/ld/db-riscv-link.x
+++ b/esp32c3-hal/ld/db-riscv-link.x
@@ -51,6 +51,7 @@ SECTIONS
     /* point of the program. */
     KEEP(*(.init));
     KEEP(*(.init.rust));
+    KEEP(*(.text.abort));
     . = ALIGN(4);
     KEEP(*(.trap));
     KEEP(*(.trap.rust));


### PR DESCRIPTION
It is possible that the linker places `abort` out of reach for the jump at https://github.com/rust-embedded/riscv-rt/blob/91d63a31173a5570a11fa3927de062638c73f050/asm.S#L102

This happened to me and this PR fixes that
