### PR TITLE
Support for multicore async GPIO:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for I2C in ESP32-H2 (#538)
 - Implement Copy and Eq for EspTwaiError (#540)
 - Add LEDC hardware fade support
+- Added support for multicore async GPIO (#542)
 
 ### Fixed
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -202,107 +202,25 @@ pub trait OutputPin: Pin {
 }
 
 #[doc(hidden)]
-pub struct SingleCoreInteruptStatusRegisterAccessBank0;
-#[doc(hidden)]
-pub struct DualCoreInteruptStatusRegisterAccessBank0;
-#[doc(hidden)]
-pub struct SingleCoreInteruptStatusRegisterAccessBank1;
-#[doc(hidden)]
-pub struct DualCoreInteruptStatusRegisterAccessBank1;
-
-#[doc(hidden)]
 pub trait InteruptStatusRegisterAccess {
     fn pro_cpu_interrupt_status_read() -> u32;
 
     fn pro_cpu_nmi_status_read() -> u32;
 
-    fn app_cpu_interrupt_status_read() -> u32;
-
-    fn app_cpu_nmi_status_read() -> u32;
-}
-
-impl InteruptStatusRegisterAccess for SingleCoreInteruptStatusRegisterAccessBank0 {
-    fn pro_cpu_interrupt_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
-    }
-
-    fn pro_cpu_nmi_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
-    }
-
     fn app_cpu_interrupt_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
+        Self::pro_cpu_interrupt_status_read()
     }
 
     fn app_cpu_nmi_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
+        Self::pro_cpu_nmi_status_read()
     }
 }
 
-#[cfg(any(esp32, esp32s2, esp32s3))]
-impl InteruptStatusRegisterAccess for SingleCoreInteruptStatusRegisterAccessBank1 {
-    fn pro_cpu_interrupt_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
-    }
+#[doc(hidden)]
+pub struct InteruptStatusRegisterAccessBank0;
 
-    fn pro_cpu_nmi_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_nmi_int1.read().bits()
-    }
-
-    fn app_cpu_interrupt_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
-    }
-
-    fn app_cpu_nmi_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_nmi_int1.read().bits()
-    }
-}
-
-// ESP32S3 is a dual-core chip however pro cpu and app cpu shares the same
-// interrupt enable bit see
-// https://github.com/espressif/esp-idf/blob/c04803e88b871a4044da152dfb3699cf47354d18/components/hal/esp32s3/include/hal/gpio_ll.h#L32
-// Treating it as SingleCore in the gpio macro makes this work.
-#[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s2, esp32s3)))]
-impl InteruptStatusRegisterAccess for DualCoreInteruptStatusRegisterAccessBank0 {
-    fn pro_cpu_interrupt_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
-    }
-
-    fn pro_cpu_nmi_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
-    }
-
-    fn app_cpu_interrupt_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.acpu_int.read().bits()
-    }
-
-    fn app_cpu_nmi_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.acpu_nmi_int.read().bits()
-    }
-}
-
-// ESP32S3 is a dual-core chip however pro cpu and app cpu shares the same
-// interrupt enable bit see
-// https://github.com/espressif/esp-idf/blob/c04803e88b871a4044da152dfb3699cf47354d18/components/hal/esp32s3/include/hal/gpio_ll.h#L32
-// Treating it as SingleCore in the gpio macro makes this work.
-#[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s2, esp32s3)))]
-impl InteruptStatusRegisterAccess for DualCoreInteruptStatusRegisterAccessBank1 {
-    fn pro_cpu_interrupt_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
-    }
-
-    fn pro_cpu_nmi_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.pcpu_nmi_int1.read().bits()
-    }
-
-    fn app_cpu_interrupt_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.acpu_int1.read().bits()
-    }
-
-    fn app_cpu_nmi_status_read() -> u32 {
-        unsafe { &*GPIO::PTR }.acpu_nmi_int1.read().bits()
-    }
-}
+#[doc(hidden)]
+pub struct InteruptStatusRegisterAccessBank1;
 
 #[doc(hidden)]
 pub trait InterruptStatusRegisters<RegisterAccess>
@@ -1530,7 +1448,6 @@ impl IO {
 #[macro_export]
 macro_rules! gpio {
     (
-        $cores:ident,
         $(
             ($gpionum:literal, $bank:literal, $type:ident
                 $(
@@ -1593,12 +1510,12 @@ macro_rules! gpio {
 
             pub struct Pins {
                 $(
-                    pub [< gpio $gpionum >] : GpioPin<Unknown, [< Bank $bank GpioRegisterAccess >], $crate::gpio::[< $cores CoreInteruptStatusRegisterAccessBank $bank >], [< $type PinType >], [<Gpio $gpionum Signals>], $gpionum>,
+                    pub [< gpio $gpionum >] : GpioPin<Unknown, [< Bank $bank GpioRegisterAccess >], $crate::gpio::[< InteruptStatusRegisterAccessBank $bank >], [< $type PinType >], [<Gpio $gpionum Signals>], $gpionum>,
                 )+
             }
 
             $(
-                pub type [<Gpio $gpionum >]<MODE> = GpioPin<MODE, [< Bank $bank GpioRegisterAccess >], $crate::gpio::[< $cores CoreInteruptStatusRegisterAccessBank $bank >], [< $type PinType >], [<Gpio $gpionum Signals>], $gpionum>;
+                pub type [<Gpio $gpionum >]<MODE> = GpioPin<MODE, [< Bank $bank GpioRegisterAccess >], $crate::gpio::[< InteruptStatusRegisterAccessBank $bank >], [< $type PinType >], [<Gpio $gpionum Signals>], $gpionum>;
             )+
 
             pub(crate) enum ErasedPin<MODE> {
@@ -1909,34 +1826,27 @@ mod asynch {
 
     #[interrupt]
     unsafe fn GPIO() {
-        // Whilst the S3 is a dual core chip, it shares the enable registers between
-        // cores so treat it as a single core device
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s2, esp32s3))] {
-                type Bank0 = SingleCoreInteruptStatusRegisterAccessBank0;
-            } else {
-                type Bank0 = DualCoreInteruptStatusRegisterAccessBank0;
-            }
-        };
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32s2, esp32s3))] {
-                type Bank1 = SingleCoreInteruptStatusRegisterAccessBank1;
-            } else {
-                type Bank1 = DualCoreInteruptStatusRegisterAccessBank1;
-            }
-        };
-
         let mut intrs = match crate::get_core() {
-            crate::Cpu::ProCpu => Bank0::pro_cpu_interrupt_status_read() as u64,
+            crate::Cpu::ProCpu => {
+                InteruptStatusRegisterAccessBank0::pro_cpu_interrupt_status_read() as u64
+            }
             #[cfg(multi_core)]
-            crate::Cpu::AppCpu => Bank0::app_cpu_interrupt_status_read() as u64,
+            crate::Cpu::AppCpu => {
+                InteruptStatusRegisterAccessBank0::app_cpu_interrupt_status_read() as u64
+            }
         };
 
         #[cfg(any(esp32, esp32s2, esp32s3))]
         match crate::get_core() {
-            crate::Cpu::ProCpu => intrs |= (Bank1::pro_cpu_interrupt_status_read() as u64) << 32,
+            crate::Cpu::ProCpu => {
+                intrs |= (InteruptStatusRegisterAccessBank1::pro_cpu_interrupt_status_read() as u64)
+                    << 32
+            }
             #[cfg(multi_core)]
-            crate::Cpu::AppCpu => intrs |= (Bank1::app_cpu_interrupt_status_read() as u64) << 32,
+            crate::Cpu::AppCpu => {
+                intrs |= (InteruptStatusRegisterAccessBank1::app_cpu_interrupt_status_read() as u64)
+                    << 32
+            }
         };
 
         log::trace!(

--- a/esp-hal-common/src/soc/esp32/gpio.rs
+++ b/esp-hal-common/src/soc/esp32/gpio.rs
@@ -9,6 +9,9 @@ use crate::{
         InputOnlyAnalogPinType,
         InputOutputAnalogPinType,
         InputOutputPinType,
+        InteruptStatusRegisterAccess,
+        InteruptStatusRegisterAccessBank0,
+        InteruptStatusRegisterAccessBank1,
         Unknown,
     },
     peripherals::GPIO,
@@ -75,6 +78,8 @@ pub(crate) fn get_io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mu
 pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
     match crate::get_core() {
         Cpu::AppCpu => int_enable as u8 | ((nmi_enable as u8) << 1),
+        // this should be bits 3 & 4 respectively, according to the TRM, but it doesn't seem to
+        // work. This does though.
         Cpu::ProCpu => (int_enable as u8) << 2 | ((nmi_enable as u8) << 3),
     }
 }
@@ -658,7 +663,6 @@ pub(crate) fn errata36(pin_num: u8, pull_up: bool, pull_down: bool) {
 }
 
 crate::gpio::gpio! {
-    Dual,
     (0, 0, InputOutputAnalog (5 => EMAC_TX_CLK) (1 => CLK_OUT1))
     (1, 0, InputOutput (5 => EMAC_RXD2) (0 => U0TXD 1 => CLK_OUT3))
     (2, 0, InputOutputAnalog (1 => HSPIWP 3 => HS2_DATA0 4 => SD_DATA0) (3 => HS2_DATA0 4 => SD_DATA0))
@@ -716,4 +720,40 @@ crate::gpio::analog! {
      (12, 15, touch_pad5,           mux_sel,        fun_sel,        fun_ie, rue,       rde      )
      (14, 16, touch_pad6,           mux_sel,        fun_sel,        fun_ie, rue,       rde      )
      (27, 17, touch_pad7,           mux_sel,        fun_sel,        fun_ie, rue,       rde      )
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
+    }
+
+    fn app_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.acpu_int.read().bits()
+    }
+
+    fn app_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.acpu_nmi_int.read().bits()
+    }
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank1 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int1.read().bits()
+    }
+
+    fn app_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.acpu_int1.read().bits()
+    }
+
+    fn app_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.acpu_nmi_int1.read().bits()
+    }
 }

--- a/esp-hal-common/src/soc/esp32/gpio.rs
+++ b/esp-hal-common/src/soc/esp32/gpio.rs
@@ -12,6 +12,7 @@ use crate::{
         Unknown,
     },
     peripherals::GPIO,
+    Cpu,
 };
 
 pub const NUM_PINS: usize = 39;
@@ -72,10 +73,10 @@ pub(crate) fn get_io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mu
 }
 
 pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8
-        | ((nmi_enable as u8) << 1)
-        | (int_enable as u8) << 2
-        | ((nmi_enable as u8) << 3)
+    match crate::get_core() {
+        Cpu::AppCpu => int_enable as u8 | ((nmi_enable as u8) << 1),
+        Cpu::ProCpu => (int_enable as u8) << 2 | ((nmi_enable as u8) << 3),
+    }
 }
 
 /// Peripheral input signals for the GPIO mux

--- a/esp-hal-common/src/soc/esp32c2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c2/gpio.rs
@@ -7,6 +7,8 @@ use crate::{
         GpioPin,
         InputOutputAnalogPinType,
         InputOutputPinType,
+        InteruptStatusRegisterAccess,
+        InteruptStatusRegisterAccessBank0,
         Unknown,
     },
     peripherals::GPIO,
@@ -139,7 +141,6 @@ pub enum OutputSignal {
 }
 
 crate::gpio::gpio! {
-    Single,
     (0, 0, InputOutputAnalog)
     (1, 0, InputOutputAnalog)
     (2, 0, InputOutputAnalog (2 => FSPIQ) (2 => FSPIQ))
@@ -162,4 +163,14 @@ crate::gpio::analog! {
     2
     3
     4
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
+    }
 }

--- a/esp-hal-common/src/soc/esp32c3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c3/gpio.rs
@@ -7,6 +7,8 @@ use crate::{
         GpioPin,
         InputOutputAnalogPinType,
         InputOutputPinType,
+        InteruptStatusRegisterAccess,
+        InteruptStatusRegisterAccessBank0,
         Unknown,
     },
     peripherals::GPIO,
@@ -165,7 +167,6 @@ pub enum OutputSignal {
 }
 
 crate::gpio::gpio! {
-    Single,
     (0, 0, InputOutputAnalog)
     (1, 0, InputOutputAnalog)
     (2, 0, InputOutputAnalog (2 => FSPIQ) (2 => FSPIQ))
@@ -197,4 +198,14 @@ crate::gpio::analog! {
     3
     4
     5
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
+    }
 }

--- a/esp-hal-common/src/soc/esp32c6/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c6/gpio.rs
@@ -7,6 +7,8 @@ use crate::{
         GpioPin,
         InputOutputAnalogPinType,
         InputOutputPinType,
+        InteruptStatusRegisterAccess,
+        InteruptStatusRegisterAccessBank0,
         Unknown,
     },
     peripherals::GPIO,
@@ -236,7 +238,6 @@ pub enum OutputSignal {
 }
 
 crate::gpio::gpio! {
-    Single,
     (0, 0, InputOutputAnalog)
     (1, 0, InputOutputAnalog)
     (2, 0, InputOutputAnalog (2 => FSPIQ) (2 => FSPIQ))
@@ -279,6 +280,16 @@ crate::gpio::analog! {
     5
     6
     7
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
+    }
 }
 
 // TODO USB pins

--- a/esp-hal-common/src/soc/esp32h2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32h2/gpio.rs
@@ -7,6 +7,8 @@ use crate::{
         GpioPin,
         InputOutputAnalogPinType,
         InputOutputPinType,
+        InteruptStatusRegisterAccess,
+        InteruptStatusRegisterAccessBank0,
         Unknown,
     },
     peripherals::GPIO,
@@ -217,7 +219,6 @@ pub enum OutputSignal {
 
 // FIXME: add alternate function numbers/signals where necessary
 crate::gpio::gpio! {
-    Single,
     (0, 0, InputOutput)
     (1, 0, InputOutputAnalog)
     (2, 0, InputOutputAnalog)
@@ -254,6 +255,16 @@ crate::gpio::analog! {
     3
     4
     5
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
+    }
 }
 
 // TODO USB pins

--- a/esp-hal-common/src/soc/esp32s2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s2/gpio.rs
@@ -8,6 +8,9 @@ use crate::{
         GpioPin,
         InputOutputAnalogPinType,
         InputOutputPinType,
+        InteruptStatusRegisterAccess,
+        InteruptStatusRegisterAccessBank0,
+        InteruptStatusRegisterAccessBank1,
         Unknown,
     },
     peripherals::GPIO,
@@ -261,7 +264,6 @@ pub enum OutputSignal {
 }
 
 crate::gpio::gpio! {
-    Single,
     (0, 0, InputOutputAnalog)
     (1, 0, InputOutputAnalog)
     (2, 0, InputOutputAnalog)
@@ -380,6 +382,26 @@ crate::gpio::analog! {
     (19, 19,  rtc_pad19,      mux_sel,             fun_sel,             fun_ie,             rue,             rde)
     (20, 20,  rtc_pad20,      mux_sel,             fun_sel,             fun_ie,             rue,             rde)
     (21, 21,  rtc_pad21,      mux_sel,             fun_sel,             fun_ie,             rue,             rde)
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
+    }
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank1 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int1.read().bits()
+    }
 }
 
 // implement marker traits on USB pins

--- a/esp-hal-common/src/soc/esp32s3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s3/gpio.rs
@@ -8,6 +8,9 @@ use crate::{
         GpioPin,
         InputOutputAnalogPinType,
         InputOutputPinType,
+        InteruptStatusRegisterAccess,
+        InteruptStatusRegisterAccessBank0,
+        InteruptStatusRegisterAccessBank1,
         Unknown,
     },
     peripherals::GPIO,
@@ -264,7 +267,6 @@ pub enum OutputSignal {
 }
 
 crate::gpio::gpio! {
-    Single,
     (0, 0, InputOutputAnalog)
     (1, 0, InputOutputAnalog)
     (2, 0, InputOutputAnalog)
@@ -335,6 +337,28 @@ crate::gpio::analog! {
      (19, 19,  rtc_pad19,      mux_sel,      fun_sel,      fun_ie,              rue,       rde)
      (20, 20,  rtc_pad20,      mux_sel,      fun_sel,      fun_ie,              rue,       rde)
      (21, 21,  rtc_pad21,      mux_sel,      fun_sel,      fun_ie,              rue,       rde)
+}
+
+// Whilst the S3 is a dual core chip, it shares the enable registers between
+// cores so treat it as a single core device
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
+    }
+}
+
+impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank1 {
+    fn pro_cpu_interrupt_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
+    }
+
+    fn pro_cpu_nmi_status_read() -> u32 {
+        unsafe { &*GPIO::PTR }.pcpu_nmi_int1.read().bits()
+    }
 }
 
 // implement marker traits on USB pins


### PR DESCRIPTION
Use the correct registers depending on which core the interrupt is being serviced on. Fixed a bug in the `esp32::gpio_intr` which would enable the interrupt on both cores. It now enables the interrupt for the core in which `listen()` is called.

I didn't add an example, as running the executor on the second core is a bit ugly due to the bounds on `start_app_core` (we probably want to take a look at improving this).

You can use this example to test it: https://gist.github.com/MabezDev/624738016d8ee67857b96e12253f656f

Closes https://github.com/esp-rs/esp-hal/issues/539

<!--
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
-->
