### PR TITLE
Update README.md to use esp-rs/esp-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We recommend using [cargo-generate] and [esp-template] in order to generate a ne
 
 ```bash
 $ cargo install cargo-generate
-$ cargo generate --git https://github.com/esp-rs/esp-template
+$ cargo generate -a esp-rs/esp-template
 ```
 
 For more information on using this template, please refer to [its README].


### PR DESCRIPTION
The former command fails:
```
cargo generate --git https://github.com/esp-rs/esp-template
🤷   Project Name: esp-no-std
🔧   Destination: /Users/tomas.vojtasek/fun/esp-no-std ...
🔧   project-name: esp-no-std ...
🔧   Generating template ...
✔ 🤷   Which MCU to target? · esp32
✔ 🤷   Configure project to use Dev Containers (VS Code, GitHub Codespaces and Gitpod)? · false
✔ 🤷   Enable allocations via the esp-alloc crate? · false
[ 1/13]   Done: .cargo/config.toml                                                                                                                                                                        [ 2/13]   Done: .cargo                                                                                                                                                                                    [ 3/13]   Done: .gitignore                                                                                                                                                                                [ 4/13]   Done: .vscode/settings.json                                                                                                                                                                     [ 5/13]   Done: .vscode                                                                                                                                                                                   [ 6/13]   Done: Cargo.toml                                                                                                                                                                                [ 7/13]   Done: LICENSE-APACHE                                                                                                                                                                            [ 8/13]   Done: LICENSE-MIT                                                                                                                                                                               [ 9/13]   Ignored: post-script.rhai                                                                                                                                                                       [10/13]   Ignored: pre-script.rhai                                                                                                                                                                        [11/13]   Done: rust-toolchain.toml                                                                                                                                                                       [12/13]   Done: src/main.rs                                                                                                                                                                               [13/13]   Done: src                                                                                                                                                                                       ✔ 🤷   The template is requesting to run the following command. Do you agree?
cargo fmt · no
Error: ⛔   Failed executing script: post-script.rhai

Caused by:
    Runtime error: User denied execution of system command `cargo fmt`.
```