### PR TITLE
Timer driver improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `psram` availability lookup in `esp-hal-common` build script (#718)
 - Fix wrong `dram_seg` length in `esp32s2-hal` linker script (#732)
 - Fix setting alarm when a timer group is used as the alarm source. (#730)
+- Fix `Instant::now()` not counting in some cases when using TIMG0 as the timebase (#737)
 
 ### Removed
 

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -75,20 +75,12 @@ impl EmbassyTimer {
         timestamp: u64,
     ) -> bool {
         critical_section::with(|cs| {
-            let now = Self::now();
-
             let n = alarm.id() as usize;
             let alarm_state = &self.alarms.borrow(cs)[n];
 
-            if timestamp < now {
-                // If alarm timestamp has passed the alarm will not fire.
-                // Disarm the alarm and return `false` to indicate that.
-                self.disarm(n);
-                alarm_state.timestamp.set(u64::MAX);
-                return false;
-            }
+            // The hardware fires the alarm even if timestamp is lower than the current
+            // time.
             alarm_state.timestamp.set(timestamp);
-
             self.arm(n, timestamp);
 
             true

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -96,15 +96,6 @@ impl EmbassyTimer {
         }
     }
 
-    fn disarm(&self, id: usize) {
-        match id {
-            0 => self.alarm0.interrupt_enable(false),
-            1 => self.alarm1.interrupt_enable(false),
-            2 => self.alarm2.interrupt_enable(false),
-            _ => {}
-        };
-    }
-
     fn arm(&self, id: usize, timestamp: u64) {
         match id {
             0 => {

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -57,6 +57,8 @@ impl EmbassyTimer {
         // divider
         timer.set_divider(clocks.apb_clock.to_MHz() as u16);
 
+        timer.set_counter_active(true);
+
         interrupt::enable(peripherals::Interrupt::TG0_T0_LEVEL, Priority::max()).unwrap();
         #[cfg(any(esp32, esp32s2, esp32s3))]
         interrupt::enable(peripherals::Interrupt::TG0_T1_LEVEL, Priority::max()).unwrap();
@@ -117,7 +119,6 @@ impl EmbassyTimer {
         tg.listen();
         tg.set_counter_decrementing(false);
         tg.set_auto_reload(false);
-        tg.set_counter_active(true);
         tg.set_alarm_active(true);
     }
 }

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -110,10 +110,6 @@ impl EmbassyTimer {
         true
     }
 
-    fn disarm<Timer: Instance>(tg: &mut Timer) {
-        tg.unlisten();
-    }
-
     fn arm<Timer: Instance>(tg: &mut Timer, timestamp: u64) {
         tg.load_alarm_value(timestamp);
         tg.listen();

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -84,7 +84,7 @@ impl EmbassyTimer {
     ) -> bool {
         critical_section::with(|cs| {
             let n = alarm.id() as usize;
-            let alarm_state = unsafe { self.alarms.borrow(cs).get_unchecked(n) };
+            let alarm_state = &self.alarms.borrow(cs)[n];
 
             #[cfg(any(esp32, esp32s2, esp32s3))]
             if n == 1 {

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -179,11 +179,9 @@ impl<T, const CHANNEL: u8> Alarm<T, CHANNEL> {
             #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
             {
                 match CHANNEL {
-                    0 => {
-                        systimer
-                            .comp0_load
-                            .write(|w| w.timer_comp0_load().set_bit());
-                    }
+                    0 => systimer
+                        .comp0_load
+                        .write(|w| w.timer_comp0_load().set_bit()),
                     1 => systimer
                         .comp1_load
                         .write(|w| w.timer_comp1_load().set_bit()),


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

---

This PR removes the unnecessary target time check from the alarm drivers. The previous logic would have had a race condition on hardware that doesn't fire when setting past alarms. However, both the SYSTIMER and the TIMG peripherals trigger the alarm if `current >= alarm`, making the check, even if implemented correctly, redundant.

I have also made a change to start the TIMG timer immediately on `init`. This is done because otherwise `Instant::now()` always returns 0 before the first timer alarm is set up. This means that code like `started.elapsed() < Duration::from_millis(n)` will not loop infinitely before the first timer alarm is set.

I have also removed some `unreachable!()` macros in favour of safe array indexing.