### PR TITLE
remove `i2c::SetupError` and make `i2c::I2C::new` infallible

### DIFF
--- a/esp32-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32-hal/examples/i2c_bmp180_calibration_data.rs
@@ -47,8 +47,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     loop {
         let mut data = [0u8; 22];

--- a/esp32-hal/examples/i2c_display.rs
+++ b/esp32-hal/examples/i2c_display.rs
@@ -59,8 +59,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     // Start timer (5 second interval)
     timer0.start(5u64.secs());

--- a/esp32c2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -48,8 +48,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     loop {
         let mut data = [0u8; 22];

--- a/esp32c2-hal/examples/i2c_display.rs
+++ b/esp32c2-hal/examples/i2c_display.rs
@@ -60,8 +60,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     // Start timer (5 second interval)
     timer0.start(5u64.secs());

--- a/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -51,8 +51,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     loop {
         let mut data = [0u8; 22];

--- a/esp32c3-hal/examples/i2c_display.rs
+++ b/esp32c3-hal/examples/i2c_display.rs
@@ -63,8 +63,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     // Start timer (5 second interval)
     timer0.start(5u64.secs());

--- a/esp32s2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32s2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -47,8 +47,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     loop {
         let mut data = [0u8; 22];

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -60,8 +60,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     // Start timer (5 second interval)
     timer0.start(5u64.secs());

--- a/esp32s3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32s3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -10,13 +10,7 @@
 #![no_main]
 
 use esp32s3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    pac::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
+    clock::ClockControl, gpio::IO, i2c::I2C, pac::Peripherals, prelude::*, timer::TimerGroup, Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -47,8 +41,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     loop {
         let mut data = [0u8; 22];

--- a/esp32s3-hal/examples/i2c_display.rs
+++ b/esp32s3-hal/examples/i2c_display.rs
@@ -20,13 +20,7 @@ use embedded_graphics::{
     text::{Alignment, Text},
 };
 use esp32s3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    pac::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
+    clock::ClockControl, gpio::IO, i2c::I2C, pac::Peripherals, prelude::*, timer::TimerGroup, Rtc,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -59,8 +53,7 @@ fn main() -> ! {
         100u32.kHz(),
         &mut system.peripheral_clock_control,
         &clocks,
-    )
-    .unwrap();
+    );
 
     // Start timer (5 second interval)
     timer0.start(5u64.secs());


### PR DESCRIPTION
This is a breaking change.
Closes #278