### PR TITLE
esp32-hal: examples: Include all cfg features dependencies for examples

### DIFF
--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -76,15 +76,15 @@ required-features = ["eh1"]
 
 [[example]]
 name              = "embassy_hello_world"
-required-features = ["embassy"]
+required-features = ["embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "embassy_wait"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "embassy_spi"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "psram"
@@ -92,8 +92,8 @@ required-features = ["psram_2m"]
 
 [[example]]
 name              = "embassy_serial"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "embassy_i2c"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -80,15 +80,15 @@ required-features = ["eh1"]
 
 [[example]]
 name              = "embassy_hello_world"
-required-features = ["embassy"]
+required-features = ["embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "embassy_wait"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "embassy_spi"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "psram"
@@ -96,8 +96,8 @@ required-features = ["psram_2m"]
 
 [[example]]
 name              = "embassy_serial"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "embassy_i2c"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -80,24 +80,24 @@ required-features = ["eh1"]
 
 [[example]]
 name              = "embassy_hello_world"
-required-features = ["embassy"]
+required-features = ["embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "embassy_wait"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "embassy_spi"
-required-features = ["embassy", "async"]
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
 name              = "psram"
 required-features = ["psram_2m"]
 
 [[example]]
-name              = "embassy_serial"
-required-features = ["embassy", "async"]
+name              = "embassy_i2c"
+required-features = ["async", "embassy", "embassy-time-timg0"]
 
 [[example]]
-name              = "embassy_i2c"
-required-features = ["embassy", "async"]
+name              = "embassy_serial"
+required-features = ["async", "embassy", "embassy-time-timg0"]


### PR DESCRIPTION
When attempting to build a single example, the suggested feature list for at least embassy-related examples was missing `embassy-time-timg0`.
