### PR TITLE
H2: Add initial ADC support with example 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for LEDC in ESP32-H2 (#560)
 - Add initial support for ASSIST_DEBUG in ESP32-H2 (#566)
 - Add all `SPI` examples for the ESP32-H2 (#549)
+- Add initial support for ADC in ESP32-H2 (#564)
 
 ### Changed
 

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -38,7 +38,7 @@ pub use fugit::{
 };
 pub use nb;
 
-#[cfg(any(esp32c2, esp32c3, esp32c6))]
+#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2))]
 pub use crate::analog::SarAdcExt as _esp_hal_analog_SarAdcExt;
 #[cfg(sens)]
 pub use crate::analog::SensExt as _esp_hal_analog_SensExt;

--- a/esp32h2-hal/examples/adc.rs
+++ b/esp32h2-hal/examples/adc.rs
@@ -1,0 +1,71 @@
+//! Connect a potentiometer to PIN2 and see the read values change when
+//! rotating the shaft. Alternatively you could also connect the PIN to GND or
+//! 3V3 to see the maximum and minimum raw values read.
+
+#![no_std]
+#![no_main]
+
+use esp32h2_hal::{
+    adc::{AdcConfig, Attenuation, ADC, ADC1},
+    clock::ClockControl,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Delay,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
+    // and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    // Create ADC instances
+    let analog = peripherals.APB_SARADC.split();
+
+    let mut adc1_config = AdcConfig::new();
+
+    let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
+
+    let mut adc1 = ADC::<ADC1>::adc(
+        &mut system.peripheral_clock_control,
+        analog.adc1,
+        adc1_config,
+    )
+    .unwrap();
+
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        let pin_value: u16 = nb::block!(adc1.read(&mut pin)).unwrap();
+        println!("PIN2 ADC reading = {}", pin_value);
+        delay.delay_ms(1500u32);
+    }
+}


### PR DESCRIPTION
We already have `analog` gpios and other stuff, so this just adds an example and export in `prelude`.
There is no calibration yet, we should wait for the calibration PR(#555) to be merged and we can address it afterward.
H2 calibration is currently not implemented in ESP-IDF (IDF-6216)