### PR TITLE
PeripheralRef/spi

### DIFF
--- a/esp-hal-common/src/cpu_control/esp32.rs
+++ b/esp-hal-common/src/cpu_control/esp32.rs
@@ -137,7 +137,7 @@ impl CpuControl {
     }
 
     fn enable_cache(&mut self, core: Cpu) {
-        let spi0 = unsafe { &(*crate::pac::SPI0::ptr()) };
+        let spi0 = unsafe { &(*crate::peripherals::SPI0::ptr()) };
 
         let dport_control = crate::pac::DPORT::PTR;
         let dport_control = unsafe { &*dport_control };

--- a/esp-hal-common/src/peripherals/esp32.rs
+++ b/esp-hal-common/src/peripherals/esp32.rs
@@ -55,5 +55,9 @@ mod peripherals {
         UART0,
         UART1,
         UART2,
+        SPI0,
+        SPI1,
+        SPI2,
+        SPI3,
     }
 }

--- a/esp-hal-common/src/peripherals/esp32.rs
+++ b/esp-hal-common/src/peripherals/esp32.rs
@@ -54,5 +54,6 @@ mod peripherals {
     crate::create_peripherals! {
         UART0,
         UART1,
+        UART2,
     }
 }

--- a/esp-hal-common/src/peripherals/esp32c2.rs
+++ b/esp-hal-common/src/peripherals/esp32c2.rs
@@ -36,5 +36,8 @@ mod peripherals {
     crate::create_peripherals! {
         UART0,
         UART1,
+        SPI0,
+        SPI1,
+        SPI2,
     }
 }

--- a/esp-hal-common/src/peripherals/esp32c3.rs
+++ b/esp-hal-common/src/peripherals/esp32c3.rs
@@ -47,5 +47,8 @@ mod peripherals {
     crate::create_peripherals! {
         UART0,
         UART1,
+        SPI0,
+        SPI1,
+        SPI2,
     }
 }

--- a/esp-hal-common/src/peripherals/esp32s2.rs
+++ b/esp-hal-common/src/peripherals/esp32s2.rs
@@ -52,5 +52,10 @@ mod peripherals {
     crate::create_peripherals! {
         UART0,
         UART1,
+        SPI0,
+        SPI1,
+        SPI2,
+        SPI3,
+        SPI4,
     }
 }

--- a/esp-hal-common/src/peripherals/esp32s3.rs
+++ b/esp-hal-common/src/peripherals/esp32s3.rs
@@ -64,5 +64,9 @@ mod peripherals {
         UART0,
         UART1,
         UART2,
+        SPI0,
+        SPI1,
+        SPI2,
+        SPI3,
     }
 }

--- a/esp-hal-common/src/peripherals/esp32s3.rs
+++ b/esp-hal-common/src/peripherals/esp32s3.rs
@@ -63,5 +63,6 @@ mod peripherals {
     crate::create_peripherals! {
         UART0,
         UART1,
+        UART2,
     }
 }


### PR DESCRIPTION
The second driver to be converted to the new PeripheralRef format.

Hopefully, this should be a better reference than the first one which got a little messy.