### PR TITLE
Update all examples to remove unnecessary disabling of watchdogs

### DIFF
--- a/esp32-hal/examples/adc.rs
+++ b/esp32-hal/examples/adc.rs
@@ -11,9 +11,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -21,20 +19,8 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32-hal/examples/advanced_serial.rs
+++ b/esp32-hal/examples/advanced_serial.rs
@@ -15,13 +15,11 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     uart::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
     },
     Delay,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -33,18 +31,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32-hal/examples/aes.rs
+++ b/esp32-hal/examples/aes.rs
@@ -11,9 +11,7 @@ use esp32_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,26 +20,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
 

--- a/esp32-hal/examples/blinky.rs
+++ b/esp32-hal/examples/blinky.rs
@@ -6,34 +6,14 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/blinky_erased_pins.rs
+++ b/esp32-hal/examples/blinky_erased_pins.rs
@@ -10,29 +10,15 @@ use esp32_hal::{
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set LED GPIOs as an output.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/clock_monitor.rs
+++ b/esp32-hal/examples/clock_monitor.rs
@@ -26,10 +26,6 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32-hal/examples/crc.rs
+++ b/esp32-hal/examples/crc.rs
@@ -11,7 +11,6 @@ use esp32_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -29,13 +28,7 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
     let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32-hal/examples/dac.rs
+++ b/esp32-hal/examples/dac.rs
@@ -5,35 +5,14 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    dac,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32_hal::{clock::ClockControl, dac, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin25 = io.pins.gpio25.into_analog();

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -14,7 +14,6 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use static_cell::make_static;
@@ -42,26 +41,11 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
-    #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
     let executor = make_static!(Executor::new());

--- a/esp32-hal/examples/embassy_i2c.rs
+++ b/esp32-hal/examples/embassy_i2c.rs
@@ -23,7 +23,6 @@ use esp32_hal::{
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -54,13 +53,6 @@ fn main() -> ! {
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timers
-    wdt.disable();
-    rtc.rwdt.disable();
-
     embassy::init(&clocks, timer_group0.timer0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/embassy_multicore.rs
+++ b/esp32-hal/examples/embassy_multicore.rs
@@ -16,7 +16,6 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_hal_common::get_core;
@@ -69,28 +68,15 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
+    let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    let mut timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
-    timer_group1.wdt.disable();
+    embassy::init(&clocks, timer_group0.timer0);
 
     // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
 
     let mut cpu_control = CpuControl::new(system.cpu_control);
 

--- a/esp32-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32-hal/examples/embassy_multicore_interrupt.rs
@@ -20,7 +20,6 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_hal_common::get_core;
@@ -86,28 +85,15 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
+    let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    let mut timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
-    timer_group1.wdt.disable();
+    embassy::init(&clocks, timer_group0.timer0);
 
     // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
 
     let mut cpu_control = CpuControl::new(system.cpu_control);
 

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -17,7 +17,6 @@ use esp32_hal::{
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -107,26 +106,11 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
-    #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -28,7 +28,6 @@ use esp32_hal::{
     prelude::*,
     spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
     timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -57,32 +56,11 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
     esp32_hal::interrupt::enable(

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -15,7 +15,6 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -38,26 +37,11 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
-    #[cfg(feature = "embassy-time-timg0")]
     embassy::init(&clocks, timer_group0.timer0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/gpio_interrupt.rs
+++ b/esp32-hal/examples/gpio_interrupt.rs
@@ -16,10 +16,8 @@ use esp32_hal::{
     macros::ram,
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
     xtensa_lx,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,21 +26,8 @@ static BUTTON: Mutex<RefCell<Option<Gpio0<Input<PullDown>>>>> = Mutex::new(RefCe
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/hello_rgb.rs
+++ b/esp32-hal/examples/hello_rgb.rs
@@ -13,16 +13,7 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    peripherals,
-    prelude::*,
-    rmt::Rmt,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-    IO,
-};
+use esp32_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
 use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
 use smart_leds::{
@@ -37,17 +28,6 @@ fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    timer_group0.wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32-hal/examples/hello_world.rs
+++ b/esp32-hal/examples/hello_world.rs
@@ -11,7 +11,6 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -29,13 +28,7 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
     let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32-hal/examples/i2c_bmp180_calibration_data.rs
@@ -9,15 +9,7 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -26,18 +18,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32-hal/examples/i2c_display.rs
+++ b/esp32-hal/examples/i2c_display.rs
@@ -26,7 +26,6 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -44,12 +43,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32-hal/examples/i2s_read.rs
+++ b/esp32-hal/examples/i2s_read.rs
@@ -20,8 +20,6 @@ use esp32_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -32,18 +30,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32-hal/examples/i2s_sound.rs
+++ b/esp32-hal/examples/i2s_sound.rs
@@ -36,8 +36,6 @@ use esp32_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -55,18 +53,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32-hal/examples/ledc.rs
+++ b/esp32-hal/examples/ledc.rs
@@ -17,8 +17,6 @@ use esp32_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,18 +25,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32-hal/examples/mcpwm.rs
+++ b/esp32-hal/examples/mcpwm.rs
@@ -12,8 +12,6 @@ use esp32_hal::{
     mcpwm::{operator::PwmPinConfig, timer::PwmWorkingMode, PeripheralClockConfig, MCPWM},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -22,18 +20,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin = io.pins.gpio4;

--- a/esp32-hal/examples/multicore.rs
+++ b/esp32-hal/examples/multicore.rs
@@ -14,7 +14,6 @@ use esp32_hal::{
     peripherals::{Peripherals, TIMG1},
     prelude::*,
     timer::{Timer, Timer0, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,7 +33,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
 
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
@@ -42,14 +40,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer1 = timer_group1.timer0;
-    let mut wdt1 = timer_group1.wdt;
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
     timer1.start(500u64.millis());

--- a/esp32-hal/examples/pcnt_encoder.rs
+++ b/esp32-hal/examples/pcnt_encoder.rs
@@ -23,8 +23,6 @@ use esp_hal::{
     pcnt::{channel, channel::PcntSource, unit, PCNT},
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_println::println;
@@ -36,20 +34,9 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let unit_number = unit::Number::Unit1;
 

--- a/esp32-hal/examples/psram.rs
+++ b/esp32-hal/examples/psram.rs
@@ -41,18 +41,6 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
-
     println!("Going to access PSRAM");
 
     let mut large_vec: alloc::vec::Vec<u32> = alloc::vec::Vec::with_capacity(500 * 1024 / 4);

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -25,9 +25,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,26 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32, this includes
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio19;

--- a/esp32-hal/examples/ram.rs
+++ b/esp32-hal/examples/ram.rs
@@ -40,12 +40,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-
-    // Disable MWDT flash boot protection
-    wdt.disable();
-    // The RWDT flash boot protection remains enabled and it being triggered is part
-    // of the example
 
     timer0.start(1u64.secs());
 

--- a/esp32-hal/examples/read_efuse.rs
+++ b/esp32-hal/examples/read_efuse.rs
@@ -4,34 +4,15 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    efuse::Efuse,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32_hal::{clock::ClockControl, efuse::Efuse, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let system = peripherals.DPORT.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     println!("MAC address {:02x?}", Efuse::get_mac_address());
     println!("Core Count {}", Efuse::get_core_count());

--- a/esp32-hal/examples/rmt_rx.rs
+++ b/esp32-hal/examples/rmt_rx.rs
@@ -10,10 +10,8 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, RxChannel, RxChannelConfig, RxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -24,14 +22,6 @@ fn main() -> ! {
     let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut out = io.pins.gpio15.into_push_pull_output();

--- a/esp32-hal/examples/rmt_tx.rs
+++ b/esp32-hal/examples/rmt_tx.rs
@@ -10,10 +10,8 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -23,14 +21,6 @@ fn main() -> ! {
     let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32-hal/examples/rng.rs
+++ b/esp32-hal/examples/rng.rs
@@ -3,34 +3,15 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rng,
-    Rtc,
-};
+use esp32_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Rng};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection:
-    wdt.disable();
-    rtc.rwdt.disable();
+    let system = peripherals.DPORT.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Instantiate the Random Number Generator peripheral:
     let mut rng = Rng::new(peripherals.RNG);

--- a/esp32-hal/examples/rsa.rs
+++ b/esp32-hal/examples/rsa.rs
@@ -22,9 +22,7 @@ use esp32_hal::{
         RsaModularMultiplication,
         RsaMultiplication,
     },
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -59,26 +57,7 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let rsa = peripherals.RSA;
     let mut rsa = Rsa::new(rsa, &mut system.peripheral_clock_control);

--- a/esp32-hal/examples/rtc_time.rs
+++ b/esp32-hal/examples/rtc_time.rs
@@ -3,33 +3,16 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let rtc = Rtc::new(peripherals.RTC_CNTL);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32-hal/examples/serial_interrupts.rs
+++ b/esp32-hal/examples/serial_interrupts.rs
@@ -15,7 +15,6 @@ use esp32_hal::{
     prelude::*,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -29,30 +28,14 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the TIMG watchdog timer.
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
     let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    rtc.rwdt.disable();
-
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30).unwrap();
     serial0.listen_at_cmd();

--- a/esp32-hal/examples/sha.rs
+++ b/esp32-hal/examples/sha.rs
@@ -9,9 +9,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,19 +20,7 @@ use sha2::{Digest, Sha512};
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data.clone();

--- a/esp32-hal/examples/sleep_timer.rs
+++ b/esp32-hal/examples/sleep_timer.rs
@@ -14,7 +14,6 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, SocResetReason},
-    timer::TimerGroup,
     Delay,
     Rtc,
 };
@@ -22,27 +21,10 @@ use hal::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     println!("up and runnning!");
     let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);

--- a/esp32-hal/examples/sleep_timer_ext0.rs
+++ b/esp32-hal/examples/sleep_timer_ext0.rs
@@ -19,7 +19,6 @@ use hal::{
         sleep::{Ext0WakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
-    timer::TimerGroup,
     Delay,
     Rtc,
     IO,
@@ -28,27 +27,10 @@ use hal::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut ext0_pin = io.pins.gpio27;

--- a/esp32-hal/examples/sleep_timer_ext1.rs
+++ b/esp32-hal/examples/sleep_timer_ext1.rs
@@ -19,7 +19,6 @@ use hal::{
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
-    timer::TimerGroup,
     Delay,
     Rtc,
     IO,
@@ -28,27 +27,10 @@ use hal::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut pin27 = io.pins.gpio27;

--- a/esp32-hal/examples/software_interrupts.rs
+++ b/esp32-hal/examples/software_interrupts.rs
@@ -16,9 +16,7 @@ use esp32_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,21 +25,9 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -25,9 +25,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiBusController, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,19 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32 this includes the RTC WDT and the
-    // TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio19;

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -23,9 +23,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -35,19 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32 this includes the RTC WDT and the
-    // TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio19;

--- a/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,9 +23,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -35,26 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32, this includes
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio19;

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -22,9 +22,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,19 +32,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32 this includes the RTC WDT and the
-    // TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio19;

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -24,9 +24,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -36,19 +34,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32 this includes
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio19;

--- a/esp32-hal/examples/timer_interrupt.rs
+++ b/esp32-hal/examples/timer_interrupt.rs
@@ -15,7 +15,6 @@ use esp32_hal::{
     peripherals::{self, Peripherals, TIMG0, TIMG1},
     prelude::*,
     timer::{Timer, Timer0, Timer1, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -30,7 +29,6 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the TIMG watchdog timer.
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -38,7 +36,6 @@ fn main() -> ! {
     );
     let mut timer00 = timer_group0.timer0;
     let mut timer01 = timer_group0.timer1;
-    let mut wdt0 = timer_group0.wdt;
 
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
@@ -47,19 +44,12 @@ fn main() -> ! {
     );
     let mut timer10 = timer_group1.timer0;
     let mut timer11 = timer_group1.timer1;
-    let mut wdt1 = timer_group1.wdt;
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    rtc.rwdt.disable();
 
     interrupt::enable(peripherals::Interrupt::TG0_T0_LEVEL, Priority::Priority2).unwrap();
     interrupt::enable(peripherals::Interrupt::TG0_T1_LEVEL, Priority::Priority2).unwrap();
     interrupt::enable(peripherals::Interrupt::TG1_T0_LEVEL, Priority::Priority3).unwrap();
     interrupt::enable(peripherals::Interrupt::TG1_T1_LEVEL, Priority::Priority3).unwrap();
+
     timer00.start(500u64.millis());
     timer00.listen();
     timer01.start(2500u64.millis());

--- a/esp32c2-hal/examples/adc.rs
+++ b/esp32c2-hal/examples/adc.rs
@@ -11,9 +11,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -23,20 +21,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c2-hal/examples/adc_cal.rs
+++ b/esp32c2-hal/examples/adc_cal.rs
@@ -12,9 +12,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -24,20 +22,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c2-hal/examples/advanced_serial.rs
+++ b/esp32c2-hal/examples/advanced_serial.rs
@@ -19,7 +19,6 @@ use esp32c2_hal::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
     },
-    Rtc,
     Uart,
     IO,
 };
@@ -33,19 +32,12 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32c2-hal/examples/blinky.rs
+++ b/esp32c2-hal/examples/blinky.rs
@@ -5,36 +5,14 @@
 #![no_std]
 #![no_main]
 
-use esp32c2_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32c2_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     // Set GPIO5 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c2-hal/examples/blinky_erased_pins.rs
+++ b/esp32c2-hal/examples/blinky_erased_pins.rs
@@ -10,31 +10,15 @@ use esp32c2_hal::{
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     // Set LED GPIOs as an output.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c2-hal/examples/clock_monitor.rs
+++ b/esp32c2-hal/examples/clock_monitor.rs
@@ -27,11 +27,6 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32c2-hal/examples/crc.rs
+++ b/esp32c2-hal/examples/crc.rs
@@ -11,7 +11,6 @@ use esp32c2_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -23,28 +22,20 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-
     timer0.start(1u64.secs());
 
     let data = "123456789";
     let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
-        serial0,
+        uart0,
         "Performing CRC calculations on test string \"{data}\""
     )
     .unwrap();
@@ -89,7 +80,7 @@ fn main() -> ! {
         );
 
         writeln!(
-            serial0,
+            uart0,
             "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
             crc_hdlc,
             crc_bzip2,

--- a/esp32c2-hal/examples/debug_assist.rs
+++ b/esp32c2-hal/examples/debug_assist.rs
@@ -13,8 +13,6 @@ use esp32c2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -25,20 +23,7 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut da = DebugAssist::new(
         peripherals.ASSIST_DEBUG,

--- a/esp32c2-hal/examples/direct-vectoring.rs
+++ b/esp32c2-hal/examples/direct-vectoring.rs
@@ -9,8 +9,6 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -22,19 +20,6 @@ unsafe fn main() -> ! {
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
     unsafe {

--- a/esp32c2-hal/examples/embassy_hello_world.rs
+++ b/esp32c2-hal/examples/embassy_hello_world.rs
@@ -9,14 +9,7 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-use esp32c2_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c2_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use static_cell::make_static;
 
@@ -43,19 +36,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -63,7 +43,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let executor = make_static!(Executor::new());
     executor.run(|spawner| {

--- a/esp32c2-hal/examples/embassy_i2c.rs
+++ b/esp32c2-hal/examples/embassy_i2c.rs
@@ -23,8 +23,6 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -50,19 +48,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -70,7 +55,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -28,8 +28,6 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -59,19 +57,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -79,7 +64,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     esp32c2_hal::interrupt::enable(
         esp32c2_hal::peripherals::Interrupt::DMA_CH0,

--- a/esp32c2-hal/examples/embassy_wait.rs
+++ b/esp32c2-hal/examples/embassy_wait.rs
@@ -15,8 +15,6 @@ use esp32c2_hal::{
     gpio::{Gpio9, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -39,18 +37,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -58,7 +44,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input

--- a/esp32c2-hal/examples/gpio_interrupt.rs
+++ b/esp32c2-hal/examples/gpio_interrupt.rs
@@ -16,9 +16,7 @@ use esp32c2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,22 +25,8 @@ static BUTTON: Mutex<RefCell<Option<Gpio9<Input<PullDown>>>>> = Mutex::new(RefCe
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     // Set GPIO5 as an output
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c2-hal/examples/hello_world.rs
+++ b/esp32c2-hal/examples/hello_world.rs
@@ -1,4 +1,4 @@
-//! This shows how to write text to serial0.
+//! This shows how to write text to uart0.
 //! You can see the output with `espflash` if you provide the `--monitor` option
 
 #![no_std]
@@ -11,7 +11,6 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -23,25 +22,18 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     timer0.start(1u64.secs());
 
     loop {
-        writeln!(serial0, "Hello world!").unwrap();
+        writeln!(uart0, "Hello world!").unwrap();
         block!(timer0.wait()).unwrap();
     }
 }

--- a/esp32c2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -9,15 +9,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c2_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c2_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -26,19 +18,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c2-hal/examples/i2c_display.rs
+++ b/esp32c2-hal/examples/i2c_display.rs
@@ -26,7 +26,6 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -38,19 +37,12 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c2-hal/examples/interrupt_preemption.rs
+++ b/esp32c2-hal/examples/interrupt_preemption.rs
@@ -32,19 +32,6 @@ fn main() -> ! {
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 
     interrupt::enable(

--- a/esp32c2-hal/examples/ledc.rs
+++ b/esp32c2-hal/examples/ledc.rs
@@ -1,5 +1,5 @@
 //! Turns on LED with the option to change LED intensity depending on `duty`
-//! value. Possible values (`u32`) are in range 0..100.
+//! value, then fades it. Possible starting values (`u32`) are in range 0..100.
 //!
 //! This assumes that a LED is connected to the pin assigned to `led`. (GPIO4)
 
@@ -18,8 +18,6 @@ use esp32c2_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,19 +26,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
@@ -65,7 +50,7 @@ fn main() -> ! {
     channel0
         .configure(channel::config::Config {
             timer: &lstimer0,
-            duty_pct: 90,
+            duty_pct: 10,
             pin_config: channel::config::PinConfig::PushPull,
         })
         .unwrap();

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -25,9 +25,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,20 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio4;

--- a/esp32c2-hal/examples/read_efuse.rs
+++ b/esp32c2-hal/examples/read_efuse.rs
@@ -4,35 +4,15 @@
 #![no_std]
 #![no_main]
 
-use esp32c2_hal::{
-    clock::ClockControl,
-    efuse::Efuse,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c2_hal::{clock::ClockControl, efuse::Efuse, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     println!("MAC address {:02x?}", Efuse::get_mac_address());
     println!("Flash Encryption {:?}", Efuse::get_flash_encryption());

--- a/esp32c2-hal/examples/rng.rs
+++ b/esp32c2-hal/examples/rng.rs
@@ -3,35 +3,15 @@
 #![no_std]
 #![no_main]
 
-use esp32c2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rng,
-    Rtc,
-};
+use esp32c2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Rng};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers:
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Instantiate the Random Number Generator peripheral:
     let mut rng = Rng::new(peripherals.RNG);

--- a/esp32c2-hal/examples/rtc_time.rs
+++ b/esp32c2-hal/examples/rtc_time.rs
@@ -3,36 +3,16 @@
 #![no_std]
 #![no_main]
 
-use esp32c2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32c2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-
+    let rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32c2-hal/examples/serial_interrupts.rs
+++ b/esp32c2-hal/examples/serial_interrupts.rs
@@ -17,7 +17,6 @@ use esp32c2_hal::{
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -31,7 +30,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
@@ -39,12 +37,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30).unwrap();

--- a/esp32c2-hal/examples/sha.rs
+++ b/esp32c2-hal/examples/sha.rs
@@ -9,8 +9,6 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -21,23 +19,10 @@ use sha2::{Digest, Sha256};
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.swd.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-    let mut remaining = source_data.clone();
+    let mut remaining = source_data;
     let mut hasher = Sha::new(
         peripherals.SHA,
         ShaMode::SHA256,

--- a/esp32c2-hal/examples/software_interrupts.rs
+++ b/esp32c2-hal/examples/software_interrupts.rs
@@ -17,9 +17,7 @@ use esp32c2_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,23 +26,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32c2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_device_loopback.rs
@@ -25,9 +25,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiBusController, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,20 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_loopback.rs
@@ -23,9 +23,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -35,20 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,9 +23,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -35,20 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio4;

--- a/esp32c2-hal/examples/spi_loopback.rs
+++ b/esp32c2-hal/examples/spi_loopback.rs
@@ -22,9 +22,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,20 +32,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -24,9 +24,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -36,20 +34,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c2-hal/examples/systimer.rs
+++ b/esp32c2-hal/examples/systimer.rs
@@ -14,9 +14,7 @@ use esp32c2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     systimer::{Alarm, Periodic, SystemTimer, Target},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -28,21 +26,8 @@ static ALARM2: Mutex<RefCell<Option<Alarm<Target, 2>>>> = Mutex::new(RefCell::ne
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.swd.disable();
-    rtc.rwdt.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32c2-hal/examples/timer_interrupt.rs
+++ b/esp32c2-hal/examples/timer_interrupt.rs
@@ -14,7 +14,6 @@ use esp32c2_hal::{
     prelude::*,
     riscv,
     timer::{Timer, Timer0, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -26,20 +25,12 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     interrupt::enable(
         peripherals::Interrupt::TG0_T0_LEVEL,

--- a/esp32c3-hal/examples/adc.rs
+++ b/esp32c3-hal/examples/adc.rs
@@ -11,9 +11,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -23,27 +21,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/adc_cal.rs
+++ b/esp32c3-hal/examples/adc_cal.rs
@@ -12,9 +12,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -24,27 +22,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -19,7 +19,6 @@ use esp32c3_hal::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
     },
-    Rtc,
     Uart,
     IO,
 };
@@ -33,26 +32,12 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32c3-hal/examples/aes.rs
+++ b/esp32c3-hal/examples/aes.rs
@@ -12,8 +12,6 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,27 +20,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
 

--- a/esp32c3-hal/examples/blinky.rs
+++ b/esp32c3-hal/examples/blinky.rs
@@ -5,43 +5,14 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set GPIO5 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c3-hal/examples/blinky_erased_pins.rs
+++ b/esp32c3-hal/examples/blinky_erased_pins.rs
@@ -10,38 +10,15 @@ use esp32c3_hal::{
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set LED GPIOs as an output.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c3-hal/examples/clock_monitor.rs
+++ b/esp32c3-hal/examples/clock_monitor.rs
@@ -27,11 +27,6 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32c3-hal/examples/crc.rs
+++ b/esp32c3-hal/examples/crc.rs
@@ -11,7 +11,6 @@ use esp32c3_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -23,7 +22,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
@@ -31,20 +29,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     timer0.start(1u64.secs());
 
     let data = "123456789";

--- a/esp32c3-hal/examples/debug_assist.rs
+++ b/esp32c3-hal/examples/debug_assist.rs
@@ -15,8 +15,6 @@ use esp32c3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -27,27 +25,7 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _ = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut da = DebugAssist::new(
         peripherals.ASSIST_DEBUG,

--- a/esp32c3-hal/examples/direct-vectoring.rs
+++ b/esp32c3-hal/examples/direct-vectoring.rs
@@ -13,8 +13,6 @@ use esp32c3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -26,27 +24,6 @@ unsafe fn main() -> ! {
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
     interrupt::enable(

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -9,14 +9,7 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-use esp32c3_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use static_cell::make_static;
 
@@ -43,26 +36,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -70,7 +43,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let executor = make_static!(Executor::new());
     executor.run(|spawner| {

--- a/esp32c3-hal/examples/embassy_i2c.rs
+++ b/esp32c3-hal/examples/embassy_i2c.rs
@@ -23,8 +23,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -50,26 +48,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -77,7 +55,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -17,8 +17,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -108,26 +106,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -135,7 +113,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -28,8 +28,6 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -59,26 +57,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -86,7 +64,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     esp32c3_hal::interrupt::enable(
         esp32c3_hal::peripherals::Interrupt::DMA_CH0,

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -15,8 +15,6 @@ use esp32c3_hal::{
     gpio::{Gpio9, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -39,26 +37,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -66,7 +44,15 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        )
+        .timer0,
+    );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -16,9 +16,7 @@ use esp32c3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,29 +25,8 @@ static BUTTON: Mutex<RefCell<Option<Gpio9<Input<PullDown>>>>> = Mutex::new(RefCe
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set GPIO5 as an output
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -11,16 +11,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    peripherals,
-    prelude::*,
-    rmt::Rmt,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-    IO,
-};
+use esp32c3_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
 use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
 use smart_leds::{
@@ -35,18 +26,6 @@ fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdogs
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/hello_world.rs
+++ b/esp32c3-hal/examples/hello_world.rs
@@ -11,7 +11,6 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -23,7 +22,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
@@ -31,19 +29,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     timer0.start(1u64.secs());
 

--- a/esp32c3-hal/examples/hmac.rs
+++ b/esp32c3-hal/examples/hmac.rs
@@ -61,9 +61,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
     Rng,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -77,27 +75,7 @@ type HmacSha256 = HmacSw<Sha256>;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
 

--- a/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -9,15 +9,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -26,26 +18,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/i2c_display.rs
+++ b/esp32c3-hal/examples/i2c_display.rs
@@ -26,7 +26,6 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -38,26 +37,12 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/i2s_read.rs
+++ b/esp32c3-hal/examples/i2s_read.rs
@@ -21,8 +21,6 @@ use esp32c3_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sReadDma, MclkPin, PinsBclkWsDin, Standard},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -33,26 +31,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/i2s_sound.rs
+++ b/esp32c3-hal/examples/i2s_sound.rs
@@ -37,8 +37,6 @@ use esp32c3_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -56,26 +54,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/interrupt_preemption.rs
+++ b/esp32c3-hal/examples/interrupt_preemption.rs
@@ -32,27 +32,6 @@ fn main() -> ! {
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 
     interrupt::enable(

--- a/esp32c3-hal/examples/ledc.rs
+++ b/esp32c3-hal/examples/ledc.rs
@@ -18,8 +18,6 @@ use esp32c3_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,26 +26,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -25,9 +25,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,27 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/ram.rs
+++ b/esp32c3-hal/examples/ram.rs
@@ -40,12 +40,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    // Disable MWDT flash boot protection
-    wdt0.disable();
-    // The RWDT flash boot protection remains enabled and it being triggered is part
-    // of the example
 
     timer0.start(1u64.secs());
 

--- a/esp32c3-hal/examples/read_efuse.rs
+++ b/esp32c3-hal/examples/read_efuse.rs
@@ -4,42 +4,15 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    efuse::Efuse,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, efuse::Efuse, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     println!("MAC address {:02x?}", Efuse::get_mac_address());
     println!("Flash Encryption {:?}", Efuse::get_flash_encryption());

--- a/esp32c3-hal/examples/rmt_rx.rs
+++ b/esp32c3-hal/examples/rmt_rx.rs
@@ -12,10 +12,8 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, RxChannel, RxChannelConfig, RxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -28,19 +26,6 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks, &mut clock_control);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/rmt_tx.rs
+++ b/esp32c3-hal/examples/rmt_tx.rs
@@ -10,9 +10,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
-    timer::TimerGroup,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_hal_common::Delay;
@@ -23,19 +21,6 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks, &mut clock_control);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/rng.rs
+++ b/esp32c3-hal/examples/rng.rs
@@ -3,42 +3,15 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rng,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Rng};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers:
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Instantiate the Random Number Generator peripheral:
     let mut rng = Rng::new(peripherals.RNG);

--- a/esp32c3-hal/examples/rsa.rs
+++ b/esp32c3-hal/examples/rsa.rs
@@ -23,8 +23,6 @@ use esp32c3_hal::{
         RsaMultiplication,
     },
     systimer::SystemTimer,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -59,27 +57,7 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
 

--- a/esp32c3-hal/examples/rtc_time.rs
+++ b/esp32c3-hal/examples/rtc_time.rs
@@ -3,43 +3,16 @@
 #![no_std]
 #![no_main]
 
-use esp32c3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
+    let rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32c3-hal/examples/serial_interrupts.rs
+++ b/esp32c3-hal/examples/serial_interrupts.rs
@@ -17,7 +17,6 @@ use esp32c3_hal::{
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -31,7 +30,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
@@ -39,19 +37,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30).unwrap();

--- a/esp32c3-hal/examples/sha.rs
+++ b/esp32c3-hal/examples/sha.rs
@@ -9,8 +9,6 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -21,23 +19,10 @@ use sha2::{Digest, Sha256};
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.swd.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-    let mut remaining = source_data.clone();
+    let mut remaining = source_data;
     let mut hasher = Sha::new(
         peripherals.SHA,
         ShaMode::SHA256,

--- a/esp32c3-hal/examples/software_interrupts.rs
+++ b/esp32c3-hal/examples/software_interrupts.rs
@@ -17,9 +17,7 @@ use esp32c3_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,31 +26,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -25,9 +25,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiBusController, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,27 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -23,9 +23,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -35,27 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,9 +23,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -35,27 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -22,9 +22,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,27 +32,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -24,9 +24,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -36,27 +34,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -14,9 +14,7 @@ use esp32c3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     systimer::{Alarm, Periodic, SystemTimer, Target},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -28,21 +26,8 @@ static ALARM2: Mutex<RefCell<Option<Alarm<Target, 2>>>> = Mutex::new(RefCell::ne
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.swd.disable();
-    rtc.rwdt.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32c3-hal/examples/timer_interrupt.rs
+++ b/esp32c3-hal/examples/timer_interrupt.rs
@@ -15,7 +15,6 @@ use esp32c3_hal::{
     prelude::*,
     riscv,
     timer::{Timer, Timer0, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,28 +27,18 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer1 = timer_group1.timer0;
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     interrupt::enable(
         peripherals::Interrupt::TG0_T0_LEVEL,

--- a/esp32c3-hal/examples/twai.rs
+++ b/esp32c3-hal/examples/twai.rs
@@ -10,15 +10,7 @@ use embedded_can::{nb::Can, Frame, Id};
 // cargo run --example twai --release
 #[cfg(not(feature = "eh1"))]
 use embedded_hal::can::{Can, Frame, Id};
-use esp32c3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    twai,
-    Rtc,
-};
+use esp32c3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, twai};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -28,26 +20,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -17,7 +17,6 @@ use esp32c3_hal::{
     riscv,
     timer::TimerGroup,
     Cpu,
-    Rtc,
     UsbSerialJtag,
 };
 use esp_backtrace as _;
@@ -31,26 +30,12 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let mut usb_serial =
         UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);

--- a/esp32c6-hal/examples/adc.rs
+++ b/esp32c6-hal/examples/adc.rs
@@ -11,9 +11,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -23,27 +21,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/adc_cal.rs
+++ b/esp32c6-hal/examples/adc_cal.rs
@@ -12,9 +12,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -24,27 +22,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/advanced_serial.rs
+++ b/esp32c6-hal/examples/advanced_serial.rs
@@ -19,7 +19,6 @@ use esp32c6_hal::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
     },
-    Rtc,
     Uart,
     IO,
 };
@@ -33,27 +32,12 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32c6-hal/examples/aes.rs
+++ b/esp32c6-hal/examples/aes.rs
@@ -12,8 +12,6 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,30 +20,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
 

--- a/esp32c6-hal/examples/blinky.rs
+++ b/esp32c6-hal/examples/blinky.rs
@@ -5,43 +5,14 @@
 #![no_std]
 #![no_main]
 
-use esp32c6_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32c6_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set GPIO5 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c6-hal/examples/blinky_erased_pins.rs
+++ b/esp32c6-hal/examples/blinky_erased_pins.rs
@@ -10,38 +10,15 @@ use esp32c6_hal::{
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set LED GPIOs as an output.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c6-hal/examples/crc.rs
+++ b/esp32c6-hal/examples/crc.rs
@@ -11,7 +11,6 @@ use esp32c6_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -24,27 +23,13 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     timer0.start(1u64.secs());
 
     let data = "123456789";

--- a/esp32c6-hal/examples/debug_assist.rs
+++ b/esp32c6-hal/examples/debug_assist.rs
@@ -15,8 +15,6 @@ use esp32c6_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -27,27 +25,7 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut da = DebugAssist::new(
         peripherals.ASSIST_DEBUG,

--- a/esp32c6-hal/examples/direct-vectoring.rs
+++ b/esp32c6-hal/examples/direct-vectoring.rs
@@ -13,8 +13,6 @@ use esp32c6_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,27 +25,6 @@ fn main() -> ! {
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
     unsafe {

--- a/esp32c6-hal/examples/embassy_hello_world.rs
+++ b/esp32c6-hal/examples/embassy_hello_world.rs
@@ -9,14 +9,7 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-use esp32c6_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c6_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use static_cell::make_static;
 
@@ -43,26 +36,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -70,7 +43,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let executor = make_static!(Executor::new());
     executor.run(|spawner| {

--- a/esp32c6-hal/examples/embassy_i2c.rs
+++ b/esp32c6-hal/examples/embassy_i2c.rs
@@ -23,8 +23,6 @@ use esp32c6_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -50,26 +48,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -77,7 +55,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -17,8 +17,6 @@ use esp32c6_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -108,26 +106,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -135,7 +113,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -28,8 +28,6 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -59,28 +57,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -88,7 +64,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     esp32c6_hal::interrupt::enable(
         esp32c6_hal::peripherals::Interrupt::DMA_IN_CH0,

--- a/esp32c6-hal/examples/embassy_wait.rs
+++ b/esp32c6-hal/examples/embassy_wait.rs
@@ -15,8 +15,6 @@ use esp32c6_hal::{
     gpio::{Gpio9, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -39,26 +37,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -66,7 +44,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input

--- a/esp32c6-hal/examples/gpio_interrupt.rs
+++ b/esp32c6-hal/examples/gpio_interrupt.rs
@@ -16,9 +16,7 @@ use esp32c6_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,30 +25,8 @@ static BUTTON: Mutex<RefCell<Option<Gpio9<Input<PullDown>>>>> = Mutex::new(RefCe
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set GPIO5 as an output
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c6-hal/examples/hello_rgb.rs
+++ b/esp32c6-hal/examples/hello_rgb.rs
@@ -10,16 +10,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c6_hal::{
-    clock::ClockControl,
-    peripherals,
-    prelude::*,
-    rmt::Rmt,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-    IO,
-};
+use esp32c6_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
 use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
 use smart_leds::{
@@ -34,26 +25,6 @@ fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
-    timer_group1.wdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/hello_world.rs
+++ b/esp32c6-hal/examples/hello_world.rs
@@ -11,7 +11,6 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -24,27 +23,13 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     timer0.start(1u64.secs());
 
     loop {

--- a/esp32c6-hal/examples/hmac.rs
+++ b/esp32c6-hal/examples/hmac.rs
@@ -61,9 +61,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
     Rng,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -77,27 +75,7 @@ type HmacSha256 = HmacSw<Sha256>;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
 

--- a/esp32c6-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c6-hal/examples/i2c_bmp180_calibration_data.rs
@@ -9,15 +9,7 @@
 #![no_std]
 #![no_main]
 
-use esp32c6_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c6_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -26,26 +18,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/i2c_display.rs
+++ b/esp32c6-hal/examples/i2c_display.rs
@@ -26,7 +26,6 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -38,26 +37,12 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/i2s_read.rs
+++ b/esp32c6-hal/examples/i2s_read.rs
@@ -21,8 +21,6 @@ use esp32c6_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sReadDma, MclkPin, PinsBclkWsDin, Standard},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -33,28 +31,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/i2s_sound.rs
+++ b/esp32c6-hal/examples/i2s_sound.rs
@@ -37,8 +37,6 @@ use esp32c6_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -56,26 +54,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/interrupt_preemption.rs
+++ b/esp32c6-hal/examples/interrupt_preemption.rs
@@ -17,8 +17,6 @@ use esp32c6_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -31,27 +29,6 @@ fn main() -> ! {
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32c6-hal/examples/ledc.rs
+++ b/esp32c6-hal/examples/ledc.rs
@@ -18,8 +18,6 @@ use esp32c6_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,28 +26,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32c6-hal/examples/lp_core_basic.rs
+++ b/esp32c6-hal/examples/lp_core_basic.rs
@@ -12,8 +12,6 @@ use esp32c6_hal::{
     lp_core,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -108,28 +106,8 @@ const CODE: &[u8] = &[
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let system = peripherals.PCR.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/mcpwm.rs
+++ b/esp32c6-hal/examples/mcpwm.rs
@@ -12,8 +12,6 @@ use esp32c6_hal::{
     mcpwm::{operator::PwmPinConfig, timer::PwmWorkingMode, PeripheralClockConfig, MCPWM},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -22,28 +20,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin = io.pins.gpio4;

--- a/esp32c6-hal/examples/parl_io_tx.rs
+++ b/esp32c6-hal/examples/parl_io_tx.rs
@@ -25,9 +25,7 @@ use esp32c6_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -37,26 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/pcnt_encoder.rs
+++ b/esp32c6-hal/examples/pcnt_encoder.rs
@@ -23,8 +23,6 @@ use esp_hal::{
     pcnt::{channel, channel::PcntSource, unit, PCNT},
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_println::println;
@@ -36,29 +34,7 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let unit_number = unit::Number::Unit1;
 

--- a/esp32c6-hal/examples/qspi_flash.rs
+++ b/esp32c6-hal/examples/qspi_flash.rs
@@ -25,9 +25,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,27 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio4;

--- a/esp32c6-hal/examples/ram.rs
+++ b/esp32c6-hal/examples/ram.rs
@@ -34,28 +34,12 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable MWDT flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    // The RWDT flash boot protection remains enabled and it being triggered is part
-    // of the example
-
     timer0.start(1u64.secs());
 
     println!("RAM function located at {:p}", function_in_ram as *const ());

--- a/esp32c6-hal/examples/read_efuse.rs
+++ b/esp32c6-hal/examples/read_efuse.rs
@@ -4,42 +4,15 @@
 #![no_std]
 #![no_main]
 
-use esp32c6_hal::{
-    clock::ClockControl,
-    efuse::Efuse,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32c6_hal::{clock::ClockControl, efuse::Efuse, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let system = peripherals.PCR.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     println!("MAC address {:02x?}", Efuse::get_mac_address());
     println!("Flash Encryption {:?}", Efuse::get_flash_encryption());

--- a/esp32c6-hal/examples/rmt_rx.rs
+++ b/esp32c6-hal/examples/rmt_rx.rs
@@ -12,10 +12,8 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, RxChannel, RxChannelConfig, RxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -28,19 +26,6 @@ fn main() -> ! {
     let system = peripherals.PCR.split();
     let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks, &mut clock_control);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/rmt_tx.rs
+++ b/esp32c6-hal/examples/rmt_tx.rs
@@ -10,10 +10,8 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -23,19 +21,6 @@ fn main() -> ! {
     let system = peripherals.PCR.split();
     let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks, &mut clock_control);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/rng.rs
+++ b/esp32c6-hal/examples/rng.rs
@@ -3,42 +3,15 @@
 #![no_std]
 #![no_main]
 
-use esp32c6_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rng,
-    Rtc,
-};
+use esp32c6_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Rng};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers:
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let system = peripherals.PCR.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Instantiate the Random Number Generator peripheral:
     let mut rng = Rng::new(peripherals.RNG);

--- a/esp32c6-hal/examples/rsa.rs
+++ b/esp32c6-hal/examples/rsa.rs
@@ -23,8 +23,6 @@ use esp32c6_hal::{
         RsaMultiplication,
     },
     systimer::SystemTimer,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -59,28 +57,7 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
 

--- a/esp32c6-hal/examples/rtc_time.rs
+++ b/esp32c6-hal/examples/rtc_time.rs
@@ -3,43 +3,16 @@
 #![no_std]
 #![no_main]
 
-use esp32c6_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32c6_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
+    let rtc = Rtc::new(peripherals.LP_CLKRST);
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32c6-hal/examples/serial_interrupts.rs
+++ b/esp32c6-hal/examples/serial_interrupts.rs
@@ -17,7 +17,6 @@ use esp32c6_hal::{
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -31,28 +30,14 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
+    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30).unwrap();
     serial0.listen_at_cmd();

--- a/esp32c6-hal/examples/sha.rs
+++ b/esp32c6-hal/examples/sha.rs
@@ -9,8 +9,6 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -21,22 +19,10 @@ use sha2::{Digest, Sha256};
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.swd.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-    let mut remaining = source_data.clone();
+    let mut remaining = source_data;
     let mut hasher = Sha::new(
         peripherals.SHA,
         ShaMode::SHA256,

--- a/esp32c6-hal/examples/software_interrupts.rs
+++ b/esp32c6-hal/examples/software_interrupts.rs
@@ -16,9 +16,7 @@ use esp32c6_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,31 +25,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32c6-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_device_loopback.rs
@@ -25,9 +25,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiBusController, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,28 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c6-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_loopback.rs
@@ -23,9 +23,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -35,28 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,9 +23,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -35,27 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio4;

--- a/esp32c6-hal/examples/spi_loopback.rs
+++ b/esp32c6-hal/examples/spi_loopback.rs
@@ -22,9 +22,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,28 +32,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -24,9 +24,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -36,28 +34,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32c6-hal/examples/systimer.rs
+++ b/esp32c6-hal/examples/systimer.rs
@@ -14,9 +14,7 @@ use esp32c6_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     systimer::{Alarm, Periodic, SystemTimer, Target},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -28,30 +26,8 @@ static ALARM2: Mutex<RefCell<Option<Alarm<Target, 2>>>> = Mutex::new(RefCell::ne
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32c6-hal/examples/timer_interrupt.rs
+++ b/esp32c6-hal/examples/timer_interrupt.rs
@@ -15,7 +15,6 @@ use esp32c6_hal::{
     prelude::*,
     riscv,
     timer::{Timer, Timer0, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,29 +27,19 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
+
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer1 = timer_group1.timer0;
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     interrupt::enable(
         peripherals::Interrupt::TG0_T0_LEVEL,

--- a/esp32c6-hal/examples/usb_serial_jtag.rs
+++ b/esp32c6-hal/examples/usb_serial_jtag.rs
@@ -16,7 +16,6 @@ use esp32c6_hal::{
     riscv,
     timer::TimerGroup,
     Cpu,
-    Rtc,
     UsbSerialJtag,
 };
 use esp_backtrace as _;
@@ -30,26 +29,12 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let mut usb_serial =
         UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);

--- a/esp32h2-hal/examples/adc.rs
+++ b/esp32h2-hal/examples/adc.rs
@@ -11,9 +11,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -23,27 +21,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/advanced_serial.rs
+++ b/esp32h2-hal/examples/advanced_serial.rs
@@ -19,7 +19,6 @@ use esp32h2_hal::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
     },
-    Rtc,
     Uart,
     IO,
 };
@@ -33,27 +32,12 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32h2-hal/examples/aes.rs
+++ b/esp32h2-hal/examples/aes.rs
@@ -1,4 +1,4 @@
-//! Encrypt/Decrypt a message using AES
+//! Encrypt/Decrypt a message using AES.
 
 #![no_std]
 #![no_main]
@@ -12,8 +12,6 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,28 +20,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
 

--- a/esp32h2-hal/examples/blinky.rs
+++ b/esp32h2-hal/examples/blinky.rs
@@ -5,43 +5,14 @@
 #![no_std]
 #![no_main]
 
-use esp32h2_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32h2_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set GPIO5 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32h2-hal/examples/blinky_erased_pins.rs
+++ b/esp32h2-hal/examples/blinky_erased_pins.rs
@@ -10,38 +10,15 @@ use esp32h2_hal::{
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set LED GPIOs as an output.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32h2-hal/examples/crc.rs
+++ b/esp32h2-hal/examples/crc.rs
@@ -11,7 +11,6 @@ use esp32h2_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -23,29 +22,14 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     timer0.start(1u64.secs());
 
     let data = "123456789";

--- a/esp32h2-hal/examples/debug_assist.rs
+++ b/esp32h2-hal/examples/debug_assist.rs
@@ -15,8 +15,6 @@ use esp32h2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -27,27 +25,7 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut da = DebugAssist::new(
         peripherals.ASSIST_DEBUG,

--- a/esp32h2-hal/examples/direct-vectoring.rs
+++ b/esp32h2-hal/examples/direct-vectoring.rs
@@ -13,8 +13,6 @@ use esp32h2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,27 +25,6 @@ fn main() -> ! {
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
     unsafe {

--- a/esp32h2-hal/examples/embassy_hello_world.rs
+++ b/esp32h2-hal/examples/embassy_hello_world.rs
@@ -9,14 +9,7 @@
 
 use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
-use esp32h2_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32h2_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use static_cell::make_static;
 
@@ -43,26 +36,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -70,7 +43,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let executor = make_static!(Executor::new());
     executor.run(|spawner| {

--- a/esp32h2-hal/examples/embassy_i2c.rs
+++ b/esp32h2-hal/examples/embassy_i2c.rs
@@ -23,8 +23,6 @@ use esp32h2_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -50,26 +48,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -77,7 +55,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -28,8 +28,6 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -59,28 +57,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -88,7 +64,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     esp32h2_hal::interrupt::enable(
         esp32h2_hal::peripherals::Interrupt::DMA_IN_CH0,

--- a/esp32h2-hal/examples/embassy_wait.rs
+++ b/esp32h2-hal/examples/embassy_wait.rs
@@ -15,8 +15,6 @@ use esp32h2_hal::{
     gpio::{Gpio9, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -39,26 +37,6 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -66,7 +44,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input

--- a/esp32h2-hal/examples/gpio_interrupt.rs
+++ b/esp32h2-hal/examples/gpio_interrupt.rs
@@ -16,9 +16,7 @@ use esp32h2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,30 +25,8 @@ static BUTTON: Mutex<RefCell<Option<Gpio9<Input<PullDown>>>>> = Mutex::new(RefCe
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     // Set GPIO5 as an output
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32h2-hal/examples/hello_rgb.rs
+++ b/esp32h2-hal/examples/hello_rgb.rs
@@ -10,16 +10,7 @@
 #![no_std]
 #![no_main]
 
-use esp32h2_hal::{
-    clock::ClockControl,
-    peripherals,
-    prelude::*,
-    rmt::Rmt,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-    IO,
-};
+use esp32h2_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
 use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
 use smart_leds::{
@@ -34,26 +25,6 @@ fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
-    timer_group1.wdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/hello_world.rs
+++ b/esp32h2-hal/examples/hello_world.rs
@@ -11,7 +11,6 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -23,29 +22,14 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     timer0.start(1u64.secs());
 
     loop {

--- a/esp32h2-hal/examples/hmac.rs
+++ b/esp32h2-hal/examples/hmac.rs
@@ -61,9 +61,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
     Rng,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -77,29 +75,7 @@ type HmacSha256 = HmacSw<Sha256>;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
 

--- a/esp32h2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32h2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -9,15 +9,7 @@
 #![no_std]
 #![no_main]
 
-use esp32h2_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32h2_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -26,26 +18,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/i2c_display.rs
+++ b/esp32h2-hal/examples/i2c_display.rs
@@ -26,7 +26,6 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -38,26 +37,12 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/i2s_read.rs
+++ b/esp32h2-hal/examples/i2s_read.rs
@@ -21,8 +21,6 @@ use esp32h2_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sReadDma, MclkPin, PinsBclkWsDin, Standard},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -33,28 +31,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/i2s_sound.rs
+++ b/esp32h2-hal/examples/i2s_sound.rs
@@ -37,8 +37,6 @@ use esp32h2_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -56,26 +54,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/interrupt_preemption.rs
+++ b/esp32h2-hal/examples/interrupt_preemption.rs
@@ -17,8 +17,6 @@ use esp32h2_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -31,27 +29,6 @@ fn main() -> ! {
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32h2-hal/examples/ledc.rs
+++ b/esp32h2-hal/examples/ledc.rs
@@ -18,8 +18,6 @@ use esp32h2_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,28 +26,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32h2-hal/examples/mcpwm.rs
+++ b/esp32h2-hal/examples/mcpwm.rs
@@ -12,8 +12,6 @@ use esp32h2_hal::{
     mcpwm::{operator::PwmPinConfig, timer::PwmWorkingMode, PeripheralClockConfig, MCPWM},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -22,28 +20,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin = io.pins.gpio4;

--- a/esp32h2-hal/examples/parl_io_tx.rs
+++ b/esp32h2-hal/examples/parl_io_tx.rs
@@ -25,9 +25,7 @@ use esp32h2_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -37,26 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/pcnt_encoder.rs
+++ b/esp32h2-hal/examples/pcnt_encoder.rs
@@ -23,8 +23,6 @@ use esp_hal::{
     pcnt::{channel, channel::PcntSource, unit, PCNT},
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_println::println;
@@ -36,29 +34,7 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let unit_number = unit::Number::Unit1;
 

--- a/esp32h2-hal/examples/qspi_flash.rs
+++ b/esp32h2-hal/examples/qspi_flash.rs
@@ -25,9 +25,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,27 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio1;

--- a/esp32h2-hal/examples/ram.rs
+++ b/esp32h2-hal/examples/ram.rs
@@ -34,28 +34,12 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable MWDT flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    // The RWDT flash boot protection remains enabled and it being triggered is part
-    // of the example
-
     timer0.start(1u64.secs());
 
     println!("RAM function located at {:p}", function_in_ram as *const ());

--- a/esp32h2-hal/examples/read_efuse.rs
+++ b/esp32h2-hal/examples/read_efuse.rs
@@ -4,42 +4,15 @@
 #![no_std]
 #![no_main]
 
-use esp32h2_hal::{
-    clock::ClockControl,
-    efuse::Efuse,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32h2_hal::{clock::ClockControl, efuse::Efuse, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let system = peripherals.PCR.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     println!("MAC address {:02x?}", Efuse::get_mac_address());
     println!("Flash Encryption {:?}", Efuse::get_flash_encryption());

--- a/esp32h2-hal/examples/rmt_rx.rs
+++ b/esp32h2-hal/examples/rmt_rx.rs
@@ -12,10 +12,8 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, RxChannel, RxChannelConfig, RxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -28,19 +26,6 @@ fn main() -> ! {
     let system = peripherals.PCR.split();
     let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks, &mut clock_control);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/rmt_tx.rs
+++ b/esp32h2-hal/examples/rmt_tx.rs
@@ -10,10 +10,8 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -23,19 +21,6 @@ fn main() -> ! {
     let system = peripherals.PCR.split();
     let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks, &mut clock_control);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/rng.rs
+++ b/esp32h2-hal/examples/rng.rs
@@ -3,42 +3,15 @@
 #![no_std]
 #![no_main]
 
-use esp32h2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rng,
-    Rtc,
-};
+use esp32h2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Rng};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers:
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let system = peripherals.PCR.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Instantiate the Random Number Generator peripheral:
     let mut rng = Rng::new(peripherals.RNG);

--- a/esp32h2-hal/examples/rsa.rs
+++ b/esp32h2-hal/examples/rsa.rs
@@ -23,8 +23,6 @@ use esp32h2_hal::{
         RsaMultiplication,
     },
     systimer::SystemTimer,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -59,28 +57,7 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
 

--- a/esp32h2-hal/examples/rtc_time.rs
+++ b/esp32h2-hal/examples/rtc_time.rs
@@ -3,43 +3,16 @@
 #![no_std]
 #![no_main]
 
-use esp32h2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32h2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
+    let rtc = Rtc::new(peripherals.LP_CLKRST);
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32h2-hal/examples/serial_interrupts.rs
+++ b/esp32h2-hal/examples/serial_interrupts.rs
@@ -17,7 +17,6 @@ use esp32h2_hal::{
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -31,28 +30,14 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
+    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30).unwrap();
     serial0.listen_at_cmd();

--- a/esp32h2-hal/examples/sha.rs
+++ b/esp32h2-hal/examples/sha.rs
@@ -9,8 +9,6 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -21,22 +19,10 @@ use sha2::{Digest, Sha256};
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.swd.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-    let mut remaining = source_data.clone();
+    let mut remaining = source_data;
     let mut hasher = Sha::new(
         peripherals.SHA,
         ShaMode::SHA256,

--- a/esp32h2-hal/examples/software_interrupts.rs
+++ b/esp32h2-hal/examples/software_interrupts.rs
@@ -3,7 +3,6 @@
 //! An example of how software interrupts can be raised and reset
 //! Should rotate through all of the available interrupts printing their number
 //! when raised.
-
 #![no_std]
 #![no_main]
 
@@ -17,9 +16,7 @@ use esp32h2_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,31 +25,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(clockctrl).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32h2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_device_loopback.rs
@@ -25,9 +25,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiBusController, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,28 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio1;

--- a/esp32h2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_loopback.rs
@@ -23,9 +23,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -35,28 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio1;

--- a/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,9 +23,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -35,27 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio1;

--- a/esp32h2-hal/examples/spi_loopback.rs
+++ b/esp32h2-hal/examples/spi_loopback.rs
@@ -22,9 +22,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,28 +32,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio1;

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -24,9 +24,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -36,28 +34,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio1;

--- a/esp32h2-hal/examples/systimer.rs
+++ b/esp32h2-hal/examples/systimer.rs
@@ -14,9 +14,7 @@ use esp32h2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     systimer::{Alarm, Periodic, SystemTimer, Target},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -28,30 +26,8 @@ static ALARM2: Mutex<RefCell<Option<Alarm<Target, 2>>>> = Mutex::new(RefCell::ne
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32h2-hal/examples/timer_interrupt.rs
+++ b/esp32h2-hal/examples/timer_interrupt.rs
@@ -15,7 +15,6 @@ use esp32h2_hal::{
     prelude::*,
     riscv,
     timer::{Timer, Timer0, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,29 +27,19 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the watchdog timers. For the ESP32-H2, this includes the Super WDT,
-    // and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
+
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer1 = timer_group1.timer0;
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     interrupt::enable(
         peripherals::Interrupt::TG0_T0_LEVEL,

--- a/esp32h2-hal/examples/usb_serial_jtag.rs
+++ b/esp32h2-hal/examples/usb_serial_jtag.rs
@@ -16,7 +16,6 @@ use esp32h2_hal::{
     riscv,
     timer::TimerGroup,
     Cpu,
-    Rtc,
     UsbSerialJtag,
 };
 use esp_backtrace as _;
@@ -30,26 +29,12 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let mut usb_serial =
         UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);

--- a/esp32s2-hal/examples/adc.rs
+++ b/esp32s2-hal/examples/adc.rs
@@ -11,9 +11,7 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -21,23 +19,10 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
-
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    // let pin3 = io.pins.gpio3.into_analog();
 
     // Create ADC instances
     let analog = peripherals.SENS.split();

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -15,13 +15,11 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     uart::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
     },
     Delay,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -33,18 +31,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32s2-hal/examples/aes.rs
+++ b/esp32s2-hal/examples/aes.rs
@@ -11,9 +11,7 @@ use esp32s2_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,26 +20,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
 

--- a/esp32s2-hal/examples/blinky.rs
+++ b/esp32s2-hal/examples/blinky.rs
@@ -5,34 +5,14 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32s2_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set GPIO4 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s2-hal/examples/blinky_erased_pins.rs
+++ b/esp32s2-hal/examples/blinky_erased_pins.rs
@@ -10,29 +10,15 @@ use esp32s2_hal::{
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set LED GPIOs as an output.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s2-hal/examples/clock_monitor.rs
+++ b/esp32s2-hal/examples/clock_monitor.rs
@@ -28,10 +28,6 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32s2-hal/examples/crc.rs
+++ b/esp32s2-hal/examples/crc.rs
@@ -11,7 +11,6 @@ use esp32s2_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -29,13 +28,8 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
     timer0.start(1u64.secs());
 

--- a/esp32s2-hal/examples/dac.rs
+++ b/esp32s2-hal/examples/dac.rs
@@ -11,29 +11,15 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin17 = io.pins.gpio17.into_analog();

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -13,8 +13,6 @@ use esp32s2_hal::{
     embassy::{self, executor::Executor},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use static_cell::make_static;
@@ -43,27 +41,15 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let executor = make_static!(Executor::new());
     executor.run(|spawner| {

--- a/esp32s2-hal/examples/embassy_i2c.rs
+++ b/esp32s2-hal/examples/embassy_i2c.rs
@@ -22,8 +22,6 @@ use esp32s2_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -49,20 +47,15 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
-
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s2-hal/examples/embassy_multiprio.rs
+++ b/esp32s2-hal/examples/embassy_multiprio.rs
@@ -18,8 +18,6 @@ use esp32s2_hal::{
     interrupt::Priority,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_hal_common::get_core;
@@ -86,28 +84,18 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
-    timer_group1.wdt.disable();
-
     // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let led = make_static!(io.pins.gpio0.into_push_pull_output());
 

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -16,8 +16,6 @@ use esp32s2_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -107,27 +105,15 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -27,8 +27,6 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -57,33 +55,15 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     esp32s2_hal::interrupt::enable(
         esp32s2_hal::peripherals::Interrupt::SPI2_DMA,

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -14,8 +14,6 @@ use esp32s2_hal::{
     gpio::{Gpio0, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -38,27 +36,15 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 0 as input

--- a/esp32s2-hal/examples/gpio_interrupt.rs
+++ b/esp32s2-hal/examples/gpio_interrupt.rs
@@ -17,10 +17,8 @@ use esp32s2_hal::{
     macros::ram,
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
     xtensa_lx,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -29,21 +27,8 @@ static BUTTON: Mutex<RefCell<Option<Gpio0<Input<PullDown>>>>> = Mutex::new(RefCe
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -11,16 +11,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    rmt::Rmt,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-    IO,
-};
+use esp32s2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
 use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
 use smart_leds::{
@@ -35,17 +26,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    timer_group0.wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -11,7 +11,6 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -29,13 +28,8 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
     timer0.start(1u64.secs());
 

--- a/esp32s2-hal/examples/hmac.rs
+++ b/esp32s2-hal/examples/hmac.rs
@@ -61,9 +61,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
     Rng,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -77,22 +75,9 @@ type HmacSha256 = HmacSw<Sha256>;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    rtc.rwdt.disable();
-    wdt.disable();
 
     // Set sw key
     let key = [0_u8; 32].as_ref();

--- a/esp32s2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32s2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -9,15 +9,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s2_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -26,18 +18,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -26,7 +26,6 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -45,12 +44,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s2-hal/examples/i2s_read.rs
+++ b/esp32s2-hal/examples/i2s_read.rs
@@ -20,8 +20,6 @@ use esp32s2_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -32,18 +30,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s2-hal/examples/i2s_sound.rs
+++ b/esp32s2-hal/examples/i2s_sound.rs
@@ -37,8 +37,6 @@ use esp32s2_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -56,18 +54,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -18,8 +18,6 @@ use esp32s2_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use xtensa_atomic_emulation_trap as _;
@@ -29,18 +27,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32s2-hal/examples/pcnt_encoder.rs
+++ b/esp32s2-hal/examples/pcnt_encoder.rs
@@ -23,8 +23,6 @@ use esp_hal::{
     pcnt::{channel, channel::PcntSource, unit, PCNT},
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_println::println;
@@ -36,20 +34,9 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let unit_number = unit::Number::Unit1;
 

--- a/esp32s2-hal/examples/psram.rs
+++ b/esp32s2-hal/examples/psram.rs
@@ -5,14 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    psram,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, psram};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -35,18 +28,6 @@ fn main() -> ! {
 
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     println!("Going to access PSRAM");
 

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -25,9 +25,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,26 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S2, this includes
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio4;

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -40,12 +40,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-
-    // Disable MWDT flash boot protection
-    wdt.disable();
-    // The RWDT flash boot protection remains enabled and it being triggered is part
-    // of the example
 
     timer0.start(1u64.secs());
 

--- a/esp32s2-hal/examples/read_efuse.rs
+++ b/esp32s2-hal/examples/read_efuse.rs
@@ -4,34 +4,16 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    efuse::Efuse,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s2_hal::{clock::ClockControl, efuse::Efuse, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
     println!("MAC address {:02x?}", Efuse::get_mac_address());
     println!("Flash Encryption {:?}", Efuse::get_flash_encryption());
 

--- a/esp32s2-hal/examples/rmt_rx.rs
+++ b/esp32s2-hal/examples/rmt_rx.rs
@@ -10,10 +10,8 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, RxChannel, RxChannelConfig, RxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -24,14 +22,6 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut out = io.pins.gpio15.into_push_pull_output();

--- a/esp32s2-hal/examples/rmt_tx.rs
+++ b/esp32s2-hal/examples/rmt_tx.rs
@@ -10,10 +10,8 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -23,14 +21,6 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut delay = Delay::new(&clocks);

--- a/esp32s2-hal/examples/rng.rs
+++ b/esp32s2-hal/examples/rng.rs
@@ -3,34 +3,15 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rng,
-    Rtc,
-};
+use esp32s2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Rng};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection:
-    wdt.disable();
-    rtc.rwdt.disable();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Instantiate the Random Number Generator peripheral:
     let mut rng = Rng::new(peripherals.RNG);

--- a/esp32s2-hal/examples/rsa.rs
+++ b/esp32s2-hal/examples/rsa.rs
@@ -22,9 +22,7 @@ use esp32s2_hal::{
         RsaModularMultiplication,
         RsaMultiplication,
     },
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -59,26 +57,8 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
     let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
 
     block!(rsa.ready()).unwrap();

--- a/esp32s2-hal/examples/rtc_time.rs
+++ b/esp32s2-hal/examples/rtc_time.rs
@@ -3,34 +3,16 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32s2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
-
+    let rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32s2-hal/examples/serial_interrupts.rs
+++ b/esp32s2-hal/examples/serial_interrupts.rs
@@ -15,7 +15,6 @@ use esp32s2_hal::{
     prelude::*,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -36,23 +35,8 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
     let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    rtc.rwdt.disable();
-
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30).unwrap();
     serial0.listen_at_cmd();

--- a/esp32s2-hal/examples/sha.rs
+++ b/esp32s2-hal/examples/sha.rs
@@ -9,9 +9,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,19 +20,7 @@ use sha2::{Digest, Sha512};
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data.clone();

--- a/esp32s2-hal/examples/software_interrupts.rs
+++ b/esp32s2-hal/examples/software_interrupts.rs
@@ -16,9 +16,7 @@ use esp32s2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,21 +25,9 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -25,9 +25,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiBusController, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,19 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S2, this includes the RTC WDT, and
-    // the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio36;

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -23,9 +23,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -35,19 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S2, this includes the RTC WDT, and
-    // the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio36;

--- a/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,9 +23,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -35,26 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S2, this includes
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio4;

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -22,9 +22,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,19 +32,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S2, this includes the RTC WDT, and
-    // the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio36;

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -24,9 +24,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -36,19 +34,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S2, this includes the RTC WDT, and
-    // the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio36;

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -14,9 +14,7 @@ use esp32s2_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     systimer::{Alarm, Periodic, SystemTimer, Target},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -28,20 +26,8 @@ static ALARM2: Mutex<RefCell<Option<Alarm<Target, 2>>>> = Mutex::new(RefCell::ne
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -15,7 +15,6 @@ use esp32s2_hal::{
     peripherals::{self, Peripherals, TIMG0, TIMG1},
     prelude::*,
     timer::{Timer, Timer0, Timer1, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -39,7 +38,6 @@ fn main() -> ! {
     );
     let mut timer00 = timer_group0.timer0;
     let mut timer01 = timer_group0.timer1;
-    let mut wdt0 = timer_group0.wdt;
 
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
@@ -48,19 +46,12 @@ fn main() -> ! {
     );
     let mut timer10 = timer_group1.timer0;
     let mut timer11 = timer_group1.timer1;
-    let mut wdt1 = timer_group1.wdt;
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    rtc.rwdt.disable();
 
     interrupt::enable(peripherals::Interrupt::TG0_T0_LEVEL, Priority::Priority2).unwrap();
     interrupt::enable(peripherals::Interrupt::TG0_T1_LEVEL, Priority::Priority2).unwrap();
     interrupt::enable(peripherals::Interrupt::TG1_T0_LEVEL, Priority::Priority3).unwrap();
     interrupt::enable(peripherals::Interrupt::TG1_T1_LEVEL, Priority::Priority3).unwrap();
+
     timer00.start(500u64.millis());
     timer00.listen();
     timer01.start(2500u64.millis());

--- a/esp32s2-hal/examples/ulp_riscv_core_basic.rs
+++ b/esp32s2-hal/examples/ulp_riscv_core_basic.rs
@@ -6,13 +6,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s2_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -37,20 +31,8 @@ const CODE: &[u8] = &[
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut ulp_core = esp32s2_hal::ulp_core::UlpCore::new(peripherals.ULP_RISCV_CORE);
 

--- a/esp32s2-hal/examples/usb_serial.rs
+++ b/esp32s2-hal/examples/usb_serial.rs
@@ -10,8 +10,6 @@ use esp32s2_hal::{
     otg_fs::{UsbBus, USB},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -23,19 +21,7 @@ static mut EP_MEMORY: [u32; 1024] = [0; 1024];
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/adc.rs
+++ b/esp32s3-hal/examples/adc.rs
@@ -11,9 +11,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -21,20 +19,8 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/adc_cal.rs
+++ b/esp32s3-hal/examples/adc_cal.rs
@@ -11,9 +11,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -21,20 +19,8 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/advanced_serial.rs
+++ b/esp32s3-hal/examples/advanced_serial.rs
@@ -15,13 +15,11 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     uart::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
     },
     Delay,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -33,18 +31,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let config = Config {
         baudrate: 115200,

--- a/esp32s3-hal/examples/aes.rs
+++ b/esp32s3-hal/examples/aes.rs
@@ -11,9 +11,7 @@ use esp32s3_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,26 +20,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
 

--- a/esp32s3-hal/examples/blinky.rs
+++ b/esp32s3-hal/examples/blinky.rs
@@ -5,34 +5,14 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set GPIO4 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s3-hal/examples/blinky_erased_pins.rs
+++ b/esp32s3-hal/examples/blinky_erased_pins.rs
@@ -10,29 +10,15 @@ use esp32s3_hal::{
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set LED GPIOs as an output.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s3-hal/examples/clock_monitor.rs
+++ b/esp32s3-hal/examples/clock_monitor.rs
@@ -27,10 +27,6 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    rtc.rwdt.disable();
-
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32s3-hal/examples/crc.rs
+++ b/esp32s3-hal/examples/crc.rs
@@ -11,7 +11,6 @@ use esp32s3_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -29,13 +28,8 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
     timer0.start(1u64.secs());
 

--- a/esp32s3-hal/examples/debug_assist.rs
+++ b/esp32s3-hal/examples/debug_assist.rs
@@ -14,8 +14,6 @@ use esp32s3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -26,19 +24,7 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut da = DebugAssist::new(
         peripherals.ASSIST_DEBUG,

--- a/esp32s3-hal/examples/embassy_i2c.rs
+++ b/esp32s3-hal/examples/embassy_i2c.rs
@@ -22,8 +22,6 @@ use esp32s3_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -49,18 +47,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -68,7 +54,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32s3-hal/examples/embassy_multicore_interrupt.rs
@@ -19,8 +19,6 @@ use esp32s3_hal::{
     interrupt::Priority,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_hal_common::get_core;
@@ -86,23 +84,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
-    timer_group1.wdt.disable();
-
     // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
@@ -113,7 +94,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let mut cpu_control = CpuControl::new(system.cpu_control);
 

--- a/esp32s3-hal/examples/embassy_multiprio.rs
+++ b/esp32s3-hal/examples/embassy_multiprio.rs
@@ -18,8 +18,6 @@ use esp32s3_hal::{
     interrupt::Priority,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_hal_common::get_core;
@@ -86,23 +84,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable watchdog timers
-    rtc.rwdt.disable();
-    timer_group0.wdt.disable();
-    timer_group1.wdt.disable();
-
     // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
@@ -113,7 +94,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let led = make_static!(io.pins.gpio0.into_push_pull_output());
 

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -16,8 +16,6 @@ use esp32s3_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -107,26 +105,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -134,7 +112,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -27,8 +27,6 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -59,26 +57,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -86,7 +64,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     esp32s3_hal::interrupt::enable(
         esp32s3_hal::peripherals::Interrupt::DMA_IN_CH0,

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -14,8 +14,6 @@ use esp32s3_hal::{
     gpio::{Gpio0, Input, PullDown},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -38,26 +36,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
-
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
@@ -65,7 +43,14 @@ fn main() -> ! {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(&clocks, timer_group0.timer0);
+    {
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
+            peripherals.TIMG0,
+            &clocks,
+            &mut system.peripheral_clock_control,
+        );
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 0 as input

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -16,10 +16,8 @@ use esp32s3_hal::{
     macros::ram,
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
     xtensa_lx,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,21 +26,8 @@ static BUTTON: Mutex<RefCell<Option<Gpio0<Input<PullDown>>>>> = Mutex::new(RefCe
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     // Set GPIO15 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s3-hal/examples/hello_rgb.rs
+++ b/esp32s3-hal/examples/hello_rgb.rs
@@ -11,16 +11,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    rmt::Rmt,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-    IO,
-};
+use esp32s3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
 use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
 use smart_leds::{
@@ -35,17 +26,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    timer_group0.wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/hello_world.rs
+++ b/esp32s3-hal/examples/hello_world.rs
@@ -11,7 +11,6 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -29,13 +28,8 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
 
     timer0.start(1u64.secs());
 

--- a/esp32s3-hal/examples/hmac.rs
+++ b/esp32s3-hal/examples/hmac.rs
@@ -61,9 +61,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
-    timer::TimerGroup,
     Rng,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -77,22 +75,9 @@ type HmacSha256 = HmacSw<Sha256>;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    rtc.rwdt.disable();
-    wdt.disable();
 
     // Set sw key
     let key = [0_u8; 32].as_ref();

--- a/esp32s3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32s3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -9,15 +9,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    i2c::I2C,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -26,18 +18,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/i2c_display.rs
+++ b/esp32s3-hal/examples/i2c_display.rs
@@ -26,7 +26,6 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use nb::block;
@@ -44,12 +43,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/i2s_read.rs
+++ b/esp32s3-hal/examples/i2s_read.rs
@@ -22,8 +22,6 @@ use esp32s3_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sReadDma, MclkPin, PinsBclkWsDin, Standard},
     peripherals::{Peripherals, I2S0},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -35,26 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/i2s_sound.rs
+++ b/esp32s3-hal/examples/i2s_sound.rs
@@ -37,8 +37,6 @@ use esp32s3_hal::{
     i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -56,26 +54,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    // Disable watchdog timers
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/ledc.rs
+++ b/esp32s3-hal/examples/ledc.rs
@@ -18,8 +18,6 @@ use esp32s3_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -28,18 +26,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();

--- a/esp32s3-hal/examples/mcpwm.rs
+++ b/esp32s3-hal/examples/mcpwm.rs
@@ -12,8 +12,6 @@ use esp32s3_hal::{
     mcpwm::{operator::PwmPinConfig, timer::PwmWorkingMode, PeripheralClockConfig, MCPWM},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -22,18 +20,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let pin = io.pins.gpio4;

--- a/esp32s3-hal/examples/multicore.rs
+++ b/esp32s3-hal/examples/multicore.rs
@@ -14,7 +14,6 @@ use esp32s3_hal::{
     peripherals::{Peripherals, TIMG1},
     prelude::*,
     timer::{Timer, Timer0, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,7 +33,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
 
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
@@ -42,14 +40,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer1 = timer_group1.timer0;
-    let mut wdt1 = timer_group1.wdt;
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    rtc.rwdt.disable();
 
     timer0.start(1u64.secs());
     timer1.start(500u64.millis());

--- a/esp32s3-hal/examples/octal_psram.rs
+++ b/esp32s3-hal/examples/octal_psram.rs
@@ -45,18 +45,6 @@ fn main() -> ! {
     )
     .freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
-
     println!("Going to access PSRAM");
     let mut large_vec: alloc::vec::Vec<u32> = alloc::vec::Vec::with_capacity(500 * 1024 / 4);
 

--- a/esp32s3-hal/examples/pcnt_encoder.rs
+++ b/esp32s3-hal/examples/pcnt_encoder.rs
@@ -23,8 +23,6 @@ use esp_hal::{
     pcnt::{channel, channel::PcntSource, unit, PCNT},
     peripherals::{self, Peripherals},
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_println::println;
@@ -36,20 +34,9 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let unit_number = unit::Number::Unit1;
 

--- a/esp32s3-hal/examples/psram.rs
+++ b/esp32s3-hal/examples/psram.rs
@@ -11,7 +11,6 @@ use esp32s3_hal::{
     prelude::*,
     psram,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -44,18 +43,6 @@ fn main() -> ! {
         esp_hal_common::clock::CpuClock::Clock240MHz,
     )
     .freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     println!("Going to access PSRAM");
     let mut large_vec: alloc::vec::Vec<u32> = alloc::vec::Vec::with_capacity(500 * 1024 / 4);

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -25,9 +25,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,27 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S3, this includes the RTC WDT, and
-    // the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio4;

--- a/esp32s3-hal/examples/ram.rs
+++ b/esp32s3-hal/examples/ram.rs
@@ -40,12 +40,6 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-
-    // Disable MWDT flash boot protection
-    wdt.disable();
-    // The RWDT flash boot protection remains enabled and it being triggered is part
-    // of the example
 
     timer0.start(1u64.secs());
 

--- a/esp32s3-hal/examples/read_efuse.rs
+++ b/esp32s3-hal/examples/read_efuse.rs
@@ -4,34 +4,16 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    efuse::Efuse,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, efuse::Efuse, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
     println!("MAC address {:02x?}", Efuse::get_mac_address());
     println!("Flash Encryption {:?}", Efuse::get_flash_encryption());
 

--- a/esp32s3-hal/examples/rmt_rx.rs
+++ b/esp32s3-hal/examples/rmt_rx.rs
@@ -12,10 +12,8 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, RxChannel, RxChannelConfig, RxChannelCreator},
-    timer::TimerGroup,
     Delay,
     Rmt,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -28,14 +26,6 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/rmt_tx.rs
+++ b/esp32s3-hal/examples/rmt_tx.rs
@@ -4,15 +4,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
 use esp_backtrace as _;
 use esp_hal_common::{
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
@@ -25,14 +17,6 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut clock_control = system.peripheral_clock_control;
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/rng.rs
+++ b/esp32s3-hal/examples/rng.rs
@@ -3,34 +3,15 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rng,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Rng};
 use esp_backtrace as _;
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection:
-    wdt.disable();
-    rtc.rwdt.disable();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Instantiate the Random Number Generator peripheral:
     let mut rng = Rng::new(peripherals.RNG);

--- a/esp32s3-hal/examples/rsa.rs
+++ b/esp32s3-hal/examples/rsa.rs
@@ -22,9 +22,7 @@ use esp32s3_hal::{
         RsaModularMultiplication,
         RsaMultiplication,
     },
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -59,26 +57,8 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
     let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
 
     block!(rsa.ready()).unwrap();

--- a/esp32s3-hal/examples/rtc_time.rs
+++ b/esp32s3-hal/examples/rtc_time.rs
@@ -3,34 +3,16 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Delay,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
-
+    let rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32s3-hal/examples/serial_interrupts.rs
+++ b/esp32s3-hal/examples/serial_interrupts.rs
@@ -15,7 +15,6 @@ use esp32s3_hal::{
     prelude::*,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
-    Rtc,
     Uart,
 };
 use esp_backtrace as _;
@@ -29,30 +28,14 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the TIMG watchdog timer.
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt0 = timer_group0.wdt;
-
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
 
     let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    rtc.rwdt.disable();
-
     serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     serial0.set_rx_fifo_full_threshold(30).unwrap();
     serial0.listen_at_cmd();

--- a/esp32s3-hal/examples/sha.rs
+++ b/esp32s3-hal/examples/sha.rs
@@ -9,9 +9,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
-    timer::TimerGroup,
     xtensa_lx,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -22,19 +20,7 @@ use sha2::{Digest, Sha512};
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data.clone();

--- a/esp32s3-hal/examples/sleep_timer.rs
+++ b/esp32s3-hal/examples/sleep_timer.rs
@@ -14,7 +14,6 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, SocResetReason},
-    timer::TimerGroup,
     Delay,
     Rtc,
 };
@@ -22,27 +21,10 @@ use hal::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     println!("up and runnning!");
     let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);

--- a/esp32s3-hal/examples/sleep_timer_ext0.rs
+++ b/esp32s3-hal/examples/sleep_timer_ext0.rs
@@ -19,7 +19,6 @@ use hal::{
         sleep::{Ext0WakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
-    timer::TimerGroup,
     Delay,
     Rtc,
     IO,
@@ -28,27 +27,10 @@ use hal::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut ext0_pin = io.pins.gpio18;

--- a/esp32s3-hal/examples/sleep_timer_ext1.rs
+++ b/esp32s3-hal/examples/sleep_timer_ext1.rs
@@ -19,7 +19,6 @@ use hal::{
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
-    timer::TimerGroup,
     Delay,
     Rtc,
     IO,
@@ -28,27 +27,10 @@ use hal::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut pin18 = io.pins.gpio18;

--- a/esp32s3-hal/examples/sleep_timer_rtcio.rs
+++ b/esp32s3-hal/examples/sleep_timer_rtcio.rs
@@ -23,7 +23,6 @@ use hal::{
         sleep::{TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
-    timer::TimerGroup,
     Delay,
     Rtc,
     IO,
@@ -32,27 +31,10 @@ use hal::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut rtcio_pin18 = io.pins.gpio18;

--- a/esp32s3-hal/examples/software_interrupts.rs
+++ b/esp32s3-hal/examples/software_interrupts.rs
@@ -16,9 +16,7 @@ use esp32s3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,21 +25,9 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let sw_int = system.software_interrupt_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -25,9 +25,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiBusController, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -37,19 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S3, this includes the RTC WDT, and
-    // the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio12;

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -23,9 +23,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
@@ -35,19 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S3, this includes the RTC WDT, and
-    // the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio12;

--- a/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,9 +23,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -35,27 +33,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio4;

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -22,9 +22,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -34,19 +32,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S3, this includes the RTC WDT, and
-    // the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio12;

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -24,9 +24,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{Spi, SpiMode},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -36,27 +34,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-S3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio6;

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -14,9 +14,7 @@ use esp32s3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     systimer::{Alarm, Periodic, SystemTimer, Target},
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -28,20 +26,8 @@ static ALARM2: Mutex<RefCell<Option<Alarm<Target, 2>>>> = Mutex::new(RefCell::ne
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let syst = SystemTimer::new(peripherals.SYSTIMER);
 

--- a/esp32s3-hal/examples/timer_interrupt.rs
+++ b/esp32s3-hal/examples/timer_interrupt.rs
@@ -15,7 +15,6 @@ use esp32s3_hal::{
     peripherals::{self, Peripherals, TIMG0, TIMG1},
     prelude::*,
     timer::{Timer, Timer0, Timer1, TimerGroup},
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -31,7 +30,6 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the TIMG watchdog timer.
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -39,7 +37,6 @@ fn main() -> ! {
     );
     let mut timer00 = timer_group0.timer0;
     let mut timer01 = timer_group0.timer1;
-    let mut wdt0 = timer_group0.wdt;
 
     let timer_group1 = TimerGroup::new(
         peripherals.TIMG1,
@@ -48,14 +45,6 @@ fn main() -> ! {
     );
     let mut timer10 = timer_group1.timer0;
     let mut timer11 = timer_group1.timer1;
-    let mut wdt1 = timer_group1.wdt;
-
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt0.disable();
-    wdt1.disable();
-    rtc.rwdt.disable();
 
     interrupt::enable(peripherals::Interrupt::TG0_T0_LEVEL, Priority::Priority2).unwrap();
     interrupt::enable(peripherals::Interrupt::TG0_T1_LEVEL, Priority::Priority2).unwrap();

--- a/esp32s3-hal/examples/twai.rs
+++ b/esp32s3-hal/examples/twai.rs
@@ -25,15 +25,7 @@ use embedded_can::{nb::Can, Frame, StandardId};
 // cargo run --example twai --release
 #[cfg(not(feature = "eh1"))]
 use embedded_hal::can::{Can, Frame, StandardId};
-use esp32s3_hal::{
-    clock::ClockControl,
-    gpio::IO,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    twai,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, twai};
 use esp_backtrace as _;
 use esp_println::println;
 use nb::block;
@@ -43,18 +35,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable watchdog timer
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/ulp_riscv_core_basic.rs
+++ b/esp32s3-hal/examples/ulp_riscv_core_basic.rs
@@ -6,13 +6,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -37,20 +31,8 @@ const CODE: &[u8] = &[
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut ulp_core = esp32s3_hal::ulp_core::UlpCore::new(peripherals.ULP_RISCV_CORE);
     ulp_core.stop();

--- a/esp32s3-hal/examples/usb_serial.rs
+++ b/esp32s3-hal/examples/usb_serial.rs
@@ -10,8 +10,6 @@ use esp32s3_hal::{
     otg_fs::{UsbBus, USB},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
-    Rtc,
     IO,
 };
 use esp_backtrace as _;
@@ -23,19 +21,7 @@ static mut EP_MEMORY: [u32; 1024] = [0; 1024];
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
-
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let mut wdt = timer_group0.wdt;
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
+    let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -16,7 +16,6 @@ use esp32s3_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     timer::TimerGroup,
-    Rtc,
     UsbSerialJtag,
 };
 use esp_backtrace as _;
@@ -30,18 +29,12 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut wdt = timer_group0.wdt;
-
-    // Disable MWDT and RWDT (Watchdog) flash boot protection
-    wdt.disable();
-    rtc.rwdt.disable();
 
     let mut usb_serial =
         UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);


### PR DESCRIPTION
This is a follow-up to #763. Sorry about this 😅 

Updates all examples to no longer explicitly disable the watchdog timers, as this is done automatically at startup now. I tried to review this the best I could, so hopefully I haven't broken anything.