### PR TITLE
Clean up `cfg` gating and `prelude` module

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -57,8 +57,8 @@ esp32s2 = { version = "0.13.0", features = ["critical-section"], optional = true
 esp32s3 = { version = "0.16.0", features = ["critical-section"], optional = true }
 
 [build-dependencies]
-basic-toml = "0.1.1"
-serde      = { version = "1.0.152", features = ["derive"] }
+basic-toml = "0.1.2"
+serde      = { version = "1.0.156", features = ["derive"] }
 
 [features]
 esp32   = ["esp32/rt"  , "xtensa", "xtensa-lx/esp32",   "xtensa-lx-rt/esp32",   "lock_api", "procmacros/esp32"]

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -45,26 +45,27 @@ pub use self::analog::dac::implementation as dac;
 pub use self::dma::gdma;
 #[cfg(pdma)]
 pub use self::dma::pdma;
+#[cfg(any(dport, interrupt_core0, interrupt_core1))]
+pub use self::interrupt::*;
 #[cfg(rmt)]
 pub use self::pulse_control::PulseControl;
 #[cfg(rng)]
 pub use self::rng::Rng;
+#[cfg(any(lp_clkrst, rtc_cntl))]
+pub use self::rtc_cntl::{Rtc, Rwdt};
 #[cfg(any(esp32, esp32s3))]
 pub use self::soc::cpu_control;
 #[cfg(efuse)]
 pub use self::soc::efuse;
+#[cfg(any(spi0, spi1, spi2, spi3))]
+pub use self::spi::Spi;
+#[cfg(any(timg0, timg1))]
+pub use self::timer::Timer;
 #[cfg(any(uart0, uart1, uart2))]
 pub use self::uart::Uart;
 #[cfg(usb_device)]
 pub use self::usb_serial_jtag::UsbSerialJtag;
-pub use self::{
-    delay::Delay,
-    interrupt::*,
-    rtc_cntl::{Rtc, Rwdt},
-    soc::peripherals,
-    spi::Spi,
-    timer::Timer,
-};
+pub use self::{delay::Delay, soc::peripherals};
 
 #[cfg(aes)]
 pub mod aes;
@@ -82,6 +83,7 @@ pub mod gpio;
 pub mod i2c;
 #[cfg(any(i2s0, i2s1))]
 pub mod i2s;
+#[cfg(any(dport, interrupt_core0, interrupt_core1))]
 pub mod interrupt;
 #[cfg(ledc)]
 pub mod ledc;
@@ -100,12 +102,14 @@ pub mod radio;
 #[cfg(rng)]
 pub mod rng;
 pub mod rom;
+#[cfg(any(lp_clkrst, rtc_cntl))]
 pub mod rtc_cntl;
 #[cfg(sha)]
 pub mod sha;
 pub mod soc;
 #[cfg(any(spi0, spi1, spi2, spi3))]
 pub mod spi;
+#[cfg(any(dport, pcr, system))]
 pub mod system;
 #[cfg(systimer)]
 pub mod systimer;

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -3,6 +3,13 @@
 //! Re-exports all traits required for interacting with the various peripheral
 //! drivers implemented in this crate.
 
+pub use embedded_dma::{
+    ReadBuffer as _embedded_dma_ReadBuffer,
+    ReadTarget as _embedded_dma_ReadTarget,
+    Word as _embedded_dma_Word,
+    WriteBuffer as _embedded_dma_WriteBuffer,
+    WriteTarget as _embedded_dma_WriteTarget,
+};
 pub use embedded_hal::{
     digital::v2::{
         InputPin as _embedded_hal_digital_v2_InputPin,
@@ -11,6 +18,17 @@ pub use embedded_hal::{
         ToggleableOutputPin as _embedded_hal_digital_v2_ToggleableOutputPin,
     },
     prelude::*,
+};
+#[cfg(feature = "async")]
+pub use embedded_hal_async::{
+    delay::DelayUs as _embedded_hal_async_delay_DelayUs,
+    digital::Wait as _embedded_hal_async_digital_Wait,
+    i2c::I2c as _embedded_hal_async_i2c_I2c,
+    spi::SpiBus as _embedded_hal_spi_SpiBus,
+    spi::SpiBusFlush as _embedded_hal_spi_SpiBusFlush,
+    spi::SpiBusRead as _embedded_hal_spi_SpiBusRead,
+    spi::SpiBusWrite as _embedded_hal_spi_SpiBusWrite,
+    spi::SpiDevice as _embedded_hal_spi_SpiDevice,
 };
 pub use fugit::{
     ExtU32 as _fugit_ExtU32,
@@ -22,8 +40,29 @@ pub use nb;
 
 #[cfg(any(esp32c2, esp32c3, esp32c6))]
 pub use crate::analog::SarAdcExt as _esp_hal_analog_SarAdcExt;
-#[cfg(any(esp32, esp32s2, esp32s3))]
+#[cfg(sens)]
 pub use crate::analog::SensExt as _esp_hal_analog_SensExt;
+#[cfg(any(gdma, pdma))]
+pub use crate::dma::{
+    DmaTransfer as _esp_hal_dma_DmaTransfer,
+    DmaTransferRxTx as _esp_hal_dma_DmaTransferRxTx,
+};
+#[cfg(gpio)]
+pub use crate::gpio::{
+    InputPin as _esp_hal_gpio_InputPin,
+    OutputPin as _esp_hal_gpio_OutputPin,
+    Pin as _esp_hal_gpio_Pin,
+};
+#[cfg(any(i2c0, i2c1))]
+pub use crate::i2c::Instance as _esp_hal_i2c_Instance;
+#[cfg(ledc)]
+pub use crate::ledc::{
+    channel::{
+        ChannelHW as _esp_hal_ledc_channel_ChannelHW,
+        ChannelIFace as _esp_hal_ledc_channel_ChannelIFace,
+    },
+    timer::{TimerHW as _esp_hal_ledc_timer_TimerHW, TimerIFace as _esp_hal_ledc_timer_TimerIFace},
+};
 #[cfg(rmt)]
 pub use crate::pulse_control::{
     ConfiguredChannel as _esp_hal_pulse_control_ConfiguredChannel,
@@ -33,46 +72,33 @@ pub use crate::pulse_control::{
 pub use crate::radio::RadioExt as _esp_hal_RadioExt;
 #[cfg(any(esp32, esp32s2))]
 pub use crate::spi::dma::WithDmaSpi3 as _esp_hal_spi_dma_WithDmaSpi3;
-pub use crate::{
-    clock::Clock as _esp_hal_clock_Clock,
-    dma::{
-        DmaTransfer as _esp_hal_dma_DmaTransfer,
-        DmaTransferRxTx as _esp_hal_dma_DmaTransferRxTx,
-    },
-    entry,
-    gpio::{
-        InputPin as _esp_hal_gpio_InputPin,
-        OutputPin as _esp_hal_gpio_OutputPin,
-        Pin as _esp_hal_gpio_Pin,
-    },
-    i2c::Instance as _esp_hal_i2c_Instance,
-    ledc::{
-        channel::{
-            ChannelHW as _esp_hal_ledc_channel_ChannelHW,
-            ChannelIFace as _esp_hal_ledc_channel_ChannelIFace,
-        },
-        timer::{
-            TimerHW as _esp_hal_ledc_timer_TimerHW,
-            TimerIFace as _esp_hal_ledc_timer_TimerIFace,
-        },
-    },
-    macros::*,
-    spi::{
-        dma::WithDmaSpi2 as _esp_hal_spi_dma_WithDmaSpi2,
-        Instance as _esp_hal_spi_Instance,
-        InstanceDma as _esp_hal_spi_InstanceDma,
-    },
-    system::SystemExt as _esp_hal_system_SystemExt,
-    timer::{
-        Instance as _esp_hal_timer_Instance,
-        TimerGroupInstance as _esp_hal_timer_TimerGroupInstance,
-    },
-    uart::{Instance as _esp_hal_uart_Instance, UartPins as _esp_hal_uart_UartPins},
+#[cfg(any(spi0, spi1, spi2, spi3))]
+pub use crate::spi::{
+    dma::WithDmaSpi2 as _esp_hal_spi_dma_WithDmaSpi2,
+    Instance as _esp_hal_spi_Instance,
+    InstanceDma as _esp_hal_spi_InstanceDma,
 };
+#[cfg(any(dport, pcr, system))]
+pub use crate::system::SystemExt as _esp_hal_system_SystemExt;
+#[cfg(any(timg0, timg1))]
+pub use crate::timer::{
+    Instance as _esp_hal_timer_Instance,
+    TimerGroupInstance as _esp_hal_timer_TimerGroupInstance,
+};
+#[cfg(any(uart0, uart1, uart2))]
+pub use crate::uart::{Instance as _esp_hal_uart_Instance, UartPins as _esp_hal_uart_UartPins};
+pub use crate::{clock::Clock as _esp_hal_clock_Clock, entry, macros::*};
 
 /// All traits required for using the 1.0.0-alpha.x release of embedded-hal
 #[cfg(feature = "eh1")]
 pub mod eh1 {
+    #[cfg(any(twai0, twai1))]
+    pub use embedded_can::{
+        blocking::Can as _embedded_can_blocking_Can,
+        nb::Can as _embedded_can_nb_Can,
+        Error as _embedded_can_Error,
+        Frame as _embedded_can_Frame,
+    };
     pub use embedded_hal_1::{
         delay::DelayUs as _embedded_hal_delay_blocking_DelayUs,
         digital::{
@@ -93,58 +119,6 @@ pub mod eh1 {
         serial::{Read as _embedded_hal_nb_serial_Read, Write as _embedded_hal_nb_serial_Write},
         spi::FullDuplex as _embedded_hal_nb_spi_FullDuplex,
     };
-    pub use fugit::{
-        ExtU32 as _fugit_ExtU32,
-        ExtU64 as _fugit_ExtU64,
-        RateExtU32 as _fugit_RateExtU32,
-        RateExtU64 as _fugit_RateExtU64,
-    };
-    pub use nb;
 
-    #[cfg(any(esp32c2, esp32c3))]
-    pub use crate::analog::SarAdcExt as _esp_hal_analog_SarAdcExt;
-    #[cfg(any(esp32, esp32s2, esp32s3))]
-    pub use crate::analog::SensExt as _esp_hal_analog_SensExt;
-    #[cfg(rmt)]
-    pub use crate::pulse_control::{
-        ConfiguredChannel as _esp_hal_pulse_control_ConfiguredChannel,
-        OutputChannel as _esp_hal_pulse_control_OutputChannel,
-    };
-    #[cfg(any(esp32, esp32s2))]
-    pub use crate::spi::dma::WithDmaSpi3 as _esp_hal_spi_dma_WithDmaSpi3;
-    pub use crate::{
-        clock::Clock as _esp_hal_clock_Clock,
-        dma::{
-            DmaTransfer as _esp_hal_dma_DmaTransfer,
-            DmaTransferRxTx as _esp_hal_dma_DmaTransferRxTx,
-        },
-        gpio::{
-            InputPin as _esp_hal_gpio_InputPin,
-            OutputPin as _esp_hal_gpio_OutputPin,
-            Pin as _esp_hal_gpio_Pin,
-        },
-        i2c::Instance as _esp_hal_i2c_Instance,
-        ledc::{
-            channel::{
-                ChannelHW as _esp_hal_ledc_channel_ChannelHW,
-                ChannelIFace as _esp_hal_ledc_channel_ChannelIFace,
-            },
-            timer::{
-                TimerHW as _esp_hal_ledc_timer_TimerHW,
-                TimerIFace as _esp_hal_ledc_timer_TimerIFace,
-            },
-        },
-        macros::*,
-        spi::{
-            dma::WithDmaSpi2 as _esp_hal_spi_dma_WithDmaSpi2,
-            Instance as _esp_hal_spi_Instance,
-            InstanceDma as _esp_hal_spi_InstanceDma,
-        },
-        system::SystemExt as _esp_hal_system_SystemExt,
-        timer::{
-            Instance as _esp_hal_timer_Instance,
-            TimerGroupInstance as _esp_hal_timer_TimerGroupInstance,
-        },
-        uart::{Instance as _esp_hal_serial_Instance, UartPins as _esp_hal_serial_UartPins},
-    };
+    pub use super::*;
 }

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -15,12 +15,12 @@ license      = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-darling          = "0.14.3"
+darling          = "0.14.4"
+proc-macro-crate = "1.3.1"
 proc-macro-error = "1.0.4"
-proc-macro2      = "1.0.51"
-quote            = "1.0.23"
-syn              = {version = "1.0.107", features = ["extra-traits", "full"]}
-proc-macro-crate = "1.3.0"
+proc-macro2      = "1.0.52"
+quote            = "1.0.26"
+syn              = {version = "1.0.109", features = ["extra-traits", "full"]}
 
 [features]
 interrupt = []

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -33,17 +33,17 @@ embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
 esp-hal-common     = { version = "0.7.0",  features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]
+aes               = "0.8.2"
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.6.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.3.1", features = ["esp32"] }
+esp-println       = { version = "0.4.0", features = ["esp32"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
-aes = "0.8.2"
 
 [features]
 default            = ["rt", "vectored", "xtal40mhz"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -37,7 +37,7 @@ critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.6.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
-esp-println       = { version = "0.3.1", features = ["esp32c2"] }
+esp-println       = { version = "0.4.0", features = ["esp32c2"] }
 sha2              = { version = "0.10.6", default-features = false}
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -41,7 +41,7 @@ embassy-executor  = { package = "embassy-executor", git = "https://github.com/em
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.6.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.3.1", features = ["esp32c3"] }
+esp-println       = { version = "0.4.0", features = ["esp32c3"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -34,19 +34,19 @@ esp-hal-common     = { version = "0.7.0",  features = ["esp32s2"], path = "../es
 xtensa-atomic-emulation-trap = { version = "0.4.0" }
 
 [dev-dependencies]
+aes               = "0.8.2"
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.6.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.3.1", features = ["esp32s2"] }
+esp-println       = { version = "0.4.0", features = ["esp32s2"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
+static_cell       = "1.0.0"
 usb-device        = { version = "0.2.9" }
 usbd-serial       = "0.1.1"
-static_cell       = "1.0.0"
-aes = "0.8.2"
 
 [features]
 default   = ["rt", "vectored"]

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -24,10 +24,8 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    rt,
     spi::{Spi, SpiBusController, SpiMode},
     timer::TimerGroup,
-    trapframe,
     Delay,
     Rtc,
 };

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -36,19 +36,19 @@ esp-hal-common     = { version = "0.7.0",  features = ["esp32s3"], path = "../es
 r0                 = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
+aes               = "0.8.2"
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.6.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.3.1", features = ["esp32s3"] }
+esp-println       = { version = "0.4.0", features = ["esp32s3"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
+static_cell       = "1.0.0"
 usb-device        = { version = "0.2.9" }
 usbd-serial       = "0.1.1"
-static_cell       = "1.0.0"
-aes = "0.8.2"
 
 [features]
 default              = ["rt", "vectored"]


### PR DESCRIPTION
Boring PR, just some cleanup:

- Improved `cfg` gating of peripherals and re-exports in `esp-hal-common`
- Simplify the `prelude`, add some missing traits, improve `cfg` gating
- Update various dependencies to their latest versions