### PR TITLE
[ESP32-C3] Restore MCUboot build after moving to `esp-riscv-rt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,8 @@ jobs:
         run: cd esp32c3-hal/ && cargo build --examples
       - name: build esp32c3-hal (direct-boot)
         run: cd esp32c3-hal/ && cargo build --examples --features=direct-boot
-      # FIXME: Building using the mcu-boot format currently results in an error.
-      # - name: build esp32c3-hal (mcu-boot)
-      #   run: cd esp32c3-hal/ && cargo build --examples --features=mcu-boot
+      - name: build esp32c3-hal (mcu-boot)
+        run: cd esp32c3-hal/ && cargo build --examples --features=mcu-boot
       # Subsequent steps can just check the examples instead, as we're already
       # confident that they link.
       - name: check esp32c3-hal (common features)

--- a/esp32c3-hal/ld/mb-riscv-link.x
+++ b/esp32c3-hal/ld/mb-riscv-link.x
@@ -46,12 +46,11 @@ SECTIONS
   .rodata :
   {
     _srodata = .;
+    *(.srodata .srodata.*);
     *(EXCLUDE_FILE (*libriscv-*.rlib:riscv.*) .rodata);
     *(EXCLUDE_FILE (*libriscv-*.rlib:riscv.*) .rodata.*);
-    *(EXCLUDE_FILE (*libriscv_rt-*.rlib:riscv-rt.*) .rodata);
-    *(EXCLUDE_FILE (*libriscv_rt-*.rlib:riscv-rt.*) .rodata.*);
-    *(.srodata .srodata.*);
-    *(.rodata .rodata.*);
+    *(EXCLUDE_FILE (*libesp_riscv_rt-*.rlib:esp-riscv-rt.*) .rodata);
+    *(EXCLUDE_FILE (*libesp_riscv_rt-*.rlib:esp-riscv-rt.*) .rodata.*);
 
     /* 4-byte align the end (VMA) of this section.
        This is required by LLD to ensure the LMA of the following .data
@@ -67,12 +66,13 @@ SECTIONS
     /* point of the program. */
     KEEP(*(.init));
     KEEP(*(.init.rust));
+    KEEP(*(.text.abort));
     . = ALIGN(4);
     KEEP(*(.trap));
     KEEP(*(.trap.rust));
 
     *libriscv-*.rlib:riscv.*(.literal .text .literal.* .text.*);
-    *libriscv_rt-*.rlib:riscv-rt.*(.literal .text .literal.* .text.*);
+    *libesp_riscv_rt-*.rlib:esp-riscv-rt.*(.literal .text .literal.* .text.*);
     *(.rwtext);
     . = ALIGN(4);
     _erwtext = .;
@@ -129,7 +129,7 @@ SECTIONS
     *(.sdata .sdata.* .sdata2 .sdata2.*);
     *(.data .data.*);
     *libriscv-*.rlib:riscv.*(.rodata .rodata.*);
-    *libriscv_rt-*.rlib:riscv-rt.*(.rodata .rodata.*);
+    *libesp_riscv_rt-*.rlib:esp-riscv-rt.*(.rodata .rodata.*);
     . = ALIGN(4);
     _edata = .;
   } > REGION_DATA AT>ROM
@@ -188,9 +188,8 @@ SECTIONS
     _stext = .;
     *(EXCLUDE_FILE (*libriscv-*.rlib:riscv.*) .text)
     *(EXCLUDE_FILE (*libriscv-*.rlib:riscv.*) .text.*)
-    *(EXCLUDE_FILE (*libriscv_rt-*.rlib:riscv-rt.*) .text)
-    *(EXCLUDE_FILE (*libriscv_rt-*.rlib:riscv-rt.*) .text.*)
-    *(.text .text.*);
+    *(EXCLUDE_FILE (*libesp_riscv_rt-*.rlib:esp-riscv-rt.*) .text)
+    *(EXCLUDE_FILE (*libesp_riscv_rt-*.rlib:esp-riscv-rt.*) .text.*)
     _etext = .;
   } > REGION_TEXT AT>ROM
 

--- a/esp32c3-hal/ld/mb-riscv-link.x
+++ b/esp32c3-hal/ld/mb-riscv-link.x
@@ -104,6 +104,19 @@ SECTIONS
     __euninit = .;
   } > REGION_BSS
 
+  .data :
+  {
+    _sdata = .;
+    /* Must be called __global_pointer$ for linker relaxations to work. */
+    PROVIDE(__global_pointer$ = . + 0x800);
+    *(.sdata .sdata.* .sdata2 .sdata2.*);
+    *(.data .data.*);
+    *libriscv-*.rlib:riscv.*(.rodata .rodata.*);
+    *libesp_riscv_rt-*.rlib:esp-riscv-rt.*(.rodata .rodata.*);
+    . = ALIGN(4);
+    _edata = .;
+  } > REGION_DATA AT>ROM
+
   /* fictitious region that represents the memory available for the heap */
   .heap (NOLOAD) :
   {
@@ -120,19 +133,6 @@ SECTIONS
     . = ABSOLUTE(_stack_start);
     _sstack = .;
   } > REGION_STACK
-
-  .data :
-  {
-    _sdata = .;
-    /* Must be called __global_pointer$ for linker relaxations to work. */
-    PROVIDE(__global_pointer$ = . + 0x800);
-    *(.sdata .sdata.* .sdata2 .sdata2.*);
-    *(.data .data.*);
-    *libriscv-*.rlib:riscv.*(.rodata .rodata.*);
-    *libesp_riscv_rt-*.rlib:esp-riscv-rt.*(.rodata .rodata.*);
-    . = ALIGN(4);
-    _edata = .;
-  } > REGION_DATA AT>ROM
 
   .rtc_fast.text :
   {

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -54,6 +54,9 @@ pub mod analog {
 extern "C" {
     cfg_if::cfg_if! {
         if #[cfg(feature = "mcu-boot")] {
+            // Required for retrieving the entry point address
+            fn _start();
+
             // Functions from internal ROM
             fn cache_suspend_icache() -> u32;
             fn cache_resume_icache(val: u32);
@@ -124,7 +127,7 @@ extern "C" {
 #[no_mangle]
 #[used]
 // Entry point address for the MCUboot image header
-static ENTRY_POINT: unsafe fn() -> ! = start_hal;
+static ENTRY_POINT: unsafe extern "C" fn() = _start;
 
 #[cfg(feature = "direct-boot")]
 #[doc(hidden)]

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -198,8 +198,8 @@ unsafe fn configure_mmu() {
         0,
     );
 
-    let peripherals = peripherals::Peripherals::steal();
-    peripherals.EXTMEM.icache_ctrl1.modify(|_, w| {
+    let extmem = unsafe { &*peripherals::EXTMEM::ptr() };
+    extmem.icache_ctrl1.modify(|_, w| {
         w.icache_shut_ibus()
             .clear_bit()
             .icache_shut_dbus()


### PR DESCRIPTION
This PR intends to fix the build for ESP32-C3 with `feature = mcu-boot`, which stopped working after #365.

Furthermore, the CI now builds the examples from `esp32c3-hal` with `--features=mcu-boot`.

## NOTE

~~Keeping the PR in draft state since it depends on https://github.com/esp-rs/esp-riscv-rt/pull/4.~~