### PR TITLE
Move rwtext after other RAM data sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ Cargo.lock
 
 # Other
 **/settings.json
+
+# wokwi related files
+diagram.json
+wokwi.toml
+
+# vscode
+.vscode

--- a/esp32c6-hal/ld/bl-riscv-link.x
+++ b/esp32c6-hal/ld/bl-riscv-link.x
@@ -82,8 +82,8 @@ INSERT BEFORE .rodata;
 /* Shared sections - ordering matters */
 INCLUDE "text.x"
 INCLUDE "rodata.x"
-INCLUDE "rwtext.x"
 INCLUDE "rwdata.x"
+INCLUDE "rwtext.x"
 INCLUDE "rtc_fast.x"
 /* End of Shared sections */
 


### PR DESCRIPTION
I have to admit, I'm not entirely sure why this works, but I do know the ordering of some sections matters so I guess that's it. I ran all the other examples for the C6 to check for regressions, and the rest still worked.

I also added some gitignore updates because I'm really really tired of having to remember the debug & wokwi configurations :D, let me know if this is an issue though and I'll remove it.


Closes #462 