### PR TITLE
Implement `embedded_hal_nb::serial::*` traits for `UsbSerialJtag`

### DIFF
--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -12,7 +12,7 @@ use critical_section::Mutex;
 use esp32c3_hal::{
     clock::ClockControl,
     interrupt,
-    peripherals::{self, Peripherals, USB_DEVICE},
+    peripherals::{self, Peripherals},
     prelude::*,
     riscv,
     timer::TimerGroup,

--- a/esp32c6-hal/examples/usb_serial_jtag.rs
+++ b/esp32c6-hal/examples/usb_serial_jtag.rs
@@ -11,7 +11,7 @@ use critical_section::Mutex;
 use esp32c6_hal::{
     clock::ClockControl,
     interrupt,
-    peripherals::{self, Peripherals, USB_DEVICE},
+    peripherals::{self, Peripherals},
     prelude::*,
     riscv,
     timer::TimerGroup,

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -13,7 +13,7 @@ use critical_section::Mutex;
 use esp32s3_hal::{
     clock::ClockControl,
     interrupt,
-    peripherals::{self, Peripherals, USB_DEVICE},
+    peripherals::{self, Peripherals},
     prelude::*,
     timer::TimerGroup,
     Rtc,


### PR DESCRIPTION
Another small PR, these traits were never implemented for this peripheral (and they're essentially the same as the previous traits, so easy enough to add).

Also fixed some warnings I accidentally introduced in a previous PR.