### PR TITLE
ESP32-S3: Move PSRAM functions to RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `change_bus_frequency` is now available on `SpiDma` (#529)
 - Fixed a bug where a GPIO interrupt could erroneously fire again causing the next `await` on that pin to instantly return `Poll::Ok` (#537) 
 - Set `vecbase` on core 1 (ESP32, ESP32-S3) (#536)
+- ESP32-S3: Move PSRAM related function to RAM (#546)
 
 ### Changed
 - Improve examples documentation (#533)


### PR DESCRIPTION
This moves functions dealing with PSRAM into RAM

