### PR TITLE
S3 sleep: Clean up register access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new RMT driver (#653, #667, #695)
 - Implemented calibrated ADC API for ESP32-S3 (#641)
 - Add MCPWM DeadTime configuration (#406)
-- Implement sleep with some wakeup methods for `esp32-s3` (#660, #689)
+- Implement sleep with some wakeup methods for `esp32-s3` (#660, #689, #696)
 
 ### Changed
 


### PR DESCRIPTION
This PR cleans up #660 as it turns out that `SYSCON` is available as `pac::APB_CTRL`, and also `BB`, `SPI0` and `SPI1` exist.