### PR TITLE
Add Rx and interrupts to UsbSerialJtag

### DIFF
--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -1,30 +1,229 @@
-use crate::pac::USB_DEVICE;
+use core::convert::Infallible;
 
-pub struct UsbSerialJtag;
+use crate::pac::{usb_device::RegisterBlock, USB_DEVICE};
 
-impl UsbSerialJtag {
-    pub fn write_bytes(&mut self, bytes: &[u8]) {
-        let reg_block = unsafe { &*USB_DEVICE::PTR };
+pub struct UsbSerialJtag<T> {
+    usb_serial: T,
+}
 
-        // TODO: 64 byte chunks max
-        for chunk in bytes.chunks(32) {
+/// Custom USB serial error type
+type Error = Infallible;
+
+impl<T> UsbSerialJtag<T>
+where
+    T: Instance,
+{
+    /// Create a new USB serial/JTAG instance with defaults
+    pub fn new(usb_serial: T) -> Self {
+        let mut dev = Self { usb_serial };
+        dev.usb_serial.disable_rx_interrupts();
+        dev.usb_serial.disable_tx_interrupts();
+
+        dev
+    }
+
+    /// Return the raw interface to the underlying USB serial/JTAG instance
+    pub fn free(self) -> T {
+        self.usb_serial
+    }
+
+    /// Write data to the serial output in chunks of up to 64 bytes
+    pub fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
+        let reg_block = self.usb_serial.register_block();
+
+        for chunk in data.chunks(64) {
             unsafe {
                 for &b in chunk {
-                    reg_block.ep1.write(|w| w.bits(b.into()))
+                    reg_block.ep1.write(|w| w.rdwr_byte().bits(b.into()))
                 }
-                reg_block.ep1_conf.write(|w| w.bits(0b001));
+                reg_block.ep1_conf.write(|w| w.wr_done().set_bit());
 
                 while reg_block.ep1_conf.read().bits() & 0b011 == 0b000 {
                     // wait
                 }
             }
         }
+
+        Ok(())
+    }
+
+    /// Write data to the serial output in a non-blocking manner
+    /// Requires manual flushing (automatically flushed every 64 bytes)
+    pub fn write_byte_nb(&mut self, word: u8) -> nb::Result<(), Error> {
+        let reg_block = self.usb_serial.register_block();
+
+        if reg_block
+            .ep1_conf
+            .read()
+            .serial_in_ep_data_free()
+            .bit_is_set()
+        {
+            // the FIFO is not full
+
+            unsafe {
+                reg_block.ep1.write(|w| w.rdwr_byte().bits(word.into()));
+            }
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    /// Flush the output FIFO and block until it has been sent
+    pub fn flush_tx(&mut self) -> Result<(), Error> {
+        let reg_block = self.usb_serial.register_block();
+        reg_block.ep1_conf.write(|w| w.wr_done().set_bit());
+
+        while reg_block.ep1_conf.read().bits() & 0b011 == 0b000 {
+            // wait
+        }
+
+        Ok(())
+    }
+
+    /// Flush the output FIFO but don't block if it isn't ready immediately
+    pub fn flush_tx_nb(&mut self) -> nb::Result<(), Error> {
+        let reg_block = self.usb_serial.register_block();
+        reg_block.ep1_conf.write(|w| w.wr_done().set_bit());
+
+        if reg_block.ep1_conf.read().bits() & 0b011 == 0b000 {
+            Err(nb::Error::WouldBlock)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn read_byte(&mut self) -> nb::Result<u8, Error> {
+        let reg_block = self.usb_serial.register_block();
+
+        // Check if there are any bytes to read
+        if reg_block
+            .ep1_conf
+            .read()
+            .serial_out_ep_data_avail()
+            .bit_is_set()
+        {
+            let value = reg_block.ep1.read().rdwr_byte().bits();
+
+            Ok(value)
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    /// Listen for RX-PACKET-RECV interrupts
+    pub fn listen_rx_packet_recv_interrupt(&mut self) {
+        let reg_block = self.usb_serial.register_block();
+        reg_block
+            .int_ena
+            .modify(|_, w| w.serial_out_recv_pkt_int_ena().set_bit());
+    }
+
+    /// Stop listening for RX-PACKET-RECV interrupts
+    pub fn unlisten_rx_packet_recv_interrupt(&mut self) {
+        let reg_block = self.usb_serial.register_block();
+        reg_block
+            .int_ena
+            .modify(|_, w| w.serial_out_recv_pkt_int_ena().clear_bit());
+    }
+
+    /// Checks if RX-PACKET-RECV interrupt is set
+    pub fn rx_packet_recv_interrupt_set(&mut self) -> bool {
+        let reg_block = unsafe { &*USB_DEVICE::PTR };
+        reg_block
+            .int_st
+            .read()
+            .serial_out_recv_pkt_int_st()
+            .bit_is_set()
+    }
+
+    /// Reset RX-PACKET-RECV interrupt
+    pub fn reset_rx_packet_recv_interrupt(&mut self) {
+        let reg_block = unsafe { &*USB_DEVICE::PTR };
+
+        reg_block
+            .int_clr
+            .write(|w| w.serial_out_recv_pkt_int_clr().set_bit())
     }
 }
 
-impl core::fmt::Write for UsbSerialJtag {
+/// USB serial/JTAG peripheral instance
+pub trait Instance {
+    fn register_block(&self) -> &RegisterBlock;
+
+    fn disable_tx_interrupts(&mut self) {
+        self.register_block()
+            .int_ena
+            .write(|w| w.serial_in_empty_int_ena().clear_bit());
+
+        self.register_block()
+            .int_clr
+            .write(|w| w.serial_in_empty_int_clr().set_bit())
+    }
+
+    fn disable_rx_interrupts(&mut self) {
+        self.register_block()
+            .int_ena
+            .write(|w| w.serial_out_recv_pkt_int_ena().clear_bit());
+
+        self.register_block()
+            .int_clr
+            .write(|w| w.serial_out_recv_pkt_int_clr().set_bit())
+    }
+
+    fn get_rx_fifo_count(&self) -> u16 {
+        let ep0_state = self.register_block().in_ep0_st.read();
+        let wr_addr = ep0_state.in_ep0_wr_addr().bits();
+        let rd_addr = ep0_state.in_ep0_rd_addr().bits();
+        (wr_addr - rd_addr).into()
+    }
+
+    fn get_tx_fifo_count(&self) -> u16 {
+        let ep1_state = self.register_block().in_ep1_st.read();
+        let wr_addr = ep1_state.in_ep1_wr_addr().bits();
+        let rd_addr = ep1_state.in_ep1_rd_addr().bits();
+        (wr_addr - rd_addr).into()
+    }
+}
+
+impl Instance for USB_DEVICE {
+    #[inline(always)]
+    fn register_block(&self) -> &RegisterBlock {
+        self
+    }
+}
+
+impl<T> core::fmt::Write for UsbSerialJtag<T>
+where
+    T: Instance,
+{
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        self.write_bytes(s.as_bytes());
-        Ok(())
+        self.write_bytes(s.as_bytes()).map_err(|_| core::fmt::Error)
+    }
+}
+
+impl<T> embedded_hal::serial::Read<u8> for UsbSerialJtag<T>
+where
+    T: Instance,
+{
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        self.read_byte()
+    }
+}
+
+impl<T> embedded_hal::serial::Write<u8> for UsbSerialJtag<T>
+where
+    T: Instance,
+{
+    type Error = Error;
+
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        self.write_byte_nb(word)
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        self.flush_tx_nb()
     }
 }

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -6,19 +6,25 @@
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
+use core::{cell::RefCell, fmt::Write};
 
+use critical_section::Mutex;
 use esp32c3_hal::{
     clock::ClockControl,
-    pac::Peripherals,
+    interrupt,
+    pac::{self, Peripherals, USB_DEVICE},
     prelude::*,
     timer::TimerGroup,
-    Delay,
+    Cpu,
     Rtc,
     UsbSerialJtag,
 };
 use esp_backtrace as _;
+use nb::block;
 use riscv_rt::entry;
+
+static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag<USB_DEVICE>>>> =
+    Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
@@ -26,9 +32,9 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut delay = Delay::new(&clocks);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
@@ -39,8 +45,52 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
-    loop {
-        writeln!(UsbSerialJtag, "Hello world!").ok();
-        delay.delay_ms(500u32);
+    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
+
+    usb_serial.listen_rx_packet_recv_interrupt();
+
+    timer0.start(1u64.secs());
+
+    critical_section::with(|cs| USB_SERIAL.borrow_ref_mut(cs).replace(usb_serial));
+
+    interrupt::enable(
+        pac::Interrupt::USB_SERIAL_JTAG,
+        interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    interrupt::set_kind(
+        Cpu::ProCpu,
+        interrupt::CpuInterrupt::Interrupt1,
+        interrupt::InterruptKind::Edge,
+    );
+
+    unsafe {
+        riscv::interrupt::enable();
     }
+
+    loop {
+        critical_section::with(|cs| {
+            writeln!(
+                USB_SERIAL.borrow_ref_mut(cs).as_mut().unwrap(),
+                "Hello world!"
+            )
+            .ok();
+        });
+
+        block!(timer0.wait()).unwrap();
+    }
+}
+
+#[interrupt]
+fn USB_SERIAL_JTAG() {
+    critical_section::with(|cs| {
+        let mut usb_serial = USB_SERIAL.borrow_ref_mut(cs);
+        let usb_serial = usb_serial.as_mut().unwrap();
+        writeln!(usb_serial, "USB serial interrupt").unwrap();
+        while let nb::Result::Ok(c) = usb_serial.read_byte() {
+            writeln!(usb_serial, "Read byte: {:02x}", c).unwrap();
+        }
+        usb_serial.reset_rx_packet_recv_interrupt();
+    });
 }

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -1,23 +1,30 @@
 //! This shows how to output text via USB Serial/JTAG.
 //! You need to connect via the Serial/JTAG interface to see any output.
 //! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
+//! PLEASE NOTE: USB Serial input on ESP32-S3 is not currently working
+//! See https://github.com/esp-rs/esp-hal/issues/269 for details
 
 #![no_std]
 #![no_main]
 
-use core::fmt::Write;
+use core::{cell::RefCell, fmt::Write};
 
+use critical_section::Mutex;
 use esp32s3_hal::{
     clock::ClockControl,
-    pac::Peripherals,
+    interrupt,
+    pac::{self, Peripherals, USB_DEVICE},
     prelude::*,
     timer::TimerGroup,
-    Delay,
     Rtc,
     UsbSerialJtag,
 };
 use esp_backtrace as _;
+use nb::block;
 use xtensa_lx_rt::entry;
+
+static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag<USB_DEVICE>>>> =
+    Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
@@ -25,17 +32,47 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut delay = Delay::new(&clocks);
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
 
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     wdt.disable();
     rtc.rwdt.disable();
 
+    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
+
+    usb_serial.listen_rx_packet_recv_interrupt();
+
+    timer0.start(1u64.secs());
+
+    critical_section::with(|cs| USB_SERIAL.borrow_ref_mut(cs).replace(usb_serial));
+
+    interrupt::enable(pac::Interrupt::USB_DEVICE, interrupt::Priority::Priority1).unwrap();
+
     loop {
-        writeln!(UsbSerialJtag, "Hello world!").ok();
-        delay.delay_ms(500u32);
+        critical_section::with(|cs| {
+            writeln!(
+                USB_SERIAL.borrow_ref_mut(cs).as_mut().unwrap(),
+                "Hello world!"
+            )
+            .ok();
+        });
+
+        block!(timer0.wait()).unwrap();
     }
+}
+
+#[interrupt]
+fn USB_DEVICE() {
+    critical_section::with(|cs| {
+        let mut usb_serial = USB_SERIAL.borrow_ref_mut(cs);
+        let usb_serial = usb_serial.as_mut().unwrap();
+        writeln!(usb_serial, "USB serial interrupt").unwrap();
+        while let nb::Result::Ok(c) = usb_serial.read_byte() {
+            writeln!(usb_serial, "Read byte: {:02x}", c).unwrap();
+        }
+        usb_serial.reset_rx_packet_recv_interrupt();
+    });
 }


### PR DESCRIPTION
This is a first cut of adding USB serial Rx and the ability to trigger interrupts when packets are received. I have attempted to make the interface as similar as possible to regular serial UART where it makes sense.
This does include a breaking change - now you actually have to create an instance of UsbSerialJtag with a peripheral instead of just using the registers directly.
I have updated the esp32c3 and esp32s3 examples to demonstrate some of the new features and tested the change on my ESP32-C3-DevKit-RUST-1. I don't have an esp32s3 handy to test its example, but it at least builds. Would appreciate if someone else could test it for me please.
To note:
- I have slightly changed the name of the Rx interrupt from "serial_out_recv_pkt" to "rx_packet_recv" because the TRM names them from the point of view of the USB host and I find it really confusing.

Possible future work:
- It looks like the esp32s3 has the ability to map the USB D+ and D- lines to arbitrary GPIO pins using the GPIO matrix. I don't have any way to test that so I've left it for now.
- I also didn't implement the Tx interrupt because I'm not sure of its utility.

Would love to hear if anyone has any useful feedback on this change.