### PR TITLE
Hide the second core in the `Cpu` enum for single-core devices

### DIFF
--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -509,6 +509,7 @@ pub fn _setup_interrupts() {
         for peripheral_interrupt in 0..255 {
             crate::soc::peripherals::Interrupt::try_from(peripheral_interrupt)
                 .map(|intr| {
+                    #[cfg(multi_core)]
                     disable(Cpu::AppCpu, intr);
                     disable(Cpu::ProCpu, intr);
                 })

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -67,8 +67,6 @@ pub unsafe fn map(core: Cpu, interrupt: Interrupt, which: CpuInterrupt) {
         Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
         #[cfg(multi_core)]
         Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
-        #[cfg(single_core)]
-        Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
     };
     intr_map_base
         .offset(interrupt_number)
@@ -83,8 +81,6 @@ pub fn disable(core: Cpu, interrupt: Interrupt) {
             Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
             #[cfg(multi_core)]
             Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
-            #[cfg(single_core)]
-            Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
         };
         intr_map_base.offset(interrupt_number).write_volatile(0);
     }
@@ -130,23 +126,6 @@ pub fn get_status(core: Cpu) -> u128 {
                         << 32
                     | ((*core1_interrupt_peripheral())
                         .app_intr_status_2
-                        .read()
-                        .bits() as u128)
-                        << 64
-            }
-            #[cfg(single_core)]
-            Cpu::AppCpu => {
-                ((*core0_interrupt_peripheral())
-                    .pro_intr_status_0
-                    .read()
-                    .bits() as u128)
-                    | ((*core0_interrupt_peripheral())
-                        .pro_intr_status_1
-                        .read()
-                        .bits() as u128)
-                        << 32
-                    | ((*core0_interrupt_peripheral())
-                        .pro_intr_status_2
                         .read()
                         .bits() as u128)
                         << 64
@@ -265,8 +244,6 @@ mod vectored {
                 Cpu::ProCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
                 #[cfg(multi_core)]
                 Cpu::AppCpu => (*core1_interrupt_peripheral()).app_mac_intr_map.as_ptr(),
-                #[cfg(single_core)]
-                Cpu::AppCpu => (*core0_interrupt_peripheral()).pro_mac_intr_map.as_ptr(),
             };
 
             let mut levels = [0u128; 8];

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -135,6 +135,7 @@ pub enum Cpu {
     /// The first core
     ProCpu = 0,
     /// The second core
+    #[cfg(multi_core)]
     AppCpu,
 }
 


### PR DESCRIPTION
This is another one of those things we've been meaning to do forever, and just haven't gotten to.

@MabezDev as far as I can tell, all the interrupt code I removed was workarounds for this problem anyway, but please confirm that I have not messed anything up here.