### PR TITLE
Support FOSC CLK calibration for ECO1+ chip revisions of ESP32C6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve examples documentation (#533)
+- esp32h2-hal: added README (#585)
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sometimes half-duplex non-DMA SPI reads were reading garbage in non-release mode (#552)
 - ESP32-C3: Fix GPIO5 ADC channel id (#562)
 - ESP32-H2: Fix direct-boot feature
+- ESP32-C6: Support FOSC CLK calibration for ECO1+ chip revisions
 
 ### Changed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -30,6 +30,7 @@ procmacros           = { version = "0.5.0", package = "esp-hal-procmacros", path
 strum                = { version = "0.24.1", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
+esp-println       = { version = "0.5.0", features = ["esp32c6"] }
 
 # async
 embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -30,7 +30,6 @@ procmacros           = { version = "0.5.0", package = "esp-hal-procmacros", path
 strum                = { version = "0.24.1", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
-esp-println       = { version = "0.5.0", features = ["esp32c6"] }
 
 # async
 embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32c6.rs
@@ -1,9 +1,11 @@
+use esp_println::println;
 use fugit::HertzU32;
 use strum::FromRepr;
 
 use crate::{
     clock::{clocks_ll::regi2c_write_mask, Clock, XtalClock},
     peripherals::{LP_AON, LP_CLKRST, PCR, PMU, TIMG0},
+    soc::efuse::{Efuse,WAFER_VERSION_MINOR, WAFER_VERSION_MAJOR},
 };
 
 const I2C_DIG_REG: u8 = 0x6d;
@@ -556,8 +558,26 @@ impl RtcClock {
 
         let cal_val = loop {
             if timg0.rtccalicfg.read().rtc_cali_rdy().bit_is_set() {
-                break timg0.rtccalicfg1.read().rtc_cali_value().bits();
-            }
+
+                let minor: u8 = Efuse::read_field_le(WAFER_VERSION_MINOR);
+                let major: u8 = Efuse::read_field_le(WAFER_VERSION_MAJOR);
+
+                // The Fosc CLK of calibration circuit is divided by 32 for ECO1.
+                // So we need to multiply the frequency of the Fosc for ECO1 and above chips by 32 times.
+                // And ensure that this modification will not affect ECO0.
+                // PS: For ESP32C6 ECO0 chip version is v0.0 only, which means that both MAJOR and MINOR are 0.
+                // The chip version is calculated using the following formula: MAJOR * 100 + MINOR. (if the result is 1, then version is v0.1)
+                if (major * 100 + minor) > 0 {
+                    if cal_clk == RtcCalSel::RtcCalRcFast {
+                        break timg0.rtccalicfg1.read().rtc_cali_value().bits() >> 5;
+                    }
+                    break timg0.rtccalicfg1.read().rtc_cali_value().bits();
+                }
+                else {
+                    break timg0.rtccalicfg1.read().rtc_cali_value().bits();
+                }
+                
+            }       
 
             if timg0.rtccalicfg2.read().rtc_cali_timeout().bit_is_set() {
                 // Timed out waiting for calibration
@@ -619,6 +639,21 @@ impl RtcClock {
     /// issue, or lack of 32 XTAL on board).
     fn calibrate(cal_clk: RtcCalSel, slowclk_cycles: u32) -> u32 {
         let xtal_freq = RtcClock::get_xtal_freq();
+
+        let minor: u8 = Efuse::read_field_le(WAFER_VERSION_MINOR);
+        let major: u8 = Efuse::read_field_le(WAFER_VERSION_MAJOR);
+
+        // The Fosc CLK of calibration circuit is divided by 32 for ECO1.
+        // So we need to divide the calibrate cycles of the FOSC for ECO1 and above chips by 32 to
+        // avoid excessive calibration time.*/
+        // PS: For ESP32C6 ECO0 chip version is v0.0 only, which means that both MAJOR and MINOR are 0.
+        // The chip version is calculated using the following formula: MAJOR * 100 + MINOR. (if the result is 1, then version is v0.1)
+        if (major * 100 + minor) > 0 {
+            if cal_clk == RtcCalSel::RtcCalRcFast {
+                slowclk_cycles = showclk_cycles >> 5;
+            }
+        }
+
         let xtal_cycles = RtcClock::calibrate_internal(cal_clk, slowclk_cycles) as u64;
         let divider = xtal_freq.mhz() as u64 * slowclk_cycles as u64;
         let period_64 = ((xtal_cycles << RtcClock::CAL_FRACT) + divider / 2u64 - 1u64) / divider;

--- a/esp32h2-hal/README.md
+++ b/esp32h2-hal/README.md
@@ -11,9 +11,9 @@ This device uses the RISC-V ISA, which is officially supported by the Rust compi
 
 <!-- ## [Documentation]
 
-[documentation]: https://docs.rs/esp32c6-hal/
+[documentation]: https://docs.rs/esp32c6-hal/ -->
 
-## Getting Started
+Getting Started
 
 ### Installing the Rust Compiler Target
 
@@ -33,7 +33,7 @@ By default, [espflash](https://github.com/esp-rs/espflash) fetches the required 
 
 #### Direct Boot
 
-[Direct Boot](https://github.com/espressif/esp32c6-direct-boot-example#direct-boot-in-esp32-c6) allows an application stored in the External Flash to be executed directly, without being copied into Internal RAM.
+Direct Boot allows an application stored in the External Flash to be executed directly, without being copied into Internal RAM.
 
 ##### Booting the Hello World example using Direct Boot
 
@@ -52,14 +52,14 @@ cargo espflash --release --format direct-boot --features direct-boot --example h
 The ROM Bootloader will identify the firmware image built with Direct Boot support and load it appropriately from the External Flash:
 
 ```shell
-ESP-ROM:esp32c6-20220919
-Build:Sep 19 2022
-rst:0x1 (POWERON),boot:0x6e (SPI_FAST_FLASH_BOOT)
+ESP-ROM:esp32h2-20221101
+Build:Nov  1 2022
+rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
 Hello world!
 Hello world!
 Hello world!
 ```
--->
+
 ## License
 
 Licensed under either of:

--- a/esp32h2-hal/README.md
+++ b/esp32h2-hal/README.md
@@ -13,7 +13,7 @@ This device uses the RISC-V ISA, which is officially supported by the Rust compi
 
 [documentation]: https://docs.rs/esp32h2-hal/ -->
 
-Getting Started
+## Getting Started
 
 ### Installing the Rust Compiler Target
 

--- a/esp32h2-hal/README.md
+++ b/esp32h2-hal/README.md
@@ -1,9 +1,9 @@
 # esp32h2-hal
 
-<!-- [![Crates.io](https://img.shields.io/crates/v/esp32c6-hal?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp32c6-hal)
-[![docs.rs](https://img.shields.io/docsrs/esp32c6-hal?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp32c6-hal)
-![Crates.io](https://img.shields.io/crates/l/esp32c6-hal?labelColor=1C2C2E&style=flat-square)
-[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org) -->
+<!-- [![Crates.io](https://img.shields.io/crates/v/esp32h2-hal?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp32h2-hal)
+[![docs.rs](https://img.shields.io/docsrs/esp32h2-hal?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp32h2-hal)
+![Crates.io](https://img.shields.io/crates/l/esp32h2-hal?labelColor=1C2C2E&style=flat-square) -->
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
 `no_std` HAL for the ESP32-H2 from Espressif. Implements a number of the traits defined by [embedded-hal](https://github.com/rust-embedded/embedded-hal).
 
@@ -11,7 +11,7 @@ This device uses the RISC-V ISA, which is officially supported by the Rust compi
 
 <!-- ## [Documentation]
 
-[documentation]: https://docs.rs/esp32c6-hal/ -->
+[documentation]: https://docs.rs/esp32h2-hal/ -->
 
 Getting Started
 
@@ -27,7 +27,7 @@ $ rustup target add riscv32imac-unknown-none-elf
 
 #### IDF Bootloader
 
-The [IDF second stage bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-guides/startup.html#second-stage-bootloader) is the default bootloader solution.
+The [IDF second stage bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32h2/api-guides/startup.html#second-stage-bootloader) is the default bootloader solution.
 
 By default, [espflash](https://github.com/esp-rs/espflash) fetches the required binaries (Bootloader and Partition Table) and flashes them onto the target device together with the Rust-based application firmware image.
 


### PR DESCRIPTION
closes #515
Reference links to corresponding changes:
https://github.com/espressif/esp-idf/commit/e3148369f32fdc6de62c35a67f7adb6f4faef4e3
