### PR TITLE
Switch to micros instead of millis in `set_periodic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - USB device support is working again (#656)
 - Add missing interrupt status read for esp32s3, which fixes USB-SERIAL-JTAG interrupts (#664)
 - GPIO interrupt status bits are now properly cleared (#670)
+- Increase frequency resolution in `set_periodic` (#686)
 
 ### Removed
 

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -2,7 +2,7 @@
 
 use core::{intrinsics::transmute, marker::PhantomData};
 
-use fugit::MillisDurationU32;
+use fugit::MicrosDurationU32;
 
 use crate::{
     peripheral::{Peripheral, PeripheralRef},
@@ -202,14 +202,14 @@ impl<const CHANNEL: u8> Alarm<Target, CHANNEL> {
 
 impl<const CHANNEL: u8> Alarm<Periodic, CHANNEL> {
     pub fn set_period(&self, period: fugit::HertzU32) {
-        let time_period: MillisDurationU32 = period.into_duration();
-        let cycles = time_period.ticks();
+        let time_period: MicrosDurationU32 = period.into_duration();
+        let us = time_period.ticks();
         self.configure(|tconf, hi, lo| unsafe {
             tconf.write(|w| {
                 w.target0_period_mode()
                     .set_bit()
                     .target0_period()
-                    .bits(cycles * (SystemTimer::TICKS_PER_SECOND as u32 / 1000))
+                    .bits(us * (SystemTimer::TICKS_PER_SECOND as u32 / 1000_000))
             });
             hi.write(|w| w.timer_target0_hi().bits(0));
             lo.write(|w| w.timer_target0_lo().bits(0));


### PR DESCRIPTION
This gives more fine-grain control to allow higher frequencies.

Closes #685 

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
