### PR TITLE
[Minor][ESP32] Update xtal feature check in build.rs

### DIFF
--- a/esp32-hal/build.rs
+++ b/esp32-hal/build.rs
@@ -61,7 +61,7 @@ fn generate_memory_extras() -> Vec<u8> {
 }
 
 fn check_features() {
-    if cfg!(feature = "esp32_40mhz") && cfg!(feature = "esp32_26mhz") {
+    if cfg!(feature = "xtal40mhz") && cfg!(feature = "xtal26mhz") {
         panic!("Only one xtal speed feature can be selected");
     }
 }


### PR DESCRIPTION
It appears that during one refactor or another a check in the esp32-hal `build.rs` was forgotten, and two feature flags were not renamed. This change addresses that minor issue. I've double checked the other SoCs, but couldn't find similar issue, so it appears it was limited to the ESP32 only.

# Template

- [ ] ~~The code compiles without `errors` or `warnings`.~~ There was already a warning prior to my change. This has not been addressed.
- [ ] ~~All examples work.~~ No possible effect
- [x] `cargo fmt` was run.
- [ ] ~~Your changes were added to the `CHANGELOG.md` in the proper section.~~  Not a significant enough change
- [x] You updated existing examples or added examples (if applicable).
- [ ] ~~Added examples are checked in CI~~ Not applicable

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] ~~You added proper docs for your newly added features and code.~~ Not applicable
