### PR TITLE
Set merge=union git attribute for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
I noticed this was added to [embedded-hal](https://github.com/rust-embedded/embedded-hal), so I copied it here. This should hopefully make pull requests less painful moving forward.