### PR TITLE
Switch RISC-V MSRV to `nightly` release channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf, riscv32imac-unknown-none-elf
-          toolchain: "1.65.0"
+          toolchain: "nightly-2022-09-16"
+          components: rust-src
       - uses: Swatinem/rust-cache@v2
 
       # Verify the MSRV for all RISC-V chips.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ There are a number of other crates within the [esp-rs organization] which can be
 
 The **M**inimum **S**upported **R**ust **V**ersions are:
 
-- `1.65.0` for RISC-V devices (**ESP32-C2**, **ESP32-C3**, **ESP32-C6**, **ESP32-H2**)
+- `nightly-2022-09-16` for RISC-V devices (**ESP32-C2**, **ESP32-C3**, **ESP32-C6**, **ESP32-H2**)
+  - This corresponds to the date that the `1.65.0` release was branched from `master`
 - `1.65.0` for Xtensa devices (**ESP32**, **ESP32-S2**, **ESP32-S3**)
 - `1.67.0` for all `async` examples (`embassy_hello_world`, `embassy_wait`, etc.)
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -23,7 +23,7 @@ embedded-hal-1       = { version = "=1.0.0-alpha.11", optional = true, package =
 embedded-hal-nb      = { version = "=1.0.0-alpha.3", optional = true }
 esp-synopsys-usb-otg = { version = "0.3.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
-log                  = "=0.4.18"
+log                  = "0.4.20"
 lock_api             = { version = "0.4.10", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.14"


### PR DESCRIPTION
Since the release of `log@0.4.19` broke our MSRV check, we had pinned this dependency to `=0.4.18`.

To resolve this, I've switched from the `stable` to the `nightly` release channel (it doesn't really make sense to use `stable` here, anyway...), using the version of `nightly` at which point the relevant release was branched from `main`. This allows us to un-pin the `log` dependency.