### PR TITLE
Some minor cleanup

### DIFF
--- a/esp-hal-common/src/analog/adc/cal_curve.rs
+++ b/esp-hal-common/src/analog/adc/cal_curve.rs
@@ -23,7 +23,7 @@ pub struct CurveCoeffs {
 
 type CurvesCoeffs = &'static [CurveCoeffs];
 
-/// Marker trait for ADC which support curve futting
+/// Marker trait for ADC which support curve fitting
 ///
 /// See also [`AdcCalCurve`].
 pub trait AdcHasCurveCal {

--- a/esp-hal-common/src/analog/adc/riscv.rs
+++ b/esp-hal-common/src/analog/adc/riscv.rs
@@ -145,7 +145,7 @@ impl Attenuation {
     /// Vref = 10 ^ (Att / 20) * Vref0
     /// where Vref0 = 1.1 V, Att - attenuation in dB
     ///
-    /// To colvert raw value to millivolts use folmula:
+    /// To convert raw value to millivolts use formula:
     /// V = D * Vref / 2 ^ R
     /// where D - raw ADC value, R - resolution in bits
     pub const fn ref_mv(&self) -> u16 {

--- a/esp-hal-common/src/clock/clocks_ll/esp32c2.rs
+++ b/esp-hal-common/src/clock/clocks_ll/esp32c2.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     clock::{ApbClock, Clock, CpuClock, PllClock, XtalClock},
     regi2c_write,

--- a/esp-hal-common/src/clock/clocks_ll/esp32c3.rs
+++ b/esp-hal-common/src/clock/clocks_ll/esp32c3.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     clock::{ApbClock, Clock, CpuClock, PllClock, XtalClock},
     regi2c_write,

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1273,7 +1273,7 @@ macro_rules! gpio {
             fn split(self) -> Self::Parts;
         }
 
-        paste!{
+        paste::paste! {
             impl GpioExt for GPIO {
                 type Parts = Pins;
                 fn split(self) -> Self::Parts {
@@ -1432,7 +1432,7 @@ macro_rules! analog {
                 $(
                     $pin_num => {
                         // disable input
-                        paste! {
+                        paste::paste! {
                             rtcio.$pin_reg.modify(|_,w| w.$fun_ie().bit(false));
 
                             // disable output
@@ -1489,7 +1489,7 @@ macro_rules! analog {
                 $(
                     $pin_num => {
 
-                        paste!{
+                        paste::paste! {
                             use $crate::gpio::[< esp32s2_get_rtc_pad_ $pin_reg>];
                             let rtc_pad = [< esp32s2_get_rtc_pad_ $pin_reg>]();
                         }

--- a/esp-hal-common/src/rom/mod.rs
+++ b/esp-hal-common/src/rom/mod.rs
@@ -24,7 +24,7 @@ extern "C" {
 #[macro_export]
 macro_rules! regi2c_write {
     ( $block: ident, $reg_add: ident, $indata: expr ) => {
-        paste! {
+        paste::paste! {
             rom_i2c_writeReg($block,
                 [<$block _HOSTID>],
                 $reg_add,
@@ -38,7 +38,7 @@ macro_rules! regi2c_write {
 #[macro_export]
 macro_rules! regi2c_write_mask {
     ( $block: ident, $reg_add: ident, $indata: expr ) => {
-        paste! {
+        paste::paste! {
             rom_i2c_writeReg_Mask($block,
                 [<$block _HOSTID>],
                 $reg_add,

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32c2.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32c2.rs
@@ -1,4 +1,3 @@
-use paste::paste;
 use strum::FromRepr;
 
 use crate::{

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32c3.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32c3.rs
@@ -1,4 +1,3 @@
-use paste::paste;
 use strum::FromRepr;
 
 use crate::{

--- a/esp-hal-common/src/soc/esp32/gpio.rs
+++ b/esp-hal-common/src/soc/esp32/gpio.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     gpio::{
         AlternateFunction,

--- a/esp-hal-common/src/soc/esp32c2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c2/gpio.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     gpio::{
         AlternateFunction,

--- a/esp-hal-common/src/soc/esp32c3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c3/gpio.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     gpio::{
         AlternateFunction,

--- a/esp-hal-common/src/soc/esp32c6/gpio.rs
+++ b/esp-hal-common/src/soc/esp32c6/gpio.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     gpio::{
         AlternateFunction,

--- a/esp-hal-common/src/soc/esp32h2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32h2/gpio.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     gpio::{
         AlternateFunction,

--- a/esp-hal-common/src/soc/esp32s2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s2/gpio.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     gpio::{
         AlternateFunction,
@@ -310,7 +308,7 @@ crate::gpio::gpio! {
 // named
 macro_rules! impl_get_rtc_pad {
     ($pad_name:ident) => {
-        paste!{
+        paste::paste! {
             pub(crate) fn [<esp32s2_get_rtc_pad_ $pad_name >]() -> &'static crate::peripherals::rtc_io::[< $pad_name:upper >] {
                 use crate::peripherals::RTC_IO;
                 let rtc_io = unsafe{ &*RTC_IO::ptr() };
@@ -322,7 +320,7 @@ macro_rules! impl_get_rtc_pad {
 
 macro_rules! impl_get_rtc_pad_indexed {
     ($pad_name:ident, $idx:literal) => {
-        paste!{
+        paste::paste! {
             pub(crate) fn [<esp32s2_get_rtc_pad_ $pad_name $idx>]() -> &'static crate::peripherals::rtc_io::[< $pad_name:upper >] {
                 use crate::peripherals::RTC_IO;
                 let rtc_io = unsafe{ &*RTC_IO::ptr() };

--- a/esp-hal-common/src/soc/esp32s3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s3/gpio.rs
@@ -1,5 +1,3 @@
-use paste::paste;
-
 use crate::{
     gpio::{
         AlternateFunction,

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -22,7 +22,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
-    dma::{DmaPriority, *},
+    dma::DmaPriority,
     embassy,
     pdma::*,
     peripherals::Peripherals,

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -22,7 +22,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32c2_hal::{
     clock::ClockControl,
-    dma::{DmaPriority, *},
+    dma::DmaPriority,
     embassy,
     gdma::*,
     peripherals::Peripherals,

--- a/esp32c3-hal/build.rs
+++ b/esp32c3-hal/build.rs
@@ -154,7 +154,6 @@ fn check_opt_level() {
                 "{}",
                 OPT_LEVEL_Z_MSG
                     .lines()
-                    .into_iter()
                     .map(|l| format!("cargo:warning={l}"))
                     .collect::<Vec<String>>()
                     .join("\n")

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -22,7 +22,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::{DmaPriority, *},
+    dma::DmaPriority,
     embassy,
     gdma::*,
     peripherals::Peripherals,

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -22,7 +22,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::{DmaPriority, *},
+    dma::DmaPriority,
     embassy,
     gdma::*,
     peripherals::Peripherals,

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -22,7 +22,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::{DmaPriority, *},
+    dma::DmaPriority,
     embassy,
     gdma::*,
     peripherals::Peripherals,

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -22,7 +22,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
-    dma::{DmaPriority, *},
+    dma::DmaPriority,
     embassy,
     pdma::*,
     peripherals::Peripherals,

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -68,51 +68,48 @@ pub extern "Rust" fn __init_data() -> bool {
 #[export_name = "__exception"] // this overrides the exception handler in xtensa_lx_rt
 #[link_section = ".rwtext"]
 unsafe fn exception(cause: ExceptionCause, save_frame: &mut trapframe::TrapFrame) {
-    match cause {
-        ExceptionCause::Illegal => {
-            let mut regs = [
-                save_frame.A0,
-                save_frame.A1,
-                save_frame.A2,
-                save_frame.A3,
-                save_frame.A4,
-                save_frame.A5,
-                save_frame.A6,
-                save_frame.A7,
-                save_frame.A8,
-                save_frame.A9,
-                save_frame.A10,
-                save_frame.A11,
-                save_frame.A12,
-                save_frame.A13,
-                save_frame.A14,
-                save_frame.A15,
-            ];
+    if let ExceptionCause::Illegal = cause {
+        let mut regs = [
+            save_frame.A0,
+            save_frame.A1,
+            save_frame.A2,
+            save_frame.A3,
+            save_frame.A4,
+            save_frame.A5,
+            save_frame.A6,
+            save_frame.A7,
+            save_frame.A8,
+            save_frame.A9,
+            save_frame.A10,
+            save_frame.A11,
+            save_frame.A12,
+            save_frame.A13,
+            save_frame.A14,
+            save_frame.A15,
+        ];
 
-            if xtensa_atomic_emulation_trap::atomic_emulation(save_frame.PC, &mut regs) {
-                save_frame.PC += 3; // 24bit instruction
+        if xtensa_atomic_emulation_trap::atomic_emulation(save_frame.PC, &mut regs) {
+            save_frame.PC += 3; // 24bit instruction
 
-                save_frame.A0 = regs[0];
-                save_frame.A1 = regs[1];
-                save_frame.A2 = regs[2];
-                save_frame.A3 = regs[3];
-                save_frame.A4 = regs[4];
-                save_frame.A5 = regs[5];
-                save_frame.A6 = regs[6];
-                save_frame.A7 = regs[7];
-                save_frame.A8 = regs[8];
-                save_frame.A9 = regs[9];
-                save_frame.A10 = regs[10];
-                save_frame.A11 = regs[11];
-                save_frame.A12 = regs[12];
-                save_frame.A13 = regs[13];
-                save_frame.A14 = regs[14];
-                save_frame.A15 = regs[15];
+            save_frame.A0 = regs[0];
+            save_frame.A1 = regs[1];
+            save_frame.A2 = regs[2];
+            save_frame.A3 = regs[3];
+            save_frame.A4 = regs[4];
+            save_frame.A5 = regs[5];
+            save_frame.A6 = regs[6];
+            save_frame.A7 = regs[7];
+            save_frame.A8 = regs[8];
+            save_frame.A9 = regs[9];
+            save_frame.A10 = regs[10];
+            save_frame.A11 = regs[11];
+            save_frame.A12 = regs[12];
+            save_frame.A13 = regs[13];
+            save_frame.A14 = regs[14];
+            save_frame.A15 = regs[15];
 
-                return;
-            }
+            return;
         }
-        _ => (),
     }
 
     extern "C" {

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -22,7 +22,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::{DmaPriority, *},
+    dma::DmaPriority,
     embassy,
     gdma::*,
     peripherals::Peripherals,


### PR DESCRIPTION
This PR cleans up a few typos, and refers to the paste macro when used inside macros so users of some macros no longer have to import paste. The PR also cleans up most of the Clippy warnings, except the ones that point to assembly.