### PR TITLE
async gpio fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - DMA is supported for SPI3 on ESP32-S3 (#507)
 - `change_bus_frequency` is now available on `SpiDma` (#529)
+- Fixed a bug where a GPIO interrupt could erroneously fire again causing the next `await` on that pin to instantly return `Poll::Ok` (#537) 
 
 ### Changed
 - Improve examples documentation (#533)


### PR DESCRIPTION
- Fix pin number calculation for bank1
- Clear interrupt status after disabling interrupt to avoid hardware pending another interrupt
- Clear interrupt on `InputFuture` creation.

Close #535 

<!--
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
-->
