### PR TITLE
Fix 802.15.4 clock enabling (ESP32-C6)

### DIFF
--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -38,7 +38,6 @@ extern "C" {
     #[allow(dead_code)]
     fn ets_delay_us(us: u32);
     fn rtc_get_reset_reason(cpu_num: u32) -> u32;
-    fn rtc_get_wakeup_cause() -> u32;
     pub fn software_reset_cpu();
     pub fn software_reset();
 }

--- a/esp-hal-common/src/soc/esp32c6/radio_clocks.rs
+++ b/esp-hal-common/src/soc/esp32c6/radio_clocks.rs
@@ -142,18 +142,94 @@ fn wifi_clock_disable() {
 
 fn ieee802154_clock_enable() {
     let modem_syscon = unsafe { &*esp32c6::MODEM_SYSCON::PTR };
+    let modem_lpcon = unsafe { &*esp32c6::MODEM_LPCON::PTR };
+
     modem_syscon
         .clk_conf
         .modify(|_, w| w.clk_zb_apb_en().set_bit().clk_zb_mac_en().set_bit());
-    wifi_clock_enable();
+
+    modem_syscon.clk_conf1.modify(|_, w| {
+        w.clk_fe_apb_en()
+            .set_bit()
+            .clk_fe_cal_160m_en()
+            .set_bit()
+            .clk_fe_160m_en()
+            .set_bit()
+            .clk_fe_80m_en()
+            .set_bit()
+            .clk_bt_apb_en()
+            .set_bit()
+            .clk_bt_en()
+            .set_bit()
+            .clk_wifibb_160x1_en()
+            .set_bit()
+            .clk_wifibb_80x1_en()
+            .set_bit()
+            .clk_wifibb_40x1_en()
+            .set_bit()
+            .clk_wifibb_80x_en()
+            .set_bit()
+            .clk_wifibb_40x_en()
+            .set_bit()
+            .clk_wifibb_80m_en()
+            .set_bit()
+            .clk_wifibb_44m_en()
+            .set_bit()
+            .clk_wifibb_40m_en()
+            .set_bit()
+            .clk_wifibb_22m_en()
+            .set_bit()
+    });
+
+    modem_lpcon
+        .clk_conf
+        .modify(|_, w| w.clk_coex_en().set_bit());
 }
 
 fn ieee802154_clock_disable() {
     let modem_syscon = unsafe { &*esp32c6::MODEM_SYSCON::PTR };
+    let modem_lpcon = unsafe { &*esp32c6::MODEM_LPCON::PTR };
+
     modem_syscon
         .clk_conf
         .modify(|_, w| w.clk_zb_apb_en().clear_bit().clk_zb_mac_en().clear_bit());
-    wifi_clock_disable();
+
+    modem_syscon.clk_conf1.modify(|_, w| {
+        w.clk_fe_apb_en()
+            .clear_bit()
+            .clk_fe_cal_160m_en()
+            .clear_bit()
+            .clk_fe_160m_en()
+            .clear_bit()
+            .clk_fe_80m_en()
+            .clear_bit()
+            .clk_bt_apb_en()
+            .clear_bit()
+            .clk_bt_en()
+            .clear_bit()
+            .clk_wifibb_160x1_en()
+            .clear_bit()
+            .clk_wifibb_80x1_en()
+            .clear_bit()
+            .clk_wifibb_40x1_en()
+            .clear_bit()
+            .clk_wifibb_80x_en()
+            .clear_bit()
+            .clk_wifibb_40x_en()
+            .clear_bit()
+            .clk_wifibb_80m_en()
+            .clear_bit()
+            .clk_wifibb_44m_en()
+            .clear_bit()
+            .clk_wifibb_40m_en()
+            .clear_bit()
+            .clk_wifibb_22m_en()
+            .clear_bit()
+    });
+
+    modem_lpcon
+        .clk_conf
+        .modify(|_, w| w.clk_coex_en().clear_bit());
 }
 
 fn reset_mac() {

--- a/esp32-hal/ld/rom-functions.x
+++ b/esp32-hal/ld/rom-functions.x
@@ -3,6 +3,5 @@ PROVIDE(ets_update_cpu_frequency_rom = 0x40008550);
 PROVIDE(rom_i2c_writeReg = 0x400041a4);
 PROVIDE(rom_i2c_writeReg_Mask = 0x400041fc);
 PROVIDE(rtc_get_reset_reason = 0x400081d4);
-PROVIDE(rtc_get_wakeup_cause = 0x400081f4);
 PROVIDE(software_reset = 0x4000824c);
 PROVIDE(software_reset_cpu = 0x40008264);

--- a/esp32c2-hal/ld/rom-functions.x
+++ b/esp32c2-hal/ld/rom-functions.x
@@ -3,6 +3,5 @@ PROVIDE(ets_update_cpu_frequency_rom = 0x40000774);
 PROVIDE(rom_i2c_writeReg = 0x400022f4);
 PROVIDE(rom_i2c_writeReg_Mask = 0x400022fc);
 PROVIDE(rtc_get_reset_reason = 0x40000018);
-PROVIDE(rtc_get_wakeup_cause = 0x40000020);
 PROVIDE(software_reset = 0x40000088);
 PROVIDE(software_reset_cpu = 0x4000008c);

--- a/esp32c3-hal/ld/rom-functions.x
+++ b/esp32c3-hal/ld/rom-functions.x
@@ -10,6 +10,5 @@ PROVIDE(ets_update_cpu_frequency_rom = 0x40000588);
 PROVIDE(rom_i2c_writeReg = 0x4000195c);
 PROVIDE(rom_i2c_writeReg_Mask = 0x40001960);
 PROVIDE(rtc_get_reset_reason = 0x40000018);
-PROVIDE(rtc_get_wakeup_cause = 0x40000024);
 PROVIDE(software_reset = 0x40000090);
 PROVIDE(software_reset_cpu = 0x40000094);

--- a/esp32c6-hal/ld/rom-functions.x
+++ b/esp32c6-hal/ld/rom-functions.x
@@ -9,7 +9,6 @@ PROVIDE(cache_resume_icache = 0x4000069c);
 PROVIDE(ets_delay_us = 0x40000040);
 PROVIDE(ets_update_cpu_frequency_rom = 0x40000048);
 PROVIDE(rtc_get_reset_reason = 0x40000018);
-PROVIDE(rtc_get_wakeup_cause = 0x40000020);
 ets_update_cpu_frequency = 0x40000048;
 PROVIDE(software_reset = 0x40000090);
 PROVIDE(software_reset_cpu = 0x40000094);

--- a/esp32s2-hal/ld/rom-functions.x
+++ b/esp32s2-hal/ld/rom-functions.x
@@ -3,6 +3,5 @@ PROVIDE(ets_update_cpu_frequency_rom = 0x4000d8a4);
 PROVIDE(rom_i2c_writeReg = 0x4000a9a8);
 PROVIDE(rom_i2c_writeReg_Mask = 0x4000aa00);
 PROVIDE(rtc_get_reset_reason = 0x4000ff58);
-PROVIDE(rtc_get_wakeup_cause = 0x4000ff7c);
 PROVIDE(software_reset = 0x40010068);
 PROVIDE(software_reset_cpu = 0x40010080);

--- a/esp32s3-hal/ld/rom-functions.x
+++ b/esp32s3-hal/ld/rom-functions.x
@@ -4,6 +4,5 @@ PROVIDE(rom_i2c_writeReg = 0x40005d60);
 PROVIDE(rom_i2c_writeReg_Mask = 0x40005d6c);
 PROVIDE(rtc_get_reset_reason = 0x4000057c);
 PROVIDE(rom_config_instruction_cache_mode = 0x40001a1c);
-PROVIDE(rtc_get_wakeup_cause = 0x400005a0);
 PROVIDE(software_reset = 0x400006d8);
 PROVIDE(software_reset_cpu = 0x400006e4);


### PR DESCRIPTION
I messed this up in the first attempt - this is the fix.

Additionally, it fixes an annoying `unused function` warning
