### PR TITLE
Preemptively add cfg's needed in upcoming releases for s2

### DIFF
--- a/esp32s2-hal/.cargo/config.toml
+++ b/esp32s2-hal/.cargo/config.toml
@@ -10,6 +10,13 @@ rustflags = [
   "-C", "target-feature=+s32c1i",
 
   # tell the core library have atomics even though it's not specified in the target definition
+  "--cfg", "target_has_atomic_load_store",
+  "--cfg", 'target_has_atomic_load_store="8"',
+  "--cfg", 'target_has_atomic_load_store="16"',
+  "--cfg", 'target_has_atomic_load_store="32"',
+  "--cfg", 'target_has_atomic_load_store="ptr"',
+  # enable cas
+  "--cfg", "target_has_atomic",
   "--cfg", 'target_has_atomic="8"',
   "--cfg", 'target_has_atomic="16"',
   "--cfg", 'target_has_atomic="32"',


### PR DESCRIPTION
Whilst builds work now, these new flags will be needed next time we rebase the compiler, so lets get ahead of the situation.