### PR TITLE
Async RMT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implement enabling/disabling BLE clock on ESP32-C6 (#784)
+- Async support for RMT (#787)
 
 ### Changed
 

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -24,6 +24,8 @@ proc-macro-error = "1.0.4"
 proc-macro2      = "1.0.66"
 quote            = "1.0.33"
 syn              = {version = "2.0.31", features = ["extra-traits", "full"]}
+# toml_edit is a dependency of proc-macro-crate. Unfortunately they raised their MSRV on 0.19.15 so we pin the version for now
+toml_edit        = "=0.19.14"
 
 [features]
 esp32     = []

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -121,3 +121,11 @@ required-features = ["embassy", "embassy-executor-thread", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "embassy-executor-thread", "async"]
+
+[[example]]
+name              = "embassy_rmt_tx"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_rmt_rx"
+required-features = ["embassy", "async"]

--- a/esp32-hal/examples/embassy_rmt_rx.rs
+++ b/esp32-hal/examples/embassy_rmt_rx.rs
@@ -1,0 +1,136 @@
+//! Demonstrates decoding pulse sequences with RMT
+//! Connect GPIO15 to GPIO4
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_time::{Duration, Timer};
+use esp32_hal::{
+    clock::ClockControl,
+    embassy::{self, executor::Executor},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use esp_hal_common::gpio::{Gpio15, Output, PushPull};
+use esp_println::{print, println};
+use static_cell::make_static;
+
+const WIDTH: usize = 80;
+
+#[cfg(debug_assertions)]
+compile_error!("Run this example in release mode");
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel2<2>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 1,
+        level2: false,
+        length2: 1,
+    }; 48];
+
+    loop {
+        println!("receive");
+        channel.receive(&mut data).await.unwrap();
+        let mut total = 0usize;
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+            total += entry.length1 as usize;
+
+            if entry.length2 == 0 {
+                break;
+            }
+            total += entry.length2 as usize;
+        }
+
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length1 as usize);
+            let c = if entry.level1 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+
+            if entry.length2 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length2 as usize);
+            let c = if entry.level2 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+        }
+
+        println!();
+    }
+}
+
+#[embassy_executor::task]
+async fn signal_task(mut pin: Gpio15<Output<PushPull>>) {
+    loop {
+        for _ in 0..10 {
+            pin.toggle().unwrap();
+            Timer::after(Duration::from_micros(10)).await;
+        }
+        Timer::after(Duration::from_millis(1000)).await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 =
+            esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio4,
+            RxChannelConfig {
+                clk_divider: 1,
+                idle_threshold: 0b111_1111_1111_1111,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32_hal::interrupt::enable(
+        esp32_hal::peripherals::Interrupt::RMT,
+        esp32_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+        spawner
+            .spawn(signal_task(io.pins.gpio15.into_push_pull_output()))
+            .ok();
+    });
+}

--- a/esp32-hal/examples/embassy_rmt_tx.rs
+++ b/esp32-hal/examples/embassy_rmt_tx.rs
@@ -1,0 +1,88 @@
+//! Demonstrates generating pulse sequences with RMT
+//! Connect a logic analyzer to GPIO4 to see the generated pulses.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_time::{Duration, Timer};
+use esp32_hal::{
+    clock::ClockControl,
+    embassy::{self, executor::Executor},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use static_cell::make_static;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel0<0>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 200,
+        level2: false,
+        length2: 50,
+    }; 20];
+
+    data[data.len() - 2] = PulseCode {
+        level1: true,
+        length1: 3000,
+        level2: false,
+        length2: 500,
+    };
+    data[data.len() - 1] = PulseCode::default();
+
+    loop {
+        esp_println::println!("transmit");
+        channel.transmit(&data).await.unwrap();
+        esp_println::println!("transmitted\n");
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.DPORT.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 =
+            esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio4.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32_hal::interrupt::enable(
+        esp32_hal::peripherals::Interrupt::RMT,
+        esp32_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -107,5 +107,13 @@ name              = "embassy_i2c"
 required-features = ["embassy", "async"]
 
 [[example]]
+name              = "embassy_rmt_tx"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_rmt_rx"
+required-features = ["embassy", "async"]
+
+[[example]]
 name = "direct-vectoring"
 required-features = ["direct-vectoring"]

--- a/esp32c3-hal/examples/embassy_rmt_rx.rs
+++ b/esp32c3-hal/examples/embassy_rmt_rx.rs
@@ -1,0 +1,126 @@
+//! Demonstrates decoding pulse sequences with RMT
+//! This uses the boot button as input - press the button a couple of
+//! times to generate a pulse sequence and then wait for the idle timeout to see
+//! the recorded pulse sequence
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use esp32c3_hal::{
+    clock::ClockControl,
+    embassy::{self},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+use static_cell::make_static;
+
+const WIDTH: usize = 80;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel2<2>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 1,
+        level2: false,
+        length2: 1,
+    }; 48];
+
+    loop {
+        println!("receive");
+        channel.receive(&mut data).await.unwrap();
+        println!("received");
+        let mut total = 0usize;
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+            total += entry.length1 as usize;
+
+            if entry.length2 == 0 {
+                break;
+            }
+            total += entry.length2 as usize;
+        }
+
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length1 as usize);
+            let c = if entry.level1 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+
+            if entry.length2 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length2 as usize);
+            let c = if entry.level2 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+        }
+
+        println!();
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio9,
+            RxChannelConfig {
+                clk_divider: 255,
+                idle_threshold: 10000,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32c3_hal::interrupt::enable(
+        esp32c3_hal::peripherals::Interrupt::RMT,
+        esp32c3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32c3-hal/examples/embassy_rmt_tx.rs
+++ b/esp32c3-hal/examples/embassy_rmt_tx.rs
@@ -1,0 +1,94 @@
+//! Demonstrates generating pulse sequences with RMT
+//! Connect a logic analyzer to GPIO1 to see the generated pulses.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32c3_hal::{
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use static_cell::make_static;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel0<0>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 200,
+        level2: false,
+        length2: 50,
+    }; 20];
+
+    data[data.len() - 2] = PulseCode {
+        level1: true,
+        length1: 3000,
+        level2: false,
+        length2: 500,
+    };
+    data[data.len() - 1] = PulseCode::default();
+
+    loop {
+        esp_println::println!("transmit");
+        channel.transmit(&data).await.unwrap();
+        esp_println::println!("transmitted\n");
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio1.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32c3_hal::interrupt::enable(
+        esp32c3_hal::peripherals::Interrupt::RMT,
+        esp32c3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -107,3 +107,11 @@ required-features = ["embassy", "async"]
 [[example]]
 name    = "direct-vectoring"
 required-features = ["direct-vectoring"]
+
+[[example]]
+name              = "embassy_rmt_tx"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_rmt_rx"
+required-features = ["embassy", "async"]

--- a/esp32c6-hal/examples/embassy_rmt_rx.rs
+++ b/esp32c6-hal/examples/embassy_rmt_rx.rs
@@ -1,0 +1,126 @@
+//! Demonstrates decoding pulse sequences with RMT
+//! This uses the boot button as input - press the button a couple of
+//! times to generate a pulse sequence and then wait for the idle timeout to see
+//! the recorded pulse sequence
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use esp32c6_hal::{
+    clock::ClockControl,
+    embassy::{self},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+use static_cell::make_static;
+
+const WIDTH: usize = 80;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel2<2>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 1,
+        level2: false,
+        length2: 1,
+    }; 48];
+
+    loop {
+        println!("receive");
+        channel.receive(&mut data).await.unwrap();
+        println!("received");
+        let mut total = 0usize;
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+            total += entry.length1 as usize;
+
+            if entry.length2 == 0 {
+                break;
+            }
+            total += entry.length2 as usize;
+        }
+
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length1 as usize);
+            let c = if entry.level1 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+
+            if entry.length2 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length2 as usize);
+            let c = if entry.level2 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+        }
+
+        println!();
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio9,
+            RxChannelConfig {
+                clk_divider: 255,
+                idle_threshold: 10000,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32c6_hal::interrupt::enable(
+        esp32c6_hal::peripherals::Interrupt::RMT,
+        esp32c6_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32c6-hal/examples/embassy_rmt_tx.rs
+++ b/esp32c6-hal/examples/embassy_rmt_tx.rs
@@ -1,0 +1,94 @@
+//! Demonstrates generating pulse sequences with RMT
+//! Connect a logic analyzer to GPIO1 to see the generated pulses.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32c6_hal::{
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use static_cell::make_static;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel0<0>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 200,
+        level2: false,
+        length2: 50,
+    }; 20];
+
+    data[data.len() - 2] = PulseCode {
+        level1: true,
+        length1: 3000,
+        level2: false,
+        length2: 500,
+    };
+    data[data.len() - 1] = PulseCode::default();
+
+    loop {
+        esp_println::println!("transmit");
+        channel.transmit(&data).await.unwrap();
+        esp_println::println!("transmitted\n");
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio1.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32c6_hal::interrupt::enable(
+        esp32c6_hal::peripherals::Interrupt::RMT,
+        esp32c6_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -101,6 +101,14 @@ name              = "embassy_wait"
 required-features = ["async", "embassy"]
 
 [[example]]
+name              = "embassy_rmt_tx"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_rmt_rx"
+required-features = ["embassy", "async"]
+
+[[example]]
 name              = "interrupt_preemption"
 required-features = ["interrupt-preemption"]
 

--- a/esp32h2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32h2-hal/examples/embassy_rmt_rx.rs
@@ -1,0 +1,126 @@
+//! Demonstrates decoding pulse sequences with RMT
+//! This uses the boot button as input - press the button a couple of
+//! times to generate a pulse sequence and then wait for the idle timeout to see
+//! the recorded pulse sequence
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use esp32h2_hal::{
+    clock::ClockControl,
+    embassy::{self},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+use static_cell::make_static;
+
+const WIDTH: usize = 80;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel2<2>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 1,
+        level2: false,
+        length2: 1,
+    }; 48];
+
+    loop {
+        println!("receive");
+        channel.receive(&mut data).await.unwrap();
+        println!("received");
+        let mut total = 0usize;
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+            total += entry.length1 as usize;
+
+            if entry.length2 == 0 {
+                break;
+            }
+            total += entry.length2 as usize;
+        }
+
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length1 as usize);
+            let c = if entry.level1 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+
+            if entry.length2 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length2 as usize);
+            let c = if entry.level2 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+        }
+
+        println!();
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32h2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio9,
+            RxChannelConfig {
+                clk_divider: 255,
+                idle_threshold: 10000,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32h2_hal::interrupt::enable(
+        esp32h2_hal::peripherals::Interrupt::RMT,
+        esp32h2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32h2-hal/examples/embassy_rmt_tx.rs
+++ b/esp32h2-hal/examples/embassy_rmt_tx.rs
@@ -1,0 +1,94 @@
+//! Demonstrates generating pulse sequences with RMT
+//! Connect a logic analyzer to GPIO1 to see the generated pulses.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Timer};
+use esp32h2_hal::{
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use static_cell::make_static;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel0<0>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 200,
+        level2: false,
+        length2: 50,
+    }; 20];
+
+    data[data.len() - 2] = PulseCode {
+        level1: true,
+        length1: 3000,
+        level2: false,
+        length2: 500,
+    };
+    data[data.len() - 1] = PulseCode::default();
+
+    loop {
+        esp_println::println!("transmit");
+        channel.transmit(&data).await.unwrap();
+        esp_println::println!("transmitted\n");
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.PCR.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32h2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio1.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32h2_hal::interrupt::enable(
+        esp32h2_hal::peripherals::Interrupt::RMT,
+        esp32h2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -118,3 +118,11 @@ required-features = ["embassy", "embassy-executor-thread", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "embassy-executor-thread", "async"]
+
+[[example]]
+name              = "embassy_rmt_tx"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_rmt_rx"
+required-features = ["embassy", "async"]

--- a/esp32s2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_rx.rs
@@ -1,0 +1,137 @@
+//! Demonstrates decoding pulse sequences with RMT
+//! Connect GPIO15 to GPIO4
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_time::{Duration, Timer};
+use esp32s2_hal::{
+    clock::ClockControl,
+    embassy::{self, executor::Executor},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use esp_hal_common::gpio::{Gpio15, Output, PushPull};
+use esp_println::{print, println};
+use static_cell::make_static;
+use xtensa_atomic_emulation_trap as _;
+
+const WIDTH: usize = 80;
+
+#[cfg(debug_assertions)]
+compile_error!("Run this example in release mode");
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel2<2>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 1,
+        level2: false,
+        length2: 1,
+    }; 48];
+
+    loop {
+        println!("receive");
+        channel.receive(&mut data).await.unwrap();
+        let mut total = 0usize;
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+            total += entry.length1 as usize;
+
+            if entry.length2 == 0 {
+                break;
+            }
+            total += entry.length2 as usize;
+        }
+
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length1 as usize);
+            let c = if entry.level1 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+
+            if entry.length2 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length2 as usize);
+            let c = if entry.level2 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+        }
+
+        println!();
+    }
+}
+
+#[embassy_executor::task]
+async fn signal_task(mut pin: Gpio15<Output<PushPull>>) {
+    loop {
+        for _ in 0..10 {
+            pin.toggle().unwrap();
+            Timer::after(Duration::from_micros(10)).await;
+        }
+        Timer::after(Duration::from_millis(1000)).await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 =
+            esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio4,
+            RxChannelConfig {
+                clk_divider: 1,
+                idle_threshold: 0b111_1111_1111_1111,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32s2_hal::interrupt::enable(
+        esp32s2_hal::peripherals::Interrupt::RMT,
+        esp32s2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+        spawner
+            .spawn(signal_task(io.pins.gpio15.into_push_pull_output()))
+            .ok();
+    });
+}

--- a/esp32s2-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_tx.rs
@@ -1,0 +1,89 @@
+//! Demonstrates generating pulse sequences with RMT
+//! Connect a logic analyzer to GPIO4 to see the generated pulses.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_time::{Duration, Timer};
+use esp32s2_hal::{
+    clock::ClockControl,
+    embassy::{self, executor::Executor},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use static_cell::make_static;
+use xtensa_atomic_emulation_trap as _;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel0<0>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 200,
+        level2: false,
+        length2: 50,
+    }; 20];
+
+    data[data.len() - 2] = PulseCode {
+        level1: true,
+        length1: 3000,
+        level2: false,
+        length2: 500,
+    };
+    data[data.len() - 1] = PulseCode::default();
+
+    loop {
+        esp_println::println!("transmit");
+        channel.transmit(&data).await.unwrap();
+        esp_println::println!("transmitted\n");
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 =
+            esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio4.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32s2_hal::interrupt::enable(
+        esp32s2_hal::peripherals::Interrupt::RMT,
+        esp32s2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -135,3 +135,11 @@ required-features = ["embassy", "embassy-executor-thread", "async"]
 [[example]]
 name              = "embassy_i2c"
 required-features = ["embassy", "embassy-executor-thread", "async"]
+
+[[example]]
+name              = "embassy_rmt_tx"
+required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_rmt_rx"
+required-features = ["embassy", "async"]

--- a/esp32s3-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s3-hal/examples/embassy_rmt_rx.rs
@@ -1,0 +1,126 @@
+//! Demonstrates decoding pulse sequences with RMT
+//! This uses the boot button as input - press the button a couple of
+//! times to generate a pulse sequence and then wait for the idle timeout to see
+//! the recorded pulse sequence
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    embassy::{self, executor::Executor},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::RxChannelAsync, Channel4, PulseCode, RxChannelConfig, RxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use esp_println::{print, println};
+use static_cell::make_static;
+
+const WIDTH: usize = 80;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel4<4>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 1,
+        level2: false,
+        length2: 1,
+    }; 48];
+
+    loop {
+        println!("receive");
+        channel.receive(&mut data).await.unwrap();
+        println!("received");
+        let mut total = 0usize;
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+            total += entry.length1 as usize;
+
+            if entry.length2 == 0 {
+                break;
+            }
+            total += entry.length2 as usize;
+        }
+
+        for entry in &data[..data.len()] {
+            if entry.length1 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length1 as usize);
+            let c = if entry.level1 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+
+            if entry.length2 == 0 {
+                break;
+            }
+
+            let count = WIDTH / (total / entry.length2 as usize);
+            let c = if entry.level2 { '-' } else { '_' };
+            for _ in 0..count + 1 {
+                print!("{}", c);
+            }
+        }
+
+        println!();
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 =
+            esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel4
+        .configure(
+            io.pins.gpio0,
+            RxChannelConfig {
+                clk_divider: 255,
+                idle_threshold: 10000,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32s3_hal::interrupt::enable(
+        esp32s3_hal::peripherals::Interrupt::RMT,
+        esp32s3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}

--- a/esp32s3-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s3-hal/examples/embassy_rmt_tx.rs
@@ -1,0 +1,93 @@
+//! Demonstrates generating pulse sequences with RMT
+//! Connect a logic analyzer to GPIO1 to see the generated pulses.
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_time::{Duration, Timer};
+use esp32s3_hal::{
+    clock::ClockControl,
+    embassy::{self, executor::Executor},
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    Rmt,
+    IO,
+};
+use esp_backtrace as _;
+use static_cell::make_static;
+
+#[embassy_executor::task]
+async fn rmt_task(mut channel: Channel0<0>) {
+    let mut data = [PulseCode {
+        level1: true,
+        length1: 200,
+        level2: false,
+        length2: 50,
+    }; 20];
+
+    data[data.len() - 2] = PulseCode {
+        level1: true,
+        length1: 3000,
+        level2: false,
+        length2: 500,
+    };
+    data[data.len() - 1] = PulseCode::default();
+
+    loop {
+        esp_println::println!("transmit");
+        channel.transmit(&data).await.unwrap();
+        esp_println::println!("transmitted\n");
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let mut clock_control = system.peripheral_clock_control;
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+
+    let channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio1.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32s3_hal::interrupt::enable(
+        esp32s3_hal::peripherals::Interrupt::RMT,
+        esp32s3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let executor = make_static!(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(rmt_task(channel)).ok();
+    });
+}


### PR DESCRIPTION
This adds async support for RMT. For now, it doesn't support wrap-mode - if we want that we should add that in a separate PR

It also fixes general RMT-RX (was broken after some refactorings)

It was necessary to pin `toml_edit` (transitive dependency) because they bumped their MSRV in 0.19.15

Once we agree on 1.66.0 as the MSRV we can unpin / remove the dependency