### PR TITLE
Remove unnecessary `rt` crate dependencies

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -60,11 +60,11 @@ esp32s2 = { version = "0.10.0", features = ["critical-section"], optional = true
 esp32s3 = { version = "0.13.0", features = ["critical-section"], optional = true }
 
 [features]
-esp32   = ["esp32/rt"  , "xtensa", "xtensa-lx/esp32",   "xtensa-lx-rt/esp32",   "lock_api"]
-esp32c2 = ["esp32c2/rt", "riscv"]
-esp32c3 = ["esp32c3/rt", "riscv"]
-esp32s2 = ["esp32s2/rt", "xtensa", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2",             "esp-synopsys-usb-otg", "usb-device"]
-esp32s3 = ["esp32s3/rt", "xtensa", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "lock_api", "esp-synopsys-usb-otg", "usb-device"]
+esp32   = ["esp32/rt"  , "xtensa", "xtensa-lx/esp32",   "xtensa-lx-rt/esp32",   "lock_api", "procmacros/esp32"]
+esp32c2 = ["esp32c2/rt", "riscv", "procmacros/esp32c2"]
+esp32c3 = ["esp32c3/rt", "riscv", "procmacros/esp32c3"]
+esp32s2 = ["esp32s2/rt", "xtensa", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2",             "esp-synopsys-usb-otg", "usb-device", "procmacros/esp32s2"]
+esp32s3 = ["esp32s3/rt", "xtensa", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "lock_api", "esp-synopsys-usb-otg", "usb-device", "procmacros/esp32s3"]
 
 esp32c2_40mhz = []
 esp32c2_26mhz = []

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp-hal-common"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -24,7 +24,7 @@ fugit                = "0.3.6"
 lock_api             = { version = "0.4.9", optional = true }
 nb                   = "1.0.0"
 paste                = "1.0.11"
-procmacros           = { version = "0.2.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+procmacros           = { version = "0.3.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 strum                = { version = "0.24.1", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
@@ -40,8 +40,8 @@ esp-riscv-rt                = { version = "0.1.0", optional = true }
 riscv-atomic-emulation-trap = { version = "0.4.0", optional = true }
 
 # Xtensa
-xtensa-lx    = { version = "0.7.0",  optional = true }
-xtensa-lx-rt = { version = "0.14.0", optional = true }
+xtensa-lx    = { version = "0.8.0",  optional = true }
+xtensa-lx-rt = { version = "0.15.0", optional = true }
 
 # Smart-LED (e.g., WS2812/SK68XX) support
 smart-leds-trait = { version = "0.2.1", optional = true }
@@ -53,11 +53,11 @@ ufmt-write = { version = "0.1.0", optional = true }
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature. We rename the PAC packages because we cannot
 # have dependencies and features with the same names.
-esp32   = { version = "0.19.0", features = ["critical-section"], optional = true }
-esp32c2 = { version = "0.7.0",  features = ["critical-section"], optional = true }
-esp32c3 = { version = "0.10.0", features = ["critical-section"], optional = true }
-esp32s2 = { version = "0.10.0", features = ["critical-section"], optional = true }
-esp32s3 = { version = "0.13.0", features = ["critical-section"], optional = true }
+esp32   = { version = "0.21.0", features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.8.0",  features = ["critical-section"], optional = true }
+esp32c3 = { version = "0.11.0", features = ["critical-section"], optional = true }
+esp32s2 = { version = "0.12.0", features = ["critical-section"], optional = true }
+esp32s3 = { version = "0.15.0", features = ["critical-section"], optional = true }
 
 [features]
 esp32   = ["esp32/rt"  , "xtensa", "xtensa-lx/esp32",   "xtensa-lx-rt/esp32",   "lock_api", "procmacros/esp32"]

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -31,7 +31,27 @@
 #[cfg_attr(esp32s3, path = "peripherals/esp32s3.rs")]
 pub mod peripherals;
 
+#[cfg(riscv)]
+pub use esp_riscv_rt;
+#[cfg(riscv)]
+pub use esp_riscv_rt::entry;
+#[cfg(riscv)]
+pub use esp_riscv_rt::riscv;
 pub use procmacros as macros;
+#[cfg(xtensa)]
+pub use xtensa_lx;
+#[cfg(xtensa)]
+pub use xtensa_lx_rt;
+#[cfg(xtensa)]
+pub use xtensa_lx_rt::entry;
+
+/// State of the CPU saved when entering exception or interrupt
+pub mod trapframe {
+    #[cfg(riscv)]
+    pub use esp_riscv_rt::TrapFrame;
+    #[cfg(xtensa)]
+    pub use xtensa_lx_rt::exception::Context as TrapFrame;
+}
 
 #[cfg(rmt)]
 pub use self::pulse_control::PulseControl;

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -37,6 +37,7 @@ pub use crate::{
         DmaTransfer as _esp_hal_dma_DmaTransfer,
         DmaTransferRxTx as _esp_hal_dma_DmaTransferRxTx,
     },
+    entry,
     gpio::{
         InputPin as _esp_hal_gpio_InputPin,
         OutputPin as _esp_hal_gpio_OutputPin,

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -20,9 +20,15 @@ proc-macro-error = "1.0.4"
 proc-macro2      = "1.0.50"
 quote            = "1.0.23"
 syn              = {version = "1.0.107", features = ["extra-traits", "full"]}
+proc-macro-crate = "1.3.0"
 
 [features]
 interrupt = []
 riscv     = []
 rtc_slow  = []
 xtensa    = []
+esp32     = []
+esp32c2   = []
+esp32c3   = []
+esp32s2   = []
+esp32s3   = []

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp-hal-procmacros"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32-hal"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -30,13 +30,13 @@ embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
-esp-hal-common     = { version = "0.5.0",  features = ["esp32"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.6.0",  features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.4.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.5.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -31,8 +31,6 @@ embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "e
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.5.0",  features = ["esp32"], path = "../esp-hal-common" }
-xtensa-lx          = { version = "0.7.0",  features = ["esp32"] }
-xtensa-lx-rt       = { version = "0.14.0", features = ["esp32"], optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
@@ -50,7 +48,7 @@ aes = "0.8.2"
 default           = ["rt", "vectored"]
 bluetooth         = []
 eh1               = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
-rt                = ["xtensa-lx-rt/esp32"]
+rt                = []
 smartled          = ["esp-hal-common/smartled"]
 ufmt              = ["esp-hal-common/ufmt"]
 vectored          = ["esp-hal-common/vectored"]

--- a/esp32-hal/examples/adc.rs
+++ b/esp32-hal/examples/adc.rs
@@ -17,7 +17,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/advanced_serial.rs
+++ b/esp32-hal/examples/advanced_serial.rs
@@ -23,7 +23,6 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/aes.rs
+++ b/esp32-hal/examples/aes.rs
@@ -10,12 +10,13 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
+    xtensa_lx,
     Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();

--- a/esp32-hal/examples/blinky.rs
+++ b/esp32-hal/examples/blinky.rs
@@ -15,7 +15,6 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/blinky_erased_pins.rs
+++ b/esp32-hal/examples/blinky_erased_pins.rs
@@ -15,7 +15,6 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/clock_monitor.rs
+++ b/esp32-hal/examples/clock_monitor.rs
@@ -16,7 +16,6 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32-hal/examples/dac.rs
+++ b/esp32-hal/examples/dac.rs
@@ -16,7 +16,6 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -38,7 +38,7 @@ async fn run2() {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -57,7 +57,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32-hal/examples/gpio_interrupt.rs
+++ b/esp32-hal/examples/gpio_interrupt.rs
@@ -17,11 +17,11 @@ use esp32_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     timer::TimerGroup,
+    xtensa_lx,
     Delay,
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 static BUTTON: Mutex<RefCell<Option<Gpio0<Input<PullDown>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32-hal/examples/hello_rgb.rs
+++ b/esp32-hal/examples/hello_rgb.rs
@@ -32,7 +32,6 @@ use smart_leds::{
     hsv::{hsv2rgb, Hsv},
     SmartLedsWrite,
 };
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/hello_world.rs
+++ b/esp32-hal/examples/hello_world.rs
@@ -16,7 +16,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32-hal/examples/i2c_bmp180_calibration_data.rs
@@ -20,7 +20,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/i2c_display.rs
+++ b/esp32-hal/examples/i2c_display.rs
@@ -31,7 +31,6 @@ use esp32_hal::{
 use esp_backtrace as _;
 use nb::block;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/i2s_read.rs
+++ b/esp32-hal/examples/i2s_read.rs
@@ -26,7 +26,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/i2s_sound.rs
+++ b/esp32-hal/examples/i2s_sound.rs
@@ -41,7 +41,6 @@ use esp32_hal::{
     IO,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,

--- a/esp32-hal/examples/ledc.rs
+++ b/esp32-hal/examples/ledc.rs
@@ -21,7 +21,6 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/mcpwm.rs
+++ b/esp32-hal/examples/mcpwm.rs
@@ -16,7 +16,6 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/multicore.rs
+++ b/esp32-hal/examples/multicore.rs
@@ -19,7 +19,6 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/pcnt_encoder.rs
+++ b/esp32-hal/examples/pcnt_encoder.rs
@@ -28,7 +28,6 @@ use esp_hal::{
     IO,
 };
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 static UNIT0: Mutex<RefCell<Option<unit::Unit>>> = Mutex::new(RefCell::new(None));
 static VALUE: AtomicI32 = AtomicI32::new(0);

--- a/esp32-hal/examples/pulse_control.rs
+++ b/esp32-hal/examples/pulse_control.rs
@@ -16,7 +16,6 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/ram.rs
+++ b/esp32-hal/examples/ram.rs
@@ -18,7 +18,6 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[ram(rtc_fast)]
 static mut SOME_INITED_DATA: [u8; 2] = [0xaa, 0xbb];

--- a/esp32-hal/examples/read_efuse.rs
+++ b/esp32-hal/examples/read_efuse.rs
@@ -14,7 +14,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/rtc_watchdog.rs
+++ b/esp32-hal/examples/rtc_watchdog.rs
@@ -18,7 +18,6 @@ use esp32_hal::{
     Rwdt,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32-hal/examples/serial_interrupts.rs
+++ b/esp32-hal/examples/serial_interrupts.rs
@@ -20,7 +20,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32-hal/examples/sha.rs
+++ b/esp32-hal/examples/sha.rs
@@ -10,13 +10,13 @@ use esp32_hal::{
     prelude::*,
     sha::{Sha, ShaMode},
     timer::TimerGroup,
+    xtensa_lx,
     Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
 use sha2::{Digest, Sha512};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -31,7 +31,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -29,7 +29,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -28,7 +28,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -30,7 +30,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/examples/timer_interrupt.rs
+++ b/esp32-hal/examples/timer_interrupt.rs
@@ -18,7 +18,6 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 static TIMER00: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));
 static TIMER01: Mutex<RefCell<Option<Timer<Timer1<TIMG0>>>>> = Mutex::new(RefCell::new(None));

--- a/esp32-hal/examples/watchdog.rs
+++ b/esp32-hal/examples/watchdog.rs
@@ -15,7 +15,6 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -13,6 +13,7 @@ pub use esp_hal_common::{
     dma,
     dma::pdma,
     efuse,
+    entry,
     gpio,
     i2c,
     i2s,
@@ -28,8 +29,10 @@ pub use esp_hal_common::{
     spi,
     system,
     timer,
+    trapframe,
     uart,
     utils,
+    xtensa_lx,
     Cpu,
     Delay,
     PulseControl,
@@ -74,17 +77,17 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
     }
 
     // set stack pointer to end of memory: no need to retain stack up to this point
-    xtensa_lx::set_stack_pointer(&mut _stack_end_cpu0);
+    esp_hal_common::xtensa_lx::set_stack_pointer(&mut _stack_end_cpu0);
 
     // copying data from flash to various data segments is done by the bootloader
     // initialization to zero needs to be done by the application
 
     // Initialize RTC RAM
-    xtensa_lx_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
-    xtensa_lx_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
+    esp_hal_common::xtensa_lx_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
+    esp_hal_common::xtensa_lx_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
 
     // continue with default reset handler
-    xtensa_lx_rt::Reset();
+    esp_hal_common::xtensa_lx_rt::Reset();
 }
 
 /// The ESP32 has a first stage bootloader that handles loading program data

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -31,7 +31,6 @@ embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "e
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.5.0",  features = ["esp32c2"], path = "../esp-hal-common" }
-esp-riscv-rt       = { version = "0.1.0", optional = true }
 r0                 = "1.0.0"
 
 [dev-dependencies]
@@ -48,7 +47,7 @@ static_cell       = "1.0.0"
 default              = ["rt", "vectored", "xtal40mhz"]
 direct-boot          = []
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
-rt                   = ["esp-riscv-rt"]
+rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
 async                = ["esp-hal-common/async", "embedded-hal-async"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32c2-hal"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -30,14 +30,14 @@ embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
-esp-hal-common     = { version = "0.5.0",  features = ["esp32c2"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.6.0",  features = ["esp32c2"], path = "../esp-hal-common" }
 r0                 = "1.0.0"
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.4.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.5.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32c2"] }
 sha2              = { version = "0.10.6", default-features = false}
 ssd1306           = "0.7.1"

--- a/esp32c2-hal/examples/adc.rs
+++ b/esp32c2-hal/examples/adc.rs
@@ -17,7 +17,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/advanced_serial.rs
+++ b/esp32c2-hal/examples/advanced_serial.rs
@@ -21,7 +21,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 use nb::block;
 
 #[entry]

--- a/esp32c2-hal/examples/blinky.rs
+++ b/esp32c2-hal/examples/blinky.rs
@@ -15,7 +15,6 @@ use esp32c2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/blinky_erased_pins.rs
+++ b/esp32c2-hal/examples/blinky_erased_pins.rs
@@ -15,7 +15,6 @@ use esp32c2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/clock_monitor.rs
+++ b/esp32c2-hal/examples/clock_monitor.rs
@@ -13,10 +13,10 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
+    riscv,
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 
 static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32c2-hal/examples/embassy_hello_world.rs
+++ b/esp32c2-hal/examples/embassy_hello_world.rs
@@ -38,7 +38,7 @@ async fn run2() {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[esp_riscv_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -57,7 +57,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[esp_riscv_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32c2-hal/examples/embassy_wait.rs
+++ b/esp32c2-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[esp_riscv_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32c2-hal/examples/gpio_interrupt.rs
+++ b/esp32c2-hal/examples/gpio_interrupt.rs
@@ -15,12 +15,12 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
+    riscv,
     timer::TimerGroup,
     Delay,
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 
 static BUTTON: Mutex<RefCell<Option<Gpio9<Input<PullDown>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32c2-hal/examples/hello_world.rs
+++ b/esp32c2-hal/examples/hello_world.rs
@@ -15,7 +15,6 @@ use esp32c2_hal::{
     Uart,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 use nb::block;
 
 #[entry]

--- a/esp32c2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -20,7 +20,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/i2c_display.rs
+++ b/esp32c2-hal/examples/i2c_display.rs
@@ -29,7 +29,6 @@ use esp32c2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 use nb::block;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 

--- a/esp32c2-hal/examples/ledc.rs
+++ b/esp32c2-hal/examples/ledc.rs
@@ -22,7 +22,6 @@ use esp32c2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/read_efuse.rs
+++ b/esp32c2-hal/examples/read_efuse.rs
@@ -14,7 +14,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/rtc_watchdog.rs
+++ b/esp32c2-hal/examples/rtc_watchdog.rs
@@ -14,11 +14,11 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
+    riscv,
     Rtc,
     Rwdt,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 
 static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32c2-hal/examples/serial_interrupts.rs
+++ b/esp32c2-hal/examples/serial_interrupts.rs
@@ -13,6 +13,7 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals, UART0},
     prelude::*,
+    riscv,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
@@ -20,7 +21,6 @@ use esp32c2_hal::{
     Uart,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 use nb::block;
 
 static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(None));

--- a/esp32c2-hal/examples/sha.rs
+++ b/esp32c2-hal/examples/sha.rs
@@ -14,7 +14,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 use nb::block;
 use sha2::{Digest, Sha256};
 

--- a/esp32c2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_device_loopback.rs
@@ -31,7 +31,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_loopback.rs
@@ -29,7 +29,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/spi_loopback.rs
+++ b/esp32c2-hal/examples/spi_loopback.rs
@@ -28,7 +28,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -30,7 +30,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c2-hal/examples/systimer.rs
+++ b/esp32c2-hal/examples/systimer.rs
@@ -20,7 +20,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 static ALARM1: Mutex<RefCell<Option<Alarm<Target, 1>>>> = Mutex::new(RefCell::new(None));

--- a/esp32c2-hal/examples/timer_interrupt.rs
+++ b/esp32c2-hal/examples/timer_interrupt.rs
@@ -12,11 +12,11 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals, TIMG0},
     prelude::*,
+    riscv,
     timer::{Timer, Timer0, TimerGroup},
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 
 static TIMER0: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32c2-hal/examples/watchdog.rs
+++ b/esp32c2-hal/examples/watchdog.rs
@@ -14,7 +14,6 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 use nb::block;
 
 #[entry]

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -9,6 +9,7 @@ pub use esp_hal_common::{
     clock,
     dma::{self, gdma},
     efuse,
+    entry,
     gpio,
     i2c,
     interrupt,
@@ -16,11 +17,13 @@ pub use esp_hal_common::{
     macros,
     peripherals,
     prelude,
+    riscv,
     sha,
     spi,
     system,
     systimer,
     timer,
+    trapframe,
     uart,
     Cpu,
     Delay,
@@ -50,7 +53,7 @@ extern "C" {
 
 #[cfg(feature = "direct-boot")]
 #[doc(hidden)]
-#[esp_riscv_rt::pre_init]
+#[esp_hal_common::esp_riscv_rt::pre_init]
 unsafe fn init() {
     r0::init_data(&mut _srwtext, &mut _erwtext, &_irwtext);
 }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -33,7 +33,6 @@ embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.5.0",  features = ["esp32c3"], path = "../esp-hal-common" }
-esp-riscv-rt       = { version = "0.1.0", optional = true }
 r0                 = "1.0.0"
 
 [dev-dependencies]
@@ -53,7 +52,7 @@ default              = ["rt", "vectored"]
 mcu-boot             = []
 direct-boot          = []
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
-rt                   = ["esp-riscv-rt"]
+rt                   = []
 smartled             = ["esp-hal-common/smartled"]
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32c3-hal"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -32,7 +32,7 @@ embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "e
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.5.0",  features = ["esp32c3"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.6.0",  features = ["esp32c3"], path = "../esp-hal-common" }
 r0                 = "1.0.0"
 
 [dev-dependencies]
@@ -40,7 +40,7 @@ aes               = "0.8.2"
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.4.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.5.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32c3"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"

--- a/esp32c3-hal/examples/adc.rs
+++ b/esp32c3-hal/examples/adc.rs
@@ -17,7 +17,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -21,7 +21,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 use nb::block;
 
 #[entry]

--- a/esp32c3-hal/examples/aes.rs
+++ b/esp32c3-hal/examples/aes.rs
@@ -15,7 +15,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/blinky.rs
+++ b/esp32c3-hal/examples/blinky.rs
@@ -15,7 +15,6 @@ use esp32c3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/blinky_erased_pins.rs
+++ b/esp32c3-hal/examples/blinky_erased_pins.rs
@@ -15,7 +15,6 @@ use esp32c3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/clock_monitor.rs
+++ b/esp32c3-hal/examples/clock_monitor.rs
@@ -13,10 +13,10 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
+    riscv,
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 
 static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -38,7 +38,7 @@ async fn run2() {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[esp_riscv_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -57,7 +57,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[esp_riscv_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[esp_riscv_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -15,12 +15,12 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
+    riscv,
     timer::TimerGroup,
     Delay,
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 
 static BUTTON: Mutex<RefCell<Option<Gpio9<Input<PullDown>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -25,7 +25,6 @@ use esp32c3_hal::{
 };
 #[allow(unused_imports)]
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 use smart_leds::{
     brightness,
     gamma,

--- a/esp32c3-hal/examples/hello_world.rs
+++ b/esp32c3-hal/examples/hello_world.rs
@@ -15,7 +15,6 @@ use esp32c3_hal::{
     Uart,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 use nb::block;
 
 #[entry]

--- a/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -20,7 +20,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/i2c_display.rs
+++ b/esp32c3-hal/examples/i2c_display.rs
@@ -29,7 +29,6 @@ use esp32c3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 use nb::block;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 

--- a/esp32c3-hal/examples/i2s_read.rs
+++ b/esp32c3-hal/examples/i2s_read.rs
@@ -27,7 +27,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/i2s_sound.rs
+++ b/esp32c3-hal/examples/i2s_sound.rs
@@ -42,7 +42,6 @@ use esp32c3_hal::{
     IO,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,

--- a/esp32c3-hal/examples/ledc.rs
+++ b/esp32c3-hal/examples/ledc.rs
@@ -22,7 +22,6 @@ use esp32c3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/pulse_control.rs
+++ b/esp32c3-hal/examples/pulse_control.rs
@@ -16,7 +16,6 @@ use esp32c3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/ram.rs
+++ b/esp32c3-hal/examples/ram.rs
@@ -17,7 +17,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 use nb::block;
 
 #[ram(rtc_fast)]

--- a/esp32c3-hal/examples/read_efuse.rs
+++ b/esp32c3-hal/examples/read_efuse.rs
@@ -14,7 +14,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/rtc_watchdog.rs
+++ b/esp32c3-hal/examples/rtc_watchdog.rs
@@ -14,11 +14,11 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
+    riscv,
     Rtc,
     Rwdt,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 
 static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32c3-hal/examples/serial_interrupts.rs
+++ b/esp32c3-hal/examples/serial_interrupts.rs
@@ -13,6 +13,7 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals, UART0},
     prelude::*,
+    riscv,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
@@ -20,7 +21,6 @@ use esp32c3_hal::{
     Uart,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 use nb::block;
 
 static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(None));

--- a/esp32c3-hal/examples/sha.rs
+++ b/esp32c3-hal/examples/sha.rs
@@ -14,7 +14,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 use nb::block;
 use sha2::{Digest, Sha256};
 

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -31,7 +31,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -29,7 +29,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -28,7 +28,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -30,7 +30,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -20,7 +20,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 static ALARM1: Mutex<RefCell<Option<Alarm<Target, 1>>>> = Mutex::new(RefCell::new(None));

--- a/esp32c3-hal/examples/timer_interrupt.rs
+++ b/esp32c3-hal/examples/timer_interrupt.rs
@@ -13,11 +13,11 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals, TIMG0, TIMG1},
     prelude::*,
+    riscv,
     timer::{Timer, Timer0, TimerGroup},
     Rtc,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 
 static TIMER0: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));

--- a/esp32c3-hal/examples/twai.rs
+++ b/esp32c3-hal/examples/twai.rs
@@ -21,7 +21,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 use nb::block;
 
 #[entry]

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -14,13 +14,13 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals, USB_DEVICE},
     prelude::*,
+    riscv,
     timer::TimerGroup,
     Cpu,
     Rtc,
     UsbSerialJtag,
 };
 use esp_backtrace as _;
-use esp_riscv_rt::{entry, riscv};
 use nb::block;
 
 static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag<USB_DEVICE>>>> =

--- a/esp32c3-hal/examples/watchdog.rs
+++ b/esp32c3-hal/examples/watchdog.rs
@@ -14,7 +14,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use esp_riscv_rt::entry;
 use nb::block;
 
 #[entry]

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -14,6 +14,7 @@ pub use esp_hal_common::{
     dma,
     dma::gdma,
     efuse,
+    entry,
     gpio,
     i2c,
     i2s,
@@ -23,11 +24,13 @@ pub use esp_hal_common::{
     peripherals,
     prelude,
     pulse_control,
+    riscv,
     sha,
     spi,
     system,
     systimer,
     timer,
+    trapframe,
     twai,
     uart,
     utils,
@@ -125,7 +128,7 @@ static ENTRY_POINT: unsafe fn() -> ! = start_hal;
 
 #[cfg(feature = "direct-boot")]
 #[doc(hidden)]
-#[esp_riscv_rt::pre_init]
+#[esp_hal_common::esp_riscv_rt::pre_init]
 unsafe fn init() {
     r0::init_data(&mut _srwtext, &mut _erwtext, &_irwtext);
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -31,15 +31,13 @@ embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "e
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.5.0",  features = ["esp32s2"], path = "../esp-hal-common" }
-xtensa-lx          = { version = "0.7.0",  features = ["esp32s2"] }
-xtensa-lx-rt       = { version = "0.14.0", features = ["esp32s2"], optional = true }
 xtensa-atomic-emulation-trap = { version = "0.3.0", features = ["esp32s2"] }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.4.0", features = ["esp32s2", "panic-handler", "print-uart"] }
+esp-backtrace     = { version = "0.4.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-println       = { version = "0.3.1", features = ["esp32s2"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
@@ -52,7 +50,7 @@ aes = "0.8.2"
 [features]
 default   = ["rt", "vectored"]
 eh1       = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
-rt        = ["xtensa-lx-rt/esp32s2"]
+rt        = []
 smartled  = ["esp-hal-common/smartled"]
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32s2-hal"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -30,14 +30,14 @@ embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
-esp-hal-common     = { version = "0.5.0",  features = ["esp32s2"], path = "../esp-hal-common" }
-xtensa-atomic-emulation-trap = { version = "0.3.0", features = ["esp32s2"] }
+esp-hal-common     = { version = "0.6.0",  features = ["esp32s2"], path = "../esp-hal-common" }
+xtensa-atomic-emulation-trap = { version = "0.4.0" }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.4.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
+esp-backtrace     = { version = "0.5.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-println       = { version = "0.3.1", features = ["esp32s2"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"

--- a/esp32s2-hal/examples/adc.rs
+++ b/esp32s2-hal/examples/adc.rs
@@ -17,8 +17,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -53,22 +51,5 @@ fn main() -> ! {
         let pin3_value: u16 = nb::block!(adc1.read(&mut pin3)).unwrap();
         println!("PIN3 ADC reading = {}", pin3_value);
         delay.delay_ms(1500u32);
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -23,8 +23,6 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -68,22 +66,5 @@ fn main() -> ! {
         }
 
         delay.delay_ms(250u32);
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/aes.rs
+++ b/esp32s2-hal/examples/aes.rs
@@ -10,12 +10,13 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
+    xtensa_lx,
     Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();

--- a/esp32s2-hal/examples/blinky.rs
+++ b/esp32s2-hal/examples/blinky.rs
@@ -15,8 +15,6 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -45,22 +43,5 @@ fn main() -> ! {
     loop {
         led.toggle().unwrap();
         delay.delay_ms(500u32);
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/blinky_erased_pins.rs
+++ b/esp32s2-hal/examples/blinky_erased_pins.rs
@@ -15,7 +15,6 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s2-hal/examples/clock_monitor.rs
+++ b/esp32s2-hal/examples/clock_monitor.rs
@@ -18,7 +18,6 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
 
@@ -67,21 +66,4 @@ fn RTC_CORE() {
 
         rtc.rwdt.clear_interrupt();
     });
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/dac.rs
+++ b/esp32s2-hal/examples/dac.rs
@@ -16,8 +16,6 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -54,22 +52,5 @@ fn main() -> ! {
         voltage_dac2 = voltage_dac2.wrapping_sub(1);
         dac2.write(voltage_dac2);
         delay.delay_ms(50u32);
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -39,7 +39,7 @@ async fn run2() {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
@@ -65,21 +65,4 @@ fn main() -> ! {
         spawner.spawn(run1()).ok();
         spawner.spawn(run2()).ok();
     });
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -57,7 +57,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -5,6 +5,7 @@
 
 #![no_std]
 #![no_main]
+#![feature(asm_experimental_arch)]
 
 use core::cell::RefCell;
 
@@ -17,12 +18,11 @@ use esp32s2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     timer::TimerGroup,
+    xtensa_lx,
     Delay,
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 static BUTTON: Mutex<RefCell<Option<Gpio0<Input<PullDown>>>>> = Mutex::new(RefCell::new(None));
 
@@ -77,21 +77,4 @@ fn GPIO() {
             .unwrap()
             .clear_interrupt()
     });
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -30,8 +30,6 @@ use smart_leds::{
     hsv::{hsv2rgb, Hsv},
     SmartLedsWrite,
 };
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -79,23 +77,6 @@ fn main() -> ! {
             led.write(brightness(gamma(data.iter().cloned()), 10))
                 .unwrap();
             delay.delay_ms(20u8);
-        }
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
         }
     }
 }

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -16,8 +16,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use nb::block;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -40,22 +38,5 @@ fn main() -> ! {
     loop {
         writeln!(serial0, "Hello world!").unwrap();
         block!(timer0.wait()).unwrap();
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32s2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -20,7 +20,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -32,7 +32,6 @@ use esp_backtrace as _;
 use nb::block;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -127,22 +126,5 @@ fn main() -> ! {
 
         // Wait 5 seconds
         block!(timer0.wait()).unwrap();
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/i2s_read.rs
+++ b/esp32s2-hal/examples/i2s_read.rs
@@ -26,7 +26,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s2-hal/examples/i2s_sound.rs
+++ b/esp32s2-hal/examples/i2s_sound.rs
@@ -42,7 +42,6 @@ use esp32s2_hal::{
     IO,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -24,7 +24,6 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use esp_println;
 use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -70,21 +69,4 @@ fn main() -> ! {
         .unwrap();
 
     loop {}
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/pcnt_encoder.rs
+++ b/esp32s2-hal/examples/pcnt_encoder.rs
@@ -28,7 +28,6 @@ use esp_hal::{
     IO,
 };
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 static UNIT0: Mutex<RefCell<Option<unit::Unit>>> = Mutex::new(RefCell::new(None));
 static VALUE: AtomicI32 = AtomicI32::new(0);

--- a/esp32s2-hal/examples/pulse_control.rs
+++ b/esp32s2-hal/examples/pulse_control.rs
@@ -16,8 +16,6 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -74,22 +72,5 @@ fn main() -> ! {
         rmt_channel0
             .send_pulse_sequence(RepeatMode::SingleShot, &seq)
             .unwrap();
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -18,8 +18,6 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[ram(rtc_fast)]
 static mut SOME_INITED_DATA: [u8; 2] = [0xaa, 0xbb];
@@ -96,21 +94,4 @@ fn function_in_ram() {
 #[ram(rtc_fast)]
 fn function_in_rtc_ram() -> u32 {
     42
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/read_efuse.rs
+++ b/esp32s2-hal/examples/read_efuse.rs
@@ -14,8 +14,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -34,21 +32,4 @@ fn main() -> ! {
     println!("Flash Encryption {:?}", Efuse::get_flash_encryption());
 
     loop {}
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/rtc_watchdog.rs
+++ b/esp32s2-hal/examples/rtc_watchdog.rs
@@ -18,8 +18,6 @@ use esp32s2_hal::{
     Rwdt,
 };
 use esp_backtrace as _;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 
@@ -60,21 +58,4 @@ fn RTC_CORE() {
         rwdt.start(5000u64.millis());
         rwdt.unlisten();
     });
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/serial_interrupts.rs
+++ b/esp32s2-hal/examples/serial_interrupts.rs
@@ -20,8 +20,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use nb::block;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(None));
 
@@ -96,21 +94,4 @@ fn UART0() {
         serial.reset_at_cmd_interrupt();
         serial.reset_rx_fifo_full_interrupt();
     });
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/sha.rs
+++ b/esp32s2-hal/examples/sha.rs
@@ -10,13 +10,13 @@ use esp32s2_hal::{
     prelude::*,
     sha::{Sha, ShaMode},
     timer::TimerGroup,
+    xtensa_lx,
     Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
 use sha2::{Digest, Sha512};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -24,15 +24,15 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
+    rt,
     spi::{Spi, SpiBusController, SpiMode},
     timer::TimerGroup,
+    trapframe,
     Delay,
     Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -146,22 +146,5 @@ fn main() -> ! {
             .expect("Huge transfer failed");
         println!(" SUCCESS");
         delay.delay_ms(250u32);
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -29,8 +29,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -118,22 +116,5 @@ fn main() -> ! {
         }
         println!(" SUCCESS");
         delay.delay_ms(250u32);
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -28,8 +28,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -72,22 +70,5 @@ fn main() -> ! {
         println!("{:x?}", data);
 
         delay.delay_ms(250u32);
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -30,8 +30,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -117,21 +115,4 @@ fn buffer1() -> &'static mut [u8; 32000] {
 fn buffer2() -> &'static mut [u8; 32000] {
     static mut BUFFER: [u8; 32000] = [0u8; 32000];
     unsafe { &mut BUFFER }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -20,8 +20,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 static ALARM1: Mutex<RefCell<Option<Alarm<Target, 1>>>> = Mutex::new(RefCell::new(None));
@@ -122,21 +120,4 @@ fn SYSTIMER_TARGET2() {
             .unwrap()
             .clear_interrupt()
     });
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -19,8 +19,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 static TIMER00: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));
 static TIMER01: Mutex<RefCell<Option<Timer<Timer1<TIMG0>>>>> = Mutex::new(RefCell::new(None));
@@ -128,21 +126,4 @@ fn TG1_T1_LEVEL() {
             println!("Interrupt Level 3 - Timer1");
         }
     });
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
-    }
 }

--- a/esp32s2-hal/examples/usb_serial.rs
+++ b/esp32s2-hal/examples/usb_serial.rs
@@ -16,7 +16,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use usb_device::prelude::{UsbDeviceBuilder, UsbVidPid};
-use xtensa_lx_rt::entry;
 
 static mut EP_MEMORY: [u32; 1024] = [0; 1024];
 

--- a/esp32s2-hal/examples/watchdog.rs
+++ b/esp32s2-hal/examples/watchdog.rs
@@ -15,8 +15,6 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_atomic_emulation_trap as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -38,22 +36,5 @@ fn main() -> ! {
         wdt.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
-    }
-}
-
-#[xtensa_lx_rt::exception]
-fn exception(
-    cause: xtensa_lx_rt::exception::ExceptionCause,
-    frame: xtensa_lx_rt::exception::Context,
-) {
-    use esp_println::*;
-
-    println!("\n\nException occured {:?} {:x?}", cause, frame);
-
-    let backtrace = esp_backtrace::arch::backtrace();
-    for b in backtrace.iter() {
-        if let Some(addr) = b {
-            println!("0x{:x}", addr)
-        }
     }
 }

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -4,6 +4,7 @@
 pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
+use esp_hal_common::xtensa_lx_rt::exception::ExceptionCause;
 #[doc(inline)]
 pub use esp_hal_common::{
     aes,
@@ -103,4 +104,64 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 #[rustfmt::skip]
 pub extern "Rust" fn __init_data() -> bool {
     false
+}
+
+/// Atomic Emulation is always enabled on ESP32-S2
+#[doc(hidden)]
+#[no_mangle]
+#[export_name = "__exception"] // this overrides the exception handler in xtensa_lx_rt
+#[link_section = ".rwtext"]
+unsafe fn exception(cause: ExceptionCause, save_frame: &mut trapframe::TrapFrame) {
+    match cause {
+        ExceptionCause::Illegal => {
+            let mut regs = [
+                save_frame.A0,
+                save_frame.A1,
+                save_frame.A2,
+                save_frame.A3,
+                save_frame.A4,
+                save_frame.A5,
+                save_frame.A6,
+                save_frame.A7,
+                save_frame.A8,
+                save_frame.A9,
+                save_frame.A10,
+                save_frame.A11,
+                save_frame.A12,
+                save_frame.A13,
+                save_frame.A14,
+                save_frame.A15,
+            ];
+
+            if xtensa_atomic_emulation_trap::atomic_emulation(save_frame.PC, &mut regs) {
+                save_frame.PC += 3; // 24bit instruction
+
+                save_frame.A0 = regs[0];
+                save_frame.A1 = regs[1];
+                save_frame.A2 = regs[2];
+                save_frame.A3 = regs[3];
+                save_frame.A4 = regs[4];
+                save_frame.A5 = regs[5];
+                save_frame.A6 = regs[6];
+                save_frame.A7 = regs[7];
+                save_frame.A8 = regs[8];
+                save_frame.A9 = regs[9];
+                save_frame.A10 = regs[10];
+                save_frame.A11 = regs[11];
+                save_frame.A12 = regs[12];
+                save_frame.A13 = regs[13];
+                save_frame.A14 = regs[14];
+                save_frame.A15 = regs[15];
+
+                return;
+            }
+        }
+        _ => (),
+    }
+
+    extern "C" {
+        fn __user_exception(cause: ExceptionCause, save_frame: &mut trapframe::TrapFrame);
+    }
+
+    __user_exception(cause, save_frame);
 }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -34,8 +34,6 @@ embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.5.0",  features = ["esp32s3"], path = "../esp-hal-common" }
 r0                 = { version = "1.0.0",  optional = true }
-xtensa-lx          = { version = "0.7.0",  features = ["esp32s3"] }
-xtensa-lx-rt       = { version = "0.14.0", features = ["esp32s3"], optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
@@ -55,14 +53,14 @@ aes = "0.8.2"
 default              = ["rt", "vectored"]
 direct-boot          = ["r0"]
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
-rt                   = ["xtensa-lx-rt/esp32s3"]
+rt                   = []
 smartled             = ["esp-hal-common/smartled"]
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
 async                = ["esp-hal-common/async", "embedded-hal-async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0    = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
+embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32s3-hal"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -32,14 +32,14 @@ embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "e
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.5.0",  features = ["esp32s3"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.6.0",  features = ["esp32s3"], path = "../esp-hal-common" }
 r0                 = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.4.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.5.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.3.1", features = ["esp32s3"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"

--- a/esp32s3-hal/examples/adc.rs
+++ b/esp32s3-hal/examples/adc.rs
@@ -17,7 +17,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/advanced_serial.rs
+++ b/esp32s3-hal/examples/advanced_serial.rs
@@ -23,7 +23,6 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/aes.rs
+++ b/esp32s3-hal/examples/aes.rs
@@ -10,12 +10,13 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
+    xtensa_lx,
     Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();

--- a/esp32s3-hal/examples/blinky.rs
+++ b/esp32s3-hal/examples/blinky.rs
@@ -15,7 +15,6 @@ use esp32s3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/blinky_erased_pins.rs
+++ b/esp32s3-hal/examples/blinky_erased_pins.rs
@@ -15,7 +15,6 @@ use esp32s3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/clock_monitor.rs
+++ b/esp32s3-hal/examples/clock_monitor.rs
@@ -17,7 +17,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -38,7 +38,7 @@ async fn run2() {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -57,7 +57,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
 
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
-#[xtensa_lx_rt::entry]
+#[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -17,11 +17,11 @@ use esp32s3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     timer::TimerGroup,
+    xtensa_lx,
     Delay,
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 static BUTTON: Mutex<RefCell<Option<Gpio0<Input<PullDown>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32s3-hal/examples/hello_rgb.rs
+++ b/esp32s3-hal/examples/hello_rgb.rs
@@ -31,7 +31,6 @@ use smart_leds::{
     hsv::{hsv2rgb, Hsv},
     SmartLedsWrite,
 };
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/hello_world.rs
+++ b/esp32s3-hal/examples/hello_world.rs
@@ -16,7 +16,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32s3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -20,7 +20,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/i2c_display.rs
+++ b/esp32s3-hal/examples/i2c_display.rs
@@ -31,7 +31,6 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use nb::block;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/i2s_read.rs
+++ b/esp32s3-hal/examples/i2s_read.rs
@@ -27,7 +27,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/i2s_sound.rs
+++ b/esp32s3-hal/examples/i2s_sound.rs
@@ -42,7 +42,6 @@ use esp32s3_hal::{
     IO,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,

--- a/esp32s3-hal/examples/ledc.rs
+++ b/esp32s3-hal/examples/ledc.rs
@@ -22,7 +22,6 @@ use esp32s3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/mcpwm.rs
+++ b/esp32s3-hal/examples/mcpwm.rs
@@ -16,7 +16,6 @@ use esp32s3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/multicore.rs
+++ b/esp32s3-hal/examples/multicore.rs
@@ -19,7 +19,6 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/pcnt_encoder.rs
+++ b/esp32s3-hal/examples/pcnt_encoder.rs
@@ -28,7 +28,6 @@ use esp_hal::{
     IO,
 };
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 static UNIT0: Mutex<RefCell<Option<unit::Unit>>> = Mutex::new(RefCell::new(None));
 static VALUE: AtomicI32 = AtomicI32::new(0);

--- a/esp32s3-hal/examples/pulse_control.rs
+++ b/esp32s3-hal/examples/pulse_control.rs
@@ -16,7 +16,6 @@ use esp32s3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/ram.rs
+++ b/esp32s3-hal/examples/ram.rs
@@ -18,7 +18,6 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[ram(rtc_fast)]
 static mut SOME_INITED_DATA: [u8; 2] = [0xaa, 0xbb];

--- a/esp32s3-hal/examples/read_efuse.rs
+++ b/esp32s3-hal/examples/read_efuse.rs
@@ -14,7 +14,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/rtc_watchdog.rs
+++ b/esp32s3-hal/examples/rtc_watchdog.rs
@@ -18,7 +18,6 @@ use esp32s3_hal::{
     Rwdt,
 };
 use esp_backtrace as _;
-use xtensa_lx_rt::entry;
 
 static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32s3-hal/examples/serial_interrupts.rs
+++ b/esp32s3-hal/examples/serial_interrupts.rs
@@ -20,7 +20,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32s3-hal/examples/sha.rs
+++ b/esp32s3-hal/examples/sha.rs
@@ -10,13 +10,13 @@ use esp32s3_hal::{
     prelude::*,
     sha::{Sha, ShaMode},
     timer::TimerGroup,
+    xtensa_lx,
     Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
 use sha2::{Digest, Sha512};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -31,7 +31,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -29,7 +29,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -28,7 +28,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -30,7 +30,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -20,7 +20,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 static ALARM1: Mutex<RefCell<Option<Alarm<Target, 1>>>> = Mutex::new(RefCell::new(None));

--- a/esp32s3-hal/examples/timer_interrupt.rs
+++ b/esp32s3-hal/examples/timer_interrupt.rs
@@ -19,7 +19,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_lx_rt::entry;
 
 static TIMER00: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));
 static TIMER01: Mutex<RefCell<Option<Timer<Timer1<TIMG0>>>>> = Mutex::new(RefCell::new(None));

--- a/esp32s3-hal/examples/twai.rs
+++ b/esp32s3-hal/examples/twai.rs
@@ -37,7 +37,6 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/usb_serial.rs
+++ b/esp32s3-hal/examples/usb_serial.rs
@@ -16,7 +16,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use usb_device::prelude::{UsbDeviceBuilder, UsbVidPid};
-use xtensa_lx_rt::entry;
 
 static mut EP_MEMORY: [u32; 1024] = [0; 1024];
 

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -21,7 +21,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag<USB_DEVICE>>>> =
     Mutex::new(RefCell::new(None));

--- a/esp32s3-hal/examples/watchdog.rs
+++ b/esp32s3-hal/examples/watchdog.rs
@@ -15,7 +15,6 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -13,6 +13,7 @@ pub use esp_hal_common::{
     cpu_control::CpuControl,
     dma::{self, gdma},
     efuse,
+    entry,
     gpio,
     i2c,
     i2s,
@@ -30,9 +31,11 @@ pub use esp_hal_common::{
     system,
     systimer,
     timer,
+    trapframe,
     twai,
     uart,
     utils,
+    xtensa_lx,
     Cpu,
     Delay,
     PulseControl,
@@ -129,8 +132,8 @@ pub unsafe fn startup_direct_boot() -> ! {
     );
 
     // Initialize RTC RAM
-    xtensa_lx_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
-    xtensa_lx_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
+    esp_hal_common::xtensa_lx_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
+    esp_hal_common::xtensa_lx_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
 
     // first of all copy rwtext
     extern "C" {
@@ -165,7 +168,7 @@ pub unsafe fn startup_direct_boot() -> ! {
         .sysclk_conf
         .modify(|_, w| w.soc_clk_sel().bits(1));
 
-    xtensa_lx_rt::Reset();
+    esp_hal_common::xtensa_lx_rt::Reset();
 }
 
 #[cfg(feature = "rt")]
@@ -222,17 +225,17 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
     }
 
     // set stack pointer to end of memory: no need to retain stack up to this point
-    xtensa_lx::set_stack_pointer(&mut _stack_end_cpu0);
+    esp_hal_common::xtensa_lx::set_stack_pointer(&mut _stack_end_cpu0);
 
     // copying data from flash to various data segments is done by the bootloader
     // initialization to zero needs to be done by the application
 
     // Initialize RTC RAM
-    xtensa_lx_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
-    xtensa_lx_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
+    esp_hal_common::xtensa_lx_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
+    esp_hal_common::xtensa_lx_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
 
     // continue with default reset handler
-    xtensa_lx_rt::Reset();
+    esp_hal_common::xtensa_lx_rt::Reset();
 }
 
 /// The ESP32 has a first stage bootloader that handles loading program data


### PR DESCRIPTION
Fixes #382 

- remove dependencies to `rt` crates and `riscv` / `xtensa-lx` from the chip specific HALs, re-export from esp-hal-common
- re-export `riscv` / `xtensa-lx` in the chip specific HALs
- `entry` is re-exported and added to the prelude
- atomic emulation is always included by the HAL for ESP32-S2 (like it's already the case for ESP32-C2 / ESP32-C3)

This PR looks huge but most of the changes are in the examples.

Nice side-effect: fixes #197 

This has some potential for bikeshedding about some names (e.g. `trapframe::TrapFrame`) - I tried to choose the names carefully but don't have strong opinions about them

_BEFORE_ merging this
- [x] publish a new `xtensa-lx-rt` version, probably also `xtensa-lx`
- [x] publish the PACs (with removed `rt` dependencies)
- [x] optionally wait for a new published `esp-backtrace`

This also bumps the versions of all contained crates
