### PR TITLE
Add a fn to poll a DMA transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add some miscellaneous examples for the ESP32-H2 (#548)
 - Add initial support for PCNT in ESP32-H2 (#551)
 - Add initial support for RMT in ESP32-H2 (#556)
+- Add a fn to poll DMA transfers
 
 ### Fixed
 

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -846,6 +846,8 @@ where
 pub trait DmaTransfer<B, T>: Drop {
     /// Wait for the transfer to finish.
     fn wait(self) -> (B, T);
+    /// Check if the transfer is finished.
+    fn is_done(&self) -> bool;
 }
 
 /// Trait to be implemented for an in progress dma transfer.
@@ -853,6 +855,8 @@ pub trait DmaTransfer<B, T>: Drop {
 pub trait DmaTransferRxTx<BR, BT, T>: Drop {
     /// Wait for the transfer to finish.
     fn wait(self) -> (BR, BT, T);
+    /// Check if the transfer is finished.
+    fn is_done(&self) -> bool;
 }
 
 #[cfg(feature = "async")]

--- a/esp-hal-common/src/i2s.rs
+++ b/esp-hal-common/src/i2s.rs
@@ -326,6 +326,11 @@ where
             (buffer, payload)
         }
     }
+
+    /// Check if the DMA transfer is complete
+    fn is_done(&self) -> bool {
+        self.i2s_tx.tx_channel.is_done()
+    }
 }
 
 impl<'d, T, P, TX, BUFFER> Drop for I2sWriteDmaTransfer<T, P, TX, BUFFER>
@@ -450,6 +455,11 @@ where
             core::mem::forget(self);
             (buffer, payload)
         }
+    }
+
+    /// Check if the DMA transfer is complete
+    fn is_done(&self) -> bool {
+        self.i2s_rx.rx_channel.is_done()
     }
 }
 

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -861,6 +861,12 @@ pub mod dma {
                 (rbuffer, tbuffer, payload)
             }
         }
+
+        /// Check if the DMA transfer is complete
+        fn is_done(&self) -> bool {
+            let ch = &self.spi_dma.channel;
+            ch.tx.is_done() && ch.rx.is_done()
+        }
     }
 
     impl<'d, T, TX, RX, P, RXBUF, TXBUF, M> Drop
@@ -917,6 +923,12 @@ pub mod dma {
                 mem::forget(self);
                 (buffer, payload)
             }
+        }
+
+        /// Check if the DMA transfer is complete
+        fn is_done(&self) -> bool {
+            let ch = &self.spi_dma.channel;
+            ch.tx.is_done() && ch.rx.is_done()
         }
     }
 

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -98,6 +98,13 @@ fn main() -> ! {
 
         let transfer = spi.dma_transfer(send, receive).unwrap();
         // here we could do something else while DMA transfer is in progress
+        let mut i = 0;
+        // Check is_done until the transfer is almost done (32000 bytes at 100kHz is
+        // 2.56 seconds), then move to wait().
+        while !transfer.is_done() && i < 10 {
+            delay.delay_ms(250u32);
+            i += 1;
+        }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
         (receive, send, spi) = transfer.wait();

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -99,6 +99,13 @@ fn main() -> ! {
 
         let transfer = spi.dma_transfer(send, receive).unwrap();
         // here we could do something else while DMA transfer is in progress
+        let mut i = 0;
+        // Check is_done until the transfer is almost done (32000 bytes at 100kHz is
+        // 2.56 seconds), then move to wait().
+        while !transfer.is_done() && i < 10 {
+            delay.delay_ms(250u32);
+            i += 1;
+        }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
         (receive, send, spi) = transfer.wait();

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -106,6 +106,13 @@ fn main() -> ! {
 
         let transfer = spi.dma_transfer(send, receive).unwrap();
         // here we could do something else while DMA transfer is in progress
+        let mut i = 0;
+        // Check is_done until the transfer is almost done (32000 bytes at 100kHz is
+        // 2.56 seconds), then move to wait().
+        while !transfer.is_done() && i < 10 {
+            delay.delay_ms(250u32);
+            i += 1;
+        }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
         (receive, send, spi) = transfer.wait();

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -107,6 +107,13 @@ fn main() -> ! {
 
         let transfer = spi.dma_transfer(send, receive).unwrap();
         // here we could do something else while DMA transfer is in progress
+        let mut i = 0;
+        // Check is_done until the transfer is almost done (32000 bytes at 100kHz is
+        // 2.56 seconds), then move to wait().
+        while !transfer.is_done() && i < 10 {
+            delay.delay_ms(250u32);
+            i += 1;
+        }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
         (receive, send, spi) = transfer.wait();

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -98,6 +98,13 @@ fn main() -> ! {
 
         let transfer = spi.dma_transfer(send, receive).unwrap();
         // here we could do something else while DMA transfer is in progress
+        let mut i = 0;
+        // Check is_done until the transfer is almost done (32000 bytes at 100kHz is
+        // 2.56 seconds), then move to wait().
+        while !transfer.is_done() && i < 10 {
+            delay.delay_ms(250u32);
+            i += 1;
+        }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
         (receive, send, spi) = transfer.wait();

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -106,6 +106,13 @@ fn main() -> ! {
 
         let transfer = spi.dma_transfer(send, receive).unwrap();
         // here we could do something else while DMA transfer is in progress
+        let mut i = 0;
+        // Check is_done until the transfer is almost done (32000 bytes at 100kHz is
+        // 2.56 seconds), then move to wait().
+        while !transfer.is_done() && i < 10 {
+            delay.delay_ms(250u32);
+            i += 1;
+        }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
         (receive, send, spi) = transfer.wait();


### PR DESCRIPTION
There's already a tree of functions to do this starting with a TxPrivate or RxPrivate ... but those aren't supposed to be used outside the HAL. Add a fn to the transaction traits instead, and implement it using the support in RxPrivate and TxPrivate.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

Unsure if examples work - I have no access to the hardware at the moment.

There are a few existing warnings, but this PR does not add any more.

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
