### PR TITLE
Fix the SPI alignment fix

### DIFF
--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -1546,7 +1546,12 @@ pub trait Instance {
 
             let fifo_ptr = reg_block.w0.as_ptr();
             for i in (0..chunk.len()).step_by(4) {
-                let word = match (chunk.len() - i) % 4 {
+                let state = if chunk.len() - i < 4 {
+                    chunk.len() % 4
+                } else {
+                    0
+                };
+                let word = match state {
                     0 => {
                         (chunk[i] as u32)
                             | (chunk[i + 1] as u32) << 8


### PR DESCRIPTION
Hey I was working with SPI today while also tracking https://github.com/esp-rs/esp-hal/pull/395 and decided to test it but I think the implementation is not quite as intended. step_by always gives a multiple of your step-size so if your chunksize was 9 it will give 0,4,8, however in the match statement you'd match 1,1,1, instead of 0,0,1. This fixes that (although I think it can be optimized). 

To see the difference in action see: https://onlinegdb.com/23bFTBT6d