### PR TITLE
Clean up a stray comment in rtc_time examples

### DIFF
--- a/esp32-hal/examples/rtc_time.rs
+++ b/esp32-hal/examples/rtc_time.rs
@@ -31,8 +31,6 @@ fn main() -> ! {
     wdt.disable();
     rtc.rwdt.disable();
 
-    // Initialize the Delay peripheral, and use it to toggle the LED state in a
-    // loop.
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32c2-hal/examples/rtc_time.rs
+++ b/esp32c2-hal/examples/rtc_time.rs
@@ -33,8 +33,6 @@ fn main() -> ! {
     rtc.rwdt.disable();
     wdt0.disable();
 
-    // Initialize the Delay peripheral, and use it to toggle the LED state in a
-    // loop.
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32c3-hal/examples/rtc_time.rs
+++ b/esp32c3-hal/examples/rtc_time.rs
@@ -40,8 +40,6 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
-    // Initialize the Delay peripheral, and use it to toggle the LED state in a
-    // loop.
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32c6-hal/examples/rtc_time.rs
+++ b/esp32c6-hal/examples/rtc_time.rs
@@ -40,8 +40,6 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
-    // Initialize the Delay peripheral, and use it to toggle the LED state in a
-    // loop.
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32h2-hal/examples/rtc_time.rs
+++ b/esp32h2-hal/examples/rtc_time.rs
@@ -40,8 +40,6 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
-    // Initialize the Delay peripheral, and use it to toggle the LED state in a
-    // loop.
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32s2-hal/examples/rtc_time.rs
+++ b/esp32s2-hal/examples/rtc_time.rs
@@ -31,8 +31,6 @@ fn main() -> ! {
     wdt.disable();
     rtc.rwdt.disable();
 
-    // Initialize the Delay peripheral, and use it to toggle the LED state in a
-    // loop.
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32s3-hal/examples/rtc_time.rs
+++ b/esp32s3-hal/examples/rtc_time.rs
@@ -31,8 +31,6 @@ fn main() -> ! {
     wdt.disable();
     rtc.rwdt.disable();
 
-    // Initialize the Delay peripheral, and use it to toggle the LED state in a
-    // loop.
     let mut delay = Delay::new(&clocks);
 
     loop {


### PR DESCRIPTION
It looks like this example was a modification of blinky, and a comment from the original stuck around. I opted to pull it entirely instead of correcting it, as the purpose of the line seemed self explanatory. If folks would rather it was corrected, I'm happy to edit.

## Thank you!
### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
