### PR TITLE
New package releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please note that only changes to the `esp-hal-common` package are tracked in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0] - 2023-08-10
 
 ### Added
 
@@ -17,9 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented calibrated ADC API for ESP32-S3 (#641)
 - Add MCPWM DeadTime configuration (#406)
 - Implement sleep with some wakeup methods for `esp32-s3` (#660, #689, #696)
-- Add feature enabling directly hooking the interrupt vector table
+- Add feature enabling directly hooking the interrupt vector table (#621)
 - Add `ClockControl::max` helper for all chips (#701)
-- Added module-level documentation for all peripherals
 - Added module-level documentation for all peripherals (#680)
 - Implement sleep with some wakeup methods for `esp32-s3` (#660)
 - Add `FlashSafeDma` wrapper for eh traits which ensure correct DMA transfer from source data in flash (ROM) (#678)
@@ -167,7 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2022-08-05
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/v0.10.0...HEAD
+[0.11.0]: https://github.com/esp-rs/esp-hal/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/esp-rs/esp-hal/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/esp-rs/esp-hal/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/esp-rs/esp-hal/compare/v0.7.1...v0.8.0

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -52,13 +52,13 @@ ufmt-write = { version = "0.1.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { git = "https://github.com/esp-rs/esp-pacs", rev = "ce6d5b5", features = ["critical-section"], optional = true }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "ce6d5b5", features = ["critical-section"], optional = true }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "ce6d5b5", features = ["critical-section"], optional = true }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "ce6d5b5", features = ["critical-section"], optional = true }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "ce6d5b5", features = ["critical-section"], optional = true }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "ce6d5b5", features = ["critical-section"], optional = true }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "ce6d5b5", features = ["critical-section"], optional = true }
+esp32   = { version = "0.25.0", features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.13.0", features = ["critical-section"], optional = true }
+esp32c3 = { version = "0.16.0", features = ["critical-section"], optional = true }
+esp32c6 = { version = "0.6.0",  features = ["critical-section"], optional = true }
+esp32h2 = { version = "0.2.0",  features = ["critical-section"], optional = true }
+esp32s2 = { version = "0.16.0", features = ["critical-section"], optional = true }
+esp32s3 = { version = "0.20.0", features = ["critical-section"], optional = true }
 
 [build-dependencies]
 basic-toml = "0.1.2"

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp-hal-common"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -15,7 +15,7 @@ license      = "MIT OR Apache-2.0"
 bitflags             = "2.3.3"
 bitfield             = "0.14.0"
 cfg-if               = "1.0.0"
-critical-section     = "1.1.1"
+critical-section     = "1.1.2"
 embedded-can         = { version = "0.4.1", optional = true }
 embedded-dma         = "0.2.0"
 embedded-hal         = { version = "0.2.7", features = ["unproven"] }
@@ -26,7 +26,7 @@ fugit                = "0.3.7"
 log                  = "=0.4.18"
 lock_api             = { version = "0.4.10", optional = true }
 nb                   = "1.1.0"
-paste                = "1.0.12"
+paste                = "1.0.14"
 procmacros           = { version = "0.6.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 strum                = { version = "0.25.0", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
@@ -39,7 +39,7 @@ embassy-time       = { version = "0.1.2", features = ["nightly"], optional = tru
 embassy-futures    = { version = "0.1.0", optional = true }
 
 # RISC-V
-esp-riscv-rt                = { version = "0.3.0", path = "../esp-riscv-rt", optional = true }
+esp-riscv-rt                = { version = "0.4.0", path = "../esp-riscv-rt", optional = true }
 riscv-atomic-emulation-trap = { version = "0.4.0", optional = true }
 
 # Xtensa
@@ -61,8 +61,8 @@ esp32s2 = { version = "0.16.0", features = ["critical-section"], optional = true
 esp32s3 = { version = "0.20.0", features = ["critical-section"], optional = true }
 
 [build-dependencies]
-basic-toml = "0.1.2"
-serde      = { version = "1.0.164", features = ["derive"] }
+basic-toml = "0.1.4"
+serde      = { version = "1.0.183", features = ["derive"] }
 
 [features]
 esp32   = ["esp32/rt",   "xtensa", "xtensa-lx/esp32", "xtensa-lx-rt/esp32", "lock_api", "procmacros/esp32"]

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-hal-smartled"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 rust-version = "1.65.0"
 description  = "RMT adapter for smartleds"
@@ -11,7 +11,7 @@ license      = "MIT OR Apache-2.0"
 features = ["esp32c3"]
 
 [dependencies]
-esp-hal-common   = { version = "0.10.0", path = "../esp-hal-common" }
+esp-hal-common   = { version = "0.11.0", path = "../esp-hal-common" }
 fugit            = "0.3.7"
 smart-leds-trait = "0.2.1"
 

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name        = "esp-hal-smartled"
-version     = "0.3.0"
-edition     = "2021"
-description = "RMT adapter for smartleds"
-repository  = "https://github.com/esp-rs/esp-hal"
-license     = "MIT OR Apache-2.0"
+name         = "esp-hal-smartled"
+version      = "0.3.0"
+edition      = "2021"
+rust-version = "1.65.0"
+description  = "RMT adapter for smartleds"
+repository   = "https://github.com/esp-rs/esp-hal"
+license      = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 features = ["esp32c3"]

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -2,7 +2,7 @@
 name         = "esp-riscv-rt"
 version      = "0.3.0"
 edition      = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 description  = "Minimal runtime / startup for RISC-V CPUs from Espressif"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-riscv-rt"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 rust-version = "1.65"
 description  = "Minimal runtime / startup for RISC-V CPUs from Espressif"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32-hal"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -30,23 +30,23 @@ embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "=0.2.0-alpha.2",   optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.3",  optional = true }
-esp-hal-common     = { version = "0.10.0",  features = ["esp32"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.11.0",  features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes               = "0.8.3"
-critical-section  = "1.1.1"
+critical-section  = "1.1.2"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embedded-graphics = "0.8.0"
+embedded-graphics = "0.8.1"
 esp-alloc         = "0.3.0"
 esp-backtrace     = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.3.0", features = ["esp32"], path = "../esp-hal-smartled" }
+esp-hal-smartled  = { version = "0.4.0", features = ["esp32"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32", "log"] }
 lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.1.0"
+static_cell       = "1.2.0"
 heapless          = "0.7.16"
 
 [features]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32c2-hal"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -30,18 +30,18 @@ embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async = { version = "=0.2.0-alpha.2",   optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.3",  optional = true }
-esp-hal-common     = { version = "0.10.0", features = ["esp32c2"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.11.0", features = ["esp32c2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-critical-section  = "1.1.1"
+critical-section  = "1.1.2"
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embedded-graphics = "0.8.0"
+embedded-graphics = "0.8.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.5.0", features = ["esp32c2"] }
 lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.7", default-features = false}
 ssd1306           = "0.8.0"
-static_cell       = "1.1.0"
+static_cell       = "1.2.0"
 heapless          = "0.7.16"
 
 [features]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32c3-hal"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -32,22 +32,22 @@ embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.10.0",  features = ["esp32c3"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.11.0",  features = ["esp32c3"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes               = "0.8.3"
-critical-section  = "1.1.1"
+critical-section  = "1.1.2"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embedded-graphics = "0.8.0"
+embedded-graphics = "0.8.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.3.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
+esp-hal-smartled  = { version = "0.4.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32c3"] }
 lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.1.0"
+static_cell       = "1.2.0"
 heapless          = "0.7.16"
 
 [features]
@@ -64,12 +64,7 @@ embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-direct-vectoring = ["esp-hal-common/direct-vectoring"]
-[profile.dev]
-opt-level = 1
-
-[profile.release]
-debug = true
+direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 
 [[example]]
 name              = "spi_eh1_loopback"

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32c6-hal"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -33,22 +33,22 @@ embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.10.0",  features = ["esp32c6"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.11.0",  features = ["esp32c6"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes               = "0.8.3"
-critical-section  = "1.1.1"
+critical-section  = "1.1.2"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embedded-graphics = "0.8.0"
+embedded-graphics = "0.8.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.3.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
+esp-hal-smartled  = { version = "0.4.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32c6"] }
 lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.1.0"
+static_cell       = "1.2.0"
 heapless          = "0.7.16"
 
 [features]

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Juraj Sadel <jurajsadel@gmail.com>",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "HAL for ESP32-C6 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Sergio Gasquez Arcos <sergio.gasquez@gmail.com",
 ]
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 description  = "HAL for ESP32-H2 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32h2-hal"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Kirill Mikhailov <playfulfence@gmail.com>",
     "Jesse Braham <jesse@beta7.io>",
@@ -33,22 +33,22 @@ embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.10.0",  features = ["esp32h2"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.11.0",  features = ["esp32h2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes               = "0.8.3"
-critical-section  = "1.1.1"
+critical-section  = "1.1.2"
 crypto-bigint     = { version = "0.5.2", default-features = false }
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embedded-graphics = "0.8.0"
+embedded-graphics = "0.8.1"
 esp-backtrace     = { version = "0.7.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.3.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
+esp-hal-smartled  = { version = "0.4.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32h2"] }
 lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.1.0"
+static_cell       = "1.2.0"
 heapless          = "0.7.16"
 
 [features]
@@ -65,6 +65,7 @@ embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tic
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
+
 [[example]]
 name              = "spi_eh1_loopback"
 required-features = ["eh1"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32s2-hal"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -30,24 +30,24 @@ embedded-hal                 = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1               = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
 embedded-hal-async           = { version = "=0.2.0-alpha.2", optional = true }
 embedded-hal-nb              = { version = "=1.0.0-alpha.3", optional = true }
-esp-hal-common               = { version = "0.10.0",  features = ["esp32s2"], path = "../esp-hal-common" }
+esp-hal-common               = { version = "0.11.0",  features = ["esp32s2"], path = "../esp-hal-common" }
 xtensa-atomic-emulation-trap = { version = "0.4.0" }
 
 [dev-dependencies]
 aes               = "0.8.3"
-critical-section  = "1.1.1"
+critical-section  = "1.1.2"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embedded-graphics = "0.8.0"
+embedded-graphics = "0.8.1"
 esp-alloc         = "0.3.0"
 esp-backtrace     = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
-esp-hal-smartled  = { version = "0.3.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
+esp-hal-smartled  = { version = "0.4.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32s2"] }
 lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.1.0"
+static_cell       = "1.2.0"
 usb-device        = "0.2.9"
 usbd-serial       = "0.1.1"
 heapless          = "0.7.16"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "esp32s3-hal"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
@@ -32,24 +32,24 @@ embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "
 embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
 embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
 embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.10.0",  features = ["esp32s3"], path = "../esp-hal-common" }
+esp-hal-common     = { version = "0.11.0",  features = ["esp32s3"], path = "../esp-hal-common" }
 r0                 = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
 aes               = "0.8.3"
-critical-section  = "1.1.1"
+critical-section  = "1.1.2"
 crypto-bigint     = { version = "0.5.2", default-features = false}
 embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embedded-graphics = "0.8.0"
+embedded-graphics = "0.8.1"
 esp-alloc         = "0.3.0"
 esp-backtrace     = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.3.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
+esp-hal-smartled  = { version = "0.4.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
 esp-println       = { version = "0.5.0", features = ["esp32s3", "log"] }
 lis3dh-async      = "0.7.0"
 sha2              = { version = "0.10.7", default-features = false}
 smart-leds        = "0.3.0"
 ssd1306           = "0.8.0"
-static_cell       = "1.1.0"
+static_cell       = "1.2.0"
 usb-device        = "0.2.9"
 usbd-serial       = "0.1.1"
 heapless          = "0.7.16"


### PR DESCRIPTION
New releases for all packages except `esp-hal-procmacros`, which has only had updates to documentation since the previous release.

Additionally closes #711.