### PR TITLE
WIP fix for ROM data transfers

### DIFF
--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -22,6 +22,8 @@ pub enum DmaError {
     Overflow,
     Exhausted,
     BufferTooSmall,
+    RxBufferNotInRam,
+    TxBufferNotInRam,
 }
 
 /// DMA Priorities
@@ -362,6 +364,10 @@ where
             return Err(DmaError::BufferTooSmall);
         }
 
+        if !crate::soc::is_valid_ram_address(data as u32) {
+            return Err(DmaError::RxBufferNotInRam);
+        }
+
         self.available = 0;
         self.read_descr_ptr = self.descriptors.as_ptr() as *const u32;
         self.last_seen_handled_descriptor_ptr = core::ptr::null();
@@ -662,6 +668,10 @@ where
 
         if circular && len < CHUNK_SIZE * 2 {
             return Err(DmaError::BufferTooSmall);
+        }
+
+        if !crate::soc::is_valid_ram_address(data as u32) {
+            return Err(DmaError::TxBufferNotInRam);
         }
 
         self.write_offset = 0;

--- a/esp-hal-common/src/soc/mod.rs
+++ b/esp-hal-common/src/soc/mod.rs
@@ -10,3 +10,43 @@ pub use self::soc::*;
 mod soc;
 
 mod efuse_field;
+
+
+pub fn is_valid_ram_address(address: u32) -> bool {
+    #[cfg(feature = "esp32")]
+    if !(0x3FFA_E000..=0x4000_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32c2")]
+    if !(0x3FCA_0000..=0x3FCE_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32c3")]
+    if !(0x3FC8_0000..=0x3FCE_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32c6")]
+    if !(0x4080_0000..=0x4088_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32s2")]
+    if !(0x3FFB_0000..=0x4000_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32s3")]
+    if !(0x3FC8_8000..=0x3FD0_0000).contains(&address) {
+        return false;
+    }
+
+    #[cfg(feature = "esp32h2")]
+    if !(0x4080_0000..=0x4085_0000).contains(&address) {
+        return false;
+    }
+
+    true
+}


### PR DESCRIPTION
Opening as a draft for early feedback. @bjoernQ I'm not sure I'm attacking this in the right place, I don't know if I should be handling this in the DMA driver instead. It would also be nice to only allocate this tmp stack buffer on the bad path, via a closure or something.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
