### PR TITLE
Assorted small fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ If you have any questions, comments, or concerns, please [open an issue], [start
 
 ## Quickstart
 
-We recommend using [cargo-generate] and [esp-template] in order to generate a new project with all the required dependencies and configuration:
+If you have not already, we strongly encourage you to read [The Rust on ESP Book] prior to starting.
+
+We recommend using [cargo-generate] and [esp-template] in order to generate a new project. This will allow you to generate a minimal project skeleton with all the required dependencies and configuration ready to go.
+
+You can install [cargo-generate] and generate a new project by running:
 
 ```bash
 $ cargo install cargo-generate
@@ -52,6 +56,7 @@ $ cargo generate -a esp-rs/esp-template
 
 For more information on using this template, please refer to [its README].
 
+[the rust on esp book]: https://esp-rs.github.io/book/
 [cargo-generate]: https://github.com/cargo-generate/cargo-generate
 [esp-template]: https://github.com/esp-rs/esp-template
 [its readme]: https://github.com/esp-rs/esp-template/blob/main/README.md
@@ -60,17 +65,19 @@ For more information on using this template, please refer to [its README].
 
 There are a number of other crates within the [esp-rs organization] which can be used in conjunction with `esp-hal`:
 
-|      Crate      |                                  Description                                   |
-| :-------------: | :----------------------------------------------------------------------------: |
-|   [esp-alloc]   |                        A simple `no_std` heap allocator                        |
-| [esp-backtrace] |                 Backtrace support for bare-metal applications                  |
-|  [esp-println]  |                Provides `print!` and `println!` implementations                |
-|  [esp-storage]  | Implementation of [embedded-storage] traits to access unencrypted flash memory |
-|   [esp-wifi]    |                      `no_std` Wi-Fi/Bluetooth LE support                       |
+|      Crate       |                                  Description                                   |
+| :--------------: | :----------------------------------------------------------------------------: |
+|   [esp-alloc]    |                        A simple `no_std` heap allocator                        |
+| [esp-backtrace]  |                 Backtrace support for bare-metal applications                  |
+| [esp-ieee802154] |          Low-level IEEE802.15.4 driver for the ESP32-C6 and ESP32-H2           |
+|  [esp-println]   |                Provides `print!` and `println!` implementations                |
+|  [esp-storage]   | Implementation of [embedded-storage] traits to access unencrypted flash memory |
+|    [esp-wifi]    |                      `no_std` Wi-Fi/Bluetooth LE support                       |
 
 [esp-rs organization]: https://github.com/esp-rs
 [esp-alloc]: https://github.com/esp-rs/esp-alloc
 [esp-backtrace]: https://github.com/esp-rs/esp-backtrace
+[esp-ieee802154]: https://github.com/esp-rs/esp-ieee802154
 [esp-println]: https://github.com/esp-rs/esp-println
 [esp-storage]: https://github.com/esp-rs/esp-storage
 [embedded-storage]: https://github.com/rust-embedded-community/embedded-storage
@@ -84,16 +91,18 @@ The **M**inimum **S**upported **R**ust **V**ersions are:
 - `1.65.0` for Xtensa devices (**ESP32**, **ESP32-S2**, **ESP32-S3**)
 - `1.67.0` for all `async` examples (`embassy_hello_world`, `embassy_wait`, etc.)
 
-Note that targeting the Xtensa ISA currently requires the use of the [esp-rs/rust] compiler fork. The [esp-rs/rust-build] repository has pre-compiled release artifacts for most common platforms, and provides installation scripts to aid you in the process.
+Note that targeting the Xtensa ISA currently requires the use of the [esp-rs/rust] compiler fork. Our recommend method of installation is [espup].
 
 RISC-V is officially supported by the official Rust compiler.
 
 [esp-rs/rust]: https://github.com/esp-rs/rust
-[esp-rs/rust-build]: https://github.com/esp-rs/rust-build
+[espup]: https://github.com/esp-rs/espup
 
 ## Git Hooks
 
-We provide a simple `pre-commit` hook to verify the formatting of each package prior to committing changes. This can be enabled by placing it in the `.git/hooks/` directory:
+We provide a simple `pre-commit` hook to verify the formatting of each package prior to committing changes. We strongly encourage use of this git hook.
+
+The hook can be enabled by placing it in the `.git/hooks/` directory:
 
 ```bash
 $ cp pre-commit .git/hooks/pre-commit

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -12,7 +12,7 @@ repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 
 [dependencies]
-bitflags             = "2.2.1"
+bitflags             = "2.3.3"
 cfg-if               = "1.0.0"
 critical-section     = "1.1.1"
 embedded-can         = { version = "0.4.1", optional = true }
@@ -21,9 +21,9 @@ embedded-hal         = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1       = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
 embedded-hal-nb      = { version = "=1.0.0-alpha.2", optional = true }
 esp-synopsys-usb-otg = { version = "0.3.1", optional = true, features = ["fs", "esp32sx"] }
-fugit                = "0.3.6"
+fugit                = "0.3.7"
 log                  = "=0.4.18"
-lock_api             = { version = "0.4.9", optional = true }
+lock_api             = { version = "0.4.10", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.12"
 procmacros           = { version = "0.5.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
@@ -61,7 +61,7 @@ esp32s3 = { version = "0.19.0", features = ["critical-section"], optional = true
 
 [build-dependencies]
 basic-toml = "0.1.2"
-serde      = { version = "1.0.160", features = ["derive"] }
+serde      = { version = "1.0.164", features = ["derive"] }
 
 [features]
 esp32   = ["esp32/rt"  , "xtensa", "xtensa-lx/esp32",   "xtensa-lx-rt/esp32",   "lock_api", "procmacros/esp32"]

--- a/esp-hal-common/src/soc/esp32/psram.rs
+++ b/esp-hal-common/src/soc/esp32/psram.rs
@@ -1,7 +1,7 @@
 const PSRAM_VADDR: u32 = 0x3F800000;
 
 pub fn psram_vaddr_start() -> usize {
-    unsafe { PSRAM_VADDR_START as usize }
+    PSRAM_VADDR_START
 }
 
 cfg_if::cfg_if! {

--- a/esp-hal-common/src/soc/esp32s2/ulp_core.rs
+++ b/esp-hal-common/src/soc/esp32s2/ulp_core.rs
@@ -35,6 +35,7 @@ impl<'d> UlpCore<'d> {
     }
 }
 
+#[allow(unused)] // TODO: remove cfg when implementation is corrected
 fn ulp_stop() {
     let rtc_cntl = unsafe { &*pac::RTC_CNTL::PTR };
     rtc_cntl

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -21,8 +21,8 @@ proc-macro = true
 darling          = "0.20.1"
 proc-macro-crate = "1.3.1"
 proc-macro-error = "1.0.4"
-proc-macro2      = "1.0.53"
-quote            = "1.0.26"
+proc-macro2      = "1.0.63"
+quote            = "1.0.28"
 syn              = {version = "2.0.22", features = ["extra-traits", "full"]}
 
 [features]

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -11,7 +11,7 @@ features = ["esp32c3"]
 
 [dependencies]
 esp-hal-common   = { version = "0.9.0", path = "../esp-hal-common" }
-fugit            = "0.3.6"
+fugit            = "0.3.7"
 smart-leds-trait = "0.2.1"
 
 [features]

--- a/esp-hal.code-workspace
+++ b/esp-hal.code-workspace
@@ -10,6 +10,9 @@
       "path": "esp-hal-smartled"
     },
     {
+      "path": "esp-riscv-rt"
+    },
+    {
       "path": "esp32-hal"
     },
     {
@@ -33,7 +36,7 @@
   ],
   "settings": {
     "editor.formatOnSave": true,
-    "rust-analyzer.checkOnSave.allTargets": false,
+    "rust-analyzer.check.allTargets": false,
     "rust-analyzer.imports.granularity.enforce": true,
     "rust-analyzer.imports.granularity.group": "crate",
     "rust-analyzer.cargo.buildScripts.enable": true,

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -33,7 +33,7 @@ embedded-hal-nb    = { version = "=1.0.0-alpha.2",  optional = true }
 esp-hal-common     = { version = "0.9.0",  features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-aes               = "0.8.2"
+aes               = "0.8.3"
 critical-section  = "1.1.1"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
@@ -43,10 +43,10 @@ esp-backtrace     = { version = "0.7.0", features = ["esp32", "panic-handler", "
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32", "log"] }
 lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.6", default-features = false}
+sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.0.0"
+static_cell       = "1.1.0"
 heapless          = "0.7.16"
 
 [features]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -39,9 +39,9 @@ embedded-graphics = "0.8.0"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.5.0", features = ["esp32c2"] }
 lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.6", default-features = false}
+sha2              = { version = "0.10.7", default-features = false}
 ssd1306           = "0.8.0"
-static_cell       = "1.0.0"
+static_cell       = "1.1.0"
 heapless          = "0.7.16"
 
 [features]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -35,7 +35,7 @@ embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.9.0",  features = ["esp32c3"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-aes               = "0.8.2"
+aes               = "0.8.3"
 critical-section  = "1.1.1"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
@@ -44,10 +44,10 @@ esp-backtrace     = { version = "0.7.0", features = ["esp32c3", "panic-handler",
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32c3"] }
 lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.6", default-features = false}
+sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.0.0"
+static_cell       = "1.1.0"
 heapless          = "0.7.16"
 
 [features]

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -36,7 +36,7 @@ embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.9.0",  features = ["esp32c6"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-aes               = "0.8.2"
+aes               = "0.8.3"
 critical-section  = "1.1.1"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
@@ -45,10 +45,10 @@ esp-backtrace     = { version = "0.7.0", features = ["esp32c6", "panic-handler",
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32c6"] }
 lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.6", default-features = false}
+sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.0.0"
+static_cell       = "1.1.0"
 heapless          = "0.7.16"
 
 [features]

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -36,7 +36,7 @@ embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.9.0",  features = ["esp32h2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-aes               = "0.8.2"
+aes               = "0.8.3"
 critical-section  = "1.1.1"
 crypto-bigint     = { version = "0.5.2", default-features = false }
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
@@ -45,10 +45,10 @@ esp-backtrace     = { version = "0.7.0", features = ["esp32h2", "panic-handler",
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32h2"] }
 lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.6", default-features = false}
+sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.0.0"
+static_cell       = "1.1.0"
 heapless          = "0.7.16"
 
 [features]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -34,7 +34,7 @@ esp-hal-common               = { version = "0.9.0",  features = ["esp32s2"], pat
 xtensa-atomic-emulation-trap = { version = "0.4.0" }
 
 [dev-dependencies]
-aes               = "0.8.2"
+aes               = "0.8.3"
 critical-section  = "1.1.1"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
@@ -44,11 +44,11 @@ esp-backtrace     = { version = "0.7.0", features = ["esp32s2", "panic-handler",
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32s2"] }
 lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.6", default-features = false}
+sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.0.0"
-usb-device        = { version = "0.2.9" }
+static_cell       = "1.1.0"
+usb-device        = "0.2.9"
 usbd-serial       = "0.1.1"
 heapless          = "0.7.16"
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -36,7 +36,7 @@ esp-hal-common     = { version = "0.9.0",  features = ["esp32s3"], path = "../es
 r0                 = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
-aes               = "0.8.2"
+aes               = "0.8.3"
 critical-section  = "1.1.1"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
@@ -46,10 +46,10 @@ esp-backtrace     = { version = "0.7.0", features = ["esp32s3", "panic-handler",
 esp-hal-smartled  = { version = "0.2.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32s3", "log"] }
 lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.6", default-features = false}
+sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.0.0"
+static_cell       = "1.1.0"
 usb-device        = "0.2.9"
 usbd-serial       = "0.1.1"
 heapless          = "0.7.16"


### PR DESCRIPTION
Mostly just pre-release housekeeping:

- Include `esp-riscv-rt` in the VS Code workspace
- Update all dependencies/dev-dependencies
- Fix build warnings
- Update top-level README