### PR TITLE
esp32c3/c2: use rwtext.wifi in dummy section calculation

### DIFF
--- a/esp32c2-hal/ld/bl-riscv-link.x
+++ b/esp32c2-hal/ld/bl-riscv-link.x
@@ -85,6 +85,7 @@ SECTIONS {
   .rwdata_dummy (NOLOAD) : {
     . = ALIGN(ALIGNOF(.rwtext));
     . = . + SIZEOF(.rwtext);
+    . = . + SIZEOF(.rwtext.wifi);
   } > RWDATA
 }
 INSERT BEFORE .data;

--- a/esp32c3-hal/ld/bl-riscv-link.x
+++ b/esp32c3-hal/ld/bl-riscv-link.x
@@ -85,6 +85,7 @@ SECTIONS {
   .rwdata_dummy (NOLOAD) : {
     . = ALIGN(ALIGNOF(.rwtext));
     . = . + SIZEOF(.rwtext);
+    . = . + SIZEOF(.rwtext.wifi);
   } > RWDATA
 }
 INSERT BEFORE .data;


### PR DESCRIPTION
In the old linker scripts, riscv put wifi ram text in the same rwtext section, in xtensa they were different sections (rwtext.wifi). With the unification the dummy region for riscv needed to be updated to add the size of rwtext.wifi.