### PR TITLE
Use latest published release of `embassy-time`

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -27,14 +27,14 @@ lock_api             = { version = "0.4.10", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.12"
 procmacros           = { version = "0.6.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-strum                = { version = "0.24.1", default-features = false, features = ["derive"] }
+strum                = { version = "0.25.0", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
 
 # async
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
 embassy-sync       = { version = "0.2.0", optional = true }
-embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }
 
 # RISC-V

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -25,7 +25,7 @@ categories = [
 ]
 
 [dependencies]
-embassy-time       = { version = "0.1.1",  features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.2",  features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "=0.2.0-alpha.2",   optional = true }
@@ -99,6 +99,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -25,7 +25,7 @@ categories = [
 ]
 
 [dependencies]
-embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "=0.2.0-alpha.2",   optional = true }
@@ -91,6 +91,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 cfg-if             = "1.0.0"
-embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
@@ -103,6 +103,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 cfg-if             = "1.0.0"
-embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
@@ -96,6 +96,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 cfg-if             = "1.0.0"
-embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
@@ -96,6 +96,3 @@ required-features = ["async", "embassy"]
 [[example]]
 name              = "interrupt_preemption"
 required-features = ["interrupt-preemption"]
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -25,7 +25,7 @@ categories = [
 ]
 
 [dependencies]
-embassy-time                 = { version = "0.1.1", features = ["nightly"], optional = true }
+embassy-time                 = { version = "0.1.2", features = ["nightly"], optional = true }
 embedded-hal                 = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1               = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async           = { version = "=0.2.0-alpha.2", optional = true }
@@ -103,6 +103,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 bare-metal         = "1.0.0"
-embassy-time       = { version = "0.1.1", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
@@ -110,6 +110,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "46a4600" }


### PR DESCRIPTION
This came out faster than I expected, I probably should have just waited a day with my last PR, but oh well 😁 

`strum@0.25.0` has been fixed as well (`strum_macros@0.25.1` was published) so I've bumped the version on that.

This isn't worth a CHANGELOG entry, IMO, since it's just fixing my previous PR.