### PR TITLE
DMA descriptor count fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected the expected DMA descriptor counts (#622)
 - DMA is supported for SPI3 on ESP32-S3 (#507)
 - `change_bus_frequency` is now available on `SpiDma` (#529)
 - Fixed a bug where a GPIO interrupt could erroneously fire again causing the next `await` on that pin to instantly return `Poll::Ok` (#537)

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -390,7 +390,8 @@ macro_rules! impl_channel {
             impl [<ChannelCreator $num>] {
                 /// Configure the channel for use
                 ///
-                /// Descriptors should be sized as (BUFFERSIZE / 4092) * 3
+                /// Descriptors should be sized as `((BUFFERSIZE + 4091) / 4092) * 3`. I.e., to
+                /// transfer buffers of size `1..=4092`, you need 3 descriptors.
                 pub fn configure<'a>(
                     self,
                     burst_mode: bool,

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -1,6 +1,7 @@
 //! Direct Memory Access Commons
 //!
-//! Descriptors should be sized as (BUFFERSIZE / 4092) * 3
+//! Descriptors should be sized as `((BUFFERSIZE + 4091) / 4092) * 3`. I.e., to
+//! transfer buffers of size `1..=4092`, you need 3 descriptors.
 
 use core::{marker::PhantomData, sync::atomic::compiler_fence};
 
@@ -347,7 +348,7 @@ where
             return Err(DmaError::InvalidDescriptorSize);
         }
 
-        if self.descriptors.len() / 3 < len / CHUNK_SIZE {
+        if self.descriptors.len() / 3 < (len + CHUNK_SIZE - 1) / CHUNK_SIZE {
             return Err(DmaError::OutOfDescriptors);
         }
 
@@ -647,7 +648,7 @@ where
             return Err(DmaError::InvalidDescriptorSize);
         }
 
-        if self.descriptors.len() / 3 < len / CHUNK_SIZE {
+        if self.descriptors.len() / 3 < (len + CHUNK_SIZE - 1) / CHUNK_SIZE {
             return Err(DmaError::OutOfDescriptors);
         }
 


### PR DESCRIPTION
This PR corrects the equation to calculate the required number of DMA descriptors. The driver requires descriptors in sets of 3, one set for each 4092 byte chunk. The former equation (`(BUFFERSIZE / 4092) * 3`) evaluates to 0 for transfers of size 0..4092, 3 for 4092..8184, etc, which is basically 3 less than required for cases where `BUFFERSIZE % 4092 != 0`.