### PR TITLE
Disallow users creating DMA channel types, fix PDMA descriptor count docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- DMA types can no longer be constructed by the user (#625)
 - Move core interrupt handling from Flash to RAM for RISC-V chips (ESP32-H2, ESP32-C2, ESP32-C3, ESP32-C6) (#541)
 - Change LED pin to GPIO2 in ESP32 blinky example (#581)
 - Update ESP32-H2 and ESP32-C6 clocks and remove `i2c_clock` for all chips but ESP32 (#592)
@@ -40,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Corrected the expected DMA descriptor counts (#622)
+- Corrected the expected DMA descriptor counts (#622, #625)
 - DMA is supported for SPI3 on ESP32-S3 (#507)
 - `change_bus_frequency` is now available on `SpiDma` (#529)
 - Fixed a bug where a GPIO interrupt could erroneously fire again causing the next `await` on that pin to instantly return `Poll::Ok` (#537)

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -9,6 +9,7 @@ use crate::{
 macro_rules! impl_channel {
     ($num: literal) => {
         paste::paste! {
+            #[non_exhaustive]
             pub struct [<Channel $num>] {}
 
             impl RegisterAccess for [<Channel $num>] {
@@ -365,6 +366,7 @@ macro_rules! impl_channel {
                 }
             }
 
+            #[non_exhaustive]
             pub struct [<Channel $num TxImpl>] {}
 
             impl<'a> TxChannel<[<Channel $num>]> for [<Channel $num TxImpl>] {
@@ -375,6 +377,7 @@ macro_rules! impl_channel {
                 }
             }
 
+            #[non_exhaustive]
             pub struct [<Channel $num RxImpl>] {}
 
             impl<'a> RxChannel<[<Channel $num>]> for [<Channel $num RxImpl>] {
@@ -385,6 +388,7 @@ macro_rules! impl_channel {
                 }
             }
 
+            #[non_exhaustive]
             pub struct [<ChannelCreator $num>] {}
 
             impl [<ChannelCreator $num>] {
@@ -437,6 +441,7 @@ macro_rules! impl_channel {
                 }
             }
 
+            #[non_exhaustive]
             pub struct [<SuitablePeripheral $num>] {}
             impl PeripheralMarker for [<SuitablePeripheral $num>] {}
 

--- a/esp-hal-common/src/dma/pdma.rs
+++ b/esp-hal-common/src/dma/pdma.rs
@@ -224,7 +224,8 @@ macro_rules! ImplSpiChannel {
             impl [<Spi $num DmaChannelCreator>] {
                 /// Configure the channel for use
                 ///
-                /// Descriptors should be sized as (BUFFERSIZE / 4092) * 3
+                /// Descriptors should be sized as `((BUFFERSIZE + 4091) / 4092) * 3`. I.e., to
+                /// transfer buffers of size `1..=4092`, you need 3 descriptors.
                 pub fn configure<'a>(
                     self,
                     burst_mode: bool,
@@ -462,7 +463,8 @@ macro_rules! ImplI2sChannel {
             impl [<I2s $num DmaChannelCreator>] {
                 /// Configure the channel for use
                 ///
-                /// Descriptors should be sized as (BUFFERSIZE / 4092) * 3
+                /// Descriptors should be sized as `((BUFFERSIZE + 4091) / 4092) * 3`. I.e., to
+                /// transfer buffers of size `1..=4092`, you need 3 descriptors.
                 pub fn configure<'a>(
                     self,
                     burst_mode: bool,

--- a/esp-hal-common/src/dma/pdma.rs
+++ b/esp-hal-common/src/dma/pdma.rs
@@ -9,6 +9,7 @@ use crate::{
 macro_rules! ImplSpiChannel {
     ($num: literal) => {
         paste::paste! {
+            #[non_exhaustive]
             pub struct [<Spi $num DmaChannel>] {}
 
             impl RegisterAccess for [<Spi $num DmaChannel>] {
@@ -195,6 +196,7 @@ macro_rules! ImplSpiChannel {
                 }
             }
 
+            #[non_exhaustive]
             pub struct [<Spi $num DmaChannelTxImpl>] {}
 
             impl<'a> TxChannel<[<Spi $num DmaChannel>]> for [<Spi $num DmaChannelTxImpl>] {
@@ -205,6 +207,7 @@ macro_rules! ImplSpiChannel {
                 }
             }
 
+            #[non_exhaustive]
             pub struct [<Spi $num DmaChannelRxImpl>] {}
 
             impl<'a> RxChannel<[<Spi $num DmaChannel>]> for [<Spi $num DmaChannelRxImpl>] {
@@ -215,6 +218,7 @@ macro_rules! ImplSpiChannel {
                 }
             }
 
+            #[non_exhaustive]
             pub struct [<Spi $num DmaChannelCreator>] {}
 
             impl [<Spi $num DmaChannelCreator>] {
@@ -511,11 +515,13 @@ macro_rules! ImplI2sChannel {
     };
 }
 
+#[non_exhaustive]
 pub struct Spi2DmaSuitablePeripheral {}
 impl PeripheralMarker for Spi2DmaSuitablePeripheral {}
 impl SpiPeripheral for Spi2DmaSuitablePeripheral {}
 impl Spi2Peripheral for Spi2DmaSuitablePeripheral {}
 
+#[non_exhaustive]
 pub struct Spi3DmaSuitablePeripheral {}
 impl PeripheralMarker for Spi3DmaSuitablePeripheral {}
 impl SpiPeripheral for Spi3DmaSuitablePeripheral {}
@@ -524,6 +530,7 @@ impl Spi3Peripheral for Spi3DmaSuitablePeripheral {}
 ImplSpiChannel!(2);
 ImplSpiChannel!(3);
 
+#[non_exhaustive]
 pub struct I2s0DmaSuitablePeripheral {}
 impl PeripheralMarker for I2s0DmaSuitablePeripheral {}
 impl I2sPeripheral for I2s0DmaSuitablePeripheral {}
@@ -531,6 +538,7 @@ impl I2s0Peripheral for I2s0DmaSuitablePeripheral {}
 
 ImplI2sChannel!(0, "I2S0");
 
+#[non_exhaustive]
 pub struct I2s1DmaSuitablePeripheral {}
 impl PeripheralMarker for I2s1DmaSuitablePeripheral {}
 impl I2sPeripheral for I2s1DmaSuitablePeripheral {}


### PR DESCRIPTION
Disallowing patterns like `ChannelCreator0 {}.configure()` may save some feet from getting shot. Probably not many, but still :)