### PR TITLE
Clean up re-exports and make small improvements to documentation

### DIFF
--- a/.github/workflows/issue_handler.yml
+++ b/.github/workflows/issue_handler.yml
@@ -1,0 +1,16 @@
+name: Add new issues to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/esp-rs/projects/2
+          github-token: ${{ secrets.PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,36 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add bare-bones PSRAM support for ESP32 (#506)
-- Add initial support for the ESP32-H2 (#513)
+- Add initial support for the ESP32-H2 (#513, #526, #527, #528, #530, #538, #544, #548, #551, #556, #560, #566, #549, #564, #569, #576, #577, #589, #591, #597)
 - Add bare-bones PSRAM support for ESP32-S3 (#517)
 - Add async support to the I2C driver (#519)
-- Add initial support for RSA in ESP32-H2 (#526)
-- Add initial support for SHA in ESP32-H2 (#527)
-- Add initial support for AES in ESP32-H2 (#528)
-- Add blinky_erased_pins example for ESP32-H2 (#530)
-- Add initial support for I2C in ESP32-H2 (#538)
 - Implement Copy and Eq for EspTwaiError (#540)
-- Add LEDC hardware fade support
+- Add LEDC hardware fade support (#475)
 - Added support for multicore async GPIO (#542)
-- Add initial support for MCPWM in ESP32-H2 (#544)
-- Add some miscellaneous examples for the ESP32-H2 (#548)
-- Add initial support for PCNT in ESP32-H2 (#551)
-- Add initial support for RMT in ESP32-H2 (#556)
-- Add a fn to poll DMA transfers
-- Add initial support for LEDC in ESP32-H2 (#560)
-- Add initial support for ASSIST_DEBUG in ESP32-H2 (#566)
-- Add all `SPI` examples for the ESP32-H2 (#549)
-- Add initial support for ADC in ESP32-H2 (#564)
+- Add a fn to poll DMA transfers (#559)
 - Simplify the `Delay` driver, derive `Clone` and `Copy` (#568)
-- Add `embassy_serial` and `embassy_wait` examples for ESP32-H2 (#569)
 - Fix Async GPIO not disabling interupts on chips with multiple banks (#572)
-- Add unified field-based efuse access
-- Add `timer_interrupt` example in ESP32-H2 and refactor `clk_src` configuration (#576)
+- Add unified field-based efuse access (#567)
 - Move `esp-riscv-rt` into esp-hal (#578)
-- Add initial implementation of radio clocks for ESP32-H2 (#577)
-- Add initial support for `esp-hal-smartled` in ESP32-H2 (#589)
-- Add CRC functions from ESP ROM
-- Add initial support for RNG in ESP32-H2 (#591)
+- Add CRC functions from ESP ROM (#587)
 - Add a `debug` feature to enable the PACs' `impl-register-debug` feature (#596)
 - Add initial support for `I2S` in ESP32-H2 (#597)
 - Fix rom::crc docs
@@ -51,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move core interrupt handling from Flash to RAM for RISC-V chips (ESP32-H2, ESP32-C2, ESP32-C3, ESP32-C6) (#541)
 - Change LED pin to GPIO2 in ESP32 blinky example (#581)
-- Udpate ESP32-H2 and C6 ESP32-clocks and remove i2c_clock for all chips but ESP32 (#592)
+- Update ESP32-H2 and ESP32-C6 clocks and remove `i2c_clock` for all chips but ESP32 (#592)
 - Use both timers in `TIMG0` for embassy time driver when able (#609)
 
 ### Fixed
@@ -64,8 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADC driver will now apply attenuation values to the correct ADC's channels. (#554)
 - Sometimes half-duplex non-DMA SPI reads were reading garbage in non-release mode (#552)
 - ESP32-C3: Fix GPIO5 ADC channel id (#562)
-- ESP32-H2: Fix direct-boot feature
-- ESP32-C6: Support FOSC CLK calibration for ECO1+ chip revisions
+- ESP32-H2: Fix direct-boot feature (#570)
+- ESP32-C6: Support FOSC CLK calibration for ECO1+ chip revisions (#593)
 - Fixed CI by pinning the log crate to 0.4.18 (#600)
 - ESP32-S3: Fix calculation of PSRAM start address
 - Fixed wrong variable access (FOSC CLK calibration for ESP32-C6 #593)
@@ -78,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - Significantly simplified user-facing GPIO pin types. (#553)
+- No longer re-export the `soc` moduleand the contents of the `interrupt` module at the package level (#607)
 
 ## [0.9.0] - 2023-05-02
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1230,6 +1230,7 @@ impl<MODE> embedded_hal_async::digital::Wait for AnyPin<Input<MODE>> {
     }
 }
 
+/// General Purpose Input/Output driver
 pub struct IO {
     _io_mux: IO_MUX,
     pub pins: Pins,

--- a/esp-hal-common/src/interrupt/mod.rs
+++ b/esp-hal-common/src/interrupt/mod.rs
@@ -1,3 +1,5 @@
+//! Interrupt support
+
 #[cfg(riscv)]
 pub use riscv::*;
 #[cfg(xtensa)]

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -69,7 +69,8 @@ pub enum InterruptKind {
     Edge,
 }
 
-/// Enumeration of available CPU interrupts.
+/// Enumeration of available CPU interrupts
+///
 /// It is possible to create a handler for each of the interrupts. (e.g.
 /// `interrupt3`)
 #[repr(u32)]
@@ -531,7 +532,7 @@ pub fn _setup_interrupts() {
     }
 }
 
-/// Disable the given peripheral interrupt.
+/// Disable the given peripheral interrupt
 pub fn disable(_core: Cpu, interrupt: Interrupt) {
     unsafe {
         let interrupt_number = interrupt as isize;
@@ -577,7 +578,7 @@ pub fn get_status(_core: Cpu) -> u128 {
     }
 }
 
-/// Assign a peripheral interrupt to an CPU interrupt.
+/// Assign a peripheral interrupt to an CPU interrupt
 ///
 /// Great care must be taken when using the `vectored` feature (enabled by
 /// default). Avoid interrupts 1 - 15 when interrupt vectoring is enabled.

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 /// Enumeration of available CPU interrupts
+///
 /// It's possible to create one handler per priority level. (e.g
 /// `level1_interrupt`)
 #[allow(unused)]
@@ -47,7 +48,7 @@ pub enum CpuInterrupt {
     Interrupt31EdgePriority5,
 }
 
-/// Assign a peripheral interrupt to an CPU interrupt.
+/// Assign a peripheral interrupt to an CPU interrupt
 ///
 /// Great care **must** be taken when using this function with interrupt
 /// vectoring (enabled by default). Avoid the following CPU interrupts:
@@ -73,7 +74,7 @@ pub unsafe fn map(core: Cpu, interrupt: Interrupt, which: CpuInterrupt) {
         .write_volatile(cpu_interrupt_number as u32);
 }
 
-/// Disable the given peripheral interrupt.
+/// Disable the given peripheral interrupt
 pub fn disable(core: Cpu, interrupt: Interrupt) {
     unsafe {
         let interrupt_number = interrupt as isize;
@@ -264,6 +265,7 @@ mod vectored {
         }
     }
 
+    /// Enable the given peripheral interrupt
     pub fn enable(interrupt: Interrupt, level: Priority) -> Result<(), Error> {
         let cpu_interrupt =
             interrupt_level_to_cpu_interrupt(level, chip_specific::interrupt_is_edge(interrupt))?;

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -151,16 +151,8 @@ extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt)
 #[no_mangle]
 extern "C" fn DefaultHandler() {}
 
-#[cfg(esp32c6)]
-pub fn disable_apm_filter() {
-    unsafe {
-        (&*esp32c6::LP_APM::PTR).func_ctrl.write(|w| w.bits(0));
-        (&*esp32c6::LP_APM0::PTR).func_ctrl.write(|w| w.bits(0));
-        (&*esp32c6::HP_APM::PTR).func_ctrl.write(|w| w.bits(0));
-    }
-}
-
-/// Enumeration of CPU cores
+/// Available CPU cores
+///
 /// The actual number of available cores depends on the target.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Cpu {
@@ -171,6 +163,7 @@ pub enum Cpu {
     AppCpu,
 }
 
+/// Which core the application is currently executing on
 pub fn get_core() -> Cpu {
     #[cfg(all(xtensa, multi_core))]
     match ((xtensa_lx::get_processor_id() >> 13) & 1) != 0 {

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -63,6 +63,8 @@ pub use self::soc::cpu_control;
 #[cfg(efuse)]
 pub use self::soc::efuse;
 pub use self::soc::peripherals;
+#[cfg(psram)]
+pub use self::soc::psram;
 #[cfg(any(spi0, spi1, spi2, spi3))]
 pub use self::spi::Spi;
 #[cfg(any(timg0, timg1))]

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -50,8 +50,8 @@ pub use self::delay::Delay;
 pub use self::dma::gdma;
 #[cfg(pdma)]
 pub use self::dma::pdma;
-#[cfg(any(dport, interrupt_core0, interrupt_core1))]
-pub use self::interrupt::*;
+#[cfg(gpio)]
+pub use self::gpio::IO;
 #[cfg(rmt)]
 pub use self::pulse_control::PulseControl;
 #[cfg(rng)]
@@ -117,7 +117,6 @@ pub mod rsa;
 pub mod rtc_cntl;
 #[cfg(sha)]
 pub mod sha;
-pub mod soc;
 #[cfg(any(spi0, spi1, spi2, spi3))]
 pub mod spi;
 #[cfg(any(dport, pcr, system))]
@@ -140,6 +139,10 @@ pub mod trapframe {
     #[cfg(xtensa)]
     pub use xtensa_lx_rt::exception::Context as TrapFrame;
 }
+
+// The `soc` module contains chip-specific implementation details and should not
+// be directly exposed.
+mod soc;
 
 #[no_mangle]
 extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {}

--- a/esp-hal-common/src/pcnt/mod.rs
+++ b/esp-hal-common/src/pcnt/mod.rs
@@ -1,3 +1,5 @@
+//! Pulse Counter peripheral driver
+
 use self::unit::Unit;
 use crate::{
     peripheral::{Peripheral, PeripheralRef},

--- a/esp-hal-common/src/peripheral.rs
+++ b/esp-hal-common/src/peripheral.rs
@@ -1,3 +1,5 @@
+//! Exclusive peripheral access
+
 use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},

--- a/esp-hal-common/src/peripheral.rs
+++ b/esp-hal-common/src/peripheral.rs
@@ -185,6 +185,7 @@ pub(crate) mod sealed {
 }
 
 mod peripheral_macros {
+    #[doc(hidden)]
     #[macro_export]
     macro_rules! peripherals {
         ($($(#[$cfg:meta])? $name:ident => $from_pac:tt),*$(,)?) => {
@@ -247,6 +248,7 @@ mod peripheral_macros {
         }
     }
 
+    #[doc(hidden)]
     #[macro_export]
     macro_rules! into_ref {
         ($($name:ident),*) => {
@@ -257,6 +259,7 @@ mod peripheral_macros {
         }
     }
 
+    #[doc(hidden)]
     #[macro_export]
     macro_rules! create_peripheral {
         ($(#[$cfg:meta])? $name:ident => true) => {

--- a/esp-hal-common/src/pulse_control.rs
+++ b/esp-hal-common/src/pulse_control.rs
@@ -886,7 +886,7 @@ macro_rules! rmt {
         )+
     )
  => {
-    /// RMT peripheral (RMT)
+    /// Remote Control (RMT) peripheral driver
     pub struct PulseControl<'d> {
         /// The underlying register block
         reg: PeripheralRef<'d, RMT>,

--- a/esp-hal-common/src/radio.rs
+++ b/esp-hal-common/src/radio.rs
@@ -1,3 +1,5 @@
+//! Wireless communication peripheral implementations
+
 pub trait RadioExt {
     type Components;
 

--- a/esp-hal-common/src/reset.rs
+++ b/esp-hal-common/src/reset.rs
@@ -1,3 +1,5 @@
+//! Hardware and Software Reset
+
 use crate::rtc_cntl::SocResetReason;
 
 pub enum SleepSource {

--- a/esp-hal-common/src/rom/mod.rs
+++ b/esp-hal-common/src/rom/mod.rs
@@ -3,8 +3,6 @@
 //! Safe abstractions to the additional libraries provided in the ESP's
 //! read-only memory.
 
-pub use paste::paste;
-
 pub mod crc;
 
 #[allow(unused)]

--- a/esp-hal-common/src/rom/mod.rs
+++ b/esp-hal-common/src/rom/mod.rs
@@ -21,6 +21,7 @@ extern "C" {
     );
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! regi2c_write {
     ( $block: ident, $reg_add: ident, $indata: expr ) => {
@@ -34,6 +35,7 @@ macro_rules! regi2c_write {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! regi2c_write_mask {
     ( $block: ident, $reg_add: ident, $indata: expr ) => {

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -1,3 +1,5 @@
+//! Low-power Management
+
 use embedded_hal::watchdog::{Watchdog, WatchdogDisable, WatchdogEnable};
 #[cfg(not(any(esp32c6, esp32h2)))]
 use fugit::HertzU32;
@@ -116,6 +118,7 @@ pub(crate) enum RtcCalSel {
     RtcCalInternalOsc = 3,
 }
 
+/// Low-power Management
 pub struct Rtc<'d> {
     _inner: PeripheralRef<'d, RtcCntl>,
     pub rwdt: Rwdt,

--- a/esp-hal-common/src/sha.rs
+++ b/esp-hal-common/src/sha.rs
@@ -1,3 +1,5 @@
+//! Secure Hash Algorithm peripheral driver
+
 use core::convert::Infallible;
 
 use crate::{

--- a/esp-hal-common/src/soc/esp32/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32/peripherals.rs
@@ -1,3 +1,5 @@
+//! Peripheral instance singletons
+
 use esp32 as pac;
 // We need to export this for users to use
 pub use pac::Interrupt;

--- a/esp-hal-common/src/soc/esp32c2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32c2/peripherals.rs
@@ -1,3 +1,5 @@
+//! Peripheral instance singletons
+
 use esp32c2 as pac;
 // We need to export this for users to use
 pub use pac::Interrupt;

--- a/esp-hal-common/src/soc/esp32c3/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32c3/peripherals.rs
@@ -1,3 +1,5 @@
+//! Peripheral instance singletons
+
 use esp32c3 as pac;
 // We need to export this for users to use
 pub use pac::Interrupt;

--- a/esp-hal-common/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32c6/peripherals.rs
@@ -1,3 +1,5 @@
+//! Peripheral instance singletons
+
 use esp32c6 as pac;
 // We need to export this for users to use
 pub use pac::Interrupt;

--- a/esp-hal-common/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32h2/peripherals.rs
@@ -1,3 +1,5 @@
+//! Peripheral instance singletons
+
 use esp32h2 as pac;
 // We need to export this for users to use
 pub use pac::Interrupt;

--- a/esp-hal-common/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32s2/peripherals.rs
@@ -1,3 +1,5 @@
+//! Peripheral instance singletons
+
 use esp32s2 as pac;
 // We need to export this for users to use
 pub use pac::Interrupt;

--- a/esp-hal-common/src/soc/esp32s3/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32s3/peripherals.rs
@@ -1,3 +1,5 @@
+//! Peripheral instance singletons
+
 use esp32s3 as pac;
 // We need to export this for users to use
 pub use pac::Interrupt;

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -411,6 +411,7 @@ pub trait HalfDuplexReadWrite {
     ) -> Result<(), Self::Error>;
 }
 
+/// SPI peripheral driver
 pub struct Spi<'d, T, M> {
     spi: PeripheralRef<'d, T>,
     _mode: PhantomData<M>,

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -1,4 +1,4 @@
-//! System
+//! System Control
 //!
 //! The SYSTEM/DPORT peripheral needs to be split into several logical parts.
 //!

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -1,3 +1,5 @@
+//! System Timer peripheral driver
+
 use core::{intrinsics::transmute, marker::PhantomData};
 
 use fugit::MillisDurationU32;

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -188,13 +188,12 @@ where
     }
 }
 
-/// General-purpose timer
+/// General-purpose Timer driver
 pub struct Timer<T> {
     timg: T,
     apb_clk_freq: HertzU32,
 }
 
-/// Timer driver
 impl<T> Timer<T>
 where
     T: Instance,

--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -1,3 +1,5 @@
+//! USB Serial JTAG peripheral driver
+
 use core::convert::Infallible;
 
 use crate::{
@@ -6,6 +8,7 @@ use crate::{
     system::PeripheralClockControl,
 };
 
+/// USB Serial JTAG driver
 pub struct UsbSerialJtag<'d> {
     usb_serial: PeripheralRef<'d, USB_DEVICE>,
 }
@@ -150,7 +153,7 @@ impl<'d> UsbSerialJtag<'d> {
     }
 }
 
-/// USB serial/JTAG peripheral instance
+/// USB Serial JTAG peripheral instance
 pub trait Instance {
     fn register_block(&self) -> &RegisterBlock;
 

--- a/esp32-hal/examples/embassy_i2c.rs
+++ b/esp32-hal/examples/embassy_i2c.rs
@@ -20,10 +20,10 @@ use esp32_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
+    interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
     timer::TimerGroup,
-    Priority,
     Rtc,
     IO,
 };
@@ -77,7 +77,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    esp32_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -12,6 +12,7 @@ use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -67,7 +68,7 @@ fn main() -> ! {
 
     let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    esp32_hal::interrupt::enable(Interrupt::UART0, esp32_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32-hal/examples/psram.rs
+++ b/esp32-hal/examples/psram.rs
@@ -9,7 +9,7 @@ use esp32_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    soc,
+    psram,
     timer::TimerGroup,
     Rtc,
 };
@@ -23,10 +23,7 @@ static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 
 fn init_psram_heap() {
     unsafe {
-        ALLOCATOR.init(
-            soc::psram::PSRAM_VADDR_START as *mut u8,
-            soc::psram::PSRAM_BYTES,
-        );
+        ALLOCATOR.init(psram::PSRAM_VADDR_START as *mut u8, psram::PSRAM_BYTES);
     }
 }
 
@@ -38,7 +35,7 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
 
     let peripherals = Peripherals::take();
-    soc::psram::init_psram(peripherals.PSRAM);
+    psram::init_psram(peripherals.PSRAM);
     init_psram_heap();
 
     let mut system = peripherals.DPORT.split();

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -8,11 +8,7 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-#[cfg(feature = "embassy")]
-pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;
-
-pub use self::gpio::IO;
 
 /// Common module for analog functions
 pub mod analog {

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -1,3 +1,10 @@
+//! `no_std` HAL for the ESP32 from Espressif.
+//!
+//! Implements a number of the traits defined by the various packages in the
+//! [embedded-hal] repository.
+//!
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 

--- a/esp32c2-hal/examples/embassy_i2c.rs
+++ b/esp32c2-hal/examples/embassy_i2c.rs
@@ -20,10 +20,10 @@ use esp32c2_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
+    interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
     timer::TimerGroup,
-    Priority,
     Rtc,
     IO,
 };
@@ -85,7 +85,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    esp32c2_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -12,6 +12,7 @@ use embassy_time::{Duration, Timer};
 use esp32c2_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -67,7 +68,7 @@ fn main() -> ! {
 
     let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    esp32c2_hal::interrupt::enable(Interrupt::UART0, esp32c2_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -8,11 +8,7 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-#[cfg(feature = "embassy")]
-pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;
-
-pub use self::gpio::IO;
 
 /// Common module for analog functions
 pub mod analog {

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -1,3 +1,10 @@
+//! `no_std` HAL for the ESP32-C2/ESP8684 from Espressif.
+//!
+//! Implements a number of the traits defined by the various packages in the
+//! [embedded-hal] repository.
+//!
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 

--- a/esp32c3-hal/examples/embassy_i2c.rs
+++ b/esp32c3-hal/examples/embassy_i2c.rs
@@ -20,10 +20,10 @@ use esp32c3_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
+    interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
     timer::TimerGroup,
-    Priority,
     Rtc,
     IO,
 };
@@ -92,7 +92,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    esp32c3_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -12,6 +12,7 @@ use embassy_time::{Duration, Timer};
 use esp32c3_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -74,7 +75,7 @@ fn main() -> ! {
 
     let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    esp32c3_hal::interrupt::enable(Interrupt::UART0, esp32c3_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -1,3 +1,10 @@
+//! `no_std` HAL for the ESP32-C3/ESP8685 from Espressif.
+//!
+//! Implements a number of the traits defined by the various packages in the
+//! [embedded-hal] repository.
+//!
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -8,14 +8,7 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-#[cfg(feature = "mcu-boot")]
-use core::mem::size_of;
-
-#[cfg(feature = "embassy")]
-pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;
-
-pub use self::gpio::IO;
 
 /// Common module for analog functions
 pub mod analog {
@@ -96,7 +89,7 @@ unsafe fn configure_mmu() {
 
     const FLASH_MMU_TABLE: *mut u32 = 0x600c_5000 as *mut u32;
     const ICACHE_MMU_SIZE: usize = 0x200;
-    const FLASH_MMU_TABLE_SIZE: usize = ICACHE_MMU_SIZE / size_of::<u32>();
+    const FLASH_MMU_TABLE_SIZE: usize = ICACHE_MMU_SIZE / core::mem::size_of::<u32>();
     const MMU_TABLE_INVALID_VAL: u32 = 0x100;
 
     for i in 0..FLASH_MMU_TABLE_SIZE {

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -4,7 +4,6 @@
 #[cfg(feature = "mcu-boot")]
 use core::mem::size_of;
 
-pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;

--- a/esp32c6-hal/examples/embassy_i2c.rs
+++ b/esp32c6-hal/examples/embassy_i2c.rs
@@ -20,10 +20,10 @@ use esp32c6_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
+    interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
     timer::TimerGroup,
-    Priority,
     Rtc,
     IO,
 };
@@ -92,7 +92,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    esp32c6_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -12,6 +12,7 @@ use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -74,7 +75,7 @@ fn main() -> ! {
 
     let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    esp32c6_hal::interrupt::enable(Interrupt::UART0, esp32c6_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -8,11 +8,7 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-#[cfg(feature = "embassy")]
-pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;
-
-pub use self::gpio::IO;
 
 /// Common module for analog functions
 pub mod analog {

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -1,3 +1,10 @@
+//! `no_std` HAL for the ESP32-C6 from Espressif.
+//!
+//! Implements a number of the traits defined by the various packages in the
+//! [embedded-hal] repository.
+//!
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 

--- a/esp32h2-hal/examples/embassy_i2c.rs
+++ b/esp32h2-hal/examples/embassy_i2c.rs
@@ -20,10 +20,10 @@ use esp32h2_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
+    interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
     timer::TimerGroup,
-    Priority,
     Rtc,
     IO,
 };
@@ -92,7 +92,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    esp32h2_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -12,6 +12,7 @@ use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -74,7 +75,7 @@ fn main() -> ! {
 
     let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    esp32h2_hal::interrupt::enable(Interrupt::UART0, esp32h2_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -8,11 +8,7 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-#[cfg(feature = "embassy")]
-pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;
-
-pub use self::gpio::IO;
 
 /// Common module for analog functions
 pub mod analog {

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -1,3 +1,10 @@
+//! `no_std` HAL for the ESP32-H2 from Espressif.
+//!
+//! Implements a number of the traits defined by the various packages in the
+//! [embedded-hal] repository.
+//!
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 

--- a/esp32s2-hal/examples/embassy_i2c.rs
+++ b/esp32s2-hal/examples/embassy_i2c.rs
@@ -20,10 +20,10 @@ use esp32s2_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
+    interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
     timer::TimerGroup,
-    Priority,
     Rtc,
     IO,
 };
@@ -78,7 +78,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    esp32s2_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -12,6 +12,7 @@ use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -67,7 +68,7 @@ fn main() -> ! {
 
     let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    esp32s2_hal::interrupt::enable(Interrupt::UART0, esp32s2_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32s2-hal/examples/psram.rs
+++ b/esp32s2-hal/examples/psram.rs
@@ -9,7 +9,7 @@ use esp32s2_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    soc,
+    psram,
     timer::TimerGroup,
     Rtc,
 };
@@ -23,17 +23,14 @@ static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 
 fn init_psram_heap() {
     unsafe {
-        ALLOCATOR.init(
-            soc::psram::PSRAM_VADDR_START as *mut u8,
-            soc::psram::PSRAM_BYTES,
-        );
+        ALLOCATOR.init(psram::PSRAM_VADDR_START as *mut u8, psram::PSRAM_BYTES);
     }
 }
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    soc::psram::init_psram(peripherals.PSRAM);
+    psram::init_psram(peripherals.PSRAM);
     init_psram_heap();
 
     let mut system = peripherals.SYSTEM.split();

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -1,3 +1,10 @@
+//! `no_std` HAL for the ESP32-S2 from Espressif.
+//!
+//! Implements a number of the traits defined by the various packages in the
+//! [embedded-hal] repository.
+//!
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -8,21 +8,10 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-#[cfg(feature = "embassy")]
-pub use esp_hal_common::embassy;
-pub use esp_hal_common::*;
-
-#[rustfmt::skip]
 use esp_hal_common::xtensa_lx_rt::exception::ExceptionCause;
-
+pub use esp_hal_common::*;
 // Always enable atomic emulation on ESP32-S2
 use xtensa_atomic_emulation_trap as _;
-
-pub mod rt {
-    pub use esp_hal_common::xtensa_lx_rt::exception::ExceptionCause;
-}
-
-pub use self::gpio::IO;
 
 /// Common module for analog functions
 pub mod analog {

--- a/esp32s3-hal/examples/embassy_i2c.rs
+++ b/esp32s3-hal/examples/embassy_i2c.rs
@@ -20,10 +20,10 @@ use esp32s3_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
+    interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
     timer::TimerGroup,
-    Priority,
     Rtc,
     IO,
 };
@@ -84,7 +84,7 @@ fn main() -> ! {
         &clocks,
     );
 
-    esp32s3_hal::interrupt::enable(Interrupt::I2C_EXT0, Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -12,6 +12,7 @@ use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -74,7 +75,7 @@ fn main() -> ! {
 
     let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    esp32s3_hal::interrupt::enable(Interrupt::UART0, esp32s3_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32s3-hal/examples/octal_psram.rs
+++ b/esp32s3-hal/examples/octal_psram.rs
@@ -9,7 +9,7 @@ use esp32s3_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    soc,
+    psram,
     timer::TimerGroup,
     Rtc,
 };
@@ -23,10 +23,7 @@ static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 
 fn init_psram_heap() {
     unsafe {
-        ALLOCATOR.init(
-            soc::psram::psram_vaddr_start() as *mut u8,
-            soc::psram::PSRAM_BYTES,
-        );
+        ALLOCATOR.init(psram::psram_vaddr_start() as *mut u8, psram::PSRAM_BYTES);
     }
 }
 
@@ -38,7 +35,7 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
 
     let peripherals = Peripherals::take();
-    soc::psram::init_psram(peripherals.PSRAM);
+    psram::init_psram(peripherals.PSRAM);
     init_psram_heap();
 
     let mut system = peripherals.SYSTEM.split();

--- a/esp32s3-hal/examples/psram.rs
+++ b/esp32s3-hal/examples/psram.rs
@@ -9,7 +9,7 @@ use esp32s3_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    soc,
+    psram,
     timer::TimerGroup,
     Rtc,
 };
@@ -23,10 +23,7 @@ static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 
 fn init_psram_heap() {
     unsafe {
-        ALLOCATOR.init(
-            soc::psram::psram_vaddr_start() as *mut u8,
-            soc::psram::PSRAM_BYTES,
-        );
+        ALLOCATOR.init(psram::psram_vaddr_start() as *mut u8, psram::PSRAM_BYTES);
     }
 }
 
@@ -38,7 +35,7 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
 
     let peripherals = Peripherals::take();
-    soc::psram::init_psram(peripherals.PSRAM);
+    psram::init_psram(peripherals.PSRAM);
     init_psram_heap();
 
     let mut system = peripherals.SYSTEM.split();

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -1,3 +1,10 @@
+//! `no_std` HAL for the ESP32-S3 from Espressif.
+//!
+//! Implements a number of the traits defined by the various packages in the
+//! [embedded-hal] repository.
+//!
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+
 #![no_std]
 #![cfg_attr(
     feature = "direct-boot",

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -6,7 +6,6 @@
 )]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-pub use embedded_hal as ehal;
 #[cfg(feature = "embassy")]
 pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -13,11 +13,7 @@
 )]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-#[cfg(feature = "embassy")]
-pub use esp_hal_common::embassy;
 pub use esp_hal_common::*;
-
-pub use self::gpio::IO;
 
 /// Common module for analog functions
 pub mod analog {


### PR DESCRIPTION
This PR got a little off the rails, so sorry for mixing different changes.

Simplifies our re-exports (both in the chip-specific HALs and in `esp-hal-common`) and hides a number of exported macros which should not be displayed in documentation.

Additionally adds package-level docs for each chip-specific HAL, and adds some basic module/type doc strings so that at least the landing page for our packages on docs.rs looks nice 😁 

@playfulFence, @SergioGasquez, and I will be working on improving documentation moving forward.