### PR TITLE
Support ESP32-C2 with 26MHz Xtal

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -63,6 +63,9 @@ esp32c3 = ["esp32c3/rt", "riscv"]
 esp32s2 = ["esp32s2/rt", "xtensa", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2",             "esp-synopsys-usb-otg", "usb-device"]
 esp32s3 = ["esp32s3/rt", "xtensa", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "lock_api", "esp-synopsys-usb-otg", "usb-device"]
 
+esp32c2_40mhz = []
+esp32c2_26mhz = []
+
 # Implement the `embedded-hal==1.0.0-alpha.x` traits
 eh1 = ["embedded-hal-1", "embedded-hal-nb"]
 

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -12,6 +12,13 @@ fn main() {
         n => panic!("Exactly 1 chip must be enabled via its Cargo feature, {n} provided"),
     }
 
+    if cfg!(feature = "esp32c2")
+        && cfg!(feature = "esp32c2_40mhz")
+        && cfg!(feature = "esp32c2_26mhz")
+    {
+        panic!("Only one xtal speed feature can be selected");
+    }
+
     // Define all required configuration symbols for the enabled chip.
     //
     // When adding a new device, at the bare minimum the following symbols MUST be

--- a/esp-hal-common/src/clock.rs
+++ b/esp-hal-common/src/clock.rs
@@ -227,7 +227,8 @@ impl ClockControl {
     /// Use what is considered the default settings after boot.
     #[allow(unused)]
     pub fn boot_defaults(clock_control: SystemClockControl) -> ClockControl {
-        ClockControl {
+        #[cfg(feature = "esp32c2_40mhz")]
+        return ClockControl {
             _private: (),
             desired_rates: RawClocks {
                 cpu_clock: HertzU32::MHz(80),
@@ -235,14 +236,28 @@ impl ClockControl {
                 xtal_clock: HertzU32::MHz(40),
                 i2c_clock: HertzU32::MHz(40),
             },
-        }
+        };
+
+        #[cfg(feature = "esp32c2_26mhz")]
+        return ClockControl {
+            _private: (),
+            desired_rates: RawClocks {
+                cpu_clock: HertzU32::MHz(80),
+                apb_clock: HertzU32::MHz(40),
+                xtal_clock: HertzU32::MHz(26),
+                i2c_clock: HertzU32::MHz(26),
+            },
+        };
     }
 
     /// Configure the CPU clock speed.
     #[allow(unused)]
     pub fn configure(clock_control: SystemClockControl, cpu_clock_speed: CpuClock) -> ClockControl {
         let apb_freq;
+        #[cfg(feature = "esp32c2_40mhz")]
         let xtal_freq = XtalClock::RtcXtalFreq40M;
+        #[cfg(feature = "esp32c2_26mhz")]
+        let xtal_freq = XtalClock::RtcXtalFreq26M;
         let pll_freq = PllClock::Pll480MHz;
 
         if cpu_clock_speed.mhz() <= xtal_freq.mhz() {

--- a/esp-hal-common/src/rtc/esp32c2.rs
+++ b/esp-hal-common/src/rtc/esp32c2.rs
@@ -59,10 +59,16 @@ pub(crate) fn init() {
 }
 
 pub(crate) fn configure_clock() {
+    #[cfg(feature = "esp32c2_40mhz")]
     assert!(matches!(
         RtcClock::get_xtal_freq(),
         XtalClock::RtcXtalFreq40M
     ));
+    #[cfg(feature = "esp32c2_26mhz")]
+    assert!(
+        matches!(RtcClock::get_xtal_freq(), XtalClock::RtcXtalFreq26M),
+        "Did you flash the right bootloader configured for 26MHz xtal?"
+    );
 
     RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
 

--- a/esp32-hal/.cargo/config.toml
+++ b/esp32-hal/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.xtensa-esp32-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 
 [build]
 rustflags = [

--- a/esp32c2-hal/.cargo/config.toml
+++ b/esp32c2-hal/.cargo/config.toml
@@ -1,12 +1,12 @@
 [target.riscv32imc-unknown-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x"
 ]
 
 # for testing: you can specify this target to see atomic emulation in action
 [target.riscv32imac-unknown-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x"
 ]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -46,7 +46,7 @@ ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
 
 [features]
-default              = ["rt", "vectored"]
+default              = ["rt", "vectored", "xtal40mhz"]
 direct-boot          = []
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
 rt                   = ["riscv-rt"]
@@ -55,7 +55,9 @@ vectored             = ["esp-hal-common/vectored"]
 async                = ["esp-hal-common/async", "embedded-hal-async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
+embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
+xtal40mhz            = ["esp-hal-common/esp32c2_40mhz"] 
+xtal26mhz            = ["esp-hal-common/esp32c2_26mhz"]
 
 [[example]]
 name              = "spi_eh1_loopback"

--- a/esp32c2-hal/build.rs
+++ b/esp32c2-hal/build.rs
@@ -2,6 +2,8 @@ use std::{env, fs::File, io::Write, path::PathBuf};
 
 #[cfg(feature = "direct-boot")]
 fn main() {
+    check_features();
+
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
@@ -36,6 +38,8 @@ fn main() {
 
 #[cfg(not(feature = "direct-boot"))]
 fn main() {
+    check_features();
+
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out.join("memory.x"))
@@ -60,6 +64,12 @@ fn main() {
     println!("cargo:rerun-if-changed=ld/memory.x");
 
     add_defaults();
+}
+
+fn check_features() {
+    if cfg!(feature = "xtal40mhz") && cfg!(feature = "xtal26mhz") {
+        panic!("Only one xtal speed feature can be selected");
+    }
 }
 
 fn add_defaults() {

--- a/esp32c3-hal/.cargo/config.toml
+++ b/esp32c3-hal/.cargo/config.toml
@@ -1,12 +1,12 @@
 [target.riscv32imc-unknown-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x"
 ]
 
 # for testing: you can specify this target to see atomic emulation in action
 [target.riscv32imac-unknown-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x"
 ]

--- a/esp32s2-hal/.cargo/config.toml
+++ b/esp32s2-hal/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.xtensa-esp32s2-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 
 [build]
 rustflags = [

--- a/esp32s3-hal/.cargo/config.toml
+++ b/esp32s3-hal/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.xtensa-esp32s3-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 
 [build]
 rustflags = [


### PR DESCRIPTION
According to [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/release-v5.0/esp32c2/get-started/windows-setup.html#get-started-windows-first-steps:~:text=If%20IDF%20monitor%20fails%20shortly%20after%20the%20upload%2C%20or%2C%20if%20instead%20of%20the%20messages%20above%2C%20you%20see%20random%20garbage%20similar%20to%20what%20is%20given%20below%2C%20your%20board%20is%20likely%20using%20a%2026%20MHz%20crystal.%20Most%20development%20board%20designs%20use%2040%20MHz%2C%20so%20ESP%2DIDF%20uses%20this%20frequency%20as%20a%20default%20value.) most development boards use a 40MHz xtal but 26MHz are available so it makes sense to support it.

However, since 40MHz is also the default for ESP-IDF it's also the default for esp-hal.

I tested this on both, 40MHz and 26MHz versions and checked SPI, I2C and UART with a logic analyzer - looks good.

Please note: If you are using a 26MHz chip you need to supply a custom bootloader configured for 26MHz otherwise clock config will panic.

Also this changes the _run_ alias to include the `flash` command - since `espflash 2.0` RCs are available for some time now we should do that - also apparently I'm the only one using `cargo run`