### PR TITLE
Use latest `xtensa-toolchain` version for all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         chip: [esp32, esp32s2, esp32s3]
     steps:
       - uses: actions/checkout@v2
-      - uses: esp-rs/xtensa-toolchain@v1.2
+      - uses: esp-rs/xtensa-toolchain@v1.4
         with:
           default: true
           ldproxy: false
@@ -190,7 +190,7 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v2
-      - uses: esp-rs/xtensa-toolchain@v1.2
+      - uses: esp-rs/xtensa-toolchain@v1.4
         with:
           default: true
           ldproxy: false


### PR DESCRIPTION
Turns out we forgot to update the version for a couple of jobs (we were 2 versions behind), hopefully this helps with the transient errors we've been experiencing.