### PR TITLE
Add support for 26Mhz xtal in ESP32-HAL

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -66,6 +66,9 @@ esp32c3 = ["esp32c3/rt", "riscv", "procmacros/esp32c3"]
 esp32s2 = ["esp32s2/rt", "xtensa", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2",             "esp-synopsys-usb-otg", "usb-device", "procmacros/esp32s2"]
 esp32s3 = ["esp32s3/rt", "xtensa", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "lock_api", "esp-synopsys-usb-otg", "usb-device", "procmacros/esp32s3"]
 
+esp32_40mhz = []
+esp32_26mhz = []
+
 esp32c2_40mhz = []
 esp32c2_26mhz = []
 

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -12,6 +12,9 @@ fn main() {
         n => panic!("Exactly 1 chip must be enabled via its Cargo feature, {n} provided"),
     }
 
+    if cfg!(feature = "esp32") && cfg!(feature = "esp32_40mhz") && cfg!(feature = "esp32_26mhz") {
+        panic!("Only one xtal speed feature can be selected");
+    }
     if cfg!(feature = "esp32c2")
         && cfg!(feature = "esp32c2_40mhz")
         && cfg!(feature = "esp32c2_26mhz")

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32.rs
@@ -9,10 +9,16 @@ use crate::{
 pub(crate) fn init() {}
 
 pub(crate) fn configure_clock() {
+    #[cfg(feature = "esp32_40mhz")]
     assert!(matches!(
         RtcClock::get_xtal_freq(),
         XtalClock::RtcXtalFreq40M
     ));
+    #[cfg(feature = "esp32_26mhz")]
+    assert!(
+        matches!(RtcClock::get_xtal_freq(), XtalClock::RtcXtalFreq26M),
+        "Did you flash the right bootloader configured for 26Mhz xtal?"
+    );
 
     RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -45,7 +45,7 @@ static_cell       = "1.0.0"
 aes = "0.8.2"
 
 [features]
-default           = ["rt", "vectored"]
+default           = ["rt", "vectored", "xtal40mhz"]
 bluetooth         = []
 eh1               = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
 rt                = []
@@ -55,6 +55,8 @@ vectored          = ["esp-hal-common/vectored"]
 async             = ["esp-hal-common/async", "embedded-hal-async"]
 embassy           = ["esp-hal-common/embassy"]
 embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
+xtal40mhz         = ["esp-hal-common/esp32_40mhz"]
+xtal26mhz         = ["esp-hal-common/esp32_26mhz"]
 
 [[example]]
 name              = "hello_rgb"

--- a/esp32-hal/build.rs
+++ b/esp32-hal/build.rs
@@ -1,6 +1,7 @@
 use std::{env, fs::File, io::Write, path::PathBuf};
 
 fn main() {
+    check_features();
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out.join("memory.x"))
@@ -67,4 +68,10 @@ fn generate_memory_extras() -> Vec<u8> {
     )
     .as_bytes()
     .to_vec()
+}
+
+fn check_features() {
+    if cfg!(feature = "esp32_40mhz") && cfg!(feature = "esp32_26mhz") {
+        panic!("Only one xtal speed feature can be selected");
+    }
 }


### PR DESCRIPTION
Referencing Issue #329, these changes add support for 26Mhz crystals to be used with the ESP32.

These changes were made in reference to the changes in PR #301 where support was added for 26Mhz crystals for the ESP32c2 chip. As such the changes here were almost identical, I have tried to keep the same convention for the features to select between crystal varieties as in #301.

I have tested these changes with a Sparkfun ESP32 Thing (the same board as referenced in #329) using the example projects in [esp32-hal](https://github.com/esp-rs/esp-hal/tree/main/esp32-hal/examples) and while I am not able to test the projects with external devices such as those using i2c (as I do not have any sensors/devices to connect) all examples using the standalone esp32 seem to be working correctly. I also unfortunately do not own a 40Mhz esp32 to test these changes on (to ensure it still works), though the examples are being built without error.

Sorry if this PR doesn't follow convention, as this is my first. I'd love any feedback on things I can improve for next time!