### PR TITLE
Erased Pin

### DIFF
--- a/esp32-hal/examples/blinky_erased_pins.rs
+++ b/esp32-hal/examples/blinky_erased_pins.rs
@@ -1,0 +1,62 @@
+//! Blinks three LEDs
+//!
+//! This assumes that LEDs are connected to GPIO25, 26 and 27.
+
+#![no_std]
+#![no_main]
+
+use esp32_hal::{
+    clock::ClockControl,
+    gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let led1 = io.pins.gpio25.into_push_pull_output();
+    let led2 = io.pins.gpio26.into_push_pull_output();
+    let led3 = io.pins.gpio27.into_push_pull_output();
+
+    let button = io.pins.gpio0.into_pull_down_input().degrade();
+
+    // you can use `into` or `degrade`
+    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        toggle_pins(&mut pins, &button);
+        delay.delay_ms(500u32);
+    }
+}
+
+fn toggle_pins(leds: &mut [AnyPin<Output<PushPull>>], button: &AnyPin<Input<PullDown>>) {
+    for pin in leds.iter_mut() {
+        pin.toggle().unwrap();
+    }
+
+    if button.is_low().unwrap() {
+        esp_println::println!("Button");
+    }
+}

--- a/esp32c2-hal/examples/blinky_erased_pins.rs
+++ b/esp32c2-hal/examples/blinky_erased_pins.rs
@@ -1,0 +1,64 @@
+//! Blinks an LED
+//!
+//! This assumes that LEDs are connected to GPIO3, 4 and 5.
+
+#![no_std]
+#![no_main]
+
+use esp32c2_hal::{
+    clock::ClockControl,
+    gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_riscv_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let led1 = io.pins.gpio3.into_push_pull_output();
+    let led2 = io.pins.gpio4.into_push_pull_output();
+    let led3 = io.pins.gpio5.into_push_pull_output();
+
+    let button = io.pins.gpio9.into_pull_down_input().degrade();
+
+    // you can use `into` or `degrade`
+    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        toggle_pins(&mut pins, &button);
+        delay.delay_ms(500u32);
+    }
+}
+
+fn toggle_pins(leds: &mut [AnyPin<Output<PushPull>>], button: &AnyPin<Input<PullDown>>) {
+    for pin in leds.iter_mut() {
+        pin.toggle().unwrap();
+    }
+
+    if button.is_low().unwrap() {
+        esp_println::println!("Button");
+    }
+}

--- a/esp32c3-hal/examples/blinky_erased_pins.rs
+++ b/esp32c3-hal/examples/blinky_erased_pins.rs
@@ -1,0 +1,67 @@
+//! Blinks an LED
+//!
+//! This assumes that LEDs are connected to GPIO3, 4 and 5.
+
+#![no_std]
+#![no_main]
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_riscv_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let led1 = io.pins.gpio3.into_push_pull_output();
+    let led2 = io.pins.gpio4.into_push_pull_output();
+    let led3 = io.pins.gpio5.into_push_pull_output();
+
+    let button = io.pins.gpio9.into_pull_down_input().degrade();
+
+    // you can use `into` or `degrade`
+    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        toggle_pins(&mut pins, &button);
+        delay.delay_ms(500u32);
+    }
+}
+
+fn toggle_pins(leds: &mut [AnyPin<Output<PushPull>>], button: &AnyPin<Input<PullDown>>) {
+    for pin in leds.iter_mut() {
+        pin.toggle().unwrap();
+    }
+
+    if button.is_low().unwrap() {
+        esp_println::println!("Button");
+    }
+}

--- a/esp32s2-hal/examples/blinky_erased_pins.rs
+++ b/esp32s2-hal/examples/blinky_erased_pins.rs
@@ -1,0 +1,63 @@
+//! Blinks an LED
+//!
+//! This assumes that LEDs are connected to GPIO3, 4 and 5.
+
+#![no_std]
+#![no_main]
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    // Set GPIO4 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let led1 = io.pins.gpio3.into_push_pull_output();
+    let led2 = io.pins.gpio4.into_push_pull_output();
+    let led3 = io.pins.gpio5.into_push_pull_output();
+
+    let button = io.pins.gpio0.into_pull_down_input().degrade();
+
+    // you can use `into` or `degrade`
+    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        toggle_pins(&mut pins, &button);
+        delay.delay_ms(500u32);
+    }
+}
+
+fn toggle_pins(leds: &mut [AnyPin<Output<PushPull>>], button: &AnyPin<Input<PullDown>>) {
+    for pin in leds.iter_mut() {
+        pin.toggle().unwrap();
+    }
+
+    if button.is_low().unwrap() {
+        esp_println::println!("Button");
+    }
+}

--- a/esp32s3-hal/examples/blinky_erased_pins.rs
+++ b/esp32s3-hal/examples/blinky_erased_pins.rs
@@ -1,0 +1,63 @@
+//! Blinks an LED
+//!
+//! This assumes that LEDs are connected to GPIO3, 4 and 5.
+
+#![no_std]
+#![no_main]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use xtensa_lx_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    // Set GPIO4 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let led1 = io.pins.gpio3.into_push_pull_output();
+    let led2 = io.pins.gpio4.into_push_pull_output();
+    let led3 = io.pins.gpio5.into_push_pull_output();
+
+    let button = io.pins.gpio0.into_pull_down_input().degrade();
+
+    // you can use `into` or `degrade`
+    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        toggle_pins(&mut pins, &button);
+        delay.delay_ms(500u32);
+    }
+}
+
+fn toggle_pins(leds: &mut [AnyPin<Output<PushPull>>], button: &AnyPin<Input<PullDown>>) {
+    for pin in leds.iter_mut() {
+        pin.toggle().unwrap();
+    }
+
+    if button.is_low().unwrap() {
+        esp_println::println!("Button");
+    }
+}


### PR DESCRIPTION
This is not necessarily meant to get merged but we can if we agree it's a good idea

This adds an `ErasedPin` type by having an enum and using the enum-dispatch pattern.
The good thing is, it's easy to use this pattern also for other heavily typed types (e.g. SPI, I2C, I2S, ...) and doesn't need any refactoring of existing code. In other places we can even use an existing macro to implement `From` and `TryInto` - but all macros I found didn't support generics which we need for the mode.

It looks like a nice solution but maybe I forgot something that makes it actually a bad thing 🤷‍♂️ 

Closes https://github.com/esp-rs/esp-hal/issues/115
Closes https://github.com/esp-rs/esp-hal/issues/277
