### PR TITLE
Update PACs and `xtensa-lx-rt` package

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -47,7 +47,7 @@ riscv-atomic-emulation-trap = { version = "0.4.0", optional = true }
 
 # Xtensa
 xtensa-lx    = { version = "0.8.0",  optional = true }
-xtensa-lx-rt = { version = "0.15.0", optional = true }
+xtensa-lx-rt = { version = "0.16.0", optional = true }
 
 # Part of `ufmt` containing only `uWrite` trait
 ufmt-write = { version = "0.1.0", optional = true }

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -55,13 +55,13 @@ ufmt-write = { version = "0.1.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.25.0", features = ["critical-section"], optional = true }
-esp32c2 = { version = "0.13.0", features = ["critical-section"], optional = true }
-esp32c3 = { version = "0.16.0", features = ["critical-section"], optional = true }
-esp32c6 = { version = "0.6.0",  features = ["critical-section"], optional = true }
-esp32h2 = { version = "0.2.0",  features = ["critical-section"], optional = true }
-esp32s2 = { version = "0.16.0", features = ["critical-section"], optional = true }
-esp32s3 = { version = "0.20.0", features = ["critical-section"], optional = true }
+esp32   = { version = "0.26.0", features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.14.0", features = ["critical-section"], optional = true }
+esp32c3 = { version = "0.17.0", features = ["critical-section"], optional = true }
+esp32c6 = { version = "0.7.0",  features = ["critical-section"], optional = true }
+esp32h2 = { version = "0.3.0",  features = ["critical-section"], optional = true }
+esp32s2 = { version = "0.17.0", features = ["critical-section"], optional = true }
+esp32s3 = { version = "0.21.0", features = ["critical-section"], optional = true }
 
 [build-dependencies]
 basic-toml = "0.1.4"

--- a/esp-hal-common/src/aes/esp32.rs
+++ b/esp-hal-common/src/aes/esp32.rs
@@ -28,7 +28,7 @@ impl<'d> Aes<'d> {
     }
 
     pub(super) fn write_mode(&mut self, mode: u32) {
-        Self::write_to_register(&mut self.aes.mode, mode);
+        self.aes.mode.write(|w| unsafe { w.bits(mode) });
     }
 
     /// Configures how the state matrix would be laid out
@@ -48,7 +48,7 @@ impl<'d> Aes<'d> {
         to_write |= (input_text_word_endianess as u32) << 3;
         to_write |= (output_text_byte_endianess as u32) << 4;
         to_write |= (output_text_word_endianess as u32) << 5;
-        Self::write_to_register(&mut self.aes.endian, to_write);
+        self.aes.endian.write(|w| unsafe { w.bits(to_write) });
     }
 
     pub(super) fn write_start(&mut self) {

--- a/esp-hal-common/src/aes/esp32cX.rs
+++ b/esp-hal-common/src/aes/esp32cX.rs
@@ -28,7 +28,7 @@ impl<'d> Aes<'d> {
     }
 
     pub(super) fn write_mode(&mut self, mode: u32) {
-        Self::write_to_register(&mut self.aes.mode, mode);
+        self.aes.mode.write(|w| unsafe { w.bits(mode) });
     }
 
     pub(super) fn write_start(&mut self) {

--- a/esp-hal-common/src/aes/esp32s2.rs
+++ b/esp-hal-common/src/aes/esp32s2.rs
@@ -36,7 +36,7 @@ impl<'d> Aes<'d> {
     }
 
     pub(super) fn write_mode(&mut self, mode: u32) {
-        Self::write_to_register(&mut self.aes.mode, mode);
+        self.aes.mode.write(|w| unsafe { w.bits(mode) });
     }
 
     /// Configures how the state matrix would be laid out.
@@ -56,7 +56,7 @@ impl<'d> Aes<'d> {
         to_write |= (input_text_word_endianess as u32) << 3;
         to_write |= (output_text_byte_endianess as u32) << 4;
         to_write |= (output_text_word_endianess as u32) << 5;
-        Self::write_to_register(&mut self.aes.endian, to_write);
+        self.aes.endian.write(|w| unsafe { w.bits(to_write) });
     }
 
     pub(super) fn write_start(&mut self) {

--- a/esp-hal-common/src/aes/esp32s3.rs
+++ b/esp-hal-common/src/aes/esp32s3.rs
@@ -28,7 +28,7 @@ impl<'d> Aes<'d> {
     }
 
     pub(super) fn write_mode(&mut self, mode: u32) {
-        Self::write_to_register(&mut self.aes.mode, mode);
+        self.aes.mode.write(|w| unsafe { w.bits(mode) });
     }
 
     pub(super) fn write_start(&mut self) {

--- a/esp-hal-common/src/aes/mod.rs
+++ b/esp-hal-common/src/aes/mod.rs
@@ -121,13 +121,6 @@ impl<'d> Aes<'d> {
             }
         }
     }
-
-    fn write_to_register<T>(reg: &mut Reg<T>, data: u32)
-    where
-        T: RegisterSpec<Ux = u32> + Resettable + Writable,
-    {
-        reg.write(|w| unsafe { w.bits(data) });
-    }
 }
 
 mod sealed {

--- a/esp-hal-common/src/rsa/esp32.rs
+++ b/esp-hal-common/src/rsa/esp32.rs
@@ -26,11 +26,11 @@ impl<'d> Rsa<'d> {
     }
 
     pub(super) fn write_multi_mode(&mut self, mode: u32) {
-        Self::write_to_register(&mut self.rsa.mult_mode, mode as u32);
+        self.rsa.mult_mode.write(|w| unsafe { w.bits(mode as u32) });
     }
 
     pub(super) fn write_modexp_mode(&mut self, mode: u32) {
-        Self::write_to_register(&mut self.rsa.modexp_mode, mode);
+        self.rsa.modexp_mode.write(|w| unsafe { w.bits(mode) });
     }
 
     pub(super) fn write_modexp_start(&mut self) {

--- a/esp-hal-common/src/rsa/esp32cX.rs
+++ b/esp-hal-common/src/rsa/esp32cX.rs
@@ -31,7 +31,7 @@ impl<'d> Rsa<'d> {
     }
 
     fn write_mode(&mut self, mode: u32) {
-        Self::write_to_register(&mut self.rsa.mode, mode as u32);
+        self.rsa.mode.write(|w| unsafe { w.bits(mode as u32) });
     }
 
     /// Enables/disables search acceleration, when enabled it would increases
@@ -56,7 +56,9 @@ impl<'d> Rsa<'d> {
     }
 
     pub(super) fn write_search_position(&mut self, search_position: u32) {
-        Self::write_to_register(&mut self.rsa.search_pos, search_position);
+        self.rsa
+            .search_pos
+            .write(|w| unsafe { w.bits(search_position) });
     }
 
     /// Enables/disables constant time acceleration, when enabled it would

--- a/esp-hal-common/src/rsa/esp32sX.rs
+++ b/esp-hal-common/src/rsa/esp32sX.rs
@@ -37,7 +37,7 @@ impl<'d> Rsa<'d> {
     }
 
     fn write_mode(&mut self, mode: u32) {
-        Self::write_to_register(&mut self.rsa.mode, mode as u32);
+        self.rsa.mode.write(|w| unsafe { w.bits(mode as u32) });
     }
 
     /// Enables/disables search acceleration, when enabled it would increases
@@ -62,7 +62,9 @@ impl<'d> Rsa<'d> {
     }
 
     pub(super) fn write_search_position(&mut self, search_position: u32) {
-        Self::write_to_register(&mut self.rsa.search_pos, search_position);
+        self.rsa
+            .search_pos
+            .write(|w| unsafe { w.bits(search_position) });
     }
 
     /// Enables/disables constant time acceleration, when enabled it would

--- a/esp-hal-common/src/rsa/mod.rs
+++ b/esp-hal-common/src/rsa/mod.rs
@@ -39,10 +39,7 @@ use core::{convert::Infallible, marker::PhantomData, ptr::copy_nonoverlapping};
 
 use crate::{
     peripheral::{Peripheral, PeripheralRef},
-    peripherals::{
-        generic::{Reg, RegisterSpec, Resettable, Writable},
-        RSA,
-    },
+    peripherals::RSA,
     system::{Peripheral as PeripheralEnable, PeripheralClockControl},
 };
 
@@ -89,7 +86,7 @@ impl<'d> Rsa<'d> {
     }
 
     fn write_mprime(&mut self, m_prime: u32) {
-        Self::write_to_register(&mut self.rsa.m_prime, m_prime);
+        self.rsa.m_prime.write(|w| unsafe { w.bits(m_prime) });
     }
 
     unsafe fn write_operand_a<const N: usize>(&mut self, operand_a: &[u8; N]) {
@@ -106,13 +103,6 @@ impl<'d> Rsa<'d> {
 
     unsafe fn read_out<const N: usize>(&mut self, outbuf: &mut [u8; N]) {
         copy_nonoverlapping(self.rsa.z_mem.as_ptr() as *const u8, outbuf.as_mut_ptr(), N);
-    }
-
-    fn write_to_register<T>(reg: &mut Reg<T>, data: u32)
-    where
-        T: RegisterSpec<Ux = u32> + Resettable + Writable,
-    {
-        reg.write(|w| unsafe { w.bits(data) });
     }
 }
 

--- a/esp32-hal/ld/link-esp32.x
+++ b/esp32-hal/ld/link-esp32.x
@@ -6,6 +6,7 @@ ENTRY(Reset)
 PROVIDE(__pre_init = DefaultPreInit);
 PROVIDE(__zero_bss = default_mem_hook);
 PROVIDE(__init_data = default_mem_hook);
+PROVIDE(__post_init = default_post_init);
 
 INCLUDE exception.x
 

--- a/esp32s2-hal/ld/link-esp32s2.x
+++ b/esp32s2-hal/ld/link-esp32s2.x
@@ -6,6 +6,7 @@ ENTRY(Reset)
 PROVIDE(__pre_init = DefaultPreInit);
 PROVIDE(__zero_bss = default_mem_hook);
 PROVIDE(__init_data = default_mem_hook);
+PROVIDE(__post_init = default_post_init);
 
 INCLUDE exception.x
 

--- a/esp32s3-hal/ld/db-esp32s3.x
+++ b/esp32s3-hal/ld/db-esp32s3.x
@@ -18,6 +18,7 @@ INCLUDE "device.x"
 PROVIDE(__pre_init = DefaultPreInit);
 PROVIDE(__zero_bss = default_mem_hook);
 PROVIDE(__init_data = default_mem_hook);
+PROVIDE(__post_init = default_post_init);
 
 /*INCLUDE exception.x*/
 /* exception vector for the ESP32, requiring high priority interrupts and register window support */

--- a/esp32s3-hal/ld/link-esp32s3.x
+++ b/esp32s3-hal/ld/link-esp32s3.x
@@ -5,6 +5,7 @@ ENTRY(ESP32Reset)
 PROVIDE(__pre_init = DefaultPreInit);
 PROVIDE(__zero_bss = default_mem_hook);
 PROVIDE(__init_data = default_mem_hook);
+PROVIDE(__post_init = default_post_init);
 
 INCLUDE exception.x
 


### PR DESCRIPTION
- Update `xtensa-lx-rt` to the latest version
    - I'm not 100% sure the linker script changes are necessary, but I've included them just to be consistent with the RISC-V devices' scripts
- Update PACs to their latest versions
    -  There was a new release of `svd2rust`, and it seems the traits have changed slightly
    - We had a couple helper functions which previously relied on these traits which broke as a result
    - I've simply removed these helpers as they were, IMO, of limited utility to begin with