### PR TITLE
Update to `1.0.0-rc.1` version of `embedded-hal-*` crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update the `embedded-hal-*` packages to `1.0.0-rc.1` and implement traits from `embedded-io` and `embedded-io-async` (#747)
+
 ### Fixed
 
 - Fix `psram` availability lookup in `esp-hal-common` build script (#718)

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -19,8 +19,9 @@ critical-section     = "1.1.2"
 embedded-can         = { version = "0.4.1", optional = true }
 embedded-dma         = "0.2.0"
 embedded-hal         = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1       = { version = "=1.0.0-alpha.11", optional = true, package = "embedded-hal" }
-embedded-hal-nb      = { version = "=1.0.0-alpha.3", optional = true }
+embedded-hal-1       = { version = "=1.0.0-rc.1", optional = true, package = "embedded-hal" }
+embedded-hal-nb      = { version = "=1.0.0-rc.1", optional = true }
+embedded-io          = "0.5.0"
 esp-synopsys-usb-otg = { version = "0.3.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
 log                  = "0.4.20"
@@ -33,9 +34,10 @@ void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
 
 # async
-embedded-hal-async = { version = "=0.2.0-alpha.2", optional = true }
+embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
+embedded-io-async  = { version = "0.5.0", optional = true }
 embassy-sync       = { version = "0.2.0", optional = true }
-embassy-time       = { version = "0.1.2", features = ["nightly"], optional = true }
+embassy-time       = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }
 
 # RISC-V
@@ -97,7 +99,7 @@ ufmt = ["ufmt-write"]
 vectored = ["procmacros/interrupt"]
 
 # Implement the `embedded-hal-async==1.0.0-alpha.x` traits
-async   = ["embedded-hal-async", "eh1", "embassy-sync", "embassy-futures"]
+async   = ["embedded-hal-async", "eh1", "embassy-sync", "embassy-futures", "embedded-io-async"]
 embassy = ["embassy-time"]
 
 embassy-time-systick = []

--- a/esp-hal-common/src/uart.rs
+++ b/esp-hal-common/src/uart.rs
@@ -75,6 +75,19 @@ pub enum Error {
     RxFifoOvf,
 }
 
+#[cfg(feature = "eh1")]
+impl embedded_hal_nb::serial::Error for Error {
+    fn kind(&self) -> embedded_hal_nb::serial::ErrorKind {
+        embedded_hal_nb::serial::ErrorKind::Other
+    }
+}
+
+impl embedded_io::Error for Error {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}
+
 /// UART configuration
 pub mod config {
     /// Number of data bits
@@ -289,13 +302,6 @@ impl<TX: OutputPin, RX: InputPin> UartPins for TxRxPins<'_, TX, RX> {
     }
 }
 
-#[cfg(feature = "eh1")]
-impl embedded_hal_1::serial::Error for Error {
-    fn kind(&self) -> embedded_hal_1::serial::ErrorKind {
-        embedded_hal_1::serial::ErrorKind::Other
-    }
-}
-
 /// UART driver
 pub struct Uart<'d, T> {
     uart: PeripheralRef<'d, T>,
@@ -363,9 +369,13 @@ where
     }
 
     /// Writes bytes
-    pub fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
+    pub fn write_bytes(&mut self, data: &[u8]) -> Result<usize, Error> {
+        let count = data.len();
+
         data.iter()
-            .try_for_each(|c| nb::block!(self.write_byte(*c)))
+            .try_for_each(|c| nb::block!(self.write_byte(*c)))?;
+
+        Ok(count)
     }
 
     /// Configures the AT-CMD detection settings.
@@ -999,13 +1009,16 @@ where
 
     #[inline]
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
-        self.write_bytes(s.as_bytes())
+        self.write_bytes(s.as_bytes())?;
+        Ok(())
     }
 
     #[inline]
     fn write_char(&mut self, ch: char) -> Result<(), Self::Error> {
         let mut buffer = [0u8; 4];
-        self.write_bytes(ch.encode_utf8(&mut buffer).as_bytes())
+        self.write_bytes(ch.encode_utf8(&mut buffer).as_bytes())?;
+
+        Ok(())
     }
 }
 
@@ -1015,7 +1028,9 @@ where
 {
     #[inline]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        self.write_bytes(s.as_bytes()).map_err(|_| core::fmt::Error)
+        self.write_bytes(s.as_bytes())
+            .map_err(|_| core::fmt::Error)?;
+        Ok(())
     }
 }
 
@@ -1046,7 +1061,7 @@ where
 }
 
 #[cfg(feature = "eh1")]
-impl<T> embedded_hal_1::serial::ErrorType for Uart<'_, T> {
+impl<T> embedded_hal_nb::serial::ErrorType for Uart<'_, T> {
     type Error = Error;
 }
 
@@ -1071,6 +1086,57 @@ where
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         self.flush_tx()
+    }
+}
+
+impl<T> embedded_io::ErrorType for Uart<'_, T> {
+    type Error = Error;
+}
+
+impl<T> embedded_io::Read for Uart<'_, T>
+where
+    T: Instance,
+{
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let mut count = 0;
+        loop {
+            if count >= buf.len() {
+                break;
+            }
+
+            match self.read_byte() {
+                Ok(byte) => {
+                    buf[count] = byte;
+                    count += 1;
+                }
+                Err(nb::Error::WouldBlock) => {
+                    // Block until we have read at least one byte
+                    if count > 0 {
+                        break;
+                    }
+                }
+                Err(nb::Error::Other(e)) => return Err(e),
+            }
+        }
+
+        Ok(count)
+    }
+}
+
+impl<T> embedded_io::Write for Uart<'_, T>
+where
+    T: Instance,
+{
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.write_bytes(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        while let Err(nb::Error::WouldBlock) = self.flush_tx() {
+            // Wait
+        }
+
+        Ok(())
     }
 }
 
@@ -1222,8 +1288,7 @@ mod asynch {
         /// # Ok
         /// When succesfull, returns the number of bytes written to
         /// buf
-
-        pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        async fn read_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
             let mut read_bytes = 0;
 
             if self.at_cmd_config.is_some() {
@@ -1259,7 +1324,8 @@ mod asynch {
             Ok(read_bytes)
         }
 
-        async fn write(&mut self, words: &[u8]) -> Result<(), Error> {
+        async fn write_async(&mut self, words: &[u8]) -> Result<usize, Error> {
+            let mut count = 0;
             let mut offset: usize = 0;
             loop {
                 let mut next_offset =
@@ -1267,54 +1333,72 @@ mod asynch {
                 if next_offset > words.len() {
                     next_offset = words.len();
                 }
-                for &byte in &words[offset..next_offset] {
-                    self.write_byte(byte).unwrap(); // should never fail
+
+                for byte in &words[offset..next_offset] {
+                    self.write_byte(*byte).unwrap(); // should never fail
+                    count += 1;
                 }
-                if next_offset == words.len() {
+
+                if next_offset >= words.len() {
                     break;
                 }
+
                 offset = next_offset;
                 UartFuture::new(Event::TxFiFoEmpty, self.inner()).await;
             }
-            Ok(())
+
+            Ok(count)
         }
 
-        async fn flush(&mut self) -> Result<(), Error> {
+        async fn flush_async(&mut self) -> Result<(), Error> {
             let count = self.inner_mut().get_tx_fifo_count();
             if count > 0 {
                 UartFuture::new(Event::TxDone, self.inner()).await;
             }
+
             Ok(())
         }
     }
 
-    impl<T> embedded_hal_async::serial::Write for Uart<'_, T>
+    impl<T> embedded_io_async::Read for Uart<'_, T>
     where
         T: Instance,
     {
-        async fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-            self.write(words).await
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            self.read_async(buf).await
+        }
+    }
+
+    impl<T> embedded_io_async::Write for Uart<'_, T>
+    where
+        T: Instance,
+    {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            self.write_async(buf).await
         }
 
         async fn flush(&mut self) -> Result<(), Self::Error> {
-            self.flush().await
+            self.flush_async().await
         }
     }
 
     fn intr_handler(uart: &RegisterBlock) -> bool {
         let int_ena_val = uart.int_ena.read();
         let int_raw_val = uart.int_raw.read();
+
         if int_ena_val.txfifo_empty_int_ena().bit_is_set()
             && int_raw_val.txfifo_empty_int_raw().bit_is_set()
         {
             uart.int_ena.write(|w| w.txfifo_empty_int_ena().clear_bit());
             return true;
         }
+
         if int_ena_val.tx_done_int_ena().bit_is_set() && int_raw_val.tx_done_int_raw().bit_is_set()
         {
             uart.int_ena.write(|w| w.tx_done_int_ena().clear_bit());
             return true;
         }
+
         if int_ena_val.at_cmd_char_det_int_ena().bit_is_set()
             && int_raw_val.at_cmd_char_det_int_raw().bit_is_set()
         {
@@ -1324,6 +1408,7 @@ mod asynch {
                 .write(|w| w.at_cmd_char_det_int_ena().clear_bit());
             return true;
         }
+
         if int_ena_val.rxfifo_full_int_ena().bit_is_set()
             && int_raw_val.rxfifo_full_int_raw().bit_is_set()
         {
@@ -1331,6 +1416,7 @@ mod asynch {
             uart.int_ena.write(|w| w.rxfifo_full_int_ena().clear_bit());
             return true;
         }
+
         if int_ena_val.rxfifo_ovf_int_ena().bit_is_set()
             && int_raw_val.rxfifo_ovf_int_raw().bit_is_set()
         {
@@ -1338,6 +1424,7 @@ mod asynch {
             uart.int_ena.write(|w| w.rxfifo_ovf_int_ena().clear_bit());
             return true;
         }
+
         false
     }
 

--- a/esp-hal-common/src/uart.rs
+++ b/esp-hal-common/src/uart.rs
@@ -1132,8 +1132,12 @@ where
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        while let Err(nb::Error::WouldBlock) = self.flush_tx() {
-            // Wait
+        loop {
+            match self.flush_tx() {
+                Ok(_) => break,
+                Err(nb::Error::WouldBlock) => { /* Wait */ }
+                Err(nb::Error::Other(e)) => return Err(e),
+            }
         }
 
         Ok(())

--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -25,6 +25,7 @@ use crate::{
     peripherals::{usb_device::RegisterBlock, USB_DEVICE},
     system::PeripheralClockControl,
 };
+
 /// USB Serial JTAG driver
 pub struct UsbSerialJtag<'d> {
     usb_serial: PeripheralRef<'d, USB_DEVICE>,
@@ -51,23 +52,25 @@ impl<'d> UsbSerialJtag<'d> {
     }
 
     /// Write data to the serial output in chunks of up to 64 bytes
-    pub fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
+    pub fn write_bytes(&mut self, data: &[u8]) -> Result<usize, Error> {
         let reg_block = self.usb_serial.register_block();
 
+        let mut count = 0;
         for chunk in data.chunks(64) {
-            unsafe {
-                for &b in chunk {
-                    reg_block.ep1.write(|w| w.rdwr_byte().bits(b.into()))
-                }
-                reg_block.ep1_conf.write(|w| w.wr_done().set_bit());
+            for byte in chunk {
+                reg_block
+                    .ep1
+                    .write(|w| unsafe { w.rdwr_byte().bits(*byte) });
+                count += 1;
+            }
+            reg_block.ep1_conf.write(|w| w.wr_done().set_bit());
 
-                while reg_block.ep1_conf.read().bits() & 0b011 == 0b000 {
-                    // wait
-                }
+            while reg_block.ep1_conf.read().bits() & 0b011 == 0b000 {
+                // wait
             }
         }
 
-        Ok(())
+        Ok(count)
     }
 
     /// Write data to the serial output in a non-blocking manner
@@ -168,6 +171,7 @@ impl<'d> UsbSerialJtag<'d> {
             .int_clr
             .write(|w| w.serial_out_recv_pkt_int_clr().set_bit())
     }
+
     #[cfg(feature = "async")]
     pub(crate) fn inner(&self) -> &USB_DEVICE {
         &self.usb_serial
@@ -232,7 +236,9 @@ impl Instance for USB_DEVICE {
 
 impl core::fmt::Write for UsbSerialJtag<'_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        self.write_bytes(s.as_bytes()).map_err(|_| core::fmt::Error)
+        self.write_bytes(s.as_bytes())
+            .map_err(|_| core::fmt::Error)?;
+        Ok(())
     }
 }
 
@@ -257,7 +263,7 @@ impl embedded_hal::serial::Write<u8> for UsbSerialJtag<'_> {
 }
 
 #[cfg(feature = "eh1")]
-impl embedded_hal_1::serial::ErrorType for UsbSerialJtag<'_> {
+impl embedded_hal_nb::serial::ErrorType for UsbSerialJtag<'_> {
     type Error = Error;
 }
 
@@ -276,6 +282,47 @@ impl embedded_hal_nb::serial::Write for UsbSerialJtag<'_> {
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         self.flush_tx_nb()
+    }
+}
+
+impl embedded_io::ErrorType for UsbSerialJtag<'_> {
+    type Error = Error;
+}
+
+impl embedded_io::Read for UsbSerialJtag<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let mut count = 0;
+        loop {
+            if count >= buf.len() {
+                break;
+            }
+
+            match self.read_byte() {
+                Ok(byte) => {
+                    buf[count] = byte;
+                    count += 1;
+                }
+                Err(nb::Error::WouldBlock) => {
+                    // Block until we have read at least one byte
+                    if count > 0 {
+                        break;
+                    }
+                }
+                Err(nb::Error::Other(e)) => return Err(e),
+            }
+        }
+
+        Ok(count)
+    }
+}
+
+impl embedded_io::Write for UsbSerialJtag<'_> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.write_bytes(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.flush_tx()
     }
 }
 
@@ -335,35 +382,43 @@ mod asynch {
     }
 
     impl UsbSerialJtag<'_> {
-        async fn write(&mut self, words: &[u8]) -> Result<(), Error> {
+        async fn write_bytes_async(&mut self, words: &[u8]) -> Result<usize, Error> {
             let reg_block = self.usb_serial.register_block();
-            for chunk in words.chunks(64 as usize) {
-                unsafe {
-                    for &b in chunk {
-                        reg_block.ep1.write(|w| w.rdwr_byte().bits(b.into()))
-                    }
-                    reg_block.ep1_conf.write(|w| w.wr_done().set_bit());
-                    UsbSerialJtagFuture::new(self.inner()).await;
+
+            let mut count = 0;
+            for chunk in words.chunks(64) {
+                for byte in chunk {
+                    reg_block
+                        .ep1
+                        .write(|w| unsafe { w.rdwr_byte().bits(*byte) });
+                    count += 1;
                 }
+                reg_block.ep1_conf.write(|w| w.wr_done().set_bit());
+
+                UsbSerialJtagFuture::new(self.inner()).await;
             }
-            Ok(())
+
+            Ok(count)
         }
 
-        async fn flush(&mut self) -> Result<(), Error> {
+        async fn flush_tx_async(&mut self) -> Result<(), Error> {
             if self.inner().txfifo_empty() {
                 UsbSerialJtagFuture::new(self.inner()).await;
             }
+
             Ok(())
         }
     }
 
-    impl embedded_hal_async::serial::Write for UsbSerialJtag<'_> {
-        async fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-            self.write(words).await
+    // TODO: implement `embedded_io_async::Read`
+
+    impl embedded_io_async::Write for UsbSerialJtag<'_> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            self.write_bytes_async(buf).await
         }
 
         async fn flush(&mut self) -> Result<(), Self::Error> {
-            self.flush().await
+            self.flush_tx_async().await
         }
     }
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
+embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -34,14 +34,14 @@ critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
-embedded-hal-async = "=0.2.0-alpha.2"
+embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.1"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32", "log"] }
 heapless           = "0.7.16"
-lis3dh-async       = "0.7.0"
+lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -36,6 +36,7 @@ embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-tim
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
+embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32"], path = "../esp-hal-smartled" }

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -34,6 +34,7 @@ embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-tim
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
+embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println        = { version = "0.5.0", features = ["esp32c2"] }
 heapless           = "0.7.16"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -26,18 +26,18 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32c2"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
+embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
-embedded-hal-async = "=0.2.0-alpha.2"
+embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.1"
 esp-backtrace      = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println        = { version = "0.5.0", features = ["esp32c2"] }
 heapless           = "0.7.16"
-lis3dh-async       = "0.7.0"
+lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 ssd1306            = "0.8.0"
 static_cell        = "1.2.0"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -39,6 +39,7 @@ embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
+embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32c3"] }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 [dependencies]
 cfg-if         = "1.0.0"
 esp-hal-common = { version = "0.11.0", features = ["esp32c3"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
+embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -37,13 +37,13 @@ embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-tim
 embedded-can       = "0.4.1"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
-embedded-hal-async = "=0.2.0-alpha.2"
+embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.1"
 esp-backtrace      = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32c3"] }
 heapless           = "0.7.16"
-lis3dh-async       = "0.7.0"
+lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -38,6 +38,7 @@ embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
+embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32c6"] }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32c6"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
+embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -35,14 +35,14 @@ critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
-embedded-hal-async = "=0.2.0-alpha.2"
+embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
 esp-backtrace      = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32c6"] }
 heapless           = "0.7.16"
-lis3dh-async       = "0.7.0"
+lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32h2"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
+embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -35,14 +35,14 @@ critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
-embedded-hal-async = "=0.2.0-alpha.2"
+embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
 esp-backtrace      = { version = "0.7.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32h2"] }
 heapless           = "0.7.16"
-lis3dh-async       = "0.7.0"
+lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -38,6 +38,7 @@ embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
+embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32h2"] }

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -37,6 +37,7 @@ embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-tim
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
+embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s2"], path = "../esp-hal-smartled" }

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common               = { version = "0.11.0", features = ["esp32s2"], path = "../esp-hal-common" }
-embassy-time                 = { version = "0.1.2", features = ["nightly"], optional = true }
+embassy-time                 = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
 xtensa-atomic-emulation-trap = "0.4.0"
 
 [dev-dependencies]
@@ -35,14 +35,14 @@ critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
-embedded-hal-async = "=0.2.0-alpha.2"
+embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.1"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32s2"] }
 heapless           = "0.7.16"
-lis3dh-async       = "0.7.0"
+lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -39,6 +39,7 @@ embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
+embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s3"], path = "../esp-hal-smartled" }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32s3"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.2", features = ["nightly"], optional = true }
+embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
 r0             = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
@@ -36,15 +36,15 @@ crypto-bigint      = { version = "0.5.2", default-features = false}
 embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-xtensa", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-alpha.11", package = "embedded-hal" }
-embedded-hal-async = "=0.2.0-alpha.2"
+embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32s3", "log"] }
 heapless           = "0.7.16"
-lis3dh-async       = "0.7.0"
+lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.0"


### PR DESCRIPTION
- Bumps the versions of `embedded-hal`, `embedded-hal-async`, and `embedded-hal-nb` to `1.0.0-rc.1`
- Adds the `embedded-io` and `embedded-io-async` packages
- Implements the `Read` and `Write` traits from `embedded-io{-async}` for UART and USB Serial JTAG

Needed to use some git dependencies for now, but we'll get that all sorted prior to the next release.

I've done some very quick testing on a couple chips and things seem to look okay so far, but I will continue to test more thoroughly.

Did a bit of cleanup in the drivers as well, so sorry for the noise there.

Closes #727
Closes #735