### PR TITLE
Add MD5 functionality from ESP ROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for `I2S` in ESP32-H2 (#597)
 - Fix rom::crc docs
 - Add octal PSRAM support for ESP32-S3 (#610)
+- Add MD5 functions from ESP ROM (#618)
 
 ### Changed
 

--- a/esp-hal-common/devices/esp32.toml
+++ b/esp-hal-common/devices/esp32.toml
@@ -61,6 +61,7 @@ peripherals = [
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",
+    "rom_md5_bsd",
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_ext0_wakeup",

--- a/esp-hal-common/devices/esp32c2.toml
+++ b/esp-hal-common/devices/esp32c2.toml
@@ -42,6 +42,7 @@ peripherals = [
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",
+    "rom_md5_mbedtls",
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_wifi_wakeup",

--- a/esp-hal-common/devices/esp32c3.toml
+++ b/esp-hal-common/devices/esp32c3.toml
@@ -54,6 +54,7 @@ peripherals = [
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",
+    "rom_md5_bsd",
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_wifi_wakeup",

--- a/esp-hal-common/devices/esp32c6.toml
+++ b/esp-hal-common/devices/esp32c6.toml
@@ -83,6 +83,7 @@ peripherals = [
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",
+    "rom_md5_bsd",
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_wifi_wakeup",

--- a/esp-hal-common/devices/esp32h2.toml
+++ b/esp-hal-common/devices/esp32h2.toml
@@ -72,4 +72,5 @@ peripherals = [
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",
+    "rom_md5_bsd",
 ]

--- a/esp-hal-common/devices/esp32s2.toml
+++ b/esp-hal-common/devices/esp32s2.toml
@@ -57,6 +57,7 @@ peripherals = [
 
     # ROM capabilities
     "rom_crc_le",
+    "rom_md5_bsd",
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_ext0_wakeup",

--- a/esp-hal-common/devices/esp32s3.toml
+++ b/esp-hal-common/devices/esp32s3.toml
@@ -70,6 +70,7 @@ peripherals = [
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",
+    "rom_md5_bsd",
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_ext0_wakeup",

--- a/esp-hal-common/src/rom/md5.rs
+++ b/esp-hal-common/src/rom/md5.rs
@@ -1,0 +1,89 @@
+//! MD5 Message-Digest Algorithm 
+
+use core::mem::MaybeUninit;
+
+#[allow(unused)]
+use core::ffi::{c_int, c_void};
+
+// If there is not exactly one of the MD5 variations defined in the device
+// toml file then `InternalContext` will be either undefined or multiple
+// defined and this module will fail to compile letting you know to fix it
+
+#[cfg(rom_md5_bsd)]
+#[repr(C)]
+struct InternalContext {
+    buf: [u32; 4],
+    bits: [u32; 2],
+    _in: [u8; 64],
+}
+
+#[cfg(rom_md5_bsd)]
+extern "C" {
+    fn esp_rom_md5_init(context: *mut InternalContext);
+    fn esp_rom_md5_update(context: *mut InternalContext, buf: *const c_void, len: u32);
+    fn esp_rom_md5_final(digest: *mut u8, context: *mut InternalContext);
+}
+
+#[cfg(rom_md5_mbedtls)]
+#[repr(C)]
+struct InternalContext {
+    total: [u32; 2],
+    state: [u32; 4],
+    buffer: [core::ffi::c_uchar; 64],
+}
+
+#[cfg(rom_md5_mbedtls)]
+extern "C" {
+    fn esp_rom_mbedtls_md5_starts_ret(context: *mut InternalContext) -> c_int;
+    fn esp_rom_mbedtls_md5_update_ret(context: *mut InternalContext, buf: *const c_void, len: u32);
+    fn esp_rom_mbedtls_md5_finish_ret(context: *mut InternalContext, digest: *mut u8);
+}
+
+pub struct Context(InternalContext);
+
+pub struct Digest(pub [u8; 16]);
+
+impl Context {
+
+    #[inline]
+    pub fn new() -> Self {
+        let mut ctx = MaybeUninit::<InternalContext>::uninit();
+
+        unsafe {
+            #[cfg(rom_md5_bsd)]
+            esp_rom_md5_init(ctx.as_mut_ptr());
+
+            #[cfg(rom_md5_mbedtls)]
+            let _ = esp_rom_mbedtls_md5_starts_ret(ctx.as_mut_ptr());
+
+            Self(ctx.assume_init())
+        }
+    }
+
+    #[inline]
+    pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
+        let data = data.as_ref();
+        unsafe {
+            #[cfg(rom_md5_bsd)]
+            esp_rom_md5_update(&mut self.0 as *mut _, data.as_ptr() as *const c_void, data.len() as u32);
+
+            #[cfg(rom_md5_mbedtls)]
+            let _ = esp_rom_mbedtls_md5_update_ret(&mut self.0 as *mut _, data.as_ptr() as *const c_void, data.len() as u32);
+        }
+    }
+
+    #[inline]
+    pub fn compute(mut self) -> Digest {
+        let mut digest = MaybeUninit::<[u8; 16]>::uninit();
+
+        unsafe {
+            #[cfg(rom_md5_bsd)]
+            esp_rom_md5_final(digest.as_mut_ptr() as *mut _, &mut self.0 as *mut _);
+
+            #[cfg(rom_md5_mbedtls)]
+            let _ = esp_rom_mbedtls_md5_finish_ret(&mut self.0 as *mut _, digest.as_mut_ptr() as *mut _);
+
+            Digest(digest.assume_init())
+        }
+    }
+}

--- a/esp-hal-common/src/rom/md5.rs
+++ b/esp-hal-common/src/rom/md5.rs
@@ -159,6 +159,13 @@ impl From<Digest> for [u8; 16] {
     }
 }
 
+impl From<Context> for Digest {
+    #[inline]
+    fn from(context: Context) -> Digest {
+        context.compute()
+    }
+}
+
 impl Deref for Digest {
     type Target = [u8; 16];
 

--- a/esp-hal-common/src/rom/md5.rs
+++ b/esp-hal-common/src/rom/md5.rs
@@ -166,7 +166,6 @@ pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
 }
 
 /// 16-byte message digest
-#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Digest(pub [u8; 16]);
 

--- a/esp-hal-common/src/rom/md5.rs
+++ b/esp-hal-common/src/rom/md5.rs
@@ -1,15 +1,20 @@
-//! MD5 Message-Digest Algorithm 
-
-use core::mem::MaybeUninit;
+//! MD5 Message-Digest Algorithm
 
 #[allow(unused)]
-use core::ffi::{c_int, c_void};
+use core::ffi::{c_int, c_uchar, c_void};
+use core::{
+    convert::From,
+    fmt,
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut},
+};
 
 // If there is not exactly one of the MD5 variations defined in the device
 // toml file then `InternalContext` will be either undefined or multiple
 // defined and this module will fail to compile letting you know to fix it
 
 #[cfg(rom_md5_bsd)]
+#[derive(Clone)]
 #[repr(C)]
 struct InternalContext {
     buf: [u32; 4],
@@ -25,30 +30,33 @@ extern "C" {
 }
 
 #[cfg(rom_md5_mbedtls)]
+#[derive(Clone)]
 #[repr(C)]
 struct InternalContext {
     total: [u32; 2],
     state: [u32; 4],
-    buffer: [core::ffi::c_uchar; 64],
+    buffer: [c_uchar; 64],
 }
 
 #[cfg(rom_md5_mbedtls)]
 extern "C" {
     fn esp_rom_mbedtls_md5_starts_ret(context: *mut InternalContext) -> c_int;
-    fn esp_rom_mbedtls_md5_update_ret(context: *mut InternalContext, buf: *const c_void, len: u32);
-    fn esp_rom_mbedtls_md5_finish_ret(context: *mut InternalContext, digest: *mut u8);
+    fn esp_rom_mbedtls_md5_update_ret(
+        context: *mut InternalContext,
+        buf: *const c_void,
+        len: u32,
+    ) -> c_int;
+    fn esp_rom_mbedtls_md5_finish_ret(context: *mut InternalContext, digest: *mut u8) -> c_int;
 }
 
+#[derive(Clone)]
 pub struct Context(InternalContext);
 
-pub struct Digest(pub [u8; 16]);
-
 impl Context {
-
+    /// Create a new MD5 context
     #[inline]
     pub fn new() -> Self {
         let mut ctx = MaybeUninit::<InternalContext>::uninit();
-
         unsafe {
             #[cfg(rom_md5_bsd)]
             esp_rom_md5_init(ctx.as_mut_ptr());
@@ -60,30 +68,109 @@ impl Context {
         }
     }
 
+    /// Feed data to the hasher
     #[inline]
     pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
         let data = data.as_ref();
         unsafe {
             #[cfg(rom_md5_bsd)]
-            esp_rom_md5_update(&mut self.0 as *mut _, data.as_ptr() as *const c_void, data.len() as u32);
+            esp_rom_md5_update(
+                &mut self.0 as *mut _,
+                data.as_ptr() as *const c_void,
+                data.len() as u32,
+            );
 
             #[cfg(rom_md5_mbedtls)]
-            let _ = esp_rom_mbedtls_md5_update_ret(&mut self.0 as *mut _, data.as_ptr() as *const c_void, data.len() as u32);
+            let _ = esp_rom_mbedtls_md5_update_ret(
+                &mut self.0 as *mut _,
+                data.as_ptr() as *const c_void,
+                data.len() as u32,
+            );
         }
     }
 
+    /// Finalize and return a digest
     #[inline]
     pub fn compute(mut self) -> Digest {
         let mut digest = MaybeUninit::<[u8; 16]>::uninit();
-
         unsafe {
             #[cfg(rom_md5_bsd)]
             esp_rom_md5_final(digest.as_mut_ptr() as *mut _, &mut self.0 as *mut _);
 
             #[cfg(rom_md5_mbedtls)]
-            let _ = esp_rom_mbedtls_md5_finish_ret(&mut self.0 as *mut _, digest.as_mut_ptr() as *mut _);
+            let _ = esp_rom_mbedtls_md5_finish_ret(
+                &mut self.0 as *mut _,
+                digest.as_mut_ptr() as *mut _,
+            );
 
             Digest(digest.assume_init())
         }
+    }
+}
+
+/// Compute a full digest from a single buffer
+#[inline]
+pub fn compute<T: AsRef<[u8]>>(data: T) -> Digest {
+    let mut ctx = Context::new();
+    ctx.consume(data);
+    ctx.compute()
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Digest(pub [u8; 16]);
+
+impl fmt::LowerHex for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for &byte in &self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for &byte in &self.0 {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Digest {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Digest as fmt::LowerHex>::fmt(self, f)
+    }
+}
+
+impl fmt::Debug for Digest {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Digest as fmt::LowerHex>::fmt(self, f)
+    }
+}
+
+impl From<Digest> for [u8; 16] {
+    #[inline]
+    fn from(digest: Digest) -> Self {
+        digest.0
+    }
+}
+
+impl Deref for Digest {
+    type Target = [u8; 16];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Digest {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/esp-hal-common/src/rom/mod.rs
+++ b/esp-hal-common/src/rom/mod.rs
@@ -4,6 +4,7 @@
 //! read-only memory.
 
 pub mod crc;
+pub mod md5;
 
 #[allow(unused)]
 extern "C" {

--- a/esp32-hal/examples/crc.rs
+++ b/esp32-hal/examples/crc.rs
@@ -9,7 +9,7 @@ use esp32_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    rom::crc,
+    rom::{crc, md5},
     timer::TimerGroup,
     Rtc,
     Uart,
@@ -40,6 +40,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     let data = "123456789";
+    let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
         serial0,
@@ -66,10 +67,38 @@ fn main() -> ! {
         assert_eq!(crc_rohc, 0xd0);
         assert_eq!(crc_smbus, 0xf4);
 
+        // Hash the sentence one word at a time to *really* test the context
+        // Use Peekable while iter_intersperse is unstable
+        let mut md5_ctx = md5::Context::new();
+        let mut it = sentence.split_whitespace().peekable();
+        while let Some(word) = it.next() {
+            md5_ctx.consume(word);
+            if it.peek().is_some() {
+                md5_ctx.consume(" ");
+            }
+        }
+        let md5_digest = md5_ctx.compute();
+
+        assert_eq!(
+            md5_digest,
+            md5::Digest([
+                0x30, 0xde, 0xd8, 0x07, 0xd6, 0x5e, 0xe0, 0x37, 0x0f, 0xc6, 0xd7, 0x3d, 0x6a, 0xb5,
+                0x5a, 0x95
+            ])
+        );
+
         writeln!(
             serial0,
-            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x}",
-            crc_hdlc, crc_bzip2, crc_mpeg2, crc_cksum, crc_kermit, crc_genibus, crc_rohc, crc_smbus
+            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
+            crc_hdlc,
+            crc_bzip2,
+            crc_mpeg2,
+            crc_cksum,
+            crc_kermit,
+            crc_genibus,
+            crc_rohc,
+            crc_smbus,
+            md5_digest
         )
         .unwrap();
 

--- a/esp32-hal/ld/rom-functions.x
+++ b/esp32-hal/ld/rom-functions.x
@@ -23,3 +23,7 @@ PROVIDE (esp_rom_crc8_be = 0x4005d114);
 PROVIDE (esp_rom_crc32_le = 0x4005cfec);
 PROVIDE (esp_rom_crc16_le = 0x4005d05c);
 PROVIDE (esp_rom_crc8_le = 0x4005d0e0);
+
+PROVIDE (esp_rom_md5_init   = 0x4005da7c);
+PROVIDE (esp_rom_md5_update = 0x4005da9c);
+PROVIDE (esp_rom_md5_final  = 0x4005db1c);

--- a/esp32c2-hal/examples/crc.rs
+++ b/esp32c2-hal/examples/crc.rs
@@ -9,7 +9,7 @@ use esp32c2_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    rom::crc,
+    rom::{crc, md5},
     timer::TimerGroup,
     Rtc,
     Uart,
@@ -41,6 +41,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     let data = "123456789";
+    let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
         serial0,
@@ -67,10 +68,38 @@ fn main() -> ! {
         assert_eq!(crc_rohc, 0xd0);
         assert_eq!(crc_smbus, 0xf4);
 
+        // Hash the sentence one word at a time to *really* test the context
+        // Use Peekable while iter_intersperse is unstable
+        let mut md5_ctx = md5::Context::new();
+        let mut it = sentence.split_whitespace().peekable();
+        while let Some(word) = it.next() {
+            md5_ctx.consume(word);
+            if it.peek().is_some() {
+                md5_ctx.consume(" ");
+            }
+        }
+        let md5_digest = md5_ctx.compute();
+
+        assert_eq!(
+            md5_digest,
+            md5::Digest([
+                0x30, 0xde, 0xd8, 0x07, 0xd6, 0x5e, 0xe0, 0x37, 0x0f, 0xc6, 0xd7, 0x3d, 0x6a, 0xb5,
+                0x5a, 0x95
+            ])
+        );
+
         writeln!(
             serial0,
-            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x}",
-            crc_hdlc, crc_bzip2, crc_mpeg2, crc_cksum, crc_kermit, crc_genibus, crc_rohc, crc_smbus
+            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
+            crc_hdlc,
+            crc_bzip2,
+            crc_mpeg2,
+            crc_cksum,
+            crc_kermit,
+            crc_genibus,
+            crc_rohc,
+            crc_smbus,
+            md5_digest
         )
         .unwrap();
 

--- a/esp32c2-hal/ld/rom-functions.x
+++ b/esp32c2-hal/ld/rom-functions.x
@@ -12,3 +12,7 @@ PROVIDE(esp_rom_crc8_be = 0x40000810);
 PROVIDE(esp_rom_crc32_le = 0x400007fc);
 PROVIDE(esp_rom_crc16_le = 0x40000800);
 PROVIDE(esp_rom_crc8_le = 0x40000804);
+
+PROVIDE(esp_rom_mbedtls_md5_starts_ret = 0x40002be4);
+PROVIDE(esp_rom_mbedtls_md5_update_ret = 0x40002be8);
+PROVIDE(esp_rom_mbedtls_md5_finish_ret = 0x40002bec);

--- a/esp32c3-hal/examples/crc.rs
+++ b/esp32c3-hal/examples/crc.rs
@@ -9,7 +9,7 @@ use esp32c3_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    rom::crc,
+    rom::{crc, md5},
     timer::TimerGroup,
     Rtc,
     Uart,
@@ -74,10 +74,30 @@ fn main() -> ! {
         assert_eq!(crc_rohc, 0xd0);
         assert_eq!(crc_smbus, 0xf4);
 
+        let mut md5_ctx = md5::Context::new();
+        md5_ctx.consume(data);
+        let md5_digest = md5_ctx.compute();
+
+        assert_eq!(
+            md5_digest,
+            md5::Digest([
+                0x25, 0xf9, 0xe7, 0x94, 0x32, 0x3b, 0x45, 0x38, 0x85, 0xf5, 0x18, 0x1f, 0x1b, 0x62,
+                0x4d, 0x0b
+            ])
+        );
+
         writeln!(
             uart0,
-            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x}",
-            crc_hdlc, crc_bzip2, crc_mpeg2, crc_cksum, crc_kermit, crc_genibus, crc_rohc, crc_smbus
+            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
+            crc_hdlc,
+            crc_bzip2,
+            crc_mpeg2,
+            crc_cksum,
+            crc_kermit,
+            crc_genibus,
+            crc_rohc,
+            crc_smbus,
+            md5_digest
         )
         .unwrap();
 

--- a/esp32c3-hal/ld/rom-functions.x
+++ b/esp32c3-hal/ld/rom-functions.x
@@ -19,3 +19,7 @@ PROVIDE(esp_rom_crc8_be = 0x4000063c);
 PROVIDE(esp_rom_crc32_le = 0x40000628);
 PROVIDE(esp_rom_crc16_le = 0x40000630);
 PROVIDE(esp_rom_crc8_le = 0x40000638);
+
+PROVIDE(esp_rom_md5_init = 0x40000614);
+PROVIDE(esp_rom_md5_update = 0x40000618);
+PROVIDE(esp_rom_md5_final = 0x4000061c);

--- a/esp32c6-hal/examples/crc.rs
+++ b/esp32c6-hal/examples/crc.rs
@@ -9,7 +9,7 @@ use esp32c6_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    rom::crc,
+    rom::{crc, md5},
     timer::TimerGroup,
     Rtc,
     Uart,
@@ -48,6 +48,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     let data = "123456789";
+    let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
         uart0,
@@ -74,10 +75,38 @@ fn main() -> ! {
         assert_eq!(crc_rohc, 0xd0);
         assert_eq!(crc_smbus, 0xf4);
 
+        // Hash the sentence one word at a time to *really* test the context
+        // Use Peekable while iter_intersperse is unstable
+        let mut md5_ctx = md5::Context::new();
+        let mut it = sentence.split_whitespace().peekable();
+        while let Some(word) = it.next() {
+            md5_ctx.consume(word);
+            if it.peek().is_some() {
+                md5_ctx.consume(" ");
+            }
+        }
+        let md5_digest = md5_ctx.compute();
+
+        assert_eq!(
+            md5_digest,
+            md5::Digest([
+                0x30, 0xde, 0xd8, 0x07, 0xd6, 0x5e, 0xe0, 0x37, 0x0f, 0xc6, 0xd7, 0x3d, 0x6a, 0xb5,
+                0x5a, 0x95
+            ])
+        );
+
         writeln!(
             uart0,
-            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x}",
-            crc_hdlc, crc_bzip2, crc_mpeg2, crc_cksum, crc_kermit, crc_genibus, crc_rohc, crc_smbus
+            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
+            crc_hdlc,
+            crc_bzip2,
+            crc_mpeg2,
+            crc_cksum,
+            crc_kermit,
+            crc_genibus,
+            crc_rohc,
+            crc_smbus,
+            md5_digest
         )
         .unwrap();
 

--- a/esp32c6-hal/ld/rom-functions.x
+++ b/esp32c6-hal/ld/rom-functions.x
@@ -19,3 +19,7 @@ PROVIDE(esp_rom_crc8_be = 0x4000076c);
 PROVIDE(esp_rom_crc32_le = 0x40000758);
 PROVIDE(esp_rom_crc16_le = 0x4000075c);
 PROVIDE(esp_rom_crc8_le = 0x40000760);
+
+PROVIDE(esp_rom_md5_init = 0x4000074c);
+PROVIDE(esp_rom_md5_update = 0x40000750);
+PROVIDE(esp_rom_md5_final = 0x40000754);

--- a/esp32h2-hal/ld/rom-functions.x
+++ b/esp32h2-hal/ld/rom-functions.x
@@ -19,3 +19,7 @@ PROVIDE(esp_rom_crc8_be = 0x40000738);
 PROVIDE(esp_rom_crc32_le = 0x40000724);
 PROVIDE(esp_rom_crc16_le = 0x40000728);
 PROVIDE(esp_rom_crc8_le = 0x4000072c);
+
+PROVIDE(esp_rom_md5_init = 0x40000718);
+PROVIDE(esp_rom_md5_update = 0x4000071c);
+PROVIDE(esp_rom_md5_final = 0x40000720);

--- a/esp32s2-hal/examples/crc.rs
+++ b/esp32s2-hal/examples/crc.rs
@@ -9,7 +9,7 @@ use esp32s2_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    rom::crc,
+    rom::{crc, md5},
     timer::TimerGroup,
     Rtc,
     Uart,
@@ -40,6 +40,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     let data = "123456789";
+    let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
         serial0,
@@ -66,10 +67,38 @@ fn main() -> ! {
         assert_eq!(crc_rohc, 0xd0);
         assert_eq!(crc_smbus, 0xf4);
 
+        // Hash the sentence one word at a time to *really* test the context
+        // Use Peekable while iter_intersperse is unstable
+        let mut md5_ctx = md5::Context::new();
+        let mut it = sentence.split_whitespace().peekable();
+        while let Some(word) = it.next() {
+            md5_ctx.consume(word);
+            if it.peek().is_some() {
+                md5_ctx.consume(" ");
+            }
+        }
+        let md5_digest = md5_ctx.compute();
+
+        assert_eq!(
+            md5_digest,
+            md5::Digest([
+                0x30, 0xde, 0xd8, 0x07, 0xd6, 0x5e, 0xe0, 0x37, 0x0f, 0xc6, 0xd7, 0x3d, 0x6a, 0xb5,
+                0x5a, 0x95
+            ])
+        );
+
         writeln!(
             serial0,
-            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x}",
-            crc_hdlc, crc_bzip2, crc_mpeg2, crc_cksum, crc_kermit, crc_genibus, crc_rohc, crc_smbus
+            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
+            crc_hdlc,
+            crc_bzip2,
+            crc_mpeg2,
+            crc_cksum,
+            crc_kermit,
+            crc_genibus,
+            crc_rohc,
+            crc_smbus,
+            md5_digest
         )
         .unwrap();
 

--- a/esp32s2-hal/ld/rom-functions.x
+++ b/esp32s2-hal/ld/rom-functions.x
@@ -23,3 +23,7 @@ PROVIDE ( esp_rom_spi_cmd_config = 0x40017c58 );
 PROVIDE(esp_rom_crc32_le = 0x400119dc);
 PROVIDE(esp_rom_crc16_le = 0x40011a10);
 PROVIDE(esp_rom_crc8_le = 0x40011a4c);
+
+PROVIDE(esp_rom_md5_final = 0x4000530c);
+PROVIDE(esp_rom_md5_init = 0x4000526c);
+PROVIDE(esp_rom_md5_update = 0x4000528c);

--- a/esp32s3-hal/examples/crc.rs
+++ b/esp32s3-hal/examples/crc.rs
@@ -9,7 +9,7 @@ use esp32s3_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    rom::crc,
+    rom::{crc, md5},
     timer::TimerGroup,
     Rtc,
     Uart,
@@ -40,6 +40,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     let data = "123456789";
+    let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
         serial0,
@@ -66,10 +67,38 @@ fn main() -> ! {
         assert_eq!(crc_rohc, 0xd0);
         assert_eq!(crc_smbus, 0xf4);
 
+        // Hash the sentence one word at a time to *really* test the context
+        // Use Peekable while iter_intersperse is unstable
+        let mut md5_ctx = md5::Context::new();
+        let mut it = sentence.split_whitespace().peekable();
+        while let Some(word) = it.next() {
+            md5_ctx.consume(word);
+            if it.peek().is_some() {
+                md5_ctx.consume(" ");
+            }
+        }
+        let md5_digest = md5_ctx.compute();
+
+        assert_eq!(
+            md5_digest,
+            md5::Digest([
+                0x30, 0xde, 0xd8, 0x07, 0xd6, 0x5e, 0xe0, 0x37, 0x0f, 0xc6, 0xd7, 0x3d, 0x6a, 0xb5,
+                0x5a, 0x95
+            ])
+        );
+
         writeln!(
             serial0,
-            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x}",
-            crc_hdlc, crc_bzip2, crc_mpeg2, crc_cksum, crc_kermit, crc_genibus, crc_rohc, crc_smbus
+            "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
+            crc_hdlc,
+            crc_bzip2,
+            crc_mpeg2,
+            crc_cksum,
+            crc_kermit,
+            crc_genibus,
+            crc_rohc,
+            crc_smbus,
+            md5_digest
         )
         .unwrap();
 

--- a/esp32s3-hal/ld/rom-functions.x
+++ b/esp32s3-hal/ld/rom-functions.x
@@ -27,6 +27,10 @@ PROVIDE(esp_rom_crc32_le = 0x40001c98);
 PROVIDE(esp_rom_crc16_le = 0x40001cb0);
 PROVIDE(esp_rom_crc8_le = 0x40001cc8);
 
+PROVIDE(esp_rom_md5_init = 0x40001c5c);
+PROVIDE(esp_rom_md5_update = 0x40001c68);
+PROVIDE(esp_rom_md5_final = 0x40001c74);
+
 PROVIDE (esp_rom_opiflash_exec_cmd = 0x400008b8);
 PROVIDE( esp_rom_spi_set_dtr_swap_mode = 0x4000093c );
 PROVIDE( esp_rom_opiflash_pin_config = 0x40000894 );


### PR DESCRIPTION
- [x] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

All the ESP32 chips include an MD5 implementation in their ROM. This PR adds linkage to them and a safe, consistent API over them that mimics the MD5 crate and can act as a drop-in replacement.

I checked the updated examples on a physical ESP32-C3 and simulated ESP32-S2. It should work on the others as the linker locations were pulled from ESP-IDF.

MD5 is needed in order to start reading the ESP32 partition tables.