### PR TITLE
Deep sleep: Decouple pin and slice lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new RMT driver (#653, #667)
 - Implemented calibrated ADC API for ESP32-S3 (#641)
 - Add MCPWM DeadTime configuration (#406)
-- Implement sleep with some wakeup methods for `esp32-s3` (#660)
+- Implement sleep with some wakeup methods for `esp32-s3` (#660, #689)
 
 ### Changed
 

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32_sleep.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32_sleep.rs
@@ -65,7 +65,7 @@ impl WakeSource for TimerWakeupSource {
     }
 }
 
-impl<'a, P: Pin + RTCPin> WakeSource for Ext0WakeupSource<'a, P> {
+impl<P: Pin + RTCPin> WakeSource for Ext0WakeupSource<'_, P> {
     fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
@@ -91,7 +91,7 @@ impl<'a, P: Pin + RTCPin> WakeSource for Ext0WakeupSource<'a, P> {
     }
 }
 
-impl<'a, P: Pin + RTCPin> Drop for Ext0WakeupSource<'a, P> {
+impl<P: Pin + RTCPin> Drop for Ext0WakeupSource<'_, P> {
     fn drop(&mut self) {
         // should we have saved the pin configuration first?
         // set pin back to IO_MUX (input_enable and func have no effect when pin is sent
@@ -102,7 +102,7 @@ impl<'a, P: Pin + RTCPin> Drop for Ext0WakeupSource<'a, P> {
     }
 }
 
-impl<'a> WakeSource for Ext1WakeupSource<'a> {
+impl WakeSource for Ext1WakeupSource<'_, '_> {
     fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
@@ -130,7 +130,7 @@ impl<'a> WakeSource for Ext1WakeupSource<'a> {
     }
 }
 
-impl<'a> Drop for Ext1WakeupSource<'a> {
+impl Drop for Ext1WakeupSource<'_, '_> {
     fn drop(&mut self) {
         // should we have saved the pin configuration first?
         // set pin back to IO_MUX (input_enable and func have no effect when pin is sent

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32s3_sleep.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32s3_sleep.rs
@@ -110,7 +110,7 @@ impl WakeSource for TimerWakeupSource {
     }
 }
 
-impl<'a, P: Pin + RTCPin> WakeSource for Ext0WakeupSource<'a, P> {
+impl<P: Pin + RTCPin> WakeSource for Ext0WakeupSource<'_, P> {
     fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
@@ -136,7 +136,7 @@ impl<'a, P: Pin + RTCPin> WakeSource for Ext0WakeupSource<'a, P> {
     }
 }
 
-impl<'a, P: Pin + RTCPin> Drop for Ext0WakeupSource<'a, P> {
+impl<P: Pin + RTCPin> Drop for Ext0WakeupSource<'_, P> {
     fn drop(&mut self) {
         // should we have saved the pin configuration first?
         // set pin back to IO_MUX (input_enable and func have no effect when pin is sent
@@ -147,7 +147,7 @@ impl<'a, P: Pin + RTCPin> Drop for Ext0WakeupSource<'a, P> {
     }
 }
 
-impl<'a> WakeSource for Ext1WakeupSource<'a> {
+impl WakeSource for Ext1WakeupSource<'_, '_> {
     fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
@@ -179,7 +179,7 @@ impl<'a> WakeSource for Ext1WakeupSource<'a> {
     }
 }
 
-impl<'a> Drop for Ext1WakeupSource<'a> {
+impl Drop for Ext1WakeupSource<'_, '_> {
     fn drop(&mut self) {
         // should we have saved the pin configuration first?
         // set pin back to IO_MUX (input_enable and func have no effect when pin is sent

--- a/esp-hal-common/src/rtc_cntl/sleep.rs
+++ b/esp-hal-common/src/rtc_cntl/sleep.rs
@@ -51,13 +51,13 @@ impl<'a, P: RTCPin + Pin> Ext0WakeupSource<'a, P> {
     }
 }
 
-pub struct Ext1WakeupSource<'a> {
-    pins: RefCell<&'a mut [&'a mut dyn RTCPin]>,
+pub struct Ext1WakeupSource<'a, 'b> {
+    pins: RefCell<&'a mut [&'b mut dyn RTCPin]>,
     level: WakeupLevel,
 }
 
-impl<'a> Ext1WakeupSource<'a> {
-    pub fn new(pins: &'a mut [&'a mut dyn RTCPin], level: WakeupLevel) -> Self {
+impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
+    pub fn new(pins: &'a mut [&'b mut dyn RTCPin], level: WakeupLevel) -> Self {
         Self {
             pins: RefCell::new(pins),
             level,


### PR DESCRIPTION
This change allows collecting exti1 pin references in a `heapless::Vec` for example without running into lifetime issues.