### PR TITLE
Initial support for RNG in ESP32-H2 

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -55,7 +55,7 @@ esp32   = { version = "0.23.0", features = ["critical-section"], optional = true
 esp32c2 = { version = "0.11.0", features = ["critical-section"], optional = true }
 esp32c3 = { version = "0.14.0", features = ["critical-section"], optional = true }
 esp32c6 = { version = "0.4.0",  features = ["critical-section"], optional = true }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "4a55004", package = "esp32h2", features = ["critical-section"], optional = true }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "5ff82e4", package = "esp32h2", features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.14.0", features = ["critical-section"], optional = true }
 esp32s3 = { version = "0.18.0", features = ["critical-section"], optional = true }
 

--- a/esp-hal-common/devices/esp32h2.toml
+++ b/esp-hal-common/devices/esp32h2.toml
@@ -40,7 +40,7 @@ peripherals = [
     "pcr",
     "pmu",
     "rmt",
-    # "rng",
+    "rng",
     "rsa",
     "sha",
     # "soc_etm",

--- a/esp-hal-common/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32h2/peripherals.rs
@@ -42,7 +42,7 @@ crate::peripherals! {
     PCR => true,
     PMU => true,
     RMT => true,
-    // RNG => true,
+    RNG => true,
     RSA => true,
     SHA => true,
     // SOC_ETM => true,

--- a/esp32h2-hal/examples/rng.rs
+++ b/esp32h2-hal/examples/rng.rs
@@ -1,0 +1,55 @@
+//! Demonstrates the use of the hardware Random Number Generator (RNG)
+
+#![no_std]
+#![no_main]
+
+use esp32h2_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers:
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    // Instantiate the Random Number Generator peripheral:
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Generate a random word (u32):
+    println!("Random u32:   {}", rng.random());
+
+    // Fill a buffer with random bytes:
+    let mut buf = [0u8; 16];
+    rng.read(&mut buf).unwrap();
+    println!("Random bytes: {:?}", buf);
+
+    loop {}
+}


### PR DESCRIPTION
Adds initial support for RNG and the `rng` example.

Output of `rng`example: 
```
Random u32:   517116262
Random bytes: [169, 227, 48, 14, 58, 141, 176, 130, 143, 242, 48, 173, 147, 180, 4, 180]
```