### PR TITLE
Remove the `allow-opt-level-z` feature from `esp32c3-hal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove the `allow-opt-level-z` feature from `esp32c3-hal` (#654)
+
 ## [0.10.0] - 2023-06-04
 
 ### Added

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -59,11 +59,10 @@ eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedde
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
-allow-opt-level-z    = []
 async                = ["esp-hal-common/async", "embedded-hal-async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
+embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 
 [profile.dev]

--- a/esp32c3-hal/build.rs
+++ b/esp32c3-hal/build.rs
@@ -1,4 +1,4 @@
-use std::{env, fs::File, io::Write, path::PathBuf, process::exit};
+use std::{env, fs::File, io::Write, path::PathBuf};
 
 // Thanks to kennytm and TheDan64 for the assert_used_features macro.
 // Source:
@@ -18,8 +18,6 @@ assert_unique_features! {"mcu-boot", "direct-boot"}
 
 #[cfg(feature = "direct-boot")]
 fn main() {
-    check_opt_level();
-
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
@@ -54,8 +52,6 @@ fn main() {
 
 #[cfg(not(any(feature = "mcu-boot", feature = "direct-boot")))]
 fn main() {
-    check_opt_level();
-
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out.join("memory.x"))
@@ -84,8 +80,6 @@ fn main() {
 
 #[cfg(feature = "mcu-boot")]
 fn main() {
-    check_opt_level();
-
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
@@ -127,38 +121,4 @@ fn add_defaults() {
         .unwrap();
 
     println!("cargo:rustc-link-search={}", out.display());
-}
-
-const OPT_LEVEL_Z_MSG: &str = r#"opt-level=z will produce broken 128-bit shifts (i.e. `1u128 << i`). The hal's interrupt handling relies on that operation, causing an 'attempt to subtract with overflow' panic if an enabled interrupt is triggered while using that opt-level.
-
-Please use `opt-level="s"` in lieu of "z", or alternatively enable `features = ["allow-opt-level-z"]` to suppress this error. The latter option is only recommended if you:
-
-  * Do not use interrupts, and
-  * Do not have any shifts of 128-bit integers (either u128 or i128) in your code
-
-See also: https://github.com/esp-rs/esp-hal/issues/196
-     and: https://github.com/llvm/llvm-project/issues/57988         
-"#;
-
-// Once a rust nightly has a fix for https://github.com/llvm/llvm-project/issues/57988 , consider:
-//   1. Removing this check in favor of bumping the minimum rust verison, and/or
-//   2. Augmenting this check to ensure that version for opt-level=z
-fn check_opt_level() {
-    if cfg!(feature = "allow-opt-level-z") {
-        return;
-    }
-
-    if let Some(ref opt_level) = env::var_os("OPT_LEVEL") {
-        if opt_level == "z" {
-            println!(
-                "{}",
-                OPT_LEVEL_Z_MSG
-                    .lines()
-                    .map(|l| format!("cargo:warning={l}"))
-                    .collect::<Vec<String>>()
-                    .join("\n")
-            );
-            exit(1);
-        }
-    }
 }


### PR DESCRIPTION
Per [this comment](https://github.com/esp-rs/esp-hal/pull/198#issuecomment-1634563927) from @MabezDev, this feature should no longer be required. I tested the `timer_interrupt` example, which was identified as problematic as this opt-level, and it worked just fine for me with `opt-level = "z"`. More testing would be appreciated, however.