### PR TITLE
Use T::clone_unchecked instead of self to avoid infinite recursion

### DIFF
--- a/esp-hal-common/src/peripheral.rs
+++ b/esp-hal-common/src/peripheral.rs
@@ -169,12 +169,12 @@ pub trait Peripheral: Sized + sealed::Sealed {
 
 impl<T> Peripheral for &mut T
 where
-    T: Peripheral,
+    T: Peripheral<P = T>,
 {
     type P = T;
 
     unsafe fn clone_unchecked(&mut self) -> Self::P {
-        self.clone_unchecked()
+        T::clone_unchecked(self)
     }
 }
 


### PR DESCRIPTION
Not sure how I missed this warning before, but also feels like infinite recursion should probably be an error...