### PR TITLE
Add basic LP_IO support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add initial LP-IO support for ESP32-C6 (#639)
+
 ### Changed
 
 - Update `embedded-hal-*` alpha packages to their latest versions (#640)

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1643,7 +1643,7 @@ pub mod lp_gpio {
         (
             $($gpionum:literal)+
         ) => {
-            paste!{
+            paste::paste!{
                 $(
                     impl<MODE> crate::gpio::lp_gpio::IntoLowPowerPin<$gpionum> for GpioPin<MODE, $gpionum> {
                         fn into_low_power(self) -> crate::gpio::lp_gpio::LowPowerPin<$gpionum> {

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1563,6 +1563,106 @@ macro_rules! analog {
     }
 }
 
+#[cfg(lp_io)]
+pub mod lp_gpio {
+    pub struct LowPowerPin<const PIN: u8> {
+        pub(crate) private: PhantomData<()>,
+    }
+
+    impl<const PIN: u8> LowPowerPin<PIN> {
+        pub fn output_enable(&mut self, enable: bool) {
+            let lp_io = unsafe { &*crate::peripherals::LP_IO::PTR };
+            if enable {
+                lp_io
+                    .out_enable_w1ts
+                    .write(|w| w.lp_gpio_enable_w1ts().variant(1 << PIN));
+            } else {
+                lp_io
+                    .out_enable_w1tc
+                    .write(|w| w.lp_gpio_enable_w1tc().variant(1 << PIN));
+            }
+        }
+
+        pub fn input_enable(&mut self, enable: bool) {
+            get_pin_reg(PIN).modify(|_, w| w.lp_gpio0_fun_ie().bit(enable));
+        }
+
+        pub fn pullup_enable(&mut self, enable: bool) {
+            get_pin_reg(PIN).modify(|_, w| w.lp_gpio0_fun_wpu().bit(enable));
+        }
+
+        pub fn pulldown_enable(&mut self, enable: bool) {
+            get_pin_reg(PIN).modify(|_, w| w.lp_gpio0_fun_wpd().bit(enable));
+        }
+
+        pub fn set_level(&mut self, level: bool) {
+            let lp_io = unsafe { &*crate::peripherals::LP_IO::PTR };
+            if level {
+                lp_io
+                    .out_data_w1ts
+                    .write(|w| w.lp_gpio_out_data_w1ts().variant(1 << PIN));
+            } else {
+                lp_io
+                    .out_data_w1tc
+                    .write(|w| w.lp_gpio_out_data_w1tc().variant(1 << PIN));
+            }
+        }
+
+        pub fn get_level(&self) -> bool {
+            let lp_io = unsafe { &*crate::peripherals::LP_IO::PTR };
+            (lp_io.in_.read().lp_gpio_in_data_next().bits() & 1 << PIN) != 0
+        }
+    }
+
+    pub(crate) fn init_low_power_pin(pin: u8) {
+        let lp_aon = unsafe { &*crate::peripherals::LP_AON::PTR };
+
+        lp_aon
+            .gpio_mux
+            .modify(|r, w| w.sel().variant(r.sel().bits() | 1 << pin));
+
+        get_pin_reg(pin).modify(|_, w| w.lp_gpio0_mcu_sel().variant(0));
+    }
+
+    #[inline(always)]
+    fn get_pin_reg(pin: u8) -> &'static crate::peripherals::lp_io::GPIO0 {
+        let lp_io = unsafe { &*crate::peripherals::LP_IO::PTR };
+
+        // ideally we should change the SVD and make the GPIOx registers into an
+        // array
+        unsafe { core::mem::transmute((lp_io.gpio0.as_ptr()).add(pin as usize)) }
+    }
+
+    pub trait IntoLowPowerPin<const PIN: u8> {
+        fn into_low_power(self) -> LowPowerPin<{ PIN }>;
+    }
+
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! lp_gpio {
+        (
+            $($gpionum:literal)+
+        ) => {
+            paste!{
+                $(
+                    impl<MODE> crate::gpio::lp_gpio::IntoLowPowerPin<$gpionum> for GpioPin<MODE, $gpionum> {
+                        fn into_low_power(self) -> crate::gpio::lp_gpio::LowPowerPin<$gpionum> {
+                            crate::gpio::lp_gpio::init_low_power_pin($gpionum);
+                            crate::gpio::lp_gpio::LowPowerPin {
+                                private: core::marker::PhantomData::default(),
+                            }
+                        }
+                    }
+                )+
+            }
+        }
+    }
+
+    use core::marker::PhantomData;
+
+    pub(crate) use lp_gpio;
+}
+
 #[cfg(feature = "async")]
 mod asynch {
     use core::task::{Context, Poll};

--- a/esp-hal-common/src/soc/esp32c6/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c6/gpio.rs
@@ -277,6 +277,17 @@ crate::gpio::analog! {
     7
 }
 
+crate::gpio::lp_gpio::lp_gpio! {
+    0
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+}
+
 impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_interrupt_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_int.read().bits()

--- a/esp32c6-hal/examples/lp_core_basic.rs
+++ b/esp32c6-hal/examples/lp_core_basic.rs
@@ -1,38 +1,108 @@
 //! This shows a very basic example of running code on the LP core.
 //!
-//! Code on LP core just increments a counter. The current value is printed by
-//! the HP core.
+//! Code on LP core increments a counter and continuously toggles GPIO1. The
+//! current value is printed by the HP core.
 
 #![no_std]
 #![no_main]
 
 use esp32c6_hal::{
     clock::ClockControl,
+    gpio::lp_gpio::IntoLowPowerPin,
+    lp_core,
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
     Rtc,
+    IO,
 };
 use esp_backtrace as _;
-use esp_hal_common::lp_core;
-use esp_println::println;
+use esp_println::{print, println};
 
-// 50000000 <_start>:
-// 50000000:       00000517                auipc   a0,0x0
-// 50000004:       01050513                addi    a0,a0,16 # 50000010 <data>
-// 50000008:       4581                    li      a1,0
-//
-// 5000000a <_loop>:
-// 5000000a:       0585                    addi    a1,a1,1
-// 5000000c:       c10c                    sw      a1,0(a0)
-// 5000000e:       bff5                    j       5000000a <_loop>
-//
-// 50000010 <data>:
-// 50000010:       0000 0000
+// 50000000 <_vector_table>:
+// 50000000:       00000013                nop
+// 50000004:       00000013                nop
+// 50000008:       00000013                nop
+// 5000000c:       00000013                nop
+// 50000010:       00000013                nop
+// 50000014:       00000013                nop
+// 50000018:       00000013                nop
+// 5000001c:       00000013                nop
+// 50000020:       00000013                nop
+// 50000024:       00000013                nop
+// 50000028:       00000013                nop
+// 5000002c:       00000013                nop
+// 50000030:       00000013                nop
+// 50000034:       00000013                nop
+// 50000038:       00000013                nop
+// 5000003c:       00000013                nop
+// 50000040:       00000013                nop
+// 50000044:       00000013                nop
+// 50000048:       00000013                nop
+// 5000004c:       00000013                nop
+// 50000050:       00000013                nop
+// 50000054:       00000013                nop
+// 50000058:       00000013                nop
+// 5000005c:       00000013                nop
+// 50000060:       00000013                nop
+// 50000064:       00000013                nop
+// 50000068:       00000013                nop
+// 5000006c:       00000013                nop
+// 50000070:       00000013                nop
+// 50000074:       00000013                nop
+// 50000078:       00000013                nop
+// 5000007c:       00000013                nop
+
+// 50000080 <_start>:
+// 50000080:       00000517                auipc   a0,0x0
+// 50000084:       04050513                addi    a0,a0,64 # 500000c0 <data>
+// 50000088:       4585                    li      a1,1
+// 5000008a:       00b50023                sb      a1,0(a0)
+// 5000008e:       600b26b7                lui     a3,0x600b2
+// 50000092:       06a1                    addi    a3,a3,8
+// 50000094:       600b2637                lui     a2,0x600b2
+// 50000098:       0611                    addi    a2,a2,4
+// 5000009a:       4709                    li      a4,2
+
+// 5000009c <_loop>:
+// 5000009c:       c218                    sw      a4,0(a2)
+// 5000009e:       000f47b7                lui     a5,0xf4
+// 500000a2:       24078793                addi    a5,a5,576 # f4240
+// <_vector_table-0x4ff0bdc0>
+
+// 500000a6 <_wait1>:
+// 500000a6:       17fd                    addi    a5,a5,-1
+// 500000a8:       fffd                    bnez    a5,500000a6 <_wait1>
+// 500000aa:       0585                    addi    a1,a1,1
+// 500000ac:       00b50023                sb      a1,0(a0)
+// 500000b0:       c298                    sw      a4,0(a3)
+// 500000b2:       000f47b7                lui     a5,0xf4
+// 500000b6:       24078793                addi    a5,a5,576 # f4240
+// <_vector_table-0x4ff0bdc0>
+
+// 500000ba <_wait2>:
+// 500000ba:       17fd                    addi    a5,a5,-1
+// 500000bc:       fffd                    bnez    a5,500000ba <_wait2>
+// 500000be:       bff9                    j       5000009c <_loop>
+
+// 500000c0 <data>:
+//         ...
 
 const CODE: &[u8] = &[
-    0x17, 0x05, 0x00, 0x00, 0x13, 0x05, 0x05, 0x01, 0x81, 0x45, 0x85, 0x05, 0x0c, 0xc1, 0xf5, 0xbf,
-    0x00, 0x00, 0x00, 0x00,
+    0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00,
+    0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00,
+    0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00,
+    0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00,
+    0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00,
+    0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00,
+    0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00,
+    0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00,
+    0x17, 0x05, 0x00, 0x00, 0x13, 0x05, 0x05, 0x04, 0x85, 0x45, 0x23, 0x00, 0xb5, 0x00, 0xb7, 0x26,
+    0x0b, 0x60, 0xa1, 0x06, 0x37, 0x26, 0x0b, 0x60, 0x11, 0x06, 0x09, 0x47, 0x18, 0xc2, 0xb7, 0x47,
+    0x0f, 0x00, 0x93, 0x87, 0x07, 0x24, 0xfd, 0x17, 0xfd, 0xff, 0x85, 0x05, 0x23, 0x00, 0xb5, 0x00,
+    0x98, 0xc2, 0xb7, 0x47, 0x0f, 0x00, 0x93, 0x87, 0x07, 0x24, 0xfd, 0x17, 0xfd, 0xff, 0xf9, 0xbf,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00,
 ];
 
 #[entry]
@@ -61,6 +131,12 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
 
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    // configure GPIO 1 as LP output pin
+    let mut lp_pin = io.pins.gpio1.into_low_power();
+    lp_pin.output_enable(true);
+
     let mut lp_core = esp32c6_hal::lp_core::LpCore::new(peripherals.LP_CORE);
     lp_core.stop();
     println!("lp core stopped");
@@ -76,8 +152,10 @@ fn main() -> ! {
     lp_core.run(lp_core::LpCoreWakeupSource::HpCpu);
     println!("lpcore run");
 
-    let data = (0x5000_0010 - 0) as *mut u32;
+    let data = (0x500000c0) as *mut u32;
     loop {
-        println!("Current {}", unsafe { data.read_volatile() });
+        print!("Current {:x}           \u{000d}", unsafe {
+            data.read_volatile()
+        });
     }
 }


### PR DESCRIPTION
This is the next baby-step towards ESP32-C6 LP core support.

It adds basic LP_IO support and updates the `lp_core_basic` example to blink an LED on GPIO 1.

Probably the next step could be to start implementing the LP-Core HAL