### PR TITLE
Pass trap frame to CPU interrupt handlers (Xtensa)

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -38,7 +38,7 @@ riscv-atomic-emulation-trap = { version = "0.3.0",  optional = true }
 
 # Xtensa
 xtensa-lx    = { version = "0.7.0",  optional = true }
-xtensa-lx-rt = { version = "0.13.0", optional = true }
+xtensa-lx-rt = { version = "0.14.0", optional = true }
 
 # Smart-LED (e.g., WS2812/SK68XX) support
 smart-leds-trait = { version = "0.2.1", optional = true }
@@ -50,11 +50,11 @@ ufmt-write = { version = "0.1.0", optional = true }
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature. We rename the PAC packages because we cannot
 # have dependencies and features with the same names.
-esp32   = { version = "0.16.0", features = ["critical-section"], optional = true }
+esp32   = { version = "0.17.0", features = ["critical-section"], optional = true }
 esp32c2 = { version = "0.5.1",  features = ["critical-section"], optional = true }
 esp32c3 = { version = "0.8.1",  features = ["critical-section"], optional = true }
-esp32s2 = { version = "0.6.0",  features = ["critical-section"], optional = true }
-esp32s3 = { version = "0.10.0",  features = ["critical-section"], optional = true }
+esp32s2 = { version = "0.7.0",  features = ["critical-section"], optional = true }
+esp32s3 = { version = "0.11.0",  features = ["critical-section"], optional = true }
 
 [features]
 esp32   = ["esp32/rt"  , "xtensa", "xtensa-lx/esp32",   "xtensa-lx-rt/esp32",   "lock_api"]

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -340,7 +340,7 @@ mod vectored {
     const CPU_INTERRUPT_EDGE: u32 = 0b_0111_0000_0100_0000_0000_1100_1000_0000;
 
     #[inline]
-    fn cpu_interrupt_nr_to_cpu_interrupt_handler(number: u32) -> Option<unsafe extern "C" fn(u32)> {
+    fn cpu_interrupt_nr_to_cpu_interrupt_handler(number: u32) -> Option<unsafe extern "C" fn(u32, save_frame: &mut Context)> {
         use xtensa_lx_rt::*;
         // we're fortunate that all esp variants use the same CPU interrupt layout
         Some(match number {
@@ -386,7 +386,7 @@ mod vectored {
                 interrupt::clear(1 << cpu_interrupt_nr);
             }
             if let Some(handler) = cpu_interrupt_nr_to_cpu_interrupt_handler(cpu_interrupt_nr) {
-                handler(level);
+                handler(level, save_frame);
             }
         } else {
             if (cpu_interrupt_mask & CPU_INTERRUPT_EDGE) != 0 {

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -32,13 +32,13 @@ embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.3.0",  features = ["esp32"], path = "../esp-hal-common" }
 xtensa-lx          = { version = "0.7.0",  features = ["esp32"] }
-xtensa-lx-rt       = { version = "0.13.0", features = ["esp32"], optional = true }
+xtensa-lx-rt       = { version = "0.14.0", features = ["esp32"], optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.3.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.4.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -39,7 +39,7 @@ riscv-rt           = { version = "0.10.0", optional = true }
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.3.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.4.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32c2"] }
 sha2              = { version = "0.10.6", default-features = false}
 ssd1306           = "0.7.1"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -40,7 +40,7 @@ riscv-rt           = { version = "0.10.0", optional = true }
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.3.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.4.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32c3"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -32,14 +32,14 @@ embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.3.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-lx          = { version = "0.7.0",  features = ["esp32s2"] }
-xtensa-lx-rt       = { version = "0.13.0", features = ["esp32s2"], optional = true }
-xtensa-atomic-emulation-trap = { version = "0.2.0", features = ["esp32s2"] }
+xtensa-lx-rt       = { version = "0.14.0", features = ["esp32s2"], optional = true }
+xtensa-atomic-emulation-trap = { version = "0.3.0", features = ["esp32s2"] }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.3.0", features = ["esp32s2", "panic-handler", "print-uart"] }
+esp-backtrace     = { version = "0.4.0", features = ["esp32s2", "panic-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32s2"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -34,13 +34,13 @@ embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.3.0",  features = ["esp32s3"], path = "../esp-hal-common" }
 r0                 = { version = "1.0.0",  optional = true }
 xtensa-lx          = { version = "0.7.0",  features = ["esp32s3"] }
-xtensa-lx-rt       = { version = "0.13.0", features = ["esp32s3"], optional = true }
+xtensa-lx-rt       = { version = "0.14.0", features = ["esp32s3"], optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.3.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.4.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32s3"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"


### PR DESCRIPTION
Pass a `&mut TrapHandler` to CPU interrupt handlers like we do for peripheral interrupt handlers