### PR TITLE
Add `async` support to the `I2C` driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
         run: cd esp32-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
       - name: check esp32-hal (async, serial)
         run: cd esp32-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
+      - name: check esp32-hal (async, i2c)
+        run: cd esp32-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
 
   esp32c2-hal:
     runs-on: ubuntu-latest
@@ -117,6 +119,8 @@ jobs:
         run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_spi --features=embassy,embassy-time-systick,async
       - name: check esp32c2-hal (async, serial)
         run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_serial --features=embassy,embassy-time-systick,async
+      - name: check esp32c2-hal (async, i2c)
+        run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
 
   esp32c3-hal:
     runs-on: ubuntu-latest
@@ -154,6 +158,8 @@ jobs:
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_spi --features=embassy,embassy-time-systick,async
       - name: check esp32c3-hal (async, serial)
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_serial --features=embassy,embassy-time-systick,async
+      - name: check esp32c3-hal (async, i2c)
+        run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
 
   esp32c6-hal:
     runs-on: ubuntu-latest
@@ -189,6 +195,8 @@ jobs:
         run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_spi --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (async, serial)
         run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_serial --features=embassy,embassy-time-systick,async
+      - name: check esp32c6-hal (async, i2c)
+        run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
 
   esp32h2-hal:
     runs-on: ubuntu-latest
@@ -254,6 +262,8 @@ jobs:
         run: cd esp32s2-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
       - name: check esp32s2-hal (async, serial)
         run: cd esp32s2-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
+      - name: check esp32s2-hal (async, i2c)
+        run: cd esp32s2-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
 
   esp32s3-hal:
     runs-on: ubuntu-latest
@@ -289,6 +299,8 @@ jobs:
         run: cd esp32s3-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
       - name: check esp32s3-hal (async, serial)
         run: cd esp32s3-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
+      - name: check esp32s3-hal (async, i2c)
+        run: cd esp32s3-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
 
   # --------------------------------------------------------------------------
   # MSRV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add bare-bones PSRAM support for ESP32 (#506)
 - Add initial support for the ESP32-H2 (#513)
 - Add bare-bones PSRAM support for ESP32-S3 (#517)
+- Add async support to the I2C driver (#519)
 
 ### Fixed
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -42,6 +42,7 @@ esp-alloc         = "0.3.0"
 esp-backtrace     = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32", "log"] }
+lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
@@ -91,4 +92,8 @@ required-features = ["psram_2m"]
 
 [[example]]
 name              = "embassy_serial"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_i2c"
 required-features = ["embassy", "async"]

--- a/esp32-hal/examples/embassy_i2c.rs
+++ b/esp32-hal/examples/embassy_i2c.rs
@@ -1,0 +1,74 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32_hal::{
+    clock::ClockControl,
+    embassy,
+    i2c::I2C,
+    peripherals::{Interrupt, Peripherals, I2C0},
+    prelude::*,
+    timer::TimerGroup,
+    Priority,
+    Rtc,
+    IO,
+};
+use esp_backtrace as _;
+use lis3dh_async::{Lis3dh, Range, SlaveAddr};
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run(i2c: I2C<'static, I2C0>) {
+    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timers
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let i2c0 = I2C::new(
+        peripherals.I2C0,
+        io.pins.gpio32,
+        io.pins.gpio33,
+        400u32.kHz(),
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    esp32_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run(i2c0)).ok();
+    });
+}

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -38,6 +38,7 @@ embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-time
 embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.5.0", features = ["esp32c2"] }
+lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.6", default-features = false}
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
@@ -83,4 +84,8 @@ required-features = ["interrupt-preemption"]
 
 [[example]]
 name              = "embassy_serial"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_i2c"
 required-features = ["embassy", "async"]

--- a/esp32c2-hal/examples/embassy_i2c.rs
+++ b/esp32c2-hal/examples/embassy_i2c.rs
@@ -1,0 +1,82 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32c2_hal::{
+    clock::ClockControl,
+    embassy,
+    i2c::I2C,
+    peripherals::{Interrupt, Peripherals, I2C0},
+    prelude::*,
+    timer::TimerGroup,
+    Priority,
+    Rtc,
+    IO,
+};
+use esp_backtrace as _;
+use lis3dh_async::{Lis3dh, Range, SlaveAddr};
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run(i2c: I2C<'static, I2C0>) {
+    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let i2c0 = I2C::new(
+        peripherals.I2C0,
+        io.pins.gpio1,
+        io.pins.gpio2,
+        400u32.kHz(),
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    esp32c2_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run(i2c0)).ok();
+    });
+}

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -43,6 +43,7 @@ embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32c3"] }
+lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
@@ -62,6 +63,12 @@ embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
+
+[profile.dev]
+opt-level = 1
+
+[profile.release]
+debug = true
 
 [[example]]
 name              = "spi_eh1_loopback"
@@ -83,9 +90,6 @@ required-features = ["embassy", "async"]
 name = "interrupt_preemption"
 required-features = ["interrupt-preemption"]
 
-[profile.dev]
-opt-level = 1
-
 [[example]]
 name              = "embassy_spi"
 required-features = ["embassy", "async"]
@@ -94,5 +98,6 @@ required-features = ["embassy", "async"]
 name              = "embassy_serial"
 required-features = ["embassy", "async"]
 
-[profile.release]
-debug = true
+[[example]]
+name              = "embassy_i2c"
+required-features = ["embassy", "async"]

--- a/esp32c3-hal/examples/embassy_i2c.rs
+++ b/esp32c3-hal/examples/embassy_i2c.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32c3_hal::{
+    clock::ClockControl,
+    embassy,
+    i2c::I2C,
+    peripherals::{Interrupt, Peripherals, I2C0},
+    prelude::*,
+    timer::TimerGroup,
+    Priority,
+    Rtc,
+    IO,
+};
+use esp_backtrace as _;
+use lis3dh_async::{Lis3dh, Range, SlaveAddr};
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run(i2c: I2C<'static, I2C0>) {
+    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let i2c0 = I2C::new(
+        peripherals.I2C0,
+        io.pins.gpio1,
+        io.pins.gpio2,
+        400u32.kHz(),
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    esp32c3_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run(i2c0)).ok();
+    });
+}

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -44,6 +44,7 @@ embedded-graphics = "0.7.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32c6"] }
+lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
@@ -88,4 +89,8 @@ required-features = ["interrupt-preemption"]
 
 [[example]]
 name              = "embassy_serial"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_i2c"
 required-features = ["embassy", "async"]

--- a/esp32c6-hal/examples/embassy_i2c.rs
+++ b/esp32c6-hal/examples/embassy_i2c.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32c6_hal::{
+    clock::ClockControl,
+    embassy,
+    i2c::I2C,
+    peripherals::{Interrupt, Peripherals, I2C0},
+    prelude::*,
+    timer::TimerGroup,
+    Priority,
+    Rtc,
+    IO,
+};
+use esp_backtrace as _;
+use lis3dh_async::{Lis3dh, Range, SlaveAddr};
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run(i2c: I2C<'static, I2C0>) {
+    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let i2c0 = I2C::new(
+        peripherals.I2C0,
+        io.pins.gpio1,
+        io.pins.gpio2,
+        400u32.kHz(),
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    esp32c6_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run(i2c0)).ok();
+    });
+}

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -43,6 +43,7 @@ esp-alloc         = "0.3.0"
 esp-backtrace     = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32s2"] }
+lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
@@ -97,5 +98,6 @@ required-features = ["psram_2m"]
 name              = "embassy_serial"
 required-features = ["embassy", "async"]
 
-[profile.release]
-debug = true
+[[example]]
+name              = "embassy_i2c"
+required-features = ["embassy", "async"]

--- a/esp32s2-hal/examples/embassy_i2c.rs
+++ b/esp32s2-hal/examples/embassy_i2c.rs
@@ -1,0 +1,75 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32s2_hal::{
+    clock::ClockControl,
+    embassy,
+    i2c::I2C,
+    peripherals::{Interrupt, Peripherals, I2C0},
+    prelude::*,
+    timer::TimerGroup,
+    Priority,
+    Rtc,
+    IO,
+};
+use esp_backtrace as _;
+use lis3dh_async::{Lis3dh, Range, SlaveAddr};
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run(i2c: I2C<'static, I2C0>) {
+    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timer
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let i2c0 = I2C::new(
+        peripherals.I2C0,
+        io.pins.gpio1,
+        io.pins.gpio2,
+        400u32.kHz(),
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    esp32s2_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run(i2c0)).ok();
+    });
+}

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -45,6 +45,7 @@ esp-alloc         = "0.3.0"
 esp-backtrace     = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32s3", "log"] }
+lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
@@ -95,4 +96,8 @@ required-features = ["psram_2m"]
 
 [[example]]
 name              = "embassy_serial"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_i2c"
 required-features = ["embassy", "async"]

--- a/esp32s3-hal/examples/embassy_i2c.rs
+++ b/esp32s3-hal/examples/embassy_i2c.rs
@@ -1,0 +1,81 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32s3_hal::{
+    clock::ClockControl,
+    embassy,
+    i2c::I2C,
+    peripherals::{Interrupt, Peripherals, I2C0},
+    prelude::*,
+    timer::TimerGroup,
+    Priority,
+    Rtc,
+    IO,
+};
+use esp_backtrace as _;
+use lis3dh_async::{Lis3dh, Range, SlaveAddr};
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run(i2c: I2C<'static, I2C0>) {
+    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+    // Disable watchdog timer
+    wdt.disable();
+    rtc.rwdt.disable();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let i2c0 = I2C::new(
+        peripherals.I2C0,
+        io.pins.gpio1,
+        io.pins.gpio2,
+        400u32.kHz(),
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    esp32s3_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(run(i2c0)).ok();
+    });
+}


### PR DESCRIPTION
I've tested all examples on hardware and confirmed they're working. The ESP32-H2 is omitted for now, until `I2C` support has been added for it.

We could probably do some refactoring to reduce code duplication a bit, but that's outside the scope of this PR, IMO.

This is the first async driver I've written so hopefully I've gotten things mostly right 😁 