### PR TITLE
feat(hmac): Add HMAC driver for hardware acceleration

### DIFF
--- a/esp-hal-common/src/hmac.rs
+++ b/esp-hal-common/src/hmac.rs
@@ -1,0 +1,337 @@
+//! HMAC Accelerator
+//!
+//! # Overview
+//!
+//! The Hash-based Message Authentication Code (HMAC) module computes Message
+//! Authentication Codes (MACs) using Hash algorithm and keys as described in
+//! RFC 2104. The hash algorithm is SHA-256, the 256-bit HMAC key is stored in
+//! an eFuse key block and can be set as read-protected, i. e., the key is not
+//! accessible from outside the HMAC accelerator itself.
+//!
+//! The HMAC module can be used in two modes - in ”upstream” mode the HMAC
+//! message is supplied by the user and the calculation result is read back by
+//! the user. In ”downstream” mode the HMAC module is used as a Key Derivation
+//! Function (KDF) for other internal hardwares.
+//!
+//! # Main features
+//!
+//! - Standard HMAC-SHA-256 algorithm.
+//! - Hash result only accessible by configurable hardware peripheral (in
+//!   downstream mode).
+//! - Compatible to challenge-response authentication algorithm.
+//! - Generates required keys for the Digital Signature (DS) peripheral (in
+//!   downstream mode).
+//! - Re-enables soft-disabled JTAG (in downstream mode).
+//!
+//! # Availability on ESP32 family
+//!
+//! The accelerator is available on ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-C6.
+//!
+//! # HMAC padding
+//!
+//! The HMAC padding is handled by the driver. In
+//! downstream mode, users do not need to input any message or apply padding.
+//! The HMAC module uses a default 32-byte pattern of 0x00 for re-enabling JTAG
+//! and a 32-byte pattern of 0xff for deriving the AES key for the DS module.
+
+use core::convert::Infallible;
+
+use crate::{
+    peripheral::{Peripheral, PeripheralRef},
+    peripherals::HMAC,
+    reg_access::AlignmentHelper,
+    system::{Peripheral as PeripheralEnable, PeripheralClockControl},
+};
+
+pub struct Hmac<'d> {
+    hmac: PeripheralRef<'d, HMAC>,
+    alignment_helper: AlignmentHelper,
+    byte_written: usize,
+    next_command: NextCommand,
+}
+
+/// HMAC interface error
+#[derive(Debug)]
+pub enum Error {
+    /// It means the purpose of the selected block does not match the
+    /// configured key purpose and the calculation will not proceed.
+    KeyPurposeMismatch,
+}
+
+/// The peripheral can be configured to deliver its output directrly to the
+/// user. It can also deliver to other periperals.
+#[derive(Clone, Copy, Debug)]
+pub enum HmacPurpose {
+    /// HMAC is used to re-enable JTAG after soft-disabling it.
+    ToJtag     = 6,
+    /// HMAC is provided to the digital signature peripheral to decrypt the
+    /// private key.
+    ToDs       = 7,
+    /// Let the user provide a message and read the result.
+    ToUser     = 8,
+    /// HMAC is used for both the digital signature or JTAG.
+    ToDsOrJtag = 5,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum KeyId {
+    Key0 = 0,
+    Key1 = 1,
+    Key2 = 2,
+    Key3 = 3,
+    Key4 = 4,
+    Key5 = 5,
+}
+
+enum NextCommand {
+    None,
+    MessageIng,
+    MessagePad,
+}
+
+impl<'d> Hmac<'d> {
+    pub fn new(
+        hmac: impl Peripheral<P = HMAC> + 'd,
+        peripheral_clock_control: &mut PeripheralClockControl,
+    ) -> Self {
+        crate::into_ref!(hmac);
+
+        peripheral_clock_control.enable(PeripheralEnable::Sha);
+        peripheral_clock_control.enable(PeripheralEnable::Hmac);
+
+        Self {
+            hmac,
+            alignment_helper: AlignmentHelper::default(),
+            byte_written: 64,
+            next_command: NextCommand::None,
+        }
+    }
+
+    pub fn free(self) -> PeripheralRef<'d, HMAC> {
+        self.hmac
+    }
+
+    /// Step 1. Enable HMAC module.
+    ///
+    /// Before these steps, the user shall set the peripheral clocks bits for
+    /// HMAC and SHA peripherals and clear the corresponding peripheral
+    /// reset bits.
+    pub fn init(&mut self) {
+        self.hmac.set_start.write(|w| w.set_start().set_bit());
+        self.alignment_helper.reset();
+        self.byte_written = 64;
+        self.next_command = NextCommand::None;
+    }
+
+    /// Step 2. Configure HMAC keys and key purposes.
+    pub fn configure(&mut self, m: HmacPurpose, key_id: KeyId) -> nb::Result<(), Error> {
+        self.hmac
+            .set_para_purpose
+            .write(|w| unsafe { w.purpose_set().bits(m as u8) });
+        self.hmac
+            .set_para_key
+            .write(|w| unsafe { w.key_set().bits(key_id as u8) });
+        self.hmac
+            .set_para_finish
+            .write(|w| w.set_para_end().set_bit());
+        if self.hmac.query_error.read().qurey_check().bit_is_set() {
+            return Err(nb::Error::Other(Error::KeyPurposeMismatch));
+        }
+        return Ok(());
+    }
+
+    /// Process the msg block after block
+    ///
+    /// Call this function as many times as necessary (msg.len() > 0)
+    pub fn update<'a>(&mut self, msg: &'a [u8]) -> nb::Result<&'a [u8], Infallible> {
+        if self.is_busy() {
+            return Err(nb::Error::WouldBlock);
+        }
+
+        self.next_command();
+
+        let remaining = self.write_data(msg).unwrap();
+
+        Ok(remaining)
+    }
+
+    pub fn finalize(&mut self, output: &mut [u8]) -> nb::Result<(), Infallible> {
+        if self.is_busy() {
+            return Err(nb::Error::WouldBlock);
+        }
+
+        self.next_command();
+
+        let msg_len = self.byte_written as u64;
+
+        nb::block!(self.write_data(&[0x80])).unwrap();
+        nb::block!(self.flush_data()).unwrap();
+        self.next_command();
+        debug_assert!(self.byte_written % 4 == 0);
+
+        self.padding(msg_len);
+
+        // Checking if the message is one block including padding
+        if msg_len < 64 + 56 {
+            self.hmac.one_block.write(|w| w.set_one_block().set_bit());
+
+            while self.is_busy() {}
+        }
+
+        self.alignment_helper.volatile_read_regset(
+            #[cfg(esp32s2)]
+            &self.hmac.rd_result_[0],
+            #[cfg(not(esp32s2))]
+            &self.hmac.rd_result_mem[0],
+            output,
+            core::cmp::min(output.len(), 32) / self.alignment_helper.align_size(),
+        );
+
+        self.hmac
+            .set_result_finish
+            .write(|w| w.set_result_end().set_bit());
+        self.byte_written = 64;
+        self.next_command = NextCommand::None;
+        Ok(())
+    }
+
+    fn is_busy(&mut self) -> bool {
+        self.hmac.query_busy.read().busy_state().bit_is_set()
+    }
+
+    fn next_command(&mut self) {
+        match self.next_command {
+            NextCommand::MessageIng => {
+                self.hmac
+                    .set_message_ing
+                    .write(|w| w.set_text_ing().set_bit());
+            }
+            NextCommand::MessagePad => {
+                self.hmac
+                    .set_message_pad
+                    .write(|w| w.set_text_pad().set_bit());
+            }
+            NextCommand::None => {}
+        }
+        self.next_command = NextCommand::None;
+    }
+
+    fn write_data<'a>(&mut self, incoming: &'a [u8]) -> nb::Result<&'a [u8], Infallible> {
+        let mod_length = self.byte_written % 64;
+
+        let (remaining, bound_reached) = self.alignment_helper.aligned_volatile_copy(
+            #[cfg(esp32s2)]
+            &mut self.hmac.wr_message_,
+            #[cfg(not(esp32s2))]
+            &mut self.hmac.wr_message_mem,
+            incoming,
+            64 / self.alignment_helper.align_size(),
+            mod_length / self.alignment_helper.align_size(),
+        );
+
+        self.byte_written = self
+            .byte_written
+            .wrapping_add(incoming.len() - remaining.len());
+
+        if bound_reached {
+            self.hmac
+                .set_message_one
+                .write(|w| w.set_text_one().set_bit());
+
+            if remaining.len() >= 56 {
+                self.next_command = NextCommand::MessageIng;
+            } else {
+                self.next_command = NextCommand::MessagePad;
+            }
+        }
+
+        Ok(remaining)
+    }
+
+    fn flush_data(&mut self) -> nb::Result<(), Infallible> {
+        if self.is_busy() {
+            return Err(nb::Error::WouldBlock);
+        }
+
+        let flushed = self.alignment_helper.flush_to(
+            #[cfg(esp32s2)]
+            &mut self.hmac.wr_message_,
+            #[cfg(not(esp32s2))]
+            &mut self.hmac.wr_message_mem,
+            (self.byte_written % 64) / self.alignment_helper.align_size(),
+        );
+
+        self.byte_written = self.byte_written.wrapping_add(flushed);
+        if flushed > 0 && self.byte_written % 64 == 0 {
+            self.hmac
+                .set_message_one
+                .write(|w| w.set_text_one().set_bit());
+            while self.is_busy() {}
+            self.next_command = NextCommand::MessagePad;
+        }
+
+        Ok(())
+    }
+
+    fn padding(&mut self, msg_len: u64) {
+        let mod_cursor = self.byte_written % 64;
+
+        // The padding will be spanned over 2 blocks
+        if mod_cursor > 56 {
+            let pad_len = 64 - mod_cursor;
+            self.alignment_helper.volatile_write_bytes(
+                #[cfg(esp32s2)]
+                &mut self.hmac.wr_message_,
+                #[cfg(not(esp32s2))]
+                &mut self.hmac.wr_message_mem,
+                0_u8,
+                pad_len / self.alignment_helper.align_size(),
+                mod_cursor / self.alignment_helper.align_size(),
+            );
+            self.hmac
+                .set_message_one
+                .write(|w| w.set_text_one().set_bit());
+            self.byte_written = self.byte_written.wrapping_add(pad_len);
+            debug_assert!(self.byte_written % 64 == 0);
+            while self.is_busy() {}
+            self.next_command = NextCommand::MessagePad;
+            self.next_command();
+        }
+
+        let mod_cursor = self.byte_written % 64;
+        let pad_len = 64 - mod_cursor - core::mem::size_of::<u64>();
+
+        self.alignment_helper.volatile_write_bytes(
+            #[cfg(esp32s2)]
+            &mut self.hmac.wr_message_,
+            #[cfg(not(esp32s2))]
+            &mut self.hmac.wr_message_mem,
+            0_u8,
+            pad_len / self.alignment_helper.align_size(),
+            mod_cursor / self.alignment_helper.align_size(),
+        );
+
+        self.byte_written = self.byte_written.wrapping_add(pad_len);
+
+        assert_eq!(self.byte_written % 64, 64 - core::mem::size_of::<u64>());
+
+        // Add padded key
+        let len_mem = (msg_len * 8).to_be_bytes();
+
+        self.alignment_helper.aligned_volatile_copy(
+            #[cfg(esp32s2)]
+            &mut self.hmac.wr_message_,
+            #[cfg(not(esp32s2))]
+            &mut self.hmac.wr_message_mem,
+            &len_mem,
+            64 / self.alignment_helper.align_size(),
+            (64 - core::mem::size_of::<u64>()) / self.alignment_helper.align_size(),
+        );
+
+        self.hmac
+            .set_message_one
+            .write(|w| w.set_text_one().set_bit());
+
+        while self.is_busy() {}
+    }
+}

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -93,6 +93,8 @@ pub mod dma;
 pub mod embassy;
 #[cfg(gpio)]
 pub mod gpio;
+#[cfg(hmac)]
+pub mod hmac;
 #[cfg(any(i2c0, i2c1))]
 pub mod i2c;
 #[cfg(any(i2s0, i2s1))]

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -104,6 +104,8 @@ pub enum Peripheral {
     Rsa,
     #[cfg(parl_io)]
     ParlIo,
+    #[cfg(hmac)]
+    Hmac,
 }
 
 pub struct SoftwareInterruptControl {
@@ -371,6 +373,10 @@ impl PeripheralClockControl {
                 perip_rst_en1.modify(|_, w| w.crypto_rsa_rst().clear_bit());
                 system.rsa_pd_ctrl.modify(|_, w| w.rsa_mem_pd().clear_bit());
             }
+            Peripheral::Hmac => {
+                perip_clk_en1.modify(|_, w| w.crypto_hmac_clk_en().set_bit());
+                perip_rst_en1.modify(|_, w| w.crypto_hmac_rst().clear_bit());
+            }
         }
     }
 }
@@ -528,6 +534,11 @@ impl PeripheralClockControl {
                 system
                     .parl_io_conf
                     .modify(|_, w| w.parl_rst_en().clear_bit());
+            }
+            #[cfg(hmac)]
+            Peripheral::Hmac => {
+                system.hmac_conf.modify(|_, w| w.hmac_clk_en().set_bit());
+                system.hmac_conf.modify(|_, w| w.hmac_rst_en().clear_bit());
             }
         }
     }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -44,6 +44,7 @@ esp-backtrace      = { version = "0.7.0", features = ["esp32c3", "panic-handler"
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32c3"] }
 heapless           = "0.7.16"
+hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false }
 smart-leds         = "0.3.0"

--- a/esp32c3-hal/examples/hmac.rs
+++ b/esp32c3-hal/examples/hmac.rs
@@ -1,0 +1,143 @@
+//! Demonstrates the use of the HMAC peripheral and compares the speed of
+//! hardware-accelerated and pure software hashing.
+//!
+//! # Writing key
+//! Before using the HMAC accelerator in upstream mode, you first need to
+//! prepare a secret 256-bit HMAC key and burn the key to an empty eFuse block.
+//!
+//! ## ⚠️ Before writing ⚠️
+//! - From the factory, the eFuse keyblocks are programmed to be 32-byte 0x00.
+//! - This example is programmed to use this value so you can skip this step if
+//!   you don't want to burn an eFuse key.
+//! - If you skip the skip burning a custom key, you still need to [burn the
+//!   purpose](#burn-key-purpose).
+//! - [Read more about eFuses](https://docs.espressif.com/projects/esptool/en/latest/esp32c3/espefuse/index.html)
+//!
+//! ## Burn key purpose
+//! You first need to burn the efuse key purpose for the specified key below
+//! (Default Key0). Purposes:
+//!
+//! | Purpose                        | Mode       | Value | Description                                   |
+//! |--------------------------------|------------|-------|-----------------------------------------------|
+//! | JTAG Re-enable                 | Downstream | 6     | EFUSE_KEY_PURPOSE_HMAC_DOWN_JTAG              |
+//! | DS Key Derivation              | Downstream | 7     | EFUSE_KEY_PURPOSE_HMAC_DOWN_DIGITAL_SIGNATURE |
+//! | HMAC Calculation               | Upstream   | 8     | EFUSE_KEY_PURPOSE_HMAC_UP                     |
+//! | Both JTAG Re-enable and DS KDF | Downstream | 5     | EFUSE_KEY_PURPOSE_HMAC_DOWN_ALL               |
+//!
+//! To burn the efuse key purpose `HMAC_UP` to `Key0`:
+//! ```sh
+//! espefuse.py burn_efuse KEY_PURPOSE_0 8
+//! ```
+//!
+//! ## Use a custom key
+//! You can generate a custom key file from a string using the following command
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary > key.bin
+//! ```
+//!
+//! You can then write your key using the following command
+//! - `BLOCK_KEY0` The keyblock to program the key to. By default this example
+//!   uses key0.
+//! - `HMAC_UP` The purpose for the key. Use HMAC_UP for upstream.
+//! - `--no-read-protect` Allow to read the key from software, after writing it.
+//! ```sh
+//! espefuse.py burn_key BLOCK_KEY0 key.bin HMAC_UP --no-read-protect
+//! ```
+//! To see the key in bytes, you can do the following:
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary | xxd -p
+//! ```
+//! or from the binary file
+//! ```sh
+//! xxd -p key.bin
+//! ```
+
+#![no_std]
+#![no_main]
+
+use esp32c3_hal::{
+    clock::ClockControl,
+    hmac::{Hmac, HmacPurpose, KeyId},
+    peripherals::Peripherals,
+    prelude::*,
+    systimer::SystemTimer,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+use hmac::{Hmac as HmacSw, Mac};
+use nb::block;
+use sha2::Sha256;
+
+type HmacSha256 = HmacSw<Sha256>;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Set sw key
+    let key = [0_u8; 32].as_ref();
+
+    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+
+    let mut src = [0_u8; 1024];
+    rng.read(src.as_mut_slice()).unwrap();
+    // println!("HMAC input {:02X?}", src);
+
+    let mut output = [0u8; 32];
+
+    println!("Beginning stress tests...");
+    println!("Testing length from 0 to {:?} bytes for HMAC...", src.len());
+    for i in 0..src.len() + 1 {
+        let (nsrc, _) = src.split_at(i);
+        let mut remaining = nsrc;
+        hw_hmac.init();
+        block!(hw_hmac.configure(HmacPurpose::ToUser, KeyId::Key0)).expect("Key purpose mismatch");
+        let pre_hw_hmac = SystemTimer::now();
+        while remaining.len() > 0 {
+            remaining = block!(hw_hmac.update(remaining)).unwrap();
+        }
+        block!(hw_hmac.finalize(output.as_mut_slice())).unwrap();
+        let post_hw_hmac = SystemTimer::now();
+        let hw_time = post_hw_hmac - pre_hw_hmac;
+        let mut sw_hmac = HmacSha256::new_from_slice(key).expect("HMAC can take key of any size");
+        let pre_sw_hash = SystemTimer::now();
+        sw_hmac.update(nsrc);
+        let soft_result = sw_hmac.finalize().into_bytes();
+        let post_sw_hash = SystemTimer::now();
+        let soft_time = post_sw_hash - pre_sw_hash;
+        for (a, b) in output.iter().zip(soft_result) {
+            assert_eq!(*a, b);
+        }
+        println!("Testing for length: {:>4} | HW: {:>6} cycles, SW: {:>7} cycles (HW HMAC is {:>2}x faster)", i, hw_time, soft_time, soft_time / hw_time);
+    }
+    println!("Finished stress tests!");
+
+    loop {}
+}

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -43,6 +43,7 @@ esp-backtrace      = { version = "0.7.0", features = ["esp32c6", "panic-handler"
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32c6"] }
 heapless           = "0.7.16"
+hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"

--- a/esp32c6-hal/examples/hmac.rs
+++ b/esp32c6-hal/examples/hmac.rs
@@ -1,0 +1,143 @@
+//! Demonstrates the use of the HMAC peripheral and compares the speed of
+//! hardware-accelerated and pure software hashing.
+//!
+//! # Writing key
+//! Before using the HMAC accelerator in upstream mode, you first need to
+//! prepare a secret 256-bit HMAC key and burn the key to an empty eFuse block.
+//!
+//! ## ⚠️ Before writing ⚠️
+//! - From the factory, the eFuse keyblocks are programmed to be 32-byte 0x00.
+//! - This example is programmed to use this value so you can skip this step if
+//!   you don't want to burn an eFuse key.
+//! - If you skip the skip burning a custom key, you still need to [burn the
+//!   purpose](#burn-key-purpose).
+//! - [Read more about eFuses](https://docs.espressif.com/projects/esptool/en/latest/esp32c6/espefuse/index.html)
+//!
+//! ## Burn key purpose
+//! You first need to burn the efuse key purpose for the specified key below
+//! (Default Key0). Purposes:
+//!
+//! | Purpose                        | Mode       | Value | Description                                   |
+//! |--------------------------------|------------|-------|-----------------------------------------------|
+//! | JTAG Re-enable                 | Downstream | 6     | EFUSE_KEY_PURPOSE_HMAC_DOWN_JTAG              |
+//! | DS Key Derivation              | Downstream | 7     | EFUSE_KEY_PURPOSE_HMAC_DOWN_DIGITAL_SIGNATURE |
+//! | HMAC Calculation               | Upstream   | 8     | EFUSE_KEY_PURPOSE_HMAC_UP                     |
+//! | Both JTAG Re-enable and DS KDF | Downstream | 5     | EFUSE_KEY_PURPOSE_HMAC_DOWN_ALL               |
+//!
+//! To burn the efuse key purpose `HMAC_UP` to `Key0`:
+//! ```sh
+//! espefuse.py burn_efuse KEY_PURPOSE_0 8
+//! ```
+//!
+//! ## Use a custom key
+//! You can generate a custom key file from a string using the following command
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary > key.bin
+//! ```
+//!
+//! You can then write your key using the following command
+//! - `BLOCK_KEY0` The keyblock to program the key to. By default this example
+//!   uses key0.
+//! - `HMAC_UP` The purpose for the key. Use HMAC_UP for upstream.
+//! - `--no-read-protect` Allow to read the key from software, after writing it.
+//! ```sh
+//! espefuse.py burn_key BLOCK_KEY0 key.bin HMAC_UP --no-read-protect
+//! ```
+//! To see the key in bytes, you can do the following:
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary | xxd -p
+//! ```
+//! or from the binary file
+//! ```sh
+//! xxd -p key.bin
+//! ```
+
+#![no_std]
+#![no_main]
+
+use esp32c6_hal::{
+    clock::ClockControl,
+    hmac::{Hmac, HmacPurpose, KeyId},
+    peripherals::Peripherals,
+    prelude::*,
+    systimer::SystemTimer,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+use hmac::{Hmac as HmacSw, Mac};
+use nb::block;
+use sha2::Sha256;
+
+type HmacSha256 = HmacSw<Sha256>;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable watchdog timers
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Set sw key
+    let key = [0_u8; 32].as_ref();
+
+    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+
+    let mut src = [0_u8; 1024];
+    rng.read(src.as_mut_slice()).unwrap();
+    // println!("HMAC input {:02X?}", src);
+
+    let mut output = [0u8; 32];
+
+    println!("Beginning stress tests...");
+    println!("Testing length from 0 to {:?} bytes for HMAC...", src.len());
+    for i in 0..src.len() + 1 {
+        let (nsrc, _) = src.split_at(i);
+        let mut remaining = nsrc;
+        hw_hmac.init();
+        block!(hw_hmac.configure(HmacPurpose::ToUser, KeyId::Key0)).expect("Key purpose mismatch");
+        let pre_hw_hmac = SystemTimer::now();
+        while remaining.len() > 0 {
+            remaining = block!(hw_hmac.update(remaining)).unwrap();
+        }
+        block!(hw_hmac.finalize(output.as_mut_slice())).unwrap();
+        let post_hw_hmac = SystemTimer::now();
+        let hw_time = post_hw_hmac - pre_hw_hmac;
+        let mut sw_hmac = HmacSha256::new_from_slice(key).expect("HMAC can take key of any size");
+        let pre_sw_hash = SystemTimer::now();
+        sw_hmac.update(nsrc);
+        let soft_result = sw_hmac.finalize().into_bytes();
+        let post_sw_hash = SystemTimer::now();
+        let soft_time = post_sw_hash - pre_sw_hash;
+        for (a, b) in output.iter().zip(soft_result) {
+            assert_eq!(*a, b);
+        }
+        println!("Testing for length: {:>4} | HW: {:>6} cycles, SW: {:>7} cycles (HW HMAC is {:>2}x faster)", i, hw_time, soft_time, soft_time / hw_time);
+    }
+    println!("Finished stress tests!");
+
+    loop {}
+}

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -43,6 +43,7 @@ esp-backtrace      = { version = "0.7.0", features = ["esp32h2", "panic-handler"
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32h2"] }
 heapless           = "0.7.16"
+hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"

--- a/esp32h2-hal/examples/hmac.rs
+++ b/esp32h2-hal/examples/hmac.rs
@@ -1,0 +1,145 @@
+//! Demonstrates the use of the HMAC peripheral and compares the speed of
+//! hardware-accelerated and pure software hashing.
+//!
+//! # Writing key
+//! Before using the HMAC accelerator in upstream mode, you first need to
+//! prepare a secret 256-bit HMAC key and burn the key to an empty eFuse block.
+//!
+//! ## ⚠️ Before writing ⚠️
+//! - From the factory, the eFuse keyblocks are programmed to be 32-byte 0x00.
+//! - This example is programmed to use this value so you can skip this step if
+//!   you don't want to burn an eFuse key.
+//! - If you skip the skip burning a custom key, you still need to [burn the
+//!   purpose](#burn-key-purpose).
+//! - [Read more about eFuses](https://docs.espressif.com/projects/esptool/en/latest/esp32h2/espefuse/index.html)
+//!
+//! ## Burn key purpose
+//! You first need to burn the efuse key purpose for the specified key below
+//! (Default Key0). Purposes:
+//!
+//! | Purpose                        | Mode       | Value | Description                                   |
+//! |--------------------------------|------------|-------|-----------------------------------------------|
+//! | JTAG Re-enable                 | Downstream | 6     | EFUSE_KEY_PURPOSE_HMAC_DOWN_JTAG              |
+//! | DS Key Derivation              | Downstream | 7     | EFUSE_KEY_PURPOSE_HMAC_DOWN_DIGITAL_SIGNATURE |
+//! | HMAC Calculation               | Upstream   | 8     | EFUSE_KEY_PURPOSE_HMAC_UP                     |
+//! | Both JTAG Re-enable and DS KDF | Downstream | 5     | EFUSE_KEY_PURPOSE_HMAC_DOWN_ALL               |
+//!
+//! To burn the efuse key purpose `HMAC_UP` to `Key0`:
+//! ```sh
+//! espefuse.py burn_efuse KEY_PURPOSE_0 8
+//! ```
+//!
+//! ## Use a custom key
+//! You can generate a custom key file from a string using the following command
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary > key.bin
+//! ```
+//!
+//! You can then write your key using the following command
+//! - `BLOCK_KEY0` The keyblock to program the key to. By default this example
+//!   uses key0.
+//! - `HMAC_UP` The purpose for the key. Use HMAC_UP for upstream.
+//! - `--no-read-protect` Allow to read the key from software, after writing it.
+//! ```sh
+//! espefuse.py burn_key BLOCK_KEY0 key.bin HMAC_UP --no-read-protect
+//! ```
+//! To see the key in bytes, you can do the following:
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary | xxd -p
+//! ```
+//! or from the binary file
+//! ```sh
+//! xxd -p key.bin
+//! ```
+
+#![no_std]
+#![no_main]
+
+use esp32h2_hal::{
+    clock::ClockControl,
+    hmac::{Hmac, HmacPurpose, KeyId},
+    peripherals::Peripherals,
+    prelude::*,
+    systimer::SystemTimer,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+use hmac::{Hmac as HmacSw, Mac};
+use nb::block;
+use sha2::Sha256;
+
+type HmacSha256 = HmacSw<Sha256>;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
+    // and the TIMG WDTs.
+    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt1 = timer_group1.wdt;
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+    wdt0.disable();
+    wdt1.disable();
+
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Set sw key
+    let key = [0_u8; 32].as_ref();
+
+    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+
+    let mut src = [0_u8; 1024];
+    rng.read(src.as_mut_slice()).unwrap();
+    // println!("HMAC input {:02X?}", src);
+
+    let mut output = [0u8; 32];
+
+    println!("Beginning stress tests...");
+    println!("Testing length from 0 to {:?} bytes for HMAC...", src.len());
+    for i in 0..src.len() + 1 {
+        let (nsrc, _) = src.split_at(i);
+        let mut remaining = nsrc;
+        hw_hmac.init();
+        block!(hw_hmac.configure(HmacPurpose::ToUser, KeyId::Key0)).expect("Key purpose mismatch");
+        let pre_hw_hmac = SystemTimer::now();
+        while remaining.len() > 0 {
+            remaining = block!(hw_hmac.update(remaining)).unwrap();
+        }
+        block!(hw_hmac.finalize(output.as_mut_slice())).unwrap();
+        let post_hw_hmac = SystemTimer::now();
+        let hw_time = post_hw_hmac - pre_hw_hmac;
+        let mut sw_hmac = HmacSha256::new_from_slice(key).expect("HMAC can take key of any size");
+        let pre_sw_hash = SystemTimer::now();
+        sw_hmac.update(nsrc);
+        let soft_result = sw_hmac.finalize().into_bytes();
+        let post_sw_hash = SystemTimer::now();
+        let soft_time = post_sw_hash - pre_sw_hash;
+        for (a, b) in output.iter().zip(soft_result) {
+            assert_eq!(*a, b);
+        }
+        println!("Testing for length: {:>4} | HW: {:>6} cycles, SW: {:>7} cycles (HW HMAC is {:>2}x faster)", i, hw_time, soft_time, soft_time / hw_time);
+    }
+    println!("Finished stress tests!");
+
+    loop {}
+}

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -43,6 +43,7 @@ esp-backtrace      = { version = "0.7.0", features = ["esp32s2", "panic-handler"
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32s2"] }
 heapless           = "0.7.16"
+hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"

--- a/esp32s2-hal/examples/hmac.rs
+++ b/esp32s2-hal/examples/hmac.rs
@@ -1,0 +1,136 @@
+//! Demonstrates the use of the HMAC peripheral and compares the speed of
+//! hardware-accelerated and pure software hashing.
+//!
+//! # Writing key
+//! Before using the HMAC accelerator in upstream mode, you first need to
+//! prepare a secret 256-bit HMAC key and burn the key to an empty eFuse block.
+//!
+//! ## ⚠️ Before writing ⚠️
+//! - From the factory, the eFuse keyblocks are programmed to be 32-byte 0x00.
+//! - This example is programmed to use this value so you can skip this step if
+//!   you don't want to burn an eFuse key.
+//! - If you skip the skip burning a custom key, you still need to [burn the
+//!   purpose](#burn-key-purpose).
+//! - [Read more about eFuses](https://docs.espressif.com/projects/esptool/en/latest/esp32s3/espefuse/index.html)
+//!
+//! ## Burn key purpose
+//! You first need to burn the efuse key purpose for the specified key below
+//! (Default Key0). Purposes:
+//!
+//! | Purpose                        | Mode       | Value | Description                                   |
+//! |--------------------------------|------------|-------|-----------------------------------------------|
+//! | JTAG Re-enable                 | Downstream | 6     | EFUSE_KEY_PURPOSE_HMAC_DOWN_JTAG              |
+//! | DS Key Derivation              | Downstream | 7     | EFUSE_KEY_PURPOSE_HMAC_DOWN_DIGITAL_SIGNATURE |
+//! | HMAC Calculation               | Upstream   | 8     | EFUSE_KEY_PURPOSE_HMAC_UP                     |
+//! | Both JTAG Re-enable and DS KDF | Downstream | 5     | EFUSE_KEY_PURPOSE_HMAC_DOWN_ALL               |
+//!
+//! To burn the efuse key purpose `HMAC_UP` to `Key0`:
+//! ```sh
+//! espefuse.py burn_efuse KEY_PURPOSE_0 8
+//! ```
+//!
+//! ## Use a custom key
+//! You can generate a custom key file from a string using the following command
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary > key.bin
+//! ```
+//!
+//! You can then write your key using the following command
+//! - `BLOCK_KEY0` The keyblock to program the key to. By default this example
+//!   uses key0.
+//! - `HMAC_UP` The purpose for the key. Use HMAC_UP for upstream.
+//! - `--no-read-protect` Allow to read the key from software, after writing it.
+//! ```sh
+//! espefuse.py burn_key BLOCK_KEY0 key.bin HMAC_UP --no-read-protect
+//! ```
+//! To see the key in bytes, you can do the following:
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary | xxd -p
+//! ```
+//! or from the binary file
+//! ```sh
+//! xxd -p key.bin
+//! ```
+
+#![no_std]
+#![no_main]
+
+use esp32s2_hal::{
+    clock::ClockControl,
+    hmac::{Hmac, HmacPurpose, KeyId},
+    peripherals::Peripherals,
+    prelude::*,
+    systimer::SystemTimer,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+use hmac::{Hmac as HmacSw, Mac};
+use nb::block;
+use sha2::Sha256;
+
+type HmacSha256 = HmacSw<Sha256>;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the RTC and TIMG watchdog timers
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    rtc.rwdt.disable();
+    wdt.disable();
+
+    // Set sw key
+    let key = [0_u8; 32].as_ref();
+
+    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+
+    let mut src = [0_u8; 1024];
+    rng.read(src.as_mut_slice()).unwrap();
+    // println!("HMAC input {:02X?}", src);
+
+    let mut output = [0u8; 32];
+
+    println!("Beginning stress tests...");
+    println!("Testing length from 0 to {:?} bytes for HMAC...", src.len());
+    for i in 0..src.len() + 1 {
+        let (nsrc, _) = src.split_at(i);
+        let mut remaining = nsrc;
+        hw_hmac.init();
+        block!(hw_hmac.configure(HmacPurpose::ToUser, KeyId::Key0)).expect("Key purpose mismatch");
+        let pre_hw_hmac = SystemTimer::now();
+        while remaining.len() > 0 {
+            remaining = block!(hw_hmac.update(remaining)).unwrap();
+        }
+        block!(hw_hmac.finalize(output.as_mut_slice())).unwrap();
+        let post_hw_hmac = SystemTimer::now();
+        let hw_time = post_hw_hmac - pre_hw_hmac;
+        let mut sw_hmac = HmacSha256::new_from_slice(key).expect("HMAC can take key of any size");
+        let pre_sw_hash = SystemTimer::now();
+        sw_hmac.update(nsrc);
+        let soft_result = sw_hmac.finalize().into_bytes();
+        let post_sw_hash = SystemTimer::now();
+        let soft_time = post_sw_hash - pre_sw_hash;
+        for (a, b) in output.iter().zip(soft_result) {
+            assert_eq!(*a, b);
+        }
+        println!("Testing for length: {:>4} | HW: {:>6} cycles, SW: {:>7} cycles (HW HMAC is {:>2}x faster)", i, hw_time, soft_time, soft_time / hw_time);
+    }
+    println!("Finished stress tests!");
+
+    loop {}
+}

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -45,6 +45,7 @@ esp-backtrace      = { version = "0.7.0", features = ["esp32s3", "panic-handler"
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.5.0", features = ["esp32s3", "log"] }
 heapless           = "0.7.16"
+hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
 smart-leds         = "0.3.0"

--- a/esp32s3-hal/examples/hmac.rs
+++ b/esp32s3-hal/examples/hmac.rs
@@ -1,0 +1,136 @@
+//! Demonstrates the use of the HMAC peripheral and compares the speed of
+//! hardware-accelerated and pure software hashing.
+//!
+//! # Writing key
+//! Before using the HMAC accelerator in upstream mode, you first need to
+//! prepare a secret 256-bit HMAC key and burn the key to an empty eFuse block.
+//!
+//! ## ⚠️ Before writing ⚠️
+//! - From the factory, the eFuse keyblocks are programmed to be 32-byte 0x00.
+//! - This example is programmed to use this value so you can skip this step if
+//!   you don't want to burn an eFuse key.
+//! - If you skip the skip burning a custom key, you still need to [burn the
+//!   purpose](#burn-key-purpose).
+//! - [Read more about eFuses](https://docs.espressif.com/projects/esptool/en/latest/esp32s3/espefuse/index.html)
+//!
+//! ## Burn key purpose
+//! You first need to burn the efuse key purpose for the specified key below
+//! (Default Key0). Purposes:
+//!
+//! | Purpose                        | Mode       | Value | Description                                   |
+//! |--------------------------------|------------|-------|-----------------------------------------------|
+//! | JTAG Re-enable                 | Downstream | 6     | EFUSE_KEY_PURPOSE_HMAC_DOWN_JTAG              |
+//! | DS Key Derivation              | Downstream | 7     | EFUSE_KEY_PURPOSE_HMAC_DOWN_DIGITAL_SIGNATURE |
+//! | HMAC Calculation               | Upstream   | 8     | EFUSE_KEY_PURPOSE_HMAC_UP                     |
+//! | Both JTAG Re-enable and DS KDF | Downstream | 5     | EFUSE_KEY_PURPOSE_HMAC_DOWN_ALL               |
+//!
+//! To burn the efuse key purpose `HMAC_UP` to `Key0`:
+//! ```sh
+//! espefuse.py burn_efuse KEY_PURPOSE_0 8
+//! ```
+//!
+//! ## Use a custom key
+//! You can generate a custom key file from a string using the following command
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary > key.bin
+//! ```
+//!
+//! You can then write your key using the following command
+//! - `BLOCK_KEY0` The keyblock to program the key to. By default this example
+//!   uses key0.
+//! - `HMAC_UP` The purpose for the key. Use HMAC_UP for upstream.
+//! - `--no-read-protect` Allow to read the key from software, after writing it.
+//! ```sh
+//! espefuse.py burn_key BLOCK_KEY0 key.bin HMAC_UP --no-read-protect
+//! ```
+//! To see the key in bytes, you can do the following:
+//! ```sh
+//! echo -n "<Your custom key>" | openssl dgst -sha256 -binary | xxd -p
+//! ```
+//! or from the binary file
+//! ```sh
+//! xxd -p key.bin
+//! ```
+
+#![no_std]
+#![no_main]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    hmac::{Hmac, HmacPurpose, KeyId},
+    peripherals::Peripherals,
+    prelude::*,
+    systimer::SystemTimer,
+    timer::TimerGroup,
+    Rng,
+    Rtc,
+};
+use esp_backtrace as _;
+use esp_println::println;
+use hmac::{Hmac as HmacSw, Mac};
+use nb::block;
+use sha2::Sha256;
+
+type HmacSha256 = HmacSw<Sha256>;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    // Disable the RTC and TIMG watchdog timers
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    let mut wdt = timer_group0.wdt;
+
+    let mut rng = Rng::new(peripherals.RNG);
+
+    // Disable MWDT and RWDT (Watchdog) flash boot protection
+    rtc.rwdt.disable();
+    wdt.disable();
+
+    // Set sw key
+    let key = [0_u8; 32].as_ref();
+
+    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+
+    let mut src = [0_u8; 1024];
+    rng.read(src.as_mut_slice()).unwrap();
+    // println!("HMAC input {:02X?}", src);
+
+    let mut output = [0u8; 32];
+
+    println!("Beginning stress tests...");
+    println!("Testing length from 0 to {:?} bytes for HMAC...", src.len());
+    for i in 0..src.len() + 1 {
+        let (nsrc, _) = src.split_at(i);
+        let mut remaining = nsrc;
+        hw_hmac.init();
+        block!(hw_hmac.configure(HmacPurpose::ToUser, KeyId::Key0)).expect("Key purpose mismatch");
+        let pre_hw_hmac = SystemTimer::now();
+        while remaining.len() > 0 {
+            remaining = block!(hw_hmac.update(remaining)).unwrap();
+        }
+        block!(hw_hmac.finalize(output.as_mut_slice())).unwrap();
+        let post_hw_hmac = SystemTimer::now();
+        let hw_time = post_hw_hmac - pre_hw_hmac;
+        let mut sw_hmac = HmacSha256::new_from_slice(key).expect("HMAC can take key of any size");
+        let pre_sw_hash = SystemTimer::now();
+        sw_hmac.update(nsrc);
+        let soft_result = sw_hmac.finalize().into_bytes();
+        let post_sw_hash = SystemTimer::now();
+        let soft_time = post_sw_hash - pre_sw_hash;
+        for (a, b) in output.iter().zip(soft_result) {
+            assert_eq!(*a, b);
+        }
+        println!("Testing for length: {:>4} | HW: {:>6} cycles, SW: {:>7} cycles (HW HMAC is {:>2}x faster)", i, hw_time, soft_time, soft_time / hw_time);
+    }
+    println!("Finished stress tests!");
+
+    loop {}
+}


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

This PR splits up https://github.com/esp-rs/esp-hal/pull/465, as suggested in https://github.com/esp-rs/esp-hal/pull/465#issuecomment-1643874670 to move the HMAC driver implementation into it's own PR to be more easily reviewable.

Code mostly taken from:
https://github.com/esp-rs/esp-hal/commit/a9807ae67da78b36b41c09bb814976f29ec4b328

I've reworked the examples a little bit.

I have tested on esp32s3, but not on the other architectures as I don't have them on hand.