### PR TITLE
Add examples for the `RNG` peripheral for all supported devices

### DIFF
--- a/esp32-hal/examples/rng.rs
+++ b/esp32-hal/examples/rng.rs
@@ -1,0 +1,43 @@
+//! Demonstrates the use of the hardware Random Number Generator (RNG)
+
+#![no_std]
+#![no_main]
+
+use esp32_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection:
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    // Instantiate the Random Number Generator peripheral:
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Generate a random word (u32):
+    println!("Random u32:   {}", rng.random());
+
+    // Fill a buffer with random bytes:
+    let mut buf = [0u8; 16];
+    rng.read(&mut buf).unwrap();
+    println!("Random bytes: {:?}", buf);
+
+    loop {}
+}

--- a/esp32c2-hal/examples/rng.rs
+++ b/esp32c2-hal/examples/rng.rs
@@ -1,0 +1,44 @@
+//! Demonstrates the use of the hardware Random Number Generator (RNG)
+
+#![no_std]
+#![no_main]
+
+use esp32c2_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+
+    // Disable watchdog timers:
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    // Instantiate the Random Number Generator peripheral:
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Generate a random word (u32):
+    println!("Random u32:   {}", rng.random());
+
+    // Fill a buffer with random bytes:
+    let mut buf = [0u8; 16];
+    rng.read(&mut buf).unwrap();
+    println!("Random bytes: {:?}", buf);
+
+    loop {}
+}

--- a/esp32c3-hal/examples/rng.rs
+++ b/esp32c3-hal/examples/rng.rs
@@ -1,0 +1,47 @@
+//! Demonstrates the use of the hardware Random Number Generator (RNG)
+
+#![no_std]
+#![no_main]
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers:
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    // Instantiate the Random Number Generator peripheral:
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Generate a random word (u32):
+    println!("Random u32:   {}", rng.random());
+
+    // Fill a buffer with random bytes:
+    let mut buf = [0u8; 16];
+    rng.read(&mut buf).unwrap();
+    println!("Random bytes: {:?}", buf);
+
+    loop {}
+}

--- a/esp32c6-hal/examples/rng.rs
+++ b/esp32c6-hal/examples/rng.rs
@@ -1,0 +1,47 @@
+//! Demonstrates the use of the hardware Random Number Generator (RNG)
+
+#![no_std]
+#![no_main]
+
+use esp32c6_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers:
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    // Instantiate the Random Number Generator peripheral:
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Generate a random word (u32):
+    println!("Random u32:   {}", rng.random());
+
+    // Fill a buffer with random bytes:
+    let mut buf = [0u8; 16];
+    rng.read(&mut buf).unwrap();
+    println!("Random bytes: {:?}", buf);
+
+    loop {}
+}

--- a/esp32s2-hal/examples/rng.rs
+++ b/esp32s2-hal/examples/rng.rs
@@ -1,0 +1,43 @@
+//! Demonstrates the use of the hardware Random Number Generator (RNG)
+
+#![no_std]
+#![no_main]
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection:
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    // Instantiate the Random Number Generator peripheral:
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Generate a random word (u32):
+    println!("Random u32:   {}", rng.random());
+
+    // Fill a buffer with random bytes:
+    let mut buf = [0u8; 16];
+    rng.read(&mut buf).unwrap();
+    println!("Random bytes: {:?}", buf);
+
+    loop {}
+}

--- a/esp32s3-hal/examples/rng.rs
+++ b/esp32s3-hal/examples/rng.rs
@@ -1,0 +1,43 @@
+//! Demonstrates the use of the hardware Random Number Generator (RNG)
+
+#![no_std]
+#![no_main]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection:
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    // Instantiate the Random Number Generator peripheral:
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Generate a random word (u32):
+    println!("Random u32:   {}", rng.random());
+
+    // Fill a buffer with random bytes:
+    let mut buf = [0u8; 16];
+    rng.read(&mut buf).unwrap();
+    println!("Random bytes: {:?}", buf);
+
+    loop {}
+}


### PR DESCRIPTION
These were never added for whatever reason (that's probably my bad), so here they are. Pretty straightforward but gives us CI coverage at least.