### PR TITLE
feat(riscv+esp32c3): demonstrate gpio_interrupt example entirely in SRAM

### DIFF
--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -268,7 +268,7 @@ mod vectored {
         }
     }
 
-    #[ram]
+    #[inline(always)]
     unsafe fn handle_interrupt(interrupt: Interrupt, save_frame: &mut TrapFrame) {
         extern "C" {
             // defined in each hal

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -220,7 +220,7 @@ mod vectored {
 
         let configured_interrupts = get_configured_interrupts(crate::get_core(), status);
         let mut interrupt_mask =
-            status & configured_interrupts[INTERRUPT_TO_PRIORITY[cpu_intr as usize - 1]];
+            status & configured_interrupts[interrupt_to_priority(cpu_intr as usize)];
         while interrupt_mask != 0 {
             let interrupt_nr = interrupt_mask.trailing_zeros();
             // Interrupt::try_from can fail if interrupt already de-asserted:
@@ -605,6 +605,11 @@ unsafe fn get_assigned_cpu_interrupt(interrupt: Interrupt) -> CpuInterrupt {
 mod classic {
     use super::{CpuInterrupt, InterruptKind, Priority};
     use crate::Cpu;
+
+    #[inline(always)]
+    pub(super) const fn interrupt_to_priority(irq: usize) -> usize {
+        irq
+    }
 
     pub(super) const PRIORITY_TO_INTERRUPT: [usize; 15] =
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -169,6 +169,7 @@ pub enum Cpu {
     AppCpu,
 }
 
+#[inline(always)]
 pub fn get_core() -> Cpu {
     #[cfg(all(xtensa, multi_core))]
     match ((xtensa_lx::get_processor_id() >> 13) & 1) != 0 {

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -31,6 +31,8 @@
     feature(impl_trait_projections)
 )]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![feature(const_mut_refs)]
+#![feature(slice_as_chunks)]
 
 #[cfg(riscv)]
 pub use esp_riscv_rt::{self, entry, riscv};

--- a/esp32c3-hal/.cargo/config.toml
+++ b/esp32c3-hal/.cargo/config.toml
@@ -2,6 +2,7 @@
 runner = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
+  "-C", "force-frame-pointers",
 
   # comment the cfgs below if you do _not_ wish to emulate atomics.
   # enable the atomic codegen option for RISCV

--- a/esp32c3-hal/.cargo/config.toml
+++ b/esp32c3-hal/.cargo/config.toml
@@ -4,6 +4,8 @@ rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "force-frame-pointers",
 
+  "-C", "llvm-args=--max-jump-table-size=0",
+
   # comment the cfgs below if you do _not_ wish to emulate atomics.
   # enable the atomic codegen option for RISCV
   "-C", "target-feature=+a",

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -65,10 +65,13 @@ embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 
 [profile.dev]
-opt-level = 1
+opt-level = 2
+lto = "thin"
 
 [profile.release]
 debug = true
+opt-level = 2
+lto = "thin"
 
 [[example]]
 name              = "spi_eh1_loopback"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -101,3 +101,6 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+esp32c3 = { git = "https://github.com/rustbox/esp-pacs", rev = "c8e7cbb1cef4f6b3fd565c8fbb30e37674657877" }

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -75,9 +75,15 @@ fn main() -> ! {
 }
 
 #[interrupt]
+#[ram]
 fn GPIO() {
     critical_section::with(|cs| {
-        esp_println::println!("GPIO interrupt");
+        // can't use println! here, because it delegates to `core::write!` which in turn
+        // is opaquely "stuck" in Flash
+        {
+            use core::fmt::Write;
+            (esp_println::Printer).write_str("GPIO interrupt\n").ok();
+        }
         BUTTON
             .borrow_ref_mut(cs)
             .as_mut()

--- a/esp32c3-hal/ld/db-riscv-link.x
+++ b/esp32c3-hal/ld/db-riscv-link.x
@@ -55,8 +55,6 @@ SECTIONS
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
     . = ALIGN(4);
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
 
     *(.text .text.*);
     _etext = .;
@@ -91,6 +89,8 @@ SECTIONS
   _data_size = _data_end - _data_start + 8;
   .rwtext ORIGIN(REGION_RWTEXT) + _data_size : AT(_text_size + _rodata_size + _data_size){
     _srwtext = .;
+    KEEP(*(.trap));
+    KEEP(*(.trap.rust));
     *(.rwtext);
     . = ALIGN(4);
     _erwtext = .;


### PR DESCRIPTION
As mentioned over on #448 the current RISC-V HAL interrupt flow isn't memory-resident, with large portions of it living in Flash.

This change set is not intended to be merged as-is, or probably at all: it's more of a "spike" or "steel thread" demonstrating the areas of work I've been able to identify in order to meet the goal of "[an] interrupt request is serviced without touching flash memory." My friend & I needed to do this because we have a hard-real-time interrupt that fires at ~480Hz (60Hz * 8), which made for some :hot_pepper: contention at the cache layer. 

As usual with these things, a lot of the wins can be had for relatively little effort. I've tried to structure these changes in increasing order from least implementation/maintenance burden to most, with each commit message giving a detailed explanation of what problem I believed I was solving at each step. Happily, they're also _largely_ in sync with the size of the wins (with the exception of the `mem*` friends, discussed later). 

What I'm hoping for from this discussion is mostly just to share my findings, and to identify where we might already have consensus on what the next steps ought to be (where any). In an effort to apply Cunningham's Law, my current beliefs about the disposition and direction of these changes are below.

## ready for (early) review

* ~fa671bb7870bc is something I intend to replicate in all the other RISC-V linker scripts, at which point that change will be ready to be merged into the mainline HAL.~ https://github.com/esp-rs/esp-hal/pull/541
* cda36dd3952 ought to be carried through to complete the conversion from `const` slices to inline-able functions. I don't yet have any 'c6s to try out the PLIC side of things, though I did order some for that purpose.
* e29f3d547dc210 (which is really https://github.com/rustbox/esp-pacs/commit/c8e7cbb1cef4f6b3fd565c8fbb30e37674657877) is worth pursuing, which would involve:
    * making a change to the `esp-pacs` generator relocating that object to `.trap.rodata` (my preference), or `.data`
    * (optionally) if using `.trap.rodata`, making a change at this point to the linker scripts that live here in `esp-hal`  to emit objects from that section
    * the release train leaves the station, I guess? it's not a breaking change if we can ensure the newer pacs are only ever used with the newer linker scripts, so there's maybe a phrasing of cargo constraints here that allows this to be a patch release. Or, we use `.data` and it's definitely not breaking.
 * 115a334591d836 is a toss-up for me; it's written, I got to feel like a C-x M-c M-butterfly programmer, and it works as far as I've tested it. But, the LLVM lookup table that it replaces is very small, about 0x40 bytes.[^llvm-lookup-small] It meets a very strict "no flash, ever" target, which I think applies more to the RTC memory stuff (that I have only surface-level knowledge of) than to interrupt handling. 
 
## here be dragons

* 34fc2fbb5e01eb140, 54fc729f6b4be, and d43df905037726 are not worth merging directly, not least because I don't think they actually have an effect on any consumers of the HAL outside the `esp32c3/src/examples` directory. They do demonstrate just how tricky it is to 1) predict and 2) validate whether a particular call graph is memory resident or not. Initially, I believed inspecting the rust functions and throwing a few `#[inline(always)]`s around would be enough to ensure that property under a wide range of conditions, but what I found was... not that.
    * If there is an action here, I think it would be to consider updating the [template project](https://github.com/esp-rs/esp-template) with some of the settings.
* b51156896042139c3aa1aa is a tough one: as you might expect, the care and feeding of a `memcpy` implementation is significantly more difficult than it first appears. Regrettably, it's just _so frickin' good_: `memcpy` (and to a lesser degree, `memset`, `memmove`, and `memcmp`) show up a _lot_: even at the highest optimization levels, there are 9 `memcpy` call sites in the `gpio_interrupt` example alone. In my downstream project, we've got ~50 `memcpy` calls that span the gamut from "one time, at startup" to "hottest of the hot path." Implementing that family of functions ourselves was a tremendous performance win across the board, and is well worth the high price of maintenance, at least for us.
    * Probably the thing to do is defer, at least for now: the `esp-hal` side of the IRQ flow only uses memset/memcpy when dealing with the `[u128; 16]` array that represents all configured interrupts, so it seems plausible that finding a different way to represent that data structure or fetching the priorities a few at a time instead of all at once might dodge the use of those functions, which here would allow us to meet the "nothing in flash" requirement without taking ownership of them.
    * I'm a little bit at a loss as to where or whom we should defer to, though: is this something that the rust-embedded folks would be interested in? It seems like a lot of microcontrollers are going to be in the same boat as the esp32c3 here, no?
* after all that, 8efc0b90772e5d6 is both anti-climactic and a little bit distressing: on the plus side, it's short! On the minus side, that's because the example is trivial, and what little of it there is points towards something I've been avoiding mentioning thus far: I have no idea what to do about `core`. The first and most immediate place that arises is, as here, in string formatting. However, it's not actually possible to work around in that way, because formatting an error message is a huge part of calls to `panic!`, most of which get emitted automatically for e.g. bounds checks on arrays, `unwap` calls, arithmetic overflow (when enabled), etc. Mostly this is :fire: fine :fire: because `panic!`s are generally non-recoverable, so taking extra time to load a string from flash right before the CPU goes into a sleep-until-reset loop isn't really a big deal. That said, it feels to me like a potentially large area of future work, with an uncertain scope and level of risk. I'm very curious what y'all's thoughts are on both how important it is to get the panic handling bits fully in RAM and whether there's any strategies that come to mind about how to do it.

## caveats

* the above applies only to the interrupt trap flow, I haven't yet examined the exception handling flow, nor the atomics emulation that's part of that. I haven't measured, yet, but that seems like a worthwhile unit of future work too.
* and, finally, I don't want to forget about moving `EspDefaultHandler`, `ExceptionHandler`, and `DefaultInterruptHandler`; those'd be separate PRs against esp-riscv-rt and esp-backtrace (probably), but I haven't put much thought yet into helping out downstream crates that might provide their own implementations.

Phew, that was a whole lot! Let me know if there's a time y'all want to hop on a video call or if there's a semi-synchronous chat I should join to go through this together! I don't expect this to be our last opportunity to connect, though, so no pressure from my end either way.

cc @MabezDev 

[^llvm-lookup-small]: I can't for the life of me identify the object in the ELF, but from looking at the hex dump of `.rodata` it's tucked in between two fairly obvious strings that at least provide an upper bound on the size.