### PR TITLE
Async serial uart read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,45 +12,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add bare-bones PSRAM support for ESP32 (#506)
-- Add initial support for the ESP32-H2 (#513)
+- Add initial support for the ESP32-H2 (#513, #526, #527, #528, #530, #538, #544, #548, #551, #556, #560, #566, #549, #564, #569, #576, #577, #589, #591, #597)
 - Add bare-bones PSRAM support for ESP32-S3 (#517)
 - Add async support to the I2C driver (#519)
-- Add initial support for RSA in ESP32-H2 (#526)
-- Add initial support for SHA in ESP32-H2 (#527)
-- Add initial support for AES in ESP32-H2 (#528)
-- Add blinky_erased_pins example for ESP32-H2 (#530)
-- Add initial support for I2C in ESP32-H2 (#538)
 - Implement Copy and Eq for EspTwaiError (#540)
-- Add LEDC hardware fade support
+- Add LEDC hardware fade support (#475)
 - Added support for multicore async GPIO (#542)
-- Add initial support for MCPWM in ESP32-H2 (#544)
-- Add some miscellaneous examples for the ESP32-H2 (#548)
-- Add initial support for PCNT in ESP32-H2 (#551)
-- Add initial support for RMT in ESP32-H2 (#556)
-- Add a fn to poll DMA transfers
-- Add initial support for LEDC in ESP32-H2 (#560)
-- Add initial support for ASSIST_DEBUG in ESP32-H2 (#566)
-- Add all `SPI` examples for the ESP32-H2 (#549)
-- Add initial support for ADC in ESP32-H2 (#564)
+- Add a fn to poll DMA transfers (#559)
 - Simplify the `Delay` driver, derive `Clone` and `Copy` (#568)
-- Add `embassy_serial` and `embassy_wait` examples for ESP32-H2 (#569)
 - Fix Async GPIO not disabling interupts on chips with multiple banks (#572)
-- Add unified field-based efuse access
-- Add `timer_interrupt` example in ESP32-H2 and refactor `clk_src` configuration (#576)
+- Add unified field-based efuse access (#567)
 - Move `esp-riscv-rt` into esp-hal (#578)
-- Add initial implementation of radio clocks for ESP32-H2 (#577)
-- Add initial support for `esp-hal-smartled` in ESP32-H2 (#589)
-- Add CRC functions from ESP ROM
-- Add initial support for RNG in ESP32-H2 (#591)
+- Add CRC functions from ESP ROM (#587)
 - Add a `debug` feature to enable the PACs' `impl-register-debug` feature (#596)
 - Add initial support for `I2S` in ESP32-H2 (#597)
-- Add embassy async `read` support for `uart`
+- Add embassy async `read` support for `uart` (#615)
+- Fix rom::crc docs
+- Add octal PSRAM support for ESP32-S3 (#610)
 
 ### Changed
 
 - Move core interrupt handling from Flash to RAM for RISC-V chips (ESP32-H2, ESP32-C2, ESP32-C3, ESP32-C6) (#541)
 - Change LED pin to GPIO2 in ESP32 blinky example (#581)
-- Udpate ESP32-H2 and C6 ESP32-clocks and remove i2c_clock for all chips but ESP32 (#592)
+- Update ESP32-H2 and ESP32-C6 clocks and remove `i2c_clock` for all chips but ESP32 (#592)
+- Use both timers in `TIMG0` for embassy time driver when able (#609)
 
 ### Fixed
 
@@ -62,9 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADC driver will now apply attenuation values to the correct ADC's channels. (#554)
 - Sometimes half-duplex non-DMA SPI reads were reading garbage in non-release mode (#552)
 - ESP32-C3: Fix GPIO5 ADC channel id (#562)
-- ESP32-H2: Fix direct-boot feature
-- ESP32-C6: Support FOSC CLK calibration for ECO1+ chip revisions
+- ESP32-H2: Fix direct-boot feature (#570)
+- ESP32-C6: Support FOSC CLK calibration for ECO1+ chip revisions (#593)
 - Fixed CI by pinning the log crate to 0.4.18 (#600)
+- ESP32-S3: Fix calculation of PSRAM start address
+- Fixed wrong variable access (FOSC CLK calibration for ESP32-C6 #593)
+- Fixed [trap location in ram](https://github.com/esp-rs/esp-hal/pull/605#issuecomment-1604039683) (#605)
+- Add embassy async `read` support for `uart` (#615)
+- Fixed a possible overlap of `.data` and `.rwtext` (#616)
 
 ### Changed
 
@@ -74,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - Significantly simplified user-facing GPIO pin types. (#553)
+- No longer re-export the `soc` moduleand the contents of the `interrupt` module at the package level (#607)
 
 ## [0.9.0] - 2023-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for RNG in ESP32-H2 (#591)
 - Add a `debug` feature to enable the PACs' `impl-register-debug` feature (#596)
 - Add initial support for `I2S` in ESP32-H2 (#597)
+- Add embassy async `read` support for `uart`
 
 ### Changed
 

--- a/esp-hal-common/src/uart.rs
+++ b/esp-hal-common/src/uart.rs
@@ -996,12 +996,11 @@ mod asynch {
     use cfg_if::cfg_if;
     use embassy_futures::select::select;
     use embassy_sync::waitqueue::AtomicWaker;
-    use esp32c3::uart0::RegisterBlock;
     use procmacros::interrupt;
 
     use super::{Error, Instance};
     use crate::{
-        uart::{FIFO_SPEC, UART_FIFO_SIZE},
+        uart::{RegisterBlock, FIFO_SPEC, UART_FIFO_SIZE},
         Uart,
     };
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -47,6 +47,7 @@ sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+heapless          = "0.7.16"
 
 [features]
 default            = ["rt", "vectored", "xtal40mhz"]

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -1,7 +1,7 @@
 //! embassy serial
 //!
 //! This is an example of running the embassy executor and asynchronously
-//! writing to a uart.
+//! writing to and reading from uart
 
 #![no_std]
 #![no_main]
@@ -14,6 +14,7 @@ use embassy_time::{with_timeout, Duration};
 use esp32_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -22,63 +23,26 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
+use heapless::Vec;
 use static_cell::StaticCell;
 
-struct Buffer<const N: usize> {
-    len: usize,
-    buf: [u8; N],
-}
-
-impl<const N: usize> Buffer<N> {
-    #[inline(always)]
-    pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..self.len]
-    }
-
-    #[inline(always)]
-    pub fn is_full(&self) -> bool {
-        self.len == N
-    }
-}
-
-impl<const N: usize> core::fmt::Write for Buffer<N> {
-    #[inline]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let sb = s.as_bytes();
-        let mut len = sb.len();
-        if self.len + len > N {
-            len = N - self.len;
-        }
-        if len > 0 {
-            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
-            self.len += len;
-        }
-        Ok(())
-    }
-}
-
-/// rx_fifo_full_threshold
+// rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 128;
-/// EOT; CTRL-D
+// EOT (CTRL-D)
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
-    /// max READ_BUF_SIZE buffers to receive
-    const MAX_BUFFERS: usize = 10;
-    /// timeout read
-    const READ_TIMEOUT: Duration = Duration::from_secs(5);
-    let mut rbuf = Buffer {
-        len: 0,
-        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
-    };
-    let mut wbuf = Buffer {
-        len: 0,
-        buf: [0; 128],
-    };
+    // max message size to receive
+    // leave some extra space for AT-CMD characters
+    const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
+    // timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(10);
 
+    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut wbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
     loop {
-        if rbuf.len == 0 {
+        if rbuf.is_empty() {
             embedded_hal_async::serial::Write::write(
                 &mut uart,
                 b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -86,8 +50,8 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
         } else {
-            wbuf.len = 0;
-            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            wbuf.clear();
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len()).unwrap();
             embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
                 .await
                 .unwrap();
@@ -102,14 +66,35 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
 
-        rbuf.len = 0;
-        while let Ok(Ok(len)) =
-            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
-        {
-            rbuf.len += len;
-            // if set_at_cmd is used than stop reading
-            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
-                break;
+        // set rbuf full capacity
+        unsafe {
+            rbuf.set_len(rbuf.capacity());
+        }
+        let mut offset = 0;
+        loop {
+            match with_timeout(READ_TIMEOUT, uart.read(&mut rbuf[offset..])).await {
+                Ok(r) => {
+                    if let Ok(len) = r {
+                        offset += len;
+                        if offset == 0 {
+                            rbuf.truncate(0);
+                            break;
+                        }
+                        // if set_at_cmd is used than stop reading
+                        if len < READ_BUF_SIZE {
+                            rbuf.truncate(offset);
+                            break;
+                        }
+                    } else {
+                        // buffer is full
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Timeout
+                    rbuf.truncate(offset);
+                    break;
+                }
             }
         }
     }
@@ -150,7 +135,7 @@ fn main() -> ! {
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
-    esp32_hal::interrupt::enable(Interrupt::UART0, esp32_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -7,8 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::fmt::Write;
+
 use embassy_executor::Executor;
-use embassy_time::{Duration, Timer};
+use embassy_time::{with_timeout, Duration};
 use esp32_hal::{
     clock::ClockControl,
     embassy,
@@ -19,18 +21,97 @@ use esp32_hal::{
     Uart,
 };
 use esp_backtrace as _;
+use esp_hal_common::uart::config::AtCmdConfig;
 use static_cell::StaticCell;
+
+struct Buffer<const N: usize> {
+    len: usize,
+    buf: [u8; N],
+}
+
+impl<const N: usize> Buffer<N> {
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    #[inline(always)]
+    pub fn is_full(&self) -> bool {
+        self.len == N
+    }
+}
+
+impl<const N: usize> core::fmt::Write for Buffer<N> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let sb = s.as_bytes();
+        let mut len = sb.len();
+        if self.len + len > N {
+            len = N - self.len;
+        }
+        if len > 0 {
+            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
+            self.len += len;
+        }
+        Ok(())
+    }
+}
+
+/// rx_fifo_full_threshold
+const READ_BUF_SIZE: usize = 128;
+/// EOT; CTRL-D
+const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
+    /// max READ_BUF_SIZE buffers to receive
+    const MAX_BUFFERS: usize = 10;
+    /// timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut rbuf = Buffer {
+        len: 0,
+        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
+    };
+    let mut wbuf = Buffer {
+        len: 0,
+        buf: [0; 128],
+    };
+
     loop {
-        embedded_hal_async::serial::Write::write(&mut uart, b"Hello async write!!!\r\n")
+        if rbuf.len == 0 {
+            embedded_hal_async::serial::Write::write(
+                &mut uart,
+                b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
+            )
             .await
             .unwrap();
+        } else {
+            wbuf.len = 0;
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, rbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, b"\r\n")
+                .await
+                .unwrap();
+        }
         embedded_hal_async::serial::Write::flush(&mut uart)
             .await
             .unwrap();
-        Timer::after(Duration::from_millis(1_000)).await;
+
+        rbuf.len = 0;
+        while let Ok(Ok(len)) =
+            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
+        {
+            rbuf.len += len;
+            // if set_at_cmd is used than stop reading
+            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
+                break;
+            }
+        }
     }
 }
 
@@ -65,7 +146,9 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
+    uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
     esp32_hal::interrupt::enable(Interrupt::UART0, esp32_hal::Priority::Priority1).unwrap();
 

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -42,6 +42,7 @@ lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.6", default-features = false}
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+heapless          = "0.7.16"
 
 [features]
 default              = ["rt", "vectored", "xtal40mhz"]

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -7,8 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::fmt::Write;
+
 use embassy_executor::Executor;
-use embassy_time::{Duration, Timer};
+use embassy_time::{with_timeout, Duration};
 use esp32c2_hal::{
     clock::ClockControl,
     embassy,
@@ -19,18 +21,97 @@ use esp32c2_hal::{
     Uart,
 };
 use esp_backtrace as _;
+use esp_hal_common::uart::config::AtCmdConfig;
 use static_cell::StaticCell;
+
+struct Buffer<const N: usize> {
+    len: usize,
+    buf: [u8; N],
+}
+
+impl<const N: usize> Buffer<N> {
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    #[inline(always)]
+    pub fn is_full(&self) -> bool {
+        self.len == N
+    }
+}
+
+impl<const N: usize> core::fmt::Write for Buffer<N> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let sb = s.as_bytes();
+        let mut len = sb.len();
+        if self.len + len > N {
+            len = N - self.len;
+        }
+        if len > 0 {
+            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
+            self.len += len;
+        }
+        Ok(())
+    }
+}
+
+/// rx_fifo_full_threshold
+const READ_BUF_SIZE: usize = 128;
+/// EOT; CTRL-D
+const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
+    /// max READ_BUF_SIZE buffers to receive
+    const MAX_BUFFERS: usize = 10;
+    /// timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut rbuf = Buffer {
+        len: 0,
+        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
+    };
+    let mut wbuf = Buffer {
+        len: 0,
+        buf: [0; 128],
+    };
+
     loop {
-        embedded_hal_async::serial::Write::write(&mut uart, b"Hello async write!!!\r\n")
+        if rbuf.len == 0 {
+            embedded_hal_async::serial::Write::write(
+                &mut uart,
+                b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
+            )
             .await
             .unwrap();
+        } else {
+            wbuf.len = 0;
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, rbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, b"\r\n")
+                .await
+                .unwrap();
+        }
         embedded_hal_async::serial::Write::flush(&mut uart)
             .await
             .unwrap();
-        Timer::after(Duration::from_millis(1_000)).await;
+
+        rbuf.len = 0;
+        while let Ok(Ok(len)) =
+            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
+        {
+            rbuf.len += len;
+            // if set_at_cmd is used than stop reading
+            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
+                break;
+            }
+        }
     }
 }
 
@@ -65,7 +146,9 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
+    uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
     esp32c2_hal::interrupt::enable(Interrupt::UART0, esp32c2_hal::Priority::Priority1).unwrap();
 

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -1,7 +1,7 @@
 //! embassy serial
 //!
 //! This is an example of running the embassy executor and asynchronously
-//! writing to a uart.
+//! writing to and reading from uart
 
 #![no_std]
 #![no_main]
@@ -14,6 +14,7 @@ use embassy_time::{with_timeout, Duration};
 use esp32c2_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -22,63 +23,26 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
+use heapless::Vec;
 use static_cell::StaticCell;
 
-struct Buffer<const N: usize> {
-    len: usize,
-    buf: [u8; N],
-}
-
-impl<const N: usize> Buffer<N> {
-    #[inline(always)]
-    pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..self.len]
-    }
-
-    #[inline(always)]
-    pub fn is_full(&self) -> bool {
-        self.len == N
-    }
-}
-
-impl<const N: usize> core::fmt::Write for Buffer<N> {
-    #[inline]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let sb = s.as_bytes();
-        let mut len = sb.len();
-        if self.len + len > N {
-            len = N - self.len;
-        }
-        if len > 0 {
-            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
-            self.len += len;
-        }
-        Ok(())
-    }
-}
-
-/// rx_fifo_full_threshold
+// rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 128;
 /// EOT; CTRL-D
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
-    /// max READ_BUF_SIZE buffers to receive
-    const MAX_BUFFERS: usize = 10;
-    /// timeout read
-    const READ_TIMEOUT: Duration = Duration::from_secs(5);
-    let mut rbuf = Buffer {
-        len: 0,
-        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
-    };
-    let mut wbuf = Buffer {
-        len: 0,
-        buf: [0; 128],
-    };
+    // max message size to receive
+    // leave some extra space for AT-CMD characters
+    const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
+    // timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(10);
 
+    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut wbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
     loop {
-        if rbuf.len == 0 {
+        if rbuf.is_empty() {
             embedded_hal_async::serial::Write::write(
                 &mut uart,
                 b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -86,8 +50,8 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
         } else {
-            wbuf.len = 0;
-            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            wbuf.clear();
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len()).unwrap();
             embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
                 .await
                 .unwrap();
@@ -102,14 +66,35 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
 
-        rbuf.len = 0;
-        while let Ok(Ok(len)) =
-            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
-        {
-            rbuf.len += len;
-            // if set_at_cmd is used than stop reading
-            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
-                break;
+        // set rbuf full capacity
+        unsafe {
+            rbuf.set_len(rbuf.capacity());
+        }
+        let mut offset = 0;
+        loop {
+            match with_timeout(READ_TIMEOUT, uart.read(&mut rbuf[offset..])).await {
+                Ok(r) => {
+                    if let Ok(len) = r {
+                        offset += len;
+                        if offset == 0 {
+                            rbuf.truncate(0);
+                            break;
+                        }
+                        // if set_at_cmd is used than stop reading
+                        if len < READ_BUF_SIZE {
+                            rbuf.truncate(offset);
+                            break;
+                        }
+                    } else {
+                        // buffer is full
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Timeout
+                    rbuf.truncate(offset);
+                    break;
+                }
             }
         }
     }
@@ -150,7 +135,7 @@ fn main() -> ! {
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
-    esp32c2_hal::interrupt::enable(Interrupt::UART0, esp32c2_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -48,6 +48,7 @@ sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+heapless          = "0.7.16"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -7,8 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::fmt::Write;
+
 use embassy_executor::Executor;
-use embassy_time::{Duration, Timer};
+use embassy_time::{with_timeout, Duration};
 use esp32c3_hal::{
     clock::ClockControl,
     embassy,
@@ -19,18 +21,97 @@ use esp32c3_hal::{
     Uart,
 };
 use esp_backtrace as _;
+use esp_hal_common::uart::config::AtCmdConfig;
 use static_cell::StaticCell;
+
+struct Buffer<const N: usize> {
+    len: usize,
+    buf: [u8; N],
+}
+
+impl<const N: usize> Buffer<N> {
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    #[inline(always)]
+    pub fn is_full(&self) -> bool {
+        self.len == N
+    }
+}
+
+impl<const N: usize> core::fmt::Write for Buffer<N> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let sb = s.as_bytes();
+        let mut len = sb.len();
+        if self.len + len > N {
+            len = N - self.len;
+        }
+        if len > 0 {
+            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
+            self.len += len;
+        }
+        Ok(())
+    }
+}
+
+/// rx_fifo_full_threshold
+const READ_BUF_SIZE: usize = 128;
+/// EOT; CTRL-D
+const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
+    /// max READ_BUF_SIZE buffers to receive
+    const MAX_BUFFERS: usize = 10;
+    /// timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut rbuf = Buffer {
+        len: 0,
+        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
+    };
+    let mut wbuf = Buffer {
+        len: 0,
+        buf: [0; 128],
+    };
+
     loop {
-        embedded_hal_async::serial::Write::write(&mut uart, b"Hello async write!!!\r\n")
+        if rbuf.len == 0 {
+            embedded_hal_async::serial::Write::write(
+                &mut uart,
+                b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
+            )
             .await
             .unwrap();
+        } else {
+            wbuf.len = 0;
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, rbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, b"\r\n")
+                .await
+                .unwrap();
+        }
         embedded_hal_async::serial::Write::flush(&mut uart)
             .await
             .unwrap();
-        Timer::after(Duration::from_millis(1_000)).await;
+
+        rbuf.len = 0;
+        while let Ok(Ok(len)) =
+            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
+        {
+            rbuf.len += len;
+            // if set_at_cmd is used than stop reading
+            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
+                break;
+            }
+        }
     }
 }
 
@@ -72,7 +153,9 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
+    uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
     esp32c3_hal::interrupt::enable(Interrupt::UART0, esp32c3_hal::Priority::Priority1).unwrap();
 

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -1,7 +1,7 @@
 //! embassy serial
 //!
 //! This is an example of running the embassy executor and asynchronously
-//! writing to a uart.
+//! writing to and reading from uart
 
 #![no_std]
 #![no_main]
@@ -14,6 +14,7 @@ use embassy_time::{with_timeout, Duration};
 use esp32c3_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -22,63 +23,26 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
+use heapless::Vec;
 use static_cell::StaticCell;
 
-struct Buffer<const N: usize> {
-    len: usize,
-    buf: [u8; N],
-}
-
-impl<const N: usize> Buffer<N> {
-    #[inline(always)]
-    pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..self.len]
-    }
-
-    #[inline(always)]
-    pub fn is_full(&self) -> bool {
-        self.len == N
-    }
-}
-
-impl<const N: usize> core::fmt::Write for Buffer<N> {
-    #[inline]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let sb = s.as_bytes();
-        let mut len = sb.len();
-        if self.len + len > N {
-            len = N - self.len;
-        }
-        if len > 0 {
-            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
-            self.len += len;
-        }
-        Ok(())
-    }
-}
-
-/// rx_fifo_full_threshold
+// rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 128;
-/// EOT; CTRL-D
+// EOT (CTRL-D)
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
-    /// max READ_BUF_SIZE buffers to receive
-    const MAX_BUFFERS: usize = 10;
-    /// timeout read
-    const READ_TIMEOUT: Duration = Duration::from_secs(5);
-    let mut rbuf = Buffer {
-        len: 0,
-        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
-    };
-    let mut wbuf = Buffer {
-        len: 0,
-        buf: [0; 128],
-    };
+    // max message size to receive
+    // leave some extra space for AT-CMD characters
+    const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
+    // timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(10);
 
+    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut wbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
     loop {
-        if rbuf.len == 0 {
+        if rbuf.is_empty() {
             embedded_hal_async::serial::Write::write(
                 &mut uart,
                 b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -86,8 +50,8 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
         } else {
-            wbuf.len = 0;
-            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            wbuf.clear();
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len()).unwrap();
             embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
                 .await
                 .unwrap();
@@ -102,14 +66,35 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
 
-        rbuf.len = 0;
-        while let Ok(Ok(len)) =
-            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
-        {
-            rbuf.len += len;
-            // if set_at_cmd is used than stop reading
-            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
-                break;
+        // set rbuf full capacity
+        unsafe {
+            rbuf.set_len(rbuf.capacity());
+        }
+        let mut offset = 0;
+        loop {
+            match with_timeout(READ_TIMEOUT, uart.read(&mut rbuf[offset..])).await {
+                Ok(r) => {
+                    if let Ok(len) = r {
+                        offset += len;
+                        if offset == 0 {
+                            rbuf.truncate(0);
+                            break;
+                        }
+                        // if set_at_cmd is used than stop reading
+                        if len < READ_BUF_SIZE {
+                            rbuf.truncate(offset);
+                            break;
+                        }
+                    } else {
+                        // buffer is full
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Timeout
+                    rbuf.truncate(offset);
+                    break;
+                }
             }
         }
     }
@@ -157,7 +142,7 @@ fn main() -> ! {
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
-    esp32c3_hal::interrupt::enable(Interrupt::UART0, esp32c3_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -49,6 +49,7 @@ sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+heapless          = "0.7.16"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -1,7 +1,7 @@
 //! embassy serial
 //!
 //! This is an example of running the embassy executor and asynchronously
-//! writing to a uart.
+//! writing to and reading from uart
 
 #![no_std]
 #![no_main]
@@ -14,6 +14,7 @@ use embassy_time::{with_timeout, Duration};
 use esp32c6_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -22,63 +23,26 @@ use esp32c6_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
+use heapless::Vec;
 use static_cell::StaticCell;
 
-struct Buffer<const N: usize> {
-    len: usize,
-    buf: [u8; N],
-}
-
-impl<const N: usize> Buffer<N> {
-    #[inline(always)]
-    pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..self.len]
-    }
-
-    #[inline(always)]
-    pub fn is_full(&self) -> bool {
-        self.len == N
-    }
-}
-
-impl<const N: usize> core::fmt::Write for Buffer<N> {
-    #[inline]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let sb = s.as_bytes();
-        let mut len = sb.len();
-        if self.len + len > N {
-            len = N - self.len;
-        }
-        if len > 0 {
-            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
-            self.len += len;
-        }
-        Ok(())
-    }
-}
-
-/// rx_fifo_full_threshold
+// rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 128;
-/// EOT; CTRL-D
+// EOT (CTRL-D)
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
-    /// max READ_BUF_SIZE buffers to receive
-    const MAX_BUFFERS: usize = 10;
-    /// timeout read
-    const READ_TIMEOUT: Duration = Duration::from_secs(5);
-    let mut rbuf = Buffer {
-        len: 0,
-        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
-    };
-    let mut wbuf = Buffer {
-        len: 0,
-        buf: [0; 128],
-    };
+    // max message size to receive
+    // leave some extra space for AT-CMD characters
+    const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
+    // timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(10);
 
+    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut wbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
     loop {
-        if rbuf.len == 0 {
+        if rbuf.is_empty() {
             embedded_hal_async::serial::Write::write(
                 &mut uart,
                 b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -86,8 +50,8 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
         } else {
-            wbuf.len = 0;
-            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            wbuf.clear();
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len()).unwrap();
             embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
                 .await
                 .unwrap();
@@ -102,14 +66,35 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
 
-        rbuf.len = 0;
-        while let Ok(Ok(len)) =
-            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
-        {
-            rbuf.len += len;
-            // if set_at_cmd is used than stop reading
-            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
-                break;
+        // set rbuf full capacity
+        unsafe {
+            rbuf.set_len(rbuf.capacity());
+        }
+        let mut offset = 0;
+        loop {
+            match with_timeout(READ_TIMEOUT, uart.read(&mut rbuf[offset..])).await {
+                Ok(r) => {
+                    if let Ok(len) = r {
+                        offset += len;
+                        if offset == 0 {
+                            rbuf.truncate(0);
+                            break;
+                        }
+                        // if set_at_cmd is used than stop reading
+                        if len < READ_BUF_SIZE {
+                            rbuf.truncate(offset);
+                            break;
+                        }
+                    } else {
+                        // buffer is full
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Timeout
+                    rbuf.truncate(offset);
+                    break;
+                }
             }
         }
     }
@@ -157,7 +142,7 @@ fn main() -> ! {
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
-    esp32c6_hal::interrupt::enable(Interrupt::UART0, esp32c6_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -48,6 +48,7 @@ sha2              = { version = "0.10.6", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
+heapless          = "0.7.16"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -1,7 +1,7 @@
 //! embassy serial
 //!
 //! This is an example of running the embassy executor and asynchronously
-//! writing to a uart.
+//! writing to and reading from uart
 
 #![no_std]
 #![no_main]
@@ -14,6 +14,7 @@ use embassy_time::{with_timeout, Duration};
 use esp32h2_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -22,63 +23,26 @@ use esp32h2_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
+use heapless::Vec;
 use static_cell::StaticCell;
 
-struct Buffer<const N: usize> {
-    len: usize,
-    buf: [u8; N],
-}
-
-impl<const N: usize> Buffer<N> {
-    #[inline(always)]
-    pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..self.len]
-    }
-
-    #[inline(always)]
-    pub fn is_full(&self) -> bool {
-        self.len == N
-    }
-}
-
-impl<const N: usize> core::fmt::Write for Buffer<N> {
-    #[inline]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let sb = s.as_bytes();
-        let mut len = sb.len();
-        if self.len + len > N {
-            len = N - self.len;
-        }
-        if len > 0 {
-            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
-            self.len += len;
-        }
-        Ok(())
-    }
-}
-
-/// rx_fifo_full_threshold
+// rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 128;
-/// EOT; CTRL-D
+// EOT (CTRL-D)
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
-    /// max READ_BUF_SIZE buffers to receive
-    const MAX_BUFFERS: usize = 10;
-    /// timeout read
-    const READ_TIMEOUT: Duration = Duration::from_secs(5);
-    let mut rbuf = Buffer {
-        len: 0,
-        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
-    };
-    let mut wbuf = Buffer {
-        len: 0,
-        buf: [0; 128],
-    };
+    // max message size to receive
+    // leave some extra space for AT-CMD characters
+    const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
+    // timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(10);
 
+    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut wbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
     loop {
-        if rbuf.len == 0 {
+        if rbuf.is_empty() {
             embedded_hal_async::serial::Write::write(
                 &mut uart,
                 b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -86,8 +50,8 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
         } else {
-            wbuf.len = 0;
-            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            wbuf.clear();
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len()).unwrap();
             embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
                 .await
                 .unwrap();
@@ -102,14 +66,35 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
 
-        rbuf.len = 0;
-        while let Ok(Ok(len)) =
-            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
-        {
-            rbuf.len += len;
-            // if set_at_cmd is used than stop reading
-            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
-                break;
+        // set rbuf full capacity
+        unsafe {
+            rbuf.set_len(rbuf.capacity());
+        }
+        let mut offset = 0;
+        loop {
+            match with_timeout(READ_TIMEOUT, uart.read(&mut rbuf[offset..])).await {
+                Ok(r) => {
+                    if let Ok(len) = r {
+                        offset += len;
+                        if offset == 0 {
+                            rbuf.truncate(0);
+                            break;
+                        }
+                        // if set_at_cmd is used than stop reading
+                        if len < READ_BUF_SIZE {
+                            rbuf.truncate(offset);
+                            break;
+                        }
+                    } else {
+                        // buffer is full
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Timeout
+                    rbuf.truncate(offset);
+                    break;
+                }
             }
         }
     }
@@ -157,7 +142,7 @@ fn main() -> ! {
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
-    esp32h2_hal::interrupt::enable(Interrupt::UART0, esp32h2_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -7,8 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::fmt::Write;
+
 use embassy_executor::Executor;
-use embassy_time::{Duration, Timer};
+use embassy_time::{with_timeout, Duration};
 use esp32h2_hal::{
     clock::ClockControl,
     embassy,
@@ -19,18 +21,97 @@ use esp32h2_hal::{
     Uart,
 };
 use esp_backtrace as _;
+use esp_hal_common::uart::config::AtCmdConfig;
 use static_cell::StaticCell;
+
+struct Buffer<const N: usize> {
+    len: usize,
+    buf: [u8; N],
+}
+
+impl<const N: usize> Buffer<N> {
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    #[inline(always)]
+    pub fn is_full(&self) -> bool {
+        self.len == N
+    }
+}
+
+impl<const N: usize> core::fmt::Write for Buffer<N> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let sb = s.as_bytes();
+        let mut len = sb.len();
+        if self.len + len > N {
+            len = N - self.len;
+        }
+        if len > 0 {
+            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
+            self.len += len;
+        }
+        Ok(())
+    }
+}
+
+/// rx_fifo_full_threshold
+const READ_BUF_SIZE: usize = 128;
+/// EOT; CTRL-D
+const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
+    /// max READ_BUF_SIZE buffers to receive
+    const MAX_BUFFERS: usize = 10;
+    /// timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut rbuf = Buffer {
+        len: 0,
+        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
+    };
+    let mut wbuf = Buffer {
+        len: 0,
+        buf: [0; 128],
+    };
+
     loop {
-        embedded_hal_async::serial::Write::write(&mut uart, b"Hello async write!!!\r\n")
+        if rbuf.len == 0 {
+            embedded_hal_async::serial::Write::write(
+                &mut uart,
+                b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
+            )
             .await
             .unwrap();
+        } else {
+            wbuf.len = 0;
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, rbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, b"\r\n")
+                .await
+                .unwrap();
+        }
         embedded_hal_async::serial::Write::flush(&mut uart)
             .await
             .unwrap();
-        Timer::after(Duration::from_millis(1_000)).await;
+
+        rbuf.len = 0;
+        while let Ok(Ok(len)) =
+            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
+        {
+            rbuf.len += len;
+            // if set_at_cmd is used than stop reading
+            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
+                break;
+            }
+        }
     }
 }
 
@@ -72,7 +153,9 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
+    uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
     esp32h2_hal::interrupt::enable(Interrupt::UART0, esp32h2_hal::Priority::Priority1).unwrap();
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -50,6 +50,7 @@ ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
 usb-device        = { version = "0.2.9" }
 usbd-serial       = "0.1.1"
+heapless          = "0.7.16"
 
 [features]
 default   = ["rt", "vectored"]

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -1,7 +1,7 @@
 //! embassy serial
 //!
 //! This is an example of running the embassy executor and asynchronously
-//! writing to a uart.
+//! writing to and reading from uart
 
 #![no_std]
 #![no_main]
@@ -14,6 +14,7 @@ use embassy_time::{with_timeout, Duration};
 use esp32s2_hal::{
     clock::ClockControl,
     embassy,
+    interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
@@ -22,63 +23,26 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
+use heapless::Vec;
 use static_cell::StaticCell;
 
-struct Buffer<const N: usize> {
-    len: usize,
-    buf: [u8; N],
-}
-
-impl<const N: usize> Buffer<N> {
-    #[inline(always)]
-    pub fn as_slice(&self) -> &[u8] {
-        &self.buf[..self.len]
-    }
-
-    #[inline(always)]
-    pub fn is_full(&self) -> bool {
-        self.len == N
-    }
-}
-
-impl<const N: usize> core::fmt::Write for Buffer<N> {
-    #[inline]
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let sb = s.as_bytes();
-        let mut len = sb.len();
-        if self.len + len > N {
-            len = N - self.len;
-        }
-        if len > 0 {
-            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
-            self.len += len;
-        }
-        Ok(())
-    }
-}
-
-/// rx_fifo_full_threshold
+// rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 128;
-/// EOT; CTRL-D
+// EOT (CTRL-D)
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
-    /// max READ_BUF_SIZE buffers to receive
-    const MAX_BUFFERS: usize = 10;
-    /// timeout read
-    const READ_TIMEOUT: Duration = Duration::from_secs(5);
-    let mut rbuf = Buffer {
-        len: 0,
-        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
-    };
-    let mut wbuf = Buffer {
-        len: 0,
-        buf: [0; 128],
-    };
+    // max message size to receive
+    // leave some extra space for AT-CMD characters
+    const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
+    // timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(10);
 
+    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut wbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
     loop {
-        if rbuf.len == 0 {
+        if rbuf.is_empty() {
             embedded_hal_async::serial::Write::write(
                 &mut uart,
                 b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -86,8 +50,8 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
         } else {
-            wbuf.len = 0;
-            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            wbuf.clear();
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len()).unwrap();
             embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
                 .await
                 .unwrap();
@@ -102,14 +66,35 @@ async fn run(mut uart: Uart<'static, UART0>) {
             .await
             .unwrap();
 
-        rbuf.len = 0;
-        while let Ok(Ok(len)) =
-            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
-        {
-            rbuf.len += len;
-            // if set_at_cmd is used than stop reading
-            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
-                break;
+        // set rbuf full capacity
+        unsafe {
+            rbuf.set_len(rbuf.capacity());
+        }
+        let mut offset = 0;
+        loop {
+            match with_timeout(READ_TIMEOUT, uart.read(&mut rbuf[offset..])).await {
+                Ok(r) => {
+                    if let Ok(len) = r {
+                        offset += len;
+                        if offset == 0 {
+                            rbuf.truncate(0);
+                            break;
+                        }
+                        // if set_at_cmd is used than stop reading
+                        if len < READ_BUF_SIZE {
+                            rbuf.truncate(offset);
+                            break;
+                        }
+                    } else {
+                        // buffer is full
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Timeout
+                    rbuf.truncate(offset);
+                    break;
+                }
             }
         }
     }
@@ -150,7 +135,7 @@ fn main() -> ! {
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
-    esp32s2_hal::interrupt::enable(Interrupt::UART0, esp32s2_hal::Priority::Priority1).unwrap();
+    interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -7,8 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::fmt::Write;
+
 use embassy_executor::Executor;
-use embassy_time::{Duration, Timer};
+use embassy_time::{with_timeout, Duration};
 use esp32s2_hal::{
     clock::ClockControl,
     embassy,
@@ -19,18 +21,97 @@ use esp32s2_hal::{
     Uart,
 };
 use esp_backtrace as _;
+use esp_hal_common::uart::config::AtCmdConfig;
 use static_cell::StaticCell;
+
+struct Buffer<const N: usize> {
+    len: usize,
+    buf: [u8; N],
+}
+
+impl<const N: usize> Buffer<N> {
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    #[inline(always)]
+    pub fn is_full(&self) -> bool {
+        self.len == N
+    }
+}
+
+impl<const N: usize> core::fmt::Write for Buffer<N> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let sb = s.as_bytes();
+        let mut len = sb.len();
+        if self.len + len > N {
+            len = N - self.len;
+        }
+        if len > 0 {
+            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
+            self.len += len;
+        }
+        Ok(())
+    }
+}
+
+/// rx_fifo_full_threshold
+const READ_BUF_SIZE: usize = 128;
+/// EOT; CTRL-D
+const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
+    /// max READ_BUF_SIZE buffers to receive
+    const MAX_BUFFERS: usize = 10;
+    /// timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut rbuf = Buffer {
+        len: 0,
+        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
+    };
+    let mut wbuf = Buffer {
+        len: 0,
+        buf: [0; 128],
+    };
+
     loop {
-        embedded_hal_async::serial::Write::write(&mut uart, b"Hello async write!!!\r\n")
+        if rbuf.len == 0 {
+            embedded_hal_async::serial::Write::write(
+                &mut uart,
+                b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
+            )
             .await
             .unwrap();
+        } else {
+            wbuf.len = 0;
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, rbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, b"\r\n")
+                .await
+                .unwrap();
+        }
         embedded_hal_async::serial::Write::flush(&mut uart)
             .await
             .unwrap();
-        Timer::after(Duration::from_millis(1_000)).await;
+
+        rbuf.len = 0;
+        while let Ok(Ok(len)) =
+            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
+        {
+            rbuf.len += len;
+            // if set_at_cmd is used than stop reading
+            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
+                break;
+            }
+        }
     }
 }
 
@@ -65,7 +146,9 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
+    uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
     esp32s2_hal::interrupt::enable(Interrupt::UART0, esp32s2_hal::Priority::Priority1).unwrap();
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -52,6 +52,7 @@ ssd1306           = "0.7.1"
 static_cell       = "1.0.0"
 usb-device        = "0.2.9"
 usbd-serial       = "0.1.1"
+heapless          = "0.7.16"
 
 [features]
 default              = ["rt", "vectored"]

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -7,8 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::fmt::Write;
+
 use embassy_executor::Executor;
-use embassy_time::{Duration, Timer};
+use embassy_time::{with_timeout, Duration};
 use esp32s3_hal::{
     clock::ClockControl,
     embassy,
@@ -19,18 +21,97 @@ use esp32s3_hal::{
     Uart,
 };
 use esp_backtrace as _;
+use esp_hal_common::uart::config::AtCmdConfig;
 use static_cell::StaticCell;
+
+struct Buffer<const N: usize> {
+    len: usize,
+    buf: [u8; N],
+}
+
+impl<const N: usize> Buffer<N> {
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    #[inline(always)]
+    pub fn is_full(&self) -> bool {
+        self.len == N
+    }
+}
+
+impl<const N: usize> core::fmt::Write for Buffer<N> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let sb = s.as_bytes();
+        let mut len = sb.len();
+        if self.len + len > N {
+            len = N - self.len;
+        }
+        if len > 0 {
+            self.buf[self.len..self.len + len].copy_from_slice(&sb[..len]);
+            self.len += len;
+        }
+        Ok(())
+    }
+}
+
+/// rx_fifo_full_threshold
+const READ_BUF_SIZE: usize = 128;
+/// EOT; CTRL-D
+const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
 async fn run(mut uart: Uart<'static, UART0>) {
+    /// max READ_BUF_SIZE buffers to receive
+    const MAX_BUFFERS: usize = 10;
+    /// timeout read
+    const READ_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut rbuf = Buffer {
+        len: 0,
+        buf: [0; MAX_BUFFERS * READ_BUF_SIZE],
+    };
+    let mut wbuf = Buffer {
+        len: 0,
+        buf: [0; 128],
+    };
+
     loop {
-        embedded_hal_async::serial::Write::write(&mut uart, b"Hello async write!!!\r\n")
+        if rbuf.len == 0 {
+            embedded_hal_async::serial::Write::write(
+                &mut uart,
+                b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
+            )
             .await
             .unwrap();
+        } else {
+            wbuf.len = 0;
+            write!(&mut wbuf, "\r\n-- received {} bytes --\r\n", rbuf.len).unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, wbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, rbuf.as_slice())
+                .await
+                .unwrap();
+            embedded_hal_async::serial::Write::write(&mut uart, b"\r\n")
+                .await
+                .unwrap();
+        }
         embedded_hal_async::serial::Write::flush(&mut uart)
             .await
             .unwrap();
-        Timer::after(Duration::from_millis(1_000)).await;
+
+        rbuf.len = 0;
+        while let Ok(Ok(len)) =
+            with_timeout(READ_TIMEOUT, uart.read(&mut rbuf.buf[rbuf.len..])).await
+        {
+            rbuf.len += len;
+            // if set_at_cmd is used than stop reading
+            if rbuf.buf[rbuf.len - 1] == AT_CMD || rbuf.is_full() {
+                break;
+            }
+        }
     }
 }
 
@@ -72,7 +153,9 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
+    uart0.set_rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
     esp32s3_hal::interrupt::enable(Interrupt::UART0, esp32s3_hal::Priority::Priority1).unwrap();
 


### PR DESCRIPTION
## serial uart `read` for `embassy` `async`

Tested on ESP32C3 only.

NOTE: `embassy_hal_async` does not have a `Read` trait for `serial,` only `Write` traits, so I could not follow the same implementation pattern as in the write case. The new function is called `read`, not sure if it is Ok, there was not a read function for nb implementation. If you think is to generic, I can change it to `read_async`

Also fix an issue with async write on large buffers, was panicking with Err Would Block. Discovered when testing reading and echoing back a large reader buffer. 

NOTE: this is a reopen of the #615 PR.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.