### PR TITLE
implement fetching the RTC timer value in milliseconds and mircroseconds

### DIFF
--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -4,16 +4,16 @@ use fugit::HertzU32;
 use fugit::MicrosDurationU64;
 
 pub use self::rtc::SocResetReason;
-use crate::clock::Clock;
 #[cfg(not(esp32c6))]
 use crate::clock::XtalClock;
 #[cfg(not(esp32))]
 use crate::efuse::Efuse;
 #[cfg(esp32c6)]
-use crate::peripherals::{LP_WDT, LP_TIMER};
+use crate::peripherals::{LP_TIMER, LP_WDT};
 #[cfg(not(esp32c6))]
 use crate::peripherals::{RTC_CNTL, TIMG0};
 use crate::{
+    clock::Clock,
     peripheral::{Peripheral, PeripheralRef},
     reset::{SleepSource, WakeupReason},
     Cpu,
@@ -143,7 +143,6 @@ impl<'d> Rtc<'d> {
 
     /// read the current value of the rtc time registers.
     pub fn get_time_raw(&self) -> u64 {
-        
         #[cfg(not(esp32c6))]
         let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
         #[cfg(esp32c6)]

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -151,7 +151,12 @@ impl<'d> Rtc<'d> {
         #[cfg(esp32)]
         let (l, h) = {
             rtc_cntl.time_update.write(|w| w.time_update().set_bit());
-            while rtc_cntl.time_update.read().time_valid().bit_is_clear() {}
+            while rtc_cntl.time_update.read().time_valid().bit_is_clear() {
+                unsafe {
+                    // might take 1 RTC slowclk period, don't flood RTC bus
+                    ets_delay_us(1);
+                }
+            }
             let h = rtc_cntl.time1.read().time_hi().bits();
             let l = rtc_cntl.time0.read().time_lo().bits();
             (l, h)

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -4,12 +4,13 @@ use fugit::HertzU32;
 use fugit::MicrosDurationU64;
 
 pub use self::rtc::SocResetReason;
+use crate::clock::Clock;
 #[cfg(not(esp32c6))]
-use crate::clock::{Clock, XtalClock};
+use crate::clock::XtalClock;
 #[cfg(not(esp32))]
 use crate::efuse::Efuse;
 #[cfg(esp32c6)]
-use crate::peripherals::LP_WDT;
+use crate::peripherals::{LP_WDT, LP_TIMER};
 #[cfg(not(esp32c6))]
 use crate::peripherals::{RTC_CNTL, TIMG0};
 use crate::{
@@ -138,6 +139,49 @@ impl<'d> Rtc<'d> {
     #[cfg(not(esp32c6))]
     pub fn estimate_xtal_frequency(&mut self) -> u32 {
         RtcClock::estimate_xtal_frequency()
+    }
+
+    /// read the current value of the rtc time registers.
+    pub fn get_time_raw(&self) -> u64 {
+        
+        #[cfg(not(esp32c6))]
+        let rtc_cntl = unsafe { &*RTC_CNTL::ptr() };
+        #[cfg(esp32c6)]
+        let rtc_cntl = unsafe { &*LP_TIMER::ptr() };
+
+        #[cfg(esp32)]
+        let (l, h) = {
+            rtc_cntl.time_update.write(|w| w.time_update().set_bit());
+            while rtc_cntl.time_update.read().time_valid().bit_is_clear() {}
+            let h = rtc_cntl.time1.read().time_hi().bits();
+            let l = rtc_cntl.time0.read().time_lo().bits();
+            (l, h)
+        };
+        #[cfg(any(esp32c2, esp32c3, esp32s3, esp32s2))]
+        let (l, h) = {
+            rtc_cntl.time_update.write(|w| w.time_update().set_bit());
+            let h = rtc_cntl.time_high0.read().timer_value0_high().bits();
+            let l = rtc_cntl.time_low0.read().timer_value0_low().bits();
+            (l, h)
+        };
+        #[cfg(esp32c6)]
+        let (l, h) = {
+            rtc_cntl.update.write(|w| w.main_timer_update().set_bit());
+            let h = rtc_cntl.main_buf0_high.read().main_timer_buf0_high().bits();
+            let l = rtc_cntl.main_buf0_low.read().main_timer_buf0_low().bits();
+            (l, h)
+        };
+        ((h as u64) << 32) | (l as u64)
+    }
+
+    /// read the current value of the rtc time registers in microseconds.
+    pub fn get_time_us(&self) -> u64 {
+        self.get_time_raw() * 1_000_000 / RtcClock::get_slow_freq().frequency().to_Hz() as u64
+    }
+
+    /// read the current value of the rtc time registers in milliseconds
+    pub fn get_time_ms(&self) -> u64 {
+        self.get_time_raw() * 1_000 / RtcClock::get_slow_freq().frequency().to_Hz() as u64
     }
 }
 

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32c6.rs
@@ -300,7 +300,7 @@ impl RtcClock {
     }
 
     /// Get the RTC_SLOW_CLK source
-    fn get_slow_freq() -> RtcSlowClock {
+    pub(crate) fn get_slow_freq() -> RtcSlowClock {
         let lp_clrst = unsafe { &*LP_CLKRST::ptr() };
 
         let slow_freq = lp_clrst.lp_clk_conf.read().slow_clk_sel().bits();

--- a/esp32-hal/examples/rtc_time.rs
+++ b/esp32-hal/examples/rtc_time.rs
@@ -1,0 +1,43 @@
+//! Prints time in milliseconds from the RTC Timer
+
+#![no_std]
+#![no_main]
+
+use esp32_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    wdt.disable();
+    rtc.rwdt.disable();
+
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        esp_println::println!("rtc time in milliseconds is {}", rtc.get_time_ms());
+        delay.delay_ms(1000u32);
+    }
+}

--- a/esp32-hal/examples/rtc_time.rs
+++ b/esp32-hal/examples/rtc_time.rs
@@ -31,7 +31,6 @@ fn main() -> ! {
     wdt.disable();
     rtc.rwdt.disable();
 
-
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
     let mut delay = Delay::new(&clocks);

--- a/esp32c2-hal/examples/rtc_time.rs
+++ b/esp32c2-hal/examples/rtc_time.rs
@@ -1,0 +1,44 @@
+//! Prints time in milliseconds from the RTC Timer
+
+#![no_std]
+#![no_main]
+
+use esp32c2_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        esp_println::println!("rtc time in milliseconds is {}", rtc.get_time_ms());
+        delay.delay_ms(1000u32);
+    }
+}

--- a/esp32c3-hal/examples/rtc_time.rs
+++ b/esp32c3-hal/examples/rtc_time.rs
@@ -1,0 +1,51 @@
+//! Prints time in milliseconds from the RTC Timer
+
+#![no_std]
+#![no_main]
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
+    // the RTC WDT, and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        esp_println::println!("rtc time in milliseconds is {}", rtc.get_time_ms());
+        delay.delay_ms(1000u32);
+    }
+}

--- a/esp32c6-hal/examples/rtc_time.rs
+++ b/esp32c6-hal/examples/rtc_time.rs
@@ -1,0 +1,51 @@
+//! Prints time in milliseconds from the RTC Timer
+
+#![no_std]
+#![no_main]
+
+use esp32c6_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
+    // and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        esp_println::println!("rtc time in milliseconds is {}", rtc.get_time_ms());
+        delay.delay_ms(1000u32);
+    }
+}

--- a/esp32s2-hal/examples/rtc_time.rs
+++ b/esp32s2-hal/examples/rtc_time.rs
@@ -1,0 +1,42 @@
+//! Prints time in milliseconds from the RTC Timer
+
+#![no_std]
+#![no_main]
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        esp_println::println!("rtc time in milliseconds is {}", rtc.get_time_ms());
+        delay.delay_ms(1000u32);
+    }
+}

--- a/esp32s3-hal/examples/rtc_time.rs
+++ b/esp32s3-hal/examples/rtc_time.rs
@@ -1,0 +1,42 @@
+//! Prints time in milliseconds from the RTC Timer
+
+#![no_std]
+#![no_main]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    // Initialize the Delay peripheral, and use it to toggle the LED state in a
+    // loop.
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        esp_println::println!("rtc time in milliseconds is {}", rtc.get_time_ms());
+        delay.delay_ms(1000u32);
+    }
+}


### PR DESCRIPTION
This implements `get_time_ms()` and `get_time_us()` on `rtc_cntl::Rtc` examples are included and have been tested on all cpu types except `esp32c2`.

Random notes:
- in the pac for esp32c6 what was all in RTC_CNTL seems broken out into a number of LP_X peripherals.
- should these be combind  in the hal api or should they remain seperate? If seperate should we do the same with other chips?

