### PR TITLE
use bitflags to decode wakeup cause

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -12,6 +12,7 @@ repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 
 [dependencies]
+bitflags             = "2.1.0"
 cfg-if               = "1.0.0"
 critical-section     = "1.1.1"
 embedded-can         = { version = "0.4.1", optional = true }

--- a/esp-hal-common/src/reset.rs
+++ b/esp-hal-common/src/reset.rs
@@ -30,39 +30,41 @@ pub enum SleepSource {
     BT,
 }
 
-#[allow(unused)]
-pub(crate) enum WakeupReason {
-    NoSleep         = 0,
-    #[cfg(pm_support_ext0_wakeup)]
-    /// EXT0 GPIO wakeup
-    ExtEvent0Trig   = 1 << 0,
-    #[cfg(pm_support_ext1_wakeup)]
-    /// EXT1 GPIO wakeup
-    ExtEvent1Trig   = 1 << 1,
-    /// GPIO wakeup (light sleep only)
-    GpioTrigEn      = 1 << 2,
-    /// Timer wakeup
-    TimerTrigEn     = 1 << 3,
-    #[cfg(pm_support_wifi_wakeup)]
-    /// MAC wakeup (light sleep only)
-    WifiTrigEn      = 1 << 5,
-    /// UART0 wakeup (light sleep only)
-    Uart0TrigEn     = 1 << 6,
-    /// UART1 wakeup (light sleep only)
-    Uart1TrigEn     = 1 << 7,
-    #[cfg(pm_support_touch_sensor_wakeup)]
-    /// Touch wakeup
-    TouchTrigEn     = 1 << 8,
-    #[cfg(ulp_supported)]
-    /// ULP wakeup
-    UlpTrigEn       = 1 << 9,
-    #[cfg(pm_support_bt_wakeup)]
-    /// BT wakeup (light sleep only)
-    BtTrigEn        = 1 << 10,
-    #[cfg(riscv_coproc_supported)]
-    CocpuTrigEn     = 1 << 11,
-    #[cfg(riscv_coproc_supported)]
-    CocpuTrapTrigEn = 1 << 13,
+bitflags::bitflags! {
+    #[allow(unused)]
+    pub(crate) struct WakeupReason: u16 {
+        const NoSleep         = 0;
+        #[cfg(pm_support_ext0_wakeup)]
+        /// EXT0 GPIO wakeup
+        const ExtEvent0Trig   = 1 << 0;
+        #[cfg(pm_support_ext1_wakeup)]
+        /// EXT1 GPIO wakeup
+        const ExtEvent1Trig   = 1 << 1;
+        /// GPIO wakeup (light sleep only)
+        const GpioTrigEn      = 1 << 2;
+        /// Timer wakeup
+        const TimerTrigEn     = 1 << 3;
+        #[cfg(pm_support_wifi_wakeup)]
+        /// MAC wakeup (light sleep only)
+        const WifiTrigEn      = 1 << 5;
+        /// UART0 wakeup (light sleep only)
+        const Uart0TrigEn     = 1 << 6;
+        /// UART1 wakeup (light sleep only)
+        const Uart1TrigEn     = 1 << 7;
+        #[cfg(pm_support_touch_sensor_wakeup)]
+        /// Touch wakeup
+        const TouchTrigEn     = 1 << 8;
+        #[cfg(ulp_supported)]
+        /// ULP wakeup
+        const UlpTrigEn       = 1 << 9;
+        #[cfg(pm_support_bt_wakeup)]
+        /// BT wakeup (light sleep only)
+        const BtTrigEn        = 1 << 10;
+        #[cfg(riscv_coproc_supported)]
+        const CocpuTrigEn     = 1 << 11;
+        #[cfg(riscv_coproc_supported)]
+        const CocpuTrapTrigEn = 1 << 13;
+    }
 }
 
 pub fn software_reset() {

--- a/esp-hal-common/src/reset.rs
+++ b/esp-hal-common/src/reset.rs
@@ -32,7 +32,7 @@ pub enum SleepSource {
 
 bitflags::bitflags! {
     #[allow(unused)]
-    pub(crate) struct WakeupReason: u16 {
+    pub(crate) struct WakeupReason: u32 {
         const NoSleep         = 0;
         #[cfg(pm_support_ext0_wakeup)]
         /// EXT0 GPIO wakeup

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -760,24 +760,24 @@ pub fn get_wakeup_cause() -> SleepSource {
     }
 
     #[cfg(esp32c6)]
-    let wakeup_cause = unsafe {
+    let wakeup_cause = WakeupReason::from_bits_retain(unsafe {
         (&*crate::peripherals::PMU::PTR)
             .slp_wakeup_status0
             .read()
             .wakeup_cause()
             .bits()
-    };
+    });
     #[cfg(not(any(esp32, esp32c6)))]
-    let wakeup_cause = unsafe {
+    let wakeup_cause = WakeupReason::from_bits_retain(unsafe {
         (&*RTC_CNTL::PTR)
             .slp_wakeup_cause
             .read()
             .wakeup_cause()
             .bits()
-    };
+    });
     #[cfg(esp32)]
     let wakeup_cause = WakeupReason::from_bits_retain(unsafe {
-        (&*RTC_CNTL::PTR).wakeup_state.read().wakeup_cause().bits()
+        (&*RTC_CNTL::PTR).wakeup_state.read().wakeup_cause().bits() as u32
     });
 
     if wakeup_cause.contains(WakeupReason::TimerTrigEn) {

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -776,52 +776,53 @@ pub fn get_wakeup_cause() -> SleepSource {
             .bits()
     };
     #[cfg(esp32)]
-    let wakeup_cause =
-        unsafe { (&*RTC_CNTL::PTR).wakeup_state.read().wakeup_cause().bits() as u32 };
+    let wakeup_cause = WakeupReason::from_bits_retain(unsafe {
+        (&*RTC_CNTL::PTR).wakeup_state.read().wakeup_cause().bits()
+    });
 
-    if (wakeup_cause & WakeupReason::TimerTrigEn as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::TimerTrigEn) {
         return SleepSource::Timer;
     }
-    if (wakeup_cause & WakeupReason::GpioTrigEn as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::GpioTrigEn) {
         return SleepSource::Gpio;
     }
-    if (wakeup_cause & (WakeupReason::Uart0TrigEn as u32 | WakeupReason::Uart1TrigEn as u32)) != 0 {
+    if wakeup_cause.intersects(WakeupReason::Uart0TrigEn | WakeupReason::Uart1TrigEn) {
         return SleepSource::Uart;
     }
 
     #[cfg(pm_support_ext0_wakeup)]
-    if (wakeup_cause & WakeupReason::ExtEvent0Trig as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::ExtEvent0Trig) {
         return SleepSource::Ext0;
     }
     #[cfg(pm_support_ext1_wakeup)]
-    if (wakeup_cause & WakeupReason::ExtEvent1Trig as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::ExtEvent1Trig) {
         return SleepSource::Ext1;
     }
 
     #[cfg(pm_support_touch_sensor_wakeup)]
-    if (wakeup_cause & WakeupReason::TouchTrigEn as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::TouchTrigEn) {
         return SleepSource::TouchPad;
     }
 
     #[cfg(ulp_supported)]
-    if (wakeup_cause & WakeupReason::UlpTrigEn as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::UlpTrigEn) {
         return SleepSource::Ulp;
     }
 
     #[cfg(pm_support_wifi_wakeup)]
-    if (wakeup_cause & WakeupReason::WifiTrigEn as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::WifiTrigEn) {
         return SleepSource::Wifi;
     }
 
     #[cfg(pm_support_bt_wakeup)]
-    if (wakeup_cause & WakeupReason::BtTrigEn as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::BtTrigEn) {
         return SleepSource::BT;
     }
 
     #[cfg(riscv_coproc_supported)]
-    if (wakeup_cause & WakeupReason::CocpuTrigEn as u32) != 0 {
+    if wakeup_cause.contains(WakeupReason::CocpuTrigEn) {
         return SleepSource::Ulp;
-    } else if (wakeup_cause & WakeupReason::CocpuTrapTrigEn as u32) != 0 {
+    } else if wakeup_cause.contains(WakeupReason::CocpuTrapTrigEn) {
         return SleepSource::CocpuTrapTrig;
     }
 


### PR DESCRIPTION
Instead of casting an enum to a u32 and anding with wakeup cause we can use bitflags and just check if it contains() the flag or intersects() with a set of flags.

Personally I find this much cleaner and more readable.
