### PR TITLE
Add LEDC duty-cycle fading support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add blinky_erased_pins example for ESP32-H2 (#530)
 - Add initial support for I2C in ESP32-H2 (#538)
 - Implement Copy and Eq for EspTwaiError (#540)
+- Add LEDC hardware fade support
 
 ### Fixed
 

--- a/esp-hal-common/src/ledc/mod.rs
+++ b/esp-hal-common/src/ledc/mod.rs
@@ -1,9 +1,8 @@
 //! LEDC (LED PWM Controller) peripheral control
 //!
-//! Currently only supports fixed-frequency output. Hardware fade support and
-//! interrupts are not currently implemented. High Speed channels are availble
-//! for the ESP32 only, while Low Speed channels are available for all supported
-//! chips.
+//! Currently only supports fixed-frequency output. Interrupts are not currently
+//! implemented. High Speed channels are available for the ESP32 only, while Low
+//! Speed channels are available for all supported chips.
 //!
 //! # LowSpeed Example:
 //!
@@ -61,7 +60,6 @@
 //! # TODO
 //!
 //! - Source clock selection
-//! - Hardware fade support
 //! - Interrupts
 
 use self::{

--- a/esp-hal-common/src/ledc/timer.rs
+++ b/esp-hal-common/src/ledc/timer.rs
@@ -114,6 +114,9 @@ pub trait TimerIFace<S: TimerSpeed> {
 
     /// Return the timer number
     fn get_number(&self) -> Number;
+
+    /// Return the timer frequency, or 0 if not configured
+    fn get_frequency(&self) -> u32;
 }
 
 /// Interface for HW configuration of timer
@@ -134,6 +137,7 @@ pub struct Timer<'a, S: TimerSpeed> {
     clock_control_config: &'a Clocks<'a>,
     number: Number,
     duty: Option<config::Duty>,
+    frequency: u32,
     configured: bool,
     use_ref_tick: bool,
     clock_source: Option<S::ClockSourceType>,
@@ -157,6 +161,7 @@ where
         let src_freq: u32 = self.get_freq().unwrap().to_Hz();
         let precision = 1 << config.duty as u32;
         let frequency: u32 = config.frequency.raw();
+        self.frequency = frequency;
 
         let mut divisor = ((src_freq as u64) << 8) / frequency as u64 / precision as u64;
 
@@ -193,6 +198,11 @@ where
     fn get_number(&self) -> Number {
         self.number
     }
+
+    /// Return the timer frequency
+    fn get_frequency(&self) -> u32 {
+        self.frequency
+    }
 }
 
 impl<'a, S: TimerSpeed> Timer<'a, S> {
@@ -207,6 +217,7 @@ impl<'a, S: TimerSpeed> Timer<'a, S> {
             clock_control_config,
             number,
             duty: None,
+            frequency: 0u32,
             configured: false,
             use_ref_tick: false,
             clock_source: None,

--- a/esp32-hal/examples/ledc.rs
+++ b/esp32-hal/examples/ledc.rs
@@ -67,5 +67,16 @@ fn main() -> ! {
         })
         .unwrap();
 
-    loop {}
+    channel0.start_duty_fade(0, 100, 2000).expect_err(
+        "Fading from 0% to 100%, at 24kHz and 5-bit resolution, over 2 seconds, should fail",
+    );
+
+    loop {
+        // Set up a breathing LED: fade from off to on over a second, then
+        // from on back off over the next second.  Then loop.
+        channel0.start_duty_fade(0, 100, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+        channel0.start_duty_fade(100, 0, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+    }
 }

--- a/esp32c2-hal/examples/ledc.rs
+++ b/esp32c2-hal/examples/ledc.rs
@@ -70,5 +70,16 @@ fn main() -> ! {
         })
         .unwrap();
 
-    loop {}
+    channel0.start_duty_fade(0, 100, 2000).expect_err(
+        "Fading from 0% to 100%, at 24kHz and 5-bit resolution, over 2 seconds, should fail",
+    );
+
+    loop {
+        // Set up a breathing LED: fade from off to on over a second, then
+        // from on back off over the next second.  Then loop.
+        channel0.start_duty_fade(0, 100, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+        channel0.start_duty_fade(100, 0, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+    }
 }

--- a/esp32c3-hal/examples/ledc.rs
+++ b/esp32c3-hal/examples/ledc.rs
@@ -1,5 +1,5 @@
 //! Turns on LED with the option to change LED intensity depending on `duty`
-//! value. Possible values (`u32`) are in range 0..100.
+//! value, then fades it. Possible starting values (`u32`) are in range 0..100.
 //!
 //! This assumes that a LED is connected to the pin assigned to `led`. (GPIO4)
 
@@ -77,5 +77,16 @@ fn main() -> ! {
         })
         .unwrap();
 
-    loop {}
+    channel0.start_duty_fade(0, 100, 2000).expect_err(
+        "Fading from 0% to 100%, at 24kHz and 5-bit resolution, over 2 seconds, should fail",
+    );
+
+    loop {
+        // Set up a breathing LED: fade from off to on over a second, then
+        // from on back off over the next second.  Then loop.
+        channel0.start_duty_fade(0, 100, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+        channel0.start_duty_fade(100, 0, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+    }
 }

--- a/esp32c6-hal/examples/ledc.rs
+++ b/esp32c6-hal/examples/ledc.rs
@@ -79,5 +79,16 @@ fn main() -> ! {
         })
         .unwrap();
 
-    loop {}
+    channel0.start_duty_fade(0, 100, 2000).expect_err(
+        "Fading from 0% to 100%, at 24kHz and 5-bit resolution, over 2 seconds, should fail",
+    );
+
+    loop {
+        // Set up a breathing LED: fade from off to on over a second, then
+        // from on back off over the next second.  Then loop.
+        channel0.start_duty_fade(0, 100, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+        channel0.start_duty_fade(100, 0, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+    }
 }

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -72,5 +72,16 @@ fn main() -> ! {
         })
         .unwrap();
 
-    loop {}
+    channel0.start_duty_fade(0, 100, 2000).expect_err(
+        "Fading from 0% to 100%, at 24kHz and 5-bit resolution, over 2 seconds, should fail",
+    );
+
+    loop {
+        // Set up a breathing LED: fade from off to on over a second, then
+        // from on back off over the next second.  Then loop.
+        channel0.start_duty_fade(0, 100, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+        channel0.start_duty_fade(100, 0, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+    }
 }

--- a/esp32s3-hal/examples/ledc.rs
+++ b/esp32s3-hal/examples/ledc.rs
@@ -71,5 +71,16 @@ fn main() -> ! {
         })
         .unwrap();
 
-    loop {}
+    channel0.start_duty_fade(0, 100, 2000).expect_err(
+        "Fading from 0% to 100%, at 24kHz and 5-bit resolution, over 2 seconds, should fail",
+    );
+
+    loop {
+        // Set up a breathing LED: fade from off to on over a second, then
+        // from on back off over the next second.  Then loop.
+        channel0.start_duty_fade(0, 100, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+        channel0.start_duty_fade(100, 0, 1000).unwrap();
+        while channel0.is_duty_fade_running() {}
+    }
 }


### PR DESCRIPTION
This code may work for other chips as well; I haven't read their reference manuals.  For now it's feature-gated to just the c3.

And without interrupts it's hard to tell when a fade has finished (for example to start another), but it seems like a reasonable start to me.