### PR TITLE
Fix RISCV stack-start

### DIFF
--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -405,6 +405,8 @@ _abs_start:
 
     // Allocate stack
     la sp, _stack_start
+    lui t0, 16
+    sub sp, sp, t0
 
     // Set frame pointer
     add s0, sp, zero


### PR DESCRIPTION
Previously in `_start` we subtracted `_hart_stack_size` (2k) from `_start_stack` before setting SP.
In #716 I removed that. However, _stack_start needs to get adjusted to be located in memory. Now we subtract 16.

The linker scripts still should make sure that _stack_start is aligned by 16 bytes.

Now we just waste 12 bytes instead of 2k

Not sure if this should be mentioned in the general HAL's CHANGELOG
