### PR TITLE
Update `esp-hal-procmacros` package dependencies and features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-work `RadioExt` implementations, add support for ESP32-H2 (#627)
 - Improve examples documentation (#533)
 - esp32h2-hal: added README (#585)
+- Update `esp-hal-procmacros` package dependencies and features (#628)
 
 ### Fixed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -105,8 +105,8 @@ embassy-time-timg0   = []
 interrupt-preemption = []
 
 # Architecture-specific features (intended for internal use)
-riscv  = ["critical-section/restore-state-u8",  "procmacros/riscv", "esp-riscv-rt", "riscv-atomic-emulation-trap", "esp-riscv-rt/zero-bss"]
-xtensa = ["critical-section/restore-state-u32", "procmacros/xtensa"]
+riscv  = ["critical-section/restore-state-u8", "esp-riscv-rt", "esp-riscv-rt/zero-bss", "riscv-atomic-emulation-trap"]
+xtensa = ["critical-section/restore-state-u32"]
 
 # Initialize / clear data sections and RTC memory
 rv-init-data     = ["esp-riscv-rt/init-data", "esp-riscv-rt/init-rw-text"]

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -18,12 +18,12 @@ features = ["esp32c3", "interrupt"]
 proc-macro = true
 
 [dependencies]
-darling          = "0.14.4"
+darling          = "0.20.1"
 proc-macro-crate = "1.3.1"
 proc-macro-error = "1.0.4"
 proc-macro2      = "1.0.53"
 quote            = "1.0.26"
-syn              = {version = "1.0.109", features = ["extra-traits", "full"]}
+syn              = {version = "2.0.22", features = ["extra-traits", "full"]}
 
 [features]
 esp32     = []

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -12,7 +12,7 @@ repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
-features = ["esp32c3", "interrupt", "riscv"]
+features = ["esp32c3", "interrupt"]
 
 [lib]
 proc-macro = true
@@ -26,10 +26,6 @@ quote            = "1.0.26"
 syn              = {version = "1.0.109", features = ["extra-traits", "full"]}
 
 [features]
-interrupt = []
-riscv     = []
-rtc_slow  = []
-xtensa    = []
 esp32     = []
 esp32c2   = []
 esp32c3   = []
@@ -37,3 +33,6 @@ esp32c6   = []
 esp32h2   = []
 esp32s2   = []
 esp32s3   = []
+
+interrupt = []
+rtc_slow  = []

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -294,12 +294,6 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
         (f.sig.inputs.len() == 1).then(|| Ident::new("context", proc_macro2::Span::call_site()));
 
     quote!(
-        macro_rules! foo {
-            () => {
-            };
-        }
-        foo!();
-
         #(#cfgs)*
         #(#attrs)*
         #[doc(hidden)]

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-use darling::FromMeta;
+use darling::{ast::NestedMeta, FromMeta};
 use proc_macro::{self, Span, TokenStream};
 use proc_macro_error::{abort, proc_macro_error};
 use quote::quote;
@@ -23,7 +23,6 @@ use syn::{
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input,
-    AttributeArgs,
 };
 
 #[derive(Debug, Default, FromMeta)]
@@ -47,7 +46,12 @@ struct RamArgs {
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
-    let attr_args = parse_macro_input!(args as AttributeArgs);
+    let attr_args = match NestedMeta::parse_meta_list(args.into()) {
+        Ok(v) => v,
+        Err(e) => {
+            return TokenStream::from(darling::Error::from(e).write_errors());
+        }
+    };
 
     let RamArgs {
         rtc_fast,
@@ -142,7 +146,12 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let mut f: ItemFn = syn::parse(input).expect("`#[interrupt]` must be applied to a function");
 
-    let attr_args = parse_macro_input!(args as AttributeArgs);
+    let attr_args = match NestedMeta::parse_meta_list(args.into()) {
+        Ok(v) => v,
+        Err(e) => {
+            return TokenStream::from(darling::Error::from(e).write_errors());
+        }
+    };
 
     if attr_args.len() > 1 {
         abort!(
@@ -156,7 +165,7 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
 
     if attr_args.len() == 1 {
         match &attr_args[0] {
-            syn::NestedMeta::Meta(Path(x)) => {
+            NestedMeta::Meta(Path(x)) => {
                 ident_s = x.get_ident().unwrap();
             }
             _ => {
@@ -351,7 +360,7 @@ fn check_attr_whitelist(attrs: &[Attribute], caller: WhiteListCaller) -> Result<
 /// Returns `true` if `attr.path` matches `name`
 #[cfg(feature = "interrupt")]
 fn eq(attr: &Attribute, name: &str) -> bool {
-    attr.style == AttrStyle::Outer && attr.path.is_ident(name)
+    attr.style == AttrStyle::Outer && attr.path().is_ident(name)
 }
 
 #[cfg(feature = "interrupt")]


### PR DESCRIPTION
I've been putting this off for awhile, didn't end up being too bad to fix the build errors 😁 

- Removed the unnecessary `riscv` and `xtensa` features from the `esp-hal-procmacros` package
- Updated the `darling` and `syn` dependencies to their latest versions, and addressed all breaking changes

Did some basic testing with `embassy_*` examples, seems to still be working as expected.