### PR TITLE
Begin next release cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Please note that only changes to the `esp-hal-common` package are tracked in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
 ## [0.12.0]
 
 ### Added
@@ -202,6 +212,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2022-08-05
 
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/v0.12.0...HEAD
 [0.12.0]: https://github.com/esp-rs/esp-hal/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/esp-rs/esp-hal/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/esp-rs/esp-hal/compare/v0.9.0...v0.10.0

--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0]
+## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## 0.5.0
 
 ### Changed
 
@@ -15,16 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix RISCV stack-start (#721)
 
-## [0.4.0] - 2023-08-10
+## 0.4.0 - 2023-08-10
 
-## [0.3.0] - 2023-03-20
+## 0.3.0 - 2023-03-20
 
-## [0.2.0] - 2023-03-14
+## 0.2.0 - 2023-03-14
 
-## [0.1.0] - 2023-01-26
-
-[0.5.0]: https://github.com/esp-rs/esp-hal/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/esp-rs/esp-hal/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/esp-rs/esp-hal/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/esp-rs/esp-hal/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/v0.1.0
+## 0.1.0 - 2023-01-26


### PR DESCRIPTION
Just updates the `CHANGELOG.md` files. Also removed the tag links for `esp-riscv-rt` since we're not currently tagging for that package, can replace them if this ever changes in the future.