### PR TITLE
Fix half-duplex SPI read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set `vecbase` on core 1 (ESP32, ESP32-S3) (#536)
 - ESP32-S3: Move PSRAM related function to RAM (#546)
 - ADC driver will now apply attenuation values to the correct ADC's channels. (#554)
+- Sometimes half-duplex non-DMA SPI reads were reading garbage in non-release mode (#552)
 
 ### Changed
 

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -2881,8 +2881,13 @@ pub trait Instance {
                 .modify(|_, w| w.usr_dummy_cyclelen().variant(dummy - 1));
         }
 
-        // re-using the full-duplex read which does dummy writes which is okay
-        self.read_bytes(buffer)
+        self.configure_datalen(buffer.len() as u32 * 8);
+        self.update();
+        reg_block.cmd.modify(|_, w| w.usr().set_bit());
+        while reg_block.cmd.read().usr().bit_is_set() {
+            // wait for completion
+        }
+        self.read_bytes_from_fifo(buffer)
     }
 
     #[cfg(not(any(esp32, esp32s2)))]


### PR DESCRIPTION
When testing with a QSPI RAM chip it turned out that the non-DMA reading sometimes reads garbage in non-release mode.
