### PR TITLE
fix CpuControl::start_app_core signature

### DIFF
--- a/esp-hal-common/src/soc/esp32/cpu_control.rs
+++ b/esp-hal-common/src/soc/esp32/cpu_control.rs
@@ -187,10 +187,10 @@ impl CpuControl {
     /// The second core will start running the closure `entry`.
     ///
     /// Dropping the returned guard will park the core.
-    pub fn start_app_core(
+    pub fn start_app_core<'a>(
         &mut self,
-        entry: &mut (dyn FnMut() + Send),
-    ) -> Result<AppCoreGuard, Error> {
+        entry: &'a mut (dyn FnMut() + Send),
+    ) -> Result<AppCoreGuard<'a>, Error> {
         let dport_control = crate::peripherals::DPORT::PTR;
         let dport_control = unsafe { &*dport_control };
 

--- a/esp-hal-common/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal-common/src/soc/esp32s3/cpu_control.rs
@@ -122,10 +122,10 @@ impl CpuControl {
     /// The second core will start running the closure `entry`.
     ///
     /// Dropping the returned guard will park the core.
-    pub fn start_app_core(
+    pub fn start_app_core<'a>(
         &mut self,
-        entry: &mut (dyn FnMut() + Send),
-    ) -> Result<AppCoreGuard, Error> {
+        entry: &'a mut (dyn FnMut() + Send),
+    ) -> Result<AppCoreGuard<'a>, Error> {
         let system_control = crate::peripherals::SYSTEM::PTR;
         let system_control = unsafe { &*system_control };
 


### PR DESCRIPTION
I now understand why those lifetime bounds were there in the first place, sorry for removing them in 2f3b6c843ca6015c6e6feac8cfbd8c3c4a004c70.

Should I find a way to add a `compile fail` test?
It could look like this:
```rust
fn test(mut cpu_control: CpuControl) {
    let mut val = 0;

    let _guard = cpu_control.start_app_core(&mut || val = 1).unwrap();

    val = 2;
}
```