### PR TITLE
Fixed wrong `dram_seg` length in `esp32s2-hal` linker script (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `psram` availability lookup in `esp-hal-common` build script (#718)
+- Fix wrong `dram_seg` length in `esp32s2-hal` linker script (#732)
 
 ### Removed
 

--- a/esp32s2-hal/ld/memory.x
+++ b/esp32s2-hal/ld/memory.x
@@ -22,7 +22,7 @@ MEMORY
   vectors_seg ( RX )     : ORIGIN = 0x40020000 + RESERVE_CACHES, len = VECTORS_SIZE /* SRAM0 */
   iram_seg ( RX )        : ORIGIN = 0x40020000 + RESERVE_CACHES + VECTORS_SIZE, len = 192k - RESERVE_CACHES - VECTORS_SIZE /* SRAM0 */
 
-  dram_seg ( RW )        : ORIGIN = 0x3FFB0000 + RESERVE_CACHES + VECTORS_SIZE, len = 192k - RESERVE_CACHES - VECTORS_SIZE
+  dram_seg ( RW )        : ORIGIN = 0x3FFB0000 + RESERVE_CACHES + VECTORS_SIZE, len = 188k - RESERVE_CACHES - VECTORS_SIZE
 
   /* external flash 
      The 0x20 offset is a convenience for the app binary image generation.


### PR DESCRIPTION
Change length of `dram_seg` in `esp32s2-hal` linker script from `192k - RESERVE_CACHES - VECTORS_SIZE` to `188k - RESERVE_CACHES - VECTORS_SIZE`. Where 188k is calculated from [`0x3FFDF000 - 0x3FFB0000`](https://github.com/esp-rs/esp-hal/issues/732#issuecomment-1680344465)

```
components\esp_system\ld\esp32s2\memory.ld.in
35:#define DATA_RAM_END      0x3FFDF000  /* 2nd stage bootloader iram_loader_seg starts at end of block 13 (reclaimed after app boots) */

components\esp_system\ld\esp32s2\memory.ld.in
33:#define RAM_DRAM_START    0x3FFB0000
```

Solves #732