### PR TITLE
Update a number of dependencies to get RISC-V HALs building again

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -34,7 +34,7 @@ embassy-sync       = { version = "0.1.0", optional = true }
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 
 # RISC-V
-riscv                       = { version = "0.10.0", optional = true }
+riscv                       = { version = "0.10.1", optional = true }
 riscv-atomic-emulation-trap = { version = "0.3.0",  optional = true }
 
 # Xtensa
@@ -52,8 +52,8 @@ ufmt-write = { version = "0.1.0", optional = true }
 # corresponding feature. We rename the PAC packages because we cannot
 # have dependencies and features with the same names.
 esp32   = { version = "0.19.0", features = ["critical-section"], optional = true }
-esp32c2 = { version = "0.6.0",  features = ["critical-section"], optional = true }
-esp32c3 = { version = "0.9.0",  features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.6.1",  features = ["critical-section"], optional = true }
+esp32c3 = { version = "0.9.1",  features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.9.0",  features = ["critical-section"], optional = true }
 esp32s3 = { version = "0.13.0", features = ["critical-section"], optional = true }
 
@@ -84,7 +84,7 @@ async   = ["embedded-hal-async", "eh1", "embassy-sync"]
 embassy = ["embassy-time"]
 
 embassy-time-systick = []
-embassy-time-timg0    = []
+embassy-time-timg0   = []
 
 # Architecture-specific features (intended for internal use)
 riscv  = ["dep:riscv", "critical-section/restore-state-u8",  "procmacros/riscv", "riscv-atomic-emulation-trap"]

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -35,7 +35,7 @@ embassy-time       = { version = "0.1.0", features = ["nightly"], optional = tru
 
 # RISC-V
 riscv                       = { version = "0.10.1", optional = true }
-riscv-atomic-emulation-trap = { version = "0.3.0",  optional = true }
+riscv-atomic-emulation-trap = { version = "0.3.1",  optional = true }
 
 # Xtensa
 xtensa-lx    = { version = "0.7.0",  optional = true }

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -36,7 +36,7 @@ xtensa-lx-rt       = { version = "0.14.0", features = ["esp32"], optional = true
 
 [dev-dependencies]
 critical-section  = "1.1.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.4.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32"] }

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -32,8 +32,8 @@ embedded-hal-async = { version = "0.1.0-alpha.3", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.4.0",  features = ["esp32c2"], path = "../esp-hal-common" }
 r0                 = "1.0.0"
-riscv              = "0.10.0"
-riscv-rt           = { version = "0.10.0", optional = true }
+riscv              = "0.10.1"
+riscv-rt           = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
@@ -55,9 +55,9 @@ vectored             = ["esp-hal-common/vectored"]
 async                = ["esp-hal-common/async", "embedded-hal-async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
-xtal40mhz            = ["esp-hal-common/esp32c2_40mhz"] 
+embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]
 xtal26mhz            = ["esp-hal-common/esp32c2_26mhz"]
+xtal40mhz            = ["esp-hal-common/esp32c2_40mhz"] 
 
 [[example]]
 name              = "spi_eh1_loopback"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -37,7 +37,7 @@ riscv-rt           = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.4.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32c2"] }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -39,7 +39,7 @@ riscv-rt           = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.4.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32c3"] }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -34,8 +34,8 @@ embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.4.0",  features = ["esp32c3"], path = "../esp-hal-common" }
 r0                 = "1.0.0"
-riscv              = "0.10.0"
-riscv-rt           = { version = "0.10.0", optional = true }
+riscv              = "0.10.1"
+riscv-rt           = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -37,7 +37,7 @@ xtensa-atomic-emulation-trap = { version = "0.3.0", features = ["esp32s2"] }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.4.0", features = ["esp32s2", "panic-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32s2"] }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -39,7 +39,7 @@ xtensa-lx-rt       = { version = "0.14.0", features = ["esp32s3"], optional = tr
 
 [dev-dependencies]
 critical-section  = "1.1.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "eed34f9", features = ["nightly", "integrated-timers"] }
+embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.4.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32s3"] }


### PR DESCRIPTION
The `riscv@0.9.0` package was yanked, and this is dealing with the fallout of that.

Closes #349