### PR TITLE
ESP32-S3: Disable usb_pad_enable when setting GPIO19/20 to input/output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move `rwtext` after other RAM data sections (#464)
 - ESP32-C3: Disable `usb_pad_enable` when setting GPIO18/19 to input/output (#461)
 - Fix 802.15.4 clock enabling (ESP32-C6) (#458)
+- ESP32-S3: Disable usb_pad_enable when setting GPIO19/20 to input/output (#645)
 
 ### Changed
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -494,6 +494,14 @@ where
                 .modify(|_, w| w.usb_pad_enable().clear_bit());
         }
 
+        // Same workaround as above for ESP32-S3
+        #[cfg(esp32s3)]
+        if GPIONUM == 19 || GPIONUM == 20 {
+            unsafe { &*crate::peripherals::USB_DEVICE::PTR }
+                .conf0
+                .modify(|_, w| w.usb_pad_enable().clear_bit());
+        }
+
         get_io_mux_reg(GPIONUM).modify(|_, w| unsafe {
             w.mcu_sel()
                 .bits(GPIO_FUNCTION as u8)
@@ -913,6 +921,14 @@ where
         //       default are assigned to the `USB_SERIAL_JTAG` peripheral.
         #[cfg(esp32c3)]
         if GPIONUM == 18 || GPIONUM == 19 {
+            unsafe { &*crate::peripherals::USB_DEVICE::PTR }
+                .conf0
+                .modify(|_, w| w.usb_pad_enable().clear_bit());
+        }
+
+        // Same workaround as above for ESP32-S3
+        #[cfg(esp32s3)]
+        if GPIONUM == 19 || GPIONUM == 20 {
             unsafe { &*crate::peripherals::USB_DEVICE::PTR }
                 .conf0
                 .modify(|_, w| w.usb_pad_enable().clear_bit());


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [X] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [X] `cargo fmt` was run.
- [X] Your changes were added to the `CHANGELOG.md` in the proper section.
- [NA] You updated existing examples or added examples (if applicable).
- [NA] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
