### PR TITLE
Simplify the `Delay` driver, derive `Clone` and `Copy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for ASSIST_DEBUG in ESP32-H2 (#566)
 - Add all `SPI` examples for the ESP32-H2 (#549)
 - Add initial support for ADC in ESP32-H2 (#564)
+- Simplify the `Delay` driver, derive `Clone` and `Copy` (#568)
 
 ### Changed
 


### PR DESCRIPTION
It's been recommended by various notable people from the embedded Rust community for quite some time now that delay sources be clone-able. This may also become a requirement of `embedded-hal` for the `SPI` driver in the future, see here:  
https://github.com/rust-embedded/embedded-hal/pull/462#issuecomment-1560014426

Since our delay providers do not own any peripheral structs and only perform reads, it's safe to clone/copy as many instances as you would like.