### PR TITLE
Embassy init updates

### DIFF
--- a/.github/workflows/ci-async.yml
+++ b/.github/workflows/ci-async.yml
@@ -23,7 +23,9 @@ jobs:
         chip_features:
           [
             { chip: esp32c2, features: "embassy,embassy-time-systick" },
+            { chip: esp32c2, features: "embassy,embassy-time-timg0" },
             { chip: esp32c3, features: "embassy,embassy-time-systick" },
+            { chip: esp32c3, features: "embassy,embassy-time-timg0" },
           ]
         toolchain: [nightly]
         example:
@@ -52,11 +54,11 @@ jobs:
       matrix:
         chip_features:
           [
-            { chip: esp32, features: "embassy,embassy-time-timg" },
+            { chip: esp32, features: "embassy,embassy-time-timg0" },
             # { chip: esp32s2, features: "embassy,embassy-time-systick" }, # Removed for now, see esp32s2-hal/Cargo.toml
-            { chip: esp32s2, features: "embassy,embassy-time-timg" },
+            { chip: esp32s2, features: "embassy,embassy-time-timg0" },
             { chip: esp32s3, features: "embassy,embassy-time-systick" },
-            { chip: esp32s3, features: "embassy,embassy-time-timg" },
+            { chip: esp32s3, features: "embassy,embassy-time-timg0" },
           ]
         example:
           [

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -80,7 +80,7 @@ async   = ["embedded-hal-async", "eh1", "embassy-sync"]
 embassy = ["embassy-time"]
 
 embassy-time-systick = []
-embassy-time-timg    = []
+embassy-time-timg0    = []
 
 # Architecture-specific features (intended for internal use)
 riscv  = ["dep:riscv", "critical-section/restore-state-u8",  "procmacros/riscv", "riscv-atomic-emulation-trap"]

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -30,6 +30,7 @@ fn main() {
     //   - 'rmt'
     //   - 'spi3'
     //   - 'systimer'
+    //   - 'timg0'
     //   - 'timg1'
     //   - 'uart2'
     //   - 'usb_otg'
@@ -49,11 +50,12 @@ fn main() {
             "pdma",
             "rmt",
             "spi3",
+            "timg0",
             "timg1",
             "uart2",
         ]
     } else if esp32c2 {
-        vec!["esp32c2", "riscv", "single_core", "gdma", "systimer"]
+        vec!["esp32c2", "riscv", "single_core", "gdma", "systimer", "timg0"]
     } else if esp32c3 {
         vec![
             "esp32c3",
@@ -64,6 +66,7 @@ fn main() {
             "rmt",
             "spi3",
             "systimer",
+            "timg0",
             "timg1",
             "usb_serial_jtag",
         ]
@@ -79,6 +82,7 @@ fn main() {
             "rmt",
             "spi3",
             "systimer",
+            "timg0",
             "timg1",
             "usb_otg",
         ]
@@ -94,6 +98,7 @@ fn main() {
             "rmt",
             "spi3",
             "systimer",
+            "timg0",
             "timg1",
             "uart2",
             "usb_otg",

--- a/esp-hal-common/src/embassy.rs
+++ b/esp-hal-common/src/embassy.rs
@@ -2,26 +2,22 @@ use core::{cell::Cell, ptr};
 
 use embassy_time::driver::{AlarmHandle, Driver};
 
-use crate::clock::Clocks;
-
 #[cfg_attr(
     all(systimer, feature = "embassy-time-systick",),
     path = "embassy/time_driver_systimer.rs"
 )]
 #[cfg_attr(
-    all(feature = "embassy-time-timg", any(esp32, esp32s2, esp32s3)),
+    all(timg0, feature = "embassy-time-timg0"),
     path = "embassy/time_driver_timg.rs"
 )]
 mod time_driver;
 
 use time_driver::EmbassyTimer;
 
-pub fn init(clocks: &Clocks) {
-    // TODO:
-    // In the future allow taking of &mut Peripheral when we move to the
-    // PeripheralRef way of driver initialization, see: https://github.com/esp-rs/esp-idf-hal/blob/5d1aea58cdda195e20d1489fcba8a8ecb6562d9a/src/peripheral.rs#L94
+use crate::clock::Clocks;
 
-    EmbassyTimer::init(clocks);
+pub fn init(clocks: &Clocks, td: time_driver::TimerType) {
+    EmbassyTimer::init(clocks, td)
 }
 
 pub struct AlarmState {

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -9,11 +9,13 @@ use crate::{
 
 pub const ALARM_COUNT: usize = 3;
 
+pub type TimerType = SystemTimer;
+
 pub struct EmbassyTimer {
-    pub alarms: Mutex<[AlarmState; ALARM_COUNT]>,
-    pub alarm0: Alarm<Target, 0>,
-    pub alarm1: Alarm<Target, 1>,
-    pub alarm2: Alarm<Target, 2>,
+    pub(crate) alarms: Mutex<[AlarmState; ALARM_COUNT]>,
+    pub(crate) alarm0: Alarm<Target, 0>,
+    pub(crate) alarm1: Alarm<Target, 1>,
+    pub(crate) alarm2: Alarm<Target, 2>,
 }
 
 const ALARM_STATE_NONE: AlarmState = AlarmState::new();
@@ -52,7 +54,7 @@ impl EmbassyTimer {
         })
     }
 
-    pub(crate) fn init(_clocks: &Clocks) {
+    pub fn init(_clocks: &Clocks, _systimer: TimerType) {
         use crate::{interrupt, interrupt::Priority, macros::interrupt};
 
         interrupt::enable(pac::Interrupt::SYSTIMER_TARGET0, Priority::max()).unwrap();

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -55,7 +55,7 @@ ufmt              = ["esp-hal-common/ufmt"]
 vectored          = ["esp-hal-common/vectored"]
 async             = ["esp-hal-common/async", "embedded-hal-async"]
 embassy           = ["esp-hal-common/embassy"]
-embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-hz-1_000_000"]
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -38,7 +38,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
     let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    embassy::init(&clocks);
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
@@ -50,6 +49,9 @@ fn main() -> ! {
     rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
 
 
     let executor = EXECUTOR.init(Executor::new());

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -55,6 +55,7 @@ vectored             = ["esp-hal-common/vectored"]
 async                = ["esp-hal-common/async", "embedded-hal-async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "spi_eh1_loopback"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -60,6 +60,7 @@ allow-opt-level-z    = []
 async                = ["esp-hal-common/async", "embedded-hal-async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -38,7 +38,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    embassy::init(&clocks);
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
@@ -52,6 +51,11 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(&clocks, esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER));
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -61,7 +61,7 @@ embassy   = ["esp-hal-common/embassy"]
 # - add 80_000_000 support to embassy time
 # - Fix https://github.com/esp-rs/esp-hal/issues/253
 # embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-1_000_000"] 
-embassy-time-timg = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-hz-1_000_000"]
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -39,7 +39,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    embassy::init(&clocks);
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
@@ -52,6 +51,8 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -60,7 +60,7 @@ vectored             = ["esp-hal-common/vectored"]
 async                = ["esp-hal-common/async", "embedded-hal-async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg    = ["esp-hal-common/embassy-time-timg", "embassy-time/tick-hz-1_000_000"]
+embassy-time-timg0    = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -38,7 +38,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    embassy::init(&clocks);
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
@@ -52,6 +51,11 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(&clocks, esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER));
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {


### PR DESCRIPTION
- Rename timg feature to timg0 to better reflect which TG is being used
- Use the time_driver::TimerType in the signature of init to close #268
- Update examples
- Fix CI features
- Add timg0 cfg to build.rs