### PR TITLE
Pin log crate to v0.4.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-C3: Fix GPIO5 ADC channel id (#562)
 - ESP32-H2: Fix direct-boot feature
 - ESP32-C6: Support FOSC CLK calibration for ECO1+ chip revisions
+- Fixed CI by pinning the log crate to 0.4.18 (#600)
 
 ### Changed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -22,7 +22,7 @@ embedded-hal-1       = { version = "=1.0.0-alpha.10", optional = true, package =
 embedded-hal-nb      = { version = "=1.0.0-alpha.2", optional = true }
 esp-synopsys-usb-otg = { version = "0.3.1", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.6"
-log                  = "0.4.17"
+log                  = "=0.4.18"
 lock_api             = { version = "0.4.9", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.12"


### PR DESCRIPTION
This is temporary measure, as the problem cannot be solved cleanly right now.

The issue is that the msrv check uses the stable compiler, which uses a stable cargo. With a stable cargo, the unstable `build-std` option is not respected within `.cargo/config.toml`. This means `core` is never rebuilt with the atomic cfg flags so we get this error when building log version 0.4.19. The 0.4.19 release uses the atomic cfg flags instead of a custom build script, so by switching back to 0.4.18 we can avoid this issue... for now at least.