### PR TITLE
Fix ESP32 radio clock code writing incorrect registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing interrupt status read for esp32s3, which fixes USB-SERIAL-JTAG interrupts (#664)
 - GPIO interrupt status bits are now properly cleared (#670)
 - Increase frequency resolution in `set_periodic` (#686)
-- Fixed ESP32, ESP32-S2, ESP32-S3, ESP32-C2, ESP32-C3 radio clock gating (#679, #681, #709)
+- Fixed ESP32-S2, ESP32-S3, ESP32-C2, ESP32-C3 radio clock gating (#679, #681)
+- Partially fix ESP32 radio clocks (#709)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing interrupt status read for esp32s3, which fixes USB-SERIAL-JTAG interrupts (#664)
 - GPIO interrupt status bits are now properly cleared (#670)
 - Increase frequency resolution in `set_periodic` (#686)
-- Fixed ESP32-S2, ESP32-S3, ESP32-C2, ESP32-C3 radio clock gating (#679, #681)
+- Fixed ESP32, ESP32-S2, ESP32-S3, ESP32-C2, ESP32-C3 radio clock gating (#679, #681, #709)
 
 ### Removed
 

--- a/esp-hal-common/src/soc/esp32/radio_clocks.rs
+++ b/esp-hal-common/src/soc/esp32/radio_clocks.rs
@@ -1,22 +1,23 @@
 use crate::system::{RadioClockControl, RadioClockController, RadioPeripherals};
 
-const SYSTEM_WIFI_CLK_WIFI_BT_COMMON_M: u32 = 0x000003c9;
-const SYSTEM_WIFI_CLK_EN: u32 = 0xFFFFFFFF;
+const DPORT_WIFI_CLK_WIFI_BT_COMMON_M: u32 = 0x000003c9;
+const DPORT_WIFI_CLK_WIFI_EN_M: u32 = 0x00000406;
+const DPORT_WIFI_CLK_BT_EN_M: u32 = 0x00030800;
 
 impl RadioClockController for RadioClockControl {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),
-            RadioPeripherals::Bt => common_wifi_bt_clock_enable(),
-            RadioPeripherals::Wifi => common_wifi_bt_clock_enable(),
+            RadioPeripherals::Bt => bt_clock_enable(),
+            RadioPeripherals::Wifi => wifi_clock_enable(),
         }
     }
 
     fn disable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => disable_phy(),
-            RadioPeripherals::Bt => common_wifi_bt_clock_disable(),
-            RadioPeripherals::Wifi => common_wifi_bt_clock_disable(),
+            RadioPeripherals::Bt => bt_clock_disable(),
+            RadioPeripherals::Wifi => wifi_clock_disable(),
         }
     }
 
@@ -38,47 +39,80 @@ impl RadioClockController for RadioClockControl {
 }
 
 fn enable_phy() {
-    let system = unsafe { &*esp32::DPORT::PTR };
-    system
+    // `periph_ll_wifi_bt_module_enable_clk_clear_rst`
+    let dport = unsafe { &*esp32::DPORT::PTR };
+    dport
         .wifi_clk_en
-        .modify(|r, w| unsafe { w.bits(r.bits() | SYSTEM_WIFI_CLK_WIFI_BT_COMMON_M) });
+        .modify(|r, w| unsafe { w.bits(r.bits() | DPORT_WIFI_CLK_WIFI_BT_COMMON_M) });
 }
 
 fn disable_phy() {
-    let system = unsafe { &*esp32::DPORT::PTR };
-    system
+    // `periph_ll_wifi_bt_module_disable_clk_set_rst`
+    let dport = unsafe { &*esp32::DPORT::PTR };
+    dport
         .wifi_clk_en
-        .modify(|r, w| unsafe { w.bits(r.bits() & !SYSTEM_WIFI_CLK_WIFI_BT_COMMON_M) });
+        .modify(|r, w| unsafe { w.bits(r.bits() & !DPORT_WIFI_CLK_WIFI_BT_COMMON_M) });
 }
 
-fn common_wifi_bt_clock_enable() {
-    let system = unsafe { &*esp32::DPORT::PTR };
-    system
-        .perip_clk_en
-        .modify(|r, w| unsafe { w.bits(r.bits() | SYSTEM_WIFI_CLK_EN) });
+fn bt_clock_enable() {
+    let dport = unsafe { &*esp32::DPORT::PTR };
+    dport
+        .wifi_clk_en
+        .modify(|r, w| unsafe { w.bits(r.bits() | DPORT_WIFI_CLK_BT_EN_M) });
 }
 
-fn common_wifi_bt_clock_disable() {
-    let system = unsafe { &*esp32::DPORT::PTR };
-    system
-        .perip_clk_en
-        .modify(|r, w| unsafe { w.bits(r.bits() & !SYSTEM_WIFI_CLK_EN) });
+fn bt_clock_disable() {
+    let dport = unsafe { &*esp32::DPORT::PTR };
+    dport
+        .wifi_clk_en
+        .modify(|r, w| unsafe { w.bits(r.bits() & !DPORT_WIFI_CLK_BT_EN_M) });
+}
+
+fn wifi_clock_enable() {
+    // `periph_ll_wifi_module_enable_clk_clear_rst`
+    let dport = unsafe { &*esp32::DPORT::PTR };
+    dport
+        .wifi_clk_en
+        .modify(|r, w| unsafe { w.bits(r.bits() | DPORT_WIFI_CLK_WIFI_EN_M) });
+}
+
+fn wifi_clock_disable() {
+    // `periph_ll_wifi_module_disable_clk_set_rst`
+    let dport = unsafe { &*esp32::DPORT::PTR };
+    dport
+        .wifi_clk_en
+        .modify(|r, w| unsafe { w.bits(r.bits() & !DPORT_WIFI_CLK_WIFI_EN_M) });
 }
 
 fn reset_mac() {
     const SYSTEM_MAC_RST: u8 = 1 << 2;
-    let syscon = unsafe { &*esp32::DPORT::PTR };
-    syscon
+    let dport = unsafe { &*esp32::DPORT::PTR };
+    dport
         .core_rst_en
         .modify(|r, w| unsafe { w.core_rst().bits(r.core_rst().bits() | SYSTEM_MAC_RST) });
-    syscon
+    dport
         .core_rst_en
         .modify(|r, w| unsafe { w.core_rst().bits(r.core_rst().bits() & !SYSTEM_MAC_RST) });
 }
 
 fn init_clocks() {
-    let syscon = unsafe { &*esp32::DPORT::PTR };
-    syscon
+    let dport = unsafe { &*esp32::DPORT::PTR };
+
+    const DPORT_WIFI_CLK_SDIOSLAVE_EN: u32 = 1 << 4;
+    const DPORT_WIFI_CLK_UNUSED_BIT5: u32 = 1 << 5;
+    const DPORT_WIFI_CLK_UNUSED_BIT12: u32 = 1 << 12;
+    const DPORT_WIFI_CLK_SDIO_HOST_EN: u32 = 1 << 13;
+    const DPORT_WIFI_CLK_EMAC_EN: u32 = 1 << 14;
+
+    const WIFI_BT_SDIO_CLK: u32 = DPORT_WIFI_CLK_WIFI_EN_M
+        | DPORT_WIFI_CLK_BT_EN_M
+        | DPORT_WIFI_CLK_UNUSED_BIT5
+        | DPORT_WIFI_CLK_UNUSED_BIT12
+        | DPORT_WIFI_CLK_SDIOSLAVE_EN
+        | DPORT_WIFI_CLK_SDIO_HOST_EN
+        | DPORT_WIFI_CLK_EMAC_EN;
+
+    dport
         .wifi_clk_en
-        .modify(|_, w| unsafe { w.bits(0xffffffff) });
+        .modify(|r, w| unsafe { w.bits(r.bits() & !WIFI_BT_SDIO_CLK) });
 }


### PR DESCRIPTION
Successor of #679 and #681.

This PR is not complete as we must blanket-enable all clocks on startup, which esp-idf doesn't do (or, at least, not where I expect it to). Still, with this PR, esp-hal no longer writes WIFI/BT clock bit patterns into the peripheral clock control register, where those bits don't belong.