### PR TITLE
Set ADC attenuation for the correct ADC instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where a GPIO interrupt could erroneously fire again causing the next `await` on that pin to instantly return `Poll::Ok` (#537)
 - Set `vecbase` on core 1 (ESP32, ESP32-S3) (#536)
 - ESP32-S3: Move PSRAM related function to RAM (#546)
+- ADC driver will now apply attenuation values to the correct ADC's channels. (#554)
 
 ### Changed
 

--- a/esp-hal-common/src/analog/adc/xtensa.rs
+++ b/esp-hal-common/src/analog/adc/xtensa.rs
@@ -275,7 +275,7 @@ where
 
         for channel in 0..attenuations.len() {
             if let Some(attenuation) = attenuations[channel] {
-                ADC1::set_attenuation(channel, attenuation as u8);
+                ADCI::set_attenuation(channel, attenuation as u8);
             }
         }
 


### PR DESCRIPTION
This PR fixes a very well hidden bug where both ADCs configure the attenuation values of ADC1.

cc #550 #326