### PR TITLE
Disable all watchdog timers at startup by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add PARL_IO TX driver for ESP32-C6 / ESP32-H2 (#733)
 - Implement `ufmt_write::uWrite` trait for USB Serial JTAG (#751)
 - Add HMAC peripheral support (#755)
-- Add multicore-aware embassy executor for Xtensa MCUs (#723).
-- Add interrupt-executor for Xtensa MCUs (#723).
 - Add PARL_IO RX driver for ESP32-C6 / ESP32-H2 (#760)
 - Add multicore-aware embassy executor for Xtensa MCUs (#723, #756).
 - Add interrupt-executor for Xtensa MCUs (#723, #756).
@@ -30,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update the `embedded-hal-*` packages to `1.0.0-rc.1` and implement traits from `embedded-io` and `embedded-io-async` (#747)
 - Moved AlignmentHelper to its own module (#753)
+- Disable all watchdog timers by default at startup (#763)
 
 ### Fixed
 

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -728,13 +728,30 @@ where
     pub fn new(_peripheral_clock_control: &mut PeripheralClockControl) -> Self {
         #[cfg(lp_wdt)]
         _peripheral_clock_control.enable(crate::system::Peripheral::Wdt);
+
         TG::configure_wdt_src_clk();
+
         Self {
             phantom: PhantomData::default(),
         }
     }
 
-    fn set_wdt_enabled(&mut self, enabled: bool) {
+    /// Enable the watchdog timer instance
+    pub fn enable(&mut self) {
+        // SAFETY: The `TG` instance being modified is owned by `self`, which is behind
+        //         a mutable reference.
+        unsafe { Self::set_wdt_enabled(true) };
+    }
+
+    /// Disable the watchdog timer instance
+    pub fn disable(&mut self) {
+        // SAFETY: The `TG` instance being modified is owned by `self`, which is behind
+        //         a mutable reference.
+        unsafe { Self::set_wdt_enabled(false) };
+    }
+
+    /// Forcibly enable or disable the watchdog timer
+    pub unsafe fn set_wdt_enabled(enabled: bool) {
         let reg_block = unsafe { &*TG::register_block() };
 
         reg_block
@@ -817,7 +834,7 @@ where
     TG: TimerGroupInstance,
 {
     fn disable(&mut self) {
-        self.set_wdt_enabled(false);
+        self.disable();
     }
 }
 
@@ -831,6 +848,7 @@ where
     where
         T: Into<Self::Time>,
     {
+        self.enable();
         self.set_timeout(period.into());
     }
 }

--- a/esp32-hal/examples/rtc_watchdog.rs
+++ b/esp32-hal/examples/rtc_watchdog.rs
@@ -28,10 +28,6 @@ fn main() -> ! {
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 
@@ -49,6 +45,8 @@ fn main() -> ! {
 #[interrupt]
 fn RTC_CORE() {
     critical_section::with(|cs| {
+        esp_println::println!("RWDT Interrupt");
+
         let mut rwdt = RWDT.borrow_ref_mut(cs);
         let rwdt = rwdt.as_mut().unwrap();
         rwdt.clear_interrupt();

--- a/esp32-hal/examples/watchdog.rs
+++ b/esp32-hal/examples/watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     loop {
-        // wdt.feed();
+        wdt.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32-hal/examples/watchdog.rs
+++ b/esp32-hal/examples/watchdog.rs
@@ -5,13 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -29,15 +23,12 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    rtc.rwdt.disable();
 
     wdt.start(2u64.secs());
     timer0.start(1u64.secs());
 
     loop {
-        wdt.feed();
+        // wdt.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -94,3 +94,18 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 pub extern "Rust" fn __init_data() -> bool {
     false
 }
+
+#[export_name = "__post_init"]
+unsafe fn post_init() {
+    use esp_hal_common::{
+        peripherals::{RTC_CNTL, TIMG0, TIMG1},
+        timer::Wdt,
+    };
+
+    // RTC domain must be enabled before we try to disable
+    let mut rtc = Rtc::new(RTC_CNTL::steal());
+    rtc.rwdt.disable();
+
+    Wdt::<TIMG0>::set_wdt_enabled(false);
+    Wdt::<TIMG1>::set_wdt_enabled(false);
+}

--- a/esp32c2-hal/examples/rtc_watchdog.rs
+++ b/esp32c2-hal/examples/rtc_watchdog.rs
@@ -29,11 +29,6 @@ fn main() -> ! {
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32c2-hal/examples/watchdog.rs
+++ b/esp32c2-hal/examples/watchdog.rs
@@ -5,13 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -22,7 +16,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -31,15 +24,11 @@ fn main() -> ! {
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
 
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
     wdt0.start(2u64.secs());
-
     timer0.start(1u64.secs());
 
     loop {
-        wdt0.feed();
+        // wdt0.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32c2-hal/examples/watchdog.rs
+++ b/esp32c2-hal/examples/watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     loop {
-        // wdt0.feed();
+        wdt0.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -75,3 +75,18 @@ pub use esp_hal_common::*;
 pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
 }
+
+#[export_name = "__post_init"]
+unsafe fn post_init() {
+    use esp_hal_common::{
+        peripherals::{RTC_CNTL, TIMG0},
+        timer::Wdt,
+    };
+
+    // RTC domain must be enabled before we try to disable
+    let mut rtc = Rtc::new(RTC_CNTL::steal());
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    Wdt::<TIMG0>::set_wdt_enabled(false);
+}

--- a/esp32c3-hal/examples/rtc_watchdog.rs
+++ b/esp32c3-hal/examples/rtc_watchdog.rs
@@ -29,11 +29,6 @@ fn main() -> ! {
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32c3-hal/examples/watchdog.rs
+++ b/esp32c3-hal/examples/watchdog.rs
@@ -5,13 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -22,7 +16,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -30,23 +23,12 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
     wdt0.start(2u64.secs());
-    wdt1.disable();
-
     timer0.start(1u64.secs());
 
     loop {
-        wdt0.feed();
+        // wdt0.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32c3-hal/examples/watchdog.rs
+++ b/esp32c3-hal/examples/watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     loop {
-        // wdt0.feed();
+        wdt0.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32c6-hal/examples/rtc_watchdog.rs
+++ b/esp32c6-hal/examples/rtc_watchdog.rs
@@ -15,7 +15,6 @@ use esp32c6_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
     Rtc,
     Rwdt,
 };
@@ -26,30 +25,10 @@ static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let system = peripherals.PCR.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    wdt0.disable();
-    wdt1.disable();
     let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32c6-hal/examples/watchdog.rs
+++ b/esp32c6-hal/examples/watchdog.rs
@@ -5,13 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c6_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c6_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -22,7 +16,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -30,23 +23,12 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
     wdt0.start(2u64.secs());
-    wdt1.disable();
-
     timer0.start(1u64.secs());
 
     loop {
-        wdt0.feed();
+        // wdt0.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32c6-hal/examples/watchdog.rs
+++ b/esp32c6-hal/examples/watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     loop {
-        // wdt0.feed();
+        wdt0.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -73,3 +73,19 @@ pub use esp_hal_common::*;
 pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
 }
+
+#[export_name = "__post_init"]
+unsafe fn post_init() {
+    use esp_hal_common::{
+        peripherals::{LP_CLKRST, TIMG0, TIMG1},
+        timer::Wdt,
+    };
+
+    // RTC domain must be enabled before we try to disable
+    let mut rtc = Rtc::new(LP_CLKRST::steal());
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    Wdt::<TIMG0>::set_wdt_enabled(false);
+    Wdt::<TIMG1>::set_wdt_enabled(false);
+}

--- a/esp32h2-hal/examples/rtc_watchdog.rs
+++ b/esp32h2-hal/examples/rtc_watchdog.rs
@@ -15,7 +15,6 @@ use esp32h2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
     Rtc,
     Rwdt,
 };
@@ -26,30 +25,10 @@ static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let system = peripherals.PCR.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    wdt0.disable();
-    wdt1.disable();
     let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32h2-hal/examples/watchdog.rs
+++ b/esp32h2-hal/examples/watchdog.rs
@@ -5,13 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32h2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32h2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -22,7 +16,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -30,23 +23,12 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
     wdt0.start(2u64.secs());
-    wdt1.disable();
-
     timer0.start(1u64.secs());
 
     loop {
-        wdt0.feed();
+        // wdt0.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32h2-hal/examples/watchdog.rs
+++ b/esp32h2-hal/examples/watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     loop {
-        // wdt0.feed();
+        wdt0.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -73,3 +73,19 @@ pub use esp_hal_common::*;
 pub mod analog {
     pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
 }
+
+#[export_name = "__post_init"]
+unsafe fn post_init() {
+    use esp_hal_common::{
+        peripherals::{LP_CLKRST, TIMG0, TIMG1},
+        timer::Wdt,
+    };
+
+    // RTC domain must be enabled before we try to disable
+    let mut rtc = Rtc::new(LP_CLKRST::steal());
+    rtc.swd.disable();
+    rtc.rwdt.disable();
+
+    Wdt::<TIMG0>::set_wdt_enabled(false);
+    Wdt::<TIMG1>::set_wdt_enabled(false);
+}

--- a/esp32s2-hal/examples/rtc_watchdog.rs
+++ b/esp32s2-hal/examples/rtc_watchdog.rs
@@ -28,10 +28,6 @@ fn main() -> ! {
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 
@@ -49,6 +45,8 @@ fn main() -> ! {
 #[interrupt]
 fn RTC_CORE() {
     critical_section::with(|cs| {
+        esp_println::println!("RWDT Interrupt");
+
         let mut rwdt = RWDT.borrow_ref_mut(cs);
         let rwdt = rwdt.as_mut().unwrap();
         rwdt.clear_interrupt();

--- a/esp32s2-hal/examples/watchdog.rs
+++ b/esp32s2-hal/examples/watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     loop {
-        // wdt.feed();
+        wdt.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32s2-hal/examples/watchdog.rs
+++ b/esp32s2-hal/examples/watchdog.rs
@@ -5,13 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -29,15 +23,12 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     wdt.start(2u64.secs());
-    rtc.rwdt.disable();
-
     timer0.start(1u64.secs());
 
     loop {
-        wdt.feed();
+        // wdt.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -148,3 +148,18 @@ unsafe fn exception(cause: ExceptionCause, save_frame: &mut trapframe::TrapFrame
 
     __user_exception(cause, save_frame);
 }
+
+#[export_name = "__post_init"]
+unsafe fn post_init() {
+    use esp_hal_common::{
+        peripherals::{RTC_CNTL, TIMG0, TIMG1},
+        timer::Wdt,
+    };
+
+    // RTC domain must be enabled before we try to disable
+    let mut rtc = Rtc::new(RTC_CNTL::steal());
+    rtc.rwdt.disable();
+
+    Wdt::<TIMG0>::set_wdt_enabled(false);
+    Wdt::<TIMG1>::set_wdt_enabled(false);
+}

--- a/esp32s3-hal/examples/rtc_watchdog.rs
+++ b/esp32s3-hal/examples/rtc_watchdog.rs
@@ -28,10 +28,6 @@ fn main() -> ! {
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 
@@ -49,6 +45,8 @@ fn main() -> ! {
 #[interrupt]
 fn RTC_CORE() {
     critical_section::with(|cs| {
+        esp_println::println!("RWDT Interrupt");
+
         let mut rwdt = RWDT.borrow_ref_mut(cs);
         let rwdt = rwdt.as_mut().unwrap();
         rwdt.clear_interrupt();

--- a/esp32s3-hal/examples/watchdog.rs
+++ b/esp32s3-hal/examples/watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     timer0.start(1u64.secs());
 
     loop {
-        // wdt.feed();
+        wdt.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32s3-hal/examples/watchdog.rs
+++ b/esp32s3-hal/examples/watchdog.rs
@@ -5,13 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -29,15 +23,12 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     wdt.start(2u64.secs());
-    rtc.rwdt.disable();
-
     timer0.start(1u64.secs());
 
     loop {
-        wdt.feed();
+        // wdt.feed();
         println!("Hello world!");
         block!(timer0.wait()).unwrap();
     }

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -275,3 +275,18 @@ pub extern "Rust" fn __init_data() -> bool {
 
     res
 }
+
+#[export_name = "__post_init"]
+unsafe fn post_init() {
+    use esp_hal_common::{
+        peripherals::{RTC_CNTL, TIMG0, TIMG1},
+        timer::Wdt,
+    };
+
+    // RTC domain must be enabled before we try to disable
+    let mut rtc = Rtc::new(RTC_CNTL::steal());
+    rtc.rwdt.disable();
+
+    Wdt::<TIMG0>::set_wdt_enabled(false);
+    Wdt::<TIMG1>::set_wdt_enabled(false);
+}


### PR DESCRIPTION
- Use the `__post_init` hook to disable all watchdog timers at startup
- Refactor the watchdog timer drivers to be less reliant on the `embedded-hal` traits, add `enable` functions
- Update the watchdog-related examples
    - All examples will need updating, and I have largely completed this already (oof), however I'd like to take some time to review all the changes and make sure I haven't done anything silly, so I will save that for another PR I think)

All modified examples have been tested, and I tried a couple others as well to ensure the watchdogs were indeed disabled.