### PR TITLE
Use 192 as mclk_multiple for 24-bit I2S

### DIFF
--- a/esp-hal-common/src/i2s.rs
+++ b/esp-hal-common/src/i2s.rs
@@ -1978,7 +1978,9 @@ mod private {
         //
         // main difference is we are using fixed-point arithmetic here
 
-        let mclk_multiple = 256;
+        // If data_bits is a power of two, use 256 as the mclk_multiple
+        // If data_bits is 24, use 192 (24 * 8) as the mclk_multiple
+        let mclk_multiple = if data_bits == 24 { 192 } else { 256 };
         let sclk = 160_000_000; // for now it's fixed PLL_160M_CLK
 
         let rate_hz: HertzU32 = sample_rate.into();


### PR DESCRIPTION
In I2S, I2SO_BCK and I2SI_BCK are generated from I2S_TX_CLK and I2S_RX_CLK respectively using an integer clock divider (ref ESP32C3 TRM p607). The existing code uses a x256 multiplier of the sample rate to generate I2S_?X_CLK in all cases. However, because 24 isn't a power of two, that means that there isn't a valid integer divisor when the bit depth is set to 24.
e.g. 2 channels, 24-bits, 48 kHz:
- BCLK should be 2.304 MHz
- MCLK is computed as 12.288 MHz
- MLCK / BCK = 5.33333...

Since we don't have a fractional divider, the closest integer is 5, which causes the BCLK to run at 2.4576 MHz and the LRCLK to run at 51.2 kHz, which is too fast.
The only way to avoid this is to use a different multiplier, one that is a multiple of 24. My CODEC (TI PCM3060) accepts 192, which seems like a reasonable option.
This patch modifies the `calculate_clock` function to make it use 192 for the 24-bit case and 256 in all others (all the other supported bit depths are powers of two).

I've tested this change on an esp32c3 and verified that the BCLK and LRCLK are correct after the change.