### PR TITLE
Simplify timg time driver impl

### DIFF
--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -189,6 +189,17 @@ pub struct Timer0<TG> {
     phantom: PhantomData<TG>,
 }
 
+impl<TG> Timer0<TG>
+where
+    TG: TimerGroupInstance,
+{
+    pub(crate) unsafe fn steal() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
 /// Timer peripheral instance
 impl<TG> Instance for Timer0<TG>
 where
@@ -335,6 +346,18 @@ where
 #[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2)))]
 pub struct Timer1<TG> {
     phantom: PhantomData<TG>,
+}
+
+#[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2)))]
+impl<TG> Timer1<TG>
+where
+    TG: TimerGroupInstance,
+{
+    pub(crate) unsafe fn steal() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
 }
 
 /// Timer peripheral instance


### PR DESCRIPTION
Once the timer has been initialized, all other operations are atomic. Therefore we can simply `steal` the timer where needed, instead of holding it in a mutex/refcell.

Fixes the issue discussed in [matrix](https://matrix.to/#/!LdaNPfUfvefOLewEIM:matrix.org/$4s-T3-8ziDFBmIX0PB314t9FJR6BW1dFsdY2gTrOTGQ?via=matrix.org&via=tchncs.de&via=mozilla.org).