### PR TITLE
Fix GPIO interrupt status not being cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - USB device support is working again (#656)
 - Add missing interrupt status read for esp32s3, which fixes USB-SERIAL-JTAG interrupts (#664)
+- GPIO interrupt status bits are now properly cleared (#670)
 
 ### Removed
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1857,11 +1857,12 @@ mod asynch {
             intrs
         );
 
-        while intrs != 0 {
-            let pin_nr = intrs.trailing_zeros();
+        let mut intr_bits = intrs;
+        while intr_bits != 0 {
+            let pin_nr = intr_bits.trailing_zeros();
             set_int_enable(pin_nr as u8, 0, 0, false);
             PIN_WAKERS[pin_nr as usize].wake(); // wake task
-            intrs &= !(1 << pin_nr);
+            intr_bits &= !(1 << pin_nr);
         }
 
         // clear interrupt bits

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1859,6 +1859,8 @@ mod asynch {
 
         let mut intr_bits = intrs;
         while intr_bits != 0 {
+            // TODO: we should probably call `leading_zeros` on Xtensa
+            // when that lowers to NSAU.
             let pin_nr = intr_bits.trailing_zeros();
             set_int_enable(pin_nr as u8, 0, 0, false);
             PIN_WAKERS[pin_nr as usize].wake(); // wake task

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1862,7 +1862,7 @@ mod asynch {
             let pin_nr = intr_bits.trailing_zeros();
             set_int_enable(pin_nr as u8, 0, 0, false);
             PIN_WAKERS[pin_nr as usize].wake(); // wake task
-            intr_bits &= !(1 << pin_nr);
+            intr_bits -= 1 << pin_nr;
         }
 
         // clear interrupt bits


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

This PR fixes an issue where `write_interrupt_status_clear` was always called with `0` as its argument, because the processing loop cleared the status bits. We also clear the bits by subtracting them instead of creating a mask first to and with - hopefully this optimizes better, too.