### PR TITLE
esp32s3: usb-serial-jtag interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - USB device support is working again (#656)
+- Add missing interrupt status read for esp32s3, which fixes USB-SERIAL-JTAG interrupts (#664)
 
 ### Removed
 


### PR DESCRIPTION
- Fix not reading the last interrupt status register on esp32s3, this happens to be where the USB-SERIAL-JTAG interrupt is kept.
- Fix `disable()` on Xtensa, according to the TRM to disable a peripheral interrupt, it must be mapped to a CPU peripheral interrupt not zero.

Closes https://github.com/esp-rs/esp-hal/issues/633

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
