### PR TITLE
Make in-progress DMA transfers potentially fallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove the `allow-opt-level-z` feature from `esp32c3-hal` (#654)
 
+### Breaking
+
+- `DmaTransfer::wait` and `I2sReadDmaTransfer::wait_receive` now return `Result` (#665)
+
 ## [0.10.0] - 2023-06-04
 
 ### Added

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -109,7 +109,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // erase sector
@@ -122,7 +122,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write enable
@@ -135,7 +135,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write data / program page
@@ -150,7 +150,7 @@ fn main() -> ! {
             send,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     loop {
@@ -168,7 +168,7 @@ fn main() -> ! {
         // here we could do something else while DMA transfer is in progress
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, spi) = transfer.wait();
+        (receive, spi) = transfer.wait().unwrap();
 
         println!("{:x?}", &receive);
         for b in &mut receive.iter() {

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -107,7 +107,7 @@ fn main() -> ! {
         }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, send, spi) = transfer.wait();
+        (receive, send, spi) = transfer.wait().unwrap();
         println!(
             "{:x?} .. {:x?}",
             &receive[..10],

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -103,7 +103,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // erase sector
@@ -116,7 +116,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write enable
@@ -129,7 +129,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write data / program page
@@ -144,7 +144,7 @@ fn main() -> ! {
             send,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     loop {
@@ -162,7 +162,7 @@ fn main() -> ! {
         // here we could do something else while DMA transfer is in progress
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, spi) = transfer.wait();
+        (receive, spi) = transfer.wait().unwrap();
 
         println!("{:x?}", &receive);
         for b in &mut receive.iter() {

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -108,7 +108,7 @@ fn main() -> ! {
         }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, send, spi) = transfer.wait();
+        (receive, send, spi) = transfer.wait().unwrap();
         println!(
             "{:x?} .. {:x?}",
             &receive[..10],

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -110,7 +110,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // erase sector
@@ -123,7 +123,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write enable
@@ -136,7 +136,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write data / program page
@@ -151,7 +151,7 @@ fn main() -> ! {
             send,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     loop {
@@ -169,7 +169,7 @@ fn main() -> ! {
         // here we could do something else while DMA transfer is in progress
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, spi) = transfer.wait();
+        (receive, spi) = transfer.wait().unwrap();
 
         println!("{:x?}", &receive);
         for b in &mut receive.iter() {

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -115,7 +115,7 @@ fn main() -> ! {
         }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, send, spi) = transfer.wait();
+        (receive, send, spi) = transfer.wait().unwrap();
         println!(
             "{:x?} .. {:x?}",
             &receive[..10],

--- a/esp32c6-hal/examples/qspi_flash.rs
+++ b/esp32c6-hal/examples/qspi_flash.rs
@@ -110,7 +110,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // erase sector
@@ -123,7 +123,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write enable
@@ -136,7 +136,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write data / program page
@@ -151,7 +151,7 @@ fn main() -> ! {
             send,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     loop {
@@ -169,7 +169,7 @@ fn main() -> ! {
         // here we could do something else while DMA transfer is in progress
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, spi) = transfer.wait();
+        (receive, spi) = transfer.wait().unwrap();
 
         println!("{:x?}", &receive);
         for b in &mut receive.iter() {

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -116,7 +116,7 @@ fn main() -> ! {
         }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, send, spi) = transfer.wait();
+        (receive, send, spi) = transfer.wait().unwrap();
         println!(
             "{:x?} .. {:x?}",
             &receive[..10],

--- a/esp32h2-hal/examples/qspi_flash.rs
+++ b/esp32h2-hal/examples/qspi_flash.rs
@@ -110,7 +110,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // erase sector
@@ -123,7 +123,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write enable
@@ -136,7 +136,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write data / program page
@@ -151,7 +151,7 @@ fn main() -> ! {
             send,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     loop {
@@ -169,7 +169,7 @@ fn main() -> ! {
         // here we could do something else while DMA transfer is in progress
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, spi) = transfer.wait();
+        (receive, spi) = transfer.wait().unwrap();
 
         println!("{:x?}", &receive);
         for b in &mut receive.iter() {

--- a/esp32h2-hal/examples/rmt_tx.rs
+++ b/esp32h2-hal/examples/rmt_tx.rs
@@ -20,7 +20,7 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -109,7 +109,7 @@ fn main() -> ! {
         // here we could do something else while DMA transfer is in progress
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, send, spi) = transfer.wait();
+        (receive, send, spi) = transfer.wait().unwrap();
         println!(
             "{:x?} .. {:x?}",
             &receive[..10],

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -109,7 +109,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // erase sector
@@ -122,7 +122,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write enable
@@ -135,7 +135,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write data / program page
@@ -150,7 +150,7 @@ fn main() -> ! {
             send,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     loop {
@@ -168,7 +168,7 @@ fn main() -> ! {
         // here we could do something else while DMA transfer is in progress
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, spi) = transfer.wait();
+        (receive, spi) = transfer.wait().unwrap();
 
         println!("{:x?}", &receive);
         for b in &mut receive.iter() {

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -107,7 +107,7 @@ fn main() -> ! {
         }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, send, spi) = transfer.wait();
+        (receive, send, spi) = transfer.wait().unwrap();
         println!(
             "{:x?} .. {:x?}",
             &receive[..10],

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -110,7 +110,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // erase sector
@@ -123,7 +123,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (zero_buf, spi) = transfer.wait();
+    (zero_buf, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write enable
@@ -136,7 +136,7 @@ fn main() -> ! {
             zero_buf,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     // write data / program page
@@ -151,7 +151,7 @@ fn main() -> ! {
             send,
         )
         .unwrap();
-    (_, spi) = transfer.wait();
+    (_, spi) = transfer.wait().unwrap();
     delay.delay_ms(250u32);
 
     loop {
@@ -169,7 +169,7 @@ fn main() -> ! {
         // here we could do something else while DMA transfer is in progress
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, spi) = transfer.wait();
+        (receive, spi) = transfer.wait().unwrap();
 
         println!("{:x?}", &receive);
         for b in &mut receive.iter() {

--- a/esp32s3-hal/examples/rmt_tx.rs
+++ b/esp32s3-hal/examples/rmt_tx.rs
@@ -18,7 +18,6 @@ use esp_hal_common::{
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
     Rmt,
 };
-use esp_println::println;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -115,7 +115,7 @@ fn main() -> ! {
         }
         // the buffers and spi is moved into the transfer and we can get it back via
         // `wait`
-        (receive, send, spi) = transfer.wait();
+        (receive, send, spi) = transfer.wait().unwrap();
         println!(
             "{:x?} .. {:x?}",
             &receive[..10],


### PR DESCRIPTION
This is a breaking change to the DMA transfer's `wait` (and for I2S `wait_receive`) functions to make them potentially fallible.
It also adds checking for DMA descriptor errors as described in #491. Probably there might be more conditions to check but at least this changes the API in a way that can be added later.

For the async API (which we only have for SPI currently) it's already fallible - so no API change there.

Closes #491
