### PR TITLE
S3: Set wifi clock enable bits in the correct register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing interrupt status read for esp32s3, which fixes USB-SERIAL-JTAG interrupts (#664)
 - GPIO interrupt status bits are now properly cleared (#670)
 - Increase frequency resolution in `set_periodic` (#686)
+- Fixed ESP32-S3 radio clock gating (#679)
 
 ### Removed
 


### PR DESCRIPTION
This PR fixes [esp-wifi/#211](https://github.com/esp-rs/esp-wifi/issues/211). The previous code modified bits in a different clock enable register, which turned off a bunch of peripherals it wasn't supposed to. This PR fixes this issue by copying esp-idf's related code (and removing seemingly nonsense operations from those).

I suspect the other lines need to be fixed as well, but I only have an ESP32-S3 at hand.