### PR TITLE
Clean up regi2c related warnings

### DIFF
--- a/esp-hal-common/src/rom/mod.rs
+++ b/esp-hal-common/src/rom/mod.rs
@@ -25,6 +25,7 @@ extern "C" {
 macro_rules! regi2c_write {
     ( $block: ident, $reg_add: ident, $indata: expr ) => {
         paste::paste! {
+            #[allow(unused_unsafe)]
             unsafe {
                 crate::rom::rom_i2c_writeReg(
                     $block as u32,
@@ -42,6 +43,7 @@ macro_rules! regi2c_write {
 macro_rules! regi2c_write_mask {
     ( $block: ident, $reg_add: ident, $indata: expr ) => {
         paste::paste! {
+            #[allow(unused_unsafe)]
             unsafe {
                 crate::rom::rom_i2c_writeReg_Mask(
                     $block as u32,

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32s3_sleep.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32s3_sleep.rs
@@ -9,7 +9,6 @@ use super::{
 use crate::{
     gpio::{Pin, RTCPin, RtcFunction},
     regi2c_write_mask,
-    rom::rom_i2c_writeReg_Mask,
     rtc_cntl::{Clock, RtcClock},
     Rtc,
 };


### PR DESCRIPTION
#660 and #641 interfered a bit and together they ended up introducing a bunch of "unnecessary unsafe block" warnings. This PR clears this up.