### PR TITLE
Ci: test crates with the intended targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,21 +425,21 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
-          components: clippy
+          toolchain: nightly
+          components: clippy, rust-src
       - uses: Swatinem/rust-cache@v2
 
       # Run clippy on all packages targeting RISC-V.
       - name: clippy (esp-riscv-rt)
-        run: cargo +stable clippy --manifest-path=esp-riscv-rt/Cargo.toml -- --no-deps
+        run: cd esp-riscv-rt/ && cargo +nightly clippy -- --no-deps
       - name: clippy (esp32c2-hal)
-        run: cargo +stable clippy --manifest-path=esp32c2-hal/Cargo.toml -- --no-deps
+        run: cd esp32c2-hal/ && cargo +nightly clippy -- --no-deps
       - name: clippy (esp32c3-hal)
-        run: cargo +stable clippy --manifest-path=esp32c3-hal/Cargo.toml -- --no-deps
+        run: cd esp32c3-hal/ && cargo +nightly clippy -- --no-deps
       - name: clippy (esp32c6-hal)
-        run: cargo +stable clippy --manifest-path=esp32c6-hal/Cargo.toml -- --no-deps
+        run: cd esp32c6-hal/ && cargo +nightly clippy -- --no-deps
       - name: clippy (esp32h2-hal)
-        run: cargo +stable clippy --manifest-path=esp32h2-hal/Cargo.toml -- --no-deps
+        run: cd esp32h2-hal/ && cargo +nightly clippy -- --no-deps
 
   clippy-xtensa:
     runs-on: ubuntu-latest
@@ -456,11 +456,11 @@ jobs:
       # The ESP32-S2 requires some additional information in order for the
       # atomic emulation crate to build.
       - name: clippy (esp32-hal)
-        run: cargo +esp clippy --manifest-path=esp32-hal/Cargo.toml -- --no-deps
+        run: cd esp32-hal/ && cargo +esp clippy -- --no-deps
       - name: clippy (esp32s2-hal)
-        run: cargo +esp clippy --manifest-path=esp32s2-hal/Cargo.toml -- --no-deps
+        run: cd esp32s2-hal/ && cargo +esp clippy -- --no-deps
       - name: clippy (esp32s3-hal)
-        run: cargo +esp clippy --manifest-path=esp32s3-hal/Cargo.toml -- --no-deps
+        run: cd esp32s3-hal/ && cargo +esp clippy -- --no-deps
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,21 +45,21 @@ jobs:
 
       # Check all RISC-V targets:
       - name: check (esp32c3)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c3
+        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c3 --target=riscv32imc-unknown-none-elf
       - name: check (esp32c6)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c6
+        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c6 --target=riscv32imac-unknown-none-elf
       - name: check (esp32h2)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32h2
+        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32h2 --target=riscv32imac-unknown-none-elf
       # Check all Xtensa targets:
       - name: check (esp32)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32,esp32_40mhz
+        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32,esp32_40mhz --target=xtensa-esp32-none-elf -Zbuild-std=core
       - name: check (esp32s2)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s2
+        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s2 --target=xtensa-esp32s2-none-elf -Zbuild-std=core
       - name: check (esp32s3)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s3
+        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s3 --target=xtensa-esp32s3-none-elf -Zbuild-std=core
       # Ensure documentation can be built (requires a chip feature!)
       - name: rustdoc
-        run: cd esp-hal-smartled/ && cargo doc --features=esp32c3,esp-hal-common/eh1
+        run: cd esp-hal-smartled/ && cargo doc --features=esp32c3,esp-hal-common/eh1 --target=riscv32imc-unknown-none-elf
 
   esp32-hal:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,9 @@ jobs:
       - name: check esp32c2-hal (async, i2c)
         run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c2-hal (interrupt-preemption)
-        run: cd esp32c2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c2-hal (direct-vectoring)
-        run: cd esp32c2-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c2-hal/ && cargo doc --features=eh1
@@ -178,9 +178,9 @@ jobs:
       - name: check esp32c3-hal (async, i2c)
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c3-hal (interrupt-preemption)
-        run: cd esp32c3-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c3-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c3-hal (direct-vectoring)
-        run: cd esp32c3-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c3-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c3-hal/ && cargo doc --features=eh1
@@ -222,9 +222,9 @@ jobs:
       - name: check esp32c6-hal (async, i2c)
         run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (interrupt-preemption)
-        run: cd esp32c6-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c6-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c6-hal (direct-vectoring)
-        run: cd esp32c6-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c6-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c6-hal/ && cargo doc --features=eh1
@@ -266,9 +266,9 @@ jobs:
       - name: check esp32h2-hal (async, i2c)
         run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32h2-hal (interrupt-preemption)
-        run: cd esp32h2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32h2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32h2-hal (direct-vectoring)
-        run: cd esp32h2-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32h2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32h2-hal/ && cargo doc --features=eh1

--- a/esp-hal-smartled/.cargo/config.toml
+++ b/esp-hal-smartled/.cargo/config.toml
@@ -1,0 +1,18 @@
+[target.xtensa-esp32s2-none-elf]
+rustflags = [
+  # enable the atomic codegen option for Xtensa
+  "-C", "target-feature=+s32c1i",
+
+  # tell the core library have atomics even though it's not specified in the target definition
+  "--cfg", "target_has_atomic_load_store",
+  "--cfg", 'target_has_atomic_load_store="8"',
+  "--cfg", 'target_has_atomic_load_store="16"',
+  "--cfg", 'target_has_atomic_load_store="32"',
+  "--cfg", 'target_has_atomic_load_store="ptr"',
+  # enable cas
+  "--cfg", "target_has_atomic",
+  "--cfg", 'target_has_atomic="8"',
+  "--cfg", 'target_has_atomic="16"',
+  "--cfg", 'target_has_atomic="32"',
+  "--cfg", 'target_has_atomic="ptr"',
+]


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

This PR is taken from #666 and changes CI to check crates with the intended target. This is not extremely important but prevents weird cases where Xtensa/RISC-V asm is checked as x86 and produces warnings. This PR also ensures that the correct rustflags are set where necessary (i.e. checking S2 vs atomics).