### PR TITLE
Fix direct boot linker script for ESP32-C2/C3

### DIFF
--- a/esp32c2-hal/ld/db-riscv-link.x
+++ b/esp32c2-hal/ld/db-riscv-link.x
@@ -105,8 +105,8 @@ SECTIONS
     /* This section is required to skip .rwtext area because REGION_RWTEXT
      * and REGION_BSS reflect the same address space on different buses.
      */
-    . = ORIGIN(REGION_BSS) + _rwtext_size;
-  } > REGION_BSS
+    . = ORIGIN(REGION_DATA) + _rwtext_size + 8 + SIZEOF(.data);
+  } > REGION_DATA
 
   .bss (NOLOAD) :
   {

--- a/esp32c3-hal/ld/db-riscv-link.x
+++ b/esp32c3-hal/ld/db-riscv-link.x
@@ -105,8 +105,8 @@ SECTIONS
     /* This section is required to skip .rwtext area because REGION_RWTEXT
      * and REGION_BSS reflect the same address space on different buses.
      */
-    . = ORIGIN(REGION_BSS) + _rwtext_size;
-  } > REGION_BSS
+    . = ORIGIN(REGION_DATA) + _rwtext_size + 8 + SIZEOF(.data);
+  } > REGION_DATA
 
   .bss (NOLOAD) :
   {


### PR DESCRIPTION
Fixes #386 

This makes sure RWTEXT isn't overwritten by BSS
