### PR TITLE
Add esp32 s3 psram to changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,18 @@
+## Thank you!
+
+Thank you for your contribution.
+Please make sure that your submission includes the following:
+
+### Must
+
+- [ ] The code compiles without `errors` or `warnings`.
+- [ ] All examples work.
+- [ ] `cargo fmt` was run.
+- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
+- [ ] You updated existing examples or added examples (if applicable).
+- [ ] Added examples are checked in CI
+
+### Nice to have
+
+- [ ] You add a description of your work to this PR.
+- [ ] You added proper docs for your newly added features and code.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,3 +414,19 @@ jobs:
         run: cargo fmt --all --manifest-path=esp32s2-hal/Cargo.toml -- --check
       - name: rustfmt (esp32s3-hal)
         run: cargo fmt --all --manifest-path=esp32s3-hal/Cargo.toml -- --check
+
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Check that changelog updated
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: CHANGELOG.md
+          skipLabels: 'skip-changelog'
+          missingUpdateErrorMessage: 'Please add a changelog entry in the CHANGELOG.md file.'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add bare-bones PSRAM support for ESP32 (#506)
 - Add initial support for the ESP32-H2 (#513)
+- Add bare-bones PSRAM support for ESP32-S3 (#517)
 
 ### Fixed
 


### PR DESCRIPTION
Adds the ESP32-S3 PSRAM feature to CHANGELOG.md

Also adds a minimal PR template (content is mostly inspired by probe-rs). However, the template is only used once it's on the default branch (i.e. not yet in this PR)



