### PR TITLE
Fix embassy-time tick rates

### DIFF
--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -26,13 +26,13 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32"], path = "../esp-hal-common" }
+embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embassy-time       = { version = "0.1.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
 embedded-hal-async = "=0.2.0-alpha.2"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -26,11 +26,11 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32c2"], path = "../esp-hal-common" }
+embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embassy-time       = { version = "0.1.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
 embedded-hal-async = "=0.2.0-alpha.2"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -27,13 +27,13 @@ categories = [
 [dependencies]
 cfg-if         = "1.0.0"
 esp-hal-common = { version = "0.11.0", features = ["esp32c3"], path = "../esp-hal-common" }
+embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embassy-time       = { version = "0.1.2", features = ["nightly"] }
 embedded-can       = "0.4.1"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -27,13 +27,13 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32c6"], path = "../esp-hal-common" }
+embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embassy-time       = { version = "0.1.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
 embedded-hal-async = "=0.2.0-alpha.2"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -27,13 +27,13 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32h2"], path = "../esp-hal-common" }
+embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
-embassy-time       = { version = "0.1.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
 embedded-hal-async = "=0.2.0-alpha.2"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -26,6 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common               = { version = "0.11.0", features = ["esp32s2"], path = "../esp-hal-common" }
+embassy-time                 = { version = "0.1.2", features = ["nightly"], optional = true }
 xtensa-atomic-emulation-trap = "0.4.0"
 
 [dev-dependencies]
@@ -33,7 +34,6 @@ aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embassy-time       = { version = "0.1.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
 embedded-hal-async = "=0.2.0-alpha.2"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -26,6 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32s3"], path = "../esp-hal-common" }
+embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
 r0             = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
@@ -33,7 +34,6 @@ aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
-embassy-time       = { version = "0.1.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }


### PR DESCRIPTION
After #736, the `embassy-time/tick-hz-x` feature was no longer being applied. This PR moves `embassy-time` back to a non-dev dependency to fix this issue.

This doesn't have a changelog entry because it wasn't an issue that existed in 0.11