### PR TITLE
Update the name of the `INTERRUPT` peripheral to `INTERRUPT_CORE0`

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -55,7 +55,7 @@ ufmt-write = { version = "0.1.0", optional = true }
 esp32   = { version = "0.19.0", features = ["critical-section"], optional = true }
 esp32c2 = { version = "0.6.1",  features = ["critical-section"], optional = true }
 esp32c3 = { version = "0.9.1",  features = ["critical-section"], optional = true }
-esp32s2 = { version = "0.9.0",  features = ["critical-section"], optional = true }
+esp32s2 = { version = "0.10.0", features = ["critical-section"], optional = true }
 esp32s3 = { version = "0.13.0", features = ["critical-section"], optional = true }
 
 [features]

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -165,12 +165,7 @@ unsafe fn core1_interrupt_peripheral() -> *const crate::peripherals::dport::Regi
     crate::peripherals::DPORT::PTR
 }
 
-#[cfg(esp32s2)]
-unsafe fn core0_interrupt_peripheral() -> *const crate::peripherals::interrupt::RegisterBlock {
-    crate::peripherals::INTERRUPT::PTR
-}
-
-#[cfg(esp32s3)]
+#[cfg(any(esp32s2, esp32s3))]
 unsafe fn core0_interrupt_peripheral() -> *const crate::peripherals::interrupt_core0::RegisterBlock
 {
     crate::peripherals::INTERRUPT_CORE0::PTR

--- a/esp-hal-common/src/peripherals/esp32s2.rs
+++ b/esp-hal-common/src/peripherals/esp32s2.rs
@@ -18,7 +18,7 @@ crate::peripherals! {
     I2C0,
     I2C1,
     I2S,
-    INTERRUPT,
+    INTERRUPT_CORE0,
     IO_MUX,
     LEDC,
     PCNT,


### PR DESCRIPTION
I was doing some interrupt-related cleanup in the SVDs and noticed that this peripheral was not in line with the other PACs, so I've updated it. Nothing exciting, but one less `#[cfg()]` 😁 