### PR TITLE
Remove unnecessary generic from `UsbSerialJtag` driver

### DIFF
--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -6,24 +6,21 @@ use crate::{
     system::PeripheralClockControl,
 };
 
-pub struct UsbSerialJtag<'d, T> {
-    usb_serial: PeripheralRef<'d, T>,
+pub struct UsbSerialJtag<'d> {
+    usb_serial: PeripheralRef<'d, USB_DEVICE>,
 }
 
 /// Custom USB serial error type
 type Error = Infallible;
 
-impl<'d, T> UsbSerialJtag<'d, T>
-where
-    T: Instance,
-{
+impl<'d> UsbSerialJtag<'d> {
     /// Create a new USB serial/JTAG instance with defaults
     pub fn new(
-        usb_serial: impl Peripheral<P = T> + 'd,
+        usb_serial: impl Peripheral<P = USB_DEVICE> + 'd,
         peripheral_clock_control: &mut PeripheralClockControl,
     ) -> Self {
         crate::into_ref!(usb_serial);
-        // #[cfg(usb_device)]
+
         peripheral_clock_control.enable(crate::system::Peripheral::Sha);
         let mut dev = Self { usb_serial };
         dev.usb_serial.disable_rx_interrupts();
@@ -198,19 +195,13 @@ impl Instance for crate::peripherals::USB_DEVICE {
     }
 }
 
-impl<T> core::fmt::Write for UsbSerialJtag<'_, T>
-where
-    T: Instance,
-{
+impl core::fmt::Write for UsbSerialJtag<'_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         self.write_bytes(s.as_bytes()).map_err(|_| core::fmt::Error)
     }
 }
 
-impl<T> embedded_hal::serial::Read<u8> for UsbSerialJtag<'_, T>
-where
-    T: Instance,
-{
+impl embedded_hal::serial::Read<u8> for UsbSerialJtag<'_> {
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
@@ -218,10 +209,7 @@ where
     }
 }
 
-impl<T> embedded_hal::serial::Write<u8> for UsbSerialJtag<'_, T>
-where
-    T: Instance,
-{
+impl embedded_hal::serial::Write<u8> for UsbSerialJtag<'_> {
     type Error = Error;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -23,8 +23,7 @@ use esp32c3_hal::{
 use esp_backtrace as _;
 use nb::block;
 
-static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag<USB_DEVICE>>>> =
-    Mutex::new(RefCell::new(None));
+static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {

--- a/esp32c6-hal/examples/usb_serial_jtag.rs
+++ b/esp32c6-hal/examples/usb_serial_jtag.rs
@@ -22,8 +22,7 @@ use esp32c6_hal::{
 use esp_backtrace as _;
 use nb::block;
 
-static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag<USB_DEVICE>>>> =
-    Mutex::new(RefCell::new(None));
+static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -22,8 +22,7 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use nb::block;
 
-static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag<USB_DEVICE>>>> =
-    Mutex::new(RefCell::new(None));
+static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {


### PR DESCRIPTION
Just happened to notice this, there's only one instance of `USB_DEVICE` so we don't need the driver to be generic.