### PR TITLE
ESP32-C2: ets_update_cpu_frequency_rom fix

### DIFF
--- a/esp32c2-hal/ld/rom-functions.x
+++ b/esp32c2-hal/ld/rom-functions.x
@@ -1,5 +1,5 @@
 PROVIDE(ets_delay_us = 0x40000044);
-PROVIDE(ets_update_cpu_frequency_rom = 0x40008550);
+PROVIDE(ets_update_cpu_frequency_rom = 0x40000774);
 PROVIDE(rom_i2c_writeReg = 0x400022f4);
 PROVIDE(rom_i2c_writeReg_Mask = 0x400022fc);
 PROVIDE(rtc_get_reset_reason = 0x40000018);


### PR DESCRIPTION
The address of `ets_update_cpu_frequency_rom` was wrong
