### PR TITLE
Add basic spi compile doctest

### DIFF
--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -22,7 +22,7 @@
 //! [esp32s2-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32s2-hal
 //! [esp32s3-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32s3-hal
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]
 #![cfg_attr(
     feature = "async",

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -4,14 +4,27 @@
 //! which way you choose, you must first create an SPI instance with
 //! [`Spi::new`].
 //!
-//! ```rust
+//! ```rust,no_run
+//! # #![no_std]
+//! # use esp_hal_common::{IO, clock::ClockControl, peripherals::Peripherals, prelude::*, spi::{Spi, SpiMode}};
+//! # fn main () {
+//! # let peripherals = Peripherals::take();
+//! # #[cfg(system)]
+//! # let mut system = peripherals.SYSTEM.split();
+//! # #[cfg(pcr)]
+//! # let mut system = peripherals.PCR.split();
+//! # #[cfg(dport)]
+//! # let mut system = peripherals.DPORT.split();
+//! # let mut peripheral_clock_control = system.peripheral_clock_control;
+//! # let mut clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+//! # 
 //! let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 //! let sclk = io.pins.gpio12;
 //! let miso = io.pins.gpio11;
 //! let mosi = io.pins.gpio13;
 //! let cs = io.pins.gpio10;
 //!
-//! let mut spi = hal::spi::Spi::new(
+//! let mut spi = Spi::new(
 //!     peripherals.SPI2,
 //!     sclk,
 //!     mosi,
@@ -22,6 +35,11 @@
 //!     &mut peripheral_clock_control,
 //!     &mut clocks,
 //! );
+//! # }
+//! # #[panic_handler]
+//! # fn panic(_ : &core::panic::PanicInfo) -> ! {
+//! #     loop {}
+//! # }
 //! ```
 //!
 //! ## Exclusive access to the SPI bus


### PR DESCRIPTION
Run with `cd esp-hal-common` & `cargo test --doc -Zdoctest-xcompile --features esp32c3 --target riscv32imc-unknown-none-elf spi`.

It sucks that we need to add a panic handler, and that SYSTEM/DPORT/PCR needs to be cfg'd (maybe we should abstract this in a different way, or consider unifying the name), but other than that it works pretty well.

FYI this is what the final documentation looks like:

![image](https://github.com/esp-rs/esp-hal/assets/6977289/23af7d6e-4331-4a84-a317-0bf2d249d931)


## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
