### PR TITLE
Document package features and supported image formats

### DIFF
--- a/esp-hal-common/src/rmt.rs
+++ b/esp-hal-common/src/rmt.rs
@@ -1365,6 +1365,7 @@ mod chip_specific {
         rmt.apb_conf.modify(|_, w| w.clk_en().set_bit());
     }
 
+    #[doc(hidden)]
     #[macro_export]
     macro_rules! impl_tx_channel {
         ($channel:ident, $signal:ident, $ch_num:literal) => {
@@ -1505,6 +1506,7 @@ mod chip_specific {
         }
     }
 
+    #[doc(hidden)]
     #[macro_export]
     macro_rules! impl_rx_channel {
         ($channel:ident, $signal:ident, $ch_num:literal) => {

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -4,6 +4,42 @@
 //! [embedded-hal] repository.
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+//!
+//! ### Cargo Features
+//!
+//! The available cargo features for this package are listed below, along with a
+//! brief description of each feature.
+//!
+//! - `async` - Enable support for asynchronous operation, with interfaces
+//!   provided by [embedded-hal-async] and [embedded-io-async]
+//! - `bluetooth` - Enable support for using the Bluetooth radio
+//! - `debug` - Enable debug features in the HAL (used for development)
+//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
+//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
+//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
+//!   framework
+//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
+//!   peripheral
+//! - `psram_2m` - Use externally connected PSRAM (2MB)
+//! - `psram_4m` - Use externally connected PSRAM (4MB)
+//! - `psram_8m` - Use externally connected PSRAM (8MB)
+//! - `rt` - Runtime support
+//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART driver
+//! - `vectored` - Enable interrupt vectoring
+//! - `xtal26mhz` - The target device uses a 26MHz crystal
+//! - `xtal40mhz` - The target device uses a 40MHz crystal
+//!
+//! #### Default Features
+//!
+//! The `rt`, `vectored`, and `xtal40mhz` features are enabled by default.
+//!
+//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
+//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
+//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
+//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
+//! [embassy]: https://github.com/embassy-rs/embassy
+//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -39,6 +39,32 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//!
+//! ### Supported Image Formats
+//!
+//! This HAL supports building multiple different application image formats. You
+//! can read about each below.
+//!
+//! The ESP-IDF Bootloader format is used unless some other format is specified
+//! via its feature.
+//!
+//! #### ESP-IDF Bootloader
+//!
+//! Use the second-stage bootloader from [ESP-IDF] and its associated
+//! application image format. See the [App Image Format] documentation for more
+//! information about this format.
+//!
+//! [ESP-IDF]: https://github.com/espressif/esp-idf
+//! [App Image Format]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html
+//!
+//! #### Direct Boot
+//!
+//! This device additionally supports direct-boot, which allows an application
+//! to be executed directly from flash, without using the second-stage
+//! bootloader. For more information please see the
+//! [esp32c3-direct-boot-example] in the Espressif organization on GitHub.
+//!
+//! [esp32c3-direct-boot-example]: https://github.com/espressif/esp32c3-direct-boot-example
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -4,6 +4,41 @@
 //! [embedded-hal] repository.
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+//!
+//! ### Cargo Features
+//!
+//! - `async` - Enable support for asynchronous operation, with interfaces
+//!   provided by [embedded-hal-async] and [embedded-io-async]
+//! - `debug` - Enable debug features in the HAL (used for development)
+//! - `direct-boot` - Use the direct boot image format
+//! - `direct-vectoring` - Enable direct vector table hooking support
+//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
+//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
+//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
+//!   framework
+//! - `embassy-time-systick` - Enable the [embassy] time driver using the
+//!   `SYSTIMER` peripheral
+//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
+//!   peripheral
+//! - `interrupt-preemption` - Enable priority-based interrupt preemption
+//! - `rt` - Runtime support
+//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
+//!   Serial JTAG drivers
+//! - `vectored` - Enable interrupt vectoring
+//! - `xtal26mhz` - The target device uses a 26MHz crystal
+//! - `xtal40mhz` - The target device uses a 40MHz crystal
+//!
+//! #### Default Features
+//!
+//! The `rt`, `vectored`, and `xtal40mhz` features are enabled by default.
+//!
+//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
+//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
+//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
+//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
+//! [embassy]: https://github.com/embassy-rs/embassy
+//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -4,6 +4,40 @@
 //! [embedded-hal] repository.
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+//!
+//! ### Cargo Features
+//!
+//! - `async` - Enable support for asynchronous operation, with interfaces
+//!   provided by [embedded-hal-async] and [embedded-io-async]
+//! - `debug` - Enable debug features in the HAL (used for development)
+//! - `direct-boot` - Use the direct boot image format
+//! - `direct-vectoring` - Enable direct vector table hooking support
+//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
+//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
+//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
+//!   framework
+//! - `embassy-time-systick` - Enable the [embassy] time driver using the
+//!   `SYSTIMER` peripheral
+//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
+//!   peripheral
+//! - `interrupt-preemption` - Enable priority-based interrupt preemption
+//! - `mcu-boot` - Use the MCUboot image format
+//! - `rt` - Runtime support
+//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
+//!   Serial JTAG drivers
+//! - `vectored` - Enable interrupt vectoring
+//!
+//! #### Default Features
+//!
+//! The `rt` and `vectored` features are enabled by default.
+//!
+//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
+//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
+//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
+//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
+//! [embassy]: https://github.com/embassy-rs/embassy
+//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -38,6 +38,39 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//!
+//! ### Supported Image Formats
+//!
+//! This HAL supports building multiple different application image formats. You
+//! can read about each below.
+//!
+//! The ESP-IDF Bootloader format is used unless some other format is specified
+//! via its feature.
+//!
+//! #### ESP-IDF Bootloader
+//!
+//! Use the second-stage bootloader from [ESP-IDF] and its associated
+//! application image format. See the [App Image Format] documentation for more
+//! information about this format.
+//!
+//! [ESP-IDF]: https://github.com/espressif/esp-idf
+//! [App Image Format]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html
+//!
+//! #### Direct Boot
+//!
+//! This device additionally supports direct-boot, which allows an application
+//! to be executed directly from flash, without using the second-stage
+//! bootloader. For more information please see the
+//! [esp32c3-direct-boot-example] in the Espressif organization on GitHub.
+//!
+//! [esp32c3-direct-boot-example]: https://github.com/espressif/esp32c3-direct-boot-example
+//!
+//! #### MCUboot
+//!
+//! Use the MCUBoot bootloader and its associated image format. See the [MCUBoot
+//! design document] for more information about this format.
+//!
+//! [MCUBoot design document]: https://docs.mcuboot.com/design.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -4,6 +4,39 @@
 //! [embedded-hal] repository.
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+//!
+//! ### Cargo Features
+//!
+//! - `async` - Enable support for asynchronous operation, with interfaces
+//!   provided by [embedded-hal-async] and [embedded-io-async]
+//! - `debug` - Enable debug features in the HAL (used for development)
+//! - `direct-boot` - Use the direct boot image format
+//! - `direct-vectoring` - Enable direct vector table hooking support
+//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
+//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
+//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
+//!   framework
+//! - `embassy-time-systick` - Enable the [embassy] time driver using the
+//!   `SYSTIMER` peripheral
+//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
+//!   peripheral
+//! - `interrupt-preemption` - Enable priority-based interrupt preemption
+//! - `rt` - Runtime support
+//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
+//!   Serial JTAG drivers
+//! - `vectored` - Enable interrupt vectoring
+//!
+//! #### Default Features
+//!
+//! The `rt` and `vectored` features are enabled by default.
+//!
+//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
+//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
+//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
+//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
+//! [embassy]: https://github.com/embassy-rs/embassy
+//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -37,6 +37,32 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//!
+//! ### Supported Image Formats
+//!
+//! This HAL supports building multiple different application image formats. You
+//! can read about each below.
+//!
+//! The ESP-IDF Bootloader format is used unless some other format is specified
+//! via its feature.
+//!
+//! #### ESP-IDF Bootloader
+//!
+//! Use the second-stage bootloader from [ESP-IDF] and its associated
+//! application image format. See the [App Image Format] documentation for more
+//! information about this format.
+//!
+//! [ESP-IDF]: https://github.com/espressif/esp-idf
+//! [App Image Format]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html
+//!
+//! #### Direct Boot
+//!
+//! This device additionally supports direct-boot, which allows an application
+//! to be executed directly from flash, without using the second-stage
+//! bootloader. For more information please see the
+//! [esp32c3-direct-boot-example] in the Espressif organization on GitHub.
+//!
+//! [esp32c3-direct-boot-example]: https://github.com/espressif/esp32c3-direct-boot-example
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -4,6 +4,39 @@
 //! [embedded-hal] repository.
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+//!
+//! ### Cargo Features
+//!
+//! - `async` - Enable support for asynchronous operation, with interfaces
+//!   provided by [embedded-hal-async] and [embedded-io-async]
+//! - `debug` - Enable debug features in the HAL (used for development)
+//! - `direct-boot` - Use the direct boot image format
+//! - `direct-vectoring` - Enable direct vector table hooking support
+//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
+//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
+//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
+//!   framework
+//! - `embassy-time-systick` - Enable the [embassy] time driver using the
+//!   `SYSTIMER` peripheral
+//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
+//!   peripheral
+//! - `interrupt-preemption` - Enable priority-based interrupt preemption
+//! - `rt` - Runtime support
+//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
+//!   Serial JTAG drivers
+//! - `vectored` - Enable interrupt vectoring
+//!
+//! #### Default Features
+//!
+//! The `rt` and `vectored` features are enabled by default.
+//!
+//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
+//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
+//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
+//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
+//! [embassy]: https://github.com/embassy-rs/embassy
+//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -37,6 +37,32 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//!
+//! ### Supported Image Formats
+//!
+//! This HAL supports building multiple different application image formats. You
+//! can read about each below.
+//!
+//! The ESP-IDF Bootloader format is used unless some other format is specified
+//! via its feature.
+//!
+//! #### ESP-IDF Bootloader
+//!
+//! Use the second-stage bootloader from [ESP-IDF] and its associated
+//! application image format. See the [App Image Format] documentation for more
+//! information about this format.
+//!
+//! [ESP-IDF]: https://github.com/espressif/esp-idf
+//! [App Image Format]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html
+//!
+//! #### Direct Boot
+//!
+//! This device additionally supports direct-boot, which allows an application
+//! to be executed directly from flash, without using the second-stage
+//! bootloader. For more information please see the
+//! [esp32c3-direct-boot-example] in the Espressif organization on GitHub.
+//!
+//! [esp32c3-direct-boot-example]: https://github.com/espressif/esp32c3-direct-boot-example
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -4,6 +4,36 @@
 //! [embedded-hal] repository.
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+//!
+//! ### Cargo Features
+//!
+//! - `async` - Enable support for asynchronous operation, with interfaces
+//!   provided by [embedded-hal-async] and [embedded-io-async]
+//! - `debug` - Enable debug features in the HAL (used for development)
+//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
+//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
+//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
+//!   framework
+//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
+//!   peripheral
+//! - `psram_2m` - Use externally connected PSRAM (2MB)
+//! - `psram_4m` - Use externally connected PSRAM (4MB)
+//! - `psram_8m` - Use externally connected PSRAM (8MB)
+//! - `rt` - Runtime support
+//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART driver
+//! - `vectored` - Enable interrupt vectoring
+//!
+//! #### Default Features
+//!
+//! The `rt` and `vectored` features are enabled by default.
+//!
+//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
+//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
+//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
+//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
+//! [embassy]: https://github.com/embassy-rs/embassy
+//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -40,6 +40,32 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//!
+//! ### Supported Image Formats
+//!
+//! This HAL supports building multiple different application image formats. You
+//! can read about each below.
+//!
+//! The ESP-IDF Bootloader format is used unless some other format is specified
+//! via its feature.
+//!
+//! #### ESP-IDF Bootloader
+//!
+//! Use the second-stage bootloader from [ESP-IDF] and its associated
+//! application image format. See the [App Image Format] documentation for more
+//! information about this format.
+//!
+//! [ESP-IDF]: https://github.com/espressif/esp-idf
+//! [App Image Format]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html
+//!
+//! #### Direct Boot
+//!
+//! This device additionally supports direct-boot, which allows an application
+//! to be executed directly from flash, without using the second-stage
+//! bootloader. For more information please see the
+//! [esp32c3-direct-boot-example] in the Espressif organization on GitHub.
+//!
+//! [esp32c3-direct-boot-example]: https://github.com/espressif/esp32c3-direct-boot-example
 
 #![no_std]
 #![cfg_attr(

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -4,6 +4,42 @@
 //! [embedded-hal] repository.
 //!
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+//!
+//! ### Cargo Features
+//!
+//! - `async` - Enable support for asynchronous operation, with interfaces
+//!   provided by [embedded-hal-async] and [embedded-io-async]
+//! - `debug` - Enable debug features in the HAL (used for development)
+//! - `direct-boot` - Use the direct boot image format
+//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
+//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
+//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
+//!   framework
+//! - `embassy-time-systick` - Enable the [embassy] time driver using the
+//!   `SYSTIMER` peripheral
+//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
+//!   peripheral
+//! - `opsram_2m` - Use externally connected Octal PSRAM (2MB)
+//! - `opsram_4m` - Use externally connected Octal PSRAM (4MB)
+//! - `opsram_8m` - Use externally connected Octal PSRAM (8MB)
+//! - `psram_2m` - Use externally connected PSRAM (2MB)
+//! - `psram_4m` - Use externally connected PSRAM (4MB)
+//! - `psram_8m` - Use externally connected PSRAM (8MB)
+//! - `rt` - Runtime support
+//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART driver
+//! - `vectored` - Enable interrupt vectoring
+//!
+//! #### Default Features
+//!
+//! The `rt` and `vectored` features are enabled by default.
+//!
+//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
+//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
+//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
+//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
+//! [embassy]: https://github.com/embassy-rs/embassy
+//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
 
 #![no_std]
 #![cfg_attr(


### PR DESCRIPTION
Documents the cargo features for each chip-specific HAL package. Additionally documents the image formats, which were removed from the `README`s in #750.

Pretty minimal but better to have something rather than nothing, we can improve upon it incrementally.