### PR TITLE
Async SPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         run: cd esp32-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
       - name: check esp32-hal (async, gpio)
         run: cd esp32-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
+      - name: check esp32-hal (async, spi)
+        run: cd esp32-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
 
   esp32c2-hal:
     runs-on: ubuntu-latest
@@ -77,6 +79,8 @@ jobs:
         run: cd esp32c2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
       - name: check esp32c2-hal (async, gpio)
         run: cd esp32c2-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-systick,async
+      - name: check esp32c2-hal (async, spi)
+        run: cd esp32c2-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-systick,async
 
   esp32c3-hal:
     runs-on: ubuntu-latest
@@ -111,6 +115,8 @@ jobs:
         run: cargo check --manifest-path=esp32c3-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --example=embassy_hello_world --features=embassy,embassy-time-timg0
       - name: check esp32c3-hal (async, gpio)
         run: cd esp32c3-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-systick,async
+      - name: check esp32c3-hal (async, spi)
+        run: cd esp32c3-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-systick,async
 
   esp32s2-hal:
     runs-on: ubuntu-latest
@@ -139,6 +145,8 @@ jobs:
         run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
       - name: check esp32s2-hal (async, gpio)
         run: cd esp32s2-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
+      - name: check esp32s2-hal (async, spi)
+        run: cd esp32s2-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
 
   esp32s3-hal:
     runs-on: ubuntu-latest
@@ -170,6 +178,8 @@ jobs:
         run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
       - name: check esp32s3-hal (async, gpio)
         run: cd esp32s3-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
+      - name: check esp32s3-hal (async, spi)
+        run: cd esp32s3-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
   # --------------------------------------------------------------------------
   # MSRV
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -33,6 +33,7 @@ usb-device           = { version = "0.2.9", optional = true }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embassy-sync       = { version = "0.1.0", optional = true }
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
+embassy-futures    = { version = "0.1.0", optional = true }
 
 # RISC-V
 esp-riscv-rt                = { version = "0.1.0", optional = true }
@@ -81,7 +82,7 @@ ufmt = ["ufmt-write"]
 vectored = ["procmacros/interrupt"]
 
 # Implement the `embedded-hal-async==1.0.0-alpha.x` traits
-async   = ["embedded-hal-async", "eh1", "embassy-sync"]
+async   = ["embedded-hal-async", "eh1", "embassy-sync", "embassy-futures"]
 embassy = ["embassy-time"]
 
 embassy-time-systick = []

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -329,11 +329,23 @@ macro_rules! impl_channel {
 
             pub struct [<Channel $num TxImpl>] {}
 
-            impl<'a> TxChannel<[<Channel $num>]> for [<Channel $num TxImpl>] {}
+            impl<'a> TxChannel<[<Channel $num>]> for [<Channel $num TxImpl>] {
+                #[cfg(feature = "async")]
+                fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker {
+                    static WAKER: embassy_sync::waitqueue::AtomicWaker = embassy_sync::waitqueue::AtomicWaker::new();
+                    &WAKER
+                }
+            }
 
             pub struct [<Channel $num RxImpl>] {}
 
-            impl<'a> RxChannel<[<Channel $num>]> for [<Channel $num RxImpl>] {}
+            impl<'a> RxChannel<[<Channel $num>]> for [<Channel $num RxImpl>] {
+                #[cfg(feature = "async")]
+                fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker {
+                    static WAKER: embassy_sync::waitqueue::AtomicWaker = embassy_sync::waitqueue::AtomicWaker::new();
+                    &WAKER
+                }
+            }
 
             pub struct [<ChannelCreator $num>] {}
 
@@ -361,8 +373,6 @@ macro_rules! impl_channel {
                         last_seen_handled_descriptor_ptr: core::ptr::null(),
                         buffer_start: core::ptr::null(),
                         buffer_len: 0,
-                        #[cfg(feature = "async")]
-                        channel_index: $num,
                         _phantom: PhantomData::default(),
                     };
 
@@ -377,8 +387,6 @@ macro_rules! impl_channel {
                         available: 0,
                         last_seen_handled_descriptor_ptr: core::ptr::null(),
                         read_buffer_start: core::ptr::null(),
-                        #[cfg(feature = "async")]
-                        channel_index: $num,
                         _phantom: PhantomData::default(),
                     };
 

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -385,8 +385,6 @@ macro_rules! impl_channel {
                     Channel {
                         tx: tx_channel,
                         rx: rx_channel,
-                        #[cfg(feature = "async")]
-                        channel_index: $num,
                         _phantom: PhantomData::default(),
                     }
                 }

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -1,7 +1,7 @@
 //! Direct Memory Access
 
 use crate::{
-    dma::gdma::private::*,
+    dma::*,
     peripheral::PeripheralRef,
     system::{Peripheral, PeripheralClockControl},
 };
@@ -403,20 +403,15 @@ macro_rules! impl_channel {
     };
 }
 
-/// Crate private implementatin details
-pub(crate) mod private {
-    use crate::dma::{private::*, *};
-
-    impl_channel!(0);
-    #[cfg(not(esp32c2))]
-    impl_channel!(1);
-    #[cfg(not(esp32c2))]
-    impl_channel!(2);
-    #[cfg(esp32s3)]
-    impl_channel!(3);
-    #[cfg(esp32s3)]
-    impl_channel!(4);
-}
+impl_channel!(0);
+#[cfg(not(esp32c2))]
+impl_channel!(1);
+#[cfg(not(esp32c2))]
+impl_channel!(2);
+#[cfg(esp32s3)]
+impl_channel!(3);
+#[cfg(esp32s3)]
+impl_channel!(4);
 
 /// GDMA Peripheral
 ///

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -4,8 +4,6 @@
 
 use core::{marker::PhantomData, sync::atomic::compiler_fence};
 
-use self::private::PeripheralMarker;
-
 #[cfg(gdma)]
 pub mod gdma;
 #[cfg(pdma)]
@@ -186,657 +184,651 @@ pub trait I2s0Peripheral: I2sPeripheral + PeripheralMarker {}
 pub trait I2s1Peripheral: I2sPeripheral + PeripheralMarker {}
 
 /// DMA Rx
-pub trait Rx: private::RxPrivate {}
+pub trait Rx: RxPrivate {}
 
 /// DMA Tx
-pub trait Tx: private::TxPrivate {}
+pub trait Tx: TxPrivate {}
 
-/// Crate private implementatin details
-pub(crate) mod private {
-    use super::*;
+/// Marker trait
+pub trait PeripheralMarker {}
 
-    /// Marker trait
-    pub trait PeripheralMarker {}
+/// The functions here are not meant to be used outside the HAL
+pub trait RxPrivate {
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority);
 
-    /// The functions here are not meant to be used outside the HAL
-    pub trait RxPrivate {
-        fn init(&mut self, burst_mode: bool, priority: DmaPriority);
+    fn init_channel(&mut self);
 
-        fn init_channel(&mut self);
+    fn prepare_transfer(
+        &mut self,
+        circular: bool,
+        peri: DmaPeripheral,
+        data: *mut u8,
+        len: usize,
+    ) -> Result<(), DmaError>;
 
-        fn prepare_transfer(
-            &mut self,
-            circular: bool,
-            peri: DmaPeripheral,
-            data: *mut u8,
-            len: usize,
-        ) -> Result<(), DmaError>;
+    fn is_done(&self) -> bool;
 
-        fn is_done(&self) -> bool;
+    fn is_listening_eof(&self) -> bool;
 
-        fn is_listening_eof(&self) -> bool;
+    fn listen_eof(&self);
 
-        fn listen_eof(&self);
+    fn unlisten_eof(&self);
 
-        fn unlisten_eof(&self);
+    fn available(&mut self) -> usize;
 
-        fn available(&mut self) -> usize;
+    fn pop(&mut self, data: &mut [u8]) -> Result<usize, DmaError>;
 
-        fn pop(&mut self, data: &mut [u8]) -> Result<usize, DmaError>;
+    fn drain_buffer(&mut self, dst: &mut [u8]) -> Result<usize, DmaError>;
 
-        fn drain_buffer(&mut self, dst: &mut [u8]) -> Result<usize, DmaError>;
+    fn channel_index(&self) -> usize;
+}
 
-        fn channel_index(&self) -> usize;
+pub trait RxChannel<R>
+where
+    R: RegisterAccess,
+{
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+        R::set_in_burstmode(burst_mode);
+        R::set_in_priority(priority);
     }
 
-    pub trait RxChannel<R>
-    where
-        R: RegisterAccess,
-    {
-        fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
-            R::set_in_burstmode(burst_mode);
-            R::set_in_priority(priority);
+    fn prepare_transfer(
+        &mut self,
+        descriptors: &mut [u32],
+        circular: bool,
+        peri: DmaPeripheral,
+        data: *mut u8,
+        len: usize,
+    ) -> Result<(), DmaError> {
+        for descr in descriptors.iter_mut() {
+            *descr = 0;
         }
 
-        fn prepare_transfer(
-            &mut self,
-            descriptors: &mut [u32],
-            circular: bool,
-            peri: DmaPeripheral,
-            data: *mut u8,
-            len: usize,
-        ) -> Result<(), DmaError> {
-            for descr in descriptors.iter_mut() {
-                *descr = 0;
-            }
+        compiler_fence(core::sync::atomic::Ordering::SeqCst);
 
-            compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        let mut processed = 0;
+        let mut descr = 0;
+        loop {
+            let chunk_size = usize::min(CHUNK_SIZE, len - processed);
+            let last = processed + chunk_size >= len;
 
-            let mut processed = 0;
-            let mut descr = 0;
-            loop {
-                let chunk_size = usize::min(CHUNK_SIZE, len - processed);
-                let last = processed + chunk_size >= len;
+            descriptors[descr + 1] = data as u32 + processed as u32;
 
-                descriptors[descr + 1] = data as u32 + processed as u32;
+            let mut dw0 = &mut descriptors[descr];
 
-                let mut dw0 = &mut descriptors[descr];
+            dw0.set_suc_eof(false);
+            dw0.set_owner(Owner::Dma);
+            dw0.set_size(chunk_size as u16); // align to 32 bits?
+            dw0.set_length(0); // actual size of the data!?
 
-                dw0.set_suc_eof(false);
-                dw0.set_owner(Owner::Dma);
-                dw0.set_size(chunk_size as u16); // align to 32 bits?
-                dw0.set_length(0); // actual size of the data!?
-
-                if !last {
-                    descriptors[descr + 2] =
-                        (&descriptors[descr + 3]) as *const _ as *const () as u32;
+            if !last {
+                descriptors[descr + 2] =
+                    (&descriptors[descr + 3]) as *const _ as *const () as u32;
+            } else {
+                descriptors[descr + 2] = if circular {
+                    descriptors.as_ptr() as *const () as u32
                 } else {
-                    descriptors[descr + 2] = if circular {
-                        descriptors.as_ptr() as *const () as u32
-                    } else {
-                        0
-                    };
-                }
-
-                processed += chunk_size;
-                descr += 3;
-
-                if processed >= len {
-                    break;
-                }
-            }
-
-            R::clear_in_interrupts();
-            R::reset_in();
-            R::set_in_descriptors(descriptors.as_ptr() as u32);
-            R::set_in_peripheral(peri as u8);
-            R::start_in();
-
-            if R::has_in_descriptor_error() {
-                return Err(DmaError::DescriptorError);
-            }
-
-            Ok(())
-        }
-
-        fn is_done(&self) -> bool {
-            R::is_in_done()
-        }
-
-        fn last_in_dscr_address(&self) -> usize {
-            R::last_in_dscr_address()
-        }
-    }
-
-    pub struct ChannelRx<'a, T, R>
-    where
-        T: RxChannel<R>,
-        R: RegisterAccess,
-    {
-        pub descriptors: &'a mut [u32],
-        pub burst_mode: bool,
-        pub rx_impl: T,
-        pub read_descr_ptr: *const u32,
-        pub available: usize,
-        pub last_seen_handled_descriptor_ptr: *const u32,
-        pub read_buffer_start: *const u8,
-        #[cfg(feature = "async")]
-        pub(crate) channel_index: usize,
-        pub _phantom: PhantomData<R>,
-    }
-
-    impl<'a, T, R> Rx for ChannelRx<'a, T, R>
-    where
-        T: RxChannel<R>,
-        R: RegisterAccess,
-    {
-    }
-
-    impl<'a, T, R> RxPrivate for ChannelRx<'a, T, R>
-    where
-        T: RxChannel<R>,
-        R: RegisterAccess,
-    {
-        fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
-            self.rx_impl.init(burst_mode, priority);
-        }
-
-        fn prepare_transfer(
-            &mut self,
-            circular: bool,
-            peri: DmaPeripheral,
-            data: *mut u8,
-            len: usize,
-        ) -> Result<(), DmaError> {
-            if self.descriptors.len() % 3 != 0 {
-                return Err(DmaError::InvalidDescriptorSize);
-            }
-
-            if self.descriptors.len() / 3 < len / CHUNK_SIZE {
-                return Err(DmaError::OutOfDescriptors);
-            }
-
-            if self.burst_mode && (len % 4 != 0 || data as u32 % 4 != 0) {
-                return Err(DmaError::InvalidAlignment);
-            }
-
-            if circular && len < CHUNK_SIZE * 2 {
-                return Err(DmaError::BufferTooSmall);
-            }
-
-            self.available = 0;
-            self.read_descr_ptr = self.descriptors.as_ptr() as *const u32;
-            self.last_seen_handled_descriptor_ptr = core::ptr::null();
-            self.read_buffer_start = data;
-
-            self.rx_impl
-                .prepare_transfer(self.descriptors, circular, peri, data, len)?;
-            Ok(())
-        }
-
-        fn is_done(&self) -> bool {
-            self.rx_impl.is_done()
-        }
-
-        fn init_channel(&mut self) {
-            R::init_channel();
-        }
-
-        fn available(&mut self) -> usize {
-            if self.last_seen_handled_descriptor_ptr.is_null() {
-                self.last_seen_handled_descriptor_ptr = self.descriptors.as_mut_ptr();
-                return 0;
-            }
-
-            if self.available != 0 {
-                return self.available;
-            }
-
-            let descr_address = self.last_seen_handled_descriptor_ptr as *mut u32;
-            let mut dw0 = unsafe { &mut descr_address.read_volatile() };
-
-            if dw0.get_owner() == Owner::Cpu && dw0.get_length() != 0 {
-                let descriptor_buffer =
-                    unsafe { descr_address.offset(1).read_volatile() } as *const u8;
-                let next_descriptor =
-                    unsafe { descr_address.offset(2).read_volatile() } as *const u32;
-
-                self.read_buffer_start = descriptor_buffer;
-                self.available = dw0.get_length() as usize;
-
-                dw0.set_owner(Owner::Dma);
-                dw0.set_length(0);
-                dw0.set_suc_eof(false);
-
-                unsafe {
-                    descr_address.write_volatile(*dw0);
-                }
-
-                if !next_descriptor.is_null() {
-                    self.last_seen_handled_descriptor_ptr = next_descriptor;
-                } else {
-                    self.last_seen_handled_descriptor_ptr = self.descriptors.as_ptr();
-                }
-            }
-
-            self.available
-        }
-
-        fn pop(&mut self, data: &mut [u8]) -> Result<usize, super::DmaError> {
-            let avail = self.available;
-
-            if avail < data.len() {
-                return Err(super::DmaError::Exhausted);
-            }
-
-            unsafe {
-                let dst = data.as_mut_ptr();
-                let src = self.read_buffer_start;
-                let count = self.available;
-                core::ptr::copy_nonoverlapping(src, dst, count);
-            }
-
-            self.available = 0;
-            Ok(data.len())
-        }
-
-        fn drain_buffer(&mut self, dst: &mut [u8]) -> Result<usize, DmaError> {
-            let mut len: usize = 0;
-            let mut dscr = self.descriptors.as_ptr() as *mut u32;
-            loop {
-                let mut dw0 = unsafe { &mut dscr.read_volatile() };
-                let buffer_ptr = unsafe { dscr.offset(1).read_volatile() } as *const u8;
-                let next_dscr = unsafe { dscr.offset(2).read_volatile() } as *const u8;
-                let chunk_len = dw0.get_length() as usize;
-                unsafe {
-                    core::ptr::copy_nonoverlapping(
-                        buffer_ptr,
-                        dst.as_mut_ptr().offset(len as isize),
-                        chunk_len,
-                    )
+                    0
                 };
-
-                len += chunk_len;
-
-                if next_dscr.is_null() {
-                    break;
-                }
-
-                dscr = unsafe { dscr.offset(3) };
             }
 
-            Ok(len)
+            processed += chunk_size;
+            descr += 3;
+
+            if processed >= len {
+                break;
+            }
         }
 
-        fn is_listening_eof(&self) -> bool {
-            R::is_listening_in_eof()
+        R::clear_in_interrupts();
+        R::reset_in();
+        R::set_in_descriptors(descriptors.as_ptr() as u32);
+        R::set_in_peripheral(peri as u8);
+        R::start_in();
+
+        if R::has_in_descriptor_error() {
+            return Err(DmaError::DescriptorError);
         }
 
-        fn listen_eof(&self) {
-            R::listen_in_eof()
-        }
-
-        fn unlisten_eof(&self) {
-            R::unlisten_in_eof()
-        }
-
-        fn channel_index(&self) -> usize {
-            self.channel_index
-        }
+        Ok(())
     }
 
-    /// The functions here are not meant to be used outside the HAL
-    pub trait TxPrivate {
-        fn init(&mut self, burst_mode: bool, priority: DmaPriority);
-
-        fn init_channel(&mut self);
-
-        fn prepare_transfer(
-            &mut self,
-            peri: DmaPeripheral,
-            circular: bool,
-            data: *const u8,
-            len: usize,
-        ) -> Result<(), DmaError>;
-
-        fn is_done(&self) -> bool;
-
-        fn is_listening_eof(&self) -> bool;
-
-        fn listen_eof(&self);
-
-        fn unlisten_eof(&self);
-
-        fn available(&mut self) -> usize;
-
-        fn push(&mut self, data: &[u8]) -> Result<usize, DmaError>;
-
-        fn channel_index(&self) -> usize;
+    fn is_done(&self) -> bool {
+        R::is_in_done()
     }
 
-    pub trait TxChannel<R>
-    where
-        R: RegisterAccess,
-    {
-        fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
-            R::set_out_burstmode(burst_mode);
-            R::set_out_priority(priority);
-        }
+    fn last_in_dscr_address(&self) -> usize {
+        R::last_in_dscr_address()
+    }
+}
 
-        fn prepare_transfer(
-            &mut self,
-            descriptors: &mut [u32],
-            circular: bool,
-            peri: DmaPeripheral,
-            data: *const u8,
-            len: usize,
-        ) -> Result<(), DmaError> {
-            for descr in descriptors.iter_mut() {
-                *descr = 0;
-            }
+pub struct ChannelRx<'a, T, R>
+where
+    T: RxChannel<R>,
+    R: RegisterAccess,
+{
+    pub descriptors: &'a mut [u32],
+    pub burst_mode: bool,
+    pub rx_impl: T,
+    pub read_descr_ptr: *const u32,
+    pub available: usize,
+    pub last_seen_handled_descriptor_ptr: *const u32,
+    pub read_buffer_start: *const u8,
+    #[cfg(feature = "async")]
+    pub(crate) channel_index: usize,
+    pub _phantom: PhantomData<R>,
+}
 
-            compiler_fence(core::sync::atomic::Ordering::SeqCst);
+impl<'a, T, R> Rx for ChannelRx<'a, T, R>
+where
+    T: RxChannel<R>,
+    R: RegisterAccess,
+{
+}
 
-            let mut processed = 0;
-            let mut descr = 0;
-            loop {
-                let chunk_size = usize::min(CHUNK_SIZE, len - processed);
-                let last = processed + chunk_size >= len;
-
-                descriptors[descr + 1] = data as u32 + processed as u32;
-
-                let mut dw0 = &mut descriptors[descr];
-
-                dw0.set_suc_eof(last);
-                dw0.set_owner(Owner::Dma);
-                dw0.set_size(chunk_size as u16); // align to 32 bits?
-                dw0.set_length(chunk_size as u16); // actual size of the data!?
-
-                if !last {
-                    descriptors[descr + 2] =
-                        (&descriptors[descr + 3]) as *const _ as *const () as u32;
-                } else {
-                    if !circular {
-                        descriptors[descr + 2] = 0;
-                    } else {
-                        descriptors[descr + 2] = descriptors.as_ptr() as u32;
-                    }
-                }
-
-                processed += chunk_size;
-                descr += 3;
-
-                if processed >= len {
-                    break;
-                }
-            }
-
-            R::clear_out_interrupts();
-            R::reset_out();
-            R::set_out_descriptors(descriptors.as_ptr() as u32);
-            R::set_out_peripheral(peri as u8);
-            R::start_out();
-
-            if R::has_out_descriptor_error() {
-                return Err(DmaError::DescriptorError);
-            }
-
-            Ok(())
-        }
-
-        fn is_done(&self) -> bool {
-            R::is_out_done()
-        }
-
-        fn descriptors_handled(&self) -> bool {
-            R::is_out_eof_interrupt_set()
-        }
-
-        fn reset_descriptors_handled(&self) {
-            R::reset_out_eof_interrupt();
-        }
-
-        fn last_out_dscr_address(&self) -> usize {
-            R::last_out_dscr_address()
-        }
+impl<'a, T, R> RxPrivate for ChannelRx<'a, T, R>
+where
+    T: RxChannel<R>,
+    R: RegisterAccess,
+{
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+        self.rx_impl.init(burst_mode, priority);
     }
 
-    pub struct ChannelTx<'a, T, R>
-    where
-        T: TxChannel<R>,
-        R: RegisterAccess,
-    {
-        pub descriptors: &'a mut [u32],
-        #[allow(unused)]
-        pub burst_mode: bool,
-        pub tx_impl: T,
-        pub write_offset: usize,
-        pub write_descr_ptr: *const u32,
-        pub available: usize,
-        pub last_seen_handled_descriptor_ptr: *const u32,
-        pub buffer_start: *const u8,
-        pub buffer_len: usize,
-        #[cfg(feature = "async")]
-        pub(crate) channel_index: usize,
-        pub _phantom: PhantomData<R>,
+    fn prepare_transfer(
+        &mut self,
+        circular: bool,
+        peri: DmaPeripheral,
+        data: *mut u8,
+        len: usize,
+    ) -> Result<(), DmaError> {
+        if self.descriptors.len() % 3 != 0 {
+            return Err(DmaError::InvalidDescriptorSize);
+        }
+
+        if self.descriptors.len() / 3 < len / CHUNK_SIZE {
+            return Err(DmaError::OutOfDescriptors);
+        }
+
+        if self.burst_mode && (len % 4 != 0 || data as u32 % 4 != 0) {
+            return Err(DmaError::InvalidAlignment);
+        }
+
+        if circular && len < CHUNK_SIZE * 2 {
+            return Err(DmaError::BufferTooSmall);
+        }
+
+        self.available = 0;
+        self.read_descr_ptr = self.descriptors.as_ptr() as *const u32;
+        self.last_seen_handled_descriptor_ptr = core::ptr::null();
+        self.read_buffer_start = data;
+
+        self.rx_impl
+            .prepare_transfer(self.descriptors, circular, peri, data, len)?;
+        Ok(())
     }
 
-    impl<'a, T, R> Tx for ChannelTx<'a, T, R>
-    where
-        T: TxChannel<R>,
-        R: RegisterAccess,
-    {
+    fn is_done(&self) -> bool {
+        self.rx_impl.is_done()
     }
 
-    impl<'a, T, R> TxPrivate for ChannelTx<'a, T, R>
-    where
-        T: TxChannel<R>,
-        R: RegisterAccess,
-    {
-        fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
-            self.tx_impl.init(burst_mode, priority);
+    fn init_channel(&mut self) {
+        R::init_channel();
+    }
+
+    fn available(&mut self) -> usize {
+        if self.last_seen_handled_descriptor_ptr.is_null() {
+            self.last_seen_handled_descriptor_ptr = self.descriptors.as_mut_ptr();
+            return 0;
         }
 
-        fn init_channel(&mut self) {
-            R::init_channel();
+        if self.available != 0 {
+            return self.available;
         }
 
-        fn prepare_transfer(
-            &mut self,
-            peri: DmaPeripheral,
-            circular: bool,
-            data: *const u8,
-            len: usize,
-        ) -> Result<(), DmaError> {
-            if self.descriptors.len() % 3 != 0 {
-                return Err(DmaError::InvalidDescriptorSize);
-            }
+        let descr_address = self.last_seen_handled_descriptor_ptr as *mut u32;
+        let mut dw0 = unsafe { &mut descr_address.read_volatile() };
 
-            if self.descriptors.len() / 3 < len / CHUNK_SIZE {
-                return Err(DmaError::OutOfDescriptors);
-            }
+        if dw0.get_owner() == Owner::Cpu && dw0.get_length() != 0 {
+            let descriptor_buffer =
+                unsafe { descr_address.offset(1).read_volatile() } as *const u8;
+            let next_descriptor =
+                unsafe { descr_address.offset(2).read_volatile() } as *const u32;
 
-            if circular && len < CHUNK_SIZE * 2 {
-                return Err(DmaError::BufferTooSmall);
-            }
+            self.read_buffer_start = descriptor_buffer;
+            self.available = dw0.get_length() as usize;
 
-            self.write_offset = 0;
-            self.available = 0;
-            self.write_descr_ptr = self.descriptors.as_ptr() as *const u32;
-            self.last_seen_handled_descriptor_ptr = self.descriptors.as_ptr() as *const u32;
-            self.buffer_start = data;
-            self.buffer_len = len;
-
-            self.tx_impl
-                .prepare_transfer(self.descriptors, circular, peri, data, len)?;
-
-            Ok(())
-        }
-
-        fn is_done(&self) -> bool {
-            self.tx_impl.is_done()
-        }
-
-        fn available(&mut self) -> usize {
-            if self.tx_impl.descriptors_handled() {
-                self.tx_impl.reset_descriptors_handled();
-                let descr_address = self.tx_impl.last_out_dscr_address() as *const u32;
-
-                if descr_address >= self.last_seen_handled_descriptor_ptr {
-                    let mut ptr = self.last_seen_handled_descriptor_ptr as *const u32;
-
-                    unsafe {
-                        while ptr < descr_address as *const u32 {
-                            let mut dw0 = &mut ptr.read_volatile();
-                            self.available += dw0.get_length() as usize;
-                            ptr = ptr.offset(3);
-                        }
-                    }
-                } else {
-                    let mut ptr = self.last_seen_handled_descriptor_ptr as *const u32;
-
-                    unsafe {
-                        loop {
-                            if ptr.offset(2).read_volatile() == 0 {
-                                break;
-                            }
-
-                            let mut dw0 = &mut ptr.read_volatile();
-                            self.available += dw0.get_length() as usize;
-                            ptr = ptr.offset(3);
-                        }
-                    }
-                }
-
-                if self.available >= self.buffer_len {
-                    unsafe {
-                        let segment_len =
-                            (&mut self.write_descr_ptr.read_volatile()).get_length() as usize;
-                        self.available -= segment_len;
-                        self.write_offset = (self.write_offset + segment_len) % self.buffer_len;
-                        let next_descriptor =
-                            self.write_descr_ptr.offset(2).read_volatile() as *const u32;
-                        self.write_descr_ptr = if next_descriptor.is_null() {
-                            self.descriptors.as_ptr() as *const u32
-                        } else {
-                            next_descriptor
-                        }
-                    }
-                }
-
-                self.last_seen_handled_descriptor_ptr = descr_address;
-            }
-
-            self.available
-        }
-
-        fn push(&mut self, data: &[u8]) -> Result<usize, super::DmaError> {
-            let avail = self.available();
-
-            if avail < data.len() {
-                return Err(super::DmaError::Overflow);
-            }
+            dw0.set_owner(Owner::Dma);
+            dw0.set_length(0);
+            dw0.set_suc_eof(false);
 
             unsafe {
-                let src = data.as_ptr();
-                let dst = self.buffer_start.offset(self.write_offset as isize) as *mut u8;
-                let count = usize::min(data.len(), self.buffer_len - self.write_offset);
-                core::ptr::copy_nonoverlapping(src, dst, count);
+                descr_address.write_volatile(*dw0);
             }
 
-            if self.write_offset + data.len() >= self.buffer_len {
-                let remainder = (self.write_offset + data.len()) % self.buffer_len;
-                let dst = self.buffer_start as *mut u8;
-                unsafe {
-                    let src = data.as_ptr().offset((data.len() - remainder) as isize);
-                    core::ptr::copy_nonoverlapping(src, dst, remainder);
+            if !next_descriptor.is_null() {
+                self.last_seen_handled_descriptor_ptr = next_descriptor;
+            } else {
+                self.last_seen_handled_descriptor_ptr = self.descriptors.as_ptr();
+            }
+        }
+
+        self.available
+    }
+
+    fn pop(&mut self, data: &mut [u8]) -> Result<usize, DmaError> {
+        let avail = self.available;
+
+        if avail < data.len() {
+            return Err(DmaError::Exhausted);
+        }
+
+        unsafe {
+            let dst = data.as_mut_ptr();
+            let src = self.read_buffer_start;
+            let count = self.available;
+            core::ptr::copy_nonoverlapping(src, dst, count);
+        }
+
+        self.available = 0;
+        Ok(data.len())
+    }
+
+    fn drain_buffer(&mut self, dst: &mut [u8]) -> Result<usize, DmaError> {
+        let mut len: usize = 0;
+        let mut dscr = self.descriptors.as_ptr() as *mut u32;
+        loop {
+            let mut dw0 = unsafe { &mut dscr.read_volatile() };
+            let buffer_ptr = unsafe { dscr.offset(1).read_volatile() } as *const u8;
+            let next_dscr = unsafe { dscr.offset(2).read_volatile() } as *const u8;
+            let chunk_len = dw0.get_length() as usize;
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    buffer_ptr,
+                    dst.as_mut_ptr().offset(len as isize),
+                    chunk_len,
+                )
+            };
+
+            len += chunk_len;
+
+            if next_dscr.is_null() {
+                break;
+            }
+
+            dscr = unsafe { dscr.offset(3) };
+        }
+
+        Ok(len)
+    }
+
+    fn is_listening_eof(&self) -> bool {
+        R::is_listening_in_eof()
+    }
+
+    fn listen_eof(&self) {
+        R::listen_in_eof()
+    }
+
+    fn unlisten_eof(&self) {
+        R::unlisten_in_eof()
+    }
+
+    fn channel_index(&self) -> usize {
+        self.channel_index
+    }
+}
+
+/// The functions here are not meant to be used outside the HAL
+pub trait TxPrivate {
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority);
+
+    fn init_channel(&mut self);
+
+    fn prepare_transfer(
+        &mut self,
+        peri: DmaPeripheral,
+        circular: bool,
+        data: *const u8,
+        len: usize,
+    ) -> Result<(), DmaError>;
+
+    fn is_done(&self) -> bool;
+
+    fn is_listening_eof(&self) -> bool;
+
+    fn listen_eof(&self);
+
+    fn unlisten_eof(&self);
+
+    fn available(&mut self) -> usize;
+
+    fn push(&mut self, data: &[u8]) -> Result<usize, DmaError>;
+
+    fn channel_index(&self) -> usize;
+}
+
+pub trait TxChannel<R>
+where
+    R: RegisterAccess,
+{
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+        R::set_out_burstmode(burst_mode);
+        R::set_out_priority(priority);
+    }
+
+    fn prepare_transfer(
+        &mut self,
+        descriptors: &mut [u32],
+        circular: bool,
+        peri: DmaPeripheral,
+        data: *const u8,
+        len: usize,
+    ) -> Result<(), DmaError> {
+        for descr in descriptors.iter_mut() {
+            *descr = 0;
+        }
+
+        compiler_fence(core::sync::atomic::Ordering::SeqCst);
+
+        let mut processed = 0;
+        let mut descr = 0;
+        loop {
+            let chunk_size = usize::min(CHUNK_SIZE, len - processed);
+            let last = processed + chunk_size >= len;
+
+            descriptors[descr + 1] = data as u32 + processed as u32;
+
+            let mut dw0 = &mut descriptors[descr];
+
+            dw0.set_suc_eof(last);
+            dw0.set_owner(Owner::Dma);
+            dw0.set_size(chunk_size as u16); // align to 32 bits?
+            dw0.set_length(chunk_size as u16); // actual size of the data!?
+
+            if !last {
+                descriptors[descr + 2] =
+                    (&descriptors[descr + 3]) as *const _ as *const () as u32;
+            } else {
+                if !circular {
+                    descriptors[descr + 2] = 0;
+                } else {
+                    descriptors[descr + 2] = descriptors.as_ptr() as u32;
                 }
             }
 
-            let mut forward = data.len();
-            loop {
+            processed += chunk_size;
+            descr += 3;
+
+            if processed >= len {
+                break;
+            }
+        }
+
+        R::clear_out_interrupts();
+        R::reset_out();
+        R::set_out_descriptors(descriptors.as_ptr() as u32);
+        R::set_out_peripheral(peri as u8);
+        R::start_out();
+
+        if R::has_out_descriptor_error() {
+            return Err(DmaError::DescriptorError);
+        }
+
+        Ok(())
+    }
+
+    fn is_done(&self) -> bool {
+        R::is_out_done()
+    }
+
+    fn descriptors_handled(&self) -> bool {
+        R::is_out_eof_interrupt_set()
+    }
+
+    fn reset_descriptors_handled(&self) {
+        R::reset_out_eof_interrupt();
+    }
+
+    fn last_out_dscr_address(&self) -> usize {
+        R::last_out_dscr_address()
+    }
+}
+
+pub struct ChannelTx<'a, T, R>
+where
+    T: TxChannel<R>,
+    R: RegisterAccess,
+{
+    pub descriptors: &'a mut [u32],
+    #[allow(unused)]
+    pub burst_mode: bool,
+    pub tx_impl: T,
+    pub write_offset: usize,
+    pub write_descr_ptr: *const u32,
+    pub available: usize,
+    pub last_seen_handled_descriptor_ptr: *const u32,
+    pub buffer_start: *const u8,
+    pub buffer_len: usize,
+    #[cfg(feature = "async")]
+    pub(crate) channel_index: usize,
+    pub _phantom: PhantomData<R>,
+}
+
+impl<'a, T, R> Tx for ChannelTx<'a, T, R>
+where
+    T: TxChannel<R>,
+    R: RegisterAccess,
+{
+}
+
+impl<'a, T, R> TxPrivate for ChannelTx<'a, T, R>
+where
+    T: TxChannel<R>,
+    R: RegisterAccess,
+{
+    fn init(&mut self, burst_mode: bool, priority: DmaPriority) {
+        self.tx_impl.init(burst_mode, priority);
+    }
+
+    fn init_channel(&mut self) {
+        R::init_channel();
+    }
+
+    fn prepare_transfer(
+        &mut self,
+        peri: DmaPeripheral,
+        circular: bool,
+        data: *const u8,
+        len: usize,
+    ) -> Result<(), DmaError> {
+        if self.descriptors.len() % 3 != 0 {
+            return Err(DmaError::InvalidDescriptorSize);
+        }
+
+        if self.descriptors.len() / 3 < len / CHUNK_SIZE {
+            return Err(DmaError::OutOfDescriptors);
+        }
+
+        if circular && len < CHUNK_SIZE * 2 {
+            return Err(DmaError::BufferTooSmall);
+        }
+
+        self.write_offset = 0;
+        self.available = 0;
+        self.write_descr_ptr = self.descriptors.as_ptr() as *const u32;
+        self.last_seen_handled_descriptor_ptr = self.descriptors.as_ptr() as *const u32;
+        self.buffer_start = data;
+        self.buffer_len = len;
+
+        self.tx_impl
+            .prepare_transfer(self.descriptors, circular, peri, data, len)?;
+
+        Ok(())
+    }
+
+    fn is_done(&self) -> bool {
+        self.tx_impl.is_done()
+    }
+
+    fn available(&mut self) -> usize {
+        if self.tx_impl.descriptors_handled() {
+            self.tx_impl.reset_descriptors_handled();
+            let descr_address = self.tx_impl.last_out_dscr_address() as *const u32;
+
+            if descr_address >= self.last_seen_handled_descriptor_ptr {
+                let mut ptr = self.last_seen_handled_descriptor_ptr as *const u32;
+
                 unsafe {
-                    let next_descriptor =
-                        self.write_descr_ptr.offset(2).read_volatile() as *const u32;
+                    while ptr < descr_address as *const u32 {
+                        let mut dw0 = &mut ptr.read_volatile();
+                        self.available += dw0.get_length() as usize;
+                        ptr = ptr.offset(3);
+                    }
+                }
+            } else {
+                let mut ptr = self.last_seen_handled_descriptor_ptr as *const u32;
+
+                unsafe {
+                    loop {
+                        if ptr.offset(2).read_volatile() == 0 {
+                            break;
+                        }
+
+                        let mut dw0 = &mut ptr.read_volatile();
+                        self.available += dw0.get_length() as usize;
+                        ptr = ptr.offset(3);
+                    }
+                }
+            }
+
+            if self.available >= self.buffer_len {
+                unsafe {
                     let segment_len =
                         (&mut self.write_descr_ptr.read_volatile()).get_length() as usize;
+                    self.available -= segment_len;
+                    self.write_offset = (self.write_offset + segment_len) % self.buffer_len;
+                    let next_descriptor =
+                        self.write_descr_ptr.offset(2).read_volatile() as *const u32;
                     self.write_descr_ptr = if next_descriptor.is_null() {
                         self.descriptors.as_ptr() as *const u32
                     } else {
                         next_descriptor
-                    };
-
-                    if forward <= segment_len {
-                        break;
-                    }
-
-                    forward -= segment_len;
-
-                    if forward == 0 {
-                        break;
                     }
                 }
             }
 
-            self.write_offset = (self.write_offset + data.len()) % self.buffer_len;
-            self.available -= data.len();
-
-            Ok(data.len())
+            self.last_seen_handled_descriptor_ptr = descr_address;
         }
 
-        fn is_listening_eof(&self) -> bool {
-            R::is_listening_out_eof()
-        }
-
-        fn listen_eof(&self) {
-            R::listen_out_eof()
-        }
-
-        fn unlisten_eof(&self) {
-            R::unlisten_out_eof()
-        }
-
-        fn channel_index(&self) -> usize {
-            self.channel_index
-        }
+        self.available
     }
 
-    pub trait RegisterAccess {
-        fn init_channel();
-        fn set_out_burstmode(burst_mode: bool);
-        fn set_out_priority(priority: DmaPriority);
-        fn clear_out_interrupts();
-        fn reset_out();
-        fn set_out_descriptors(address: u32);
-        fn has_out_descriptor_error() -> bool;
-        fn set_out_peripheral(peripheral: u8);
-        fn start_out();
-        fn is_out_done() -> bool;
-        fn is_out_eof_interrupt_set() -> bool;
-        fn reset_out_eof_interrupt();
-        fn last_out_dscr_address() -> usize;
+    fn push(&mut self, data: &[u8]) -> Result<usize, DmaError> {
+        let avail = self.available();
 
-        fn set_in_burstmode(burst_mode: bool);
-        fn set_in_priority(priority: DmaPriority);
-        fn clear_in_interrupts();
-        fn reset_in();
-        fn set_in_descriptors(address: u32);
-        fn has_in_descriptor_error() -> bool;
-        fn set_in_peripheral(peripheral: u8);
-        fn start_in();
-        fn is_in_done() -> bool;
-        fn last_in_dscr_address() -> usize;
+        if avail < data.len() {
+            return Err(DmaError::Overflow);
+        }
 
-        fn is_listening_in_eof() -> bool;
-        fn is_listening_out_eof() -> bool;
+        unsafe {
+            let src = data.as_ptr();
+            let dst = self.buffer_start.offset(self.write_offset as isize) as *mut u8;
+            let count = usize::min(data.len(), self.buffer_len - self.write_offset);
+            core::ptr::copy_nonoverlapping(src, dst, count);
+        }
 
-        fn listen_in_eof();
-        fn listen_out_eof();
-        fn unlisten_in_eof();
-        fn unlisten_out_eof();
+        if self.write_offset + data.len() >= self.buffer_len {
+            let remainder = (self.write_offset + data.len()) % self.buffer_len;
+            let dst = self.buffer_start as *mut u8;
+            unsafe {
+                let src = data.as_ptr().offset((data.len() - remainder) as isize);
+                core::ptr::copy_nonoverlapping(src, dst, remainder);
+            }
+        }
+
+        let mut forward = data.len();
+        loop {
+            unsafe {
+                let next_descriptor =
+                    self.write_descr_ptr.offset(2).read_volatile() as *const u32;
+                let segment_len =
+                    (&mut self.write_descr_ptr.read_volatile()).get_length() as usize;
+                self.write_descr_ptr = if next_descriptor.is_null() {
+                    self.descriptors.as_ptr() as *const u32
+                } else {
+                    next_descriptor
+                };
+
+                if forward <= segment_len {
+                    break;
+                }
+
+                forward -= segment_len;
+
+                if forward == 0 {
+                    break;
+                }
+            }
+        }
+
+        self.write_offset = (self.write_offset + data.len()) % self.buffer_len;
+        self.available -= data.len();
+
+        Ok(data.len())
+    }
+
+    fn is_listening_eof(&self) -> bool {
+        R::is_listening_out_eof()
+    }
+
+    fn listen_eof(&self) {
+        R::listen_out_eof()
+    }
+
+    fn unlisten_eof(&self) {
+        R::unlisten_out_eof()
+    }
+
+    fn channel_index(&self) -> usize {
+        self.channel_index
     }
 }
 
+pub trait RegisterAccess {
+    fn init_channel();
+    fn set_out_burstmode(burst_mode: bool);
+    fn set_out_priority(priority: DmaPriority);
+    fn clear_out_interrupts();
+    fn reset_out();
+    fn set_out_descriptors(address: u32);
+    fn has_out_descriptor_error() -> bool;
+    fn set_out_peripheral(peripheral: u8);
+    fn start_out();
+    fn is_out_done() -> bool;
+    fn is_out_eof_interrupt_set() -> bool;
+    fn reset_out_eof_interrupt();
+    fn last_out_dscr_address() -> usize;
+
+    fn set_in_burstmode(burst_mode: bool);
+    fn set_in_priority(priority: DmaPriority);
+    fn clear_in_interrupts();
+    fn reset_in();
+    fn set_in_descriptors(address: u32);
+    fn has_in_descriptor_error() -> bool;
+    fn set_in_peripheral(peripheral: u8);
+    fn start_in();
+    fn is_in_done() -> bool;
+    fn last_in_dscr_address() -> usize;
+
+    fn is_listening_in_eof() -> bool;
+    fn is_listening_out_eof() -> bool;
+
+    fn listen_in_eof();
+    fn listen_out_eof();
+    fn unlisten_in_eof();
+    fn unlisten_out_eof();
+}
 /// DMA Channel
 pub struct Channel<TX, RX, P>
 where
@@ -867,7 +859,6 @@ pub trait DmaTransferRxTx<BR, BT, T>: Drop {
 #[cfg(feature = "async")]
 pub(crate) mod asynch {
     use core::task::Poll;
-    use crate::dma::private::*;
     use embassy_sync::waitqueue::AtomicWaker;
 
     use super::*;
@@ -961,7 +952,7 @@ pub(crate) mod asynch {
 
         #[interrupt]
         fn DMA_CH0() {
-            type Channel = crate::dma::gdma::private::Channel0;
+            type Channel = crate::dma::gdma::Channel0;
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
@@ -978,7 +969,7 @@ pub(crate) mod asynch {
 
         #[interrupt]
         fn DMA_CH1() {
-            type Channel = crate::dma::gdma::private::Channel1;
+            type Channel = crate::dma::gdma::Channel1;
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
@@ -995,7 +986,7 @@ pub(crate) mod asynch {
 
         #[interrupt]
         fn DMA_CH2() {
-            type Channel = crate::dma::gdma::private::Channel2;
+            type Channel = crate::dma::gdma::Channel2;
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -846,8 +846,6 @@ where
 {
     pub(crate) tx: TX,
     pub(crate) rx: RX,
-    #[cfg(feature = "async")]
-    pub(crate) channel_index: usize,
     _phantom: PhantomData<P>,
 }
 

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -263,8 +263,7 @@ where
             dw0.set_length(0); // actual size of the data!?
 
             if !last {
-                descriptors[descr + 2] =
-                    (&descriptors[descr + 3]) as *const _ as *const () as u32;
+                descriptors[descr + 2] = (&descriptors[descr + 3]) as *const _ as *const () as u32;
             } else {
                 descriptors[descr + 2] = if circular {
                     descriptors.as_ptr() as *const () as u32
@@ -392,10 +391,8 @@ where
         let mut dw0 = unsafe { &mut descr_address.read_volatile() };
 
         if dw0.get_owner() == Owner::Cpu && dw0.get_length() != 0 {
-            let descriptor_buffer =
-                unsafe { descr_address.offset(1).read_volatile() } as *const u8;
-            let next_descriptor =
-                unsafe { descr_address.offset(2).read_volatile() } as *const u32;
+            let descriptor_buffer = unsafe { descr_address.offset(1).read_volatile() } as *const u8;
+            let next_descriptor = unsafe { descr_address.offset(2).read_volatile() } as *const u32;
 
             self.read_buffer_start = descriptor_buffer;
             self.available = dw0.get_length() as usize;
@@ -551,8 +548,7 @@ where
             dw0.set_length(chunk_size as u16); // actual size of the data!?
 
             if !last {
-                descriptors[descr + 2] =
-                    (&descriptors[descr + 3]) as *const _ as *const () as u32;
+                descriptors[descr + 2] = (&descriptors[descr + 3]) as *const _ as *const () as u32;
             } else {
                 if !circular {
                     descriptors[descr + 2] = 0;
@@ -755,10 +751,8 @@ where
         let mut forward = data.len();
         loop {
             unsafe {
-                let next_descriptor =
-                    self.write_descr_ptr.offset(2).read_volatile() as *const u32;
-                let segment_len =
-                    (&mut self.write_descr_ptr.read_volatile()).get_length() as usize;
+                let next_descriptor = self.write_descr_ptr.offset(2).read_volatile() as *const u32;
+                let segment_len = (&mut self.write_descr_ptr.read_volatile()).get_length() as usize;
                 self.write_descr_ptr = if next_descriptor.is_null() {
                     self.descriptors.as_ptr() as *const u32
                 } else {
@@ -861,7 +855,6 @@ pub trait DmaTransferRxTx<BR, BT, T>: Drop {
     fn wait(self) -> (BR, BT, T);
 }
 
-
 #[cfg(feature = "async")]
 pub(crate) mod asynch {
     use core::task::Poll;
@@ -871,7 +864,7 @@ pub(crate) mod asynch {
 
     pub struct DmaTxFuture<'a, TX> {
         pub(crate) tx: &'a mut TX,
-        _a: ()
+        _a: (),
     }
 
     impl<'a, TX> DmaTxFuture<'a, TX>
@@ -880,10 +873,7 @@ pub(crate) mod asynch {
     {
         pub fn new(tx: &'a mut TX) -> Self {
             tx.listen_eof();
-            Self {
-                tx,
-                _a: ()
-            }
+            Self { tx, _a: () }
         }
     }
 
@@ -910,17 +900,14 @@ pub(crate) mod asynch {
         pub(crate) rx: &'a mut RX,
         _a: (),
     }
-    
+
     impl<'a, RX> DmaRxFuture<'a, RX>
     where
         RX: Rx,
     {
         pub fn new(rx: &'a mut RX) -> Self {
             rx.listen_eof();
-            Self {
-                rx,
-                _a: ()
-            }
+            Self { rx, _a: () }
         }
     }
 
@@ -949,14 +936,18 @@ pub(crate) mod asynch {
 
         #[interrupt]
         fn DMA_CH0() {
-            use crate::dma::gdma::{Channel0 as Channel, Channel0TxImpl as ChannelTxImpl, Channel0RxImpl as ChannelRxImpl};
+            use crate::dma::gdma::{
+                Channel0 as Channel,
+                Channel0RxImpl as ChannelRxImpl,
+                Channel0TxImpl as ChannelTxImpl,
+            };
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
                 Channel::unlisten_in_eof();
                 ChannelRxImpl::waker().wake()
             }
-            
+
             if Channel::is_out_done() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
@@ -966,14 +957,18 @@ pub(crate) mod asynch {
 
         #[interrupt]
         fn DMA_CH1() {
-            use crate::dma::gdma::{Channel1 as Channel, Channel1TxImpl as ChannelTxImpl, Channel1RxImpl as ChannelRxImpl};
+            use crate::dma::gdma::{
+                Channel1 as Channel,
+                Channel1RxImpl as ChannelRxImpl,
+                Channel1TxImpl as ChannelTxImpl,
+            };
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
                 Channel::unlisten_in_eof();
                 ChannelRxImpl::waker().wake()
             }
-            
+
             if Channel::is_out_done() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
@@ -983,14 +978,18 @@ pub(crate) mod asynch {
 
         #[interrupt]
         fn DMA_CH2() {
-            use crate::dma::gdma::{Channel2 as Channel, Channel2TxImpl as ChannelTxImpl, Channel2RxImpl as ChannelRxImpl};
+            use crate::dma::gdma::{
+                Channel2 as Channel,
+                Channel2RxImpl as ChannelRxImpl,
+                Channel2TxImpl as ChannelTxImpl,
+            };
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
                 Channel::unlisten_in_eof();
                 ChannelRxImpl::waker().wake()
             }
-            
+
             if Channel::is_out_done() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
@@ -1098,14 +1097,18 @@ pub(crate) mod asynch {
 
         #[interrupt]
         fn SPI2_DMA() {
-            use crate::dma::pdma::{Spi2DmaChannel as Channel, Spi2DmaChannelTxImpl as ChannelTxImpl, Spi2DmaChannelRxImpl as ChannelRxImpl};
+            use crate::dma::pdma::{
+                Spi2DmaChannel as Channel,
+                Spi2DmaChannelRxImpl as ChannelRxImpl,
+                Spi2DmaChannelTxImpl as ChannelTxImpl,
+            };
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
                 Channel::unlisten_in_eof();
                 ChannelRxImpl::waker().wake()
             }
-            
+
             if Channel::is_out_done() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
@@ -1115,14 +1118,18 @@ pub(crate) mod asynch {
 
         #[interrupt]
         fn SPI3_DMA() {
-            use crate::dma::pdma::{Spi3DmaChannel as Channel, Spi3DmaChannelTxImpl as ChannelTxImpl, Spi3DmaChannelRxImpl as ChannelRxImpl};
+            use crate::dma::pdma::{
+                Spi3DmaChannel as Channel,
+                Spi3DmaChannelRxImpl as ChannelRxImpl,
+                Spi3DmaChannelTxImpl as ChannelTxImpl,
+            };
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
                 Channel::unlisten_in_eof();
                 ChannelRxImpl::waker().wake()
             }
-            
+
             if Channel::is_out_done() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -999,6 +999,99 @@ pub(crate) mod asynch {
         }
     }
 
+    #[cfg(esp32s3)]
+    mod interrupt {
+        use super::*;
+
+        #[interrupt]
+        fn DMA_IN_CH0() {
+            use crate::dma::gdma::{Channel0 as Channel, Channel0RxImpl as ChannelRxImpl};
+
+            if Channel::is_in_done() {
+                Channel::clear_in_interrupts();
+                Channel::unlisten_in_eof();
+                ChannelRxImpl::waker().wake()
+            }
+        }
+
+        #[interrupt]
+        fn DMA_OUT_CH0() {
+            use crate::dma::gdma::{Channel0 as Channel, Channel0TxImpl as ChannelTxImpl};
+
+            if Channel::is_out_done() {
+                Channel::clear_out_interrupts();
+                Channel::unlisten_out_eof();
+                ChannelTxImpl::waker().wake()
+            }
+        }
+
+        #[interrupt]
+        fn DMA_IN_CH1() {
+            use crate::dma::gdma::{Channel1 as Channel, Channel1RxImpl as ChannelRxImpl};
+
+            if Channel::is_in_done() {
+                Channel::clear_in_interrupts();
+                Channel::unlisten_in_eof();
+                ChannelRxImpl::waker().wake()
+            }
+        }
+
+        #[interrupt]
+        fn DMA_OUT_CH1() {
+            use crate::dma::gdma::{Channel1 as Channel, Channel1TxImpl as ChannelTxImpl};
+
+            if Channel::is_out_done() {
+                Channel::clear_out_interrupts();
+                Channel::unlisten_out_eof();
+                ChannelTxImpl::waker().wake()
+            }
+        }
+
+        #[interrupt]
+        fn DMA_IN_CH3() {
+            use crate::dma::gdma::{Channel3 as Channel, Channel3RxImpl as ChannelRxImpl};
+
+            if Channel::is_in_done() {
+                Channel::clear_in_interrupts();
+                Channel::unlisten_in_eof();
+                ChannelRxImpl::waker().wake()
+            }
+        }
+
+        #[interrupt]
+        fn DMA_OUT_CH3() {
+            use crate::dma::gdma::{Channel3 as Channel, Channel3TxImpl as ChannelTxImpl};
+
+            if Channel::is_out_done() {
+                Channel::clear_out_interrupts();
+                Channel::unlisten_out_eof();
+                ChannelTxImpl::waker().wake()
+            }
+        }
+
+        #[interrupt]
+        fn DMA_IN_CH4() {
+            use crate::dma::gdma::{Channel4 as Channel, Channel4RxImpl as ChannelRxImpl};
+
+            if Channel::is_in_done() {
+                Channel::clear_in_interrupts();
+                Channel::unlisten_in_eof();
+                ChannelRxImpl::waker().wake()
+            }
+        }
+
+        #[interrupt]
+        fn DMA_OUT_CH4() {
+            use crate::dma::gdma::{Channel4 as Channel, Channel4TxImpl as ChannelTxImpl};
+
+            if Channel::is_out_done() {
+                Channel::clear_out_interrupts();
+                Channel::unlisten_out_eof();
+                ChannelTxImpl::waker().wake()
+            }
+        }
+    }
+
     #[cfg(any(esp32s2, esp32))]
     mod interrupt {
         use super::*;

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -212,7 +212,13 @@ pub(crate) mod private {
             len: usize,
         ) -> Result<(), DmaError>;
 
-        fn is_done(&mut self) -> bool;
+        fn is_done(&self) -> bool;
+
+        fn is_listening_eof(&self) -> bool;
+
+        fn listen_eof(&self);
+
+        fn unlisten_eof(&self);
 
         fn available(&mut self) -> usize;
 
@@ -291,7 +297,7 @@ pub(crate) mod private {
             Ok(())
         }
 
-        fn is_done(&mut self) -> bool {
+        fn is_done(&self) -> bool {
             R::is_in_done()
         }
 
@@ -312,6 +318,8 @@ pub(crate) mod private {
         pub available: usize,
         pub last_seen_handled_descriptor_ptr: *const u32,
         pub read_buffer_start: *const u8,
+        #[cfg(feature = "async")]
+        pub(crate) channel_index: usize,
         pub _phantom: PhantomData<R>,
     }
 
@@ -364,7 +372,7 @@ pub(crate) mod private {
             Ok(())
         }
 
-        fn is_done(&mut self) -> bool {
+        fn is_done(&self) -> bool {
             self.rx_impl.is_done()
         }
 
@@ -457,6 +465,18 @@ pub(crate) mod private {
 
             Ok(len)
         }
+
+        fn is_listening_eof(&self) -> bool {
+            R::is_listening_in_eof()
+        }
+
+        fn listen_eof(&self) {
+            R::listen_in_eof()
+        }
+
+        fn unlisten_eof(&self) {
+            R::unlisten_in_eof()
+        }
     }
 
     /// The functions here are not meant to be used outside the HAL
@@ -473,7 +493,13 @@ pub(crate) mod private {
             len: usize,
         ) -> Result<(), DmaError>;
 
-        fn is_done(&mut self) -> bool;
+        fn is_done(&self) -> bool;
+
+        fn is_listening_eof(&self) -> bool;
+
+        fn listen_eof(&self);
+
+        fn unlisten_eof(&self);
 
         fn available(&mut self) -> usize;
 
@@ -550,7 +576,7 @@ pub(crate) mod private {
             Ok(())
         }
 
-        fn is_done(&mut self) -> bool {
+        fn is_done(&self) -> bool {
             R::is_out_done()
         }
 
@@ -582,6 +608,8 @@ pub(crate) mod private {
         pub last_seen_handled_descriptor_ptr: *const u32,
         pub buffer_start: *const u8,
         pub buffer_len: usize,
+        #[cfg(feature = "async")]
+        pub(crate) channel_index: usize,
         pub _phantom: PhantomData<R>,
     }
 
@@ -637,7 +665,7 @@ pub(crate) mod private {
             Ok(())
         }
 
-        fn is_done(&mut self) -> bool {
+        fn is_done(&self) -> bool {
             self.tx_impl.is_done()
         }
 
@@ -747,6 +775,18 @@ pub(crate) mod private {
 
             Ok(data.len())
         }
+
+        fn is_listening_eof(&self) -> bool {
+            R::is_listening_out_eof()
+        }
+
+        fn listen_eof(&self) {
+            R::listen_out_eof()
+        }
+
+        fn unlisten_eof(&self) {
+            R::unlisten_out_eof()
+        }
     }
 
     pub trait RegisterAccess {
@@ -774,6 +814,14 @@ pub(crate) mod private {
         fn start_in();
         fn is_in_done() -> bool;
         fn last_in_dscr_address() -> usize;
+
+        fn is_listening_in_eof() -> bool;
+        fn is_listening_out_eof() -> bool;
+
+        fn listen_in_eof();
+        fn listen_out_eof();
+        fn unlisten_in_eof();
+        fn unlisten_out_eof();
     }
 }
 
@@ -786,6 +834,8 @@ where
 {
     pub(crate) tx: TX,
     pub(crate) rx: RX,
+    #[cfg(feature = "async")]
+    pub(crate) channel_index: usize,
     _phantom: PhantomData<P>,
 }
 

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -998,4 +998,43 @@ pub(crate) mod asynch {
             }
         }
     }
+
+    #[cfg(any(esp32s2, esp32))]
+    mod interrupt {
+        use super::*;
+
+        #[interrupt]
+        fn SPI2_DMA() {
+            use crate::dma::pdma::{Spi2DmaChannel as Channel, Spi2DmaChannelTxImpl as ChannelTxImpl, Spi2DmaChannelRxImpl as ChannelRxImpl};
+
+            if Channel::is_in_done() {
+                Channel::clear_in_interrupts();
+                Channel::unlisten_in_eof();
+                ChannelRxImpl::waker().wake()
+            }
+            
+            if Channel::is_out_done() {
+                Channel::clear_out_interrupts();
+                Channel::unlisten_out_eof();
+                ChannelTxImpl::waker().wake()
+            }
+        }
+
+        #[interrupt]
+        fn SPI3_DMA() {
+            use crate::dma::pdma::{Spi3DmaChannel as Channel, Spi3DmaChannelTxImpl as ChannelTxImpl, Spi3DmaChannelRxImpl as ChannelRxImpl};
+
+            if Channel::is_in_done() {
+                Channel::clear_in_interrupts();
+                Channel::unlisten_in_eof();
+                ChannelRxImpl::waker().wake()
+            }
+            
+            if Channel::is_out_done() {
+                Channel::clear_out_interrupts();
+                Channel::unlisten_out_eof();
+                ChannelTxImpl::waker().wake()
+            }
+        }
+    }
 }

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -220,6 +220,7 @@ pub trait RxPrivate {
 
     fn drain_buffer(&mut self, dst: &mut [u8]) -> Result<usize, DmaError>;
 
+    #[cfg(feature = "async")]
     fn channel_index(&self) -> usize;
 }
 
@@ -474,6 +475,7 @@ where
         R::unlisten_in_eof()
     }
 
+    #[cfg(feature = "async")]
     fn channel_index(&self) -> usize {
         self.channel_index
     }
@@ -505,6 +507,7 @@ pub trait TxPrivate {
 
     fn push(&mut self, data: &[u8]) -> Result<usize, DmaError>;
 
+    #[cfg(feature = "async")]
     fn channel_index(&self) -> usize;
 }
 
@@ -790,6 +793,7 @@ where
         R::unlisten_out_eof()
     }
 
+    #[cfg(feature = "async")]
     fn channel_index(&self) -> usize {
         self.channel_index
     }
@@ -956,13 +960,13 @@ pub(crate) mod asynch {
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
-                Channel::unlisten_out_eof();
+                Channel::unlisten_in_eof();
                 CHANNEL_IN_WAKERS[0].wake()
             }
-
+            
             if Channel::is_out_done() {
                 Channel::clear_out_interrupts();
-                Channel::unlisten_in_eof();
+                Channel::unlisten_out_eof();
                 CHANNEL_OUT_WAKERS[0].wake()
             }
         }
@@ -973,13 +977,13 @@ pub(crate) mod asynch {
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
-                Channel::unlisten_out_eof();
+                Channel::unlisten_in_eof();
                 CHANNEL_IN_WAKERS[1].wake()
             }
-
+            
             if Channel::is_out_done() {
                 Channel::clear_out_interrupts();
-                Channel::unlisten_in_eof();
+                Channel::unlisten_out_eof();
                 CHANNEL_OUT_WAKERS[1].wake()
             }
         }
@@ -990,13 +994,13 @@ pub(crate) mod asynch {
 
             if Channel::is_in_done() {
                 Channel::clear_in_interrupts();
-                Channel::unlisten_out_eof();
+                Channel::unlisten_in_eof();
                 CHANNEL_IN_WAKERS[2].wake()
             }
-
+            
             if Channel::is_out_done() {
                 Channel::clear_out_interrupts();
-                Channel::unlisten_in_eof();
+                Channel::unlisten_out_eof();
                 CHANNEL_OUT_WAKERS[2].wake()
             }
         }

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -930,7 +930,33 @@ pub(crate) mod asynch {
         }
     }
 
-    #[cfg(any(esp32c3, esp32c2))]
+    #[cfg(esp32c2)]
+    mod interrupt {
+        use super::*;
+
+        #[interrupt]
+        fn DMA_CH0() {
+            use crate::dma::gdma::{
+                Channel0 as Channel,
+                Channel0RxImpl as ChannelRxImpl,
+                Channel0TxImpl as ChannelTxImpl,
+            };
+
+            if Channel::is_in_done() {
+                Channel::clear_in_interrupts();
+                Channel::unlisten_in_eof();
+                ChannelRxImpl::waker().wake()
+            }
+
+            if Channel::is_out_done() {
+                Channel::clear_out_interrupts();
+                Channel::unlisten_out_eof();
+                ChannelTxImpl::waker().wake()
+            }
+        }
+    }
+
+    #[cfg(esp32c3)]
     mod interrupt {
         use super::*;
 

--- a/esp-hal-common/src/dma/pdma.rs
+++ b/esp-hal-common/src/dma/pdma.rs
@@ -1,8 +1,9 @@
 //! Direct Memory Access
 
 use crate::{
+    dma::*,
     peripheral::PeripheralRef,
-    system::{Peripheral, PeripheralClockControl}, dma::*,
+    system::{Peripheral, PeripheralClockControl},
 };
 
 macro_rules! ImplSpiChannel {

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -22,6 +22,7 @@
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]
 #![cfg_attr(feature = "async", allow(incomplete_features))]
 #![cfg_attr(feature = "async", feature(async_fn_in_trait))]
+#![cfg_attr(feature = "async", feature(impl_trait_projections))]
 
 #[cfg_attr(esp32, path = "peripherals/esp32.rs")]
 #[cfg_attr(esp32c3, path = "peripherals/esp32c3.rs")]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -77,3 +77,7 @@ required-features = ["embassy"]
 [[example]]
 name              = "embassy_wait"
 required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_spi"
+required-features = ["embassy", "async"]

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -1,0 +1,118 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32_hal::{
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+    pdma::*,
+    dma::*,
+    spi::{Spi, SpiMode, dma::SpiDma},
+    IO,
+    dma::DmaPriority,
+};
+use esp_backtrace as _;
+use static_cell::StaticCell;
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+pub type SpiType<'d> = SpiDma<'d, esp32_hal::peripherals::SPI2, ChannelTx<'d, Spi2DmaChannelTxImpl, Spi2DmaChannel>, ChannelRx<'d, Spi2DmaChannelRxImpl, Spi2DmaChannel>, Spi2DmaSuitablePeripheral>; 
+
+#[embassy_executor::task]
+async fn spi_task(spi: &'static mut SpiType<'static>) {
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        // TODO is recv buffer is < send buffer it hangs?
+        // TODO is send/recv buffer is < 8 bytes it also hangs
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer).await.unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[xtensa_lx_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    esp32_hal::interrupt::enable(esp32_hal::peripherals::Interrupt::SPI2_DMA, esp32_hal::interrupt::Priority::Priority1).unwrap();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio19;
+    let miso = io.pins.gpio25;
+    let mosi = io.pins.gpio23;
+    let cs = io.pins.gpio22;
+
+    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma_channel = dma.spi2channel;
+
+    let descriptors = singleton!([0u32; 8 * 3]);
+    let rx_descriptors = singleton!([0u32; 8 * 3]);
+
+    let spi = singleton!(Spi::new(
+        peripherals.SPI2,
+        sclk,
+        mosi,
+        miso,
+        cs,
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        descriptors,
+        rx_descriptors,
+        DmaPriority::Priority0,
+    )));
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(spi_task(spi)).ok();
+    });
+}

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -45,8 +45,6 @@ pub type SpiType<'d> = SpiDma<
 async fn spi_task(spi: &'static mut SpiType<'static>) {
     let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
     loop {
-        // TODO is recv buffer is < send buffer it hangs?
-        // TODO is send/recv buffer is < 8 bytes it also hangs
         let mut buffer = [0; 8];
         esp_println::println!("Sending bytes");
         embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -73,3 +73,7 @@ required-features = ["embassy"]
 [[example]]
 name              = "embassy_wait"
 required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_spi"
+required-features = ["embassy", "async"]

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -45,8 +45,6 @@ pub type SpiType<'d> = SpiDma<
 async fn spi_task(spi: &'static mut SpiType<'static>) {
     let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
     loop {
-        // TODO is recv buffer is < send buffer it hangs?
-        // TODO is send/recv buffer is < 8 bytes it also hangs
         let mut buffer = [0; 8];
         esp_println::println!("Sending bytes");
         embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -1,0 +1,127 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32c2_hal::{
+    clock::ClockControl,
+    dma::{DmaPriority, *},
+    embassy,
+    gdma::*,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{dma::SpiDma, Spi, SpiMode},
+    timer::TimerGroup,
+    Rtc,
+    IO,
+};
+use esp_backtrace as _;
+use static_cell::StaticCell;
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+pub type SpiType<'d> = SpiDma<
+    'd,
+    esp32c2_hal::peripherals::SPI2,
+    ChannelTx<'d, Channel0TxImpl, esp32c2_hal::gdma::Channel0>,
+    ChannelRx<'d, Channel0RxImpl, esp32c2_hal::gdma::Channel0>,
+    SuitablePeripheral0,
+>;
+
+#[embassy_executor::task]
+async fn spi_task(spi: &'static mut SpiType<'static>) {
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        // TODO is recv buffer is < send buffer it hangs?
+        // TODO is send/recv buffer is < 8 bytes it also hangs
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[esp_riscv_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    esp32c2_hal::interrupt::enable(
+        esp32c2_hal::peripherals::Interrupt::DMA_CH0,
+        esp32c2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio6;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio7;
+    let cs = io.pins.gpio10;
+
+    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma_channel = dma.channel0;
+
+    let descriptors = singleton!([0u32; 8 * 3]);
+    let rx_descriptors = singleton!([0u32; 8 * 3]);
+
+    let spi = singleton!(Spi::new(
+        peripherals.SPI2,
+        sclk,
+        mosi,
+        miso,
+        cs,
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        descriptors,
+        rx_descriptors,
+        DmaPriority::Priority0,
+    )));
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(spi_task(spi)).ok();
+    });
+}

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -85,3 +85,7 @@ required-features = ["embassy", "async"]
 
 [profile.dev]
 opt-level = 1
+
+[[example]]
+name              = "embassy_spi"
+required-features = ["embassy", "async"]

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -45,8 +45,6 @@ pub type SpiType<'d> = SpiDma<
 async fn spi_task(spi: &'static mut SpiType<'static>) {
     let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
     loop {
-        // TODO is recv buffer is < send buffer it hangs?
-        // TODO is send/recv buffer is < 8 bytes it also hangs
         let mut buffer = [0; 8];
         esp_println::println!("Sending bytes");
         embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -1,0 +1,119 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32c3_hal::{
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+    gdma::*,
+    dma::*,
+    spi::{Spi, SpiMode, dma::SpiDma},
+    IO,
+    dma::DmaPriority,
+};
+use esp_backtrace as _;
+use static_cell::StaticCell;
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+pub type SpiType<'d> = SpiDma<'d, esp32c3_hal::peripherals::SPI2, ChannelTx<'d, Channel0TxImpl, esp32c3_hal::gdma::Channel0>, ChannelRx<'d, Channel0RxImpl, esp32c3_hal::gdma::Channel0>, SuitablePeripheral0>;
+
+#[embassy_executor::task]
+async fn spi_task(spi: &'static mut SpiType<'static>) {
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        // TODO is recv buffer is < send buffer it hangs?
+        // TODO is send/recv buffer is < 8 bytes it also hangs
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer).await.unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[esp_riscv_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    esp32c3_hal::interrupt::enable(esp32c3_hal::peripherals::Interrupt::DMA_CH0, esp32c3_hal::interrupt::Priority::Priority1).unwrap();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio6;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio7;
+    let cs = io.pins.gpio10;
+
+    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma_channel = dma.channel0;
+
+    let descriptors = singleton!([0u32; 8 * 3]);
+    let rx_descriptors = singleton!([0u32; 8 * 3]);
+
+    let spi = singleton!(Spi::new(
+        peripherals.SPI2,
+        sclk,
+        mosi,
+        miso,
+        cs,
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        descriptors,
+        rx_descriptors,
+        DmaPriority::Priority0,
+    )));
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(spi_task(spi)).ok();
+    });
+}

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -83,3 +83,7 @@ required-features = ["embassy"]
 [[example]]
 name              = "embassy_wait"
 required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_spi"
+required-features = ["embassy", "async"]

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -45,8 +45,6 @@ pub type SpiType<'d> = SpiDma<
 async fn spi_task(spi: &'static mut SpiType<'static>) {
     let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
     loop {
-        // TODO is recv buffer is < send buffer it hangs?
-        // TODO is send/recv buffer is < 8 bytes it also hangs
         let mut buffer = [0; 8];
         esp_println::println!("Sending bytes");
         embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -11,16 +11,15 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
+    dma::{DmaPriority, *},
     embassy,
+    pdma::*,
     peripherals::Peripherals,
     prelude::*,
+    spi::{dma::SpiDma, Spi, SpiMode},
     timer::TimerGroup,
     Rtc,
-    pdma::*,
-    dma::*,
-    spi::{Spi, SpiMode, dma::SpiDma},
     IO,
-    dma::DmaPriority,
 };
 use esp_backtrace as _;
 use static_cell::StaticCell;
@@ -34,7 +33,13 @@ macro_rules! singleton {
     }};
 }
 
-pub type SpiType<'d> = SpiDma<'d, esp32s2_hal::peripherals::SPI2, ChannelTx<'d, Spi2DmaChannelTxImpl, Spi2DmaChannel>, ChannelRx<'d, Spi2DmaChannelRxImpl, Spi2DmaChannel>, Spi2DmaSuitablePeripheral>; 
+pub type SpiType<'d> = SpiDma<
+    'd,
+    esp32s2_hal::peripherals::SPI2,
+    ChannelTx<'d, Spi2DmaChannelTxImpl, Spi2DmaChannel>,
+    ChannelRx<'d, Spi2DmaChannelRxImpl, Spi2DmaChannel>,
+    Spi2DmaSuitablePeripheral,
+>;
 
 #[embassy_executor::task]
 async fn spi_task(spi: &'static mut SpiType<'static>) {
@@ -44,7 +49,9 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         // TODO is send/recv buffer is < 8 bytes it also hangs
         let mut buffer = [0; 8];
         esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer).await.unwrap();
+        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
         esp_println::println!("Bytes recieved: {:?}", buffer);
         Timer::after(Duration::from_millis(5_000)).await;
     }
@@ -79,7 +86,11 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    esp32s2_hal::interrupt::enable(esp32s2_hal::peripherals::Interrupt::SPI2_DMA, esp32s2_hal::interrupt::Priority::Priority1).unwrap();
+    esp32s2_hal::interrupt::enable(
+        esp32s2_hal::peripherals::Interrupt::SPI2_DMA,
+        esp32s2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio36;

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -1,0 +1,118 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32s2_hal::{
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+    pdma::*,
+    dma::*,
+    spi::{Spi, SpiMode, dma::SpiDma},
+    IO,
+    dma::DmaPriority,
+};
+use esp_backtrace as _;
+use static_cell::StaticCell;
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+pub type SpiType<'d> = SpiDma<'d, esp32s2_hal::peripherals::SPI2, ChannelTx<'d, Spi2DmaChannelTxImpl, Spi2DmaChannel>, ChannelRx<'d, Spi2DmaChannelRxImpl, Spi2DmaChannel>, Spi2DmaSuitablePeripheral>; 
+
+#[embassy_executor::task]
+async fn spi_task(spi: &'static mut SpiType<'static>) {
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        // TODO is recv buffer is < send buffer it hangs?
+        // TODO is send/recv buffer is < 8 bytes it also hangs
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer).await.unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[xtensa_lx_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    esp32s2_hal::interrupt::enable(esp32s2_hal::peripherals::Interrupt::SPI2_DMA, esp32s2_hal::interrupt::Priority::Priority1).unwrap();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio36;
+    let miso = io.pins.gpio37;
+    let mosi = io.pins.gpio35;
+    let cs = io.pins.gpio34;
+
+    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma_channel = dma.spi2channel;
+
+    let descriptors = singleton!([0u32; 8 * 3]);
+    let rx_descriptors = singleton!([0u32; 8 * 3]);
+
+    let spi = singleton!(Spi::new(
+        peripherals.SPI2,
+        sclk,
+        mosi,
+        miso,
+        cs,
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        descriptors,
+        rx_descriptors,
+        DmaPriority::Priority0,
+    )));
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(spi_task(spi)).ok();
+    });
+}

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -83,3 +83,7 @@ required-features = ["embassy"]
 [[example]]
 name              = "embassy_wait"
 required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_spi"
+required-features = ["embassy", "async"]

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -45,8 +45,6 @@ pub type SpiType<'d> = SpiDma<
 async fn spi_task(spi: &'static mut SpiType<'static>) {
     let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
     loop {
-        // TODO is recv buffer is < send buffer it hangs?
-        // TODO is send/recv buffer is < 8 bytes it also hangs
         let mut buffer = [0; 8];
         esp_println::println!("Sending bytes");
         embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -11,16 +11,15 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
+    dma::{DmaPriority, *},
     embassy,
+    gdma::*,
     peripherals::Peripherals,
     prelude::*,
+    spi::{dma::SpiDma, Spi, SpiMode},
     timer::TimerGroup,
     Rtc,
-    gdma::*,
-    dma::*,
-    spi::{Spi, SpiMode, dma::SpiDma},
     IO,
-    dma::DmaPriority,
 };
 use esp_backtrace as _;
 use static_cell::StaticCell;
@@ -34,7 +33,13 @@ macro_rules! singleton {
     }};
 }
 
-pub type SpiType<'d> = SpiDma<'d, esp32s3_hal::peripherals::SPI2, ChannelTx<'d, Channel0TxImpl, esp32s3_hal::gdma::Channel0>, ChannelRx<'d, Channel0RxImpl, esp32s3_hal::gdma::Channel0>, SuitablePeripheral0>;
+pub type SpiType<'d> = SpiDma<
+    'd,
+    esp32s3_hal::peripherals::SPI2,
+    ChannelTx<'d, Channel0TxImpl, esp32s3_hal::gdma::Channel0>,
+    ChannelRx<'d, Channel0RxImpl, esp32s3_hal::gdma::Channel0>,
+    SuitablePeripheral0,
+>;
 
 #[embassy_executor::task]
 async fn spi_task(spi: &'static mut SpiType<'static>) {
@@ -44,7 +49,9 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         // TODO is send/recv buffer is < 8 bytes it also hangs
         let mut buffer = [0; 8];
         esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer).await.unwrap();
+        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
         esp_println::println!("Bytes recieved: {:?}", buffer);
         Timer::after(Duration::from_millis(5_000)).await;
     }
@@ -80,8 +87,16 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    esp32s3_hal::interrupt::enable(esp32s3_hal::peripherals::Interrupt::DMA_IN_CH0, esp32s3_hal::interrupt::Priority::Priority1).unwrap();
-    esp32s3_hal::interrupt::enable(esp32s3_hal::peripherals::Interrupt::DMA_OUT_CH0, esp32s3_hal::interrupt::Priority::Priority1).unwrap();
+    esp32s3_hal::interrupt::enable(
+        esp32s3_hal::peripherals::Interrupt::DMA_IN_CH0,
+        esp32s3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+    esp32s3_hal::interrupt::enable(
+        esp32s3_hal::peripherals::Interrupt::DMA_OUT_CH0,
+        esp32s3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -1,0 +1,120 @@
+//! embassy hello world
+//!
+//! This is an example of running the embassy executor with multiple tasks
+//! concurrently.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32s3_hal::{
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+    gdma::*,
+    dma::*,
+    spi::{Spi, SpiMode, dma::SpiDma},
+    IO,
+    dma::DmaPriority,
+};
+use esp_backtrace as _;
+use static_cell::StaticCell;
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+pub type SpiType<'d> = SpiDma<'d, esp32s3_hal::peripherals::SPI2, ChannelTx<'d, Channel0TxImpl, esp32s3_hal::gdma::Channel0>, ChannelRx<'d, Channel0RxImpl, esp32s3_hal::gdma::Channel0>, SuitablePeripheral0>;
+
+#[embassy_executor::task]
+async fn spi_task(spi: &'static mut SpiType<'static>) {
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        // TODO is recv buffer is < send buffer it hangs?
+        // TODO is send/recv buffer is < 8 bytes it also hangs
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer).await.unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[xtensa_lx_rt::entry]
+fn main() -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    esp32s3_hal::interrupt::enable(esp32s3_hal::peripherals::Interrupt::DMA_IN_CH0, esp32s3_hal::interrupt::Priority::Priority1).unwrap();
+    esp32s3_hal::interrupt::enable(esp32s3_hal::peripherals::Interrupt::DMA_OUT_CH0, esp32s3_hal::interrupt::Priority::Priority1).unwrap();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio6;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio7;
+    let cs = io.pins.gpio10;
+
+    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma_channel = dma.channel0;
+
+    let descriptors = singleton!([0u32; 8 * 3]);
+    let rx_descriptors = singleton!([0u32; 8 * 3]);
+
+    let spi = singleton!(Spi::new(
+        peripherals.SPI2,
+        sclk,
+        mosi,
+        miso,
+        cs,
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        descriptors,
+        rx_descriptors,
+        DmaPriority::Priority0,
+    )));
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(spi_task(spi)).ok();
+    });
+}


### PR DESCRIPTION
This PR implements a `Future` based abstraction around the current DMA implementations and uses said abstraction to implement the Async SPI traits from e-h on `SpiDma`.

FYI the diff looks kinda weird because of the fmt commit, perhaps compare the commits _before_ that fmt commit for easier viewing.

## Breaking changes

`dma::private`, `gdma::private`, and `pdma::private` no longer exist. All the DMA types/traits are now public. The ideal solution would be to erase these types see #381.

## Future work

- The error handling for the DMA needs some work at the moment DMA errors are unchecked.
- We could implement the e-h-a SPI traits on the normal `Spi` struct using the peripheral FIFO + interrupts, but this is less efficient and unnecessary for this initial implementation. 