### PR TITLE
Create the `esp32c6-lp-hal` package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,26 @@ jobs:
       - name: rustdoc
         run: cd esp32c6-hal/ && cargo doc --features=eh1
 
+  esp32c6-lp-hal:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          target: riscv32imac-unknown-none-elf
+          toolchain: nightly
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+
+      # Perform a full build initially to verify that the examples not only
+      # build, but also link successfully.
+      - name: build esp32c6-lp-hal (no features)
+        run: cd esp32c6-lp-hal/ && cargo +nightly build --examples
+      # Ensure documentation can be built
+      - name: rustdoc
+        run: cd esp32c6-lp-hal/ && cargo doc
+
   esp32h2-hal:
     runs-on: ubuntu-latest
 
@@ -393,6 +413,8 @@ jobs:
         run: cd esp32c3-hal/ && cargo check --features=eh1,ufmt
       - name: msrv (esp32c6-hal)
         run: cd esp32c6-hal/ && cargo check --features=eh1,ufmt
+      - name: msrv (esp32c6-lp-hal)
+        run: cd esp32c6-lp-hal/ && cargo check
       - name: msrv (esp32h2-hal)
         run: cd esp32h2-hal/ && cargo check --features=eh1,ufmt
 
@@ -438,6 +460,8 @@ jobs:
         run: cargo +stable clippy --manifest-path=esp32c3-hal/Cargo.toml -- --no-deps
       - name: clippy (esp32c6-hal)
         run: cargo +stable clippy --manifest-path=esp32c6-hal/Cargo.toml -- --no-deps
+      - name: clippy (esp32c6-lp-hal)
+        run: cargo +stable clippy --manifest-path=esp32c6-lp-hal/Cargo.toml -- --no-deps
       - name: clippy (esp32h2-hal)
         run: cargo +stable clippy --manifest-path=esp32h2-hal/Cargo.toml -- --no-deps
 
@@ -494,6 +518,8 @@ jobs:
         run: cargo fmt --all --manifest-path=esp32c3-hal/Cargo.toml -- --check
       - name: rustfmt (esp32c6-hal)
         run: cargo fmt --all --manifest-path=esp32c6-hal/Cargo.toml -- --check
+      - name: rustfmt (esp32c6-lp-hal)
+        run: cargo fmt --all --manifest-path=esp32c6-lp-hal/Cargo.toml -- --check
       - name: rustfmt (esp32h2-hal)
         run: cargo fmt --all --manifest-path=esp32h2-hal/Cargo.toml -- --check
       - name: rustfmt (esp32s2-hal)
@@ -505,14 +531,13 @@ jobs:
   # Changelog
 
   changelog:
-    name: Changelog
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Check that changelog updated
-        uses: dangoslen/changelog-enforcer@v3
+      - uses: dangoslen/changelog-enforcer@v3
         with:
           changeLogPath: CHANGELOG.md
           skipLabels: "skip-changelog"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Please note that only changes to the `esp-hal-common` package are tracked in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add the `esp32c6-lp-hal` package (#714)
+
+### Changed
+
+### Fixed
+
+### Removed
+
 ## [0.11.0] - 2023-08-10
 
 ### Added
@@ -166,6 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2022-08-05
 
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/esp-rs/esp-hal/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/esp-rs/esp-hal/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/esp-rs/esp-hal/compare/v0.8.0...v0.9.0

--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ This project is still in the early stages of development, and as such there shou
 
 If you have any questions, comments, or concerns, please [open an issue], [start a new discussion], or join us on [Matrix]. For additional information regarding any of the crates in this repository, please refer to the crate's README.
 
-|     Crate     |             Target             | Technical Reference Manual |
-| :-----------: | :----------------------------: | :------------------------: |
-|  [esp32-hal]  |    `xtensa-esp32-none-elf`     |          [ESP32]           |
-| [esp32c2-hal] | `riscv32imc-unknown-none-elf`  |         [ESP32-C2]         |
-| [esp32c3-hal] | `riscv32imc-unknown-none-elf`  |         [ESP32-C3]         |
-| [esp32c6-hal] | `riscv32imac-unknown-none-elf` |         [ESP32-C6]         |
-| [esp32h2-hal] | `riscv32imac-unknown-none-elf` |         [ESP32-H2]         |
-| [esp32s2-hal] |   `xtensa-esp32s2-none-elf`    |         [ESP32-S2]         |
-| [esp32s3-hal] |   `xtensa-esp32s3-none-elf`    |         [ESP32-S3]         |
+|      Crate       |             Target             | Technical Reference Manual |
+| :--------------: | :----------------------------: | :------------------------: |
+|   [esp32-hal]    |    `xtensa-esp32-none-elf`     |          [ESP32]           |
+|  [esp32c2-hal]   | `riscv32imc-unknown-none-elf`  |         [ESP32-C2]         |
+|  [esp32c3-hal]   | `riscv32imc-unknown-none-elf`  |         [ESP32-C3]         |
+|  [esp32c6-hal]   | `riscv32imac-unknown-none-elf` |         [ESP32-C6]         |
+| [esp32c6-lp-hal] | `riscv32imac-unknown-none-elf` |            N/A             |
+|  [esp32h2-hal]   | `riscv32imac-unknown-none-elf` |         [ESP32-H2]         |
+|  [esp32s2-hal]   |   `xtensa-esp32s2-none-elf`    |         [ESP32-S2]         |
+|  [esp32s3-hal]   |   `xtensa-esp32s3-none-elf`    |         [ESP32-S3]         |
 
 [here]: https://github.com/esp-rs/esp-hal/issues/19
 [esp-idf-hal]: https://github.com/esp-rs/esp-idf-hal
@@ -31,6 +32,7 @@ If you have any questions, comments, or concerns, please [open an issue], [start
 [esp32c2-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32c2-hal
 [esp32c3-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32c3-hal
 [esp32c6-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32c6-hal
+[esp32c6-lp-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32c6-lp-hal
 [esp32h2-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32h2-hal
 [esp32s2-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32s2-hal
 [esp32s3-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp32s3-hal

--- a/esp-hal.code-workspace
+++ b/esp-hal.code-workspace
@@ -25,6 +25,9 @@
       "path": "esp32c6-hal"
     },
     {
+      "path": "esp32c6-lp-hal"
+    },
+    {
       "path": "esp32h2-hal"
     },
     {
@@ -34,13 +37,19 @@
       "path": "esp32s3-hal"
     }
   ],
+
   "settings": {
     "editor.formatOnSave": true,
+
+    "rust-analyzer.cargo.buildScripts.enable": true,
     "rust-analyzer.check.allTargets": false,
     "rust-analyzer.imports.granularity.enforce": true,
     "rust-analyzer.imports.granularity.group": "crate",
-    "rust-analyzer.cargo.buildScripts.enable": true,
     "rust-analyzer.procMacro.attributes.enable": true,
-    "rust-analyzer.procMacro.enable": true
+    "rust-analyzer.procMacro.enable": true,
+
+    "[toml]": {
+      "editor.formatOnSave": false
+    }
   }
 }

--- a/esp32c6-lp-hal/.cargo/config.toml
+++ b/esp32c6-lp-hal/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.riscv32imac-unknown-none-elf]
+runner = "espflash flash --monitor"
+rustflags = [
+  "-C", "link-arg=-Tlinkall.x",
+]
+
+[build]
+target = "riscv32imac-unknown-none-elf"
+
+[unstable]
+build-std = ["core"]

--- a/esp32c6-lp-hal/Cargo.toml
+++ b/esp32c6-lp-hal/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name         = "esp32c6-lp-hal"
+version      = "0.1.0"
+edition      = "2021"
+rust-version = "1.65.0"
+description  = "HAL for ESP32-C6's low-power coprocessor"
+repository   = "https://github.com/esp-rs/esp-hal"
+license      = "MIT OR Apache-2.0"
+
+keywords = [
+    "embedded",
+    "embedded-hal",
+    "esp",
+    "esp32c6",
+    "no-std",
+]
+categories = [
+    "embedded",
+    "hardware-support",
+    "no-std",
+]
+
+[dependencies]
+critical-section = { version = "1.1.2", features = ["restore-state-u8"] }
+embedded-hal     = { version = "0.2.7", features = ["unproven"] }
+esp32c6-lp       = { git = "https://github.com/esp-rs/esp-pacs", rev = "a9cad5e", features = ["critical-section"] }
+riscv            = "0.10.1"
+
+[features]
+default = []
+debug   = ["esp32c6-lp/impl-register-debug"]

--- a/esp32c6-lp-hal/README.md
+++ b/esp32c6-lp-hal/README.md
@@ -1,0 +1,39 @@
+# esp32c6-lp-hal
+
+[![Crates.io](https://img.shields.io/crates/v/esp32c6-lp-hal?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp32c6-lp-hal)
+[![docs.rs](https://img.shields.io/docsrs/esp32c6-lp-hal?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp32c6-lp-hal)
+![Crates.io](https://img.shields.io/crates/l/esp32c6-lp-hal?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
+
+`no_std` HAL for the ESP32-C6 from Espressif's low-power coprocessor. Implements a number of the traits defined by [embedded-hal](https://github.com/rust-embedded/embedded-hal).
+
+This device uses the RISC-V ISA, which is officially supported by the Rust compiler via the `riscv32imac-unknown-none-elf` target. Refer to the [Getting Started](#getting-started) section below for more information.
+
+## [Documentation]
+
+[documentation]: https://docs.rs/esp32c6-lp-hal/
+
+## Getting Started
+
+### Installing the Rust Compiler Target
+
+The compilation target for this device is officially supported via the `stable` release channel and can be installed via [rustup](https://rustup.rs/):
+
+```shell
+$ rustup target add riscv32imac-unknown-none-elf
+```
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in
+the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without
+any additional terms or conditions.

--- a/esp32c6-lp-hal/build.rs
+++ b/esp32c6-lp-hal/build.rs
@@ -1,0 +1,17 @@
+use std::{env, fs::File, io::Write, path::PathBuf};
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    File::create(out.join("link.x"))
+        .unwrap()
+        .write_all(include_bytes!("ld/link.x"))
+        .unwrap();
+
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // Only re-run the build script when memory.x is changed,
+    // instead of when any part of the source code changes.
+    println!("cargo:rerun-if-changed=ld/memory.x");
+}

--- a/esp32c6-lp-hal/ld/link.x
+++ b/esp32c6-lp-hal/ld/link.x
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ENTRY(reset_vector)
+
+CONFIG_ULP_COPROC_RESERVE_MEM = 1024 * 16;
+CONFIG_ULP_SHARED_MEM = 0;
+
+MEMORY
+{
+    /*first 128byte for exception/interrupt vectors*/
+    vector_table(RX) :   ORIGIN = 0x50000000, LENGTH = 0x80
+    ram(RWX) :           ORIGIN = 0x50000080, LENGTH = CONFIG_ULP_COPROC_RESERVE_MEM - 0x80 - CONFIG_ULP_SHARED_MEM
+}
+
+SECTIONS
+{
+    .vector.text :
+    {
+        /*exception/interrupt vectors*/
+        __mtvec_base = .;
+        KEEP (*(.init.vector))
+        __mtvec_end = .;
+    } > vector_table
+
+    . = ORIGIN(ram);
+
+    .text ALIGN(4):
+    {
+        *(.text.vectors) /* Default reset vector must link to offset 0x80 */
+        
+        KEEP(*(.init));
+        KEEP(*(.init.rust));        
+        *(.text)
+        *(.text*)
+    } > ram
+
+    .rodata ALIGN(4):
+    {
+        *(.rodata)
+        *(.rodata*)
+    } > ram
+
+    .data ALIGN(4):
+    {
+        *(.data)
+        *(.data*)
+        *(.sdata)
+        *(.sdata*)
+    } > ram
+
+    .bss ALIGN(4) :
+    {
+        *(.bss)
+        *(.bss*)
+        *(.sbss)
+        *(.sbss*)
+        PROVIDE(end = .);
+    } > ram
+
+    __stack_top = ORIGIN(ram) + LENGTH(ram);
+}

--- a/esp32c6-lp-hal/src/lib.rs
+++ b/esp32c6-lp-hal/src/lib.rs
@@ -1,0 +1,79 @@
+#![no_std]
+
+use core::arch::global_asm;
+
+pub mod riscv {
+    //! Low level access to RISC-V processors.
+    //!
+    //! Re-exports <https://crates.io/crates/riscv>
+
+    pub use riscv::*;
+}
+
+global_asm!(
+    r#"
+    .section    .init.vector, "ax"
+        /* This is the vector table. It is currently empty, but will be populated
+         * with exception and interrupt handlers when this is supported
+        */
+
+        .align  0x4, 0xff
+        .global _vector_table
+        .type _vector_table, @function
+_vector_table:
+        .option push
+        .option norvc
+
+        .rept 32
+        nop
+        .endr
+
+        .option pop
+        .size _vector_table, .-_vector_table
+
+        .section .init, "ax"
+        .global reset_vector
+
+    /* The reset vector, jumps to startup code */
+    reset_vector:
+        j __start
+
+    __start:
+        /* setup the stack pointer */
+        la sp, __stack_top
+        call lp_core_startup
+    loop:
+        j loop
+"#
+);
+
+#[link_section = ".init.rust"]
+#[export_name = "lp_core_startup"]
+unsafe extern "C" fn lp_core_startup() -> ! {
+    extern "Rust" {
+        fn main() -> !;
+    }
+
+    main();
+}
+
+mod critical_section_impl {
+    struct CriticalSection;
+
+    critical_section::set_impl!(CriticalSection);
+
+    unsafe impl critical_section::Impl for CriticalSection {
+        unsafe fn acquire() -> critical_section::RawRestoreState {
+            let mut mstatus = 0u32;
+            core::arch::asm!("csrrci {0}, mstatus, 8", inout(reg) mstatus);
+            let interrupts_active = (mstatus & 0b1000) != 0;
+            interrupts_active as _
+        }
+
+        unsafe fn release(token: critical_section::RawRestoreState) {
+            if token != 0 {
+                riscv::interrupt::enable();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a (mostly empty) package to begin work on a HAL for the ESP32-C6's LP coprocessor. This doesn't do anything yet, but provides a base to build up from.