### PR TITLE
S2: reexport SYSCON from PAC

### DIFF
--- a/esp-hal-common/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32s2/peripherals.rs
@@ -38,6 +38,7 @@ crate::peripherals! {
     SPI2 => true,
     SPI3 => true,
     SPI4 => true,
+    SYSCON => true,
     SYSTEM => true,
     SYSTIMER => true,
     TIMG0 => true,


### PR DESCRIPTION
Necessary for https://github.com/esp-rs/esp-wifi/pull/220