### PR TITLE
Don't clear interrupt status in `PinFuture`

### DIFF
--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1781,8 +1781,6 @@ mod asynch {
         P: crate::gpio::Pin + embedded_hal_1::digital::ErrorType,
     {
         pub fn new(pin: &'a mut P, event: Event) -> Self {
-            pin.clear_interrupt(); // clear stale interrupt flags, when we await we want to know when an event
-                                   // occurs from the await call, not if the pin event has happened recently.
             pin.listen(event);
             Self { pin }
         }


### PR DESCRIPTION
`PinFuture` **should** not need to clear the interrupt status. `PinFuture` resolves if its interrupt source is no longer active, it is not dependent on the interrupt status.