### PR TITLE
Update to `embedded-hal@1.0.0-alpha.10` and `embedded-hal-nb@1.0.0-alpha.2`

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -18,8 +18,8 @@ critical-section     = "1.1.1"
 embedded-can         = { version = "0.4.1", optional = true }
 embedded-dma         = "0.2.0"
 embedded-hal         = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1       = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
-embedded-hal-nb      = { version = "=1.0.0-alpha.1", optional = true }
+embedded-hal-1       = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
+embedded-hal-nb      = { version = "=1.0.0-alpha.2", optional = true }
 esp-synopsys-usb-otg = { version = "0.3.1", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.6"
 lock_api             = { version = "0.4.9", optional = true }

--- a/esp-hal-common/src/delay.rs
+++ b/esp-hal-common/src/delay.rs
@@ -28,12 +28,8 @@ where
 
 #[cfg(feature = "eh1")]
 impl embedded_hal_1::delay::DelayUs for Delay {
-    type Error = core::convert::Infallible;
-
-    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+    fn delay_us(&mut self, us: u32) {
         self.delay(us);
-
-        Ok(())
     }
 }
 

--- a/esp-hal-common/src/i2c.rs
+++ b/esp-hal-common/src/i2c.rs
@@ -212,13 +212,6 @@ where
         self.peripheral.master_write(address, bytes)
     }
 
-    fn write_iter<B>(&mut self, _address: u8, _bytes: B) -> Result<(), Self::Error>
-    where
-        B: IntoIterator<Item = u8>,
-    {
-        todo!()
-    }
-
     fn write_read(
         &mut self,
         address: u8,
@@ -228,30 +221,11 @@ where
         self.peripheral.master_write_read(address, bytes, buffer)
     }
 
-    fn write_iter_read<B>(
-        &mut self,
-        _address: u8,
-        _bytes: B,
-        _buffer: &mut [u8],
-    ) -> Result<(), Self::Error>
-    where
-        B: IntoIterator<Item = u8>,
-    {
-        todo!()
-    }
-
     fn transaction<'a>(
         &mut self,
         _address: u8,
         _operations: &mut [embedded_hal_1::i2c::Operation<'a>],
     ) -> Result<(), Self::Error> {
-        todo!()
-    }
-
-    fn transaction_iter<'a, O>(&mut self, _address: u8, _operations: O) -> Result<(), Self::Error>
-    where
-        O: IntoIterator<Item = embedded_hal_1::i2c::Operation<'a>>,
-    {
         todo!()
     }
 }

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -27,9 +27,9 @@ categories = [
 [dependencies]
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
+embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -27,9 +27,9 @@ categories = [
 [dependencies]
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
+embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32c2"], path = "../esp-hal-common" }
 
 [dev-dependencies]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -28,9 +28,9 @@ categories = [
 cfg-if             = "1.0.0"
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
+embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32c3"], path = "../esp-hal-common" }
 

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -29,9 +29,9 @@ categories = [
 cfg-if             = "1.0.0"
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
+embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32c6"], path = "../esp-hal-common" }
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -27,9 +27,9 @@ categories = [
 [dependencies]
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
+embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-atomic-emulation-trap = { version = "0.4.0" }
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -28,9 +28,9 @@ categories = [
 bare-metal         = "1.0.0"
 embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.9", optional = true, package = "embedded-hal" }
+embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.1", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32s3"], path = "../esp-hal-common" }
 r0                 = { version = "1.0.0",  optional = true }


### PR DESCRIPTION
The changes in the new `embedded-hal` release affect `Delay`, `I2C`, and `SPI`.

The changes for `Delay` and `I2C` were trivial. `SPI` was a bit more interesting; `SpiDevice` has changed, and there are additionally now `SpiDeviceRead` and `SpiDeviceWrite` traits.

We don't really have any examples exercising the alpha `Delay` or `I2C` traits, so wasn't really able to test that. Assuming the previous implementation works, though, there's no reason to believe these changes should make any difference.

I was able to test `SpiDevice` at least using the `spi_eh1_device_loopback` example, which succeeded, however the new traits have not been directly tested. With that said, their implementations are the same as `SpiDevice`, so no reason to expect them not to work.

My knowledge is admittedly lacking when it comes to the `core::cell` module, so I wasn't really sure why I had to dereference the `bus` variable, but that made the compiler happy at least. If there's better syntax for this lemme know.

Closes #468