### PR TITLE
Avoid SDA/SCL low  during pin config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed wrong variable access (FOSC CLK calibration for ESP32-C6 #593)
 - Fixed [trap location in ram](https://github.com/esp-rs/esp-hal/pull/605#issuecomment-1604039683) (#605)
 - Fixed a possible overlap of `.data` and `.rwtext` (#616)
+- Avoid SDA/SCL being low while configuring pins for I2C
 
 ### Changed
 
@@ -63,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - Significantly simplified user-facing GPIO pin types. (#553)
-- No longer re-export the `soc` moduleand the contents of the `interrupt` module at the package level (#607)
+- No longer re-export the `soc` module and the contents of the `interrupt` module at the package level (#607)
 
 ## [0.9.0] - 2023-05-02
 

--- a/esp-hal-common/src/i2c.rs
+++ b/esp-hal-common/src/i2c.rs
@@ -250,7 +250,10 @@ where
 
         let mut i2c = I2C { peripheral: i2c };
 
-        // initialize SCL first to not confuse some devices like MPU6050
+        // avoid SCL/SDA going low during configuration
+        scl.set_output_high(true);
+        sda.set_output_high(true);
+
         scl.set_to_open_drain_output()
             .enable_input(true)
             .internal_pull_up(true)


### PR DESCRIPTION
This avoids SDA/SCL from being low for a short time while configuring the pins for I2C.
