### PR TITLE
Minor linker script additions

### DIFF
--- a/esp-hal-common/ld/sections/rodata.x
+++ b/esp-hal-common/ld/sections/rodata.x
@@ -6,6 +6,7 @@ SECTIONS {
     _rodata_start = ABSOLUTE(.);
     . = ALIGN (4);
     *(.rodata .rodata.*)
+    *(.srodata .srodata.*)
     _rodata_end = ABSOLUTE(.);
   } > RODATA
 

--- a/esp32-hal/ld/link-esp32.x
+++ b/esp32-hal/ld/link-esp32.x
@@ -28,7 +28,7 @@ INCLUDE "rtc_slow.x"
 INCLUDE "external.x"
 /* End of Shared sections */
 
-// an uninitialized section for use as the wifi-heap in esp-wifi
+/* an uninitialized section for use as the wifi-heap in esp-wifi */
 SECTIONS {
     .dram2_uninit (NOLOAD) : ALIGN(4) {
         *(.dram2_uninit)

--- a/esp32-hal/ld/link-esp32.x
+++ b/esp32-hal/ld/link-esp32.x
@@ -28,6 +28,13 @@ INCLUDE "rtc_slow.x"
 INCLUDE "external.x"
 /* End of Shared sections */
 
+// an uninitialized section for use as the wifi-heap in esp-wifi
+SECTIONS {
+    .dram2_uninit (NOLOAD) : ALIGN(4) {
+        *(.dram2_uninit)
+    } > dram2_seg
+}
+
 _heap_end = ABSOLUTE(ORIGIN(dram_seg))+LENGTH(dram_seg) - 2*STACK_SIZE;
 
 _stack_start_cpu1 = _heap_end;


### PR DESCRIPTION
While implementing mbedtls support a few changes to the linker scripts were needed.

Additionally, this adds the `.dram2_uninit` section for ESP32 since TLS needs a lot of memory and wouldn't be useable otherwise with esp-wifi

There will be also a PR for esp-wifi in preparation of mbedtls support.
