### PR TITLE
Add a `debug` feature to enable the PACs' `impl-register-debug` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for `esp-hal-smartled` in ESP32-H2 (#589)
 - Add CRC functions from ESP ROM
 - Add initial support for RNG in ESP32-H2 (#591)
+- Add a `debug` feature to enable the PACs' `impl-register-debug` feature (#596)
 - Add initial support for `I2S` in ESP32-H2 (#597)
 
 ### Changed

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -51,13 +51,13 @@ ufmt-write = { version = "0.1.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.23.0", features = ["critical-section"], optional = true }
-esp32c2 = { version = "0.11.0", features = ["critical-section"], optional = true }
-esp32c3 = { version = "0.14.0", features = ["critical-section"], optional = true }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1b88c54", package = "esp32c6", features = ["critical-section"], optional = true }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "5ff82e4", package = "esp32h2", features = ["critical-section"], optional = true }
-esp32s2 = { version = "0.14.0", features = ["critical-section"], optional = true }
-esp32s3 = { version = "0.18.0", features = ["critical-section"], optional = true }
+esp32   = { version = "0.24.0", features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.12.0", features = ["critical-section"], optional = true }
+esp32c3 = { version = "0.15.0", features = ["critical-section"], optional = true }
+esp32c6 = { version = "0.5.0",  features = ["critical-section"], optional = true }
+esp32h2 = { version = "0.1.0",  features = ["critical-section"], optional = true }
+esp32s2 = { version = "0.15.0", features = ["critical-section"], optional = true }
+esp32s3 = { version = "0.19.0", features = ["critical-section"], optional = true }
 
 [build-dependencies]
 basic-toml = "0.1.2"
@@ -108,3 +108,14 @@ xtensa = ["critical-section/restore-state-u32", "procmacros/xtensa"]
 rv-init-data     = ["esp-riscv-rt/init-data", "esp-riscv-rt/init-rw-text"]
 rv-zero-rtc-bss  = ["esp-riscv-rt/zero-rtc-fast-bss"]
 rv-init-rtc-data = ["esp-riscv-rt/init-rtc-fast-data", "esp-riscv-rt/init-rtc-fast-text"]
+
+# Enable the `impl-register-debug` feature for the selected PAC
+debug = [
+    "esp32?/impl-register-debug",
+    "esp32c2?/impl-register-debug",
+    "esp32c3?/impl-register-debug",
+    "esp32c6?/impl-register-debug",
+    "esp32h2?/impl-register-debug",
+    "esp32s2?/impl-register-debug",
+    "esp32s3?/impl-register-debug",
+]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -51,6 +51,7 @@ static_cell       = "1.0.0"
 [features]
 default            = ["rt", "vectored", "xtal40mhz"]
 bluetooth          = []
+debug              = ["esp-hal-common/debug"]
 eh1                = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
 rt                 = []
 ufmt               = ["esp-hal-common/ufmt"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -45,6 +45,7 @@ static_cell       = "1.0.0"
 
 [features]
 default              = ["rt", "vectored", "xtal40mhz"]
+debug                = ["esp-hal-common/debug"]
 direct-boot          = ["esp-hal-common/rv-init-data"]
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
 rt                   = []

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -51,6 +51,7 @@ static_cell       = "1.0.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
+debug                = ["esp-hal-common/debug"]
 mcu-boot             = []
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -52,6 +52,7 @@ static_cell       = "1.0.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
+debug                = ["esp-hal-common/debug"]
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
 rt                   = []

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -51,6 +51,7 @@ static_cell       = "1.0.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
+debug                = ["esp-hal-common/debug"]
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
 rt                   = []

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -53,6 +53,7 @@ usbd-serial       = "0.1.1"
 
 [features]
 default   = ["rt", "vectored"]
+debug     = ["esp-hal-common/debug"]
 eh1       = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
 rt        = []
 ufmt      = ["esp-hal-common/ufmt"]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -55,6 +55,7 @@ usbd-serial       = "0.1.1"
 
 [features]
 default              = ["rt", "vectored"]
+debug                = ["esp-hal-common/debug"]
 direct-boot          = ["r0"]
 eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
 rt                   = []


### PR DESCRIPTION
Updates the PACs to their latest versions (and switches to the published version for the ESP32-H2). Additionally added a `debug` feature to each HAL which enables the respective PAC's `impl-register-debug` feature.