### PR TITLE
Export InputSignal and OutputSignal

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1311,4 +1311,5 @@ pub use impl_interrupt_status_register_access;
 pub use impl_output;
 pub use impl_output_wrap;
 
-use self::types::{InputSignal, OutputSignal, ONE_INPUT, ZERO_INPUT};
+pub use self::types::{InputSignal, OutputSignal};
+use self::types::{ONE_INPUT, ZERO_INPUT};


### PR DESCRIPTION
In order to write something like [this](https://github.com/IsaacDynamo/esp32-c3-p1-bridge/blob/master/esp_buffered_serial/src/optional_pin.rs), `InputSignal` and `OutputSignal` need to be made public.

Can they be made public, or is there a good reason that they are currently not public?