### PR TITLE
Ensure that documentation can be generated for all packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**/README.md"
   push:
+    paths-ignore:
+      - "**/README.md"
   workflow_dispatch:
 
 env:
@@ -21,7 +25,7 @@ concurrency:
 
 jobs:
   # --------------------------------------------------------------------------
-  # Check
+  # Check Packages
 
   esp-hal-smartled:
     runs-on: ubuntu-latest
@@ -53,6 +57,9 @@ jobs:
         run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s2
       - name: check (esp32s3)
         run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s3
+      # Ensure documentation can be built (requires a chip feature!)
+      - name: rustdoc
+        run: cd esp-hal-smartled/ && cargo doc --features=esp32c3
 
   esp32-hal:
     runs-on: ubuntu-latest
@@ -84,6 +91,9 @@ jobs:
         run: cd esp32-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
       - name: check esp32-hal (async, i2c)
         run: cd esp32-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp32-hal/ && cargo doc
 
   esp32c2-hal:
     runs-on: ubuntu-latest
@@ -123,6 +133,9 @@ jobs:
         run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c2-hal (interrupt-preemption)
         run: cd esp32c2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp32c2-hal/ && cargo doc
 
   esp32c3-hal:
     runs-on: ubuntu-latest
@@ -164,6 +177,9 @@ jobs:
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c3-hal (interrupt-preemption)
         run: cd esp32c3-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp32c3-hal/ && cargo doc
 
   esp32c6-hal:
     runs-on: ubuntu-latest
@@ -203,6 +219,9 @@ jobs:
         run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (interrupt-preemption)
         run: cd esp32c6-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp32c6-hal/ && cargo doc
 
   esp32h2-hal:
     runs-on: ubuntu-latest
@@ -242,6 +261,9 @@ jobs:
         run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32h2-hal (interrupt-preemption)
         run: cd esp32h2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp32h2-hal/ && cargo doc
 
   esp32s2-hal:
     runs-on: ubuntu-latest
@@ -276,6 +298,9 @@ jobs:
         run: cd esp32s2-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
       - name: check esp32s2-hal (async, i2c)
         run: cd esp32s2-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp32s2-hal/ && cargo doc
 
   esp32s3-hal:
     runs-on: ubuntu-latest
@@ -315,6 +340,9 @@ jobs:
         run: cd esp32s3-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
       - name: check esp32s3-hal (octal psram)
         run: cd esp32s3-hal/ && cargo check --example=octal_psram --features=opsram_2m --release # This example requires release!
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp32s3-hal/ && cargo doc
 
   esp-riscv-rt:
     runs-on: ubuntu-latest
@@ -332,6 +360,9 @@ jobs:
         run: cd esp-riscv-rt/ && cargo check --target=riscv32imc-unknown-none-elf -Zbuild-std=core
       - name: Check esp-riscv-rt (imac)
         run: cd esp-riscv-rt/ && cargo check --target=riscv32imac-unknown-none-elf -Zbuild-std=core
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp-riscv-rt/ && cargo doc
 
   # --------------------------------------------------------------------------
   # MSRV

--- a/esp-hal-common/src/rom/md5.rs
+++ b/esp-hal-common/src/rom/md5.rs
@@ -58,9 +58,6 @@ use core::{
 // toml file then `InternalContext` will be either undefined or multiple
 // defined and this module will fail to compile letting you know to fix it
 
-#[cfg(doc)]
-struct InternalContext;
-
 #[cfg(rom_md5_bsd)]
 #[derive(Clone)]
 #[repr(C)]


### PR DESCRIPTION
- Removes `#[cfg]` from `esp-hal-common` which was preventing documentation from building
- Added CI checks to ensure that we are able to build documentation for each package
    - I initially had this as its own job, however it took too long having to build each package before documenting
    - Much faster to document after each package has already been built in its own job

Closes #658