### PR TITLE
Allow `into_analog` for all analog capable pins

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1360,7 +1360,7 @@ impl<MODE, RA, IRA, PINTYPE, SIG, const GPIONUM: u8> GpioPin<MODE, RA, IRA, PINT
 where
     RA: BankGpioRegisterAccess,
     IRA: InteruptStatusRegisterAccess,
-    PINTYPE: IsOutputPin,
+    PINTYPE: IsAnalogPin,
     SIG: GpioSignal,
 {
     pub fn into_analog(self) -> GpioPin<Analog, RA, IRA, PINTYPE, SIG, GPIONUM> {


### PR DESCRIPTION
Fixes #388
