### PR TITLE
Allow Debug interrupts in Xtensa critical sections

### DIFF
--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -135,7 +135,7 @@ mod critical_section_impl {
         unsafe impl critical_section::Impl for super::CriticalSection {
             unsafe fn acquire() -> critical_section::RawRestoreState {
                 let tkn: critical_section::RawRestoreState;
-                core::arch::asm!("rsil {0}, 15", out(reg) tkn);
+                core::arch::asm!("rsil {0}, 5", out(reg) tkn);
                 #[cfg(multi_core)]
                 {
                     let guard = super::multicore::MULTICORE_LOCK.lock();


### PR DESCRIPTION
Right now if you step into a critical section whilst debugging it will hang forever. This changes reduces the interrupt level down to 5, where level 6 is the debug interrupt on all our esp32 Xtensa-based chips.