### PR TITLE
Make sure to re-export xtensa-lx-rt

### DIFF
--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -33,6 +33,7 @@ pub use esp_hal_common::{
     uart,
     utils,
     xtensa_lx,
+    xtensa_lx_rt,
     Cpu,
     Delay,
     PulseControl,

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -35,6 +35,7 @@ pub use esp_hal_common::{
     uart,
     utils,
     xtensa_lx,
+    xtensa_lx_rt,
     Cpu,
     Delay,
     PulseControl,

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -36,6 +36,7 @@ pub use esp_hal_common::{
     uart,
     utils,
     xtensa_lx,
+    xtensa_lx_rt,
     Cpu,
     Delay,
     PulseControl,


### PR DESCRIPTION
HAL users unfortunately might need things like `xtensa_lx_rt::interrupt::CpuInterruptLevel`, so re-export `xtensa-lx-rt`
