### PR TITLE
Split up GPIO handling into two loops

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1826,38 +1826,43 @@ mod asynch {
 
     #[interrupt]
     unsafe fn GPIO() {
-        let mut intrs = match crate::get_core() {
+        let intrs_bank0 = match crate::get_core() {
             crate::Cpu::ProCpu => {
-                InterruptStatusRegisterAccessBank0::pro_cpu_interrupt_status_read() as u64
+                InterruptStatusRegisterAccessBank0::pro_cpu_interrupt_status_read()
             }
             #[cfg(multi_core)]
             crate::Cpu::AppCpu => {
-                InterruptStatusRegisterAccessBank0::app_cpu_interrupt_status_read() as u64
+                InterruptStatusRegisterAccessBank0::app_cpu_interrupt_status_read()
             }
         };
 
         #[cfg(any(esp32, esp32s2, esp32s3))]
-        match crate::get_core() {
+        let intrs_bank1 = match crate::get_core() {
             crate::Cpu::ProCpu => {
-                intrs |= (InterruptStatusRegisterAccessBank1::pro_cpu_interrupt_status_read()
-                    as u64)
-                    << 32
+                InterruptStatusRegisterAccessBank1::pro_cpu_interrupt_status_read()
             }
             #[cfg(multi_core)]
             crate::Cpu::AppCpu => {
-                intrs |= (InterruptStatusRegisterAccessBank1::app_cpu_interrupt_status_read()
-                    as u64)
-                    << 32
+                InterruptStatusRegisterAccessBank1::app_cpu_interrupt_status_read()
             }
         };
 
+        #[cfg(not(any(esp32, esp32s2, esp32s3)))]
         log::trace!(
-            "Handling interrupt on {:?} - {:064b}",
+            "Handling interrupt on {:?} - {:032b}",
             crate::get_core(),
-            intrs
+            intrs_bank0,
         );
 
-        let mut intr_bits = intrs;
+        #[cfg(any(esp32, esp32s2, esp32s3))]
+        log::trace!(
+            "Handling interrupt on {:?} - {:032b}{:032b}",
+            crate::get_core(),
+            intrs_bank1,
+            intrs_bank0,
+        );
+
+        let mut intr_bits = intrs_bank0;
         while intr_bits != 0 {
             // TODO: we should probably call `leading_zeros` on Xtensa
             // when that lowers to NSAU.
@@ -1868,8 +1873,20 @@ mod asynch {
         }
 
         // clear interrupt bits
-        Bank0GpioRegisterAccess::write_interrupt_status_clear(intrs as u32);
+        Bank0GpioRegisterAccess::write_interrupt_status_clear(intrs_bank0);
+
         #[cfg(any(esp32, esp32s2, esp32s3))]
-        Bank1GpioRegisterAccess::write_interrupt_status_clear((intrs >> 32) as u32);
+        {
+            let mut intr_bits = intrs_bank1;
+            while intr_bits != 0 {
+                // TODO: we should probably call `leading_zeros` on Xtensa
+                // when that lowers to NSAU.
+                let pin_nr = intr_bits.trailing_zeros();
+                set_int_enable(pin_nr as u8 + 32, 0, 0, false);
+                PIN_WAKERS[pin_nr as usize + 32].wake(); // wake task
+                intr_bits -= 1 << pin_nr;
+            }
+            Bank1GpioRegisterAccess::write_interrupt_status_clear(intrs_bank1);
+        }
     }
 }


### PR DESCRIPTION
As requested (https://github.com/esp-rs/esp-hal/pull/670#issuecomment-1646617274). Let's call this change is an experiment to see if the reduced instruction count of a single loop, or the simpler algorithms of working with native word sizes are more important.