### PR TITLE
Pin and RTCPin improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - `DmaTransfer::wait` and `I2sReadDmaTransfer::wait_receive` now return `Result` (#665)
+- `gpio::Pin` is now object-safe (#687)
 
 ## [0.10.0] - 2023-06-04
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -110,9 +110,9 @@ pub trait AnalogPin {}
 pub trait Pin {
     fn number(&self) -> u8;
 
-    fn sleep_mode(&mut self, on: bool) -> &mut Self;
+    fn sleep_mode(&mut self, on: bool);
 
-    fn set_alternate_function(&mut self, alternate: AlternateFunction) -> &mut Self;
+    fn set_alternate_function(&mut self, alternate: AlternateFunction);
 
     fn listen(&mut self, event: Event) {
         self.listen_with_options(event, true, false, false)
@@ -629,15 +629,12 @@ where
         GPIONUM
     }
 
-    fn sleep_mode(&mut self, on: bool) -> &mut Self {
+    fn sleep_mode(&mut self, on: bool) {
         get_io_mux_reg(GPIONUM).modify(|_, w| w.slp_sel().bit(on));
-
-        self
     }
 
-    fn set_alternate_function(&mut self, alternate: AlternateFunction) -> &mut Self {
+    fn set_alternate_function(&mut self, alternate: AlternateFunction) {
         get_io_mux_reg(GPIONUM).modify(|_, w| unsafe { w.mcu_sel().bits(alternate as u8) });
-        self
     }
 
     fn listen_with_options(

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -97,7 +97,7 @@ pub enum RtcFunction {
     Digital = 1,
 }
 
-pub trait RTCPin {
+pub trait RTCPin: Pin {
     fn rtc_number(&self) -> u8;
     fn rtc_set_config(&mut self, input_enable: bool, mux: bool, func: RtcFunction);
 }


### PR DESCRIPTION
 - `RTCPin` now extends Pin
 - `Pin` is now object-safe

This change allows, for example, reading a pin's pin_number when one only has a `&dyn RTCPin`.