### PR TITLE
Remove references to imac target to avoid confusion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@ If you have any questions, comments, or concerns, please [open an issue], [start
 |     Crate     |                               Target                                | Technical Reference Manual |
 | :-----------: | :-----------------------------------------------------------------: | :------------------------: |
 |  [esp32-hal]  |                       `xtensa-esp32-none-elf`                       |          [ESP32]           |
-| [esp32c2-hal] | `riscv32imc-unknown-none-elf`<br />`riscv32imac-unknown-none-elf`\* |         [ESP32-C2]         |
-| [esp32c3-hal] | `riscv32imc-unknown-none-elf`<br />`riscv32imac-unknown-none-elf`\* |         [ESP32-C3]         |
+| [esp32c2-hal] |                    `riscv32imc-unknown-none-elf`                    |         [ESP32-C2]         |
+| [esp32c3-hal] |                    `riscv32imc-unknown-none-elf`                    |         [ESP32-C3]         |
 | [esp32s2-hal] |                      `xtensa-esp32s2-none-elf`                      |         [ESP32-S2]         |
 | [esp32s3-hal] |                      `xtensa-esp32s3-none-elf`                      |         [ESP32-S3]         |
-
-_\* via [atomic emulation]_
 
 [here]: https://github.com/esp-rs/esp-hal/issues/19
 [esp-idf-hal]: https://github.com/esp-rs/esp-idf-hal

--- a/esp32c2-hal/.cargo/config.toml
+++ b/esp32c2-hal/.cargo/config.toml
@@ -1,14 +1,23 @@
 [target.riscv32imc-unknown-none-elf]
 runner = "espflash flash --monitor"
 rustflags = [
-  "-C", "link-arg=-Tlinkall.x"
-]
+  "-C", "link-arg=-Tlinkall.x",
 
-# for testing: you can specify this target to see atomic emulation in action
-[target.riscv32imac-unknown-none-elf]
-runner = "espflash flash --monitor"
-rustflags = [
-  "-C", "link-arg=-Tlinkall.x"
+  # comment the cfgs below if you do _not_ wish to emulate atomics.
+  # enable the atomic codegen option for RISCV
+  "-C", "target-feature=+a",
+  # tell the core library have atomics even though it's not specified in the target definition
+  "--cfg", "target_has_atomic_load_store",
+  "--cfg", 'target_has_atomic_load_store="8"',
+  "--cfg", 'target_has_atomic_load_store="16"',
+  "--cfg", 'target_has_atomic_load_store="32"',
+  "--cfg", 'target_has_atomic_load_store="ptr"',
+  # enable cas
+  "--cfg", "target_has_atomic",
+  "--cfg", 'target_has_atomic="8"',
+  "--cfg", 'target_has_atomic="16"',
+  "--cfg", 'target_has_atomic="32"',
+  "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [build]

--- a/esp32c3-hal/.cargo/config.toml
+++ b/esp32c3-hal/.cargo/config.toml
@@ -1,14 +1,23 @@
 [target.riscv32imc-unknown-none-elf]
 runner = "espflash flash --monitor"
 rustflags = [
-  "-C", "link-arg=-Tlinkall.x"
-]
+  "-C", "link-arg=-Tlinkall.x",
 
-# for testing: you can specify this target to see atomic emulation in action
-[target.riscv32imac-unknown-none-elf]
-runner = "espflash flash --monitor"
-rustflags = [
-  "-C", "link-arg=-Tlinkall.x"
+  # comment the cfgs below if you do _not_ wish to emulate atomics.
+  # enable the atomic codegen option for RISCV
+  "-C", "target-feature=+a",
+  # tell the core library have atomics even though it's not specified in the target definition
+  "--cfg", "target_has_atomic_load_store",
+  "--cfg", 'target_has_atomic_load_store="8"',
+  "--cfg", 'target_has_atomic_load_store="16"',
+  "--cfg", 'target_has_atomic_load_store="32"',
+  "--cfg", 'target_has_atomic_load_store="ptr"',
+  # enable cas
+  "--cfg", "target_has_atomic",
+  "--cfg", 'target_has_atomic="8"',
+  "--cfg", 'target_has_atomic="16"',
+  "--cfg", 'target_has_atomic="32"',
+  "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [build]


### PR DESCRIPTION
What this PR does:

- Removes any mention of the imac target
- Keep atomic emulation enabled by default

Next steps:

- PR to the template to apply the same config.toml changes.