### PR TITLE
Convert dependencies to dev-dependencies where able

### DIFF
--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -25,39 +25,37 @@ categories = [
 ]
 
 [dependencies]
-embassy-time       = { version = "0.1.2",  features = ["nightly"], optional = true }
-embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "=0.2.0-alpha.2",   optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.3",  optional = true }
-esp-hal-common     = { version = "0.11.0",  features = ["esp32"], path = "../esp-hal-common" }
+esp-hal-common = { version = "0.11.0", features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-aes               = "0.8.3"
-critical-section  = "1.1.2"
-crypto-bigint     = { version = "0.5.2", default-features = false}
-embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embedded-graphics = "0.8.1"
-esp-alloc         = "0.3.0"
-esp-backtrace     = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.4.0", features = ["esp32"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.5.0", features = ["esp32", "log"] }
-lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.7", default-features = false}
-smart-leds        = "0.3.0"
-ssd1306           = "0.8.0"
-static_cell       = "1.2.0"
-heapless          = "0.7.16"
+aes                = "0.8.3"
+critical-section   = "1.1.2"
+crypto-bigint      = { version = "0.5.2", default-features = false}
+embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
+embassy-time       = { version = "0.1.2", features = ["nightly"] }
+embedded-graphics  = "0.8.1"
+embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
+embedded-hal-async = "=0.2.0-alpha.2"
+esp-alloc          = "0.3.0"
+esp-backtrace      = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
+esp-hal-smartled   = { version = "0.4.0", features = ["esp32"], path = "../esp-hal-smartled" }
+esp-println        = { version = "0.5.0", features = ["esp32", "log"] }
+heapless           = "0.7.16"
+lis3dh-async       = "0.7.0"
+sha2               = { version = "0.10.7", default-features = false}
+smart-leds         = "0.3.0"
+ssd1306            = "0.8.0"
+static_cell        = "1.2.0"
 
 [features]
 default            = ["rt", "vectored", "xtal40mhz"]
 bluetooth          = []
 debug              = ["esp-hal-common/debug"]
-eh1                = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
+eh1                = ["esp-hal-common/eh1"]
 rt                 = []
 ufmt               = ["esp-hal-common/ufmt"]
 vectored           = ["esp-hal-common/vectored"]
-async              = ["esp-hal-common/async", "embedded-hal-async"]
+async              = ["esp-hal-common/async"]
 embassy            = ["esp-hal-common/embassy"]
 embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 xtal40mhz          = ["esp-hal-common/esp32_40mhz"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -25,34 +25,32 @@ categories = [
 ]
 
 [dependencies]
-embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
-embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "=0.2.0-alpha.2",   optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.3",  optional = true }
-esp-hal-common     = { version = "0.11.0", features = ["esp32c2"], path = "../esp-hal-common" }
+esp-hal-common = { version = "0.11.0", features = ["esp32c2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-critical-section  = "1.1.2"
-embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embedded-graphics = "0.8.1"
-esp-backtrace     = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
-esp-println       = { version = "0.5.0", features = ["esp32c2"] }
-lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.7", default-features = false}
-ssd1306           = "0.8.0"
-static_cell       = "1.2.0"
-heapless          = "0.7.16"
+critical-section   = "1.1.2"
+embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-time       = { version = "0.1.2", features = ["nightly"] }
+embedded-graphics  = "0.8.1"
+embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
+embedded-hal-async = "=0.2.0-alpha.2"
+esp-backtrace      = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
+esp-println        = { version = "0.5.0", features = ["esp32c2"] }
+heapless           = "0.7.16"
+lis3dh-async       = "0.7.0"
+sha2               = { version = "0.10.7", default-features = false}
+ssd1306            = "0.8.0"
+static_cell        = "1.2.0"
 
 [features]
 default              = ["rt", "vectored", "xtal40mhz"]
 debug                = ["esp-hal-common/debug"]
 direct-boot          = ["esp-hal-common/rv-init-data"]
-eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
+eh1                  = ["esp-hal-common/eh1"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
-async                = ["esp-hal-common/async", "embedded-hal-async"]
+async                = ["esp-hal-common/async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -25,41 +25,40 @@ categories = [
 ]
 
 [dependencies]
-cfg-if             = "1.0.0"
-embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
-embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
-embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.11.0",  features = ["esp32c3"], path = "../esp-hal-common" }
+cfg-if         = "1.0.0"
+esp-hal-common = { version = "0.11.0", features = ["esp32c3"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-aes               = "0.8.3"
-critical-section  = "1.1.2"
-crypto-bigint     = { version = "0.5.2", default-features = false}
-embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embedded-graphics = "0.8.1"
-esp-backtrace     = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.4.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.5.0", features = ["esp32c3"] }
-lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.7", default-features = false}
-smart-leds        = "0.3.0"
-ssd1306           = "0.8.0"
-static_cell       = "1.2.0"
-heapless          = "0.7.16"
+aes                = "0.8.3"
+critical-section   = "1.1.2"
+crypto-bigint      = { version = "0.5.2", default-features = false }
+embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-time       = { version = "0.1.2", features = ["nightly"] }
+embedded-can       = "0.4.1"
+embedded-graphics  = "0.8.1"
+embedded-hal       = { version = "0.2.7", features = ["unproven"] }
+embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
+embedded-hal-async = "=0.2.0-alpha.2"
+esp-backtrace      = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
+esp-hal-smartled   = { version = "0.4.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
+esp-println        = { version = "0.5.0", features = ["esp32c3"] }
+heapless           = "0.7.16"
+lis3dh-async       = "0.7.0"
+sha2               = { version = "0.10.7", default-features = false }
+smart-leds         = "0.3.0"
+ssd1306            = "0.8.0"
+static_cell        = "1.2.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
 debug                = ["esp-hal-common/debug"]
 mcu-boot             = []
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
-eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
+eh1                  = ["esp-hal-common/eh1"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
-async                = ["esp-hal-common/async", "embedded-hal-async"]
+async                = ["esp-hal-common/async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -26,40 +26,37 @@ categories = [
 ]
 
 [dependencies]
-cfg-if             = "1.0.0"
-embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
-embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
-embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.11.0",  features = ["esp32c6"], path = "../esp-hal-common" }
+esp-hal-common = { version = "0.11.0", features = ["esp32c6"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-aes               = "0.8.3"
-critical-section  = "1.1.2"
-crypto-bigint     = { version = "0.5.2", default-features = false}
-embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embedded-graphics = "0.8.1"
-esp-backtrace     = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.4.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.5.0", features = ["esp32c6"] }
-lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.7", default-features = false}
-smart-leds        = "0.3.0"
-ssd1306           = "0.8.0"
-static_cell       = "1.2.0"
-heapless          = "0.7.16"
+aes                = "0.8.3"
+critical-section   = "1.1.2"
+crypto-bigint      = { version = "0.5.2", default-features = false}
+embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-time       = { version = "0.1.2", features = ["nightly"] }
+embedded-graphics  = "0.8.1"
+embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
+embedded-hal-async = "=0.2.0-alpha.2"
+embedded-can       = "0.4.1"
+esp-backtrace      = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
+esp-hal-smartled   = { version = "0.4.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
+esp-println        = { version = "0.5.0", features = ["esp32c6"] }
+heapless           = "0.7.16"
+lis3dh-async       = "0.7.0"
+sha2               = { version = "0.10.7", default-features = false}
+smart-leds         = "0.3.0"
+ssd1306            = "0.8.0"
+static_cell        = "1.2.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
 debug                = ["esp-hal-common/debug"]
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
-eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
+eh1                  = ["esp-hal-common/eh1"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
-async                = ["esp-hal-common/async", "embedded-hal-async"]
+async                = ["esp-hal-common/async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -26,40 +26,37 @@ categories = [
 ]
 
 [dependencies]
-cfg-if             = "1.0.0"
-embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
-embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
-embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.11.0",  features = ["esp32h2"], path = "../esp-hal-common" }
+esp-hal-common = { version = "0.11.0", features = ["esp32h2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
-aes               = "0.8.3"
-critical-section  = "1.1.2"
-crypto-bigint     = { version = "0.5.2", default-features = false }
-embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embedded-graphics = "0.8.1"
-esp-backtrace     = { version = "0.7.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.4.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.5.0", features = ["esp32h2"] }
-lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.7", default-features = false}
-smart-leds        = "0.3.0"
-ssd1306           = "0.8.0"
-static_cell       = "1.2.0"
-heapless          = "0.7.16"
+aes                = "0.8.3"
+critical-section   = "1.1.2"
+crypto-bigint      = { version = "0.5.2", default-features = false }
+embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-time       = { version = "0.1.2", features = ["nightly"] }
+embedded-graphics  = "0.8.1"
+embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
+embedded-hal-async = "=0.2.0-alpha.2"
+embedded-can       = "0.4.1"
+esp-backtrace      = { version = "0.7.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
+esp-hal-smartled   = { version = "0.4.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
+esp-println        = { version = "0.5.0", features = ["esp32h2"] }
+heapless           = "0.7.16"
+lis3dh-async       = "0.7.0"
+sha2               = { version = "0.10.7", default-features = false}
+smart-leds         = "0.3.0"
+ssd1306            = "0.8.0"
+static_cell        = "1.2.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
 debug                = ["esp-hal-common/debug"]
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
-eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
+eh1                  = ["esp-hal-common/eh1"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
-async                = ["esp-hal-common/async", "embedded-hal-async"]
+async                = ["esp-hal-common/async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -25,41 +25,39 @@ categories = [
 ]
 
 [dependencies]
-embassy-time                 = { version = "0.1.2", features = ["nightly"], optional = true }
-embedded-hal                 = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1               = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
-embedded-hal-async           = { version = "=0.2.0-alpha.2", optional = true }
-embedded-hal-nb              = { version = "=1.0.0-alpha.3", optional = true }
-esp-hal-common               = { version = "0.11.0",  features = ["esp32s2"], path = "../esp-hal-common" }
-xtensa-atomic-emulation-trap = { version = "0.4.0" }
+esp-hal-common               = { version = "0.11.0", features = ["esp32s2"], path = "../esp-hal-common" }
+xtensa-atomic-emulation-trap = "0.4.0"
 
 [dev-dependencies]
-aes               = "0.8.3"
-critical-section  = "1.1.2"
-crypto-bigint     = { version = "0.5.2", default-features = false}
-embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embedded-graphics = "0.8.1"
-esp-alloc         = "0.3.0"
-esp-backtrace     = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
-esp-hal-smartled  = { version = "0.4.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.5.0", features = ["esp32s2"] }
-lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.7", default-features = false}
-smart-leds        = "0.3.0"
-ssd1306           = "0.8.0"
-static_cell       = "1.2.0"
-usb-device        = "0.2.9"
-usbd-serial       = "0.1.1"
-heapless          = "0.7.16"
+aes                = "0.8.3"
+critical-section   = "1.1.2"
+crypto-bigint      = { version = "0.5.2", default-features = false}
+embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
+embassy-time       = { version = "0.1.2", features = ["nightly"] }
+embedded-graphics  = "0.8.1"
+embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
+embedded-hal-async = "=0.2.0-alpha.2"
+esp-alloc          = "0.3.0"
+esp-backtrace      = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
+esp-hal-smartled   = { version = "0.4.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
+esp-println        = { version = "0.5.0", features = ["esp32s2"] }
+heapless           = "0.7.16"
+lis3dh-async       = "0.7.0"
+sha2               = { version = "0.10.7", default-features = false}
+smart-leds         = "0.3.0"
+ssd1306            = "0.8.0"
+static_cell        = "1.2.0"
+usb-device         = "0.2.9"
+usbd-serial        = "0.1.1"
 
 [features]
 default   = ["rt", "vectored"]
 debug     = ["esp-hal-common/debug"]
-eh1       = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb"]
+eh1       = ["esp-hal-common/eh1"]
 rt        = []
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
-async     = ["esp-hal-common/async", "embedded-hal-async"]
+async     = ["esp-hal-common/async"]
 embassy   = ["esp-hal-common/embassy"]
 # FIXME:
 # - add 80_000_000 support to embassy time

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -25,44 +25,42 @@ categories = [
 ]
 
 [dependencies]
-bare-metal         = "1.0.0"
-embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
-embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
-embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
-embedded-hal-nb    = { version = "=1.0.0-alpha.3", optional = true }
-embedded-can       = { version = "0.4.1", optional = true }
-esp-hal-common     = { version = "0.11.0",  features = ["esp32s3"], path = "../esp-hal-common" }
-r0                 = { version = "1.0.0",  optional = true }
+esp-hal-common = { version = "0.11.0", features = ["esp32s3"], path = "../esp-hal-common" }
+r0             = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
-aes               = "0.8.3"
-critical-section  = "1.1.2"
-crypto-bigint     = { version = "0.5.2", default-features = false}
-embassy-executor  = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embedded-graphics = "0.8.1"
-esp-alloc         = "0.3.0"
-esp-backtrace     = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
-esp-hal-smartled  = { version = "0.4.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
-esp-println       = { version = "0.5.0", features = ["esp32s3", "log"] }
-lis3dh-async      = "0.7.0"
-sha2              = { version = "0.10.7", default-features = false}
-smart-leds        = "0.3.0"
-ssd1306           = "0.8.0"
-static_cell       = "1.2.0"
-usb-device        = "0.2.9"
-usbd-serial       = "0.1.1"
-heapless          = "0.7.16"
+aes                = "0.8.3"
+critical-section   = "1.1.2"
+crypto-bigint      = { version = "0.5.2", default-features = false}
+embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
+embassy-time       = { version = "0.1.2", features = ["nightly"] }
+embedded-graphics  = "0.8.1"
+embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
+embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
+embedded-hal-async = "=0.2.0-alpha.2"
+embedded-can       = "0.4.1"
+esp-alloc          = "0.3.0"
+esp-backtrace      = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
+esp-hal-smartled   = { version = "0.4.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
+esp-println        = { version = "0.5.0", features = ["esp32s3", "log"] }
+heapless           = "0.7.16"
+lis3dh-async       = "0.7.0"
+sha2               = { version = "0.10.7", default-features = false}
+smart-leds         = "0.3.0"
+ssd1306            = "0.8.0"
+static_cell        = "1.2.0"
+usb-device         = "0.2.9"
+usbd-serial        = "0.1.1"
 
 [features]
 default              = ["rt", "vectored"]
 debug                = ["esp-hal-common/debug"]
 direct-boot          = ["r0"]
-eh1                  = ["esp-hal-common/eh1", "dep:embedded-hal-1", "dep:embedded-hal-nb", "dep:embedded-can"]
+eh1                  = ["esp-hal-common/eh1"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
-async                = ["esp-hal-common/async", "embedded-hal-async"]
+async                = ["esp-hal-common/async"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]


### PR DESCRIPTION
I noticed that most of the dependencies in the chip-specific HAL packages should actually be dev dependencies, so I've switched them over. I think this is just a relic from the past, probably, and we've just neglected these a bit.