### PR TITLE
doc: remove `#[doc(inline)]` from esp-hal-common re-exports

### DIFF
--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -4,7 +4,6 @@
 pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
-#[doc(inline)]
 pub use esp_hal_common::*;
 
 pub use self::gpio::IO;

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -4,7 +4,6 @@
 pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
-#[doc(inline)]
 pub use esp_hal_common::*;
 
 pub use self::gpio::IO;

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -7,7 +7,6 @@ use core::mem::size_of;
 pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
-#[doc(inline)]
 pub use esp_hal_common::*;
 
 pub use self::gpio::IO;

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -4,9 +4,11 @@
 pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
-use esp_hal_common::xtensa_lx_rt::exception::ExceptionCause;
-#[doc(inline)]
 pub use esp_hal_common::*;
+
+#[rustfmt::skip]
+use esp_hal_common::xtensa_lx_rt::exception::ExceptionCause;
+
 // Always enable atomic emulation on ESP32-S2
 use xtensa_atomic_emulation_trap as _;
 

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -9,7 +9,6 @@
 pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
-#[doc(inline)]
 pub use esp_hal_common::*;
 
 pub use self::gpio::IO;


### PR DESCRIPTION
We no longer seem to need this in the latest version of Rust.

Previously, we added the `#[doc(inline)]` attribute in #256 to improve readability, but it appears that the effect of the attribute has been lost in the latest version of rustdoc.