### PR TITLE
H2: Add `timer_interrupt` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `embassy_serial` and `embassy_wait` examples for ESP32-H2 (#569)
 - Fix Async GPIO not disabling interupts on chips with multiple banks (#572)
 - Add unified field-based efuse access
+- Add `timer_interrupt` example in ESP32-H2 and refactor `clk_src` configuration (#575)
 
 ### Changed
 

--- a/esp-hal-common/src/soc/esp32c6/mod.rs
+++ b/esp-hal-common/src/soc/esp32c6/mod.rs
@@ -6,3 +6,7 @@ pub mod radio_clocks;
 pub(crate) mod registers {
     pub const INTERRUPT_MAP_BASE: u32 = 0x60010000;
 }
+
+pub(crate) mod constants {
+    pub const TIMG_DEFAULT_CLK_SRC: u8 = 1;
+}

--- a/esp-hal-common/src/soc/esp32h2/mod.rs
+++ b/esp-hal-common/src/soc/esp32h2/mod.rs
@@ -6,3 +6,7 @@ pub mod radio_clocks;
 pub(crate) mod registers {
     pub const INTERRUPT_MAP_BASE: u32 = 0x60010000;
 }
+
+pub(crate) mod constants {
+    pub const TIMG_DEFAULT_CLK_SRC: u8 = 2;
+}

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -455,37 +455,22 @@ impl PeripheralClockControl {
             Peripheral::Timg0 => {
                 system
                     .timergroup0_timer_clk_conf
-                    .write(|w| w.tg0_timer_clk_en().set_bit());
-                let bits = if cfg!(esp32c6) { 1 } else { 2 };
-                system
-                    .timergroup0_timer_clk_conf
-                    .write(|w| unsafe { w.tg0_timer_clk_sel().bits(bits) });
+                    .modify(|_, w| w.tg0_timer_clk_en().set_bit());
             }
             #[cfg(timg1)]
             Peripheral::Timg1 => {
                 system
                     .timergroup1_timer_clk_conf
-                    .write(|w| w.tg1_timer_clk_en().set_bit());
-                let bits = if cfg!(esp32c6) { 1 } else { 2 };
-                system
-                    .timergroup1_timer_clk_conf
-                    .write(|w| unsafe { w.tg1_timer_clk_sel().bits(bits) });
+                    .modify(|_, w| w.tg1_timer_clk_en().set_bit());
             }
             #[cfg(lp_wdt)]
             Peripheral::Wdt => {
                 system
                     .timergroup0_wdt_clk_conf
-                    .write(|w| w.tg0_wdt_clk_en().set_bit());
-                system
-                    .timergroup0_wdt_clk_conf
-                    .write(|w| unsafe { w.tg0_wdt_clk_sel().bits(1) });
-
+                    .modify(|_, w| w.tg0_wdt_clk_en().set_bit());
                 system
                     .timergroup1_timer_clk_conf
-                    .write(|w| w.tg1_timer_clk_en().set_bit());
-                system
-                    .timergroup1_timer_clk_conf
-                    .write(|w| unsafe { w.tg1_timer_clk_sel().bits(1) });
+                    .modify(|_, w| w.tg1_timer_clk_en().set_bit());
             }
             #[cfg(sha)]
             Peripheral::Sha => {

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -72,11 +72,26 @@ where
     ) -> Self {
         crate::into_ref!(timer_group);
 
+        use esp_println::println;
+
+        println!("123");
+
+        #[cfg(not(esp32h2))]
         let timer0 = Timer::new(
             Timer0 {
                 phantom: PhantomData::default(),
             },
             clocks.apb_clock,
+            peripheral_clock_control,
+        );
+
+        // ESP32-H2 is using PLL_48M_CLK source instead of APB_CLK
+        #[cfg(esp32h2)]
+        let timer0 = Timer::new(
+            Timer0 {
+                phantom: PhantomData::default(),
+            },
+            clocks.pll_48m_clock,
             peripheral_clock_control,
         );
 
@@ -120,6 +135,9 @@ where
     ) -> Self {
         // TODO: this currently assumes APB_CLK is being used, as we don't yet have a
         //       way to select the XTAL_CLK.
+        use esp_println::println;
+
+        println!("LOLP {}", apb_clk_freq.to_Hz());
         timg.enable_peripheral(peripheral_clock_control);
         Self { timg, apb_clk_freq }
     }

--- a/esp32h2-hal/examples/timer_interrupt.rs
+++ b/esp32h2-hal/examples/timer_interrupt.rs
@@ -1,0 +1,110 @@
+//! This shows how to use the TIMG peripheral interrupts.
+//! There is TIMG0 and TIMG1 each of them containing a general purpose timer and
+//! a watchdog timer.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use critical_section::Mutex;
+use esp32h2_hal::{
+    clock::ClockControl,
+    interrupt,
+    peripherals::{self, Peripherals, TIMG0, TIMG1},
+    prelude::*,
+    riscv,
+    timer::{Timer, Timer0, TimerGroup},
+    Rtc,
+};
+use esp_backtrace as _;
+
+static TIMER0: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell::new(None));
+static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
+    // and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer0 = timer_group0.timer0;
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer1 = timer_group1.timer0;
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    interrupt::enable(
+        peripherals::Interrupt::TG0_T0_LEVEL,
+        interrupt::Priority::Priority2,
+    )
+    .unwrap();
+
+    timer0.start(500u64.millis());
+
+    timer0.listen();
+
+    interrupt::enable(
+        peripherals::Interrupt::TG1_T0_LEVEL,
+        interrupt::Priority::Priority2,
+    )
+    .unwrap();
+
+    timer1.start(1u64.secs());
+    timer1.listen();
+
+    critical_section::with(|cs| {
+        TIMER0.borrow_ref_mut(cs).replace(timer0);
+        TIMER1.borrow_ref_mut(cs).replace(timer1);
+    });
+
+    unsafe {
+        riscv::interrupt::enable();
+    }
+
+    loop {}
+}
+
+#[interrupt]
+fn TG0_T0_LEVEL() {
+    critical_section::with(|cs| {
+        esp_println::println!("Interrupt 1");
+
+        let mut timer0 = TIMER0.borrow_ref_mut(cs);
+        let timer0 = timer0.as_mut().unwrap();
+
+        timer0.clear_interrupt();
+        timer0.start(1000u64.millis());
+    });
+}
+
+#[interrupt]
+fn TG1_T0_LEVEL() {
+    critical_section::with(|cs| {
+        esp_println::println!("Interrupt 11");
+
+        let mut timer1 = TIMER1.borrow_ref_mut(cs);
+        let timer1 = timer1.as_mut().unwrap();
+
+        timer1.clear_interrupt();
+        timer1.start(1u64.secs());
+    });
+}

--- a/esp32h2-hal/examples/timer_interrupt.rs
+++ b/esp32h2-hal/examples/timer_interrupt.rs
@@ -92,7 +92,7 @@ fn TG0_T0_LEVEL() {
         let timer0 = timer0.as_mut().unwrap();
 
         timer0.clear_interrupt();
-        timer0.start(1000u64.millis());
+        timer0.start(500u64.millis());
     });
 }
 


### PR DESCRIPTION
Refactors timer driver a little bit - adds helper functions which configure default `clk_src` for `Timgs` and `Wdts`.
Removes `steal()` warning