### PR TITLE
Update to embassy-executor 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,12 +320,12 @@ jobs:
       # FIXME: `time-systick` feature disabled for now, see 'esp32s2-hal/Cargo.toml'.
       # - name: check esp32s2-hal (async, systick)
       #   run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
-      - name: check esp32-hal (embassy, timg0)
+      - name: check esp32s2-hal (embassy, timg0)
         run: |
           cd esp32s2-hal/
           cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
           cargo check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
-      - name: check esp32-hal (embassy, timg0, async)
+      - name: check esp32s2-hal (embassy, timg0, async)
         run: |
           cd esp32s2-hal/
           cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
@@ -360,28 +360,28 @@ jobs:
       # confident that they link.
       - name: check esp32s3-hal (common features)
         run: cd esp32s3-hal/ && cargo check --examples --features=eh1,ufmt
-      - name: check esp32-hal (embassy, timg0)
+      - name: check esp32s3-hal (embassy, timg0)
         run: |
           cd esp32s3-hal/
           cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
           cargo check --example=embassy_multicore --features=embassy,embassy-time-timg0,embassy-executor-thread
           cargo check --example=embassy_multicore_interrupt --features=embassy,embassy-time-timg0,embassy-executor-interrupt
           cargo check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
-      - name: check esp32-hal (embassy, systick)
+      - name: check esp32s3-hal (embassy, systick)
         run: |
           cd esp32s3-hal/
           cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,embassy-executor-thread
           cargo check --example=embassy_multicore --features=embassy,embassy-time-systick,embassy-executor-thread
           cargo check --example=embassy_multicore_interrupt --features=embassy,embassy-time-systick,embassy-executor-interrupt
           cargo check --example=embassy_multiprio --features=embassy,embassy-time-systick,embassy-executor-interrupt
-      - name: check esp32-hal (embassy, timg0, async)
+      - name: check esp32s3-hal (embassy, timg0, async)
         run: |
           cd esp32s3-hal/
           cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-      - name: check esp32-hal (embassy, systick, async)
+      - name: check esp32s3-hal (embassy, systick, async)
         run: |
           cd esp32s3-hal/
           cargo check --example=embassy_wait --features=embassy,embassy-time-systick,async,embassy-executor-thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add multicore-aware embassy executor for Xtensa MCUs (#723).
 - Add interrupt-executor for Xtensa MCUs (#723).
 - Add PARL_IO RX driver for ESP32-C6 / ESP32-H2 (#760)
+- Add multicore-aware embassy executor for Xtensa MCUs (#723, #756).
+- Add interrupt-executor for Xtensa MCUs (#723, #756).
 
 ### Changed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -36,7 +36,7 @@ usb-device           = { version = "0.2.9", optional = true }
 # async
 embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-io-async  = { version = "0.5.0", optional = true }
-embassy-executor   = { version = "0.2.1", features = ["pender-callback", "integrated-timers"], optional = true } # pender is temporary
+embassy-executor   = { version = "0.3.0", features = ["integrated-timers"], optional = true }
 embassy-sync       = { version = "0.2.0", optional = true }
 embassy-time       = { version = "0.1.3", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }

--- a/esp-hal-common/src/embassy/executor/xtensa/mod.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/mod.rs
@@ -11,3 +11,23 @@ pub mod thread;
 
 #[cfg(feature = "embassy-executor-thread")]
 pub use thread::*;
+
+#[export_name = "__pender"]
+fn __pender(context: *mut ()) {
+    let context = (context as usize).to_le_bytes();
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "embassy-executor-interrupt")] {
+            match context[0] {
+                #[cfg(feature = "embassy-executor-thread")]
+                0 => pend_thread_mode(context[1] as usize),
+                1 => FromCpu1::pend(),
+                2 => FromCpu2::pend(),
+                3 => FromCpu3::pend(),
+                _ => {}
+            }
+        } else {
+            pend_thread_mode(context[1] as usize);
+        }
+    }
+}

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -32,7 +32,7 @@ embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
-embassy-executor   = { version = "0.2.1", features = ["nightly"] }
+embassy-executor   = { version = "0.3.0", features = ["nightly"] }
 embassy-sync       = "0.2.0"
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -30,7 +30,7 @@ embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"
-embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-executor   = { version = "0.3.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -33,7 +33,7 @@ embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
-embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-executor   = { version = "0.3.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-can       = "0.4.1"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -33,7 +33,7 @@ embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false}
-embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-executor   = { version = "0.3.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -33,7 +33,7 @@ embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
-embassy-executor   = { version = "0.2.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-executor   = { version = "0.3.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -33,7 +33,7 @@ xtensa-atomic-emulation-trap = "0.4.0"
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
-embassy-executor   = { version = "0.2.1", features = ["nightly"] }
+embassy-executor   = { version = "0.3.0", features = ["nightly"] }
 embassy-sync       = "0.2.0"
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -33,7 +33,7 @@ r0             = { version = "1.0.0",  optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.2", default-features = false }
-embassy-executor   = { version = "0.2.1", features = ["nightly"] }
+embassy-executor   = { version = "0.3.0", features = ["nightly"] }
 embassy-sync       = "0.2.0"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

Updates the build-in executors to use the newest embassy-executor crate. This change means that calling a pender no longer goes through a function pointer - but it needs a runtime branch to figure out which interrupt to fire.

I renamed a macro parameter as it wasn't very well named, so that increases the noise level a bit, but hopefully will reduce future confusion potential.

This PR does not change user-facing APIs. Hopefully, I've feature-guarded the `__pender` function correctly, too, in case someone wants to use their own executors. Unfortunately, it is not possible to mix one of ours (thread or interrupt) with a custom executor. This tradeoff was acceptable to the embassy project, so I hope this shortfall won't cause much problems here, either.

~Unfortunately, due to some transitive sadness, we have to use the git dependency until a new embassy-time is released.~ Thanks Jesse for the embassy-time release!