### PR TITLE
Peripheral ref/gpio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
         with:
           profile: minimal
           target: riscv32imc-unknown-none-elf
-          toolchain: "1.60.0"
+          toolchain: "1.65.0"
           default: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -195,7 +195,7 @@ jobs:
           default: true
           ldproxy: false
           buildtargets: ${{ matrix.chip_features.chip }}
-          version: "1.60.0"
+          version: "1.65.0"
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ There are a number of other crates within the [esp-rs organization] which can be
 
 The **M**inimum **S**upported **R**ust **V**ersions are:
 
-- `1.60.0` for RISC-V devices (**ESP32-C2**, **ESP32-C3**)
-- `1.60.0` for Xtensa devices (**ESP32**, **ESP32-S2**, **ESP32-S3**)
+- `1.65.0` for RISC-V devices (**ESP32-C2**, **ESP32-C3**)
+- `1.65.0` for Xtensa devices (**ESP32**, **ESP32-S2**, **ESP32-S3**)
 
 Note that targeting the Xtensa ISA currently requires the use of the [esp-rs/rust] compiler fork. The [esp-rs/rust-build] repository has pre-compiled release artifacts for most common platforms, and provides installation scripts to aid you in the process.
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "HAL implementations for peripherals common among Espressif devices; should not be used directly"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -907,6 +907,40 @@ where
     }
 }
 
+impl<MODE, RA, PINTYPE, const GPIONUM: u8> crate::peripheral::Peripheral
+    for GpioPin<MODE, RA, PINTYPE, GPIONUM>
+where
+    RA: BankGpioRegisterAccess,
+    PINTYPE: PinType,
+{
+    type P = GpioPin<MODE, RA, PINTYPE, GPIONUM>;
+
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        core::ptr::read(self as *const _)
+    }
+}
+
+impl<MODE, RA, PINTYPE, const GPIONUM: u8> crate::peripheral::Peripheral
+    for &mut GpioPin<MODE, RA, PINTYPE, GPIONUM>
+where
+    RA: BankGpioRegisterAccess,
+    PINTYPE: PinType,
+{
+    type P = GpioPin<MODE, RA, PINTYPE, GPIONUM>;
+
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        core::ptr::read(*self as *const _)
+    }
+}
+
+impl<MODE, RA, PINTYPE, const GPIONUM: u8> crate::peripheral::sealed::Sealed
+    for GpioPin<MODE, RA, PINTYPE, GPIONUM>
+where
+    RA: BankGpioRegisterAccess,
+    PINTYPE: PinType,
+{
+}
+
 impl<RA, PINTYPE, const GPIONUM: u8> From<GpioPin<Unknown, RA, PINTYPE, GPIONUM>>
     for GpioPin<Input<Floating>, RA, PINTYPE, GPIONUM>
 where

--- a/esp-hal-common/src/i2c.rs
+++ b/esp-hal-common/src/i2c.rs
@@ -266,13 +266,13 @@ where
     /// automatically disabled when this gets dropped.
     pub fn new<SDA: OutputPin + InputPin, SCL: OutputPin + InputPin>(
         i2c: impl Peripheral<P = T> + 'd,
-        mut sda: SDA,
-        mut scl: SCL,
+        sda: impl Peripheral<P = SDA> + 'd,
+        scl: impl Peripheral<P = SCL> + 'd,
         frequency: HertzU32,
         peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self {
-        crate::into_ref!(i2c);
+        crate::into_ref!(i2c, sda, scl);
         enable_peripheral(&i2c, peripheral_clock_control);
 
         let mut i2c = I2C { peripheral: i2c };

--- a/esp-hal-common/src/ledc/channel.rs
+++ b/esp-hal-common/src/ledc/channel.rs
@@ -8,7 +8,8 @@ use super::{
 };
 use crate::{
     gpio::{types::OutputSignal, OutputPin},
-    peripherals::ledc::RegisterBlock, peripheral::{PeripheralRef, Peripheral},
+    peripheral::{Peripheral, PeripheralRef},
+    peripherals::ledc::RegisterBlock,
 };
 
 /// Channel errors

--- a/esp-hal-common/src/ledc/mod.rs
+++ b/esp-hal-common/src/ledc/mod.rs
@@ -150,7 +150,7 @@ impl<'d> LEDC<'d> {
     pub fn get_channel<S: TimerSpeed, O: OutputPin>(
         &self,
         number: channel::Number,
-        output_pin: O,
+        output_pin: impl Peripheral<P = O> + 'd,
     ) -> Channel<S, O> {
         Channel::new(number, output_pin)
     }

--- a/esp-hal-common/src/otg_fs.rs
+++ b/esp-hal-common/src/otg_fs.rs
@@ -4,9 +4,9 @@ pub use esp_synopsys_usb_otg::UsbBus;
 use esp_synopsys_usb_otg::UsbPeripheral;
 
 use crate::{
-    peripheral::PeripheralRef,
+    peripheral::{PeripheralRef, Peripheral},
     peripherals,
-    system::{Peripheral, PeripheralClockControl},
+    system::{Peripheral as PeripheralEnable, PeripheralClockControl},
     types::InputSignal,
 };
 
@@ -26,9 +26,9 @@ where
     M: UsbDm + Send + Sync,
 {
     _usb0: PeripheralRef<'d, peripherals::USB0>,
-    _usb_sel: S,
-    _usb_dp: P,
-    _usb_dm: M,
+    _usb_sel: PeripheralRef<'d, S>,
+    _usb_dp: PeripheralRef<'d, P>,
+    _usb_dm: PeripheralRef<'d, M>,
 }
 
 impl<'d, S, P, M> USB<'d, S, P, M>
@@ -38,13 +38,14 @@ where
     M: UsbDm + Send + Sync,
 {
     pub fn new(
-        usb0: impl crate::peripheral::Peripheral<P = peripherals::USB0> + 'd,
-        usb_sel: S,
-        usb_dp: P,
-        usb_dm: M,
+        usb0: impl Peripheral<P = peripherals::USB0> + 'd,
+        usb_sel: impl Peripheral<P = S> + 'd,
+        usb_dp: impl Peripheral<P = P> + 'd,
+        usb_dm: impl Peripheral<P = M> + 'd,
         peripheral_clock_control: &mut PeripheralClockControl,
     ) -> Self {
-        peripheral_clock_control.enable(Peripheral::Usb);
+        crate::into_ref!(usb_sel, usb_dp, usb_dm);
+        peripheral_clock_control.enable(PeripheralEnable::Usb);
         Self {
             _usb0: usb0.into_ref(),
             _usb_sel: usb_sel,

--- a/esp-hal-common/src/otg_fs.rs
+++ b/esp-hal-common/src/otg_fs.rs
@@ -4,7 +4,7 @@ pub use esp_synopsys_usb_otg::UsbBus;
 use esp_synopsys_usb_otg::UsbPeripheral;
 
 use crate::{
-    peripheral::{PeripheralRef, Peripheral},
+    peripheral::{Peripheral, PeripheralRef},
     peripherals,
     system::{Peripheral as PeripheralEnable, PeripheralClockControl},
     types::InputSignal,

--- a/esp-hal-common/src/peripheral.rs
+++ b/esp-hal-common/src/peripheral.rs
@@ -301,7 +301,8 @@ mod peripheral_macros {
     macro_rules! into_ref {
     ($($name:ident),*) => {
         $(
-            let $name = $name.into_ref();
+            #[allow(unused_mut)]
+            let mut $name = $name.into_ref();
         )*
     }
 }

--- a/esp-hal-common/src/pulse_control.rs
+++ b/esp-hal-common/src/pulse_control.rs
@@ -212,10 +212,10 @@ impl From<PulseCode> for u32 {
 
 /// Functionality that every OutputChannel must support
 pub trait OutputChannel {
-
     /// Output channel type
     type ConfiguredChannel<'d, P>
-        where P: OutputPin + 'd;
+    where
+        P: OutputPin + 'd;
 
     /// Set the logical level that the connected pin is pulled to
     /// while the channel is idle
@@ -236,7 +236,10 @@ pub trait OutputChannel {
     fn set_clock_source(&mut self, source: ClockSource) -> &mut Self;
 
     /// Assign a pin that should be driven by this channel
-    fn assign_pin<'d, P: OutputPin>(self, pin: impl Peripheral<P = P> + 'd) -> Self::ConfiguredChannel<'d, P>;
+    fn assign_pin<'d, P: OutputPin>(
+        self,
+        pin: impl Peripheral<P = P> + 'd,
+    ) -> Self::ConfiguredChannel<'d, P>;
 }
 
 /// Functionality that is allowed only on `ConfiguredChannel`
@@ -657,7 +660,7 @@ macro_rules! output_channel {
 
             type ConfiguredChannel<'d, P> = [<Configured $cxi>]<'d, P>
                 where P: OutputPin + 'd;
-            
+
             /// Set the logical level that the connected pin is pulled to
             /// while the channel is idle
             #[inline(always)]

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -115,16 +115,16 @@ where
     /// Constructs an SPI instance in 8bit dataframe mode.
     pub fn new<SCK: OutputPin, MOSI: OutputPin, MISO: InputPin, CS: OutputPin>(
         spi: impl Peripheral<P = T> + 'd,
-        mut sck: SCK,
-        mut mosi: MOSI,
-        mut miso: MISO,
-        mut cs: CS,
+        sck: impl Peripheral<P = SCK> + 'd,
+        mosi: impl Peripheral<P = MOSI> + 'd,
+        miso: impl Peripheral<P = MISO> + 'd,
+        cs: impl Peripheral<P = CS> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
         peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self {
-        crate::into_ref!(spi);
+        crate::into_ref!(spi, sck, mosi, miso, cs);
         sck.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.sclk_signal());
 
@@ -143,15 +143,15 @@ where
     /// Constructs an SPI instance in 8bit dataframe mode without CS pin.
     pub fn new_no_cs<SCK: OutputPin, MOSI: OutputPin, MISO: InputPin>(
         spi: impl Peripheral<P = T> + 'd,
-        mut sck: SCK,
-        mut mosi: MOSI,
-        mut miso: MISO,
+        sck: impl Peripheral<P = SCK> + 'd,
+        mosi: impl Peripheral<P = MOSI> + 'd,
+        miso: impl Peripheral<P = MISO> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
         peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self {
-        crate::into_ref!(spi);
+        crate::into_ref!(spi, sck, mosi, miso);
         sck.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.sclk_signal());
 
@@ -168,14 +168,14 @@ where
     /// pin.
     pub fn new_no_cs_no_miso<SCK: OutputPin, MOSI: OutputPin>(
         spi: impl Peripheral<P = T> + 'd,
-        mut sck: SCK,
-        mut mosi: MOSI,
+        sck: impl Peripheral<P = SCK> + 'd,
+        mosi: impl Peripheral<P = MOSI> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
         peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self {
-        crate::into_ref!(spi);
+        crate::into_ref!(spi, sck, mosi);
         sck.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.sclk_signal());
 
@@ -191,13 +191,13 @@ where
     /// waveforms…)
     pub fn new_mosi_only<MOSI: OutputPin>(
         spi: impl Peripheral<P = T> + 'd,
-        mut mosi: MOSI,
+        mosi: impl Peripheral<P = MOSI> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
         peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self {
-        crate::into_ref!(spi);
+        crate::into_ref!(spi, mosi);
         mosi.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.mosi_signal());
 

--- a/esp-hal-common/src/uart.rs
+++ b/esp-hal-common/src/uart.rs
@@ -144,16 +144,22 @@ pub trait UartPins {
 }
 
 /// All pins offered by UART
-pub struct AllPins<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> {
-    pub tx: Option<TX>,
-    pub rx: Option<RX>,
-    pub cts: Option<CTS>,
-    pub rts: Option<RTS>,
+pub struct AllPins<'d, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> {
+    pub(crate) tx: Option<PeripheralRef<'d, TX>>,
+    pub(crate) rx: Option<PeripheralRef<'d, RX>>,
+    pub(crate) cts: Option<PeripheralRef<'d, CTS>>,
+    pub(crate) rts: Option<PeripheralRef<'d, RTS>>,
 }
 
 /// Tx and Rx pins
-impl<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> AllPins<TX, RX, CTS, RTS> {
-    pub fn new(tx: TX, rx: RX, cts: CTS, rts: RTS) -> AllPins<TX, RX, CTS, RTS> {
+impl<'d, TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> AllPins<'d, TX, RX, CTS, RTS> {
+    pub fn new(
+        tx: impl Peripheral<P = TX> + 'd,
+        rx: impl Peripheral<P = RX> + 'd,
+        cts: impl Peripheral<P = CTS> + 'd,
+        rts: impl Peripheral<P = RTS> + 'd,
+    ) -> AllPins<'d, TX, RX, CTS, RTS> {
+        crate::into_ref!(tx, rx, cts, rts);
         AllPins {
             tx: Some(tx),
             rx: Some(rx),
@@ -164,7 +170,7 @@ impl<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> AllPins<TX, RX,
 }
 
 impl<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> UartPins
-    for AllPins<TX, RX, CTS, RTS>
+    for AllPins<'_, TX, RX, CTS, RTS>
 {
     fn configure_pins(
         &mut self,
@@ -193,13 +199,17 @@ impl<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin> UartPins
     }
 }
 
-pub struct TxRxPins<TX: OutputPin, RX: InputPin> {
-    pub tx: Option<TX>,
-    pub rx: Option<RX>,
+pub struct TxRxPins<'d, TX: OutputPin, RX: InputPin> {
+    pub tx: Option<PeripheralRef<'d, TX>>,
+    pub rx: Option<PeripheralRef<'d, RX>>,
 }
 
-impl<TX: OutputPin, RX: InputPin> TxRxPins<TX, RX> {
-    pub fn new_tx_rx(tx: TX, rx: RX) -> TxRxPins<TX, RX> {
+impl<'d, TX: OutputPin, RX: InputPin> TxRxPins<'d, TX, RX> {
+    pub fn new_tx_rx(
+        tx: impl Peripheral<P = TX> + 'd,
+        rx: impl Peripheral<P = RX> + 'd,
+    ) -> TxRxPins<'d, TX, RX> {
+        crate::into_ref!(tx, rx);
         TxRxPins {
             tx: Some(tx),
             rx: Some(rx),
@@ -207,7 +217,7 @@ impl<TX: OutputPin, RX: InputPin> TxRxPins<TX, RX> {
     }
 }
 
-impl<TX: OutputPin, RX: InputPin> UartPins for TxRxPins<TX, RX> {
+impl<TX: OutputPin, RX: InputPin> UartPins for TxRxPins<'_, TX, RX> {
     fn configure_pins(
         &mut self,
         tx_signal: OutputSignal,

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "Procedural macros for ESP-HAL"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "HAL for ESP32 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32-hal/examples/i2s_read.rs
+++ b/esp32-hal/examples/i2s_read.rs
@@ -66,7 +66,10 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(io.pins.gpio12,io.pins.gpio13,io.pins.gpio17,
+    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
+        io.pins.gpio12,
+        io.pins.gpio13,
+        io.pins.gpio17,
     ));
 
     let buffer = dma_buffer();

--- a/esp32-hal/examples/i2s_read.rs
+++ b/esp32-hal/examples/i2s_read.rs
@@ -66,11 +66,8 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin {
-        bclk: io.pins.gpio12,
-        ws: io.pins.gpio13,
-        din: io.pins.gpio17,
-    });
+    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(io.pins.gpio12,io.pins.gpio13,io.pins.gpio17,
+    ));
 
     let buffer = dma_buffer();
 

--- a/esp32-hal/examples/i2s_sound.rs
+++ b/esp32-hal/examples/i2s_sound.rs
@@ -89,11 +89,8 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout {
-        bclk: io.pins.gpio12,
-        ws: io.pins.gpio13,
-        dout: io.pins.gpio14,
-    });
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(io.pins.gpio12,io.pins.gpio13,io.pins.gpio14,
+    ));
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32-hal/examples/i2s_sound.rs
+++ b/esp32-hal/examples/i2s_sound.rs
@@ -89,7 +89,10 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(io.pins.gpio12,io.pins.gpio13,io.pins.gpio14,
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio12,
+        io.pins.gpio13,
+        io.pins.gpio14,
     ));
 
     let data =

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "HAL for ESP32-C2 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "HAL for ESP32-C3 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32c3-hal/examples/i2s_read.rs
+++ b/esp32c3-hal/examples/i2s_read.rs
@@ -57,9 +57,7 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S,
-        MclkPin {
-            mclk: io.pins.gpio4,
-        },
+        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -73,11 +71,11 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin {
-        bclk: io.pins.gpio1,
-        ws: io.pins.gpio2,
-        din: io.pins.gpio5,
-    });
+    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio5,
+    ));
 
     let buffer = dma_buffer();
 

--- a/esp32c3-hal/examples/i2s_sound.rs
+++ b/esp32c3-hal/examples/i2s_sound.rs
@@ -80,9 +80,7 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S,
-        MclkPin {
-            mclk: io.pins.gpio4,
-        },
+        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -96,11 +94,11 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout {
-        bclk: io.pins.gpio1,
-        ws: io.pins.gpio2,
-        dout: io.pins.gpio3,
-    });
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio3,
+    ));
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "HAL for ESP32-S2 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32s2-hal/examples/i2s_read.rs
+++ b/esp32s2-hal/examples/i2s_read.rs
@@ -66,11 +66,8 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin {
-        bclk: io.pins.gpio1,
-        ws: io.pins.gpio2,
-        din: io.pins.gpio5,
-    });
+    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(io.pins.gpio1, io.pins.gpio2,io.pins.gpio5,
+    ));
 
     let buffer = dma_buffer();
 

--- a/esp32s2-hal/examples/i2s_read.rs
+++ b/esp32s2-hal/examples/i2s_read.rs
@@ -66,7 +66,10 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(io.pins.gpio1, io.pins.gpio2,io.pins.gpio5,
+    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio5,
     ));
 
     let buffer = dma_buffer();

--- a/esp32s2-hal/examples/i2s_sound.rs
+++ b/esp32s2-hal/examples/i2s_sound.rs
@@ -76,9 +76,7 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S,
-        MclkPin {
-            mclk: io.pins.gpio4,
-        },
+        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -92,11 +90,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout {
-        bclk: io.pins.gpio1,
-        ws: io.pins.gpio2,
-        dout: io.pins.gpio3,
-    });
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(io.pins.gpio1,io.pins.gpio2,io.pins.gpio3));
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32s2-hal/examples/i2s_sound.rs
+++ b/esp32s2-hal/examples/i2s_sound.rs
@@ -90,7 +90,11 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(io.pins.gpio1,io.pins.gpio2,io.pins.gpio3));
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio3,
+    ));
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "HAL for ESP32-S3 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32s3-hal/examples/i2s_read.rs
+++ b/esp32s3-hal/examples/i2s_read.rs
@@ -57,9 +57,7 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin {
-            mclk: io.pins.gpio4,
-        },
+        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -73,11 +71,11 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin {
-        bclk: io.pins.gpio1,
-        ws: io.pins.gpio2,
-        din: io.pins.gpio5,
-    });
+    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio5,
+    ));
 
     let buffer = dma_buffer();
 

--- a/esp32s3-hal/examples/i2s_sound.rs
+++ b/esp32s3-hal/examples/i2s_sound.rs
@@ -80,9 +80,7 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin {
-            mclk: io.pins.gpio4,
-        },
+        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -96,11 +94,11 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout {
-        bclk: io.pins.gpio1,
-        ws: io.pins.gpio2,
-        dout: io.pins.gpio3,
-    });
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio3,
+    ));
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };


### PR DESCRIPTION
The final update in this conversion step.

A couple of things had to change to get this working:

- I2S pin structs now have constructors
- MSRV bumped to 1.65 because pulse control traits now use GATs

I *think* I've covered everywhere we use pins but I would appreciate a triple-check on that.