### PR TITLE
Support lld linker

### DIFF
--- a/esp32-hal/.cargo/config.toml
+++ b/esp32-hal/.cargo/config.toml
@@ -3,8 +3,13 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
+  # GNU LD
   "-C", "link-arg=-nostartfiles",
   "-C", "link-arg=-Wl,-Tlinkall.x",
+
+  # LLD
+  # "-C", "linker=rust-lld",
+  # "-C", "link-arg=-Tlinkall.x",
 ]
 target = "xtensa-esp32-none-elf"
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -45,6 +45,9 @@ smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
 
+[patch.crates-io]
+xtensa-lx-rt = { version = "0.14.0", features = ["esp32"], git = "https://github.com/esp-rs/xtensa-lx-rt" }
+
 [features]
 default           = ["rt", "vectored"]
 bluetooth         = []

--- a/esp32-hal/ld/link-esp32.x
+++ b/esp32-hal/ld/link-esp32.x
@@ -18,7 +18,8 @@ SECTIONS {
     . = ALIGN (4);
     _text_start = ABSOLUTE(.);
     . = ALIGN (4);
-    *(.literal .text .literal.* .text.*)
+    *(.literal .literal.*)
+    *(.text .text.*)
     _text_end = ABSOLUTE(.);
     _etext = .;
   } > ROTEXT
@@ -65,7 +66,8 @@ SECTIONS {
   .rwtext : ALIGN(4)
   {
     . = ALIGN (4);
-    *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
+    *(.rwtext.literal .rwtext.literal.*)
+    *(.rwtext .rwtext.*)
   } > RWTEXT
 
  /* must be last segment using RWTEXT */

--- a/esp32-hal/ld/memory.x
+++ b/esp32-hal/ld/memory.x
@@ -53,7 +53,8 @@ INCLUDE "alias.x"
 SECTIONS {
   .rtc_fast.text : {
    . = ALIGN(4);
-    *(.rtc_fast.literal .rtc_fast.text .rtc_fast.literal.* .rtc_fast.text.*)
+    *(.rtc_fast.literal .rtc_fast.literal.*)
+    *(.rtc_fast.text .rtc_fast.text.*)
   } > rtc_fast_iram_seg AT > RODATA
 
   /*
@@ -63,7 +64,7 @@ SECTIONS {
   .rtc_fast.dummy (NOLOAD) :
   {
     _rtc_dummy_start = ABSOLUTE(.); /* needed to make section proper size */
-    . = SIZEOF(.rtc_fast.text);
+    . += SIZEOF(.rtc_fast.text);
     _rtc_dummy_end = ABSOLUTE(.); /* needed to make section proper size */
   } > rtc_fast_dram_seg
   
@@ -93,7 +94,8 @@ SECTIONS {
 
  .rtc_slow.text : {
    . = ALIGN(4);
-    *(.rtc_slow.literal .rtc_slow.text .rtc_slow.literal.* .rtc_slow.text.*)
+    *(.rtc_slow.literal .rtc_slow.literal.*)
+    *(.rtc_slow.text .rtc_slow.text.*)
   } > rtc_slow_seg AT > RODATA
 
   .rtc_slow.data :

--- a/esp32s2-hal/.cargo/config.toml
+++ b/esp32s2-hal/.cargo/config.toml
@@ -3,8 +3,13 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
+  # GNU LD
   "-C", "link-arg=-nostartfiles",
   "-C", "link-arg=-Wl,-Tlinkall.x",
+
+  # LLD
+  # "-C", "linker=rust-lld",
+  # "-C", "link-arg=-Tlinkall.x",
 
   # enable the atomic codegen option for Xtensa
   "-C", "target-feature=+s32c1i",

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -48,6 +48,9 @@ usb-device        = { version = "0.2.9" }
 usbd-serial       = "0.1.1"
 static_cell       = "1.0.0"
 
+[patch.crates-io]
+xtensa-lx-rt = { version = "0.14.0", features = ["esp32s2"], git = "https://github.com/esp-rs/xtensa-lx-rt" }
+
 [features]
 default   = ["rt", "vectored"]
 eh1       = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]

--- a/esp32s2-hal/ld/link-esp32s2.x
+++ b/esp32s2-hal/ld/link-esp32s2.x
@@ -18,7 +18,8 @@ SECTIONS {
     . = ALIGN (4);
     _text_start = ABSOLUTE(.);
     . = ALIGN (4);
-    *(.literal .text .literal.* .text.*)
+    *(.literal .literal.*)
+    *(.text .text.*)
     _text_end = ABSOLUTE(.);
     _etext = .;
   } > ROTEXT
@@ -43,7 +44,8 @@ SECTIONS {
   .rwtext : ALIGN(4)
   {
     . = ALIGN (4);
-    *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
+    *(.rwtext.literal .rwtext.literal.*)
+    *(.rwtext .rwtext.*)
     . = ALIGN (4);
   } > RWTEXT
 

--- a/esp32s2-hal/ld/memory.x
+++ b/esp32s2-hal/ld/memory.x
@@ -66,7 +66,8 @@ INCLUDE "alias.x"
 SECTIONS {
   .rtc_fast.text : {
    . = ALIGN(4);
-    *(.rtc_fast.literal .rtc_fast.text .rtc_fast.literal.* .rtc_fast.text.*)
+    *(.rtc_fast.literal .rtc_fast.literal.*)
+    *(.rtc_fast.text .rtc_fast.text.*)
   } > rtc_fast_iram_seg AT > RODATA
 
   /*
@@ -76,7 +77,7 @@ SECTIONS {
   .rtc_fast.dummy (NOLOAD) :
   {
     _rtc_dummy_start = ABSOLUTE(.); /* needed to make section proper size */
-    . = SIZEOF(.rtc_fast.text);
+    . += SIZEOF(.rtc_fast.text);
     _rtc_dummy_end = ABSOLUTE(.); /* needed to make section proper size */
   } > rtc_fast_dram_seg
   
@@ -106,7 +107,8 @@ SECTIONS {
 
  .rtc_slow.text : {
    . = ALIGN(4);
-    *(.rtc_slow.literal .rtc_slow.text .rtc_slow.literal.* .rtc_slow.text.*)
+    *(.rtc_slow.literal .rtc_slow.literal.*)
+    *(.rtc_slow.text .rtc_slow.text.*)
   } > rtc_slow_seg AT > RODATA
 
   .rtc_slow.data :

--- a/esp32s3-hal/.cargo/config.toml
+++ b/esp32s3-hal/.cargo/config.toml
@@ -3,8 +3,13 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
+  # GNU LD
   "-C", "link-arg=-nostartfiles",
   "-C", "link-arg=-Wl,-Tlinkall.x",
+
+  # LLD
+  # "-C", "linker=rust-lld",
+  # "-C", "link-arg=-Tlinkall.x",
 ]
 target = "xtensa-esp32s3-none-elf"
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -50,6 +50,9 @@ usb-device        = { version = "0.2.9" }
 usbd-serial       = "0.1.1"
 static_cell       = "1.0.0"
 
+[patch.crates-io]
+xtensa-lx-rt = { version = "0.14.0", features = ["esp32s3"], git = "https://github.com/esp-rs/xtensa-lx-rt" }
+
 [features]
 default              = ["rt", "vectored"]
 direct-boot          = ["r0"]

--- a/esp32s3-hal/ld/esp32s3.x
+++ b/esp32s3-hal/ld/esp32s3.x
@@ -17,7 +17,8 @@ SECTIONS {
     . = ALIGN (4);
     _text_start = ABSOLUTE(.);
     . = ALIGN (4);
-    *(.literal .text .literal.* .text.*)
+    *(.literal .literal.*)
+    *(.text .text.*)
     _text_end = ABSOLUTE(.);
     _etext = .;
   } > ROTEXT
@@ -34,7 +35,7 @@ SECTIONS {
 
     /* Create an empty gap as big as .text section */
 
-    . = SIZEOF(.text);
+    . += SIZEOF(.text);
 
     /* Prepare the alignment of the section above. Few bytes (0x20) must be
      * added for the mapping header.
@@ -61,7 +62,8 @@ SECTIONS {
   .rwtext : ALIGN(4)
   {
     . = ALIGN (4);
-    *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
+    *(.rwtext.literal .rwtext.literal.*)
+    *(.rwtext .rwtext.*)
   } > RWTEXT
 
   /* wifi data */
@@ -89,7 +91,7 @@ SECTIONS {
     /*  Create an empty gap as big as .rwtext section - 32k (SRAM0) 
      *  because SRAM1 is available on the data bus and instruction bus 
      */
-    . = MAX(SIZEOF(.rwtext) + SIZEOF(.rwtext.wifi) + RESERVE_ICACHE + VECTORS_SIZE, 32k) - 32k;
+    . += MAX(SIZEOF(.rwtext) + SIZEOF(.rwtext.wifi) + RESERVE_ICACHE + VECTORS_SIZE, 32k) - 32k;
 
     /* Prepare the alignment of the section above. */
     . = ALIGN(4);

--- a/esp32s3-hal/ld/memory.x
+++ b/esp32s3-hal/ld/memory.x
@@ -64,7 +64,8 @@ INCLUDE "alias.x"
 SECTIONS {
   .rtc_fast.text : {
    . = ALIGN(4);
-    *(.rtc_fast.literal .rtc_fast.text .rtc_fast.literal.* .rtc_fast.text.*)
+    *(.rtc_fast.literal .rtc_fast.literal.*)
+    *(.rtc_fast.text .rtc_fast.text.*)
   } > rtc_fast_iram_seg AT > RODATA
 
   /*
@@ -74,7 +75,7 @@ SECTIONS {
   .rtc_fast.dummy (NOLOAD) :
   {
     _rtc_dummy_start = ABSOLUTE(.); /* needed to make section proper size */
-    . = SIZEOF(.rtc_fast.text);
+    . += SIZEOF(.rtc_fast.text);
     _rtc_dummy_end = ABSOLUTE(.); /* needed to make section proper size */
   } > rtc_fast_dram_seg
   
@@ -104,7 +105,8 @@ SECTIONS {
 
  .rtc_slow.text : {
    . = ALIGN(4);
-    *(.rtc_slow.literal .rtc_slow.text .rtc_slow.literal.* .rtc_slow.text.*)
+    *(.rtc_slow.literal .rtc_slow.literal.*)
+    *(.rtc_slow.text .rtc_slow.text.*)
   } > rtc_slow_seg AT > RODATA
 
   .rtc_slow.data :


### PR DESCRIPTION
Adds LLD support for all Xtensa chips (Direct boot scripts not yet changed for s3). 

To test just comment the GNU parts and uncomment the LLD parts. You'll need a copy of Xtensa enabled lld from here: https://github.com/espressif/llvm-project/releases/tag/esp-15.0.0-20221201. If you try and build it will tell you where you need to copy the executable, and remember to rename it to `rust-lld`! In the future you won't need to bother with this as we will ship with the toolchain.

To add some context to the changes, I'll break them down into two parts. The first part is straightforward, LLD does not have the same semantics when using absolute addresses inside sections, see https://github.com/esp-rs/xtensa-lx-rt/pull/52 for more details. The second part is where it gets interesting. We have some [hand-rolled assembly inside](https://github.com/esp-rs/xtensa-lx-rt/blob/7324ef0b47ec1d1c341f9914a9f262b76770a099/src/exception/assembly_esp32.rs#L576) that handles interrupts. Part of that code is responsible for setting the processor state (`PS` special register)  which looks like `movi    a0, (\level | PS_WOE)`. `PS_WOE` is just something we need to enable to allow the window ABI to work correctly, the level is the current interrupt level, e.g 1. The resultant value of this is `0x40001`. The `movi` instruction can only hold values up to 2048 (see below), so the assembler does something clever. It "relaxes" the `movi` instruction to a `l32r` instruction. The `l32r` allows reading a 32-bit value from memory (known as a literal), with a **negative** offset from the _current_ program counter value; because the offset must be negative, this means the literal we want to read **MUST** be placed before the code that wishes to read it! Hence the literals section placement now comes before the text section definitions and allows the program to run correctly. So why did the original scripts work with the GNU toolchain? It worked because there is a flag that is enabled by default called `text-section-literals` which merges the literal and text sections and ensures the relevant literals are placed before the reference to them in the code.

![image](https://user-images.githubusercontent.com/6977289/214150476-f2563640-5721-43fb-a1a6-e72b8a4a1757.png)
![image](https://user-images.githubusercontent.com/6977289/214151391-aad358da-0562-4fb7-83c3-27c4e012916e.png)

### To Do

- [x] Update `xtensa-lx-rt` dependency once a new version has been published
- [ ] Update the direct-boot linker scripts for the ESP32-S3