### PR TITLE
Fix number of ADC attenuations for ESP32-C6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix wrong `dram_seg` length in `esp32s2-hal` linker script (#732)
 - Fix setting alarm when a timer group is used as the alarm source. (#730)
 - Fix `Instant::now()` not counting in some cases when using TIMG0 as the timebase (#737)
+- Fix number of ADC attenuations for ESP32-C6 (#771)
 
 ### Removed
 

--- a/esp-hal-common/src/analog/adc/riscv.rs
+++ b/esp-hal-common/src/analog/adc/riscv.rs
@@ -108,6 +108,16 @@ cfg_if::cfg_if! {
     }
 }
 
+// The number of analog IO pins, and in turn the number of attentuations,
+// depends on which chip is being used
+cfg_if::cfg_if! {
+    if #[cfg(esp32c6)] {
+        const NUM_ATTENS: usize = 7;
+    } else {
+        const NUM_ATTENS: usize = 5;
+    }
+}
+
 /// The sampling/readout resolution of the ADC
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum Resolution {
@@ -179,7 +189,7 @@ where
 
 pub struct AdcConfig<ADCI> {
     pub resolution: Resolution,
-    pub attenuations: [Option<Attenuation>; 5],
+    pub attenuations: [Option<Attenuation>; NUM_ATTENS],
     _phantom: PhantomData<ADCI>,
 }
 
@@ -271,7 +281,7 @@ impl<ADCI> Default for AdcConfig<ADCI> {
     fn default() -> Self {
         AdcConfig {
             resolution: Resolution::Resolution12Bit,
-            attenuations: [None; 5],
+            attenuations: [None; NUM_ATTENS],
             _phantom: PhantomData::default(),
         }
     }
@@ -537,7 +547,7 @@ impl CalibrationAccess for ADC2 {
 
 pub struct ADC<'d, ADCI> {
     _adc: PeripheralRef<'d, ADCI>,
-    attenuations: [Option<Attenuation>; 5],
+    attenuations: [Option<Attenuation>; NUM_ATTENS],
     active_channel: Option<u8>,
 }
 


### PR DESCRIPTION
Quickly checked the other implementations as well, but I think they're all okay.

Closes #769