### PR TITLE
Remove a bunch of generic params from GpioPin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-- As part of the refactoring in #537, the public GPIO type has changed.
+- Significantly simplified user-facing GPIO pin types. (#553)
 
 ## [0.9.0] - 2023-05-02
 

--- a/esp-hal-common/src/soc/esp32/gpio.rs
+++ b/esp-hal-common/src/soc/esp32/gpio.rs
@@ -3,15 +3,10 @@ use paste::paste;
 use crate::{
     gpio::{
         AlternateFunction,
-        Bank0GpioRegisterAccess,
-        Bank1GpioRegisterAccess,
         GpioPin,
-        InputOnlyAnalogPinType,
-        InputOutputAnalogPinType,
-        InputOutputPinType,
-        InteruptStatusRegisterAccess,
-        InteruptStatusRegisterAccessBank0,
-        InteruptStatusRegisterAccessBank1,
+        InterruptStatusRegisterAccess,
+        InterruptStatusRegisterAccessBank0,
+        InterruptStatusRegisterAccessBank1,
         Unknown,
     },
     peripherals::GPIO,
@@ -722,7 +717,7 @@ crate::gpio::analog! {
      (27, 17, touch_pad7,           mux_sel,        fun_sel,        fun_ie, rue,       rde      )
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
     }
@@ -740,7 +735,7 @@ impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
     }
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank1 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
     }

--- a/esp-hal-common/src/soc/esp32c2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c2/gpio.rs
@@ -3,12 +3,9 @@ use paste::paste;
 use crate::{
     gpio::{
         AlternateFunction,
-        Bank0GpioRegisterAccess,
         GpioPin,
-        InputOutputAnalogPinType,
-        InputOutputPinType,
-        InteruptStatusRegisterAccess,
-        InteruptStatusRegisterAccessBank0,
+        InterruptStatusRegisterAccess,
+        InterruptStatusRegisterAccessBank0,
         Unknown,
     },
     peripherals::GPIO,
@@ -165,7 +162,7 @@ crate::gpio::analog! {
     4
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
     }

--- a/esp-hal-common/src/soc/esp32c3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c3/gpio.rs
@@ -3,12 +3,9 @@ use paste::paste;
 use crate::{
     gpio::{
         AlternateFunction,
-        Bank0GpioRegisterAccess,
         GpioPin,
-        InputOutputAnalogPinType,
-        InputOutputPinType,
-        InteruptStatusRegisterAccess,
-        InteruptStatusRegisterAccessBank0,
+        InterruptStatusRegisterAccess,
+        InterruptStatusRegisterAccessBank0,
         Unknown,
     },
     peripherals::GPIO,
@@ -200,7 +197,7 @@ crate::gpio::analog! {
     5
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
     }

--- a/esp-hal-common/src/soc/esp32c6/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c6/gpio.rs
@@ -3,12 +3,9 @@ use paste::paste;
 use crate::{
     gpio::{
         AlternateFunction,
-        Bank0GpioRegisterAccess,
         GpioPin,
-        InputOutputAnalogPinType,
-        InputOutputPinType,
-        InteruptStatusRegisterAccess,
-        InteruptStatusRegisterAccessBank0,
+        InterruptStatusRegisterAccess,
+        InterruptStatusRegisterAccessBank0,
         Unknown,
     },
     peripherals::GPIO,
@@ -282,7 +279,7 @@ crate::gpio::analog! {
     7
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
     }

--- a/esp-hal-common/src/soc/esp32h2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32h2/gpio.rs
@@ -3,12 +3,9 @@ use paste::paste;
 use crate::{
     gpio::{
         AlternateFunction,
-        Bank0GpioRegisterAccess,
         GpioPin,
-        InputOutputAnalogPinType,
-        InputOutputPinType,
-        InteruptStatusRegisterAccess,
-        InteruptStatusRegisterAccessBank0,
+        InterruptStatusRegisterAccess,
+        InterruptStatusRegisterAccessBank0,
         Unknown,
     },
     peripherals::GPIO,
@@ -257,7 +254,7 @@ crate::gpio::analog! {
     5
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
     }

--- a/esp-hal-common/src/soc/esp32s2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s2/gpio.rs
@@ -3,14 +3,10 @@ use paste::paste;
 use crate::{
     gpio::{
         AlternateFunction,
-        Bank0GpioRegisterAccess,
-        Bank1GpioRegisterAccess,
         GpioPin,
-        InputOutputAnalogPinType,
-        InputOutputPinType,
-        InteruptStatusRegisterAccess,
-        InteruptStatusRegisterAccessBank0,
-        InteruptStatusRegisterAccessBank1,
+        InterruptStatusRegisterAccess,
+        InterruptStatusRegisterAccessBank0,
+        InterruptStatusRegisterAccessBank1,
         Unknown,
     },
     peripherals::GPIO,
@@ -384,7 +380,7 @@ crate::gpio::analog! {
     (21, 21,  rtc_pad21,      mux_sel,             fun_sel,             fun_ie,             rue,             rde)
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
     }
@@ -394,7 +390,7 @@ impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
     }
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank1 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
     }

--- a/esp-hal-common/src/soc/esp32s3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s3/gpio.rs
@@ -3,14 +3,10 @@ use paste::paste;
 use crate::{
     gpio::{
         AlternateFunction,
-        Bank0GpioRegisterAccess,
-        Bank1GpioRegisterAccess,
         GpioPin,
-        InputOutputAnalogPinType,
-        InputOutputPinType,
-        InteruptStatusRegisterAccess,
-        InteruptStatusRegisterAccessBank0,
-        InteruptStatusRegisterAccessBank1,
+        InterruptStatusRegisterAccess,
+        InterruptStatusRegisterAccessBank0,
+        InterruptStatusRegisterAccessBank1,
         Unknown,
     },
     peripherals::GPIO,
@@ -341,7 +337,7 @@ crate::gpio::analog! {
 
 // Whilst the S3 is a dual core chip, it shares the enable registers between
 // cores so treat it as a single core device
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()
     }
@@ -351,7 +347,7 @@ impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank0 {
     }
 }
 
-impl InteruptStatusRegisterAccess for InteruptStatusRegisterAccessBank1 {
+impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int1.read().bits()
     }


### PR DESCRIPTION
- [ ] The code compiles without `errors` or `warnings`. - even the original code had warnings.
- [ ] All examples work. - if they compile, they should work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable). - as above.
- [ ] Added examples are checked in CI
- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code. - no new features

# PR description

We had a conversation with @MabezDev over at matrix where he mentioned that ideally GPIOs should have fewer generic parameters. Since their capabilities are tied to the hardware, this PR refactors those generic parameters into a companion trait.