### PR TITLE
DMA-enable SPI3 on ESP32-S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- DMA is supported for SPI3 on ESP32-S3
+- DMA is supported for SPI3 on ESP32-S3 (#507)
 
 ## [0.9.0] - 2023-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- DMA is supported for SPI3 on ESP32-S3
+
 ## [0.9.0] - 2023-05-02
 
 ### Added

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -442,6 +442,7 @@ macro_rules! impl_channel {
             // with GDMA every channel can be used for any peripheral
             impl SpiPeripheral for [<SuitablePeripheral $num>] {}
             impl Spi2Peripheral for [<SuitablePeripheral $num>] {}
+            impl Spi3Peripheral for [<SuitablePeripheral $num>] {}
             impl I2sPeripheral for [<SuitablePeripheral $num>] {}
             impl I2s0Peripheral for [<SuitablePeripheral $num>] {}
             impl I2s1Peripheral for [<SuitablePeripheral $num>] {}

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -442,6 +442,7 @@ macro_rules! impl_channel {
             // with GDMA every channel can be used for any peripheral
             impl SpiPeripheral for [<SuitablePeripheral $num>] {}
             impl Spi2Peripheral for [<SuitablePeripheral $num>] {}
+            #[cfg(esp32s3)]
             impl Spi3Peripheral for [<SuitablePeripheral $num>] {}
             impl I2sPeripheral for [<SuitablePeripheral $num>] {}
             impl I2s0Peripheral for [<SuitablePeripheral $num>] {}

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -732,7 +732,7 @@ pub mod dma {
 
     use embedded_dma::{ReadBuffer, WriteBuffer};
 
-    #[cfg(any(esp32, esp32s2))]
+    #[cfg(any(esp32, esp32s2, esp32s3))]
     use super::Spi3Instance;
     use super::{
         Address,
@@ -747,7 +747,7 @@ pub mod dma {
         SpiDataMode,
         MAX_DMA_SIZE,
     };
-    #[cfg(any(esp32, esp32s2))]
+    #[cfg(any(esp32, esp32s2, esp32s3))]
     use crate::dma::Spi3Peripheral;
     use crate::{
         dma::{Channel, DmaTransfer, DmaTransferRxTx, Rx, Spi2Peripheral, SpiPeripheral, Tx},
@@ -765,7 +765,7 @@ pub mod dma {
         fn with_dma(self, channel: Channel<TX, RX, P>) -> SpiDma<'d, T, TX, RX, P, M>;
     }
 
-    #[cfg(any(esp32, esp32s2))]
+    #[cfg(any(esp32, esp32s2, esp32s3))]
     pub trait WithDmaSpi3<'d, T, RX, TX, P, M>
     where
         T: Instance + Spi3Instance,
@@ -796,7 +796,7 @@ pub mod dma {
         }
     }
 
-    #[cfg(any(esp32, esp32s2))]
+    #[cfg(any(esp32, esp32s2, esp32s3))]
     impl<'d, T, RX, TX, P, M> WithDmaSpi3<'d, T, RX, TX, P, M> for Spi<'d, T, M>
     where
         T: Instance + Spi3Instance,
@@ -1944,7 +1944,7 @@ where
     fn dma_peripheral(&self) -> DmaPeripheral {
         match self.spi_num() {
             2 => DmaPeripheral::Spi2,
-            #[cfg(any(esp32, esp32s2))]
+            #[cfg(any(esp32, esp32s2, esp32s3))]
             3 => DmaPeripheral::Spi3,
             _ => panic!("Illegal SPI instance"),
         }


### PR DESCRIPTION
Fixes #505 

You can test this easily by modifying the `spi_loopback_dma` by using SPI3 instead of SPI2 in line 74 plus adding a `use esp32s3_hal::spi::dma::WithDmaSpi3`
