### PR TITLE
Udpate H2 and C6 clocks. Remove i2c_clock for all chips but ESP32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for `esp-hal-smartled` in ESP32-H2 (#589)
 - Add CRC functions from ESP ROM
 - Add initial support for RNG in ESP32-H2 (#591)
--
+
 ### Changed
 
 - Move core interrupt handling from Flash to RAM for RISC-V chips (ESP32-H2, ESP32-C2, ESP32-C3, ESP32-C6) (#541)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for `esp-hal-smartled` in ESP32-H2 (#589)
 - Add CRC functions from ESP ROM
 - Add initial support for RNG in ESP32-H2 (#591)
-
+-
 ### Changed
 
 - Move core interrupt handling from Flash to RAM for RISC-V chips (ESP32-H2, ESP32-C2, ESP32-C3, ESP32-C6) (#541)
 - Change LED pin to GPIO2 in ESP32 blinky example (#581)
+- Udpate ESP32-H2 and C6 ESP32-clocks and remove i2c_clock for all chips but ESP32 (#592)
 
 ### Fixed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -54,7 +54,7 @@ ufmt-write = { version = "0.1.0", optional = true }
 esp32   = { version = "0.23.0", features = ["critical-section"], optional = true }
 esp32c2 = { version = "0.11.0", features = ["critical-section"], optional = true }
 esp32c3 = { version = "0.14.0", features = ["critical-section"], optional = true }
-esp32c6 = { version = "0.4.0",  features = ["critical-section"], optional = true }
+esp32c6 = { git = "https://github.com/SergioGasquez/esp-pacs", branch = "feature/c6-pcr", package = "esp32c6", features = ["critical-section"], optional = true }
 esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "5ff82e4", package = "esp32h2", features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.14.0", features = ["critical-section"], optional = true }
 esp32s3 = { version = "0.18.0", features = ["critical-section"], optional = true }

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -54,7 +54,7 @@ ufmt-write = { version = "0.1.0", optional = true }
 esp32   = { version = "0.23.0", features = ["critical-section"], optional = true }
 esp32c2 = { version = "0.11.0", features = ["critical-section"], optional = true }
 esp32c3 = { version = "0.14.0", features = ["critical-section"], optional = true }
-esp32c6 = { git = "https://github.com/SergioGasquez/esp-pacs", branch = "feature/c6-pcr", package = "esp32c6", features = ["critical-section"], optional = true }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1b88c54", package = "esp32c6", features = ["critical-section"], optional = true }
 esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "5ff82e4", package = "esp32h2", features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.14.0", features = ["critical-section"], optional = true }
 esp32s3 = { version = "0.18.0", features = ["critical-section"], optional = true }

--- a/esp-hal-common/src/clock/clocks_ll/esp32h2.rs
+++ b/esp-hal-common/src/clock/clocks_ll/esp32h2.rs
@@ -160,13 +160,6 @@ pub(crate) fn esp32h2_rtc_bbpll_enable() {
 
     pmu.imm_hp_ck_power
         .modify(|_, w| w.tie_high_global_bbpll_icg().set_bit());
-
-    let pcr = unsafe { &*crate::peripherals::PCR::PTR };
-
-    // switch spimem to PLL 64Mhz clock
-    unsafe {
-        pcr.mspi_conf.modify(|_, w| w.mspi_clk_sel().bits(0b10));
-    }
 }
 
 pub(crate) fn esp32h2_rtc_update_to_xtal(freq: XtalClock, _div: u8) {
@@ -175,8 +168,7 @@ pub(crate) fn esp32h2_rtc_update_to_xtal(freq: XtalClock, _div: u8) {
         ets_update_cpu_frequency(freq.mhz());
         // Set divider from XTAL to APB clock. Need to set divider to 1 (reg. value 0)
         // first.
-        pcr.ahb_freq_conf
-            .modify(|_, w| w.ahb_div_num().bits(_div - 1));
+        clk_ll_ahb_set_divider(_div as u32);
 
         pcr.cpu_freq_conf
             .modify(|_, w| w.cpu_div_num().bits(_div - 1));

--- a/esp-hal-common/src/clock/mod.rs
+++ b/esp-hal-common/src/clock/mod.rs
@@ -30,14 +30,15 @@ pub trait Clock {
 /// CPU clock speed
 #[derive(Debug, Clone, Copy)]
 pub enum CpuClock {
+    #[cfg(not(esp32h2))]
     Clock80MHz,
     #[cfg(esp32h2)]
     Clock96MHz,
     #[cfg(esp32c2)]
     Clock120MHz,
-    #[cfg(not(esp32c2))]
+    #[cfg(not(any(esp32c2, esp32h2)))]
     Clock160MHz,
-    #[cfg(not(any(esp32c2, esp32c3, esp32c6)))]
+    #[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2)))]
     Clock240MHz,
 }
 
@@ -45,14 +46,15 @@ pub enum CpuClock {
 impl Clock for CpuClock {
     fn frequency(&self) -> HertzU32 {
         match self {
+            #[cfg(not(esp32h2))]
             CpuClock::Clock80MHz => HertzU32::MHz(80),
             #[cfg(esp32h2)]
             CpuClock::Clock96MHz => HertzU32::MHz(96),
             #[cfg(esp32c2)]
             CpuClock::Clock120MHz => HertzU32::MHz(120),
-            #[cfg(not(esp32c2))]
+            #[cfg(not(any(esp32c2, esp32h2)))]
             CpuClock::Clock160MHz => HertzU32::MHz(160),
-            #[cfg(not(any(esp32c2, esp32c3, esp32c6)))]
+            #[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2)))]
             CpuClock::Clock240MHz => HertzU32::MHz(240),
         }
     }
@@ -65,8 +67,9 @@ pub(crate) enum XtalClock {
     RtcXtalFreq24M,
     #[cfg(any(esp32, esp32c2))]
     RtcXtalFreq26M,
-    #[cfg(any(esp32c3, esp32s3, esp32h2))]
+    #[cfg(any(esp32c3, esp32h2, esp32s3))]
     RtcXtalFreq32M,
+    #[cfg(not(esp32h2))]
     RtcXtalFreq40M,
     RtcXtalFreqOther(u32),
 }
@@ -78,8 +81,9 @@ impl Clock for XtalClock {
             XtalClock::RtcXtalFreq24M => HertzU32::MHz(24),
             #[cfg(any(esp32, esp32c2))]
             XtalClock::RtcXtalFreq26M => HertzU32::MHz(26),
-            #[cfg(any(esp32c3, esp32s3, esp32h2))]
+            #[cfg(any(esp32c3, esp32h2, esp32s3))]
             XtalClock::RtcXtalFreq32M => HertzU32::MHz(32),
+            #[cfg(not(esp32h2))]
             XtalClock::RtcXtalFreq40M => HertzU32::MHz(40),
             XtalClock::RtcXtalFreqOther(mhz) => HertzU32::MHz(*mhz),
         }
@@ -89,15 +93,32 @@ impl Clock for XtalClock {
 #[allow(unused)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum PllClock {
-    #[cfg(not(any(esp32c2, esp32c6)))]
+    #[cfg(any(esp32c6, esp32h2))]
+    Pll48MHz,
+    #[cfg(esp32h2)]
+    Pll64MHz,
+    #[cfg(esp32c6)]
+    Pll80MHz,
+    #[cfg(esp32h2)]
+    Pll96MHz,
+    #[cfg(esp32c6)]
+    Pll160MHz,
+    #[cfg(esp32c6)]
+    Pll240MHz,
+    #[cfg(not(any(esp32c2, esp32c6, esp32h2)))]
     Pll320MHz,
+    #[cfg(not(esp32h2))]
     Pll480MHz,
 }
 
 #[allow(unused)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ApbClock {
+    #[cfg(esp32h2)]
+    ApbFreq32MHz,
+    #[cfg(not(esp32h2))]
     ApbFreq40MHz,
+    #[cfg(not(esp32h2))]
     ApbFreq80MHz,
     ApbFreqOther(u32),
 }
@@ -105,7 +126,11 @@ pub(crate) enum ApbClock {
 impl Clock for ApbClock {
     fn frequency(&self) -> HertzU32 {
         match self {
+            #[cfg(esp32h2)]
+            ApbClock::ApbFreq32MHz => HertzU32::MHz(32),
+            #[cfg(not(esp32h2))]
             ApbClock::ApbFreq40MHz => HertzU32::MHz(40),
+            #[cfg(not(esp32h2))]
             ApbClock::ApbFreq80MHz => HertzU32::MHz(80),
             ApbClock::ApbFreqOther(mhz) => HertzU32::MHz(*mhz),
         }
@@ -121,12 +146,13 @@ pub struct Clocks<'d> {
     pub cpu_clock: HertzU32,
     pub apb_clock: HertzU32,
     pub xtal_clock: HertzU32,
+    #[cfg(esp32)]
     pub i2c_clock: HertzU32,
     #[cfg(esp32)]
     pub pwm_clock: HertzU32,
     #[cfg(esp32s3)]
     pub crypto_pwm_clock: HertzU32,
-    #[cfg(esp32c6)]
+    #[cfg(any(esp32c6, esp32h2))]
     pub crypto_clock: HertzU32,
     #[cfg(esp32h2)]
     pub pll_48m_clock: HertzU32,
@@ -148,12 +174,13 @@ impl<'d> Clocks<'d> {
             cpu_clock: raw_clocks.cpu_clock,
             apb_clock: raw_clocks.apb_clock,
             xtal_clock: raw_clocks.xtal_clock,
+            #[cfg(esp32)]
             i2c_clock: raw_clocks.i2c_clock,
             #[cfg(esp32)]
             pwm_clock: raw_clocks.pwm_clock,
             #[cfg(esp32s3)]
             crypto_pwm_clock: raw_clocks.crypto_pwm_clock,
-            #[cfg(esp32c6)]
+            #[cfg(any(esp32c6, esp32h2))]
             crypto_clock: raw_clocks.crypto_clock,
             #[cfg(esp32h2)]
             pll_48m_clock: raw_clocks.pll_48m_clock,
@@ -166,12 +193,13 @@ pub struct RawClocks {
     pub cpu_clock: HertzU32,
     pub apb_clock: HertzU32,
     pub xtal_clock: HertzU32,
+    #[cfg(esp32)]
     pub i2c_clock: HertzU32,
     #[cfg(esp32)]
     pub pwm_clock: HertzU32,
     #[cfg(esp32s3)]
     pub crypto_pwm_clock: HertzU32,
-    #[cfg(esp32c6)]
+    #[cfg(any(esp32c6, esp32h2))]
     pub crypto_clock: HertzU32,
     #[cfg(esp32h2)]
     pub pll_48m_clock: HertzU32,
@@ -281,7 +309,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: HertzU32::MHz(80),
                 apb_clock: HertzU32::MHz(40),
                 xtal_clock: HertzU32::MHz(40),
-                i2c_clock: HertzU32::MHz(40),
             },
         };
 
@@ -292,7 +319,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: HertzU32::MHz(80),
                 apb_clock: HertzU32::MHz(40),
                 xtal_clock: HertzU32::MHz(26),
-                i2c_clock: HertzU32::MHz(26),
             },
         };
     }
@@ -328,7 +354,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: cpu_clock_speed.frequency(),
                 apb_clock: apb_freq.frequency(),
                 xtal_clock: xtal_freq.frequency(),
-                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -347,7 +372,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: HertzU32::MHz(80),
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
-                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -380,7 +404,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: cpu_clock_speed.frequency(),
                 apb_clock: apb_freq.frequency(),
                 xtal_clock: xtal_freq.frequency(),
-                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -399,7 +422,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: HertzU32::MHz(80),
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
-                i2c_clock: HertzU32::MHz(40),
                 crypto_clock: HertzU32::MHz(160),
             },
         }
@@ -433,7 +455,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: cpu_clock_speed.frequency(),
                 apb_clock: apb_freq.frequency(),
                 xtal_clock: xtal_freq.frequency(),
-                i2c_clock: HertzU32::MHz(40),
                 crypto_clock: HertzU32::MHz(160),
             },
         }
@@ -453,8 +474,8 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: HertzU32::MHz(96),
                 apb_clock: HertzU32::MHz(32),
                 xtal_clock: HertzU32::MHz(32),
-                i2c_clock: HertzU32::MHz(32),
                 pll_48m_clock: HertzU32::MHz(48),
+                crypto_clock: HertzU32::MHz(96),
             },
         }
     }
@@ -466,15 +487,15 @@ impl<'d> ClockControl<'d> {
         cpu_clock_speed: CpuClock,
     ) -> ClockControl<'d> {
         let apb_freq;
-        let xtal_freq = XtalClock::RtcXtalFreqOther(32);
-        let pll_freq = PllClock::Pll320MHz;
+        let xtal_freq = XtalClock::RtcXtalFreq32M;
+        let pll_freq = PllClock::Pll96MHz;
 
         if cpu_clock_speed.mhz() <= xtal_freq.mhz() {
             apb_freq = ApbClock::ApbFreqOther(cpu_clock_speed.mhz());
             clocks_ll::esp32h2_rtc_update_to_xtal(xtal_freq, 1);
             clocks_ll::esp32h2_rtc_apb_freq_update(apb_freq);
         } else {
-            apb_freq = ApbClock::ApbFreqOther(32);
+            apb_freq = ApbClock::ApbFreq32MHz;
             clocks_ll::esp32h2_rtc_bbpll_enable();
             clocks_ll::esp32h2_rtc_bbpll_configure(xtal_freq, pll_freq);
             clocks_ll::esp32h2_rtc_freq_to_pll_mhz(cpu_clock_speed);
@@ -487,8 +508,8 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: cpu_clock_speed.frequency(),
                 apb_clock: apb_freq.frequency(),
                 xtal_clock: xtal_freq.frequency(),
-                i2c_clock: HertzU32::MHz(32),
                 pll_48m_clock: HertzU32::MHz(48),
+                crypto_clock: HertzU32::MHz(96),
             },
         }
     }
@@ -507,7 +528,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: HertzU32::MHz(80),
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
-                i2c_clock: HertzU32::MHz(80),
             },
         }
     }
@@ -526,7 +546,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: cpu_clock_speed.frequency(),
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
-                i2c_clock: HertzU32::MHz(40),
             },
         }
     }
@@ -545,7 +564,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: HertzU32::MHz(80),
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
-                i2c_clock: HertzU32::MHz(40),
                 crypto_pwm_clock: HertzU32::MHz(160),
             },
         }
@@ -565,7 +583,6 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: cpu_clock_speed.frequency(),
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
-                i2c_clock: HertzU32::MHz(40),
                 crypto_pwm_clock: HertzU32::MHz(160),
             },
         }

--- a/esp-hal-common/src/clock/mod.rs
+++ b/esp-hal-common/src/clock/mod.rs
@@ -93,6 +93,8 @@ impl Clock for XtalClock {
 #[allow(unused)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum PllClock {
+    #[cfg(esp32h2)]
+    Pll8MHz,
     #[cfg(any(esp32c6, esp32h2))]
     Pll48MHz,
     #[cfg(esp32h2)]
@@ -101,6 +103,8 @@ pub(crate) enum PllClock {
     Pll80MHz,
     #[cfg(esp32h2)]
     Pll96MHz,
+    #[cfg(esp32c6)]
+    Pll120MHz,
     #[cfg(esp32c6)]
     Pll160MHz,
     #[cfg(esp32c6)]

--- a/esp-hal-common/src/i2c.rs
+++ b/esp-hal-common/src/i2c.rs
@@ -646,7 +646,10 @@ pub trait Instance {
         self.set_filter(Some(7), Some(7));
 
         // Configure frequency
+        #[cfg(esp32)]
         self.set_frequency(clocks.i2c_clock.convert(), frequency);
+        #[cfg(not(esp32))]
+        self.set_frequency(clocks.xtal_clock.convert(), frequency);
 
         self.update_config();
 

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -368,7 +368,7 @@ impl PeripheralClockControl {
             }
             #[cfg(i2c0)]
             Peripheral::I2cExt0 => {
-                #[cfg(esp32h2)]
+                #[cfg(any(esp32c6, esp32h2))]
                 {
                     system.i2c0_conf.modify(|_, w| w.i2c0_clk_en().set_bit());
                     system.i2c0_conf.modify(|_, w| w.i2c0_rst_en().clear_bit());

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -368,12 +368,6 @@ impl PeripheralClockControl {
             }
             #[cfg(i2c0)]
             Peripheral::I2cExt0 => {
-                // TODO: align register names between C6 and H2 in the PACs
-                #[cfg(esp32c6)]
-                {
-                    system.i2c_conf.modify(|_, w| w.i2c_clk_en().set_bit());
-                    system.i2c_conf.modify(|_, w| w.i2c_rst_en().clear_bit());
-                }
                 #[cfg(esp32h2)]
                 {
                     system.i2c0_conf.modify(|_, w| w.i2c0_clk_en().set_bit());


### PR DESCRIPTION
- Update clocks and add missing clocks for H2 and C6
- Align i2c0 C6 fields with H2
- Remove i2c_clocks for all chips but esp32

Gathered some information about I2C clocks in the different chips in this HackMD: https://hackmd.io/@SergioGasquez/r1dvX1AHh

Checked the I2C freq for some devices: 
- ESP32:
<img width="1389" alt="I2C_ESP32" src="https://github.com/esp-rs/esp-hal/assets/12926049/9f34c1af-c03f-48fa-9df2-6716dca3667a">
- ESP32-C6:
<img width="1389" alt="I2C_C6" src="https://github.com/esp-rs/esp-hal/assets/12926049/b3b4efa1-68ef-4fe1-9d24-b75cfe1bbde1">
- ESP32-H2:
<img width="1389" alt="I2C_H2" src="https://github.com/esp-rs/esp-hal/assets/12926049/af0cb47e-e458-465e-b91e-669af8502566">


~~Draft PR until PACs are updated (https://github.com/esp-rs/esp-pacs/pull/130 and https://github.com/esp-rs/esp-pacs/pull/129)~~