### PR TITLE
Only implement RTCPin for actual RTCIO pins

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1426,43 +1426,40 @@ macro_rules! gpio {
 #[macro_export]
 macro_rules! rtc_pins {
     (
-        $( ( $pin_num:expr, $rtc_pin:expr, $pin_reg:expr, $prefix:pat ) )+
+        $pin_num:expr, $rtc_pin:expr, $pin_reg:expr, $prefix:pat
     ) => {
-        impl<MODE, const GPIONUM: u8> crate::gpio::RTCPin for GpioPin<MODE, GPIONUM>
+        impl<MODE> crate::gpio::RTCPin for GpioPin<MODE, $pin_num>
         where
             Self: crate::gpio::GpioProperties,
-            <Self as crate::gpio::GpioProperties>::PinType: crate::gpio::IsAnalogPin,
         {
             fn rtc_number(&self) -> u8 {
-                match GPIONUM {
-                    $(
-                        $pin_num => $rtc_pin,
-                    )+
-                    _ => unreachable!(),
-                }
+                $rtc_pin
             }
+
             /// Set the RTC properties of the pin. If `mux` is true then then pin is
             /// routed to RTC, when false it is routed to IO_MUX.
             fn rtc_set_config(&mut self, input_enable: bool, mux: bool, func: u8) {
                 use crate::peripherals::RTC_IO;
                 let rtcio = unsafe{ &*RTC_IO::ptr() };
-                match GPIONUM {
-                    $(
-                        $pin_num => {
-                            // disable input
-                            paste::paste!{
-                                rtcio.$pin_reg.modify(|_,w| unsafe {w
-                                    .[<$prefix fun_ie>]().bit(input_enable)
-                                    .[<$prefix mux_sel>]().bit(mux)
-                                    .[<$prefix fun_sel>]().bits(func)
-                                });
-                            }
-                        }
-                    )+
-                        _ => unreachable!(),
+
+                // disable input
+                paste::paste!{
+                    rtcio.$pin_reg.modify(|_,w| unsafe {w
+                        .[<$prefix fun_ie>]().bit(input_enable)
+                        .[<$prefix mux_sel>]().bit(mux)
+                        .[<$prefix fun_sel>]().bits(func)
+                    });
                 }
             }
         }
+    };
+
+    (
+        $( ( $pin_num:expr, $rtc_pin:expr, $pin_reg:expr, $prefix:pat ) )+
+    ) => {
+        $(
+            crate::gpio::rtc_pins!($pin_num, $rtc_pin, $pin_reg, $prefix);
+        )+
     };
 }
 


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

Previously, RTCPin was implemented for all GpioPin: IsAnalogPin. This is somewhat incorrect as, for example, the S3 has RTCIO pins that are not analog, or, at least they don't have analog functions (RTC_GPIO0, RTC_GPIO21). Either way, relying on IsAnalogPin seems more fragile than it should be, so let's implement RTCPin for the pins that are listed in the rtc_pins! macro invocation.

One bonus of this PR is that implementing pullup/pulldown control will become simpler as I will not need to write unnecessary matches and unreachable branches, I think :)