### PR TITLE
Async GPIO multibank fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for ADC in ESP32-H2 (#564)
 - Simplify the `Delay` driver, derive `Clone` and `Copy` (#568)
 - Add `embassy_serial` and `embassy_wait` examples for ESP32-H2 (#569)
+- Fix Async GPIO not disabling interupts on chips with multiple banks (#572)
 
 ### Changed
 


### PR DESCRIPTION
- Removes dead code from the default impl of the BankAccess trait
- Adds one new function to the async module to control the interrupt enable for any pin

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.


Closes https://github.com/esp-rs/esp-hal/issues/571
