### PR TITLE
Add defmt support, make `log` optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,10 @@ jobs:
       # Subsequent steps can just check the examples instead, as we're already
       # confident that they link.
       - name: check esp32-hal (common features)
-        run: cd esp32-hal/ && cargo check --examples --features=eh1,ufmt
+        run: |
+          cd esp32-hal/
+          cargo check --examples --features=eh1,ufmt,log
+          cargo check --examples --features=eh1,ufmt,defmt
       - name: check esp32-hal (embassy)
         run: |
           cd esp32-hal/
@@ -88,6 +91,8 @@ jobs:
           cargo check --example=embassy_multicore --features=embassy,embassy-time-timg0,embassy-executor-thread
           cargo check --example=embassy_multicore_interrupt --features=embassy,embassy-time-timg0,embassy-executor-interrupt
           cargo check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
+          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
       - name: check esp32-hal (embassy, async)
         run: |
           cd esp32-hal/
@@ -95,6 +100,11 @@ jobs:
           cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+      - name: check esp32-hal (embassy, log/defmt)
+        run: |
+          cd esp32-hal/
+          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
+          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32-hal/ && cargo doc --features=eh1
@@ -122,7 +132,10 @@ jobs:
       # Subsequent steps can just check the examples instead, as we're already
       # confident that they link.
       - name: check esp32c2-hal (common features)
-        run: cd esp32c2-hal/ && cargo +nightly check --examples --features=eh1,ufmt
+        run: |
+          cd esp32c2-hal/
+          cargo +nightly check --examples --features=eh1,ufmt,log
+          cargo +nightly check --examples --features=eh1,ufmt,defmt
       - name: check esp32c2-hal (async, systick)
         run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32c2-hal (async, timg0)
@@ -139,6 +152,11 @@ jobs:
         run: cd esp32c2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c2-hal (direct-vectoring)
         run: cd esp32c2-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+      - name: check esp32c2-hal (embassy, log/defmt)
+        run: |
+          cd esp32c2-hal/
+          cargo +nightly check --examples --features=embassy,embassy-time-timg0,defmt
+          cargo +nightly check --examples --features=embassy,embassy-time-timg0,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c2-hal/ && cargo doc --features=eh1
@@ -168,7 +186,10 @@ jobs:
       # Subsequent steps can just check the examples instead, as we're already
       # confident that they link.
       - name: check esp32c3-hal (common features)
-        run: cd esp32c3-hal/ && cargo +nightly check --examples --features=eh1,ufmt
+        run: |
+          cd esp32c3-hal/
+          cargo +nightly check --examples --features=eh1,ufmt,log
+          cargo +nightly check --examples --features=eh1,ufmt,defmt
       - name: check esp32c3-hal (async, systick)
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32c3-hal (async, timg0)
@@ -185,6 +206,11 @@ jobs:
         run: cd esp32c3-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c3-hal (direct-vectoring)
         run: cd esp32c3-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+      - name: check esp32c3-hal (embassy, log/defmt)
+        run: |
+          cd esp32c3-hal/
+          cargo +nightly check --examples --features=embassy,embassy-time-timg0,defmt
+          cargo +nightly check --examples --features=embassy,embassy-time-timg0,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c3-hal/ && cargo doc --features=eh1
@@ -212,7 +238,10 @@ jobs:
       # Subsequent steps can just check the examples instead, as we're already
       # confident that they link.
       - name: check esp32c6-hal (common features)
-        run: cd esp32c6-hal/ && cargo +nightly check --examples --features=eh1,ufmt
+        run: |
+          cd esp32c6-hal/
+          cargo +nightly check --examples --features=eh1,ufmt,log
+          cargo +nightly check --examples --features=eh1,ufmt,defmt
       - name: check esp32c6-hal (async, systick)
         run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32c6-hal (async, timg0)
@@ -229,6 +258,11 @@ jobs:
         run: cd esp32c6-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c6-hal (direct-vectoring)
         run: cd esp32c6-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+      - name: check esp32c6-hal (embassy, log/defmt)
+        run: |
+          cd esp32c6-hal/
+          cargo +nightly check --examples --features=embassy,embassy-time-timg0,defmt
+          cargo +nightly check --examples --features=embassy,embassy-time-timg0,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c6-hal/ && cargo doc --features=eh1
@@ -276,7 +310,10 @@ jobs:
       # Subsequent steps can just check the examples instead, as we're already
       # confident that they link.
       - name: check esp32h2-hal (common features)
-        run: cd esp32h2-hal/ && cargo +nightly check --examples --features=eh1,ufmt
+        run: |
+          cd esp32h2-hal/
+          cargo +nightly check --examples --features=eh1,ufmt,log
+          cargo +nightly check --examples --features=eh1,ufmt,defmt
       - name: check esp32h2-hal (async, systick)
         run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32h2-hal (async, timg0)
@@ -293,6 +330,11 @@ jobs:
         run: cd esp32h2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32h2-hal (direct-vectoring)
         run: cd esp32h2-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+      - name: check esp32h2-hal (embassy, log/defmt)
+        run: |
+          cd esp32h2-hal/
+          cargo +nightly check --examples --features=embassy,embassy-time-timg0,defmt
+          cargo +nightly check --examples --features=embassy,embassy-time-timg0,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32h2-hal/ && cargo doc --features=eh1
@@ -316,7 +358,10 @@ jobs:
       # Subsequent steps can just check the examples instead, as we're already
       # confident that they link.
       - name: check esp32s2-hal (common features)
-        run: cd esp32s2-hal/ && cargo check --examples --features=eh1,ufmt
+        run: |
+          cd esp32s2-hal/
+          cargo check --examples --features=eh1,ufmt,log
+          cargo check --examples --features=eh1,ufmt,defmt
       # FIXME: `time-systick` feature disabled for now, see 'esp32s2-hal/Cargo.toml'.
       # - name: check esp32s2-hal (async, systick)
       #   run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
@@ -332,6 +377,11 @@ jobs:
           cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+      - name: check esp32s2-hal (embassy, log/defmt)
+        run: |
+          cd esp32s2-hal/
+          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
+          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32s2-hal/ && cargo doc --features=eh1
@@ -359,7 +409,10 @@ jobs:
       # Subsequent steps can just check the examples instead, as we're already
       # confident that they link.
       - name: check esp32s3-hal (common features)
-        run: cd esp32s3-hal/ && cargo check --examples --features=eh1,ufmt
+        run: |
+          cd esp32s3-hal/
+          cargo check --examples --features=eh1,ufmt,log
+          cargo check --examples --features=eh1,ufmt,defmt
       - name: check esp32s3-hal (embassy, timg0)
         run: |
           cd esp32s3-hal/
@@ -390,6 +443,11 @@ jobs:
           cargo check --example=embassy_i2c --features=embassy,embassy-time-systick,async,embassy-executor-thread
       - name: check esp32s3-hal (octal psram)
         run: cd esp32s3-hal/ && cargo check --example=octal_psram --features=opsram_2m --release # This example requires release!
+      - name: check esp32s3-hal (embassy, log/defmt)
+        run: |
+          cd esp32s3-hal/
+          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
+          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32s3-hal/ && cargo doc --features=eh1
@@ -431,15 +489,15 @@ jobs:
 
       # Verify the MSRV for all RISC-V chips.
       - name: msrv (esp32c2-hal)
-        run: cd esp32c2-hal/ && cargo check --features=eh1,ufmt
+        run: cd esp32c2-hal/ && cargo check --features=eh1,ufmt,log
       - name: msrv (esp32c3-hal)
-        run: cd esp32c3-hal/ && cargo check --features=eh1,ufmt
+        run: cd esp32c3-hal/ && cargo check --features=eh1,ufmt,log
       - name: msrv (esp32c6-hal)
-        run: cd esp32c6-hal/ && cargo check --features=eh1,ufmt
+        run: cd esp32c6-hal/ && cargo check --features=eh1,ufmt,log
       - name: msrv (esp32c6-lp-hal)
         run: cd esp32c6-lp-hal/ && cargo check
       - name: msrv (esp32h2-hal)
-        run: cd esp32h2-hal/ && cargo check --features=eh1,ufmt
+        run: cd esp32h2-hal/ && cargo check --features=eh1,ufmt,log
 
   msrv-xtensa:
     runs-on: ubuntu-latest
@@ -454,11 +512,11 @@ jobs:
 
       # Verify the MSRV for all Xtensa chips.
       - name: msrv (esp32-hal)
-        run: cd esp32-hal/ && cargo check --features=eh1,ufmt
+        run: cd esp32-hal/ && cargo check --features=eh1,ufmt,log
       - name: msrv (esp32s2-hal)
-        run: cd esp32s2-hal/ && cargo check --features=eh1,ufmt
+        run: cd esp32s2-hal/ && cargo check --features=eh1,ufmt,log
       - name: msrv (esp32s3-hal)
-        run: cd esp32s3-hal/ && cargo check --features=eh1,ufmt
+        run: cd esp32s3-hal/ && cargo check --features=eh1,ufmt,log
 
   # --------------------------------------------------------------------------
   # Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add interrupt-executor for Xtensa MCUs (#723, #756).
 - Add missing `Into<Gpio<Analog, GPIONUN>>` conversion (#764)
 - Updated `clock` module documentation (#774)
+- Add `log` feature to enable log output (#773)
+- Add `defmt` feature to enable log output (#773)
 
 ### Changed
 
 - Update the `embedded-hal-*` packages to `1.0.0-rc.1` and implement traits from `embedded-io` and `embedded-io-async` (#747)
 - Moved AlignmentHelper to its own module (#753)
 - Disable all watchdog timers by default at startup (#763)
+- `log` crate is now opt-in (#773)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The **M**inimum **S**upported **R**ust **V**ersions are:
   - This corresponds to the date that the `1.65.0` release was branched from `master`
 - `1.65.0` for Xtensa devices (**ESP32**, **ESP32-S2**, **ESP32-S3**)
 - `1.67.0` for all `async` examples (`embassy_hello_world`, `embassy_wait`, etc.)
+- latest `stable` when using the `defmt` feature
 
 It should be noted that targeting the Xtensa ISA currently requires the use of the [esp-rs/rust] compiler fork. Our recommend method of installation is [espup].
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -24,7 +24,7 @@ embedded-hal-nb      = { version = "=1.0.0-rc.1", optional = true }
 embedded-io          = "0.5.0"
 esp-synopsys-usb-otg = { version = "0.3.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
-log                  = "0.4.20"
+log                  = { version = "0.4.20", optional = true }
 lock_api             = { version = "0.4.10", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.14"
@@ -132,3 +132,5 @@ debug = [
     "esp32s2?/impl-register-debug",
     "esp32s3?/impl-register-debug",
 ]
+
+log = ["dep:log"]

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -16,6 +16,7 @@ bitflags             = "2.3.3"
 bitfield             = "0.14.0"
 cfg-if               = "1.0.0"
 critical-section     = "1.1.2"
+defmt                = { version = "=0.3.5", optional = true }
 embedded-can         = { version = "0.4.1", optional = true }
 embedded-dma         = "0.2.0"
 embedded-hal         = { version = "0.2.7", features = ["unproven"] }
@@ -134,3 +135,13 @@ debug = [
 ]
 
 log = ["dep:log"]
+defmt = [
+    "dep:defmt",
+    "embassy-executor?/defmt",
+    "embassy-sync?/defmt",
+    "embassy-time?/defmt",
+    "embassy-futures?/defmt",
+    "embedded-hal-1?/defmt-03",
+    "embedded-io/defmt-03",
+    "embedded-io-async?/defmt-03",
+]

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -79,6 +79,7 @@ const CHUNK_SIZE: usize = 4092;
 
 /// DMA Errors
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaError {
     InvalidAlignment,
     OutOfDescriptors,
@@ -96,6 +97,7 @@ pub enum DmaError {
 /// DMA Priorities
 #[cfg(gdma)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaPriority {
     Priority0 = 0,
     Priority1 = 1,
@@ -113,6 +115,7 @@ pub enum DmaPriority {
 /// The values need to match the TRM
 #[cfg(pdma)]
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaPriority {
     Priority0 = 0,
 }
@@ -120,6 +123,7 @@ pub enum DmaPriority {
 /// DMA capable peripherals
 /// The values need to match the TRM
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaPeripheral {
     Spi2   = 0,
     #[cfg(any(pdma, esp32s3))]

--- a/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
@@ -43,10 +43,10 @@ macro_rules! from_cpu {
                 fn enable(priority: interrupt::Priority) {
                     let mask = 1 << $irq;
                     if FROM_CPU_IRQ_USED.fetch_or(mask, Ordering::SeqCst) & mask != 0 {
-                        panic!(concat!("FROM_CPU_", $irq, " is already used by a different executor."));
+                        panic!("FROM_CPU_{} is already used by a different executor.", $irq);
                     }
 
-                    interrupt::enable(peripherals::Interrupt::[<FROM_CPU_INTR $irq>], priority).unwrap();
+                    unwrap!(interrupt::enable(peripherals::Interrupt::[<FROM_CPU_INTR $irq>], priority));
                 }
 
                 fn number() -> usize {

--- a/esp-hal-common/src/embassy/executor/xtensa/thread.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/thread.rs
@@ -65,11 +65,10 @@ impl Executor {
     /// Create a new Executor.
     pub fn new() -> Self {
         #[cfg(multi_core)]
-        interrupt::enable(
+        unwrap!(interrupt::enable(
             peripherals::Interrupt::FROM_CPU_INTR0,
             interrupt::Priority::Priority1,
-        )
-        .unwrap();
+        ));
 
         Self {
             inner: raw::Executor::new(usize::from_le_bytes([0, get_core() as u8, 0, 0]) as *mut ()),

--- a/esp-hal-common/src/embassy/executor/xtensa/thread.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/thread.rs
@@ -37,13 +37,6 @@ fn FROM_CPU_INTR0() {
 }
 
 pub(super) fn pend_thread_mode(core: usize) {
-    use core::sync::atomic::Ordering;
-
-    #[cfg(dport)]
-    use crate::peripherals::DPORT as SystemPeripheral;
-    #[cfg(system)]
-    use crate::peripherals::SYSTEM as SystemPeripheral;
-
     // Signal that there is work to be done.
     SIGNAL_WORK_THREAD_MODE[core].store(true, Ordering::SeqCst);
 

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -51,9 +51,18 @@ impl EmbassyTimer {
     pub fn init(_clocks: &Clocks, _systimer: TimerType) {
         use crate::{interrupt, interrupt::Priority, macros::interrupt};
 
-        interrupt::enable(peripherals::Interrupt::SYSTIMER_TARGET0, Priority::max()).unwrap();
-        interrupt::enable(peripherals::Interrupt::SYSTIMER_TARGET1, Priority::max()).unwrap();
-        interrupt::enable(peripherals::Interrupt::SYSTIMER_TARGET2, Priority::max()).unwrap();
+        unwrap!(interrupt::enable(
+            peripherals::Interrupt::SYSTIMER_TARGET0,
+            Priority::max()
+        ));
+        unwrap!(interrupt::enable(
+            peripherals::Interrupt::SYSTIMER_TARGET1,
+            Priority::max()
+        ));
+        unwrap!(interrupt::enable(
+            peripherals::Interrupt::SYSTIMER_TARGET2,
+            Priority::max()
+        ));
 
         #[interrupt]
         fn SYSTIMER_TARGET0() {

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -59,9 +59,15 @@ impl EmbassyTimer {
 
         timer.set_counter_active(true);
 
-        interrupt::enable(peripherals::Interrupt::TG0_T0_LEVEL, Priority::max()).unwrap();
+        unwrap!(interrupt::enable(
+            peripherals::Interrupt::TG0_T0_LEVEL,
+            Priority::max()
+        ));
         #[cfg(any(esp32, esp32s2, esp32s3))]
-        interrupt::enable(peripherals::Interrupt::TG0_T1_LEVEL, Priority::max()).unwrap();
+        unwrap!(interrupt::enable(
+            peripherals::Interrupt::TG0_T1_LEVEL,
+            Priority::max()
+        ));
 
         #[interrupt]
         fn TG0_T0_LEVEL() {

--- a/esp-hal-common/src/fmt.rs
+++ b/esp-hal-common/src/fmt.rs
@@ -1,0 +1,148 @@
+#![macro_use]
+#![allow(unused_macros)]
+
+macro_rules! assert {
+    ($($x:tt)*) => {
+        {
+            ::core::assert!($($x)*);
+        }
+    };
+}
+
+macro_rules! assert_eq {
+    ($($x:tt)*) => {
+        {
+            ::core::assert_eq!($($x)*);
+        }
+    };
+}
+
+macro_rules! assert_ne {
+    ($($x:tt)*) => {
+        {
+            ::core::assert_ne!($($x)*);
+        }
+    };
+}
+
+macro_rules! debug_assert {
+    ($($x:tt)*) => {
+        {
+            ::core::debug_assert!($($x)*);
+        }
+    };
+}
+
+macro_rules! debug_assert_eq {
+    ($($x:tt)*) => {
+        {
+            ::core::debug_assert_eq!($($x)*);
+        }
+    };
+}
+
+macro_rules! debug_assert_ne {
+    ($($x:tt)*) => {
+        {
+            ::core::debug_assert_ne!($($x)*);
+        }
+    };
+}
+
+macro_rules! todo {
+    ($($x:tt)*) => {
+        {
+            ::core::todo!($($x)*);
+        }
+    };
+}
+
+macro_rules! unreachable {
+    ($($x:tt)*) => {
+        {
+            ::core::unreachable!($($x)*);
+        }
+    };
+}
+
+macro_rules! panic {
+    ($($x:tt)*) => {
+        {
+            ::core::panic!($($x)*);
+        }
+    };
+}
+
+macro_rules! trace {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::trace!($s $(, $x)*);
+            #[cfg(not(feature = "log"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+macro_rules! debug {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::debug!($s $(, $x)*);
+            #[cfg(not(feature = "log"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+macro_rules! info {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::info!($s $(, $x)*);
+            #[cfg(not(feature = "log"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+macro_rules! warn {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::warn!($s $(, $x)*);
+            #[cfg(not(feature = "log"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+macro_rules! error {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "log")]
+            ::log::error!($s $(, $x)*);
+            #[cfg(not(feature = "log"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+macro_rules! unwrap {
+    ($arg:expr) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(e) => {
+                ::core::panic!("unwrap of `{}` failed: {:?}", ::core::stringify!($arg), e);
+            }
+        }
+    };
+    ($arg:expr, $($msg:expr),+ $(,)? ) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(e) => {
+                ::core::panic!("unwrap of `{}` failed: {}: {:?}", ::core::stringify!($arg), ::core::format_args!($($msg,)*), e);
+            }
+        }
+    }
+}

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1851,7 +1851,7 @@ mod asynch {
             }
         };
 
-        log::trace!(
+        trace!(
             "Handling interrupt on {:?} - {:064b}",
             crate::get_core(),
             intrs

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 
 /// Interrupt kind
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum InterruptKind {
     /// Level interrupt
     Level,
@@ -37,6 +38,7 @@ pub enum InterruptKind {
 /// `interrupt3`)
 #[repr(u32)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CpuInterrupt {
     Interrupt1 = 1,
     Interrupt2,
@@ -72,6 +74,7 @@ pub enum CpuInterrupt {
 }
 
 /// Interrupt priority levels.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum Priority {
     None = 0,
@@ -152,6 +155,7 @@ mod vectored {
 
     /// Interrupt Error
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum Error {
         InvalidInterruptPriority,
     }

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -12,6 +12,7 @@ use crate::{
 /// `level1_interrupt`)
 #[allow(unused)]
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u32)]
 pub enum CpuInterrupt {
     Interrupt0LevelPriority1 = 0,
@@ -193,12 +194,14 @@ mod vectored {
     use crate::get_core;
 
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum Error {
         InvalidInterrupt,
     }
 
     /// Interrupt priority levels.
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[repr(u8)]
     pub enum Priority {
         None = 0,

--- a/esp-hal-common/src/ledc/timer.rs
+++ b/esp-hal-common/src/ledc/timer.rs
@@ -248,7 +248,7 @@ impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
     #[cfg(esp32)]
     /// Configure the HW for the timer
     fn configure_hw(&self, divisor: u32) {
-        let duty = self.duty.unwrap() as u8;
+        let duty = unwrap!(self.duty) as u8;
         let use_apb = !self.use_ref_tick;
 
         match self.number {
@@ -306,7 +306,7 @@ impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
     #[cfg(not(esp32))]
     /// Configure the HW for the timer
     fn configure_hw(&self, divisor: u32) {
-        let duty = self.duty.unwrap() as u8;
+        let duty = unwrap!(self.duty) as u8;
         let use_ref_tick = self.use_ref_tick;
 
         match self.number {
@@ -397,7 +397,7 @@ impl<'a> TimerHW<HighSpeed> for Timer<'a, HighSpeed> {
 
     /// Configure the HW for the timer
     fn configure_hw(&self, divisor: u32) {
-        let duty = self.duty.unwrap() as u8;
+        let duty = unwrap!(self.duty) as u8;
         let sel_hstimer = self.clock_source == Some(HSClockSource::APBClk);
 
         match self.number {

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -32,6 +32,9 @@
 )]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
+// MUST be the first module
+mod fmt;
+
 #[cfg(riscv)]
 pub use esp_riscv_rt::{self, entry, riscv};
 pub use procmacros as macros;

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -170,6 +170,7 @@ extern "C" fn DefaultHandler() {}
 ///
 /// The actual number of available cores depends on the target.
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Cpu {
     /// The first core
     ProCpu = 0,

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -964,7 +964,7 @@ pub fn get_reset_reason(cpu: Cpu) -> Option<SocResetReason> {
 }
 
 pub fn get_wakeup_cause() -> SleepSource {
-    if get_reset_reason(Cpu::ProCpu).unwrap() != SocResetReason::CoreDeepSleep {
+    if get_reset_reason(Cpu::ProCpu) != Some(SocResetReason::CoreDeepSleep) {
         return SleepSource::Undefined;
     }
 

--- a/esp-hal-common/src/soc/esp32/cpu_control.rs
+++ b/esp-hal-common/src/soc/esp32/cpu_control.rs
@@ -77,7 +77,7 @@ pub struct Stack<const SIZE: usize> {
 }
 
 impl<const SIZE: usize> Stack<SIZE> {
-    const _ALIGNED: () = assert!(SIZE % 16 == 0); // Make sure stack top is aligned, too.
+    const _ALIGNED: () = ::core::assert!(SIZE % 16 == 0); // Make sure stack top is aligned, too.
 
     /// Construct a stack of length SIZE, uninitialized
     #[allow(path_statements)]
@@ -269,7 +269,7 @@ impl CpuControl {
         xtensa_lx::timer::set_ccompare2(0);
 
         // set stack pointer to end of memory: no need to retain stack up to this point
-        set_stack_pointer(unsafe { APP_CORE_STACK_TOP.unwrap() });
+        set_stack_pointer(unsafe { unwrap!(APP_CORE_STACK_TOP) });
 
         extern "C" {
             static mut _init_start: u32;

--- a/esp-hal-common/src/soc/esp32/psram.rs
+++ b/esp-hal-common/src/soc/esp32/psram.rs
@@ -281,6 +281,7 @@ pub(crate) mod utils {
     }
 
     #[derive(PartialEq, Eq, Debug, Default)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct PsramIo {
         flash_clk_io: u8,
         flash_cs_io: u8,
@@ -392,7 +393,7 @@ pub(crate) mod utils {
             // EFUSE_SPICONFIG_RET_SPIHD(spiconfig);
             // psram_io.psram_spiwp_sd3_io = bootloader_flash_get_wp_pin();
         }
-        log::info!("PS-RAM pins {:?}", &psram_io);
+        info!("PS-RAM pins {:?}", &psram_io);
 
         write_peri_reg(SPI0_EXT3_REG, 0x1);
         clear_peri_reg_mask(SPI1_USER_REG, SPI_USR_PREP_HOLD_M);
@@ -469,7 +470,7 @@ pub(crate) mod utils {
         psram_set_cs_timing_spi0(mode, clk_mode); // SPI_CACHE_PORT
         psram_enable_qio_mode_spi1(clk_mode, mode);
 
-        log::info!(
+        info!(
             "PS-RAM vaddrmode = {:?}",
             PsramVaddrMode::PsramVaddrModeLowhigh
         );
@@ -484,6 +485,7 @@ pub(crate) mod utils {
 
     #[allow(unused)]
     #[derive(Debug, Clone, Copy, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum PsramVaddrMode {
         /// App and pro CPU use their own flash cache for external RAM access
         PsramVaddrModeNormal = 0,
@@ -502,11 +504,9 @@ pub(crate) mod utils {
         clk_mode: PsramClkMode,
         extra_dummy: u32,
     ) {
-        log::info!(
+        info!(
             "PS-RAM cache_init, psram_cache_mode={:?}, extra_dummy={}, clk_mode={:?}",
-            psram_cache_mode,
-            extra_dummy,
-            clk_mode
+            psram_cache_mode, extra_dummy, clk_mode
         );
         match psram_cache_mode {
             PsramCacheSpeed::PsramCacheF80mS80m => {
@@ -1262,7 +1262,7 @@ pub(crate) mod utils {
         gpio_hal_iomux_func_sel(gpio_pin_mux_reg(psram_io.psram_spiwp_sd3_io), PIN_FUNC_GPIO);
 
         let flash_id: u32 = unsafe { g_rom_flashchip.device_id };
-        log::info!("Flash-ID = {}", flash_id);
+        info!("Flash-ID = {}", flash_id);
 
         if flash_id == FLASH_ID_GD25LQ32C {
             // Set drive ability for 1.8v flash in 80Mhz.

--- a/esp-hal-common/src/soc/esp32s2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s2/gpio.rs
@@ -119,7 +119,7 @@ pub(crate) const fn get_io_mux_reg(gpio_num: u8) -> &'static crate::peripherals:
             44 => core::mem::transmute(&(iomux.gpio44)),
             45 => core::mem::transmute(&(iomux.gpio45)),
             46 => core::mem::transmute(&(iomux.gpio46)),
-            _ => panic!(),
+            _ => ::core::unreachable!(),
         }
     }
 }

--- a/esp-hal-common/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal-common/src/soc/esp32s3/cpu_control.rs
@@ -77,7 +77,7 @@ pub struct Stack<const SIZE: usize> {
 }
 
 impl<const SIZE: usize> Stack<SIZE> {
-    const _ALIGNED: () = assert!(SIZE % 16 == 0); // Make sure stack top is aligned, too.
+    const _ALIGNED: () = ::core::assert!(SIZE % 16 == 0); // Make sure stack top is aligned, too.
 
     /// Construct a stack of length SIZE, uninitialized
     #[allow(path_statements)]
@@ -205,7 +205,7 @@ impl CpuControl {
         xtensa_lx::timer::set_ccompare2(0);
 
         // set stack pointer to end of memory: no need to retain stack up to this point
-        set_stack_pointer(unsafe { APP_CORE_STACK_TOP.unwrap() });
+        set_stack_pointer(unsafe { unwrap!(APP_CORE_STACK_TOP) });
 
         extern "C" {
             static mut _init_start: u32;

--- a/esp-hal-common/src/soc/esp32s3/psram.rs
+++ b/esp-hal-common/src/soc/esp32s3/psram.rs
@@ -15,6 +15,7 @@
 //! 0x3f500000. The `PSRAM` module size depends on the configuration specified
 //! during the compilation process. The available `PSRAM` sizes are `2MB`,
 //! `4MB`, and `8MB`.
+
 static mut PSRAM_VADDR: u32 = 0x3C000000;
 
 pub fn psram_vaddr_start() -> usize {
@@ -113,7 +114,7 @@ pub fn init_psram(_peripheral: impl crate::peripheral::Peripheral<P = crate::per
                 break;
             }
         }
-        log::debug!("PSRAM start address = {:x}", start);
+        debug!("PSRAM start address = {:x}", start);
         PSRAM_VADDR = start;
 
         // Configure the mode of instruction cache : cache size, cache line size.
@@ -390,11 +391,9 @@ pub(crate) mod utils {
         let flash_div: u32 = get_flash_clock_divider();
         let psram_div: u32 = get_psram_clock_divider();
 
-        log::info!(
+        info!(
             "PSRAM core_clock {:?}, flash_div = {}, psram_div = {}",
-            core_clock,
-            flash_div,
-            psram_div
+            core_clock, flash_div, psram_div
         );
 
         // Set SPI01 core clock
@@ -1194,7 +1193,7 @@ pub(crate) mod utils {
         print_psram_info(&mode_reg);
 
         if mode_reg.vendor_id() != OCT_PSRAM_VENDOR_ID {
-            log::warn!("PSRAM ID read error: {:x}, PSRAM chip not found or not supported, or wrong PSRAM line mode", mode_reg.vendor_id());
+            warn!("PSRAM ID read error: {:x}, PSRAM chip not found or not supported, or wrong PSRAM line mode", mode_reg.vendor_id());
             return;
         }
 
@@ -1206,7 +1205,7 @@ pub(crate) mod utils {
             0x7 => PSRAM_SIZE_32MB,
             _ => 0,
         };
-        log::info!("{psram_size} bytes of PSRAM");
+        info!("{} bytes of PSRAM", psram_size);
 
         // Do PSRAM timing tuning, we use SPI1 to do the tuning, and set the
         // SPI0 PSRAM timing related registers accordingly
@@ -1597,7 +1596,7 @@ pub(crate) mod utils {
     }
 
     fn print_psram_info(reg_val: &OpiPsramModeReg) {
-        log::info!(
+        info!(
             "vendor id    : {:02x} ({})",
             reg_val.vendor_id(),
             if reg_val.vendor_id() == 0x0d {
@@ -1606,12 +1605,12 @@ pub(crate) mod utils {
                 "UNKNOWN"
             }
         );
-        log::info!(
+        info!(
             "dev id       : {:02x} (generation {})",
             reg_val.dev_id(),
             reg_val.dev_id() + 1
         );
-        log::info!(
+        info!(
             "density      : {:02x} ({} Mbit)",
             reg_val.density(),
             if reg_val.density() == 0x1 {
@@ -1626,12 +1625,12 @@ pub(crate) mod utils {
                 0
             }
         );
-        log::info!(
+        info!(
             "good-die     : {:02x} ({})",
             reg_val.gb(),
             if reg_val.gb() == 1 { "Pass" } else { "Fail" }
         );
-        log::info!(
+        info!(
             "Latency      : {:02x} ({})",
             reg_val.lt(),
             if reg_val.lt() == 1 {
@@ -1640,17 +1639,17 @@ pub(crate) mod utils {
                 "Variable"
             }
         );
-        log::info!(
+        info!(
             "VCC          : {:02x} ({})",
             reg_val.vcc(),
             if reg_val.vcc() == 1 { "3V" } else { "1.8V" }
         );
-        log::info!(
+        info!(
             "SRF          : {:02x} ({} Refresh)",
             reg_val.srf(),
             if reg_val.srf() == 0x1 { "Fast" } else { "Slow" }
         );
-        log::info!(
+        info!(
             "BurstType    : {:02x} ({} Wrap)",
             reg_val.bt(),
             if reg_val.bt() == 1 && reg_val.bl() != 3 {
@@ -1659,7 +1658,7 @@ pub(crate) mod utils {
                 ""
             }
         );
-        log::info!(
+        info!(
             "BurstLen     : {:02x} ({} Byte)",
             reg_val.bl(),
             if reg_val.bl() == 0x00 {
@@ -1672,7 +1671,7 @@ pub(crate) mod utils {
                 1024
             }
         );
-        log::info!(
+        info!(
             "Readlatency  : {:02x} ({} cycles@{})",
             reg_val.read_latency(),
             reg_val.read_latency() * 2 + 6,
@@ -1682,7 +1681,7 @@ pub(crate) mod utils {
                 "Variable"
             }
         );
-        log::info!(
+        info!(
             "DriveStrength: {:02x} (1/{})",
             reg_val.drive_str(),
             if reg_val.drive_str() == 0x00 {

--- a/esp-hal-common/src/soc/esp32s3/psram.rs
+++ b/esp-hal-common/src/soc/esp32s3/psram.rs
@@ -188,6 +188,7 @@ pub(crate) mod utils {
 
     #[allow(unused)]
     #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum SpiTimingConfigCoreClock {
         SpiTimingConfigCoreClock80m,
         SpiTimingConfigCoreClock120m,
@@ -806,6 +807,7 @@ pub(crate) mod utils {
 
     #[allow(unused)]
     #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum SpiTimingConfigCoreClock {
         SpiTimingConfigCoreClock80m,
         SpiTimingConfigCoreClock120m,

--- a/esp-hal-common/src/twai/filter.rs
+++ b/esp-hal-common/src/twai/filter.rs
@@ -41,7 +41,7 @@ macro_rules! set_bit_from_byte {
                 $mask |= 1 << $shift;
             }
             b'x' => {}
-            _ => panic!("BitFilter bits must be either '1', '0' or 'x'."),
+            _ => ::core::panic!("BitFilter bits must be either '1', '0' or 'x'."),
         }
     };
 }

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -71,6 +71,8 @@ psram_2m  = ["esp-hal-common/psram_2m", "psram"]
 psram_4m  = ["esp-hal-common/psram_4m", "psram"]
 psram_8m  = ["esp-hal-common/psram_8m", "psram"]
 
+log = ["esp-hal-common/log"]
+
 [profile.release]
 debug = true
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -39,9 +39,9 @@ embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
-esp-backtrace      = { version = "0.7.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace      = { version = "0.8.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.5.0", features = ["esp32", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32", "log"] }
 heapless           = "0.7.16"
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -72,6 +72,7 @@ psram_4m  = ["esp-hal-common/psram_4m", "psram"]
 psram_8m  = ["esp-hal-common/psram_8m", "psram"]
 
 log = ["esp-hal-common/log"]
+defmt = ["esp-hal-common/defmt"]
 
 [profile.release]
 debug = true

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -24,6 +24,7 @@
 //!   executor
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
+//! - `log` - enable log output using the `log` crate
 //! - `psram_2m` - Use externally connected PSRAM (2MB)
 //! - `psram_4m` - Use externally connected PSRAM (4MB)
 //! - `psram_8m` - Use externally connected PSRAM (8MB)

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -14,6 +14,7 @@
 //!   provided by [embedded-hal-async] and [embedded-io-async]
 //! - `bluetooth` - Enable support for using the Bluetooth radio
 //! - `debug` - Enable debug features in the HAL (used for development)
+//! - `defmt` - Enable [`defmt::Format`] on certain types
 //! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
 //!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
 //! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
@@ -45,6 +46,7 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -35,8 +35,8 @@ embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-io-async  = "0.5.0"
-esp-backtrace      = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
-esp-println        = { version = "0.5.0", features = ["esp32c2", "log"] }
+esp-backtrace      = { version = "0.8.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
+esp-println        = { version = "0.6.0", features = ["esp32c2", "log"] }
 heapless           = "0.7.16"
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -61,6 +61,7 @@ interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 
 log = ["esp-hal-common/log"]
+defmt = ["esp-hal-common/defmt"]
 
 [profile.release]
 debug = true

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -36,7 +36,7 @@ embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
-esp-println        = { version = "0.5.0", features = ["esp32c2"] }
+esp-println        = { version = "0.5.0", features = ["esp32c2", "log"] }
 heapless           = "0.7.16"
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
 sha2               = { version = "0.10.7", default-features = false}
@@ -59,6 +59,8 @@ xtal26mhz            = ["esp-hal-common/esp32c2_26mhz"]
 xtal40mhz            = ["esp-hal-common/esp32c2_40mhz"] 
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
+
+log = ["esp-hal-common/log"]
 
 [profile.release]
 debug = true

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -21,6 +21,7 @@
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
 //! - `interrupt-preemption` - Enable priority-based interrupt preemption
+//! - `log` - enable log output using the `log` crate
 //! - `rt` - Runtime support
 //! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
 //!   Serial JTAG drivers

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `async` - Enable support for asynchronous operation, with interfaces
 //!   provided by [embedded-hal-async] and [embedded-io-async]
 //! - `debug` - Enable debug features in the HAL (used for development)
+//! - `defmt` - Enable [`defmt::Format`] on certain types
 //! - `direct-boot` - Use the direct boot image format
 //! - `direct-vectoring` - Enable direct vector table hooking support
 //! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
@@ -40,6 +41,7 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
 //!
 //! ### Supported Image Formats
 //!

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -40,9 +40,9 @@ embedded-hal       = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-io-async  = "0.5.0"
-esp-backtrace      = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace      = { version = "0.8.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.5.0", features = ["esp32c3", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32c3", "log"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -68,6 +68,7 @@ interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 
 log = ["esp-hal-common/log"]
+defmt = ["esp-hal-common/defmt"]
 
 [profile.release]
 debug = true

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -42,7 +42,7 @@ embedded-hal-async = "=1.0.0-rc.1"
 embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.5.0", features = ["esp32c3"] }
+esp-println        = { version = "0.5.0", features = ["esp32c3", "log"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
@@ -66,6 +66,8 @@ embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tic
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
+
+log = ["esp-hal-common/log"]
 
 [profile.release]
 debug = true

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `async` - Enable support for asynchronous operation, with interfaces
 //!   provided by [embedded-hal-async] and [embedded-io-async]
 //! - `debug` - Enable debug features in the HAL (used for development)
+//! - `defmt` - Enable [`defmt::Format`] on certain types
 //! - `direct-boot` - Use the direct boot image format
 //! - `direct-vectoring` - Enable direct vector table hooking support
 //! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
@@ -39,6 +40,7 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
 //!
 //! ### Supported Image Formats
 //!

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -21,6 +21,7 @@
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
 //! - `interrupt-preemption` - Enable priority-based interrupt preemption
+//! - `log` - enable log output using the `log` crate
 //! - `mcu-boot` - Use the MCUboot image format
 //! - `rt` - Runtime support
 //! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -66,6 +66,7 @@ interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 
 log = ["esp-hal-common/log"]
+defmt = ["esp-hal-common/defmt"]
 
 [profile.release]
 debug = true

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -65,6 +65,8 @@ embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tic
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 
+log = ["esp-hal-common/log"]
+
 [profile.release]
 debug = true
 

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -39,9 +39,9 @@ embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
 embedded-io-async  = "0.5.0"
-esp-backtrace      = { version = "0.7.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace      = { version = "0.8.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.5.0", features = ["esp32c6", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32c6", "log"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -21,6 +21,7 @@
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
 //! - `interrupt-preemption` - Enable priority-based interrupt preemption
+//! - `log` - enable log output using the `log` crate
 //! - `rt` - Runtime support
 //! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
 //!   Serial JTAG drivers

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `async` - Enable support for asynchronous operation, with interfaces
 //!   provided by [embedded-hal-async] and [embedded-io-async]
 //! - `debug` - Enable debug features in the HAL (used for development)
+//! - `defmt` - Enable [`defmt::Format`] on certain types
 //! - `direct-boot` - Use the direct boot image format
 //! - `direct-vectoring` - Enable direct vector table hooking support
 //! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
@@ -38,6 +39,7 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
 //!
 //! ### Supported Image Formats
 //!

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -66,6 +66,7 @@ interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 
 log = ["esp-hal-common/log"]
+defmt = ["esp-hal-common/defmt"]
 
 [profile.release]
 debug = true

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -65,6 +65,8 @@ embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tic
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 
+log = ["esp-hal-common/log"]
+
 [profile.release]
 debug = true
 

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -39,9 +39,9 @@ embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
 embedded-io-async  = "0.5.0"
-esp-backtrace      = { version = "0.7.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace      = { version = "0.8.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.5.0", features = ["esp32h2", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32h2", "log"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -21,6 +21,7 @@
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
 //! - `interrupt-preemption` - Enable priority-based interrupt preemption
+//! - `log` - enable log output using the `log` crate
 //! - `rt` - Runtime support
 //! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
 //!   Serial JTAG drivers

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `async` - Enable support for asynchronous operation, with interfaces
 //!   provided by [embedded-hal-async] and [embedded-io-async]
 //! - `debug` - Enable debug features in the HAL (used for development)
+//! - `defmt` - Enable [`defmt::Format`] on certain types
 //! - `direct-boot` - Use the direct boot image format
 //! - `direct-vectoring` - Enable direct vector table hooking support
 //! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
@@ -38,6 +39,7 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
 //!
 //! ### Supported Image Formats
 //!

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -42,7 +42,7 @@ embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.5.0", features = ["esp32s2"] }
+esp-println        = { version = "0.5.0", features = ["esp32s2", "log"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }
@@ -75,6 +75,8 @@ psram     = []
 psram_2m  = ["esp-hal-common/psram_2m", "psram"]
 psram_4m  = ["esp-hal-common/psram_4m", "psram"]
 psram_8m  = ["esp-hal-common/psram_8m", "psram"]
+
+log = ["esp-hal-common/log"]
 
 [profile.release]
 debug = true

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -77,6 +77,7 @@ psram_4m  = ["esp-hal-common/psram_4m", "psram"]
 psram_8m  = ["esp-hal-common/psram_8m", "psram"]
 
 log = ["esp-hal-common/log"]
+defmt = ["esp-hal-common/defmt"]
 
 [profile.release]
 debug = true

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -40,9 +40,9 @@ embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
-esp-backtrace      = { version = "0.7.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
+esp-backtrace      = { version = "0.8.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.5.0", features = ["esp32s2", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32s2", "log"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -18,6 +18,7 @@
 //! - `embassy-executor-thread` - Use the thread-mode embassy executor
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
+//! - `log` - enable log output using the `log` crate
 //! - `psram_2m` - Use externally connected PSRAM (2MB)
 //! - `psram_4m` - Use externally connected PSRAM (4MB)
 //! - `psram_8m` - Use externally connected PSRAM (8MB)

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `async` - Enable support for asynchronous operation, with interfaces
 //!   provided by [embedded-hal-async] and [embedded-io-async]
 //! - `debug` - Enable debug features in the HAL (used for development)
+//! - `defmt` - Enable [`defmt::Format`] on certain types
 //! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
 //!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
 //! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
@@ -37,6 +38,7 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
 
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -14,6 +14,8 @@
 //!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
 //! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
 //!   framework
+//! - `embassy-executor-interrupt` - Use the interrupt-mode embassy executor
+//! - `embassy-executor-thread` - Use the thread-mode embassy executor
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
 //! - `psram_2m` - Use externally connected PSRAM (2MB)

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -79,6 +79,8 @@ opsram_2m  = ["esp-hal-common/opsram_2m", "psram"]
 opsram_4m  = ["esp-hal-common/opsram_4m", "psram"]
 opsram_8m  = ["esp-hal-common/opsram_8m", "psram"]
 
+log = ["esp-hal-common/log"]
+
 [profile.release]
 debug = true
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -80,6 +80,7 @@ opsram_4m  = ["esp-hal-common/opsram_4m", "psram"]
 opsram_8m  = ["esp-hal-common/opsram_8m", "psram"]
 
 log = ["esp-hal-common/log"]
+defmt = ["esp-hal-common/defmt"]
 
 [profile.release]
 debug = true

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -42,9 +42,9 @@ embedded-hal-async = "=1.0.0-rc.1"
 embedded-can       = "0.4.1"
 embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
-esp-backtrace      = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace      = { version = "0.8.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.4.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.5.0", features = ["esp32s3", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32s3", "log"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = { git = "https://github.com/jessebraham/lis3dh-rs-async", branch = "feature/eh-rc1" }

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -23,6 +23,7 @@
 //!   `SYSTIMER` peripheral
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
+//! - `log` - enable log output using the `log` crate
 //! - `opsram_2m` - Use externally connected Octal PSRAM (2MB)
 //! - `opsram_4m` - Use externally connected Octal PSRAM (4MB)
 //! - `opsram_8m` - Use externally connected Octal PSRAM (8MB)

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `async` - Enable support for asynchronous operation, with interfaces
 //!   provided by [embedded-hal-async] and [embedded-io-async]
 //! - `debug` - Enable debug features in the HAL (used for development)
+//! - `defmt` - Enable [`defmt::Format`] on certain types
 //! - `direct-boot` - Use the direct boot image format
 //! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
 //!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
@@ -45,6 +46,7 @@
 //! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
 //! [embassy]: https://github.com/embassy-rs/embassy
 //! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
+//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
 //!
 //! ### Supported Image Formats
 //!


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

Logging isn't particularly widely used in the HAL, but maybe defmt support may change that :)

PR is blocked on a new esp-println release