### PR TITLE
feat(riscv): relocate `.trap` machinery to RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add bare-bones PSRAM support for ESP32-S3 (#517)
 - Add async support to the I2C driver (#519)
 
+### Changed
+
+- Move core interrupt handling from Flash to RAM for RISC-V chips (ESP32-H2, ESP32-C2, ESP32-C3, ESP32-C6) (#541)
+
 ### Fixed
 
 - DMA is supported for SPI3 on ESP32-S3 (#507)

--- a/esp32c2-hal/ld/bl-riscv-link.x
+++ b/esp32c2-hal/ld/bl-riscv-link.x
@@ -56,11 +56,18 @@ SECTIONS {
     KEEP(*(.init));
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
   } > ROTEXT
 }
 INSERT BEFORE .text;
+
+SECTIONS {
+  .trap : ALIGN(4)
+  {
+    KEEP(*(.trap));
+    *(.trap.*);
+  } > RWTEXT
+}
+INSERT AFTER .rwtext;
 
 SECTIONS {
   /**
@@ -86,6 +93,7 @@ SECTIONS {
     . = ALIGN(ALIGNOF(.rwtext));
     . = . + SIZEOF(.rwtext);
     . = . + SIZEOF(.rwtext.wifi);
+    . = . + SIZEOF(.trap);
   } > RWDATA
 }
 INSERT BEFORE .data;

--- a/esp32c2-hal/ld/db-riscv-link.x
+++ b/esp32c2-hal/ld/db-riscv-link.x
@@ -55,8 +55,6 @@ SECTIONS
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
     . = ALIGN(4);
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
 
     *(.text .text.*);
     _etext = .;
@@ -93,6 +91,8 @@ SECTIONS
     _srwtext = .;
     *(.rwtext);
     . = ALIGN(4);
+    KEEP(*(.trap));
+    *(.trap.*);
     _erwtext = .;
   } > REGION_RWTEXT
   _rwtext_size = _erwtext - _srwtext + 8;

--- a/esp32c3-hal/ld/bl-riscv-link.x
+++ b/esp32c3-hal/ld/bl-riscv-link.x
@@ -56,11 +56,18 @@ SECTIONS {
     KEEP(*(.init));
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
   } > ROTEXT
 }
 INSERT BEFORE .text;
+
+SECTIONS {
+  .trap : ALIGN(4)
+  {
+    KEEP(*(.trap));
+    *(.trap.*);
+  } > RWTEXT
+}
+INSERT AFTER .rwtext;
 
 SECTIONS {
   /**
@@ -86,6 +93,7 @@ SECTIONS {
     . = ALIGN(ALIGNOF(.rwtext));
     . = . + SIZEOF(.rwtext);
     . = . + SIZEOF(.rwtext.wifi);
+    . = . + SIZEOF(.trap);
   } > RWDATA
 }
 INSERT BEFORE .data;

--- a/esp32c3-hal/ld/db-riscv-link.x
+++ b/esp32c3-hal/ld/db-riscv-link.x
@@ -89,10 +89,10 @@ SECTIONS
   _data_size = _data_end - _data_start + 8;
   .rwtext ORIGIN(REGION_RWTEXT) + _data_size : AT(_text_size + _rodata_size + _data_size){
     _srwtext = .;
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
     *(.rwtext);
     . = ALIGN(4);
+    KEEP(*(.trap));
+    *(.trap.*);
     _erwtext = .;
   } > REGION_RWTEXT
   _rwtext_size = _erwtext - _srwtext + 8;

--- a/esp32c3-hal/ld/db-riscv-link.x
+++ b/esp32c3-hal/ld/db-riscv-link.x
@@ -55,8 +55,6 @@ SECTIONS
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
     . = ALIGN(4);
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
 
     *(.text .text.*);
     _etext = .;
@@ -91,6 +89,8 @@ SECTIONS
   _data_size = _data_end - _data_start + 8;
   .rwtext ORIGIN(REGION_RWTEXT) + _data_size : AT(_text_size + _rodata_size + _data_size){
     _srwtext = .;
+    KEEP(*(.trap));
+    KEEP(*(.trap.rust));
     *(.rwtext);
     . = ALIGN(4);
     _erwtext = .;

--- a/esp32c3-hal/ld/mb-riscv-link.x
+++ b/esp32c3-hal/ld/mb-riscv-link.x
@@ -66,7 +66,7 @@ SECTIONS
     KEEP(*(.text.abort));
     . = ALIGN(4);
     KEEP(*(.trap));
-    KEEP(*(.trap.rust));
+    *(.trap.*);
 
     *libriscv-*.rlib:riscv.*(.literal .text .literal.* .text.*);
     *libesp_riscv_rt-*.rlib:esp-riscv-rt.*(.literal .text .literal.* .text.*);

--- a/esp32c6-hal/ld/bl-riscv-link.x
+++ b/esp32c6-hal/ld/bl-riscv-link.x
@@ -60,11 +60,18 @@ SECTIONS {
     KEEP(*(.init));
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
   } > ROTEXT
 }
 INSERT BEFORE .text;
+
+SECTIONS {
+  .trap : ALIGN(4)
+  {
+    KEEP(*(.trap));
+    *(.trap.*);
+  } > RWTEXT
+}
+INSERT AFTER .rwtext;
 
 SECTIONS {
   /**

--- a/esp32c6-hal/ld/db-riscv-link.x
+++ b/esp32c6-hal/ld/db-riscv-link.x
@@ -60,8 +60,6 @@ SECTIONS
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
     . = ALIGN(4);
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
 
     *(.text .text.*);
     _etext = .;
@@ -98,6 +96,8 @@ SECTIONS
     _srwtext = .;
     *(.rwtext);
     . = ALIGN(4);
+    KEEP(*(.trap));
+    *(.trap.*);
     _erwtext = .;
   } > REGION_RWTEXT
   _rwtext_size = _erwtext - _srwtext + 8;

--- a/esp32h2-hal/ld/bl-riscv-link.x
+++ b/esp32h2-hal/ld/bl-riscv-link.x
@@ -54,11 +54,18 @@ SECTIONS {
     KEEP(*(.init));
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
   } > ROTEXT
 }
 INSERT BEFORE .text;
+
+SECTIONS {
+  .trap : ALIGN(4)
+  {
+    KEEP(*(.trap));
+    *(.trap.*);
+  } > RWTEXT
+}
+INSERT AFTER .rwtext;
 
 SECTIONS {
   /**

--- a/esp32h2-hal/ld/db-riscv-link.x
+++ b/esp32h2-hal/ld/db-riscv-link.x
@@ -60,8 +60,6 @@ SECTIONS
     KEEP(*(.init.rust));
     KEEP(*(.text.abort));
     . = ALIGN(4);
-    KEEP(*(.trap));
-    KEEP(*(.trap.rust));
 
     *(.text .text.*);
     _etext = .;
@@ -98,6 +96,8 @@ SECTIONS
     _srwtext = .;
     *(.rwtext);
     . = ALIGN(4);
+    KEEP(*(.trap));
+    *(.trap.*);
     _erwtext = .;
   } > REGION_RWTEXT
   _rwtext_size = _erwtext - _srwtext + 8;


### PR DESCRIPTION
This change follows through on relocating the `_vector_table`, `_start_trap`, and `_start_trap_rust` functions for all present build/link modes for the 'c2, 'c3, 'c6, and 'h2. 

It has been tested by running the `software_interrupts` example for the 'c3 in direct-boot and esp-bootloader contexts, but I wasn't able to identify how to run the `mcu-boot` mode for the 'c3, nor do I have present access to any of the other devices for testing.

### Must

- [x] The code compiles without `errors` or `warnings`.
    - at least, it introduces no new ones: I do see something about `Timer0::steal` for all devices and `RtcFastClockXtalD2` for the 'h2
- [x] All examples work.
    - that I was able to test, anyway (see above)
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
