### PR TITLE
Bugfix/set vecbase for core1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DMA is supported for SPI3 on ESP32-S3 (#507)
 - `change_bus_frequency` is now available on `SpiDma` (#529)
 - Fixed a bug where a GPIO interrupt could erroneously fire again causing the next `await` on that pin to instantly return `Poll::Ok` (#537) 
-- Set `vecbase` on core 1 (ESP32, ESP32-S3)
+- Set `vecbase` on core 1 (ESP32, ESP32-S3) (#536)
 
 ### Changed
 - Improve examples documentation (#533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DMA is supported for SPI3 on ESP32-S3 (#507)
 - `change_bus_frequency` is now available on `SpiDma` (#529)
 - Fixed a bug where a GPIO interrupt could erroneously fire again causing the next `await` on that pin to instantly return `Poll::Ok` (#537) 
+- Set `vecbase` on core 1 (ESP32, ESP32-S3)
 
 ### Changed
 - Improve examples documentation (#533)

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -159,6 +159,7 @@ pub fn disable_apm_filter() {
 
 /// Enumeration of CPU cores
 /// The actual number of available cores depends on the target.
+#[derive(Debug, PartialEq, Eq)]
 pub enum Cpu {
     /// The first core
     ProCpu = 0,

--- a/esp-hal-common/src/soc/esp32/cpu_control.rs
+++ b/esp-hal-common/src/soc/esp32/cpu_control.rs
@@ -174,6 +174,16 @@ impl CpuControl {
         // set stack pointer to end of memory: no need to retain stack up to this point
         set_stack_pointer(&mut _stack_end_cpu1);
 
+        extern "C" {
+            static mut _init_start: u32;
+        }
+
+        unsafe {
+            // move vec table
+            let base = &_init_start as *const u32;
+            core::arch::asm!("wsr.vecbase {0}", in(reg) base, options(nostack));
+        }
+
         match START_CORE1_FUNCTION.take() {
             Some(entry) => (*entry)(),
             None => panic!("No start function set"),

--- a/esp-hal-common/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal-common/src/soc/esp32s3/cpu_control.rs
@@ -109,6 +109,16 @@ impl CpuControl {
         // set stack pointer to end of memory: no need to retain stack up to this point
         set_stack_pointer(&mut _stack_end_cpu1);
 
+        extern "C" {
+            static mut _init_start: u32;
+        }
+
+        unsafe {
+            // move vec table
+            let base = &_init_start as *const u32;
+            core::arch::asm!("wsr.vecbase {0}", in(reg) base, options(nostack));
+        }
+
         match START_CORE1_FUNCTION.take() {
             Some(entry) => (*entry)(),
             None => panic!("No start function set"),


### PR DESCRIPTION
Previously we didn't set `vecbase` on CORE1 for ESP32, ESP32-S3 - this prevented interrupts from working on the second core.

Note: After this it will work correctly on ESP32, for ESP32-S3 there is a SVD/PAC update needed
