### PR TITLE
Update `esp-synopsys-usb-otg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- USB device support is working again
+
 ### Removed
 
 ## [0.10.0] - 2023-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- USB device support is working again
+- USB device support is working again (#656)
 
 ### Removed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -20,7 +20,7 @@ embedded-dma         = "0.2.0"
 embedded-hal         = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1       = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-nb      = { version = "=1.0.0-alpha.3", optional = true }
-esp-synopsys-usb-otg = { version = "0.3.1", optional = true, features = ["fs", "esp32sx"] }
+esp-synopsys-usb-otg = { version = "0.3.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
 log                  = "=0.4.18"
 lock_api             = { version = "0.4.10", optional = true }


### PR DESCRIPTION
I release a new version of `esp-synopsys-usb-otg`

While it's a patch release and not strictly needed I bump the version of the dependency here.

Fixes #495 
