### PR TITLE
Update `embassy-time` to version `0.1.3`

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -37,7 +37,7 @@ usb-device           = { version = "0.2.9", optional = true }
 embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-io-async  = { version = "0.5.0", optional = true }
 embassy-sync       = { version = "0.2.0", optional = true }
-embassy-time       = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.3", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }
 
 # RISC-V

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32"], path = "../esp-hal-common" }
-embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32c2"], path = "../esp-hal-common" }
-embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 [dependencies]
 cfg-if         = "1.0.0"
 esp-hal-common = { version = "0.11.0", features = ["esp32c3"], path = "../esp-hal-common" }
-embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32c6"], path = "../esp-hal-common" }
-embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32h2"], path = "../esp-hal-common" }
-embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common               = { version = "0.11.0", features = ["esp32s2"], path = "../esp-hal-common" }
-embassy-time                 = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
+embassy-time                 = { version = "0.1.3", features = ["nightly"], optional = true }
 xtensa-atomic-emulation-trap = "0.4.0"
 
 [dev-dependencies]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.11.0", features = ["esp32s3"], path = "../esp-hal-common" }
-embassy-time   = { git = "https://github.com/embassy-rs/embassy", rev = "4f453d7", features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.3", features = ["nightly"], optional = true }
 r0             = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Just clearing out this git dependency in preparation for our next release.