### PR TITLE
Update `embedded-hal-async` and `embassy-*` dependencies

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -31,9 +31,9 @@ void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
 
 # async
-embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embassy-sync       = { version = "0.1.0", optional = true }
-embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
+embassy-sync       = { version = "0.2.0", optional = true }
+embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }
 
 # RISC-V
@@ -59,7 +59,7 @@ esp32s3 = { version = "0.18.0", features = ["critical-section"], optional = true
 
 [build-dependencies]
 basic-toml = "0.1.2"
-serde      = { version = "1.0.158", features = ["derive"] }
+serde      = { version = "1.0.160", features = ["derive"] }
 
 [features]
 esp32   = ["esp32/rt"  , "xtensa", "xtensa-lx/esp32",   "xtensa-lx-rt/esp32",   "lock_api", "procmacros/esp32"]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -36,7 +36,6 @@ esp-hal-common     = { version = "0.8.0",  features = ["esp32"], path = "../esp-
 aes               = "0.8.2"
 critical-section  = "1.1.1"
 crypto-bigint     = {version = "0.5.1", default-features = false}
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32"], path = "../esp-hal-smartled" }
@@ -45,6 +44,12 @@ sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+
+[dev-dependencies.embassy-executor]
+package  = "embassy-executor"
+git      = "https://github.com/embassy-rs/embassy/"
+rev      = "fb27594"
+features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"]
 
 [features]
 default            = ["rt", "vectored", "xtal40mhz"]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -25,26 +25,26 @@ categories = [
 ]
 
 [dependencies]
-embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.1",  features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.1",   optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.2",  optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes               = "0.8.2"
 critical-section  = "1.1.1"
+crypto-bigint     = {version = "0.5.1", default-features = false}
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.6.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.4.0", features = ["esp32"] }
+esp-println       = { version = "0.5.0", features = ["esp32"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
-crypto-bigint = {version = "0.5.0-pre.3",default-features = false}
 
 [features]
 default            = ["rt", "vectored", "xtal40mhz"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -34,13 +34,18 @@ esp-hal-common     = { version = "0.8.0", features = ["esp32c2"], path = "../esp
 
 [dev-dependencies]
 critical-section  = "1.1.1"
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.5.0", features = ["esp32c2"] }
 sha2              = { version = "0.10.6", default-features = false}
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+
+[dev-dependencies.embassy-executor]
+package  = "embassy-executor"
+git      = "https://github.com/embassy-rs/embassy/"
+rev      = "fb27594"
+features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"]
 
 [features]
 default              = ["rt", "vectored", "xtal40mhz"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -25,19 +25,19 @@ categories = [
 ]
 
 [dependencies]
-embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
-esp-hal-common     = { version = "0.8.0",  features = ["esp32c2"], path = "../esp-hal-common" }
+embedded-hal-async = { version = "0.2.0-alpha.1",   optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.2",  optional = true }
+esp-hal-common     = { version = "0.8.0", features = ["esp32c2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 critical-section  = "1.1.1"
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.6.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
-esp-println       = { version = "0.4.0", features = ["esp32c2"] }
+esp-backtrace     = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
+esp-println       = { version = "0.5.0", features = ["esp32c2"] }
 sha2              = { version = "0.10.6", default-features = false}
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -38,7 +38,6 @@ esp-hal-common     = { version = "0.8.0",  features = ["esp32c3"], path = "../es
 aes               = "0.8.2"
 critical-section  = "1.1.1"
 crypto-bigint     = {version = "0.5.1",default-features = false}
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
@@ -47,6 +46,12 @@ sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+
+[dev-dependencies.embassy-executor]
+package  = "embassy-executor"
+git      = "https://github.com/embassy-rs/embassy/"
+rev      = "fb27594"
+features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"]
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -26,10 +26,10 @@ categories = [
 
 [dependencies]
 cfg-if             = "1.0.0"
-embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32c3"], path = "../esp-hal-common" }
@@ -37,16 +37,16 @@ esp-hal-common     = { version = "0.8.0",  features = ["esp32c3"], path = "../es
 [dev-dependencies]
 aes               = "0.8.2"
 critical-section  = "1.1.1"
+crypto-bigint     = {version = "0.5.1",default-features = false}
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.6.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.4.0", features = ["esp32c3"] }
+esp-println       = { version = "0.5.0", features = ["esp32c3"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
-crypto-bigint = {version = "0.5.0-pre.3",default-features = false}
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -39,7 +39,6 @@ esp-hal-common     = { version = "0.8.0",  features = ["esp32c6"], path = "../es
 aes               = "0.8.2"
 critical-section  = "1.1.1"
 crypto-bigint     = {version = "0.5.1",default-features = false}
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
@@ -48,6 +47,12 @@ sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+
+[dev-dependencies.embassy-executor]
+package  = "embassy-executor"
+git      = "https://github.com/embassy-rs/embassy/"
+rev      = "fb27594"
+features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"]
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -27,10 +27,10 @@ categories = [
 
 [dependencies]
 cfg-if             = "1.0.0"
-embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32c6"], path = "../esp-hal-common" }
@@ -38,17 +38,16 @@ esp-hal-common     = { version = "0.8.0",  features = ["esp32c6"], path = "../es
 [dev-dependencies]
 aes               = "0.8.2"
 critical-section  = "1.1.1"
+crypto-bigint     = {version = "0.5.1",default-features = false}
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.6.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.4.0", features = ["esp32c6"] }
+esp-println       = { version = "0.5.0", features = ["esp32c6"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
-crypto-bigint = {version = "0.5.0-pre.3",default-features = false}
-
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -25,29 +25,29 @@ categories = [
 ]
 
 [dependencies]
-embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
-embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
-esp-hal-common     = { version = "0.8.0",  features = ["esp32s2"], path = "../esp-hal-common" }
+embassy-time                 = { version = "0.1.1", features = ["nightly"], optional = true }
+embedded-hal                 = { version = "0.2.7",  features = ["unproven"] }
+embedded-hal-1               = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
+embedded-hal-async           = { version = "0.2.0-alpha.1", optional = true }
+embedded-hal-nb              = { version = "=1.0.0-alpha.2", optional = true }
+esp-hal-common               = { version = "0.8.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-atomic-emulation-trap = { version = "0.4.0" }
 
 [dev-dependencies]
 aes               = "0.8.2"
 critical-section  = "1.1.1"
+crypto-bigint     = {version = "0.5.1",default-features = false}
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.6.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
+esp-backtrace     = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.4.0", features = ["esp32s2"] }
+esp-println       = { version = "0.5.0", features = ["esp32s2"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
 usb-device        = { version = "0.2.9" }
 usbd-serial       = "0.1.1"
-crypto-bigint = {version = "0.5.0-pre.3",default-features = false}
 
 [features]
 default   = ["rt", "vectored"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -37,7 +37,6 @@ xtensa-atomic-emulation-trap = { version = "0.4.0" }
 aes               = "0.8.2"
 critical-section  = "1.1.1"
 crypto-bigint     = {version = "0.5.1",default-features = false}
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
@@ -48,6 +47,12 @@ ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
 usb-device        = { version = "0.2.9" }
 usbd-serial       = "0.1.1"
+
+[dev-dependencies.embassy-executor]
+package  = "embassy-executor"
+git      = "https://github.com/embassy-rs/embassy/"
+rev      = "fb27594"
+features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"]
 
 [features]
 default   = ["rt", "vectored"]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -39,7 +39,6 @@ r0                 = { version = "1.0.0",  optional = true }
 aes               = "0.8.2"
 critical-section  = "1.1.1"
 crypto-bigint     = {version = "0.5.1",default-features = false}
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
@@ -50,6 +49,12 @@ ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
 usb-device        = "0.2.9"
 usbd-serial       = "0.1.1"
+
+[dev-dependencies.embassy-executor]
+package  = "embassy-executor"
+git      = "https://github.com/embassy-rs/embassy/"
+rev      = "fb27594"
+features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"]
 
 [features]
 default              = ["rt", "vectored"]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -26,10 +26,10 @@ categories = [
 
 [dependencies]
 bare-metal         = "1.0.0"
-embassy-time       = { version = "0.1.0", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.0", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.8.0",  features = ["esp32s3"], path = "../esp-hal-common" }
@@ -38,18 +38,18 @@ r0                 = { version = "1.0.0",  optional = true }
 [dev-dependencies]
 aes               = "0.8.2"
 critical-section  = "1.1.1"
+crypto-bigint     = {version = "0.5.1",default-features = false}
 embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"] }
 embedded-graphics = "0.7.1"
-esp-backtrace     = { version = "0.6.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace     = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.1.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.4.0", features = ["esp32s3"] }
+esp-println       = { version = "0.5.0", features = ["esp32s3"] }
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
-usb-device        = { version = "0.2.9" }
+usb-device        = "0.2.9"
 usbd-serial       = "0.1.1"
-crypto-bigint = {version = "0.5.0-pre.3",default-features = false}
 
 [features]
 default              = ["rt", "vectored"]


### PR DESCRIPTION
- No changes required for `embedded-hal-async`, only new traits were added
- The `embassy-executor` package now requires two additional features
- Updated `esp-backtrace` and `esp-println` while I was in here, as well