### PR TITLE
Actually enforce clippy lints in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,17 +476,17 @@ jobs:
 
       # Run clippy on all packages targeting RISC-V.
       - name: clippy (esp-riscv-rt)
-        run: cargo +stable clippy --manifest-path=esp-riscv-rt/Cargo.toml -- --no-deps
+        run: cargo +stable clippy --manifest-path=esp-riscv-rt/Cargo.toml -- -D warnings
       - name: clippy (esp32c2-hal)
-        run: cargo +stable clippy --manifest-path=esp32c2-hal/Cargo.toml -- --no-deps
+        run: cargo +stable clippy --manifest-path=esp32c2-hal/Cargo.toml -- -D warnings
       - name: clippy (esp32c3-hal)
-        run: cargo +stable clippy --manifest-path=esp32c3-hal/Cargo.toml -- --no-deps
+        run: cargo +stable clippy --manifest-path=esp32c3-hal/Cargo.toml -- -D warnings
       - name: clippy (esp32c6-hal)
-        run: cargo +stable clippy --manifest-path=esp32c6-hal/Cargo.toml -- --no-deps
+        run: cargo +stable clippy --manifest-path=esp32c6-hal/Cargo.toml -- -D warnings
       - name: clippy (esp32c6-lp-hal)
-        run: cargo +stable clippy --manifest-path=esp32c6-lp-hal/Cargo.toml -- --no-deps
+        run: cargo +stable clippy --manifest-path=esp32c6-lp-hal/Cargo.toml -- -D warnings
       - name: clippy (esp32h2-hal)
-        run: cargo +stable clippy --manifest-path=esp32h2-hal/Cargo.toml -- --no-deps
+        run: cargo +stable clippy --manifest-path=esp32h2-hal/Cargo.toml -- -D warnings
 
   clippy-xtensa:
     runs-on: ubuntu-latest
@@ -499,15 +499,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       # Run clippy on all packages targeting Xtensa.
-      #
-      # The ESP32-S2 requires some additional information in order for the
-      # atomic emulation crate to build.
       - name: clippy (esp32-hal)
-        run: cargo +esp clippy --manifest-path=esp32-hal/Cargo.toml -- --no-deps
+        run: cargo +esp clippy --manifest-path=esp32-hal/Cargo.toml -- -D warnings
       - name: clippy (esp32s2-hal)
-        run: cargo +esp clippy --manifest-path=esp32s2-hal/Cargo.toml -- --no-deps
+        run: cargo +esp clippy --manifest-path=esp32s2-hal/Cargo.toml -- -D warnings
       - name: clippy (esp32s3-hal)
-        run: cargo +esp clippy --manifest-path=esp32s3-hal/Cargo.toml -- --no-deps
+        run: cargo +esp clippy --manifest-path=esp32s3-hal/Cargo.toml -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,7 @@ jobs:
       - name: clippy (esp32c6-hal)
         run: cargo +stable clippy --manifest-path=esp32c6-hal/Cargo.toml -- -D warnings
       - name: clippy (esp32c6-lp-hal)
-        run: cargo +stable clippy --manifest-path=esp32c6-lp-hal/Cargo.toml -- -D warnings
+        run: cargo +stable clippy --manifest-path=esp32c6-lp-hal/Cargo.toml -- -D warnings -A asm-sub-register
       - name: clippy (esp32h2-hal)
         run: cargo +stable clippy --manifest-path=esp32h2-hal/Cargo.toml -- -D warnings
 

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -48,6 +48,11 @@ extern "C" {
 ///
 /// Zeros bss section, initializes data section and calls main. This function
 /// never returns.
+///
+/// # Safety
+///
+/// This function should not be called directly by the user, and should instead
+/// be invoked by the runtime implicitly.
 #[link_section = ".init.rust"]
 #[export_name = "_start_rust"]
 pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
@@ -115,6 +120,11 @@ pub struct TrapFrame {
 /// `scause`/`mcause` is read to determine the cause of the trap. XLEN-1 bit
 /// indicates if it's an interrupt or an exception. The result is examined and
 /// ExceptionHandler or one of the core interrupt handlers is called.
+///
+/// # Safety
+///
+/// This function should not be called directly by the user, and should instead
+/// be invoked by the runtime implicitly.
 #[link_section = ".trap.rust"]
 #[export_name = "_start_trap_rust"]
 pub unsafe extern "C" fn start_trap_rust(trap_frame: *const TrapFrame) {

--- a/esp32c6-lp-hal/src/delay.rs
+++ b/esp32c6-lp-hal/src/delay.rs
@@ -19,6 +19,12 @@ impl Delay {
     }
 }
 
+impl Default for Delay {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DelayUs<u64> for Delay {
     #[inline(always)]
     fn delay_us(&mut self, us: u64) {


### PR DESCRIPTION
These were disabled [exactly one year ago to the day](https://github.com/esp-rs/esp-hal/commit/797d9b5e02087a6ae121e8dbb1a0791fec9b8068) (funny coincidence that I'm just fixing it now 😅 ).

I think the project has progressed enough that we can re-enable these, IIRC a large part of the pain was with adding new chips, and this process has been significantly streamlined over the last year.

Additionally fixed a couple lint errors in `esp-riscv-rt` and `esp32c6-lp-hal` to get CI green again. I'd added one lint as an exception for `esp32c6-lp-hal` for the time being.