### PR TITLE
Fix RMT spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add initial LP-IO support for ESP32-C6 (#639)
 - Implement sleep with some wakeup methods for `esp32` (#574)
-- Add a new RMT driver (#653)
+- Add a new RMT driver (#653, #667)
 
 ### Changed
 


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

This PR is taken from #666 and fixes the typos in the RMT driver. The changes affect the public API so the PR is added to the changelog, next to the RMT implementation.