### PR TITLE
Only set the set_suc_eof flag on the last item

### DIFF
--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -513,7 +513,7 @@ pub(crate) mod private {
 
                 let mut dw0 = &mut descriptors[descr];
 
-                dw0.set_suc_eof(true);
+                dw0.set_suc_eof(last);
                 dw0.set_owner(Owner::Dma);
                 dw0.set_size(chunk_size as u16); // align to 32 bits?
                 dw0.set_length(chunk_size as u16); // actual size of the data!?


### PR DESCRIPTION
It was previously hardcoded to true, which meant a DMA suc eof interrupt would fire for every descriptor that was processed.