### PR TITLE
Fix the `octal_psram` example for ESP32-S3, check example in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,8 @@ jobs:
         run: cd esp32s3-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
       - name: check esp32s3-hal (async, i2c)
         run: cd esp32s3-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
+      - name: check esp32s3-hal (octal psram)
+        run: cd esp32s3-hal/ && cargo check --example=octal_psram --features=opsram_2m --release # This example requires release!
 
   esp-riscv-rt:
     runs-on: ubuntu-latest

--- a/esp32s3-hal/examples/octal_psram.rs
+++ b/esp32s3-hal/examples/octal_psram.rs
@@ -24,7 +24,7 @@ static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 fn init_psram_heap() {
     unsafe {
         ALLOCATOR.init(
-            soc::psram::PSRAM_VADDR_START as *mut u8,
+            soc::psram::psram_vaddr_start() as *mut u8,
             soc::psram::PSRAM_BYTES,
         );
     }


### PR DESCRIPTION
#601 was merged prior to #610, which ultimately caused this issue. Since the example was not being checked in CI (due the the requirement on a feature) we missed this.

This resolves the build error in the `octal_psram` example for the ESP32-S3, and additionally adds a check to CI to make sure this doesn't happen again.