### PR TITLE
Fix psram check in esp-hal-common build.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `psram` availability lookup in `esp-hal-common` build script (#718)
+
 ### Removed
 
 ## [0.11.0] - 2023-08-10

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -156,7 +156,7 @@ fn main() {
     }
 
     // Check PSRAM features are only given if the target supports PSRAM
-    if !&device.peripherals.contains(&String::from("psram"))
+    if !&device.symbols.contains(&String::from("psram"))
         && (cfg!(feature = "psram_2m") || cfg!(feature = "psram_4m") || cfg!(feature = "psram_8m"))
     {
         panic!("The target does not support PSRAM");


### PR DESCRIPTION
In the `esp-hal-common` build script, `psram` is a peripheral "defined by the developers". A few weeks ago these were moved from `device.peripherals` to `device.symbols`. When looking up whether `psram` is available, now needs to be looked up in `symbols`.

Closes #717 