### PR TITLE
Update `embedded-hal-*` alpha packages to their latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Please note that only changes to the `esp-hal-common` package are tracked in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- Update `embedded-hal-*` alpha packages to their latest versions (#640)
+
+### Fixed
+
+### Removed
+
 ## [0.10.0] - 2023-06-04
 
 ### Added
@@ -122,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2022-08-05
 
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/v0.10.0...HEAD
 [0.10.0]: https://github.com/esp-rs/esp-hal/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/esp-rs/esp-hal/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/esp-rs/esp-hal/compare/v0.7.1...v0.8.0

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -123,6 +123,3 @@ debug = [
     "esp32s2?/impl-register-debug",
     "esp32s3?/impl-register-debug",
 ]
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -18,8 +18,8 @@ critical-section     = "1.1.1"
 embedded-can         = { version = "0.4.1", optional = true }
 embedded-dma         = "0.2.0"
 embedded-hal         = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1       = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-nb      = { version = "=1.0.0-alpha.2", optional = true }
+embedded-hal-1       = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
+embedded-hal-nb      = { version = "=1.0.0-alpha.3", optional = true }
 esp-synopsys-usb-otg = { version = "0.3.1", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
 log                  = "=0.4.18"
@@ -32,7 +32,7 @@ void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
 
 # async
-embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
+embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
 embassy-sync       = { version = "0.2.0", optional = true }
 embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }
@@ -123,3 +123,6 @@ debug = [
     "esp32s2?/impl-register-debug",
     "esp32s3?/impl-register-debug",
 ]
+
+[patch.crates-io]
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -24,11 +24,8 @@ pub use embedded_hal_async::{
     delay::DelayUs as _embedded_hal_async_delay_DelayUs,
     digital::Wait as _embedded_hal_async_digital_Wait,
     i2c::I2c as _embedded_hal_async_i2c_I2c,
-    spi::SpiBus as _embedded_hal_spi_SpiBus,
-    spi::SpiBusFlush as _embedded_hal_spi_SpiBusFlush,
-    spi::SpiBusRead as _embedded_hal_spi_SpiBusRead,
-    spi::SpiBusWrite as _embedded_hal_spi_SpiBusWrite,
-    spi::SpiDevice as _embedded_hal_spi_SpiDevice,
+    spi::SpiBus as _embedded_hal_async_spi_SpiBus,
+    spi::SpiDevice as _embedded_hal_async_spi_SpiDevice,
 };
 pub use fugit::{
     ExtU32 as _fugit_ExtU32,
@@ -100,20 +97,15 @@ pub mod eh1 {
         Frame as _embedded_can_Frame,
     };
     pub use embedded_hal_1::{
-        delay::DelayUs as _embedded_hal_delay_blocking_DelayUs,
+        delay::DelayUs as _embedded_hal_1_delay_DelayUs,
         digital::{
-            InputPin as _embedded_hal_digital_blocking_InputPin,
-            OutputPin as _embedded_hal_digital_blocking_OutputPin,
-            StatefulOutputPin as _embedded_hal_digital_blocking_StatefulOutputPin,
-            ToggleableOutputPin as _embedded_hal_digital_blocking_ToggleableOutputPin,
+            InputPin as _embedded_hal_1_digital_InputPin,
+            OutputPin as _embedded_hal_1_digital_OutputPin,
+            StatefulOutputPin as _embedded_hal_1_digital_StatefulOutputPin,
+            ToggleableOutputPin as _embedded_hal_1_digital_ToggleableOutputPin,
         },
-        i2c::I2c as _embedded_hal_i2c_blocking_I2c,
-        spi::{
-            SpiBus as _embedded_hal_spi_blocking_SpiBus,
-            SpiBusFlush as _embedded_hal_spi_blocking_SpiBusFlush,
-            SpiBusRead as _embedded_hal_spi_blocking_SpiBusRead,
-            SpiBusWrite as _embedded_hal_spi_blocking_SpiBusWrite,
-        },
+        i2c::I2c as _embedded_hal_1_i2c_I2c,
+        spi::{SpiBus as _embedded_hal_1_spi_SpiBus, SpiDevice as _embedded_hal_1_spi_SpiDevice},
     };
     pub use embedded_hal_nb::{
         serial::{Read as _embedded_hal_nb_serial_Read, Write as _embedded_hal_nb_serial_Write},

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -1252,46 +1252,7 @@ pub mod dma {
     mod asynch {
         use super::*;
 
-        impl<'d, T, C, M> embedded_hal_async::spi::SpiBusWrite for SpiDma<'d, T, C, M>
-        where
-            T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-            C: ChannelTypes,
-            C::P: SpiPeripheral,
-            M: IsFullDuplex,
-        {
-            async fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-                for chunk in words.chunks(MAX_DMA_SIZE) {
-                    self.spi.start_write_bytes_dma(
-                        chunk.as_ptr(),
-                        chunk.len(),
-                        &mut self.channel.tx,
-                    )?;
-
-                    crate::dma::asynch::DmaTxFuture::new(&mut self.channel.tx).await;
-
-                    // FIXME: in the future we should use the peripheral DMA status registers to
-                    // await on both the dma transfer _and_ the peripherals status
-                    self.spi.flush()?;
-                }
-
-                Ok(())
-            }
-        }
-
-        impl<'d, T, C, M> embedded_hal_async::spi::SpiBusFlush for SpiDma<'d, T, C, M>
-        where
-            T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-            C: ChannelTypes,
-            C::P: SpiPeripheral,
-            M: IsFullDuplex,
-        {
-            async fn flush(&mut self) -> Result<(), Self::Error> {
-                // TODO use async flush in the future
-                self.spi.flush()
-            }
-        }
-
-        impl<'d, T, C, M> embedded_hal_async::spi::SpiBusRead for SpiDma<'d, T, C, M>
+        impl<'d, T, C, M> embedded_hal_async::spi::SpiBus for SpiDma<'d, T, C, M>
         where
             T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
             C: ChannelTypes,
@@ -1309,20 +1270,26 @@ pub mod dma {
 
                 Ok(())
             }
-        }
 
-        impl<'d, T, C, M> embedded_hal_async::spi::SpiBus for SpiDma<'d, T, C, M>
-        where
-            T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-            C: ChannelTypes,
-            C::P: SpiPeripheral,
-            M: IsFullDuplex,
-        {
-            async fn transfer<'a>(
-                &'a mut self,
-                read: &'a mut [u8],
-                write: &'a [u8],
-            ) -> Result<(), Self::Error> {
+            async fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+                for chunk in words.chunks(MAX_DMA_SIZE) {
+                    self.spi.start_write_bytes_dma(
+                        chunk.as_ptr(),
+                        chunk.len(),
+                        &mut self.channel.tx,
+                    )?;
+
+                    crate::dma::asynch::DmaTxFuture::new(&mut self.channel.tx).await;
+
+                    // FIXME: in the future we should use the peripheral DMA status registers to
+                    // await on both the dma transfer _and_ the peripherals status
+                    self.spi.flush()?;
+                }
+
+                Ok(())
+            }
+
+            async fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
                 let mut idx = 0;
                 loop {
                     let write_idx = isize::min(idx, write.len() as isize);
@@ -1359,10 +1326,7 @@ pub mod dma {
                 Ok(())
             }
 
-            async fn transfer_in_place<'a>(
-                &'a mut self,
-                words: &'a mut [u8],
-            ) -> Result<(), Self::Error> {
+            async fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
                 for chunk in words.chunks_mut(MAX_DMA_SIZE) {
                     self.spi.start_transfer_dma(
                         chunk.as_ptr(),
@@ -1386,12 +1350,17 @@ pub mod dma {
 
                 Ok(())
             }
+
+            async fn flush(&mut self) -> Result<(), Self::Error> {
+                // TODO use async flush in the future
+                self.spi.flush()
+            }
         }
     }
 
     #[cfg(feature = "eh1")]
     mod ehal1 {
-        use embedded_hal_1::spi::{SpiBus, SpiBusFlush, SpiBusRead, SpiBusWrite};
+        use embedded_hal_1::spi::SpiBus;
 
         use super::{super::InstanceDma, SpiDma, SpiPeripheral};
         use crate::{dma::ChannelTypes, spi::IsFullDuplex};
@@ -1406,21 +1375,7 @@ pub mod dma {
             type Error = super::super::Error;
         }
 
-        impl<'d, T, C, M> SpiBusWrite for SpiDma<'d, T, C, M>
-        where
-            T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-            C: ChannelTypes,
-            C::P: SpiPeripheral,
-            M: IsFullDuplex,
-        {
-            /// See also: [`write_bytes`].
-            fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-                self.spi.write_bytes_dma(words, &mut self.channel.tx)?;
-                self.flush()
-            }
-        }
-
-        impl<'d, T, C, M> SpiBusRead for SpiDma<'d, T, C, M>
+        impl<'d, T, C, M> SpiBus for SpiDma<'d, T, C, M>
         where
             T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
             C: ChannelTypes,
@@ -1432,23 +1387,12 @@ pub mod dma {
                     .transfer_dma(&[], words, &mut self.channel.tx, &mut self.channel.rx)?;
                 self.flush()
             }
-        }
 
-        impl<'d, T, C, M> SpiBus for SpiDma<'d, T, C, M>
-        where
-            T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-            C: ChannelTypes,
-            C::P: SpiPeripheral,
-            M: IsFullDuplex,
-        {
-            /// Write out data from `write`, read response into `read`.
-            ///
-            /// `read` and `write` are allowed to have different lengths. If
-            /// `write` is longer, all other bytes received are
-            /// discarded. If `read` is longer, [`EMPTY_WRITE_PAD`]
-            /// is written out as necessary until enough bytes have
-            /// been read. Reading and writing happens
-            /// simultaneously.
+            fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+                self.spi.write_bytes_dma(words, &mut self.channel.tx)?;
+                self.flush()
+            }
+
             fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
                 self.spi
                     .transfer_dma(write, read, &mut self.channel.tx, &mut self.channel.rx)?;
@@ -1459,8 +1403,8 @@ pub mod dma {
             ///
             /// Writes data from `words` out on the bus and stores the reply
             /// into `words`. A convenient wrapper around
-            /// [`write`](SpiBusWrite::write), [`flush`](SpiBusFlush::flush) and
-            /// [`read`](SpiBusRead::read).
+            /// [`write`](SpiBus::write), [`flush`](SpiBus::flush) and
+            /// [`read`](SpiBus::read).
             fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
                 self.spi.transfer_in_place_dma(
                     words,
@@ -1469,15 +1413,7 @@ pub mod dma {
                 )?;
                 self.flush()
             }
-        }
 
-        impl<'d, T, C, M> SpiBusFlush for SpiDma<'d, T, C, M>
-        where
-            T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-            C: ChannelTypes,
-            C::P: SpiPeripheral,
-            M: IsFullDuplex,
-        {
             fn flush(&mut self) -> Result<(), Self::Error> {
                 self.spi.flush()
             }
@@ -1492,18 +1428,7 @@ pub use ehal1::*;
 mod ehal1 {
     use core::cell::RefCell;
 
-    use embedded_hal_1::spi::{
-        self,
-        ErrorType,
-        Operation,
-        SpiBus,
-        SpiBusFlush,
-        SpiBusRead,
-        SpiBusWrite,
-        SpiDevice,
-        SpiDeviceRead,
-        SpiDeviceWrite,
-    };
+    use embedded_hal_1::spi::{self, ErrorType, Operation, SpiBus, SpiDevice};
     use embedded_hal_nb::spi::FullDuplex;
 
     use super::*;
@@ -1527,46 +1452,25 @@ mod ehal1 {
         }
     }
 
-    impl<T, M> SpiBusWrite for Spi<'_, T, M>
-    where
-        T: Instance,
-        M: IsFullDuplex,
-    {
-        /// See also: [`write_bytes`].
-        fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-            self.spi.write_bytes(words)
-        }
-    }
-
-    impl<T, M> SpiBusRead for Spi<'_, T, M>
-    where
-        T: Instance,
-        M: IsFullDuplex,
-    {
-        /// See also: [`read_bytes`].
-        fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
-            self.spi.read_bytes(words)
-        }
-    }
-
     impl<T, M> SpiBus for Spi<'_, T, M>
     where
         T: Instance,
         M: IsFullDuplex,
     {
-        /// Write out data from `write`, read response into `read`.
-        ///
-        /// `read` and `write` are allowed to have different lengths. If `write`
-        /// is longer, all other bytes received are discarded. If `read`
-        /// is longer, [`EMPTY_WRITE_PAD`] is written out as necessary
-        /// until enough bytes have been read. Reading and writing happens
-        /// simultaneously.
+        fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+            self.spi.read_bytes(words)
+        }
+
+        fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+            self.spi.write_bytes(words)
+        }
+
         fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
             // Optimizations
             if read.len() == 0 {
-                SpiBusWrite::write(self, write)?;
+                SpiBus::write(self, write)?;
             } else if write.len() == 0 {
-                SpiBusRead::read(self, read)?;
+                SpiBus::read(self, read)?;
             }
 
             let mut write_from = 0;
@@ -1588,12 +1492,12 @@ mod ehal1 {
                     // Read more than we write, must pad writing part with zeros
                     let mut empty = [EMPTY_WRITE_PAD; FIFO_SIZE];
                     empty[0..write_inc].copy_from_slice(&write[write_from..write_to]);
-                    SpiBusWrite::write(self, &empty)?;
+                    SpiBus::write(self, &empty)?;
                 } else {
-                    SpiBusWrite::write(self, &write[write_from..write_to])?;
+                    SpiBus::write(self, &write[write_from..write_to])?;
                 }
 
-                SpiBusFlush::flush(self)?;
+                SpiBus::flush(self)?;
 
                 if read_inc > 0 {
                     self.spi
@@ -1606,28 +1510,16 @@ mod ehal1 {
             Ok(())
         }
 
-        /// Transfer data in place.
-        ///
-        /// Writes data from `words` out on the bus and stores the reply into
-        /// `words`. A convenient wrapper around
-        /// [`write`](SpiBusWrite::write), [`flush`](SpiBusFlush::flush) and
-        /// [`read`](SpiBusRead::read).
         fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
             // Since we have the traits so neatly implemented above, use them!
             for chunk in words.chunks_mut(FIFO_SIZE) {
-                SpiBusWrite::write(self, chunk)?;
-                SpiBusFlush::flush(self)?;
+                SpiBus::write(self, chunk)?;
+                SpiBus::flush(self)?;
                 self.spi.read_bytes_from_fifo(chunk)?;
             }
             Ok(())
         }
-    }
 
-    impl<T, M> SpiBusFlush for Spi<'_, T, M>
-    where
-        T: Instance,
-        M: IsFullDuplex,
-    {
         fn flush(&mut self) -> Result<(), Self::Error> {
             self.spi.flush()
         }
@@ -1698,60 +1590,6 @@ mod ehal1 {
         type Error = spi::ErrorKind;
     }
 
-    impl<'a, 'd, I, CS, M> SpiDeviceRead<u8> for SpiBusDevice<'a, 'd, I, CS, M>
-    where
-        I: Instance,
-        CS: OutputPin,
-        M: IsFullDuplex,
-    {
-        fn read_transaction(&mut self, operations: &mut [&mut [u8]]) -> Result<(), Self::Error> {
-            critical_section::with(|cs| {
-                let mut bus = self.bus.lock.borrow_ref_mut(cs);
-                self.cs.connect_peripheral_to_output(bus.spi.cs_signal());
-
-                let op_res = operations
-                    .iter_mut()
-                    .try_for_each(|buf| SpiBusRead::read(&mut (*bus), buf));
-
-                // On failure, it's important to still flush and de-assert CS.
-                let flush_res = bus.flush();
-                self.cs.disconnect_peripheral_from_output();
-
-                op_res.map_err(|_| spi::ErrorKind::Other)?;
-                flush_res.map_err(|_| spi::ErrorKind::Other)?;
-
-                Ok(())
-            })
-        }
-    }
-
-    impl<'a, 'd, I, CS, M> SpiDeviceWrite<u8> for SpiBusDevice<'a, 'd, I, CS, M>
-    where
-        I: Instance,
-        CS: OutputPin,
-        M: IsFullDuplex,
-    {
-        fn write_transaction(&mut self, operations: &[&[u8]]) -> Result<(), Self::Error> {
-            critical_section::with(|cs| {
-                let mut bus = self.bus.lock.borrow_ref_mut(cs);
-                self.cs.connect_peripheral_to_output(bus.spi.cs_signal());
-
-                let op_res = operations
-                    .iter()
-                    .try_for_each(|buf| SpiBusWrite::write(&mut (*bus), buf));
-
-                // On failure, it's important to still flush and de-assert CS.
-                let flush_res = bus.flush();
-                self.cs.disconnect_peripheral_from_output();
-
-                op_res.map_err(|_| spi::ErrorKind::Other)?;
-                flush_res.map_err(|_| spi::ErrorKind::Other)?;
-
-                Ok(())
-            })
-        }
-    }
-
     impl<'a, 'd, I, CS, M> SpiDevice<u8> for SpiBusDevice<'a, 'd, I, CS, M>
     where
         I: Instance,
@@ -1764,10 +1602,11 @@ mod ehal1 {
                 self.cs.connect_peripheral_to_output(bus.spi.cs_signal());
 
                 let op_res = operations.iter_mut().try_for_each(|op| match op {
-                    Operation::Read(buf) => SpiBusRead::read(&mut (*bus), buf),
-                    Operation::Write(buf) => SpiBusWrite::write(&mut (*bus), buf),
+                    Operation::Read(buf) => SpiBus::read(&mut (*bus), buf),
+                    Operation::Write(buf) => SpiBus::write(&mut (*bus), buf),
                     Operation::Transfer(read, write) => bus.transfer(read, write),
                     Operation::TransferInPlace(buf) => bus.transfer_in_place(buf),
+                    Operation::DelayUs(_delay) => unimplemented!(),
                 });
 
                 // On failure, it's important to still flush and de-assert CS.

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -27,9 +27,9 @@ categories = [
 [dependencies]
 embassy-time       = { version = "0.1.1",  features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.1",   optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2",  optional = true }
+embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
+embedded-hal-async = { version = "=0.2.0-alpha.2",   optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.3",  optional = true }
 esp-hal-common     = { version = "0.10.0",  features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]
@@ -99,3 +99,6 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -27,9 +27,9 @@ categories = [
 [dependencies]
 embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.1",   optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2",  optional = true }
+embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
+embedded-hal-async = { version = "=0.2.0-alpha.2",   optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.3",  optional = true }
 esp-hal-common     = { version = "0.10.0", features = ["esp32c2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
@@ -91,3 +91,6 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -28,9 +28,9 @@ categories = [
 cfg-if             = "1.0.0"
 embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
+embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
+embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.10.0",  features = ["esp32c3"], path = "../esp-hal-common" }
 
@@ -103,3 +103,6 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -29,9 +29,9 @@ categories = [
 cfg-if             = "1.0.0"
 embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
+embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
+embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.10.0",  features = ["esp32c6"], path = "../esp-hal-common" }
 
@@ -96,3 +96,6 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -29,9 +29,9 @@ categories = [
 cfg-if             = "1.0.0"
 embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
+embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
+embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.10.0",  features = ["esp32h2"], path = "../esp-hal-common" }
 
@@ -96,3 +96,6 @@ required-features = ["async", "embassy"]
 [[example]]
 name              = "interrupt_preemption"
 required-features = ["interrupt-preemption"]
+
+[patch.crates-io]
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -27,9 +27,9 @@ categories = [
 [dependencies]
 embassy-time                 = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal                 = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1               = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async           = { version = "0.2.0-alpha.1", optional = true }
-embedded-hal-nb              = { version = "=1.0.0-alpha.2", optional = true }
+embedded-hal-1               = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
+embedded-hal-async           = { version = "=0.2.0-alpha.2", optional = true }
+embedded-hal-nb              = { version = "=1.0.0-alpha.3", optional = true }
 esp-hal-common               = { version = "0.10.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-atomic-emulation-trap = { version = "0.4.0" }
 
@@ -103,3 +103,6 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -28,9 +28,9 @@ categories = [
 bare-metal         = "1.0.0"
 embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.10", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.2", optional = true }
+embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
+embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
+embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
 esp-hal-common     = { version = "0.10.0",  features = ["esp32s3"], path = "../esp-hal-common" }
 r0                 = { version = "1.0.0",  optional = true }
@@ -110,3 +110,6 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }


### PR DESCRIPTION
- Update `embedded-hal-1` to the latest alpha version
- Update `embedded-hal-async` to the latest alpha version
- Update `embedded-hal-nb` to the latest alpha version
- Make required changes to SPI trait implementations
- Make required changes to the `prelude` module

I had to patch `embassy-time` in order to do this, so once there's a new release we can remove the patches.

I have also not yet implemented `Operation::DelayUs`, wasn't sure how best to accomplish this (I didn't try very hard) so I just left it out.