### PR TITLE
Initial support for SHA  in ESP32-H2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for the ESP32-H2 (#513)
 - Add bare-bones PSRAM support for ESP32-S3 (#517)
 - Add async support to the I2C driver (#519)
+- Add initial support for SHA in ESP32-H2 (#527)
 
 ### Fixed
 

--- a/esp-hal-common/devices/esp32h2.toml
+++ b/esp-hal-common/devices/esp32h2.toml
@@ -1,5 +1,5 @@
 [device]
-arch  = "riscv"
+arch = "riscv"
 cores = "single_core"
 
 peripherals = [
@@ -42,7 +42,7 @@ peripherals = [
     # "rmt",
     # "rng",
     # "rsa",
-    # "sha",
+    "sha",
     # "soc_etm",
     # "spi0",
     # "spi1",

--- a/esp-hal-common/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32h2/peripherals.rs
@@ -44,7 +44,7 @@ crate::peripherals! {
     // RMT => true,
     // RNG => true,
     // RSA => true,
-    // SHA => true,
+    SHA => true,
     // SOC_ETM => true,
     // SPI0 => true,
     // SPI1 => true,

--- a/esp32h2-hal/examples/sha.rs
+++ b/esp32h2-hal/examples/sha.rs
@@ -1,0 +1,88 @@
+//! Demonstrates the use of the SHA peripheral and compares the speed of
+//! hardware-accelerated and pure software hashing.
+
+#![no_std]
+#![no_main]
+
+use esp32h2_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    sha::{Sha, ShaMode},
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+use nb::block;
+use sha2::{Digest, Sha256};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    wdt.disable();
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+    let mut remaining = source_data.clone();
+    let mut hasher = Sha::new(
+        peripherals.SHA,
+        ShaMode::SHA256,
+        &mut system.peripheral_clock_control,
+    );
+
+    // Short hashes can be created by decreasing the output buffer to the desired
+    // length
+    let mut output = [0u8; 32];
+
+    // let pre_calc = xtensa_lx::timer::get_cycle_count();
+    // The hardware implementation takes a subslice of the input, and returns the
+    // unprocessed parts The unprocessed parts can be input in the next
+    // iteration, you can always add more data until finish() is called. After
+    // finish() is called update()'s will contribute to a new hash which
+    // can be extracted again with finish().
+
+    while remaining.len() > 0 {
+        // Can add println to view progress, however println takes a few orders of
+        // magnitude longer than the Sha function itself so not useful for
+        // comparing processing time println!("Remaining len: {}",
+        // remaining.len());
+
+        // All the HW Sha functions are infallible so unwrap is fine to use if you use
+        // block!
+        remaining = block!(hasher.update(remaining)).unwrap();
+    }
+
+    // Finish can be called as many times as desired to get mutliple copies of the
+    // output.
+    block!(hasher.finish(output.as_mut_slice())).unwrap();
+    // let post_calc = xtensa_lx::timer::get_cycle_count();
+    // let hw_time = post_calc - pre_calc;
+    // println!("Took {} cycles", hw_time);
+    println!("SHA256 Hash output {:02x?}", output);
+
+    // let pre_calc = xtensa_lx::timer::get_cycle_count();
+    let mut hasher = Sha256::new();
+    hasher.update(source_data);
+    let soft_result = hasher.finalize();
+    // let post_calc = xtensa_lx::timer::get_cycle_count();
+    // let soft_time = post_calc - pre_calc;
+    // println!("Took {} cycles", soft_time);
+    println!("SHA256 Hash output {:02x?}", soft_result);
+
+    // println!("HW SHA is {}x faster", soft_time/hw_time);
+
+    loop {}
+}


### PR DESCRIPTION
Adds initial support for SHA and the `sha` example. 

Tested the `sha` example and here is the output:
```
SHA256 Hash output [1e, bb, da, b3, 35, e0, 54, 01, 5f, 0f, c1, 7f, 62, 77, 06, 09, 72, 3d, 92, c6, 40, b6, 5b, a9, 97, 4d, 66, 6c, 36, 4a, 3a, 63]
SHA256 Hash output [1e, bb, da, b3, 35, e0, 54, 01, 5f, 0f, c1, 7f, 62, 77, 06, 09, 72, 3d, 92, c6, 40, b6, 5b, a9, 97, 4d, 66, 6c, 36, 4a, 3a, 63]
```