### PR TITLE
esp32c3: disable wdts in post_init

### DIFF
--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -768,6 +768,24 @@ where
             .wdtwprotect
             .write(|w| unsafe { w.wdt_wkey().bits(0u32) });
     }
+
+    pub unsafe fn force_set_wdt_enabled(enabled: bool) {
+        let reg_block = unsafe { &*TG::register_block() };
+
+        reg_block
+            .wdtwprotect
+            .write(|w| unsafe { w.wdt_wkey().bits(0x50D8_3AA1u32) });
+
+        if !enabled {
+            reg_block.wdtconfig0.write(|w| unsafe { w.bits(0) });
+        } else {
+            reg_block.wdtconfig0.write(|w| w.wdt_en().bit(true));
+        }
+
+        reg_block
+            .wdtwprotect
+            .write(|w| unsafe { w.wdt_wkey().bits(0u32) });
+    }
 }
 
 impl<TG> WatchdogDisable for Wdt<TG>

--- a/esp32c3-hal/examples/adc.rs
+++ b/esp32c3-hal/examples/adc.rs
@@ -11,9 +11,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -23,27 +21,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/adc_cal.rs
+++ b/esp32c3-hal/examples/adc_cal.rs
@@ -12,9 +12,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -24,27 +22,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -19,7 +19,6 @@ use esp32c3_hal::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
     },
-    Rtc,
     Uart,
     IO,
 };
@@ -33,26 +32,12 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32c3-hal/examples/aes.rs
+++ b/esp32c3-hal/examples/aes.rs
@@ -12,8 +12,6 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -23,26 +21,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
 

--- a/esp32c3-hal/examples/blinky.rs
+++ b/esp32c3-hal/examples/blinky.rs
@@ -5,43 +5,14 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set GPIO5 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c3-hal/examples/blinky_erased_pins.rs
+++ b/esp32c3-hal/examples/blinky_erased_pins.rs
@@ -10,9 +10,7 @@ use esp32c3_hal::{
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -21,27 +19,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set LED GPIOs as an output.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c3-hal/examples/crc.rs
+++ b/esp32c3-hal/examples/crc.rs
@@ -11,7 +11,6 @@ use esp32c3_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -23,7 +22,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
@@ -31,20 +29,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     timer0.start(1u64.secs());
 
     let data = "123456789";

--- a/esp32c3-hal/examples/debug_assist.rs
+++ b/esp32c3-hal/examples/debug_assist.rs
@@ -15,8 +15,6 @@ use esp32c3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -27,27 +25,7 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _ = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut da = DebugAssist::new(
         peripherals.ASSIST_DEBUG,

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -9,14 +9,7 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-use esp32c3_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use static_cell::StaticCell;
 
@@ -45,26 +38,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -72,7 +45,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {

--- a/esp32c3-hal/examples/embassy_i2c.rs
+++ b/esp32c3-hal/examples/embassy_i2c.rs
@@ -23,8 +23,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -52,26 +50,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -79,7 +57,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -17,8 +17,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -107,26 +105,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -134,7 +112,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -28,8 +28,6 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -70,26 +68,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -97,7 +75,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     esp32c3_hal::interrupt::enable(
         esp32c3_hal::peripherals::Interrupt::DMA_CH0,

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -15,8 +15,6 @@ use esp32c3_hal::{
     gpio::{Gpio9, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -41,26 +39,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -68,7 +46,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -16,9 +16,7 @@ use esp32c3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -29,27 +27,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set GPIO5 as an output
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -11,16 +11,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    peripherals,
-    prelude::*,
-    rmt::Rmt,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-    IO,
-};
+use esp32c3_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
 use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
 use smart_leds::{
@@ -35,18 +26,6 @@ fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdogs
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/hello_world.rs
+++ b/esp32c3-hal/examples/hello_world.rs
@@ -23,7 +23,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
@@ -31,19 +30,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -9,15 +9,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -26,26 +18,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/i2c_display.rs
+++ b/esp32c3-hal/examples/i2c_display.rs
@@ -19,15 +19,7 @@ use embedded_graphics::{
     prelude::*,
     text::{Alignment, Text},
 };
-use esp32c3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use nb::block;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
@@ -37,27 +29,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/i2s_read.rs
+++ b/esp32c3-hal/examples/i2s_read.rs
@@ -21,8 +21,6 @@ use esp32c3_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sReadDma, MclkPin, PinsBclkWsDin, Standard},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -33,26 +31,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/i2s_sound.rs
+++ b/esp32c3-hal/examples/i2s_sound.rs
@@ -57,26 +57,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);

--- a/esp32c3-hal/examples/interrupt_preemption.rs
+++ b/esp32c3-hal/examples/interrupt_preemption.rs
@@ -32,27 +32,6 @@ fn main() -> ! {
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 
     interrupt::enable(

--- a/esp32c3-hal/examples/ledc.rs
+++ b/esp32c3-hal/examples/ledc.rs
@@ -18,8 +18,6 @@ use esp32c3_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,26 +26,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -25,9 +25,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,27 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/read_efuse.rs
+++ b/esp32c3-hal/examples/read_efuse.rs
@@ -4,14 +4,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    efuse::Efuse,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, efuse::Efuse, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -20,26 +13,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     println!("MAC address {:02x?}", Efuse::get_mac_address());
     println!("Flash Encryption {:?}", Efuse::get_flash_encryption());

--- a/esp32c3-hal/examples/rmt_rx.rs
+++ b/esp32c3-hal/examples/rmt_rx.rs
@@ -12,10 +12,8 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, RxChannel, RxChannelConfig, RxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -28,19 +26,6 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks, &mut clock_control);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/rmt_tx.rs
+++ b/esp32c3-hal/examples/rmt_tx.rs
@@ -10,9 +10,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
-    timer::TimerGroup,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_hal_common::Delay;
@@ -23,19 +21,6 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks, &mut clock_control);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/rng.rs
+++ b/esp32c3-hal/examples/rng.rs
@@ -3,14 +3,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rng,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Rng};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -19,26 +12,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers:
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Instantiate the Random Number Generator peripheral:
     let mut rng = Rng::new(peripherals.RNG);

--- a/esp32c3-hal/examples/rsa.rs
+++ b/esp32c3-hal/examples/rsa.rs
@@ -23,8 +23,6 @@ use esp32c3_hal::{
         RsaMultiplication,
     },
     systimer::SystemTimer,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -60,26 +58,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
 

--- a/esp32c3-hal/examples/rtc_time.rs
+++ b/esp32c3-hal/examples/rtc_time.rs
@@ -3,14 +3,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
 use esp_backtrace as _;
 
 #[entry]
@@ -19,27 +12,7 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32c3-hal/examples/serial_interrupts.rs
+++ b/esp32c3-hal/examples/serial_interrupts.rs
@@ -17,7 +17,6 @@ use esp32c3_hal::{
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -31,7 +30,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
@@ -39,19 +37,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30).unwrap();

--- a/esp32c3-hal/examples/sha.rs
+++ b/esp32c3-hal/examples/sha.rs
@@ -9,8 +9,6 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,19 +20,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.swd.disable();
-    rtc.rwdt.disable();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data.clone();

--- a/esp32c3-hal/examples/software_interrupts.rs
+++ b/esp32c3-hal/examples/software_interrupts.rs
@@ -17,9 +17,7 @@ use esp32c3_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -32,27 +30,6 @@ fn main() -> ! {
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -25,9 +25,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiBusController, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,27 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -23,9 +23,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -35,27 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,9 +23,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -35,27 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -22,9 +22,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,27 +32,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -24,9 +24,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -36,27 +34,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -14,9 +14,7 @@ use esp32c3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     systimer::{Alarm, Periodic, SystemTimer, Target},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -30,19 +28,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.swd.disable();
-    rtc.rwdt.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32c3-hal/examples/timer_interrupt.rs
+++ b/esp32c3-hal/examples/timer_interrupt.rs
@@ -28,28 +28,18 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer1 = timer_group1.timer0;
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     interrupt::enable(
         peripherals::Interrupt::TG0_T0_LEVEL,

--- a/esp32c3-hal/examples/twai.rs
+++ b/esp32c3-hal/examples/twai.rs
@@ -10,15 +10,7 @@ use embedded_can::{nb::Can, Frame, Id};
 // cargo run --example twai --release
 #[cfg(not(feature = "eh1"))]
 use embedded_hal::can::{Can, Frame, Id};
-use esp32c3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    twai,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, twai};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -28,26 +20,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -15,9 +15,7 @@ use esp32c3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
     Cpu,
-    Rtc,
     UsbSerialJtag,
 };
 use esp_backtrace as _;
@@ -30,27 +28,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let mut usb_serial =
         UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);

--- a/esp32c3-hal/examples/watchdog.rs
+++ b/esp32c3-hal/examples/watchdog.rs
@@ -22,7 +22,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -30,16 +29,7 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
     wdt0.start(2u64.secs());
     wdt1.disable();
 

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -142,9 +142,18 @@ unsafe fn configure_mmu() {
 #[export_name = "__post_init"]
 #[doc(hidden)]
 #[cfg_attr(feature = "mcu-boot", link_section = ".rwtext")]
-pub fn post_init() {
+unsafe fn post_init() {
     #[cfg(feature = "mcu-boot")]
     unsafe {
         configure_mmu();
     }
+    use esp_hal_common::{peripherals::*, prelude::*, timer::Wdt};
+
+    // RTC domain must be enabled before wet try and disable
+    let mut rtc = Rtc::new(RTC_CNTL::steal());
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    Wdt::<TIMG0>::force_set_wdt_enabled(false);
+    Wdt::<TIMG1>::force_set_wdt_enabled(false);
 }


### PR DESCRIPTION
An exploration of something @jessebraham was looking into. This greatly simplifies the boilerplate for each example, by disabling the watchdogs before main. The watchdogs are enabled as a side effect of the ROM/second stage bootloader.

I probably won't finish this PR, but I hope it serves as a guide if someone wants to take on the rest of the chips :).

This will also require some changes in xtensa-lx-rt, to add `__post_init` support.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
