### PR TITLE
Add missing GPIO conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add PARL_IO RX driver for ESP32-C6 / ESP32-H2 (#760)
 - Add multicore-aware embassy executor for Xtensa MCUs (#723, #756).
 - Add interrupt-executor for Xtensa MCUs (#723, #756).
+- Add missing `Into<Gpio<Analog, GPIONUN>>` conversion (#764)
 
 ### Changed
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -859,7 +859,7 @@ where
     <Self as GpioProperties>::PinType: IsOutputPin,
     GpioPin<Unknown, GPIONUM>: GpioProperties,
 {
-    fn from(pin: GpioPin<Unknown, GPIONUM>) -> GpioPin<Input<Floating>, GPIONUM> {
+    fn from(pin: GpioPin<Unknown, GPIONUM>) -> Self {
         pin.into_floating_input()
     }
 }
@@ -870,7 +870,7 @@ where
     <Self as GpioProperties>::PinType: IsOutputPin,
     GpioPin<Unknown, GPIONUM>: GpioProperties,
 {
-    fn from(pin: GpioPin<Unknown, GPIONUM>) -> GpioPin<Input<PullUp>, GPIONUM> {
+    fn from(pin: GpioPin<Unknown, GPIONUM>) -> Self {
         pin.into_pull_up_input()
     }
 }
@@ -881,7 +881,7 @@ where
     <Self as GpioProperties>::PinType: IsInputPin,
     GpioPin<Unknown, GPIONUM>: GpioProperties,
 {
-    fn from(pin: GpioPin<Unknown, GPIONUM>) -> GpioPin<Input<PullDown>, GPIONUM> {
+    fn from(pin: GpioPin<Unknown, GPIONUM>) -> Self {
         pin.into_pull_down_input()
     }
 }
@@ -893,8 +893,20 @@ where
     GpioPin<Unknown, GPIONUM>: GpioProperties,
     <GpioPin<Unknown, GPIONUM> as GpioProperties>::PinType: IsOutputPin,
 {
-    fn from(pin: GpioPin<Unknown, GPIONUM>) -> GpioPin<Output<PushPull>, GPIONUM> {
+    fn from(pin: GpioPin<Unknown, GPIONUM>) -> Self {
         pin.into_push_pull_output()
+    }
+}
+
+impl<const GPIONUM: u8> From<GpioPin<Unknown, GPIONUM>> for GpioPin<Analog, GPIONUM>
+where
+    Self: GpioProperties,
+    <Self as GpioProperties>::PinType: IsAnalogPin,
+    GpioPin<Unknown, GPIONUM>: GpioProperties,
+    <GpioPin<Unknown, GPIONUM> as GpioProperties>::PinType: IsAnalogPin,
+{
+    fn from(pin: GpioPin<Unknown, GPIONUM>) -> Self {
+        pin.into_analog()
     }
 }
 
@@ -905,7 +917,7 @@ where
     GpioPin<Unknown, GPIONUM>: GpioProperties,
     <GpioPin<Unknown, GPIONUM> as GpioProperties>::PinType: IsOutputPin,
 {
-    fn from(pin: GpioPin<Unknown, GPIONUM>) -> GpioPin<Output<OpenDrain>, GPIONUM> {
+    fn from(pin: GpioPin<Unknown, GPIONUM>) -> Self {
         pin.into_open_drain_output()
     }
 }
@@ -917,7 +929,7 @@ where
     GpioPin<Unknown, GPIONUM>: GpioProperties,
     <GpioPin<Unknown, GPIONUM> as GpioProperties>::PinType: IsOutputPin,
 {
-    fn from(pin: GpioPin<Unknown, GPIONUM>) -> GpioPin<Alternate<AF1>, GPIONUM> {
+    fn from(pin: GpioPin<Unknown, GPIONUM>) -> Self {
         pin.into_alternate_1()
     }
 }
@@ -929,7 +941,7 @@ where
     GpioPin<Unknown, GPIONUM>: GpioProperties,
     <GpioPin<Unknown, GPIONUM> as GpioProperties>::PinType: IsOutputPin,
 {
-    fn from(pin: GpioPin<Unknown, GPIONUM>) -> GpioPin<Alternate<AF2>, GPIONUM> {
+    fn from(pin: GpioPin<Unknown, GPIONUM>) -> Self {
         pin.into_alternate_2()
     }
 }


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

When I noticed that GPIOs implement `From<Gpio<Unknown...>` and decided to do some cleanup with it, I found that converting to analog pin mode wasn't implemented. This PR adds this implementation and also cleans up return values.