### PR TITLE
Async: GPIO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         run: cd esp32-hal/ && cargo check --examples --features=eh1,smartled,ufmt
       - name: check esp32-hal (async)
         run: cd esp32-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
+      - name: check esp32-hal (async, gpio)
+        run: cd esp32-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
 
   esp32c2-hal:
     runs-on: ubuntu-latest
@@ -75,6 +77,8 @@ jobs:
         run: cd esp32c2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32c2-hal (async, timg0)
         run: cd esp32c2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
+      - name: check esp32c2-hal (async, gpio)
+        run: cd esp32c2-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-systick,async
 
   esp32c3-hal:
     runs-on: ubuntu-latest
@@ -109,6 +113,8 @@ jobs:
         run: cargo check --manifest-path=esp32c3-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32c3-hal (async, timg0)
         run: cargo check --manifest-path=esp32c3-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --example=embassy_hello_world --features=embassy,embassy-time-timg0
+      - name: check esp32c3-hal (async, gpio)
+        run: cd esp32c3-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-systick,async
 
   esp32s2-hal:
     runs-on: ubuntu-latest
@@ -135,6 +141,8 @@ jobs:
       #   run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32s2-hal (async, timg0)
         run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
+      - name: check esp32s2-hal (async, gpio)
+        run: cd esp32s2-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
 
   esp32s3-hal:
     runs-on: ubuntu-latest
@@ -164,7 +172,8 @@ jobs:
         run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32s3-hal (async, timg0)
         run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
-
+      - name: check esp32s3-hal (async, gpio)
+        run: cd esp32s3-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
   # --------------------------------------------------------------------------
   # MSRV
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The **M**inimum **S**upported **R**ust **V**ersions are:
 
 - `1.65.0` for RISC-V devices (**ESP32-C2**, **ESP32-C3**)
 - `1.65.0` for Xtensa devices (**ESP32**, **ESP32-S2**, **ESP32-S3**)
+- `1.67.0` for all `async` examples (`embassy_hello_world`, `embassy_wait`, etc.)
 
 Note that targeting the Xtensa ISA currently requires the use of the [esp-rs/rust] compiler fork. The [esp-rs/rust-build] repository has pre-compiled release artifacts for most common platforms, and provides installation scripts to aid you in the process.
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -30,7 +30,7 @@ void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
 
 # async
-embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embassy-sync       = { version = "0.1.0", optional = true }
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1751,7 +1751,7 @@ mod asynch {
                     if pin_nr < 32 {
                         Bank0GpioRegisterAccess::set_int_enable(pin_nr as u8, 0, 0, false);
                     } else {
-                        Bank0GpioRegisterAccess::set_int_enable(pin_nr as u8, 0, 0, false);
+                        Bank1GpioRegisterAccess::set_int_enable(pin_nr as u8, 0, 0, false);
                     }
                 } else {
                     Bank0GpioRegisterAccess::set_int_enable(pin_nr as u8, 0, 0, false);

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -404,13 +404,7 @@ pub trait BankGpioRegisterAccess {
         gpio.func_in_sel_cfg[signal as usize].modify(|_, w| w.sel().clear_bit());
     }
 
-    fn set_int_enable(
-        &self,
-        gpio_num: u8,
-        int_ena: u32,
-        int_type: u8,
-        wake_up_from_light_sleep: bool,
-    ) {
+    fn set_int_enable(gpio_num: u8, int_ena: u32, int_type: u8, wake_up_from_light_sleep: bool) {
         let gpio = unsafe { &*crate::peripherals::GPIO::PTR };
         gpio.pin[gpio_num as usize].modify(|_, w| unsafe {
             w.int_ena()
@@ -1652,3 +1646,119 @@ pub(crate) use gpio;
 
 pub use self::types::{InputSignal, OutputSignal};
 use self::types::{ONE_INPUT, ZERO_INPUT};
+
+#[cfg(feature = "async")]
+mod asynch {
+    use core::task::{Context, Poll};
+
+    use embassy_sync::waitqueue::AtomicWaker;
+    use embedded_hal_async::digital::Wait;
+
+    use super::*;
+    use crate::prelude::*;
+
+    #[allow(clippy::declare_interior_mutable_const)]
+    const NEW_AW: AtomicWaker = AtomicWaker::new();
+    static PIN_WAKERS: [AtomicWaker; NUM_PINS] = [NEW_AW; NUM_PINS];
+
+    impl<MODE, RA, IRA, PINTYPE, SIG, const GPIONUM: u8> Wait
+        for GpioPin<Input<MODE>, RA, IRA, PINTYPE, SIG, GPIONUM>
+    where
+        RA: BankGpioRegisterAccess,
+        PINTYPE: IsOutputPin,
+        IRA: InteruptStatusRegisterAccess,
+        SIG: GpioSignal,
+    {
+        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+            PinFuture::new(self, Event::HighLevel).await
+        }
+
+        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+            PinFuture::new(self, Event::LowLevel).await
+        }
+
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+            PinFuture::new(self, Event::RisingEdge).await
+        }
+
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+            PinFuture::new(self, Event::FallingEdge).await
+        }
+
+        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+            PinFuture::new(self, Event::AnyEdge).await
+        }
+    }
+
+    pub struct PinFuture<'a, P> {
+        pin: &'a mut P,
+    }
+
+    impl<'a, P> PinFuture<'a, P>
+    where
+        P: crate::gpio::Pin + embedded_hal_1::digital::ErrorType,
+    {
+        pub fn new(pin: &'a mut P, event: Event) -> Self {
+            pin.listen(event);
+            Self { pin }
+        }
+    }
+
+    impl<'a, P> core::future::Future for PinFuture<'a, P>
+    where
+        P: crate::gpio::Pin + embedded_hal_1::digital::ErrorType,
+    {
+        type Output = Result<(), P::Error>;
+
+        fn poll(self: core::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            PIN_WAKERS[self.pin.number() as usize].register(cx.waker());
+
+            // if pin is no longer listening its been triggered
+            // therefore the future has resolved
+            if !self.pin.is_listening() {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        }
+    }
+
+    #[interrupt]
+    unsafe fn GPIO() {
+        // TODO how to handle dual core reg access
+        // we need to check which core the interrupt is currently firing on
+        // and only fire interrupts registered for that core
+        type Bank0 = SingleCoreInteruptStatusRegisterAccessBank0;
+        #[cfg(any(esp32, esp32s2, esp32s3))]
+        type Bank1 = SingleCoreInteruptStatusRegisterAccessBank1;
+
+        let mut intrs = Bank0::pro_cpu_interrupt_status_read() as u64;
+
+        #[cfg(any(esp32, esp32s2, esp32s3))]
+        {
+            intrs |= (Bank1::pro_cpu_interrupt_status_read() as u64) << 32;
+        }
+
+        // clear interrupts
+        Bank0GpioRegisterAccess::write_interrupt_status_clear(!0);
+        #[cfg(any(esp32, esp32s2, esp32s3))]
+        Bank1GpioRegisterAccess::write_interrupt_status_clear(!0);
+
+        while intrs != 0 {
+            let pin_nr = intrs.trailing_zeros();
+            cfg_if::cfg_if! {
+                if #[cfg(any(esp32, esp32s2, esp32s3))] {
+                    if pin_nr < 32 {
+                        Bank0GpioRegisterAccess::set_int_enable(pin_nr as u8, 0, 0, false);
+                    } else {
+                        Bank0GpioRegisterAccess::set_int_enable(pin_nr as u8, 0, 0, false);
+                    }
+                } else {
+                    Bank0GpioRegisterAccess::set_int_enable(pin_nr as u8, 0, 0, false);
+                }
+            }
+            PIN_WAKERS[pin_nr as usize].wake(); // wake task
+            intrs &= !(1 << pin_nr);
+        }
+    }
+}

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -117,6 +117,8 @@ pub trait Pin {
         self.listen_with_options(event, true, false, false)
     }
 
+    fn is_listening(&self) -> bool;
+
     fn listen_with_options(
         &mut self,
         event: Event,
@@ -835,6 +837,14 @@ where
                     .bit(wake_up_from_light_sleep)
             });
         }
+    }
+
+    fn is_listening(&self) -> bool {
+        let bits = unsafe { &*GPIO::PTR }.pin[GPIONUM as usize]
+            .read()
+            .int_ena()
+            .bits();
+        bits != 0
     }
 
     fn unlisten(&mut self) {

--- a/esp-hal-common/src/gpio/esp32.rs
+++ b/esp-hal-common/src/gpio/esp32.rs
@@ -13,6 +13,8 @@ use crate::{
     Unknown,
 };
 
+pub const NUM_PINS: usize = 39;
+
 pub type OutputSignalType = u16;
 pub const OUTPUT_SIGNAL_MAX: u16 = 548;
 pub const INPUT_SIGNAL_MAX: u16 = 539;

--- a/esp-hal-common/src/gpio/esp32c2.rs
+++ b/esp-hal-common/src/gpio/esp32c2.rs
@@ -11,6 +11,8 @@ use crate::{
     Unknown,
 };
 
+pub const NUM_PINS: usize = 20;
+
 pub type OutputSignalType = u8;
 pub const OUTPUT_SIGNAL_MAX: u8 = 128;
 pub const INPUT_SIGNAL_MAX: u8 = 100;

--- a/esp-hal-common/src/gpio/esp32c3.rs
+++ b/esp-hal-common/src/gpio/esp32c3.rs
@@ -11,6 +11,8 @@ use crate::{
     Unknown,
 };
 
+pub const NUM_PINS: usize = 21;
+
 pub type OutputSignalType = u8;
 pub const OUTPUT_SIGNAL_MAX: u8 = 128;
 pub const INPUT_SIGNAL_MAX: u8 = 100;

--- a/esp-hal-common/src/gpio/esp32s2.rs
+++ b/esp-hal-common/src/gpio/esp32s2.rs
@@ -12,6 +12,8 @@ use crate::{
     Unknown,
 };
 
+pub const NUM_PINS: usize = 46;
+
 pub type OutputSignalType = u16;
 pub const OUTPUT_SIGNAL_MAX: u16 = 256;
 pub const INPUT_SIGNAL_MAX: u16 = 204;

--- a/esp-hal-common/src/gpio/esp32s3.rs
+++ b/esp-hal-common/src/gpio/esp32s3.rs
@@ -12,6 +12,8 @@ use crate::{
     Unknown,
 };
 
+pub const NUM_PINS: usize = 48;
+
 pub type OutputSignalType = u16;
 pub const OUTPUT_SIGNAL_MAX: u16 = 256;
 pub const INPUT_SIGNAL_MAX: u16 = 189;

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -20,6 +20,8 @@
 
 #![no_std]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]
+#![cfg_attr(feature = "async", allow(incomplete_features))]
+#![cfg_attr(feature = "async", feature(async_fn_in_trait))]
 
 #[cfg_attr(esp32, path = "peripherals/esp32.rs")]
 #[cfg_attr(esp32c3, path = "peripherals/esp32c3.rs")]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -73,3 +73,7 @@ required-features = ["eh1"]
 [[example]]
 name              = "embassy_hello_world"
 required-features = ["embassy"]
+
+[[example]]
+name              = "embassy_wait"
+required-features = ["embassy", "async"]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -28,7 +28,7 @@ categories = [
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.4.0",  features = ["esp32"], path = "../esp-hal-common" }
 xtensa-lx          = { version = "0.7.0",  features = ["esp32"] }

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -1,3 +1,8 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -4,18 +4,19 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-
+use embedded_hal_async::digital::Wait;
 use esp32_hal::{
     clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc, embassy, peripherals::Peripherals, IO,
+    Rtc,
+    IO,
 };
 use esp_backtrace as _;
-use esp_hal_common::{PullDown, Input, Gpio0};
+use esp_hal_common::{Gpio0, Input, PullDown};
 use static_cell::StaticCell;
-
-use embedded_hal_async::digital::Wait;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio0<Input<PullDown>>) {

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -1,3 +1,7 @@
+//! embassy wait
+//!
+//! This is an example of asynchronously `Wait`ing for a pin state to change.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+
+use esp32_hal::{
+    clock::ClockControl,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc, embassy, peripherals::Peripherals, IO,
+};
+use esp_backtrace as _;
+use esp_hal_common::{PullDown, Input, Gpio0};
+use static_cell::StaticCell;
+
+use embedded_hal_async::digital::Wait;
+
+#[embassy_executor::task]
+async fn ping(mut pin: Gpio0<Input<PullDown>>) {
+    loop {
+        esp_println::println!("Waiting...");
+        pin.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[xtensa_lx_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    // GPIO 0 as input
+    let input = io.pins.gpio0.into_pull_down_input();
+
+    // Async requires the GPIO interrupt to wake futures
+    esp32_hal::interrupt::enable(
+        esp32_hal::peripherals::Interrupt::GPIO,
+        esp32_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(ping(input)).ok();
+    });
+}

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -70,3 +70,7 @@ required-features = ["eh1"]
 [[example]]
 name              = "embassy_hello_world"
 required-features = ["embassy"]
+
+[[example]]
+name              = "embassy_wait"
+required-features = ["embassy", "async"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -28,7 +28,7 @@ categories = [
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.4.0",  features = ["esp32c2"], path = "../esp-hal-common" }
 r0                 = "1.0.0"

--- a/esp32c2-hal/examples/embassy_hello_world.rs
+++ b/esp32c2-hal/examples/embassy_hello_world.rs
@@ -1,3 +1,8 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32c2-hal/examples/embassy_wait.rs
+++ b/esp32c2-hal/examples/embassy_wait.rs
@@ -1,3 +1,7 @@
+//! embassy wait
+//!
+//! This is an example of asynchronously `Wait`ing for a pin state to change.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32c2-hal/examples/embassy_wait.rs
+++ b/esp32c2-hal/examples/embassy_wait.rs
@@ -4,18 +4,19 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-
+use embedded_hal_async::digital::Wait;
 use esp32c2_hal::{
     clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc, embassy, peripherals::Peripherals, IO,
+    Rtc,
+    IO,
 };
 use esp_backtrace as _;
-use esp_hal_common::{PullDown, Input, Gpio9};
+use esp_hal_common::{Gpio9, Input, PullDown};
 use static_cell::StaticCell;
-
-use embedded_hal_async::digital::Wait;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio9<Input<PullDown>>) {
@@ -45,7 +46,10 @@ fn main() -> ! {
     wdt0.disable();
 
     #[cfg(feature = "embassy-time-systick")]
-    embassy::init(&clocks, esp32c2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER));
+    embassy::init(
+        &clocks,
+        esp32c2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
 
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);

--- a/esp32c2-hal/examples/embassy_wait.rs
+++ b/esp32c2-hal/examples/embassy_wait.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+
+use esp32c2_hal::{
+    clock::ClockControl,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc, embassy, peripherals::Peripherals, IO,
+};
+use esp_backtrace as _;
+use esp_hal_common::{PullDown, Input, Gpio9};
+use static_cell::StaticCell;
+
+use embedded_hal_async::digital::Wait;
+
+#[embassy_executor::task]
+async fn ping(mut pin: Gpio9<Input<PullDown>>) {
+    loop {
+        esp_println::println!("Waiting...");
+        pin.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[riscv_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(&clocks, esp32c2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER));
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    // GPIO 9 as input
+    let input = io.pins.gpio9.into_pull_down_input();
+
+    // Async requires the GPIO interrupt to wake futures
+    esp32c2_hal::interrupt::enable(
+        esp32c2_hal::peripherals::Interrupt::GPIO,
+        esp32c2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(ping(input)).ok();
+    });
+}

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -29,7 +29,7 @@ cfg-if             = "1.0.0"
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.4.0",  features = ["esp32c3"], path = "../esp-hal-common" }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -80,5 +80,9 @@ required-features = ["eh1"]
 name              = "embassy_hello_world"
 required-features = ["embassy"]
 
+[[example]]
+name              = "embassy_wait"
+required-features = ["embassy", "async"]
+
 [profile.dev]
 opt-level = 1

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -1,3 +1,8 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -1,3 +1,7 @@
+//! embassy wait
+//!
+//! This is an example of asynchronously `Wait`ing for a pin state to change.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -4,18 +4,19 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-
+use embedded_hal_async::digital::Wait;
 use esp32c3_hal::{
     clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc, embassy, peripherals::Peripherals, IO,
+    Rtc,
+    IO,
 };
 use esp_backtrace as _;
-use esp_hal_common::{PullDown, Input, Gpio9};
+use esp_hal_common::{Gpio9, Input, PullDown};
 use static_cell::StaticCell;
-
-use embedded_hal_async::digital::Wait;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio9<Input<PullDown>>) {
@@ -49,7 +50,10 @@ fn main() -> ! {
     wdt1.disable();
 
     #[cfg(feature = "embassy-time-systick")]
-    embassy::init(&clocks, esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER));
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
 
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -1,0 +1,72 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc, embassy, peripherals::Peripherals, IO,
+};
+use esp_backtrace as _;
+use esp_hal_common::{PullDown, Input, Gpio9};
+use static_cell::StaticCell;
+
+use embedded_hal_async::digital::Wait;
+
+#[embassy_executor::task]
+async fn ping(mut pin: Gpio9<Input<PullDown>>) {
+    loop {
+        esp_println::println!("Waiting...");
+        pin.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[riscv_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(&clocks, esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER));
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    // GPIO 9 as input
+    let input = io.pins.gpio9.into_pull_down_input();
+
+    // Async requires the GPIO interrupt to wake futures
+    esp32c3_hal::interrupt::enable(
+        esp32c3_hal::peripherals::Interrupt::GPIO,
+        esp32c3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(ping(input)).ok();
+    });
+}

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -28,7 +28,7 @@ categories = [
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.4.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-lx          = { version = "0.7.0",  features = ["esp32s2"] }

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -79,3 +79,7 @@ required-features = ["eh1"]
 [[example]]
 name              = "embassy_hello_world"
 required-features = ["embassy"]
+
+[[example]]
+name              = "embassy_wait"
+required-features = ["embassy", "async"]

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -1,3 +1,8 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc, embassy, peripherals::Peripherals, IO,
+};
+use esp_backtrace as _;
+use esp_hal_common::{PullDown, Input, Gpio0};
+use static_cell::StaticCell;
+
+use embedded_hal_async::digital::Wait;
+
+#[embassy_executor::task]
+async fn ping(mut pin: Gpio0<Input<PullDown>>) {
+    loop {
+        esp_println::println!("Waiting...");
+        pin.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[xtensa_lx_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    // GPIO 0 as input
+    let input = io.pins.gpio0.into_pull_down_input();
+
+    // Async requires the GPIO interrupt to wake futures
+    esp32s2_hal::interrupt::enable(
+        esp32s2_hal::peripherals::Interrupt::GPIO,
+        esp32s2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(ping(input)).ok();
+    });
+}

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -1,3 +1,7 @@
+//! embassy wait
+//!
+//! This is an example of asynchronously `Wait`ing for a pin state to change.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -4,18 +4,19 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-
+use embedded_hal_async::digital::Wait;
 use esp32s2_hal::{
     clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc, embassy, peripherals::Peripherals, IO,
+    Rtc,
+    IO,
 };
 use esp_backtrace as _;
-use esp_hal_common::{PullDown, Input, Gpio0};
+use esp_hal_common::{Gpio0, Input, PullDown};
 use static_cell::StaticCell;
-
-use embedded_hal_async::digital::Wait;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio0<Input<PullDown>>) {

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -29,7 +29,7 @@ bare-metal         = "1.0.0"
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.4.0",  features = ["esp32s3"], path = "../esp-hal-common" }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -79,3 +79,7 @@ required-features = ["eh1"]
 [[example]]
 name              = "embassy_hello_world"
 required-features = ["embassy"]
+
+[[example]]
+name              = "embassy_wait"
+required-features = ["embassy", "async"]

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -1,3 +1,8 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -1,3 +1,7 @@
+//! embassy wait
+//!
+//! This is an example of asynchronously `Wait`ing for a pin state to change.
+
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -1,0 +1,72 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc, embassy, peripherals::Peripherals, IO,
+};
+use esp_backtrace as _;
+use esp_hal_common::{PullDown, Input, Gpio0};
+use static_cell::StaticCell;
+
+use embedded_hal_async::digital::Wait;
+
+#[embassy_executor::task]
+async fn ping(mut pin: Gpio0<Input<PullDown>>) {
+    loop {
+        esp_println::println!("Waiting...");
+        pin.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[xtensa_lx_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(&clocks, esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER));
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    // GPIO 0 as input
+    let input = io.pins.gpio0.into_pull_down_input();
+
+    // Async requires the GPIO interrupt to wake futures
+    esp32s3_hal::interrupt::enable(
+        esp32s3_hal::peripherals::Interrupt::GPIO,
+        esp32s3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(ping(input)).ok();
+    });
+}

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -4,18 +4,19 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-
+use embedded_hal_async::digital::Wait;
 use esp32s3_hal::{
     clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc, embassy, peripherals::Peripherals, IO,
+    Rtc,
+    IO,
 };
 use esp_backtrace as _;
-use esp_hal_common::{PullDown, Input, Gpio0};
+use esp_hal_common::{Gpio0, Input, PullDown};
 use static_cell::StaticCell;
-
-use embedded_hal_async::digital::Wait;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio0<Input<PullDown>>) {
@@ -49,7 +50,10 @@ fn main() -> ! {
     wdt1.disable();
 
     #[cfg(feature = "embassy-time-systick")]
-    embassy::init(&clocks, esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER));
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
 
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);


### PR DESCRIPTION
- Upgrade to new eha
- Implement `Wait` for GpioPin
- Add an example for C3

## TODO
- [x] Add examples for all chips
- [x] Make the interrupt handler cleaner by being able to conjure a pin type

## Blocked on
- [x] We need `impl_trait_projections` compiler feature to be available in the Xtensa fork (26th of Jan )
- [x] #332 

## future work (probably not going in this PR)

- Adding support for multi-core chips that have interrupt registration per core.