### PR TITLE
Clean up `AlarmState`

### DIFF
--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -34,12 +34,11 @@ impl EmbassyTimer {
 
     pub(crate) fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
         let alarm = &self.alarms.borrow(cs)[n];
-        // safety:
-        // - we can ignore the possiblity of `f` being unset (null) because of the
-        //   safety contract of `allocate_alarm`.
-        // - other than that we only store valid function pointers into alarm.callback
-        let f: fn(*mut ()) = unsafe { core::mem::transmute(alarm.callback.get()) };
-        f(alarm.ctx.get());
+        alarm.timestamp.set(u64::MAX);
+
+        if let Some((f, ctx)) = alarm.callback.get() {
+            f(ctx);
+        }
     }
 
     fn on_interrupt(&self, id: u8) {

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -34,12 +34,11 @@ impl EmbassyTimer {
 
     pub(crate) fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
         let alarm = &self.alarms.borrow(cs)[n];
-        // safety:
-        // - we can ignore the possiblity of `f` being unset (null) because of the
-        //   safety contract of `allocate_alarm`.
-        // - other than that we only store valid function pointers into alarm.callback
-        let f: fn(*mut ()) = unsafe { core::mem::transmute(alarm.callback.get()) };
-        f(alarm.ctx.get());
+        alarm.timestamp.set(u64::MAX);
+
+        if let Some((f, ctx)) = alarm.callback.get() {
+            f(ctx);
+        }
     }
 
     fn on_interrupt(&self, id: u8) {


### PR DESCRIPTION
Fn ptrs can appear in `const fn` since [1.61](https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html#more-capabilities-for-const-fn), so let's clean this up.