### PR TITLE
Use built-in LED pin (gpio2) in blinky example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move core interrupt handling from Flash to RAM for RISC-V chips (ESP32-H2, ESP32-C2, ESP32-C3, ESP32-C6) (#541)
+- Change LED pin to GPIO2 in ESP32 blinky example (#581)
 
 ### Fixed
 

--- a/esp32-hal/examples/blinky.rs
+++ b/esp32-hal/examples/blinky.rs
@@ -1,6 +1,6 @@
 //! Blinks an LED
 //!
-//! This assumes that a LED is connected to the pin assigned to `led`. (GPIO15)
+//! This uses the built-in LED that is connected to pin GPIO2.
 
 #![no_std]
 #![no_main]
@@ -34,9 +34,9 @@ fn main() -> ! {
     wdt.disable();
     rtc.rwdt.disable();
 
-    // Set GPIO15 as an output, and set its state high initially.
+    // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let mut led = io.pins.gpio15.into_push_pull_output();
+    let mut led = io.pins.gpio2.into_push_pull_output();
 
     led.set_high().unwrap();
 

--- a/esp32-hal/examples/blinky.rs
+++ b/esp32-hal/examples/blinky.rs
@@ -1,6 +1,7 @@
 //! Blinks an LED
 //!
-//! This uses the built-in LED that is connected to pin GPIO2.
+//! This assumes that a LED is connected to the pin assigned to `led` (GPIO2).
+//! For the the DOIT ESP32 Devkit v1, GPIO2 is the onboard LED pin.
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
Hi, I was just running the blinky example and noticed the comments about an LED being connected to pin GPIO25. I was thinking it might makes more sense to use the built-in LED pin instead, and no external hardware would be required.