### PR TITLE
Create separate `CHANGELOG.md` files for `esp-riscv-rt` and `esp32c6-lp-hal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add the `esp32c6-lp-hal` package (#714)
-- Add GPIO (output) and delay functionality to `esp32c6-lp-hal` (#715)
 - Implement RTCIO pullup, pulldown and hold control for Xtensa MCUs (#684)
-- Add GPIO input support and implement additional `embedded-hal` output traits for the C6's LP core [#720]
 - S3: Implement RTCIO wakeup source (#690)
-- Add PARL_IO TX driver for ESP32-C6 / ESP32-H2 (#733)
+- Add PARL_IO driver for ESP32-C6 / ESP32-H2 (#733, #760)
 - Implement `ufmt_write::uWrite` trait for USB Serial JTAG (#751)
 - Add HMAC peripheral support (#755)
-- Add PARL_IO RX driver for ESP32-C6 / ESP32-H2 (#760)
 - Add multicore-aware embassy executor for Xtensa MCUs (#723, #756).
 - Add interrupt-executor for Xtensa MCUs (#723, #756).
 - Add missing `Into<Gpio<Analog, GPIONUN>>` conversion (#764)

--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fix RISCV stack-start (#721)
+
+### Removed
+
+## [0.4.0] - 2023-08-10
+
+## [0.3.0] - 2023-03-20
+
+## [0.2.0] - 2023-03-14
+
+## [0.1.0] - 2023-01-26
+
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/esp-rs/esp-hal/releases/tag/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/esp-rs/esp-hal/releases/tag/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/esp-rs/esp-hal/releases/tag/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/v0.1.0

--- a/esp32c6-lp-hal/CHANGELOG.md
+++ b/esp32c6-lp-hal/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add the `esp32c6-lp-hal` package (#714)
+- Add GPIO (output) and delay functionality to `esp32c6-lp-hal` (#715)
+- Add GPIO input support and implement additional `embedded-hal` output traits for the C6's LP core [#720]
+
+### Changed
+
+### Fixed
+
+### Removed
+
+[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/esp32c6-lp-hal


### PR DESCRIPTION
These packages do not depend on `esp-hal-common` like the other HAL packages, so they deserve their own `CHANGELOG.md` files.