### PR TITLE
Multicore-aware executors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,13 @@ jobs:
       # confident that they link.
       - name: check esp32-hal (common features)
         run: cd esp32-hal/ && cargo check --examples --features=eh1,ufmt
-      - name: check esp32-hal (async)
-        run: cd esp32-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
+      - name: check esp32-hal (embassy)
+        run: |
+          cd esp32-hal/
+          cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
+          cargo check --example=embassy_multicore --features=embassy,embassy-time-timg0,embassy-executor-thread
+          cargo check --example=embassy_multicore_interrupt --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+          cargo check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
       - name: check esp32-hal (embassy, async)
         run: |
           cd esp32-hal/
@@ -315,9 +320,12 @@ jobs:
       # FIXME: `time-systick` feature disabled for now, see 'esp32s2-hal/Cargo.toml'.
       # - name: check esp32s2-hal (async, systick)
       #   run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
-      - name: check esp32s2-hal (async, timg0)
-        run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,executor
-      - name: check esp32-hal (embassy, async)
+      - name: check esp32-hal (embassy, timg0)
+        run: |
+          cd esp32s2-hal/
+          cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
+          cargo check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+      - name: check esp32-hal (embassy, timg0, async)
         run: |
           cd esp32s2-hal/
           cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
@@ -352,17 +360,34 @@ jobs:
       # confident that they link.
       - name: check esp32s3-hal (common features)
         run: cd esp32s3-hal/ && cargo check --examples --features=eh1,ufmt
-      - name: check esp32s3-hal (async, systick)
-        run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
-      - name: check esp32s3-hal (async, timg0)
-        run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,executor
-      - name: check esp32-hal (embassy, async)
+      - name: check esp32-hal (embassy, timg0)
+        run: |
+          cd esp32s3-hal/
+          cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
+          cargo check --example=embassy_multicore --features=embassy,embassy-time-timg0,embassy-executor-thread
+          cargo check --example=embassy_multicore_interrupt --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+          cargo check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+      - name: check esp32-hal (embassy, systick)
+        run: |
+          cd esp32s3-hal/
+          cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,embassy-executor-thread
+          cargo check --example=embassy_multicore --features=embassy,embassy-time-systick,embassy-executor-thread
+          cargo check --example=embassy_multicore_interrupt --features=embassy,embassy-time-systick,embassy-executor-interrupt
+          cargo check --example=embassy_multiprio --features=embassy,embassy-time-systick,embassy-executor-interrupt
+      - name: check esp32-hal (embassy, timg0, async)
         run: |
           cd esp32s3-hal/
           cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+      - name: check esp32-hal (embassy, systick, async)
+        run: |
+          cd esp32s3-hal/
+          cargo check --example=embassy_wait --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo check --example=embassy_spi --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo check --example=embassy_serial --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo check --example=embassy_i2c --features=embassy,embassy-time-systick,async,embassy-executor-thread
       - name: check esp32s3-hal (octal psram)
         run: cd esp32s3-hal/ && cargo check --example=octal_psram --features=opsram_2m --release # This example requires release!
       # Ensure documentation can be built

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,15 +82,14 @@ jobs:
       - name: check esp32-hal (common features)
         run: cd esp32-hal/ && cargo check --examples --features=eh1,ufmt
       - name: check esp32-hal (async)
-        run: cd esp32-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
-      - name: check esp32-hal (async, gpio)
-        run: cd esp32-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
-      - name: check esp32-hal (async, spi)
-        run: cd esp32-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
-      - name: check esp32-hal (async, serial)
-        run: cd esp32-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
-      - name: check esp32-hal (async, i2c)
-        run: cd esp32-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
+        run: cd esp32-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
+      - name: check esp32-hal (embassy, async)
+        run: |
+          cd esp32-hal/
+          cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32-hal/ && cargo doc --features=eh1
@@ -315,17 +314,16 @@ jobs:
         run: cd esp32s2-hal/ && cargo check --examples --features=eh1,ufmt
       # FIXME: `time-systick` feature disabled for now, see 'esp32s2-hal/Cargo.toml'.
       # - name: check esp32s2-hal (async, systick)
-      #   run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick
+      #   run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
       - name: check esp32s2-hal (async, timg0)
-        run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
-      - name: check esp32s2-hal (async, gpio)
-        run: cd esp32s2-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
-      - name: check esp32s2-hal (async, spi)
-        run: cd esp32s2-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
-      - name: check esp32s2-hal (async, serial)
-        run: cd esp32s2-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
-      - name: check esp32s2-hal (async, i2c)
-        run: cd esp32s2-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
+        run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,executor
+      - name: check esp32-hal (embassy, async)
+        run: |
+          cd esp32s2-hal/
+          cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32s2-hal/ && cargo doc --features=eh1
@@ -355,17 +353,16 @@ jobs:
       - name: check esp32s3-hal (common features)
         run: cd esp32s3-hal/ && cargo check --examples --features=eh1,ufmt
       - name: check esp32s3-hal (async, systick)
-        run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick
+        run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
       - name: check esp32s3-hal (async, timg0)
-        run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0
-      - name: check esp32s3-hal (async, gpio)
-        run: cd esp32s3-hal/ && cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async
-      - name: check esp32s3-hal (async, spi)
-        run: cd esp32s3-hal/ && cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async
-      - name: check esp32s3-hal (async, serial)
-        run: cd esp32s3-hal/ && cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async
-      - name: check esp32s3-hal (async, i2c)
-        run: cd esp32s3-hal/ && cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async
+        run: cd esp32s3-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,executor
+      - name: check esp32-hal (embassy, async)
+        run: |
+          cd esp32s3-hal/
+          cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       - name: check esp32s3-hal (octal psram)
         run: cd esp32s3-hal/ && cargo check --example=octal_psram --features=opsram_2m --release # This example requires release!
       # Ensure documentation can be built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add PARL_IO TX driver for ESP32-C6 / ESP32-H2 (#733)
 - Implement `ufmt_write::uWrite` trait for USB Serial JTAG (#751)
 - Add HMAC peripheral support (#755)
+- Add multicore-aware embassy executor for Xtensa MCUs (#723).
+- Add interrupt-executor for Xtensa MCUs (#723).
 
 ### Changed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -36,6 +36,7 @@ usb-device           = { version = "0.2.9", optional = true }
 # async
 embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-io-async  = { version = "0.5.0", optional = true }
+embassy-executor   = { version = "0.2.1", features = ["pender-callback"], optional = true } # pender is temporary
 embassy-sync       = { version = "0.2.0", optional = true }
 embassy-time       = { version = "0.1.3", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }
@@ -99,8 +100,11 @@ ufmt = ["ufmt-write"]
 vectored = ["procmacros/interrupt"]
 
 # Implement the `embedded-hal-async==1.0.0-alpha.x` traits
-async   = ["embedded-hal-async", "eh1", "embassy-sync", "embassy-futures", "embedded-io-async"]
-embassy = ["embassy-time"]
+async    = ["embedded-hal-async", "eh1", "embassy-sync", "embassy-futures", "embedded-io-async"]
+embassy  = ["embassy-time"]
+
+embassy-executor-thread    = ["embassy", "embassy-executor"]
+embassy-executor-interrupt = ["embassy", "embassy-executor"]
 
 embassy-time-systick = []
 embassy-time-timg0   = []

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -36,7 +36,7 @@ usb-device           = { version = "0.2.9", optional = true }
 # async
 embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-io-async  = { version = "0.5.0", optional = true }
-embassy-executor   = { version = "0.2.1", features = ["pender-callback"], optional = true } # pender is temporary
+embassy-executor   = { version = "0.2.1", features = ["pender-callback", "integrated-timers"], optional = true } # pender is temporary
 embassy-sync       = { version = "0.2.0", optional = true }
 embassy-time       = { version = "0.1.3", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }

--- a/esp-hal-common/src/embassy/executor/mod.rs
+++ b/esp-hal-common/src/embassy/executor/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(xtensa)]
+pub use xtensa::*;
+
+#[cfg(xtensa)]
+mod xtensa;

--- a/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
@@ -4,20 +4,19 @@ use core::{
     marker::PhantomData,
     mem::MaybeUninit,
     ptr,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use embassy_executor::{
     raw::{self, Pender},
     SendSpawner,
-    Spawner,
 };
 #[cfg(esp32)]
 use peripherals::DPORT as SystemPeripheral;
 #[cfg(not(esp32))]
 use peripherals::SYSTEM as SystemPeripheral;
 
-use crate::{get_core, interrupt, peripherals, prelude::interrupt};
+use crate::{get_core, interrupt, peripherals};
 
 static FROM_CPU_IRQ_USED: AtomicUsize = AtomicUsize::new(0);
 
@@ -45,7 +44,7 @@ macro_rules! from_cpu {
 
             impl SwPendableInterrupt for [<FromCpu $cpu>] {
                 fn enable(priority: interrupt::Priority) {
-                    let mask = 1 << get_core() as usize;
+                    let mask = 1 << $cpu;
                     if FROM_CPU_IRQ_USED.fetch_or(mask, Ordering::SeqCst) & mask != 0 {
                         panic!(concat!("FROM_CPU_", $cpu, " is already used by a different executor."));
                     }

--- a/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
@@ -1,0 +1,180 @@
+//! Multicore-aware interrupt-mode executor.
+use core::{
+    cell::UnsafeCell,
+    marker::PhantomData,
+    mem::MaybeUninit,
+    ptr,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use embassy_executor::{
+    raw::{self, Pender},
+    SendSpawner,
+    Spawner,
+};
+#[cfg(esp32)]
+use peripherals::DPORT as SystemPeripheral;
+#[cfg(not(esp32))]
+use peripherals::SYSTEM as SystemPeripheral;
+
+use crate::{get_core, interrupt, peripherals, prelude::interrupt};
+
+static FROM_CPU_IRQ_USED: AtomicUsize = AtomicUsize::new(0);
+
+pub trait SwPendableInterrupt {
+    fn enable(priority: interrupt::Priority);
+    fn pend();
+    fn clear();
+}
+
+macro_rules! from_cpu {
+    ($cpu:literal) => {
+        paste::paste! {
+            pub struct [<FromCpu $cpu>];
+
+            /// We don't allow using the same interrupt for multiple executors.
+
+            impl [<FromCpu $cpu>] {
+                fn set_bit(value: bool) {
+                    let system = unsafe { &*SystemPeripheral::PTR };
+                    system
+                        .[<cpu_intr_from_cpu_ $cpu>]
+                        .write(|w| w.[<cpu_intr_from_cpu_ $cpu>]().bit(value));
+                }
+            }
+
+            impl SwPendableInterrupt for [<FromCpu $cpu>] {
+                fn enable(priority: interrupt::Priority) {
+                    let mask = 1 << get_core() as usize;
+                    if FROM_CPU_IRQ_USED.fetch_or(mask, Ordering::SeqCst) & mask != 0 {
+                        panic!(concat!("FROM_CPU_", $cpu, " is already used by a different executor."));
+                    }
+
+                    interrupt::enable(peripherals::Interrupt::[<FROM_CPU_INTR $cpu>], priority).unwrap();
+                }
+
+                fn pend() {
+                    Self::set_bit(true);
+                }
+
+                fn clear() {
+                    Self::set_bit(false);
+                }
+            }
+        }
+    };
+}
+
+from_cpu!(1);
+from_cpu!(2);
+from_cpu!(3);
+
+/// Interrupt mode executor.
+///
+/// This executor runs tasks in interrupt mode. The interrupt handler is set up
+/// to poll tasks, and when a task is woken the interrupt is pended from
+/// software.
+///
+/// # Interrupt requirements
+///
+/// You must write the interrupt handler yourself, and make it call
+/// [`Self::on_interrupt()`]
+///
+/// ```rust,ignore
+/// #[interrupt]
+/// fn FROM_CPU_INTR1() {
+///     unsafe { INT_EXECUTOR.on_interrupt() }
+/// }
+/// ```
+pub struct InterruptExecutor<SWI>
+where
+    SWI: SwPendableInterrupt,
+{
+    core: AtomicUsize,
+    executor: UnsafeCell<MaybeUninit<raw::Executor>>,
+    _interrupt: PhantomData<SWI>,
+}
+
+unsafe impl<SWI: SwPendableInterrupt> Send for InterruptExecutor<SWI> {}
+unsafe impl<SWI: SwPendableInterrupt> Sync for InterruptExecutor<SWI> {}
+
+impl<SWI> InterruptExecutor<SWI>
+where
+    SWI: SwPendableInterrupt,
+{
+    /// Create a new `InterruptExecutor`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            core: AtomicUsize::new(usize::MAX),
+            executor: UnsafeCell::new(MaybeUninit::uninit()),
+            _interrupt: PhantomData,
+        }
+    }
+
+    /// Executor interrupt callback.
+    ///
+    /// # Safety
+    ///
+    /// You MUST call this from the interrupt handler, and from nowhere else.
+    // TODO: it would be pretty sweet if we could register our own interrupt handler
+    // when vectoring is enabled. The user shouldn't need to provide the handler for
+    // us.
+    pub unsafe fn on_interrupt(&'static self) {
+        SWI::clear();
+        let executor = unsafe { (*self.executor.get()).assume_init_ref() };
+        executor.poll();
+    }
+
+    /// Start the executor at the given priority level.
+    ///
+    /// This initializes the executor, enables the interrupt, and returns.
+    /// The executor keeps running in the background through the interrupt.
+    ///
+    /// This returns a [`SendSpawner`] you can use to spawn tasks on it. A
+    /// [`SendSpawner`] is returned instead of a [`Spawner`] because the
+    /// executor effectively runs in a different "thread" (the interrupt),
+    /// so spawning tasks on it is effectively sending them.
+    ///
+    /// To obtain a [`Spawner`] for this executor, use
+    /// [`Spawner::for_current_executor()`] from a task running in it.
+    ///
+    /// # Interrupt requirements
+    ///
+    /// You must write the interrupt handler yourself, and make it call
+    /// [`Self::on_interrupt()`]
+    ///
+    /// This method already enables (unmasks) the interrupt, you must NOT do it
+    /// yourself.
+    ///
+    /// [`Spawner`]: embassy_executor::Spawner
+    /// [`Spawner::for_current_executor()`]: embassy_executor::Spawner::for_current_executor()
+    pub fn start(&'static self, priority: interrupt::Priority) -> SendSpawner {
+        if self
+            .core
+            .compare_exchange(
+                usize::MAX,
+                get_core() as usize,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            panic!("InterruptExecutor::start() called multiple times on the same executor.");
+        }
+
+        unsafe {
+            (*self.executor.get())
+                .as_mut_ptr()
+                .write(raw::Executor::new(Pender::new_from_callback(
+                    |_| SWI::pend(),
+                    ptr::null_mut(),
+                )))
+        }
+
+        SWI::enable(priority);
+
+        let executor = unsafe { (*self.executor.get()).assume_init_ref() };
+        executor.spawner().make_send()
+    }
+}

--- a/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
@@ -11,9 +11,9 @@ use embassy_executor::{
     raw::{self, Pender},
     SendSpawner,
 };
-#[cfg(esp32)]
+#[cfg(dport)]
 use peripherals::DPORT as SystemPeripheral;
-#[cfg(not(esp32))]
+#[cfg(system)]
 use peripherals::SYSTEM as SystemPeripheral;
 
 use crate::{get_core, interrupt, peripherals};

--- a/esp-hal-common/src/embassy/executor/xtensa/mod.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/mod.rs
@@ -1,0 +1,13 @@
+//! Multicore-aware embassy executors.
+
+#[cfg(feature = "embassy-executor-interrupt")]
+pub mod interrupt;
+
+#[cfg(feature = "embassy-executor-interrupt")]
+pub use interrupt::*;
+
+#[cfg(feature = "embassy-executor-thread")]
+pub mod thread;
+
+#[cfg(feature = "embassy-executor-thread")]
+pub use thread::*;

--- a/esp-hal-common/src/embassy/executor/xtensa/thread.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/thread.rs
@@ -1,0 +1,136 @@
+//! Multicore-aware thread-mode embassy executor.
+use core::{
+    marker::PhantomData,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use embassy_executor::{
+    raw::{self, Pender},
+    Spawner,
+};
+#[cfg(esp32)]
+use peripherals::DPORT as SystemPeripheral;
+#[cfg(not(esp32))]
+use peripherals::SYSTEM as SystemPeripheral;
+
+use crate::{get_core, interrupt, peripherals, prelude::interrupt};
+
+/// global atomic used to keep track of whether there is work to do since sev()
+/// is not available on Xtensa
+#[cfg(not(multi_core))]
+static SIGNAL_WORK_THREAD_MODE: [AtomicBool; 1] = [AtomicBool::new(false)];
+#[cfg(multi_core)]
+static SIGNAL_WORK_THREAD_MODE: [AtomicBool; 2] = [AtomicBool::new(false), AtomicBool::new(false)];
+
+#[interrupt]
+fn FROM_CPU_INTR0() {
+    #[cfg(multi_core)]
+    {
+        // This interrupt is fired when the thread-mode executor's core needs to be
+        // woken. It doesn't matter which core handles this interrupt first, the
+        // point is just to wake up the core that is currently executing
+        // `waiti`.
+        let system = unsafe { &*SystemPeripheral::PTR };
+        system
+            .cpu_intr_from_cpu_0
+            .write(|w| w.cpu_intr_from_cpu_0().bit(false));
+    }
+}
+
+/// Multi-core Xtensa Executor
+pub struct Executor {
+    inner: raw::Executor,
+    not_send: PhantomData<*mut ()>,
+}
+
+impl Executor {
+    /// Create a new Executor.
+    pub fn new() -> Self {
+        #[cfg(multi_core)]
+        interrupt::enable(
+            peripherals::Interrupt::FROM_CPU_INTR0,
+            interrupt::Priority::Priority1,
+        )
+        .unwrap();
+
+        Self {
+            inner: raw::Executor::new(Pender::new_from_callback(
+                |ctx| {
+                    let core = ctx as usize;
+
+                    // Signal that there is work to be done.
+                    SIGNAL_WORK_THREAD_MODE[core].store(true, Ordering::SeqCst);
+
+                    // If we are pending a task on the current core, we're done. Otherwise, we
+                    // need to make sure the other core wakes up.
+                    #[cfg(multi_core)]
+                    if core != get_core() as usize {
+                        // We need to clear the interrupt from software.
+
+                        let system = unsafe { &*SystemPeripheral::PTR };
+                        system
+                            .cpu_intr_from_cpu_0
+                            .write(|w| w.cpu_intr_from_cpu_0().bit(true));
+                    }
+                },
+                get_core() as usize as *mut (),
+            )),
+            not_send: PhantomData,
+        }
+    }
+
+    /// Run the executor.
+    ///
+    /// The `init` closure is called with a [`Spawner`] that spawns tasks on
+    /// this executor. Use it to spawn the initial task(s). After `init`
+    /// returns, the executor starts running the tasks.
+    ///
+    /// To spawn more tasks later, you may keep copies of the [`Spawner`] (it is
+    /// `Copy`), for example by passing it as an argument to the initial
+    /// tasks.
+    ///
+    /// This function requires `&'static mut self`. This means you have to store
+    /// the Executor instance in a place where it'll live forever and grants
+    /// you mutable access. There's a few ways to do this:
+    ///
+    /// - a [StaticCell](https://docs.rs/static_cell/latest/static_cell/) (safe)
+    /// - a `static mut` (unsafe)
+    /// - a local variable in a function you know never returns (like `fn main()
+    ///   -> !`), upgrading its lifetime with `transmute`. (unsafe)
+    ///
+    /// This function never returns.
+    pub fn run(&'static mut self, init: impl FnOnce(Spawner)) -> ! {
+        init(self.inner.spawner());
+
+        let cpu = get_core() as usize;
+
+        loop {
+            unsafe {
+                self.inner.poll();
+
+                // Manual critical section implementation that only masks interrupts handlers.
+                // We must not acquire the cross-core on dual-core systems because that would
+                // prevent the other core from doing useful work while this core is sleeping.
+                let token: critical_section::RawRestoreState;
+                core::arch::asm!("rsil {0}, 5", out(reg) token);
+
+                // we do not care about race conditions between the load and store operations,
+                // interrupts will only set this value to true.
+                if SIGNAL_WORK_THREAD_MODE[cpu].load(Ordering::SeqCst) {
+                    SIGNAL_WORK_THREAD_MODE[cpu].store(false, Ordering::SeqCst);
+
+                    // if there is work to do, exit critical section and loop back to polling
+                    core::arch::asm!(
+                    "wsr.ps {0}",
+                    "rsync", in(reg) token)
+                } else {
+                    // waiti sets the PS.INTLEVEL when slipping into sleep
+                    // because critical sections in Xtensa are implemented via increasing
+                    // PS.INTLEVEL the critical section ends here
+                    // take care not add code after `waiti` if it needs to be inside the CS
+                    core::arch::asm!("waiti 0"); // critical section ends here
+                }
+            }
+        }
+    }
+}

--- a/esp-hal-common/src/embassy/executor/xtensa/thread.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/thread.rs
@@ -10,10 +10,12 @@ use embassy_executor::{
 };
 #[cfg(esp32)]
 use peripherals::DPORT as SystemPeripheral;
-#[cfg(not(esp32))]
+#[cfg(all(not(esp32), multi_core))]
 use peripherals::SYSTEM as SystemPeripheral;
 
-use crate::{get_core, interrupt, peripherals, prelude::interrupt};
+use crate::{get_core, prelude::interrupt};
+#[cfg(multi_core)]
+use crate::{interrupt, peripherals};
 
 /// global atomic used to keep track of whether there is work to do since sev()
 /// is not available on Xtensa

--- a/esp-hal-common/src/embassy/executor/xtensa/thread.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/thread.rs
@@ -8,9 +8,9 @@ use embassy_executor::{
     raw::{self, Pender},
     Spawner,
 };
-#[cfg(esp32)]
+#[cfg(all(dport, multi_core))]
 use peripherals::DPORT as SystemPeripheral;
-#[cfg(all(not(esp32), multi_core))]
+#[cfg(all(system, multi_core))]
 use peripherals::SYSTEM as SystemPeripheral;
 
 use crate::{get_core, prelude::interrupt};

--- a/esp-hal-common/src/embassy/mod.rs
+++ b/esp-hal-common/src/embassy/mod.rs
@@ -22,11 +22,16 @@
 //!       about the alarm's timestamp, a callback function to be executed when
 //!       the alarm triggers, and a context pointer for passing user-defined
 //!       data to the callback.
+//!   * `executor` module
+//!     - This module contains the implementations of a multi-core safe
+//!       thread-mode and an interrupt-mode executor for Xtensa-based ESP chips.
 //!
 //! ## Example
 //! The following example demonstrates how to use the `embassy` driver to
 //! schedule asynchronous tasks.<br> In this example, we use the `embassy`
-//! driver to wait for a GPIO 9 pin state to change. ```no_run
+//! driver to wait for a GPIO 9 pin state to change.
+//!
+//! ```no_run
 //! #[cfg(feature = "embassy-time-systick")]
 //! embassy::init(
 //!     &clocks,
@@ -52,7 +57,7 @@
 //!     spawner.spawn(ping(input)).ok();
 //! });
 //! ```
-//! 
+//!
 //! Where `ping` defined as:
 //! ```no_run
 //! async fn ping(mut pin: Gpio9<Input<PullDown>>) {
@@ -67,12 +72,18 @@
 //! For more embassy-related examples check out the [examples repo](https://github.com/esp-rs/esp-hal/tree/main/esp32-hal/examples)
 //! for a corresponding board.
 
+#[cfg(any(
+    feature = "embassy-executor-interrupt",
+    feature = "embassy-executor-thread"
+))]
+pub mod executor;
+
 use core::cell::Cell;
 
 use embassy_time::driver::{AlarmHandle, Driver};
 
 #[cfg_attr(
-    all(systimer, feature = "embassy-time-systick",),
+    all(systimer, feature = "embassy-time-systick"),
     path = "time_driver_systimer.rs"
 )]
 #[cfg_attr(

--- a/esp-hal-common/src/embassy/mod.rs
+++ b/esp-hal-common/src/embassy/mod.rs
@@ -52,7 +52,7 @@
 //! )
 //! .unwrap();
 //!
-//! let executor = EXECUTOR.init(Executor::new());
+//! let executor = make_static!(Executor::new());
 //! executor.run(|spawner| {
 //!     spawner.spawn(ping(input)).ok();
 //! });

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -31,7 +31,9 @@ embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
-crypto-bigint      = { version = "0.5.2", default-features = false}
+crypto-bigint      = { version = "0.5.2", default-features = false }
+embassy-executor   = { version = "0.2.1", features = ["nightly"] }
+embassy-sync       = "0.2.0"
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
@@ -83,6 +85,18 @@ required-features = ["eh1"]
 [[example]]
 name              = "embassy_hello_world"
 required-features = ["embassy", "embassy-executor-thread"]
+
+[[example]]
+name              = "embassy_multicore"
+required-features = ["embassy", "embassy-executor-thread"]
+
+[[example]]
+name              = "embassy_multicore_interrupt"
+required-features = ["embassy", "embassy-executor-interrupt"]
+
+[[example]]
+name              = "embassy_multiprio"
+required-features = ["embassy", "embassy-executor-interrupt"]
 
 [[example]]
 name              = "embassy_wait"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -47,7 +47,7 @@ lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", b
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"
-static_cell        = "1.2.0"
+static_cell        = { version = "1.2.0", features = ["nightly"] }
 
 [features]
 default            = ["rt", "vectored", "xtal40mhz"]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -32,7 +32,6 @@ embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
-embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
@@ -62,6 +61,9 @@ embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz
 xtal40mhz          = ["esp-hal-common/esp32_40mhz"]
 xtal26mhz          = ["esp-hal-common/esp32_26mhz"]
 
+embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
+embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
+
 psram     = []
 psram_2m  = ["esp-hal-common/psram_2m", "psram"]
 psram_4m  = ["esp-hal-common/psram_4m", "psram"]
@@ -80,15 +82,15 @@ required-features = ["eh1"]
 
 [[example]]
 name              = "embassy_hello_world"
-required-features = ["embassy"]
+required-features = ["embassy", "embassy-executor-thread"]
 
 [[example]]
 name              = "embassy_wait"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "embassy_spi"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "psram"
@@ -96,8 +98,8 @@ required-features = ["psram_2m"]
 
 [[example]]
 name              = "embassy_serial"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "embassy_i2c"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -7,11 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -17,7 +17,7 @@ use esp32_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run1() {
@@ -34,8 +34,6 @@ async fn run2() {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -66,7 +64,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run1()).ok();
         spawner.spawn(run2()).ok();

--- a/esp32-hal/examples/embassy_i2c.rs
+++ b/esp32-hal/examples/embassy_i2c.rs
@@ -28,7 +28,7 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run(i2c: I2C<'static, I2C0>) {
@@ -42,8 +42,6 @@ async fn run(i2c: I2C<'static, I2C0>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -78,7 +76,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(i2c0)).ok();
     });

--- a/esp32-hal/examples/embassy_i2c.rs
+++ b/esp32-hal/examples/embassy_i2c.rs
@@ -14,11 +14,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     i2c::I2C,
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},

--- a/esp32-hal/examples/embassy_multicore.rs
+++ b/esp32-hal/examples/embassy_multicore.rs
@@ -1,0 +1,123 @@
+//! This example shows how to spawn async tasks on the second core.
+//! The second core runs a simple LED blinking task, that is controlled by a
+//! signal set by the task running on the other core.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Ticker};
+use esp32_hal::{
+    clock::ClockControl,
+    cpu_control::{CpuControl, Stack},
+    embassy::{self, executor::Executor},
+    gpio::{GpioPin, Output, PushPull, IO},
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_hal_common::get_core;
+use esp_println::println;
+use static_cell::StaticCell;
+
+static mut APP_CORE_STACK: Stack<8192> = Stack::new();
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+/// Waits for a message that contains a duration, then flashes a led for that
+/// duration of time.
+#[embassy_executor::task]
+async fn control_led(
+    mut led: GpioPin<Output<PushPull>, 0>,
+    control: &'static Signal<CriticalSectionRawMutex, bool>,
+) {
+    println!("Starting control_led() on core {}", get_core() as usize);
+    loop {
+        if control.wait().await {
+            esp_println::println!("LED on");
+            led.set_low().unwrap();
+        } else {
+            esp_println::println!("LED off");
+            led.set_high().unwrap();
+        }
+    }
+}
+
+/// Sends periodic messages to control_led, enabling or disabling it.
+#[embassy_executor::task]
+async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bool>) {
+    println!(
+        "Starting enable_disable_led() on core {}",
+        get_core() as usize
+    );
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        esp_println::println!("Sending LED on");
+        control.signal(true);
+        ticker.next().await;
+
+        esp_println::println!("Sending LED off");
+        control.signal(false);
+        ticker.next().await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let mut timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    timer_group0.wdt.disable();
+    timer_group1.wdt.disable();
+
+    // Set GPIO2 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let mut cpu_control = CpuControl::new(system.cpu_control);
+
+    let led_ctrl_signal = &*singleton!(Signal::new());
+
+    let led = io.pins.gpio0.into_push_pull_output();
+    let cpu1_fnctn = move || {
+        let executor = singleton!(Executor::new());
+        executor.run(|spawner| {
+            spawner.spawn(control_led(led, led_ctrl_signal)).ok();
+        });
+    };
+    let _guard = cpu_control
+        .start_app_core(unsafe { &mut APP_CORE_STACK }, cpu1_fnctn)
+        .unwrap();
+
+    let executor = singleton!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(enable_disable_led(led_ctrl_signal)).ok();
+    });
+}

--- a/esp32-hal/examples/embassy_multicore.rs
+++ b/esp32-hal/examples/embassy_multicore.rs
@@ -21,18 +21,9 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_hal_common::get_core;
 use esp_println::println;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 static mut APP_CORE_STACK: Stack<8192> = Stack::new();
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
-}
 
 /// Waits for a message that contains a duration, then flashes a led for that
 /// duration of time.
@@ -103,11 +94,11 @@ fn main() -> ! {
 
     let mut cpu_control = CpuControl::new(system.cpu_control);
 
-    let led_ctrl_signal = &*singleton!(Signal::new());
+    let led_ctrl_signal = &*make_static!(Signal::new());
 
     let led = io.pins.gpio0.into_push_pull_output();
     let cpu1_fnctn = move || {
-        let executor = singleton!(Executor::new());
+        let executor = make_static!(Executor::new());
         executor.run(|spawner| {
             spawner.spawn(control_led(led, led_ctrl_signal)).ok();
         });
@@ -116,7 +107,7 @@ fn main() -> ! {
         .start_app_core(unsafe { &mut APP_CORE_STACK }, cpu1_fnctn)
         .unwrap();
 
-    let executor = singleton!(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(enable_disable_led(led_ctrl_signal)).ok();
     });

--- a/esp32-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32-hal/examples/embassy_multicore_interrupt.rs
@@ -25,7 +25,7 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_hal_common::get_core;
 use esp_println::println;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 static mut APP_CORE_STACK: Stack<8192> = Stack::new();
 
@@ -40,15 +40,6 @@ fn FROM_CPU_INTR1() {
 #[interrupt]
 fn FROM_CPU_INTR2() {
     unsafe { INT_EXECUTOR_CORE_1.on_interrupt() }
-}
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
 }
 
 /// Waits for a message that contains a duration, then flashes a led for that
@@ -120,7 +111,7 @@ fn main() -> ! {
 
     let mut cpu_control = CpuControl::new(system.cpu_control);
 
-    let led_ctrl_signal = &*singleton!(Signal::new());
+    let led_ctrl_signal = &*make_static!(Signal::new());
 
     let led = io.pins.gpio0.into_push_pull_output();
     let cpu1_fnctn = move || {

--- a/esp32-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32-hal/examples/embassy_multicore_interrupt.rs
@@ -1,0 +1,143 @@
+//! This example shows how to use the interrupt executors on either core.
+//! The second core runs a simple LED blinking task, that is controlled by a
+//! signal set by the task running on the other core.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Ticker};
+use esp32_hal::{
+    clock::ClockControl,
+    cpu_control::{CpuControl, Stack},
+    embassy::{
+        self,
+        executor::{FromCpu1, FromCpu2, InterruptExecutor},
+    },
+    gpio::{GpioPin, Output, PushPull, IO},
+    interrupt::Priority,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_hal_common::get_core;
+use esp_println::println;
+use static_cell::StaticCell;
+
+static mut APP_CORE_STACK: Stack<8192> = Stack::new();
+
+static INT_EXECUTOR_CORE_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
+static INT_EXECUTOR_CORE_1: InterruptExecutor<FromCpu2> = InterruptExecutor::new();
+
+#[interrupt]
+fn FROM_CPU_INTR1() {
+    unsafe { INT_EXECUTOR_CORE_0.on_interrupt() }
+}
+
+#[interrupt]
+fn FROM_CPU_INTR2() {
+    unsafe { INT_EXECUTOR_CORE_1.on_interrupt() }
+}
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+/// Waits for a message that contains a duration, then flashes a led for that
+/// duration of time.
+#[embassy_executor::task]
+async fn control_led(
+    mut led: GpioPin<Output<PushPull>, 0>,
+    control: &'static Signal<CriticalSectionRawMutex, bool>,
+) {
+    println!("Starting control_led() on core {}", get_core() as usize);
+    loop {
+        if control.wait().await {
+            esp_println::println!("LED on");
+            led.set_low().unwrap();
+        } else {
+            esp_println::println!("LED off");
+            led.set_high().unwrap();
+        }
+    }
+}
+
+/// Sends periodic messages to control_led, enabling or disabling it.
+#[embassy_executor::task]
+async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bool>) {
+    println!(
+        "Starting enable_disable_led() on core {}",
+        get_core() as usize
+    );
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        esp_println::println!("Sending LED on");
+        control.signal(true);
+        ticker.next().await;
+
+        esp_println::println!("Sending LED off");
+        control.signal(false);
+        ticker.next().await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let mut timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    timer_group0.wdt.disable();
+    timer_group1.wdt.disable();
+
+    // Set GPIO2 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let mut cpu_control = CpuControl::new(system.cpu_control);
+
+    let led_ctrl_signal = &*singleton!(Signal::new());
+
+    let led = io.pins.gpio0.into_push_pull_output();
+    let cpu1_fnctn = move || {
+        let spawner = INT_EXECUTOR_CORE_1.start(Priority::Priority1);
+
+        spawner.spawn(control_led(led, led_ctrl_signal)).ok();
+
+        // Just loop to show that the main thread does not need to poll the executor.
+        loop {}
+    };
+    let _guard = cpu_control
+        .start_app_core(unsafe { &mut APP_CORE_STACK }, cpu1_fnctn)
+        .unwrap();
+
+    let spawner = INT_EXECUTOR_CORE_0.start(Priority::Priority1);
+    spawner.spawn(enable_disable_led(led_ctrl_signal)).ok();
+
+    // Just loop to show that the main thread does not need to poll the executor.
+    loop {}
+}

--- a/esp32-hal/examples/embassy_multiprio.rs
+++ b/esp32-hal/examples/embassy_multiprio.rs
@@ -24,7 +24,7 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_hal_common::get_core;
 use esp_println::println;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 static INT_EXECUTOR_1: InterruptExecutor<FromCpu2> = InterruptExecutor::new();
@@ -37,15 +37,6 @@ fn FROM_CPU_INTR1() {
 #[interrupt]
 fn FROM_CPU_INTR2() {
     unsafe { INT_EXECUTOR_1.on_interrupt() }
-}
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
 }
 
 /// Periodically turns the LED on and off.
@@ -118,7 +109,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let led = singleton!(io.pins.gpio0.into_push_pull_output());
+    let led = make_static!(io.pins.gpio0.into_push_pull_output());
 
     let spawner = INT_EXECUTOR_0.start(Priority::Priority2);
     spawner.spawn(high_prio(led)).ok();

--- a/esp32-hal/examples/embassy_multiprio.rs
+++ b/esp32-hal/examples/embassy_multiprio.rs
@@ -1,0 +1,132 @@
+//! This example shows how to use the interrupt executors to prioritize some
+//! tasks over others. The low priority task will not be able to run its async
+//! task while the blocking task is running, but the high priority task will be
+//! able to blink the LED regardless.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_time::{Duration, Instant, Ticker};
+use esp32_hal::{
+    clock::ClockControl,
+    embassy::{
+        self,
+        executor::{FromCpu1, FromCpu2, InterruptExecutor},
+    },
+    gpio::{GpioPin, Output, PushPull, IO},
+    interrupt::Priority,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_hal_common::get_core;
+use esp_println::println;
+use static_cell::StaticCell;
+
+static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
+static INT_EXECUTOR_1: InterruptExecutor<FromCpu2> = InterruptExecutor::new();
+
+#[interrupt]
+fn FROM_CPU_INTR1() {
+    unsafe { INT_EXECUTOR_0.on_interrupt() }
+}
+
+#[interrupt]
+fn FROM_CPU_INTR2() {
+    unsafe { INT_EXECUTOR_1.on_interrupt() }
+}
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+/// Periodically turns the LED on and off.
+#[embassy_executor::task]
+async fn high_prio(led: &'static mut GpioPin<Output<PushPull>, 0>) {
+    println!("Starting high_prio() on core {}", get_core() as usize);
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        esp_println::println!("LED on");
+        led.set_low().unwrap();
+        ticker.next().await;
+
+        esp_println::println!("LED off");
+        led.set_high().unwrap();
+        ticker.next().await;
+    }
+}
+
+/// Simulates some blocking (badly behaving) task.
+#[embassy_executor::task]
+async fn low_prio_blocking() {
+    println!(
+        "Starting low_prio_blocking() on core {}",
+        get_core() as usize
+    );
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(10) {}
+    esp_println::println!("Low prio task finished");
+}
+
+/// Simulates a well-behaved async task that prints to the serial output.
+#[embassy_executor::task]
+async fn low_prio_async() {
+    println!("Starting low_prio_async() on core {}", get_core() as usize);
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        // Note that when the blocking task finishes, the ticker will fire multiple
+        // times.
+        println!("Tick from low priority async task");
+        ticker.next().await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let mut timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    timer_group0.wdt.disable();
+    timer_group1.wdt.disable();
+
+    // Set GPIO2 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let led = singleton!(io.pins.gpio0.into_push_pull_output());
+
+    let spawner = INT_EXECUTOR_0.start(Priority::Priority2);
+    spawner.spawn(high_prio(led)).ok();
+
+    let spawner = INT_EXECUTOR_1.start(Priority::Priority1);
+    spawner.spawn(low_prio_async()).ok();
+    spawner.spawn(low_prio_blocking()).ok();
+
+    // Just loop to show that the main thread does not need to poll the executor.
+    loop {}
+}

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -9,11 +9,10 @@
 
 use core::fmt::Write;
 
-use embassy_executor::Executor;
 use embassy_time::{with_timeout, Duration};
 use esp32_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -23,7 +23,7 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
 use heapless::Vec;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -100,8 +100,6 @@ async fn run(mut uart: Uart<'static, UART0>) {
     }
 }
 
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
-
 #[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
@@ -139,7 +137,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(uart0)).ok();
     });

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -32,16 +32,7 @@ use esp32_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
-}
+use static_cell::make_static;
 
 pub type SpiType<'d> = SpiDma<'d, esp32_hal::peripherals::SPI2, Spi2DmaChannel, FullDuplexMode>;
 
@@ -58,8 +49,6 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -111,10 +100,10 @@ fn main() -> ! {
     let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
     let dma_channel = dma.spi2channel;
 
-    let descriptors = singleton!([0u32; 8 * 3]);
-    let rx_descriptors = singleton!([0u32; 8 * 3]);
+    let descriptors = make_static!([0u32; 8 * 3]);
+    let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let spi = singleton!(Spi::new(
+    let spi = make_static!(Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -132,7 +121,7 @@ fn main() -> ! {
         DmaPriority::Priority0,
     )));
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(spi_task(spi)).ok();
     });

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -18,12 +18,11 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy,
+    embassy::{self, executor::Executor},
     pdma::*,
     peripherals::Peripherals,
     prelude::*,

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -19,7 +19,7 @@ use esp32_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio0<Input<PullDown>>) {
@@ -30,8 +30,6 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -73,7 +71,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(ping(input)).ok();
     });

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -6,12 +6,11 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
 use esp32_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     gpio::{Gpio0, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -41,7 +41,7 @@ heapless           = "0.7.16"
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 ssd1306            = "0.8.0"
-static_cell        = "1.2.0"
+static_cell        = { version = "1.2.0", features = ["nightly"] }
 
 [features]
 default              = ["rt", "vectored", "xtal40mhz"]

--- a/esp32c2-hal/examples/embassy_hello_world.rs
+++ b/esp32c2-hal/examples/embassy_hello_world.rs
@@ -18,7 +18,7 @@ use esp32c2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run1() {
@@ -35,8 +35,6 @@ async fn run2() {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -67,7 +65,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run1()).ok();
         spawner.spawn(run2()).ok();

--- a/esp32c2-hal/examples/embassy_i2c.rs
+++ b/esp32c2-hal/examples/embassy_i2c.rs
@@ -29,7 +29,7 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run(i2c: I2C<'static, I2C0>) {
@@ -43,8 +43,6 @@ async fn run(i2c: I2C<'static, I2C0>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -87,7 +85,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(i2c0)).ok();
     });

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -24,7 +24,7 @@ use esp32c2_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
 use heapless::Vec;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -101,8 +101,6 @@ async fn run(mut uart: Uart<'static, UART0>) {
     }
 }
 
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
-
 #[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
@@ -140,7 +138,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(uart0)).ok();
     });

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -33,16 +33,7 @@ use esp32c2_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
-}
+use static_cell::make_static;
 
 pub type SpiType<'d> =
     SpiDma<'d, esp32c2_hal::peripherals::SPI2, esp32c2_hal::gdma::Channel0, FullDuplexMode>;
@@ -60,8 +51,6 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -107,10 +96,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
     let dma_channel = dma.channel0;
 
-    let descriptors = singleton!([0u32; 8 * 3]);
-    let rx_descriptors = singleton!([0u32; 8 * 3]);
+    let descriptors = make_static!([0u32; 8 * 3]);
+    let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let spi = singleton!(Spi::new(
+    let spi = make_static!(Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -128,7 +117,7 @@ fn main() -> ! {
         DmaPriority::Priority0,
     )));
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(spi_task(spi)).ok();
     });

--- a/esp32c2-hal/examples/embassy_wait.rs
+++ b/esp32c2-hal/examples/embassy_wait.rs
@@ -20,7 +20,7 @@ use esp32c2_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio9<Input<PullDown>>) {
@@ -31,8 +31,6 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -73,7 +71,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(ping(input)).ok();
     });

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -49,7 +49,7 @@ lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", b
 sha2               = { version = "0.10.7", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"
-static_cell        = "1.2.0"
+static_cell        = { version = "1.2.0", features = ["nightly"] }
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -18,7 +18,7 @@ use esp32c3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run1() {
@@ -35,8 +35,6 @@ async fn run2() {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -74,7 +72,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run1()).ok();
         spawner.spawn(run2()).ok();

--- a/esp32c3-hal/examples/embassy_i2c.rs
+++ b/esp32c3-hal/examples/embassy_i2c.rs
@@ -29,7 +29,7 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run(i2c: I2C<'static, I2C0>) {
@@ -43,8 +43,6 @@ async fn run(i2c: I2C<'static, I2C0>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -94,7 +92,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(i2c0)).ok();
     });

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -24,7 +24,7 @@ use esp32c3_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
 use heapless::Vec;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -101,8 +101,6 @@ async fn run(mut uart: Uart<'static, UART0>) {
     }
 }
 
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
-
 #[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
@@ -147,7 +145,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(uart0)).ok();
     });

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -33,16 +33,7 @@ use esp32c3_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
-}
+use static_cell::make_static;
 
 pub type SpiType<'d> =
     SpiDma<'d, esp32c3_hal::peripherals::SPI2, esp32c3_hal::gdma::Channel0, FullDuplexMode>;
@@ -60,8 +51,6 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -114,10 +103,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
     let dma_channel = dma.channel0;
 
-    let descriptors = singleton!([0u32; 8 * 3]);
-    let rx_descriptors = singleton!([0u32; 8 * 3]);
+    let descriptors = make_static!([0u32; 8 * 3]);
+    let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let spi = singleton!(Spi::new(
+    let spi = make_static!(Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -135,7 +124,7 @@ fn main() -> ! {
         DmaPriority::Priority0,
     )));
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(spi_task(spi)).ok();
     });

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -20,7 +20,7 @@ use esp32c3_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio9<Input<PullDown>>) {
@@ -31,8 +31,6 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -81,7 +79,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(ping(input)).ok();
     });

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -48,7 +48,7 @@ lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", b
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"
-static_cell        = "1.2.0"
+static_cell        = { version = "1.2.0", features = ["nightly"] }
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c6-hal/examples/embassy_hello_world.rs
+++ b/esp32c6-hal/examples/embassy_hello_world.rs
@@ -18,7 +18,7 @@ use esp32c6_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run1() {
@@ -35,8 +35,6 @@ async fn run2() {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -74,7 +72,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run1()).ok();
         spawner.spawn(run2()).ok();

--- a/esp32c6-hal/examples/embassy_i2c.rs
+++ b/esp32c6-hal/examples/embassy_i2c.rs
@@ -29,7 +29,7 @@ use esp32c6_hal::{
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run(i2c: I2C<'static, I2C0>) {
@@ -43,8 +43,6 @@ async fn run(i2c: I2C<'static, I2C0>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -94,7 +92,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(i2c0)).ok();
     });

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -24,7 +24,7 @@ use esp32c6_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
 use heapless::Vec;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -101,8 +101,6 @@ async fn run(mut uart: Uart<'static, UART0>) {
     }
 }
 
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
-
 #[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
@@ -147,7 +145,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(uart0)).ok();
     });

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -33,16 +33,7 @@ use esp32c6_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
-}
+use static_cell::make_static;
 
 pub type SpiType<'d> =
     SpiDma<'d, esp32c6_hal::peripherals::SPI2, esp32c6_hal::gdma::Channel0, FullDuplexMode>;
@@ -60,8 +51,6 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -121,10 +110,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
     let dma_channel = dma.channel0;
 
-    let descriptors = singleton!([0u32; 8 * 3]);
-    let rx_descriptors = singleton!([0u32; 8 * 3]);
+    let descriptors = make_static!([0u32; 8 * 3]);
+    let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let spi = singleton!(Spi::new(
+    let spi = make_static!(Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -142,7 +131,7 @@ fn main() -> ! {
         DmaPriority::Priority0,
     )));
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(spi_task(spi)).ok();
     });

--- a/esp32c6-hal/examples/embassy_wait.rs
+++ b/esp32c6-hal/examples/embassy_wait.rs
@@ -20,7 +20,7 @@ use esp32c6_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio9<Input<PullDown>>) {
@@ -31,8 +31,6 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -81,7 +79,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(ping(input)).ok();
     });

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -48,7 +48,7 @@ lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", b
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"
-static_cell        = "1.2.0"
+static_cell        = { version = "1.2.0", features = ["nightly"] }
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32h2-hal/examples/embassy_hello_world.rs
+++ b/esp32h2-hal/examples/embassy_hello_world.rs
@@ -18,7 +18,7 @@ use esp32h2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run1() {
@@ -35,8 +35,6 @@ async fn run2() {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -74,7 +72,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run1()).ok();
         spawner.spawn(run2()).ok();

--- a/esp32h2-hal/examples/embassy_i2c.rs
+++ b/esp32h2-hal/examples/embassy_i2c.rs
@@ -29,7 +29,7 @@ use esp32h2_hal::{
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run(i2c: I2C<'static, I2C0>) {
@@ -43,8 +43,6 @@ async fn run(i2c: I2C<'static, I2C0>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -94,7 +92,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(i2c0)).ok();
     });

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -24,7 +24,7 @@ use esp32h2_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
 use heapless::Vec;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -101,8 +101,6 @@ async fn run(mut uart: Uart<'static, UART0>) {
     }
 }
 
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
-
 #[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
@@ -147,7 +145,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(uart0)).ok();
     });

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -33,16 +33,7 @@ use esp32h2_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
-}
+use static_cell::make_static;
 
 pub type SpiType<'d> =
     SpiDma<'d, esp32h2_hal::peripherals::SPI2, esp32h2_hal::gdma::Channel0, FullDuplexMode>;
@@ -60,8 +51,6 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -121,10 +110,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
     let dma_channel = dma.channel0;
 
-    let descriptors = singleton!([0u32; 8 * 3]);
-    let rx_descriptors = singleton!([0u32; 8 * 3]);
+    let descriptors = make_static!([0u32; 8 * 3]);
+    let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let spi = singleton!(Spi::new(
+    let spi = make_static!(Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -142,7 +131,7 @@ fn main() -> ! {
         DmaPriority::Priority0,
     )));
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(spi_task(spi)).ok();
     });

--- a/esp32h2-hal/examples/embassy_wait.rs
+++ b/esp32h2-hal/examples/embassy_wait.rs
@@ -20,7 +20,7 @@ use esp32h2_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio9<Input<PullDown>>) {
@@ -31,8 +31,6 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -81,7 +79,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(ping(input)).ok();
     });

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -33,6 +33,8 @@ xtensa-atomic-emulation-trap = "0.4.0"
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
+embassy-executor   = { version = "0.2.1", features = ["nightly"] }
+embassy-sync       = "0.2.0"
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
@@ -44,7 +46,7 @@ esp-println        = { version = "0.5.0", features = ["esp32s2"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
-sha2               = { version = "0.10.7", default-features = false}
+sha2               = { version = "0.10.7", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"
 static_cell        = "1.2.0"
@@ -88,6 +90,10 @@ required-features = ["eh1"]
 [[example]]
 name              = "embassy_hello_world"
 required-features = ["embassy", "embassy-executor-thread"]
+
+[[example]]
+name              = "embassy_multiprio"
+required-features = ["embassy", "embassy-executor-interrupt"]
 
 [[example]]
 name              = "embassy_wait"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -49,7 +49,7 @@ lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", b
 sha2               = { version = "0.10.7", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"
-static_cell        = "1.2.0"
+static_cell        = { version = "1.2.0", features = ["nightly"] }
 usb-device         = "0.2.9"
 usbd-serial        = "0.1.1"
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -32,8 +32,7 @@ xtensa-atomic-emulation-trap = "0.4.0"
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
-crypto-bigint      = { version = "0.5.2", default-features = false}
-embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
+crypto-bigint      = { version = "0.5.2", default-features = false }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
@@ -67,6 +66,9 @@ embassy   = ["esp-hal-common/embassy"]
 # embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-1_000_000"] 
 embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
+embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
+embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
+
 psram     = []
 psram_2m  = ["esp-hal-common/psram_2m", "psram"]
 psram_4m  = ["esp-hal-common/psram_4m", "psram"]
@@ -85,15 +87,15 @@ required-features = ["eh1"]
 
 [[example]]
 name              = "embassy_hello_world"
-required-features = ["embassy"]
+required-features = ["embassy", "embassy-executor-thread"]
 
 [[example]]
 name              = "embassy_wait"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "embassy_spi"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "psram"
@@ -101,8 +103,8 @@ required-features = ["psram_2m"]
 
 [[example]]
 name              = "embassy_serial"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "embassy_i2c"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -7,11 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -17,7 +17,7 @@ use esp32s2_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 use xtensa_atomic_emulation_trap as _;
 
 #[embassy_executor::task]
@@ -35,8 +35,6 @@ async fn run2() {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -67,7 +65,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run1()).ok();
         spawner.spawn(run2()).ok();

--- a/esp32s2-hal/examples/embassy_i2c.rs
+++ b/esp32s2-hal/examples/embassy_i2c.rs
@@ -14,11 +14,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     i2c::I2C,
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},

--- a/esp32s2-hal/examples/embassy_i2c.rs
+++ b/esp32s2-hal/examples/embassy_i2c.rs
@@ -28,7 +28,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run(i2c: I2C<'static, I2C0>) {
@@ -42,8 +42,6 @@ async fn run(i2c: I2C<'static, I2C0>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -79,7 +77,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(i2c0)).ok();
     });

--- a/esp32s2-hal/examples/embassy_multiprio.rs
+++ b/esp32s2-hal/examples/embassy_multiprio.rs
@@ -24,7 +24,7 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use esp_hal_common::get_core;
 use esp_println::println;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 static INT_EXECUTOR_1: InterruptExecutor<FromCpu2> = InterruptExecutor::new();
@@ -37,15 +37,6 @@ fn FROM_CPU_INTR1() {
 #[interrupt]
 fn FROM_CPU_INTR2() {
     unsafe { INT_EXECUTOR_1.on_interrupt() }
-}
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
 }
 
 /// Periodically turns the LED on and off.
@@ -118,7 +109,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let led = singleton!(io.pins.gpio0.into_push_pull_output());
+    let led = make_static!(io.pins.gpio0.into_push_pull_output());
 
     let spawner = INT_EXECUTOR_0.start(Priority::Priority2);
     spawner.spawn(high_prio(led)).ok();

--- a/esp32s2-hal/examples/embassy_multiprio.rs
+++ b/esp32s2-hal/examples/embassy_multiprio.rs
@@ -1,0 +1,132 @@
+//! This example shows how to use the interrupt executors to prioritize some
+//! tasks over others. The low priority task will not be able to run its async
+//! task while the blocking task is running, but the high priority task will be
+//! able to blink the LED regardless.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_time::{Duration, Instant, Ticker};
+use esp32s2_hal::{
+    clock::ClockControl,
+    embassy::{
+        self,
+        executor::{FromCpu1, FromCpu2, InterruptExecutor},
+    },
+    gpio::{GpioPin, Output, PushPull, IO},
+    interrupt::Priority,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_hal_common::get_core;
+use esp_println::println;
+use static_cell::StaticCell;
+
+static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
+static INT_EXECUTOR_1: InterruptExecutor<FromCpu2> = InterruptExecutor::new();
+
+#[interrupt]
+fn FROM_CPU_INTR1() {
+    unsafe { INT_EXECUTOR_0.on_interrupt() }
+}
+
+#[interrupt]
+fn FROM_CPU_INTR2() {
+    unsafe { INT_EXECUTOR_1.on_interrupt() }
+}
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+/// Periodically turns the LED on and off.
+#[embassy_executor::task]
+async fn high_prio(led: &'static mut GpioPin<Output<PushPull>, 0>) {
+    println!("Starting high_prio() on core {}", get_core() as usize);
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        esp_println::println!("LED on");
+        led.set_low().unwrap();
+        ticker.next().await;
+
+        esp_println::println!("LED off");
+        led.set_high().unwrap();
+        ticker.next().await;
+    }
+}
+
+/// Simulates some blocking (badly behaving) task.
+#[embassy_executor::task]
+async fn low_prio_blocking() {
+    println!(
+        "Starting low_prio_blocking() on core {}",
+        get_core() as usize
+    );
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(10) {}
+    esp_println::println!("Low prio task finished");
+}
+
+/// Simulates a well-behaved async task that prints to the serial output.
+#[embassy_executor::task]
+async fn low_prio_async() {
+    println!("Starting low_prio_async() on core {}", get_core() as usize);
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        // Note that when the blocking task finishes, the ticker will fire multiple
+        // times.
+        println!("Tick from low priority async task");
+        ticker.next().await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let mut timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    timer_group0.wdt.disable();
+    timer_group1.wdt.disable();
+
+    // Set GPIO2 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let led = singleton!(io.pins.gpio0.into_push_pull_output());
+
+    let spawner = INT_EXECUTOR_0.start(Priority::Priority2);
+    spawner.spawn(high_prio(led)).ok();
+
+    let spawner = INT_EXECUTOR_1.start(Priority::Priority1);
+    spawner.spawn(low_prio_async()).ok();
+    spawner.spawn(low_prio_blocking()).ok();
+
+    // Just loop to show that the main thread does not need to poll the executor.
+    loop {}
+}

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -9,11 +9,10 @@
 
 use core::fmt::Write;
 
-use embassy_executor::Executor;
 use embassy_time::{with_timeout, Duration};
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -23,7 +23,7 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
 use heapless::Vec;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -100,8 +100,6 @@ async fn run(mut uart: Uart<'static, UART0>) {
     }
 }
 
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
-
 #[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
@@ -139,7 +137,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(uart0)).ok();
     });

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -18,12 +18,11 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy,
+    embassy::{self, executor::Executor},
     pdma::*,
     peripherals::Peripherals,
     prelude::*,

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -32,16 +32,7 @@ use esp32s2_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
-}
+use static_cell::make_static;
 
 pub type SpiType<'d> = SpiDma<'d, esp32s2_hal::peripherals::SPI2, Spi2DmaChannel, FullDuplexMode>;
 
@@ -58,8 +49,6 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -111,10 +100,10 @@ fn main() -> ! {
     let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
     let dma_channel = dma.spi2channel;
 
-    let descriptors = singleton!([0u32; 8 * 3]);
-    let rx_descriptors = singleton!([0u32; 8 * 3]);
+    let descriptors = make_static!([0u32; 8 * 3]);
+    let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let spi = singleton!(Spi::new(
+    let spi = make_static!(Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -132,7 +121,7 @@ fn main() -> ! {
         DmaPriority::Priority0,
     )));
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(spi_task(spi)).ok();
     });

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -6,12 +6,11 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     gpio::{Gpio0, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -19,7 +19,7 @@ use esp32s2_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio0<Input<PullDown>>) {
@@ -30,8 +30,6 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -73,7 +71,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(ping(input)).ok();
     });

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -33,7 +33,6 @@ r0             = { version = "1.0.0",  optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
-embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
@@ -67,6 +66,9 @@ embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
+embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
+embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
+
 psram     = []
 psram_2m  = ["esp-hal-common/psram_2m", "psram"]
 psram_4m  = ["esp-hal-common/psram_4m", "psram"]
@@ -88,15 +90,15 @@ required-features = ["eh1"]
 
 [[example]]
 name              = "embassy_hello_world"
-required-features = ["embassy"]
+required-features = ["embassy", "embassy-executor-thread"]
 
 [[example]]
 name              = "embassy_wait"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "embassy_spi"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "psram"
@@ -108,8 +110,8 @@ required-features = ["opsram_2m"]
 
 [[example]]
 name              = "embassy_serial"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]
 
 [[example]]
 name              = "embassy_i2c"
-required-features = ["embassy", "async"]
+required-features = ["embassy", "embassy-executor-thread", "async"]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -32,7 +32,9 @@ r0             = { version = "1.0.0",  optional = true }
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
-crypto-bigint      = { version = "0.5.2", default-features = false}
+crypto-bigint      = { version = "0.5.2", default-features = false }
+embassy-executor   = { version = "0.2.1", features = ["nightly"] }
+embassy-sync       = "0.2.0"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
@@ -46,7 +48,7 @@ esp-println        = { version = "0.5.0", features = ["esp32s3", "log"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
-sha2               = { version = "0.10.7", default-features = false}
+sha2               = { version = "0.10.7", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"
 static_cell        = "1.2.0"
@@ -91,6 +93,18 @@ required-features = ["eh1"]
 [[example]]
 name              = "embassy_hello_world"
 required-features = ["embassy", "embassy-executor-thread"]
+
+[[example]]
+name              = "embassy_multicore"
+required-features = ["embassy", "embassy-executor-thread"]
+
+[[example]]
+name              = "embassy_multicore_interrupt"
+required-features = ["embassy", "embassy-executor-interrupt"]
+
+[[example]]
+name              = "embassy_multiprio"
+required-features = ["embassy", "embassy-executor-interrupt"]
 
 [[example]]
 name              = "embassy_wait"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -51,7 +51,7 @@ lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", b
 sha2               = { version = "0.10.7", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"
-static_cell        = "1.2.0"
+static_cell        = { version = "1.2.0", features = ["nightly"] }
 usb-device         = "0.2.9"
 usbd-serial        = "0.1.1"
 

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -7,11 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -17,7 +17,7 @@ use esp32s3_hal::{
     Rtc,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run1() {
@@ -34,8 +34,6 @@ async fn run2() {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -73,7 +71,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run1()).ok();
         spawner.spawn(run2()).ok();

--- a/esp32s3-hal/examples/embassy_i2c.rs
+++ b/esp32s3-hal/examples/embassy_i2c.rs
@@ -28,7 +28,7 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run(i2c: I2C<'static, I2C0>) {
@@ -42,8 +42,6 @@ async fn run(i2c: I2C<'static, I2C0>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -85,7 +83,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(i2c0)).ok();
     });

--- a/esp32s3-hal/examples/embassy_i2c.rs
+++ b/esp32s3-hal/examples/embassy_i2c.rs
@@ -14,11 +14,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     i2c::I2C,
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},

--- a/esp32s3-hal/examples/embassy_multicore.rs
+++ b/esp32s3-hal/examples/embassy_multicore.rs
@@ -1,0 +1,129 @@
+//! This example shows how to spawn async tasks on the second core.
+//! The second core runs a simple LED blinking task, that is controlled by a
+//! signal set by the task running on the other core.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Ticker};
+use esp32s3_hal::{
+    clock::ClockControl,
+    cpu_control::{CpuControl, Stack},
+    embassy::{self, executor::Executor},
+    gpio::{GpioPin, Output, PushPull, IO},
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_hal_common::get_core;
+use esp_println::println;
+use static_cell::StaticCell;
+
+static mut APP_CORE_STACK: Stack<8192> = Stack::new();
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+/// Waits for a message that contains a duration, then flashes a led for that
+/// duration of time.
+#[embassy_executor::task]
+async fn control_led(
+    mut led: GpioPin<Output<PushPull>, 0>,
+    control: &'static Signal<CriticalSectionRawMutex, bool>,
+) {
+    println!("Starting control_led() on core {}", get_core() as usize);
+    loop {
+        if control.wait().await {
+            esp_println::println!("LED on");
+            led.set_low().unwrap();
+        } else {
+            esp_println::println!("LED off");
+            led.set_high().unwrap();
+        }
+    }
+}
+
+/// Sends periodic messages to control_led, enabling or disabling it.
+#[embassy_executor::task]
+async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bool>) {
+    println!(
+        "Starting enable_disable_led() on core {}",
+        get_core() as usize
+    );
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        esp_println::println!("Sending LED on");
+        control.signal(true);
+        ticker.next().await;
+
+        esp_println::println!("Sending LED off");
+        control.signal(false);
+        ticker.next().await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let mut timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    timer_group0.wdt.disable();
+    timer_group1.wdt.disable();
+
+    // Set GPIO2 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let mut cpu_control = CpuControl::new(system.cpu_control);
+
+    let led_ctrl_signal = &*singleton!(Signal::new());
+
+    let led = io.pins.gpio0.into_push_pull_output();
+    let cpu1_fnctn = move || {
+        let executor = singleton!(Executor::new());
+        executor.run(|spawner| {
+            spawner.spawn(control_led(led, led_ctrl_signal)).ok();
+        });
+    };
+    let _guard = cpu_control
+        .start_app_core(unsafe { &mut APP_CORE_STACK }, cpu1_fnctn)
+        .unwrap();
+
+    let executor = singleton!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(enable_disable_led(led_ctrl_signal)).ok();
+    });
+}

--- a/esp32s3-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32s3-hal/examples/embassy_multicore_interrupt.rs
@@ -25,7 +25,7 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_hal_common::get_core;
 use esp_println::println;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 static mut APP_CORE_STACK: Stack<8192> = Stack::new();
 
@@ -40,15 +40,6 @@ fn FROM_CPU_INTR1() {
 #[interrupt]
 fn FROM_CPU_INTR2() {
     unsafe { INT_EXECUTOR_CORE_1.on_interrupt() }
-}
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
 }
 
 /// Waits for a message that contains a duration, then flashes a led for that
@@ -126,7 +117,7 @@ fn main() -> ! {
 
     let mut cpu_control = CpuControl::new(system.cpu_control);
 
-    let led_ctrl_signal = &*singleton!(Signal::new());
+    let led_ctrl_signal = &*make_static!(Signal::new());
 
     let led = io.pins.gpio0.into_push_pull_output();
     let cpu1_fnctn = move || {

--- a/esp32s3-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32s3-hal/examples/embassy_multicore_interrupt.rs
@@ -1,0 +1,149 @@
+//! This example shows how to use the interrupt executors on either core.
+//! The second core runs a simple LED blinking task, that is controlled by a
+//! signal set by the task running on the other core.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Ticker};
+use esp32s3_hal::{
+    clock::ClockControl,
+    cpu_control::{CpuControl, Stack},
+    embassy::{
+        self,
+        executor::{FromCpu1, FromCpu2, InterruptExecutor},
+    },
+    gpio::{GpioPin, Output, PushPull, IO},
+    interrupt::Priority,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_hal_common::get_core;
+use esp_println::println;
+use static_cell::StaticCell;
+
+static mut APP_CORE_STACK: Stack<8192> = Stack::new();
+
+static INT_EXECUTOR_CORE_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
+static INT_EXECUTOR_CORE_1: InterruptExecutor<FromCpu2> = InterruptExecutor::new();
+
+#[interrupt]
+fn FROM_CPU_INTR1() {
+    unsafe { INT_EXECUTOR_CORE_0.on_interrupt() }
+}
+
+#[interrupt]
+fn FROM_CPU_INTR2() {
+    unsafe { INT_EXECUTOR_CORE_1.on_interrupt() }
+}
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+/// Waits for a message that contains a duration, then flashes a led for that
+/// duration of time.
+#[embassy_executor::task]
+async fn control_led(
+    mut led: GpioPin<Output<PushPull>, 0>,
+    control: &'static Signal<CriticalSectionRawMutex, bool>,
+) {
+    println!("Starting control_led() on core {}", get_core() as usize);
+    loop {
+        if control.wait().await {
+            esp_println::println!("LED on");
+            led.set_low().unwrap();
+        } else {
+            esp_println::println!("LED off");
+            led.set_high().unwrap();
+        }
+    }
+}
+
+/// Sends periodic messages to control_led, enabling or disabling it.
+#[embassy_executor::task]
+async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bool>) {
+    println!(
+        "Starting enable_disable_led() on core {}",
+        get_core() as usize
+    );
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        esp_println::println!("Sending LED on");
+        control.signal(true);
+        ticker.next().await;
+
+        esp_println::println!("Sending LED off");
+        control.signal(false);
+        ticker.next().await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let mut timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    timer_group0.wdt.disable();
+    timer_group1.wdt.disable();
+
+    // Set GPIO2 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let mut cpu_control = CpuControl::new(system.cpu_control);
+
+    let led_ctrl_signal = &*singleton!(Signal::new());
+
+    let led = io.pins.gpio0.into_push_pull_output();
+    let cpu1_fnctn = move || {
+        let spawner = INT_EXECUTOR_CORE_1.start(Priority::Priority1);
+
+        spawner.spawn(control_led(led, led_ctrl_signal)).ok();
+
+        // Just loop to show that the main thread does not need to poll the executor.
+        loop {}
+    };
+    let _guard = cpu_control
+        .start_app_core(unsafe { &mut APP_CORE_STACK }, cpu1_fnctn)
+        .unwrap();
+
+    let spawner = INT_EXECUTOR_CORE_0.start(Priority::Priority1);
+    spawner.spawn(enable_disable_led(led_ctrl_signal)).ok();
+
+    // Just loop to show that the main thread does not need to poll the executor.
+    loop {}
+}

--- a/esp32s3-hal/examples/embassy_multiprio.rs
+++ b/esp32s3-hal/examples/embassy_multiprio.rs
@@ -1,0 +1,138 @@
+//! This example shows how to use the interrupt executors to prioritize some
+//! tasks over others. The low priority task will not be able to run its async
+//! task while the blocking task is running, but the high priority task will be
+//! able to blink the LED regardless.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_time::{Duration, Instant, Ticker};
+use esp32s3_hal::{
+    clock::ClockControl,
+    embassy::{
+        self,
+        executor::{FromCpu1, FromCpu2, InterruptExecutor},
+    },
+    gpio::{GpioPin, Output, PushPull, IO},
+    interrupt::Priority,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_hal_common::get_core;
+use esp_println::println;
+use static_cell::StaticCell;
+
+static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
+static INT_EXECUTOR_1: InterruptExecutor<FromCpu2> = InterruptExecutor::new();
+
+#[interrupt]
+fn FROM_CPU_INTR1() {
+    unsafe { INT_EXECUTOR_0.on_interrupt() }
+}
+
+#[interrupt]
+fn FROM_CPU_INTR2() {
+    unsafe { INT_EXECUTOR_1.on_interrupt() }
+}
+
+macro_rules! singleton {
+    ($val:expr) => {{
+        type T = impl Sized;
+        static STATIC_CELL: StaticCell<T> = StaticCell::new();
+        let (x,) = STATIC_CELL.init(($val,));
+        x
+    }};
+}
+
+/// Periodically turns the LED on and off.
+#[embassy_executor::task]
+async fn high_prio(led: &'static mut GpioPin<Output<PushPull>, 0>) {
+    println!("Starting high_prio() on core {}", get_core() as usize);
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        esp_println::println!("LED on");
+        led.set_low().unwrap();
+        ticker.next().await;
+
+        esp_println::println!("LED off");
+        led.set_high().unwrap();
+        ticker.next().await;
+    }
+}
+
+/// Simulates some blocking (badly behaving) task.
+#[embassy_executor::task]
+async fn low_prio_blocking() {
+    println!(
+        "Starting low_prio_blocking() on core {}",
+        get_core() as usize
+    );
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(10) {}
+    esp_println::println!("Low prio task finished");
+}
+
+/// Simulates a well-behaved async task that prints to the serial output.
+#[embassy_executor::task]
+async fn low_prio_async() {
+    println!("Starting low_prio_async() on core {}", get_core() as usize);
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        // Note that when the blocking task finishes, the ticker will fire multiple
+        // times.
+        println!("Tick from low priority async task");
+        ticker.next().await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let mut timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+
+    // Disable watchdog timers
+    rtc.rwdt.disable();
+    timer_group0.wdt.disable();
+    timer_group1.wdt.disable();
+
+    // Set GPIO2 as an output, and set its state high initially.
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let led = singleton!(io.pins.gpio0.into_push_pull_output());
+
+    let spawner = INT_EXECUTOR_0.start(Priority::Priority2);
+    spawner.spawn(high_prio(led)).ok();
+
+    let spawner = INT_EXECUTOR_1.start(Priority::Priority1);
+    spawner.spawn(low_prio_async()).ok();
+    spawner.spawn(low_prio_blocking()).ok();
+
+    // Just loop to show that the main thread does not need to poll the executor.
+    loop {}
+}

--- a/esp32s3-hal/examples/embassy_multiprio.rs
+++ b/esp32s3-hal/examples/embassy_multiprio.rs
@@ -24,7 +24,7 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_hal_common::get_core;
 use esp_println::println;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 static INT_EXECUTOR_1: InterruptExecutor<FromCpu2> = InterruptExecutor::new();
@@ -37,15 +37,6 @@ fn FROM_CPU_INTR1() {
 #[interrupt]
 fn FROM_CPU_INTR2() {
     unsafe { INT_EXECUTOR_1.on_interrupt() }
-}
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
 }
 
 /// Periodically turns the LED on and off.
@@ -124,7 +115,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
-    let led = singleton!(io.pins.gpio0.into_push_pull_output());
+    let led = make_static!(io.pins.gpio0.into_push_pull_output());
 
     let spawner = INT_EXECUTOR_0.start(Priority::Priority2);
     spawner.spawn(high_prio(led)).ok();

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -9,11 +9,10 @@
 
 use core::fmt::Write;
 
-use embassy_executor::Executor;
 use embassy_time::{with_timeout, Duration};
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -23,7 +23,7 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::config::AtCmdConfig;
 use heapless::Vec;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -100,8 +100,6 @@ async fn run(mut uart: Uart<'static, UART0>) {
     }
 }
 
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
-
 #[entry]
 fn main() -> ! {
     esp_println::println!("Init!");
@@ -146,7 +144,7 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(run(uart0)).ok();
     });

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -18,12 +18,11 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy,
+    embassy::{self, executor::Executor},
     gdma::*,
     peripherals::Peripherals,
     prelude::*,

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -32,16 +32,7 @@ use esp32s3_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
-
-macro_rules! singleton {
-    ($val:expr) => {{
-        type T = impl Sized;
-        static STATIC_CELL: StaticCell<T> = StaticCell::new();
-        let (x,) = STATIC_CELL.init(($val,));
-        x
-    }};
-}
+use static_cell::make_static;
 
 // This example uses SPI3 to test that WithDmaSpi3 is included in the prelude.
 pub type SpiType<'d> =
@@ -60,8 +51,6 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
         Timer::after(Duration::from_millis(5_000)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -119,10 +108,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
     let dma_channel = dma.channel0;
 
-    let descriptors = singleton!([0u32; 8 * 3]);
-    let rx_descriptors = singleton!([0u32; 8 * 3]);
+    let descriptors = make_static!([0u32; 8 * 3]);
+    let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let spi = singleton!(Spi::new(
+    let spi = make_static!(Spi::new(
         peripherals.SPI3,
         sclk,
         mosi,
@@ -140,7 +129,7 @@ fn main() -> ! {
         DmaPriority::Priority0,
     )));
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(spi_task(spi)).ok();
     });

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -6,12 +6,11 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy,
+    embassy::{self, executor::Executor},
     gpio::{Gpio0, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -19,7 +19,7 @@ use esp32s3_hal::{
     IO,
 };
 use esp_backtrace as _;
-use static_cell::StaticCell;
+use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn ping(mut pin: Gpio0<Input<PullDown>>) {
@@ -30,8 +30,6 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
         Timer::after(Duration::from_millis(100)).await;
     }
 }
-
-static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[entry]
 fn main() -> ! {
@@ -80,7 +78,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = EXECUTOR.init(Executor::new());
+    let executor = make_static!(Executor::new());
     executor.run(|spawner| {
         spawner.spawn(ping(input)).ok();
     });


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples
- [x] You or added examples: interrupt-mode, cross-core thread-mode
  - [x] esp32
  - [x] esp32s2
  - [x] esp32s3
- [x] Added examples are checked in CI
  - [x] Make sure to check examples with both timg0 and systimer where available.

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

---

The Xtensa executor in embassy-executor is not safe on multiple cores. There are two reasons for this:
 - there exists a single global "there's more work" flag
 - it is not possible for one core to wake the other

This PR remedies this issue, implementing:
 - a thread-mode executor using `FROM_CPU_0`
 - an interrupt executor, which can use the rest of the `FROM_CPU_x` interrupts (one per executor)

On single-core (S2) we could probably use other interrupts as well. I'll probably need to add a list of crosscore-compatible, sw pendable interrupts for ESP32 and S3 (which is probably just the 4 FROM_CPU interrupt), so that we can safely disallow arbitrary interrupts on multicore.

---

We can't implement this in embassy, because there is no cross-core communication possibility in the Xtensa ISA. However, for consistency's sake I've also included non-multicore support (S2), which is basically identical to what's in embassy.

---

No, this isn't an executor that spreads load to two cores. Instead, this is an executor that is safe to use on both cores where one core's tasks can wake up the other core's tasks.