### PR TITLE
Radio Peripheral impls

### DIFF
--- a/esp-hal-common/src/analog/mod.rs
+++ b/esp-hal-common/src/analog/mod.rs
@@ -43,15 +43,6 @@ impl crate::peripheral::Peripheral for ADC1 {
     }
 }
 
-impl crate::peripheral::Peripheral for &mut ADC1 {
-    type P = ADC1;
-    #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
-        ADC1 { _private: () }
-    }
-}
-
-impl crate::peripheral::sealed::Sealed for &mut ADC1 {}
 impl crate::peripheral::sealed::Sealed for ADC1 {}
 
 impl crate::peripheral::Peripheral for ADC2 {
@@ -62,15 +53,6 @@ impl crate::peripheral::Peripheral for ADC2 {
     }
 }
 
-impl crate::peripheral::Peripheral for &mut ADC2 {
-    type P = ADC2;
-    #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
-        ADC2 { _private: () }
-    }
-}
-
-impl crate::peripheral::sealed::Sealed for &mut ADC2 {}
 impl crate::peripheral::sealed::Sealed for ADC2 {}
 
 impl crate::peripheral::Peripheral for DAC1 {
@@ -81,15 +63,6 @@ impl crate::peripheral::Peripheral for DAC1 {
     }
 }
 
-impl crate::peripheral::Peripheral for &mut DAC1 {
-    type P = DAC1;
-    #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
-        DAC1 { _private: () }
-    }
-}
-
-impl crate::peripheral::sealed::Sealed for &mut DAC1 {}
 impl crate::peripheral::sealed::Sealed for DAC1 {}
 
 impl crate::peripheral::Peripheral for DAC2 {
@@ -101,16 +74,6 @@ impl crate::peripheral::Peripheral for DAC2 {
     }
 }
 
-impl crate::peripheral::Peripheral for &mut DAC2 {
-    type P = DAC2;
-
-    #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
-        DAC2 { _private: () }
-    }
-}
-
-impl crate::peripheral::sealed::Sealed for &mut DAC2 {}
 impl crate::peripheral::sealed::Sealed for DAC2 {}
 
 cfg_if::cfg_if! {

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1000,33 +1000,8 @@ where
     }
 }
 
-impl<MODE, RA, IRA, PINTYPE, SIG, const GPIONUM: u8> crate::peripheral::Peripheral
-    for &mut GpioPin<MODE, RA, IRA, PINTYPE, SIG, GPIONUM>
-where
-    RA: BankGpioRegisterAccess,
-    IRA: InteruptStatusRegisterAccess,
-    PINTYPE: PinType,
-    SIG: GpioSignal,
-{
-    type P = GpioPin<MODE, RA, IRA, PINTYPE, SIG, GPIONUM>;
-
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
-        core::ptr::read(*self as *const _)
-    }
-}
-
 impl<MODE, RA, IRA, PINTYPE, SIG, const GPIONUM: u8> crate::peripheral::sealed::Sealed
     for GpioPin<MODE, RA, IRA, PINTYPE, SIG, GPIONUM>
-where
-    RA: BankGpioRegisterAccess,
-    IRA: InteruptStatusRegisterAccess,
-    PINTYPE: PinType,
-    SIG: GpioSignal,
-{
-}
-
-impl<MODE, RA, IRA, PINTYPE, SIG, const GPIONUM: u8> crate::peripheral::sealed::Sealed
-    for &mut GpioPin<MODE, RA, IRA, PINTYPE, SIG, GPIONUM>
 where
     RA: BankGpioRegisterAccess,
     IRA: InteruptStatusRegisterAccess,

--- a/esp-hal-common/src/peripheral.rs
+++ b/esp-hal-common/src/peripheral.rs
@@ -167,6 +167,19 @@ pub trait Peripheral: Sized + sealed::Sealed {
     }
 }
 
+impl<T> Peripheral for &mut T
+where
+    T: Peripheral,
+{
+    type P = T;
+
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        self.clone_unchecked()
+    }
+}
+
+impl<T> sealed::Sealed for &mut T where T: sealed::Sealed {}
+
 pub(crate) mod sealed {
     pub trait Sealed {}
 }
@@ -298,17 +311,7 @@ mod peripheral_macros {
                 }
             }
 
-            impl crate::peripheral::Peripheral for &mut $name {
-                type P = $name;
-
-                #[inline]
-                unsafe fn clone_unchecked(&mut self) -> Self::P {
-                    $name::steal()
-                }
-            }
-
             impl crate::peripheral::sealed::Sealed for $name {}
-            impl crate::peripheral::sealed::Sealed for &mut $name {}
         };
         ($(#[$cfg:meta])? $name:ident => false) => {
             $(#[$cfg])?
@@ -338,17 +341,7 @@ mod peripheral_macros {
                 }
             }
 
-            impl crate::peripheral::Peripheral for &mut $name {
-                type P = $name;
-
-                #[inline]
-                unsafe fn clone_unchecked(&mut self) -> Self::P {
-                    $name::steal()
-                }
-            }
-
             impl crate::peripheral::sealed::Sealed for $name {}
-            impl crate::peripheral::sealed::Sealed for &mut $name {}
         }
     }
 }

--- a/esp-hal-common/src/radio.rs
+++ b/esp-hal-common/src/radio.rs
@@ -25,17 +25,47 @@ impl Wifi {
     }
 }
 
+impl crate::peripheral::Peripheral for Wifi {
+    type P = Self;
+
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        Self::steal()
+    }
+}
+
+impl crate::peripheral::sealed::Sealed for Wifi {}
+
 impl Bluetooth {
     pub const unsafe fn steal() -> Self {
         Self { _private: () }
     }
 }
 
+impl crate::peripheral::Peripheral for Bluetooth {
+    type P = Self;
+
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        Self::steal()
+    }
+}
+
+impl crate::peripheral::sealed::Sealed for Bluetooth {}
+
 impl LowRate {
     pub const unsafe fn steal() -> Self {
         Self { _private: () }
     }
 }
+
+impl crate::peripheral::Peripheral for LowRate {
+    type P = Self;
+
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        Self::steal()
+    }
+}
+
+impl crate::peripheral::sealed::Sealed for LowRate {}
 
 cfg_if::cfg_if! {
     if #[cfg(any(esp32, esp32c2, esp32c3, esp32s3))] {

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -320,17 +320,7 @@ impl crate::peripheral::Peripheral for SystemClockControl {
     }
 }
 
-impl crate::peripheral::Peripheral for &mut SystemClockControl {
-    type P = SystemClockControl;
-
-    #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
-        SystemClockControl { _private: () }
-    }
-}
-
 impl crate::peripheral::sealed::Sealed for SystemClockControl {}
-impl crate::peripheral::sealed::Sealed for &mut SystemClockControl {}
 
 #[cfg(pdma)]
 mod dma_peripheral {
@@ -343,14 +333,6 @@ mod dma_peripheral {
             Dma { _private: () }
         }
     }
-    impl crate::peripheral::Peripheral for &mut Dma {
-        type P = Dma;
-        #[inline]
-        unsafe fn clone_unchecked(&mut self) -> Self::P {
-            Dma { _private: () }
-        }
-    }
 
     impl crate::peripheral::sealed::Sealed for Dma {}
-    impl crate::peripheral::sealed::Sealed for &mut Dma {}
 }


### PR DESCRIPTION
Something I missed initially :facepalm:.

- Adds Peripheral impls for the radio structs 
- also added blanket impls for &mut Sealed and &mut Peripheral to avoid repeated manual impls