### PR TITLE
PR template related changes and The Big Warning Cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,12 +5,10 @@ Please make sure that your submission includes the following:
 
 ### Must
 
-- [ ] The code compiles without `errors` or `warnings`.
+- [ ] All examples compile without warnings.
 - [ ] All examples work.
-- [ ] `cargo fmt` was run.
-- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
 - [ ] You updated existing examples or added examples (if applicable).
-- [ ] Added examples are checked in CI
+- [ ] Added examples are checked in CI.
 
 ### Nice to have
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: cd esp32-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
       # Ensure documentation can be built
       - name: rustdoc
-        run: cd esp32-hal/ && cargo doc
+        run: cd esp32-hal/ && cargo doc --features=eh1
 
   esp32c2-hal:
     runs-on: ubuntu-latest
@@ -139,7 +139,7 @@ jobs:
         run: cd esp32c2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
       # Ensure documentation can be built
       - name: rustdoc
-        run: cd esp32c2-hal/ && cargo doc
+        run: cd esp32c2-hal/ && cargo doc --features=eh1
 
   esp32c3-hal:
     runs-on: ubuntu-latest
@@ -185,7 +185,7 @@ jobs:
         run: cd esp32c3-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
       # Ensure documentation can be built
       - name: rustdoc
-        run: cd esp32c3-hal/ && cargo doc
+        run: cd esp32c3-hal/ && cargo doc --features=eh1
 
   esp32c6-hal:
     runs-on: ubuntu-latest
@@ -229,7 +229,7 @@ jobs:
         run: cd esp32c6-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
       # Ensure documentation can be built
       - name: rustdoc
-        run: cd esp32c6-hal/ && cargo doc
+        run: cd esp32c6-hal/ && cargo doc --features=eh1
 
   esp32h2-hal:
     runs-on: ubuntu-latest
@@ -273,7 +273,7 @@ jobs:
         run: cd esp32h2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
       # Ensure documentation can be built
       - name: rustdoc
-        run: cd esp32h2-hal/ && cargo doc
+        run: cd esp32h2-hal/ && cargo doc --features=eh1
 
   esp32s2-hal:
     runs-on: ubuntu-latest
@@ -312,7 +312,7 @@ jobs:
         run: cd esp32s2-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
       # Ensure documentation can be built
       - name: rustdoc
-        run: cd esp32s2-hal/ && cargo doc
+        run: cd esp32s2-hal/ && cargo doc --features=eh1
 
   esp32s3-hal:
     runs-on: ubuntu-latest
@@ -356,7 +356,7 @@ jobs:
         run: cd esp32s3-hal/ && cargo check --example=octal_psram --features=opsram_2m --release # This example requires release!
       # Ensure documentation can be built
       - name: rustdoc
-        run: cd esp32s3-hal/ && cargo doc
+        run: cd esp32s3-hal/ && cargo doc --features=eh1
 
   esp-riscv-rt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,21 +431,21 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
-          components: clippy
+          toolchain: nightly
+          components: clippy, rust-src
       - uses: Swatinem/rust-cache@v2
 
       # Run clippy on all packages targeting RISC-V.
       - name: clippy (esp-riscv-rt)
-        run: cargo +stable clippy --manifest-path=esp-riscv-rt/Cargo.toml -- --no-deps
+        run: cd esp-riscv-rt/ && cargo +nightly clippy -- --no-deps
       - name: clippy (esp32c2-hal)
-        run: cargo +stable clippy --manifest-path=esp32c2-hal/Cargo.toml -- --no-deps
+        run: cd esp32c2-hal/ && cargo +nightly clippy -- --no-deps
       - name: clippy (esp32c3-hal)
-        run: cargo +stable clippy --manifest-path=esp32c3-hal/Cargo.toml -- --no-deps
+        run: cd esp32c3-hal/ && cargo +nightly clippy -- --no-deps
       - name: clippy (esp32c6-hal)
-        run: cargo +stable clippy --manifest-path=esp32c6-hal/Cargo.toml -- --no-deps
+        run: cd esp32c6-hal/ && cargo +nightly clippy -- --no-deps
       - name: clippy (esp32h2-hal)
-        run: cargo +stable clippy --manifest-path=esp32h2-hal/Cargo.toml -- --no-deps
+        run: cd esp32h2-hal/ && cargo +nightly clippy -- --no-deps
 
   clippy-xtensa:
     runs-on: ubuntu-latest
@@ -462,11 +462,11 @@ jobs:
       # The ESP32-S2 requires some additional information in order for the
       # atomic emulation crate to build.
       - name: clippy (esp32-hal)
-        run: cargo +esp clippy --manifest-path=esp32-hal/Cargo.toml -- --no-deps
+        run: cd esp32-hal/ && cargo +esp clippy -- --no-deps
       - name: clippy (esp32s2-hal)
-        run: cargo +esp clippy --manifest-path=esp32s2-hal/Cargo.toml -- --no-deps
+        run: cd esp32s2-hal/ && cargo +esp clippy -- --no-deps
       - name: clippy (esp32s3-hal)
-        run: cargo +esp clippy --manifest-path=esp32s3-hal/Cargo.toml -- --no-deps
+        run: cd esp32s3-hal/ && cargo +esp clippy -- --no-deps
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,21 +45,21 @@ jobs:
 
       # Check all RISC-V targets:
       - name: check (esp32c3)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c3
+        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c3 --target=riscv32imc-unknown-none-elf
       - name: check (esp32c6)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c6
+        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c6 --target=riscv32imac-unknown-none-elf
       - name: check (esp32h2)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32h2
+        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32h2 --target=riscv32imac-unknown-none-elf
       # Check all Xtensa targets:
       - name: check (esp32)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32,esp32_40mhz
+        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32,esp32_40mhz --target=xtensa-esp32-none-elf -Zbuild-std=core
       - name: check (esp32s2)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s2
+        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s2 --target=xtensa-esp32s2-none-elf -Zbuild-std=core
       - name: check (esp32s3)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s3
+        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s3 --target=xtensa-esp32s3-none-elf -Zbuild-std=core
       # Ensure documentation can be built (requires a chip feature!)
       - name: rustdoc
-        run: cd esp-hal-smartled/ && cargo doc --features=esp32c3
+        run: cd esp-hal-smartled/ && cargo doc --features=esp32c3,esp-hal-common/eh1 --target=riscv32imc-unknown-none-elf
 
   esp32-hal:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: check esp32c2-hal (async, i2c)
         run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c2-hal (interrupt-preemption)
-        run: cd esp32c2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c2-hal/ && cargo doc --features=eh1
@@ -182,7 +182,7 @@ jobs:
       - name: check esp32c3-hal (async, i2c)
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c3-hal (interrupt-preemption)
-        run: cd esp32c3-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c3-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c3-hal/ && cargo doc --features=eh1
@@ -226,7 +226,7 @@ jobs:
       - name: check esp32c6-hal (async, i2c)
         run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (interrupt-preemption)
-        run: cd esp32c6-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c6-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c6-hal/ && cargo doc --features=eh1
@@ -270,7 +270,7 @@ jobs:
       - name: check esp32h2-hal (async, i2c)
         run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32h2-hal (interrupt-preemption)
-        run: cd esp32h2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32h2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32h2-hal/ && cargo doc --features=eh1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
 
+      - name: check esp32-hal
+        run: cd esp32-hal/ && cargo check
       # Perform a full build initially to verify that the examples not only
       # build, but also link successfully.
       - name: build esp32-hal (no features)
@@ -107,6 +109,8 @@ jobs:
           components: rust-src
       - uses: Swatinem/rust-cache@v2
 
+      - name: check esp32c62hal
+        run: cd esp32c2-hal/ && cargo +nightly check
       # Perform a full build initially to verify that the examples not only
       # build, but also link successfully.
       # We also use this as an opportunity to verify that the examples link
@@ -149,6 +153,8 @@ jobs:
           components: rust-src
       - uses: Swatinem/rust-cache@v2
 
+      - name: check esp32c3-hal
+        run: cd esp32c3-hal/ && cargo +nightly check
       # Perform a full build initially to verify that the examples not only
       # build, but also link successfully.
       # We also use this as an opportunity to verify that the examples link
@@ -193,6 +199,8 @@ jobs:
           components: rust-src
       - uses: Swatinem/rust-cache@v2
 
+      - name: check esp32c6-hal
+        run: cd esp32c6-hal/ && cargo +nightly check
       # Perform a full build initially to verify that the examples not only
       # build, but also link successfully.
       # We also use this as an opportunity to verify that the examples link
@@ -235,6 +243,8 @@ jobs:
           components: rust-src
       - uses: Swatinem/rust-cache@v2
 
+      - name: check esp32h2-hal
+        run: cd esp32h2-hal/ && cargo +nightly check
       # Perform a full build initially to verify that the examples not only
       # build, but also link successfully.
       # We also use this as an opportunity to verify that the examples link
@@ -277,6 +287,8 @@ jobs:
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
 
+      - name: check esp32s2-hal
+        run: cd esp32s2-hal/ && cargo check
       # Perform a full build initially to verify that the examples not only
       # build, but also link successfully.
       - name: check esp32s2-hal (no features)
@@ -314,6 +326,8 @@ jobs:
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
 
+      - name: check esp32s3-hal
+        run: cd esp32s3-hal/ && cargo check
       # Perform a full build initially to verify that the examples not only
       # build, but also link successfully.
       # We also use this as an opportunity to verify that the examples link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `embedded-hal-*` alpha packages to their latest versions (#640)
-- Implement the `Clone` and `Copy` traits for the `Rng` driver (#650)
+- Implement the `Clone` and `Copy` traits for the `Rng` driver (#650, #666)
 
 ### Fixed
 

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -250,6 +250,7 @@ fn gen_efuse_table(device_name: &str, out_dir: impl AsRef<Path>) {
             fields.next().map(|s| s.trim()),
         ) {
             (Some(name), Some(block), Some(bit_off), Some(bit_len), Some(desc)) => {
+                let desc = desc.replace('[', "`[").replace(']', "]`");
                 writeln!(writer, "/// {desc}").unwrap();
                 writeln!(
                     writer,

--- a/esp-hal-common/src/analog/adc/cal_curve.rs
+++ b/esp-hal-common/src/analog/adc/cal_curve.rs
@@ -38,8 +38,8 @@ pub trait AdcHasCurveCal {
 /// This scheme implements final polynomial error correction using predefined
 /// coefficient sets for each attenuation.
 ///
-/// This scheme also includes basic calibration ([`AdcCalBasic`]) and line
-/// fitting ([`AdcCalLine`]).
+/// This scheme also includes basic calibration ([`super::AdcCalBasic`]) and
+/// line fitting ([`AdcCalLine`]).
 #[derive(Clone, Copy)]
 pub struct AdcCalCurve<ADCI> {
     line: AdcCalLine<ADCI>,
@@ -131,7 +131,7 @@ mod impls {
     }
 
     coeff_tables! {
-        /// Error curve coefficients derived from https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32c3/curve_fitting_coefficients.c
+        /// Error curve coefficients derived from <https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32c3/curve_fitting_coefficients.c>
         #[cfg(esp32c3)]
         CURVES_COEFFS1 [
             Attenuation0dB => [
@@ -158,7 +158,7 @@ mod impls {
             ],
         ];
 
-        /// Error curve coefficients derived from https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32c6/curve_fitting_coefficients.c
+        /// Error curve coefficients derived from <https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32c6/curve_fitting_coefficients.c>
         #[cfg(esp32c6)]
         CURVES_COEFFS1 [
             Attenuation0dB => [
@@ -183,7 +183,7 @@ mod impls {
             ],
         ];
 
-        /// Error curve coefficients derived from https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32s3/curve_fitting_coefficients.c
+        /// Error curve coefficients derived from <https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32s3/curve_fitting_coefficients.c>
         #[cfg(esp32s3)]
         CURVES_COEFFS1 [
             Attenuation0dB => [
@@ -210,7 +210,7 @@ mod impls {
             ],
         ];
 
-        /// Error curve coefficients derived from https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32s3/curve_fitting_coefficients.c
+        /// Error curve coefficients derived from <https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32s3/curve_fitting_coefficients.c>
         #[cfg(esp32s3)]
         CURVES_COEFFS2 [
             Attenuation0dB => [

--- a/esp-hal-common/src/analog/adc/xtensa.rs
+++ b/esp-hal-common/src/analog/adc/xtensa.rs
@@ -420,7 +420,6 @@ pub mod implementation {
 
     use embedded_hal::adc::Channel;
 
-    use super::impl_adc_interface;
     pub use crate::analog::{adc::*, ADC1, ADC2};
     use crate::gpio::*;
 

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -1,4 +1,4 @@
-use xtensa_lx::interrupt::{self, InterruptNumber};
+use xtensa_lx::interrupt;
 use xtensa_lx_rt::exception::Context;
 
 use crate::{
@@ -93,7 +93,7 @@ pub fn disable(core: Cpu, interrupt: Interrupt) {
 /// Clear the given CPU interrupt
 pub fn clear(_core: Cpu, which: CpuInterrupt) {
     unsafe {
-        xtensa_lx::interrupt::clear(1 << which as u32);
+        interrupt::clear(1 << which as u32);
     }
 }
 
@@ -161,25 +161,23 @@ pub fn get_status(core: Cpu) -> u128 {
 }
 
 #[cfg(esp32)]
-unsafe fn core0_interrupt_peripheral() -> *const crate::peripherals::dport::RegisterBlock {
-    crate::peripherals::DPORT::PTR
+unsafe fn core0_interrupt_peripheral() -> *const peripherals::dport::RegisterBlock {
+    peripherals::DPORT::PTR
 }
 
 #[cfg(esp32)]
-unsafe fn core1_interrupt_peripheral() -> *const crate::peripherals::dport::RegisterBlock {
-    crate::peripherals::DPORT::PTR
+unsafe fn core1_interrupt_peripheral() -> *const peripherals::dport::RegisterBlock {
+    peripherals::DPORT::PTR
 }
 
 #[cfg(any(esp32s2, esp32s3))]
-unsafe fn core0_interrupt_peripheral() -> *const crate::peripherals::interrupt_core0::RegisterBlock
-{
-    crate::peripherals::INTERRUPT_CORE0::PTR
+unsafe fn core0_interrupt_peripheral() -> *const peripherals::interrupt_core0::RegisterBlock {
+    peripherals::INTERRUPT_CORE0::PTR
 }
 
 #[cfg(esp32s3)]
-unsafe fn core1_interrupt_peripheral() -> *const crate::peripherals::interrupt_core1::RegisterBlock
-{
-    crate::peripherals::INTERRUPT_CORE1::PTR
+unsafe fn core1_interrupt_peripheral() -> *const peripherals::interrupt_core1::RegisterBlock {
+    peripherals::INTERRUPT_CORE1::PTR
 }
 
 #[cfg(feature = "vectored")]
@@ -188,6 +186,7 @@ pub use vectored::*;
 #[cfg(feature = "vectored")]
 mod vectored {
     use procmacros::ram;
+    use xtensa_lx::interrupt::InterruptNumber;
 
     use super::*;
     use crate::get_core;
@@ -298,9 +297,7 @@ mod vectored {
         unsafe {
             map(get_core(), interrupt, cpu_interrupt);
 
-            xtensa_lx::interrupt::enable_mask(
-                xtensa_lx::interrupt::get_mask() | 1 << cpu_interrupt as u32,
-            );
+            interrupt::enable_mask(interrupt::get_mask() | 1 << cpu_interrupt as u32);
         }
         Ok(())
     }

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -31,6 +31,7 @@
     feature(impl_trait_projections)
 )]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![deny(warnings)]
 
 #[cfg(riscv)]
 pub use esp_riscv_rt::{self, entry, riscv};

--- a/esp-hal-common/src/soc/esp32c2/efuse.rs
+++ b/esp-hal-common/src/soc/esp32c2/efuse.rs
@@ -39,10 +39,10 @@ impl Efuse {
 
     /// Get efuse block version
     ///
-    /// see https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30
+    /// see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30>
     pub fn get_block_version() -> (u8, u8) {
-        // see https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c2/include/hal/efuse_ll.h#L65-L73
-        // https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L90-L91
+        // see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c2/include/hal/efuse_ll.h#L65-L73>
+        // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L90-L91>
         (
             Self::read_field_le::<u8>(BLK_VERSION_MAJOR),
             Self::read_field_le::<u8>(BLK_VERSION_MINOR),
@@ -51,7 +51,7 @@ impl Efuse {
 
     /// Get version of RTC calibration block
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L14
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L14>
     pub fn get_rtc_calib_version() -> u8 {
         let (major, _minor) = Self::get_block_version();
         if major == 0 {
@@ -63,7 +63,7 @@ impl Efuse {
 
     /// Get ADC initial code for specified attenuation from efuse
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L27
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L27>
     pub fn get_rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
         let version = Self::get_rtc_calib_version();
 
@@ -71,7 +71,7 @@ impl Efuse {
             return None;
         }
 
-        // see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L94
+        // see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L94>
         let diff_code0: u16 = Self::read_field_le(ADC1_INIT_CODE_ATTEN0);
         let code0 = if diff_code0 & (1 << 7) != 0 {
             2160 - (diff_code0 & 0x7f)
@@ -83,7 +83,7 @@ impl Efuse {
             return Some(code0);
         }
 
-        // see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L95
+        // see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L95>
         let diff_code11: u16 = Self::read_field_le(ADC1_INIT_CODE_ATTEN3);
         let code11 = code0 + diff_code11;
 
@@ -92,7 +92,7 @@ impl Efuse {
 
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L65
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L65>
     pub fn get_rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::Attenuation0dB => 400,
@@ -102,7 +102,7 @@ impl Efuse {
 
     /// Get ADC reference point digital code for specified attenuation
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L65
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L65>
     pub fn get_rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
         let version = Self::get_rtc_calib_version();
 
@@ -110,7 +110,7 @@ impl Efuse {
             return None;
         }
 
-        // see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L96
+        // see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L96>
         let diff_code0: u16 = Self::read_field_le(ADC1_CAL_VOL_ATTEN0);
         let code0 = if diff_code0 & (1 << 7) != 0 {
             1540 - (diff_code0 & 0x7f)
@@ -122,7 +122,7 @@ impl Efuse {
             return Some(code0);
         }
 
-        // see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L97
+        // see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L97>
         let diff_code11: u16 = Self::read_field_le(ADC1_CAL_VOL_ATTEN3);
         let code11 = if diff_code0 & (1 << 5) != 0 {
             code0 - (diff_code11 & 0x1f)

--- a/esp-hal-common/src/soc/esp32c3/efuse.rs
+++ b/esp-hal-common/src/soc/esp32c3/efuse.rs
@@ -39,11 +39,11 @@ impl Efuse {
 
     /// Get efuse block version
     ///
-    /// see https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30
+    /// see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30>
     pub fn get_block_version() -> (u8, u8) {
-        // see https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c3/include/hal/efuse_ll.h#L70-L78
-        // https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L163
-        // https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L173
+        // see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c3/include/hal/efuse_ll.h#L70-L78>
+        // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L163>
+        // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L173>
         (
             Self::read_field_le::<u8>(BLK_VERSION_MAJOR),
             Self::read_field_le::<u8>(BLK_VERSION_MINOR),
@@ -52,7 +52,7 @@ impl Efuse {
 
     /// Get version of RTC calibration block
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L12
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L12>
     pub fn get_rtc_calib_version() -> u8 {
         let (major, _minor) = Self::get_block_version();
         if major == 1 {
@@ -64,7 +64,7 @@ impl Efuse {
 
     /// Get ADC initial code for specified attenuation from efuse
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L25
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L25>
     pub fn get_rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
         let version = Self::get_rtc_calib_version();
 
@@ -72,7 +72,7 @@ impl Efuse {
             return None;
         }
 
-        // See https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L176-L179
+        // See <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L176-L179>
         let init_code: u16 = Self::read_field_le(match atten {
             Attenuation::Attenuation0dB => ADC1_INIT_CODE_ATTEN0,
             Attenuation::Attenuation2p5dB => ADC1_INIT_CODE_ATTEN1,
@@ -85,7 +85,7 @@ impl Efuse {
 
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L49
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L49>
     pub fn get_rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::Attenuation0dB => 400,
@@ -97,7 +97,7 @@ impl Efuse {
 
     /// Get ADC reference point digital code for specified attenuation
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L49
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L49>
     pub fn get_rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
         let version = Self::get_rtc_calib_version();
 
@@ -105,7 +105,7 @@ impl Efuse {
             return None;
         }
 
-        // See https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L180-L183
+        // See <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L180-L183>
         let cal_code: u16 = Self::read_field_le(match atten {
             Attenuation::Attenuation0dB => ADC1_CAL_VOL_ATTEN0,
             Attenuation::Attenuation2p5dB => ADC1_CAL_VOL_ATTEN1,

--- a/esp-hal-common/src/soc/esp32c6/efuse.rs
+++ b/esp-hal-common/src/soc/esp32c6/efuse.rs
@@ -39,10 +39,10 @@ impl Efuse {
 
     /// Get efuse block version
     ///
-    /// see https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30
+    /// see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30>
     pub fn get_block_version() -> (u8, u8) {
-        // see https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c6/include/hal/efuse_ll.h#L65-L73
-        // https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L156
+        // see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c6/include/hal/efuse_ll.h#L65-L73>
+        // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L156>
         (
             Self::read_field_le::<u8>(BLK_VERSION_MAJOR),
             Self::read_field_le::<u8>(BLK_VERSION_MINOR),
@@ -51,7 +51,7 @@ impl Efuse {
 
     /// Get version of RTC calibration block
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L20
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L20>
     pub fn get_rtc_calib_version() -> u8 {
         let (_major, minor) = Self::get_block_version();
         if minor >= 1 {
@@ -63,7 +63,7 @@ impl Efuse {
 
     /// Get ADC initial code for specified attenuation from efuse
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L32
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L32>
     pub fn get_rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
         let version = Self::get_rtc_calib_version();
 
@@ -71,7 +71,7 @@ impl Efuse {
             return None;
         }
 
-        // See https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L147-L152
+        // See <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L147-L152>
         let init_code: u16 = Self::read_field_le(match atten {
             Attenuation::Attenuation0dB => ADC1_INIT_CODE_ATTEN0,
             Attenuation::Attenuation2p5dB => ADC1_INIT_CODE_ATTEN1,
@@ -84,7 +84,7 @@ impl Efuse {
 
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42>
     pub fn get_rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::Attenuation0dB => 400,
@@ -96,7 +96,7 @@ impl Efuse {
 
     /// Get ADC reference point digital code for specified attenuation
     ///
-    /// see https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42
+    /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42>
     pub fn get_rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
         let version = Self::get_rtc_calib_version();
 
@@ -104,7 +104,7 @@ impl Efuse {
             return None;
         }
 
-        // See https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L153-L156
+        // See <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L153-L156>
         let cal_code: u16 = Self::read_field_le(match atten {
             Attenuation::Attenuation0dB => ADC1_CAL_VOL_ATTEN0,
             Attenuation::Attenuation2p5dB => ADC1_CAL_VOL_ATTEN1,

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -34,17 +34,16 @@
 //! - Use the [`SpiBus`](embedded_hal_1::spi::SpiBus) trait (requires the "eh1"
 //!   feature) and its associated functions to initiate transactions with
 //!   simultaneous reads and writes, or
-//! - Use the [`SpiBusWrite`](embedded_hal_1::spi::SpiBusWrite) and
-//!   [`SpiBusRead`](embedded_hal_1::spi::SpiBusRead) traits (requires the "eh1"
-//!   feature) and their associated functions to read or write mutiple bytes at
-//!   a time.
+// TODO async moved to embedded-hal-bus:
+//! - Use the `ExclusiveDevice` struct from `embedded-hal-bus` or
+//!   `embedded-hal-async` (recommended).
 //!
 //!
 //! ## Shared SPI access
 //!
 //! If you have multiple devices on the same SPI bus that each have their own CS
-//! line, you may want to have a look at the [`SpiBusController`] and
-//! [`SpiBusDevice`] implemented here. These give exclusive access to the
+//! line, you may want to have a look at the [`ehal1::SpiBusController`] and
+//! [`ehal1::SpiBusDevice`] implemented here. These give exclusive access to the
 //! underlying SPI bus by means of a Mutex. This ensures that device
 //! transactions do not interfere with each other.
 
@@ -2408,7 +2407,7 @@ pub trait Instance {
     /// sequential transfers are performed. This function will return before
     /// all bytes of the last chunk to transmit have been sent to the wire. If
     /// you must ensure that the whole messages was written correctly, use
-    /// [`flush`].
+    /// [`Self::flush`].
     // FIXME: See below.
     fn write_bytes(&mut self, words: &[u8]) -> Result<(), Error> {
         let reg_block = self.register_block();
@@ -2472,7 +2471,7 @@ pub trait Instance {
     ///
     /// Sends out a stuffing byte for every byte to read. This function doesn't
     /// perform flushing. If you want to read the response to something you
-    /// have written before, consider using [`transfer`] instead.
+    /// have written before, consider using [`Self::transfer`] instead.
     fn read_bytes(&mut self, words: &mut [u8]) -> Result<(), Error> {
         let empty_array = [EMPTY_WRITE_PAD; FIFO_SIZE];
 
@@ -2488,7 +2487,7 @@ pub trait Instance {
     ///
     /// Copies the contents of the SPI receive FIFO into `words`. This function
     /// doesn't perform flushing. If you want to read the response to
-    /// something you have written before, consider using [`transfer`]
+    /// something you have written before, consider using [`Self::transfer`]
     /// instead.
     // FIXME: Using something like `core::slice::from_raw_parts` and
     // `copy_from_slice` on the receive registers works only for the esp32 and

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -2,6 +2,7 @@
 //! marking interrupt handlers.
 
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![deny(warnings)]
 
 use darling::{ast::NestedMeta, FromMeta};
 use proc_macro::{self, Span, TokenStream};

--- a/esp-hal-smartled/.cargo/config.toml
+++ b/esp-hal-smartled/.cargo/config.toml
@@ -1,0 +1,18 @@
+[target.xtensa-esp32s2-none-elf]
+rustflags = [
+  # enable the atomic codegen option for Xtensa
+  "-C", "target-feature=+s32c1i",
+
+  # tell the core library have atomics even though it's not specified in the target definition
+  "--cfg", "target_has_atomic_load_store",
+  "--cfg", 'target_has_atomic_load_store="8"',
+  "--cfg", 'target_has_atomic_load_store="16"',
+  "--cfg", 'target_has_atomic_load_store="32"',
+  "--cfg", 'target_has_atomic_load_store="ptr"',
+  # enable cas
+  "--cfg", "target_has_atomic",
+  "--cfg", 'target_has_atomic="8"',
+  "--cfg", 'target_has_atomic="16"',
+  "--cfg", 'target_has_atomic="32"',
+  "--cfg", 'target_has_atomic="ptr"',
+]

--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -26,8 +26,9 @@
 //! ```
 
 #![no_std]
-#![deny(missing_docs)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![deny(missing_docs)]
+#![deny(warnings)]
 
 use core::slice::IterMut;
 

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -51,7 +51,7 @@ extern "C" {
 /// never returns.
 #[link_section = ".init.rust"]
 #[export_name = "_start_rust"]
-pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
+extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
     extern "Rust" {
         // This symbol will be provided by the user via `#[entry]`
         fn main(a0: usize, a1: usize, a2: usize) -> !;
@@ -62,11 +62,13 @@ pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
 
     }
 
-    __post_init();
+    unsafe {
+        __post_init();
 
-    _setup_interrupts();
+        _setup_interrupts();
 
-    main(a0, a1, a2);
+        main(a0, a1, a2);
+    }
 }
 
 /// Registers saved in trap handler
@@ -118,7 +120,7 @@ pub struct TrapFrame {
 /// ExceptionHandler or one of the core interrupt handlers is called.
 #[link_section = ".trap.rust"]
 #[export_name = "_start_trap_rust"]
-pub unsafe extern "C" fn start_trap_rust(trap_frame: *const TrapFrame) {
+extern "C" fn start_trap_rust(trap_frame: *const TrapFrame) {
     extern "C" {
         fn ExceptionHandler(trap_frame: &TrapFrame);
         fn DefaultHandler();

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -15,6 +15,7 @@
 
 // NOTE: Adapted from riscv-rt/src/lib.rs
 #![no_std]
+#![deny(warnings)]
 
 use core::arch::global_asm;
 

--- a/esp32h2-hal/examples/rmt_tx.rs
+++ b/esp32h2-hal/examples/rmt_tx.rs
@@ -20,7 +20,7 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 

--- a/esp32s3-hal/examples/rmt_tx.rs
+++ b/esp32s3-hal/examples/rmt_tx.rs
@@ -18,7 +18,6 @@ use esp_hal_common::{
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
     Rmt,
 };
-use esp_println::println;
 
 #[entry]
 fn main() -> ! {


### PR DESCRIPTION
This PR updates the PR template to remove checklist items that are covered by CI. The PR also ensures that warnings are rejected by CI where possible (sadly, not for examples).

- CI now sets the correct CPU target triples where necessary, mostly to prevent weird asm macro warnings
- Clippy checks now correctly apply config.toml settings
- Some paths have been replaced by existing imports
- Bracketed names in efuse descriptions are now inline code. It helps with readability besides preventing link warnings.
- Fixed broken doc links
- enabled `eh1` feature for rustdoc so that ehal1 references don't trigger warnings
- Fixed some spelling mistakes in RMT, which affects the public API, too
- `:(` warnings in examples are not denied because -D warnings breaks some of them (by ignoring flags from config.toml)

I've tried to not use `#[deny(warnings)]` as it is an antipattern and has the potential of breaking future code. Unfortunately, other attempts (`RUSTFLAG`, `cargo rustc -- -D warnings`) have failed and I'm out of ideas besides grepping for warnings or using a github action if one exists. These latter ideas seemed way too much work for today and at this point I'm sufficiently frustrated.