### PR TITLE
Set alarm on correct timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `psram` availability lookup in `esp-hal-common` build script (#718)
 - Fix wrong `dram_seg` length in `esp32s2-hal` linker script (#732)
+- Fix setting alarm when a timer group is used as the alarm source. (#730)
 
 ### Removed
 

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -322,7 +322,7 @@ impl<TG> Timer0<TG>
 where
     TG: TimerGroupInstance,
 {
-    #[cfg(feature = "embassy-time-timg0")]
+    #[allow(unused)]
     pub(crate) unsafe fn steal() -> Self {
         Self {
             phantom: PhantomData,
@@ -483,7 +483,7 @@ impl<TG> Timer1<TG>
 where
     TG: TimerGroupInstance,
 {
-    #[cfg(feature = "embassy-time-timg1")]
+    #[allow(unused)]
     pub(crate) unsafe fn steal() -> Self {
         Self {
             phantom: PhantomData,


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

When multiple executors are used, each allocates a different alarm. Previously, a single TIMG-based alarm was supported, and since #609 this restriction has been lifted. However, that PR was incomplete: even though multiple alarms could be allocated, actually setting an alarm always configured timer 0 of TIMG0. This issue can lead to problems when multiple executors are started.