### PR TITLE
Half-duplex SPI

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -14,6 +14,12 @@ use crate::peripherals::{GPIO, IO_MUX};
 pub use crate::soc::gpio::*;
 pub(crate) use crate::{analog, gpio};
 
+/// Convenience type-alias for a no-pin / don't care - pin
+pub type NoPinType = Gpio0<Unknown>;
+
+/// Convenience constant for `Option::None` pin
+pub const NO_PIN: Option<NoPinType> = None;
+
 #[derive(Copy, Clone)]
 pub enum Event {
     RisingEdge  = 1,

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -16,7 +16,7 @@ use esp32_hal::{
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, Spi, SpiMode},
+    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
     timer::TimerGroup,
     Rtc,
     IO,
@@ -39,6 +39,7 @@ pub type SpiType<'d> = SpiDma<
     ChannelTx<'d, Spi2DmaChannelTxImpl, Spi2DmaChannel>,
     ChannelRx<'d, Spi2DmaChannelRxImpl, Spi2DmaChannel>,
     Spi2DmaSuitablePeripheral,
+    FullDuplexMode,
 >;
 
 #[embassy_executor::task]

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -1,0 +1,192 @@
+//! SPI write and read a flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO19
+//! MISO/IO0        GPIO18
+//! MOSI/IO1        GPIO5
+//! IO2             GPIO17
+//! IO3             GPIO16
+//! CS              GPIO4
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32_hal::{
+    clock::ClockControl,
+    dma::DmaPriority,
+    gpio::IO,
+    pdma::Dma,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32, this includes
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio19;
+    let miso = io.pins.gpio18;
+    let mosi = io.pins.gpio5;
+    let sio2 = io.pins.gpio17;
+    let sio3 = io.pins.gpio16;
+    let cs = io.pins.gpio4;
+
+    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma_channel = dma.spi2channel;
+
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        &mut descriptors,
+        &mut rx_descriptors,
+        DmaPriority::Priority0,
+    ));
+
+    let mut delay = Delay::new(&clocks);
+
+    // DMA buffer require a static life-time
+    let send = send_buffer();
+    let mut receive = receive_buffer();
+    let mut zero_buf = zero_buffer();
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // erase sector
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x20, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write data / program page
+    send.fill(b'!');
+    send[0..][..5].copy_from_slice(&b"Hello"[..]);
+    let transfer = spi
+        .write(
+            SpiDataMode::Quad,
+            Command::Command8(0x32, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            send,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    loop {
+        // quad fast read
+        let transfer = spi
+            .read(
+                SpiDataMode::Quad,
+                Command::Command8(0xeb, SpiDataMode::Single),
+                Address::Address32(0x000000 << 8, SpiDataMode::Quad),
+                4,
+                receive,
+            )
+            .unwrap();
+
+        // here we could do something else while DMA transfer is in progress
+        // the buffers and spi is moved into the transfer and we can get it back via
+        // `wait`
+        (receive, spi) = transfer.wait();
+
+        println!("{:x?}", &receive);
+        for b in &mut receive.iter() {
+            if *b >= 32 && *b <= 127 {
+                print!("{}", *b as char);
+            } else {
+                print!(".");
+            }
+        }
+        println!();
+
+        delay.delay_ms(250u32);
+    }
+}
+
+fn zero_buffer() -> &'static mut [u8; 0] {
+    static mut BUFFER: [u8; 0] = [0u8; 0];
+    unsafe { &mut BUFFER }
+}
+
+fn send_buffer() -> &'static mut [u8; 256] {
+    static mut BUFFER: [u8; 256] = [0u8; 256];
+    unsafe { &mut BUFFER }
+}
+
+fn receive_buffer() -> &'static mut [u8; 320] {
+    static mut BUFFER: [u8; 320] = [0u8; 320];
+    unsafe { &mut BUFFER }
+}

--- a/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -1,0 +1,115 @@
+//! SPI read manufacturer id from flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO19
+//! MISO/IO0        GPIO18
+//! MOSI/IO1        GPIO5
+//! IO2             GPIO17
+//! IO3             GPIO16
+//! CS              GPIO4
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32, this includes
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio19;
+    let miso = io.pins.gpio18;
+    let mosi = io.pins.gpio5;
+    let sio2 = io.pins.gpio17;
+    let sio3 = io.pins.gpio16;
+    let cs = io.pins.gpio4;
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Single,
+            Command::Command8(0x90, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Single {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Dual,
+            Command::Command8(0x92, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Dual),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Dual {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Quad,
+            Command::Command8(0x94, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Quad),
+            4,
+            &mut data,
+        )
+        .unwrap();
+        println!("Quad {:x?}", data);
+        delay.delay_ms(1500u32);
+    }
+}

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // Disable the watchdog timers. For the ESP32 this includes
     // the RTC WDT, and the TIMG WDTs.
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -16,7 +16,7 @@ use esp32c2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, Spi, SpiMode},
+    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
     timer::TimerGroup,
     Rtc,
     IO,
@@ -39,6 +39,7 @@ pub type SpiType<'d> = SpiDma<
     ChannelTx<'d, Channel0TxImpl, esp32c2_hal::gdma::Channel0>,
     ChannelRx<'d, Channel0RxImpl, esp32c2_hal::gdma::Channel0>,
     SuitablePeripheral0,
+    FullDuplexMode,
 >;
 
 #[embassy_executor::task]

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -1,0 +1,190 @@
+//! SPI write and read a flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO4
+//! MISOI/IO0       GPIO5
+//! MOSI/IO1        GPIO6
+//! IO2             GPIO7
+//! IO3             GPIO8
+//! CS              GPIO9
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32c2_hal::{
+    clock::ClockControl,
+    dma::DmaPriority,
+    gdma::Gdma,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio4;
+    let miso = io.pins.gpio5;
+    let mosi = io.pins.gpio6;
+    let sio2 = io.pins.gpio7;
+    let sio3 = io.pins.gpio8;
+    let cs = io.pins.gpio9;
+
+    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma_channel = dma.channel0;
+
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        &mut descriptors,
+        &mut rx_descriptors,
+        DmaPriority::Priority0,
+    ));
+
+    let mut delay = Delay::new(&clocks);
+
+    // DMA buffer require a static life-time
+    let send = send_buffer();
+    let mut receive = receive_buffer();
+    let mut zero_buf = zero_buffer();
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // erase sector
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x20, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write data / program page
+    send.fill(b'!');
+    send[0..][..5].copy_from_slice(&b"Hello"[..]);
+    let transfer = spi
+        .write(
+            SpiDataMode::Quad,
+            Command::Command8(0x32, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            send,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    loop {
+        // quad fast read
+        let transfer = spi
+            .read(
+                SpiDataMode::Quad,
+                Command::Command8(0xeb, SpiDataMode::Single),
+                Address::Address32(0x000000 << 8, SpiDataMode::Quad),
+                4,
+                receive,
+            )
+            .unwrap();
+
+        // here we could do something else while DMA transfer is in progress
+        // the buffers and spi is moved into the transfer and we can get it back via
+        // `wait`
+        (receive, spi) = transfer.wait();
+
+        println!("{:x?}", &receive);
+        for b in &mut receive.iter() {
+            if *b >= 32 && *b <= 127 {
+                print!("{}", *b as char);
+            } else {
+                print!(".");
+            }
+        }
+        println!();
+
+        delay.delay_ms(250u32);
+    }
+}
+
+fn zero_buffer() -> &'static mut [u8; 0] {
+    static mut BUFFER: [u8; 0] = [0u8; 0];
+    unsafe { &mut BUFFER }
+}
+
+fn send_buffer() -> &'static mut [u8; 256] {
+    static mut BUFFER: [u8; 256] = [0u8; 256];
+    unsafe { &mut BUFFER }
+}
+
+fn receive_buffer() -> &'static mut [u8; 320] {
+    static mut BUFFER: [u8; 320] = [0u8; 320];
+    unsafe { &mut BUFFER }
+}

--- a/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -1,0 +1,113 @@
+//! SPI read manufacturer id from flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO4
+//! MISOI/IO0       GPIO5
+//! MOSI/IO1        GPIO6
+//! IO2             GPIO7
+//! IO3             GPIO8
+//! CS              GPIO9
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32c2_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio4;
+    let miso = io.pins.gpio5;
+    let mosi = io.pins.gpio6;
+    let sio2 = io.pins.gpio7;
+    let sio3 = io.pins.gpio8;
+    let cs = io.pins.gpio9;
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Single,
+            Command::Command8(0x90, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Single {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Dual,
+            Command::Command8(0x92, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Dual),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Dual {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Quad,
+            Command::Command8(0x94, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Quad),
+            4,
+            &mut data,
+        )
+        .unwrap();
+        println!("Quad {:x?}", data);
+        delay.delay_ms(1500u32);
+    }
+}

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -16,7 +16,7 @@ use esp32c3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, Spi, SpiMode},
+    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
     timer::TimerGroup,
     Rtc,
     IO,
@@ -39,6 +39,7 @@ pub type SpiType<'d> = SpiDma<
     ChannelTx<'d, Channel0TxImpl, esp32c3_hal::gdma::Channel0>,
     ChannelRx<'d, Channel0RxImpl, esp32c3_hal::gdma::Channel0>,
     SuitablePeripheral0,
+    FullDuplexMode,
 >;
 
 #[embassy_executor::task]

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -1,0 +1,193 @@
+//! SPI write and read a flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO6
+//! MISOI/IO0       GPIO2
+//! MOSI/IO1        GPIO3
+//! IO2             GPIO4
+//! IO3             GPIO5
+//! CS              GPIO10
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    dma::DmaPriority,
+    gdma::Gdma,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio6;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio3;
+    let sio2 = io.pins.gpio4;
+    let sio3 = io.pins.gpio5;
+    let cs = io.pins.gpio10;
+
+    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma_channel = dma.channel0;
+
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        &mut descriptors,
+        &mut rx_descriptors,
+        DmaPriority::Priority0,
+    ));
+
+    let mut delay = Delay::new(&clocks);
+
+    // DMA buffer require a static life-time
+    let send = send_buffer();
+    let mut receive = receive_buffer();
+    let mut zero_buf = zero_buffer();
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // erase sector
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x20, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write data / program page
+    send.fill(b'!');
+    send[0..][..5].copy_from_slice(&b"Hello"[..]);
+    let transfer = spi
+        .write(
+            SpiDataMode::Quad,
+            Command::Command8(0x32, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            send,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    loop {
+        // quad fast read
+        let transfer = spi
+            .read(
+                SpiDataMode::Quad,
+                Command::Command8(0xeb, SpiDataMode::Single),
+                Address::Address32(0x000000 << 8, SpiDataMode::Quad),
+                4,
+                receive,
+            )
+            .unwrap();
+
+        // here we could do something else while DMA transfer is in progress
+        // the buffers and spi is moved into the transfer and we can get it back via
+        // `wait`
+        (receive, spi) = transfer.wait();
+
+        println!("{:x?}", &receive);
+        for b in &mut receive.iter() {
+            if *b >= 32 && *b <= 127 {
+                print!("{}", *b as char);
+            } else {
+                print!(".");
+            }
+        }
+        println!();
+
+        delay.delay_ms(250u32);
+    }
+}
+
+fn zero_buffer() -> &'static mut [u8; 0] {
+    static mut BUFFER: [u8; 0] = [0u8; 0];
+    unsafe { &mut BUFFER }
+}
+
+fn send_buffer() -> &'static mut [u8; 256] {
+    static mut BUFFER: [u8; 256] = [0u8; 256];
+    unsafe { &mut BUFFER }
+}
+
+fn receive_buffer() -> &'static mut [u8; 320] {
+    static mut BUFFER: [u8; 320] = [0u8; 320];
+    unsafe { &mut BUFFER }
+}

--- a/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -1,0 +1,116 @@
+//! SPI read manufacturer id from flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO6
+//! MISO/IO0        GPIO2
+//! MOSI/IO1        GPIO3
+//! IO2             GPIO4
+//! IO3             GPIO5
+//! CS              GPIO10
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio6;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio3;
+    let sio2 = io.pins.gpio4;
+    let sio3 = io.pins.gpio5;
+    let cs = io.pins.gpio10;
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Single,
+            Command::Command8(0x90, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Single {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Dual,
+            Command::Command8(0x92, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Dual),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Dual {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Quad,
+            Command::Command8(0x94, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Quad),
+            4,
+            &mut data,
+        )
+        .unwrap();
+        println!("Quad {:x?}", data);
+        delay.delay_ms(1500u32);
+    }
+}

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -16,7 +16,7 @@ use esp32c6_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, Spi, SpiMode},
+    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
     timer::TimerGroup,
     Rtc,
     IO,
@@ -39,6 +39,7 @@ pub type SpiType<'d> = SpiDma<
     ChannelTx<'d, Channel0TxImpl, esp32c6_hal::gdma::Channel0>,
     ChannelRx<'d, Channel0RxImpl, esp32c6_hal::gdma::Channel0>,
     SuitablePeripheral0,
+    FullDuplexMode,
 >;
 
 #[embassy_executor::task]

--- a/esp32c6-hal/examples/qspi_flash.rs
+++ b/esp32c6-hal/examples/qspi_flash.rs
@@ -1,0 +1,193 @@
+//! SPI write and read a flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO4
+//! MISOI/IO0       GPIO5
+//! MOSI/IO1        GPIO6
+//! IO2             GPIO7
+//! IO3             GPIO0
+//! CS              GPIO1
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32c6_hal::{
+    clock::ClockControl,
+    dma::DmaPriority,
+    gdma::Gdma,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio4;
+    let miso = io.pins.gpio5;
+    let mosi = io.pins.gpio6;
+    let sio2 = io.pins.gpio7;
+    let sio3 = io.pins.gpio0;
+    let cs = io.pins.gpio1;
+
+    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma_channel = dma.channel0;
+
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        &mut descriptors,
+        &mut rx_descriptors,
+        DmaPriority::Priority0,
+    ));
+
+    let mut delay = Delay::new(&clocks);
+
+    // DMA buffer require a static life-time
+    let send = send_buffer();
+    let mut receive = receive_buffer();
+    let mut zero_buf = zero_buffer();
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // erase sector
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x20, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write data / program page
+    send.fill(b'!');
+    send[0..][..5].copy_from_slice(&b"Hello"[..]);
+    let transfer = spi
+        .write(
+            SpiDataMode::Quad,
+            Command::Command8(0x32, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            send,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    loop {
+        // quad fast read
+        let transfer = spi
+            .read(
+                SpiDataMode::Quad,
+                Command::Command8(0xeb, SpiDataMode::Single),
+                Address::Address32(0x000000 << 8, SpiDataMode::Quad),
+                4,
+                receive,
+            )
+            .unwrap();
+
+        // here we could do something else while DMA transfer is in progress
+        // the buffers and spi is moved into the transfer and we can get it back via
+        // `wait`
+        (receive, spi) = transfer.wait();
+
+        println!("{:x?}", &receive);
+        for b in &mut receive.iter() {
+            if *b >= 32 && *b <= 127 {
+                print!("{}", *b as char);
+            } else {
+                print!(".");
+            }
+        }
+        println!();
+
+        delay.delay_ms(250u32);
+    }
+}
+
+fn zero_buffer() -> &'static mut [u8; 0] {
+    static mut BUFFER: [u8; 0] = [0u8; 0];
+    unsafe { &mut BUFFER }
+}
+
+fn send_buffer() -> &'static mut [u8; 256] {
+    static mut BUFFER: [u8; 256] = [0u8; 256];
+    unsafe { &mut BUFFER }
+}
+
+fn receive_buffer() -> &'static mut [u8; 320] {
+    static mut BUFFER: [u8; 320] = [0u8; 320];
+    unsafe { &mut BUFFER }
+}

--- a/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -1,0 +1,116 @@
+//! SPI read manufacturer id from flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO4
+//! MISOI/IO0       GPIO5
+//! MOSI/IO1        GPIO6
+//! IO2             GPIO7
+//! IO3             GPIO0
+//! CS              GPIO1
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32c6_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio4;
+    let miso = io.pins.gpio5;
+    let mosi = io.pins.gpio6;
+    let sio2 = io.pins.gpio7;
+    let sio3 = io.pins.gpio0;
+    let cs = io.pins.gpio1;
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Single,
+            Command::Command8(0x90, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Single {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Dual,
+            Command::Command8(0x92, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Dual),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Dual {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Quad,
+            Command::Command8(0x94, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Quad),
+            4,
+            &mut data,
+        )
+        .unwrap();
+        println!("Quad {:x?}", data);
+        delay.delay_ms(1500u32);
+    }
+}

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -16,7 +16,7 @@ use esp32s2_hal::{
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, Spi, SpiMode},
+    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
     timer::TimerGroup,
     Rtc,
     IO,
@@ -39,6 +39,7 @@ pub type SpiType<'d> = SpiDma<
     ChannelTx<'d, Spi2DmaChannelTxImpl, Spi2DmaChannel>,
     ChannelRx<'d, Spi2DmaChannelRxImpl, Spi2DmaChannel>,
     Spi2DmaSuitablePeripheral,
+    FullDuplexMode,
 >;
 
 #[embassy_executor::task]

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -1,0 +1,191 @@
+//! SPI write and read a flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO4
+//! MISO/IO0        GPIO5
+//! MOSI/IO1        GPIO6
+//! IO2             GPIO7
+//! IO3             GPIO15
+//! CS              GPIO16
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    dma::DmaPriority,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc, pdma::Dma,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-S2, this includes
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio4;
+    let miso = io.pins.gpio5;
+    let mosi = io.pins.gpio6;
+    let sio2 = io.pins.gpio7;
+    let sio3 = io.pins.gpio15;
+    let cs = io.pins.gpio16;
+
+    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma_channel = dma.spi2channel;
+
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        &mut descriptors,
+        &mut rx_descriptors,
+        DmaPriority::Priority0,
+    ));
+
+    let mut delay = Delay::new(&clocks);
+
+    // DMA buffer require a static life-time
+    let send = send_buffer();
+    let mut receive = receive_buffer();
+    let mut zero_buf = zero_buffer();
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // erase sector
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x20, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write data / program page
+    send.fill(b'!');
+    send[0..][..5].copy_from_slice(&b"Hello"[..]);
+    let transfer = spi
+        .write(
+            SpiDataMode::Quad,
+            Command::Command8(0x32, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            send,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    loop {
+        // quad fast read
+        let transfer = spi
+            .read(
+                SpiDataMode::Quad,
+                Command::Command8(0xeb, SpiDataMode::Single),
+                Address::Address32(0x000000 << 8, SpiDataMode::Quad),
+                4,
+                receive,
+            )
+            .unwrap();
+
+        // here we could do something else while DMA transfer is in progress
+        // the buffers and spi is moved into the transfer and we can get it back via
+        // `wait`
+        (receive, spi) = transfer.wait();
+
+        println!("{:x?}", &receive);
+        for b in &mut receive.iter() {
+            if *b >= 32 && *b <= 127 {
+                print!("{}", *b as char);
+            } else {
+                print!(".");
+            }
+        }
+        println!();
+
+        delay.delay_ms(250u32);
+    }
+}
+
+fn zero_buffer() -> &'static mut [u8; 0] {
+    static mut BUFFER: [u8; 0] = [0u8; 0];
+    unsafe { &mut BUFFER }
+}
+
+fn send_buffer() -> &'static mut [u8; 256] {
+    static mut BUFFER: [u8; 256] = [0u8; 256];
+    unsafe { &mut BUFFER }
+}
+
+fn receive_buffer() -> &'static mut [u8; 320] {
+    static mut BUFFER: [u8; 320] = [0u8; 320];
+    unsafe { &mut BUFFER }
+}

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -21,12 +21,13 @@ use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     gpio::IO,
+    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
     timer::TimerGroup,
     Delay,
-    Rtc, pdma::Dma,
+    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};

--- a/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -1,0 +1,115 @@
+//! SPI read manufacturer id from flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO4
+//! MISO/IO0        GPIO5
+//! MOSI/IO1        GPIO6
+//! IO2             GPIO7
+//! IO3             GPIO15
+//! CS              GPIO16
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-S2, this includes
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio4;
+    let miso = io.pins.gpio5;
+    let mosi = io.pins.gpio6;
+    let sio2 = io.pins.gpio7;
+    let sio3 = io.pins.gpio15;
+    let cs = io.pins.gpio16;
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Single,
+            Command::Command8(0x90, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Single {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Dual,
+            Command::Command8(0x92, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Dual),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Dual {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Quad,
+            Command::Command8(0x94, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Quad),
+            4,
+            &mut data,
+        )
+        .unwrap();
+        println!("Quad {:x?}", data);
+        delay.delay_ms(1500u32);
+    }
+}

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -16,7 +16,7 @@ use esp32s3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, Spi, SpiMode},
+    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
     timer::TimerGroup,
     Rtc,
     IO,
@@ -39,6 +39,7 @@ pub type SpiType<'d> = SpiDma<
     ChannelTx<'d, Channel0TxImpl, esp32s3_hal::gdma::Channel0>,
     ChannelRx<'d, Channel0RxImpl, esp32s3_hal::gdma::Channel0>,
     SuitablePeripheral0,
+    FullDuplexMode,
 >;
 
 #[embassy_executor::task]

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -1,0 +1,193 @@
+//! SPI write and read a flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO4
+//! MISOI/IO0       GPIO5
+//! MOSI/IO1        GPIO6
+//! IO2             GPIO7
+//! IO3             GPIO15
+//! CS              GPIO16
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    dma::DmaPriority,
+    gdma::Gdma,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio4;
+    let miso = io.pins.gpio5;
+    let mosi = io.pins.gpio6;
+    let sio2 = io.pins.gpio7;
+    let sio3 = io.pins.gpio15;
+    let cs = io.pins.gpio16;
+
+    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma_channel = dma.channel0;
+
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    )
+    .with_dma(dma_channel.configure(
+        false,
+        &mut descriptors,
+        &mut rx_descriptors,
+        DmaPriority::Priority0,
+    ));
+
+    let mut delay = Delay::new(&clocks);
+
+    // DMA buffer require a static life-time
+    let send = send_buffer();
+    let mut receive = receive_buffer();
+    let mut zero_buf = zero_buffer();
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // erase sector
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x20, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (zero_buf, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write enable
+    let transfer = spi
+        .write(
+            SpiDataMode::Single,
+            Command::Command8(0x06, SpiDataMode::Single),
+            Address::None,
+            0,
+            zero_buf,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    // write data / program page
+    send.fill(b'!');
+    send[0..][..5].copy_from_slice(&b"Hello"[..]);
+    let transfer = spi
+        .write(
+            SpiDataMode::Quad,
+            Command::Command8(0x32, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            send,
+        )
+        .unwrap();
+    (_, spi) = transfer.wait();
+    delay.delay_ms(250u32);
+
+    loop {
+        // quad fast read
+        let transfer = spi
+            .read(
+                SpiDataMode::Quad,
+                Command::Command8(0xeb, SpiDataMode::Single),
+                Address::Address32(0x000000 << 8, SpiDataMode::Quad),
+                4,
+                receive,
+            )
+            .unwrap();
+
+        // here we could do something else while DMA transfer is in progress
+        // the buffers and spi is moved into the transfer and we can get it back via
+        // `wait`
+        (receive, spi) = transfer.wait();
+
+        println!("{:x?}", &receive);
+        for b in &mut receive.iter() {
+            if *b >= 32 && *b <= 127 {
+                print!("{}", *b as char);
+            } else {
+                print!(".");
+            }
+        }
+        println!();
+
+        delay.delay_ms(250u32);
+    }
+}
+
+fn zero_buffer() -> &'static mut [u8; 0] {
+    static mut BUFFER: [u8; 0] = [0u8; 0];
+    unsafe { &mut BUFFER }
+}
+
+fn send_buffer() -> &'static mut [u8; 256] {
+    static mut BUFFER: [u8; 256] = [0u8; 256];
+    unsafe { &mut BUFFER }
+}
+
+fn receive_buffer() -> &'static mut [u8; 320] {
+    static mut BUFFER: [u8; 320] = [0u8; 320];
+    unsafe { &mut BUFFER }
+}

--- a/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -1,0 +1,116 @@
+//! SPI read manufacturer id from flash chip
+//!
+//! Folowing pins are used:
+//! SCLK            GPIO4
+//! MISO/IO0        GPIO5
+//! MOSI/IO1        GPIO6
+//! IO2             GPIO7
+//! IO3             GPIO15
+//! CS              GPIO16
+//!
+//! Depending on your target and the board you are using you have to change the
+//! pins.
+//!
+//! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
+//! register is set.
+
+#![no_std]
+#![no_main]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-S3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let sclk = io.pins.gpio4;
+    let miso = io.pins.gpio5;
+    let mosi = io.pins.gpio6;
+    let sio2 = io.pins.gpio7;
+    let sio3 = io.pins.gpio15;
+    let cs = io.pins.gpio16;
+
+    let mut spi = Spi::new_half_duplex(
+        peripherals.SPI2,
+        Some(sclk),
+        Some(mosi),
+        Some(miso),
+        Some(sio2),
+        Some(sio3),
+        Some(cs),
+        100u32.kHz(),
+        SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Single,
+            Command::Command8(0x90, SpiDataMode::Single),
+            Address::Address24(0x000000, SpiDataMode::Single),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Single {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Dual,
+            Command::Command8(0x92, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Dual),
+            0,
+            &mut data,
+        )
+        .unwrap();
+        println!("Dual {:x?}", data);
+        delay.delay_ms(250u32);
+
+        // READ MANUFACTURER ID FROM FLASH CHIP
+        let mut data = [0u8; 2];
+        spi.read(
+            SpiDataMode::Quad,
+            Command::Command8(0x94, SpiDataMode::Single),
+            Address::Address32(0x000000_00, SpiDataMode::Quad),
+            4,
+            &mut data,
+        )
+        .unwrap();
+        println!("Quad {:x?}", data);
+        delay.delay_ms(1500u32);
+    }
+}

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // Disable the watchdog timers. For the ESP32-S3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);


### PR DESCRIPTION
This adds half-duplex SPI support including dual and quad SPI, including DMA support. 
Examples for all supported targets are included.

The examples need an SPI flash chip with support for quad-SPI. I used GD25Q64C - make sure to enable the QE bit in the status register before connecting HOLD / SIO3

Some of the targets even support OSPI but since I have no way to test that and also, I assume it's not too popular (besides of the on-module flash/ram) it's not included here

Please note: in non-DMA mode we cannot transfer data larger than the FIFO, in DMA mode we can transfer 32k of data
