### PR TITLE
Adding `async`  support for `RSA` peripheral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `defmt` feature to enable log output (#773)
 - A new macro to load LP core code on ESP32-C6 (#779)
 - Add `ECC`` peripheral driver (#785)
-- Adding async support for RSA peripheral (#790)
+- Adding async support for RSA peripheral(doesn't work properly for `esp32` chip - issue will be created)(#790)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `defmt` feature to enable log output (#773)
 - A new macro to load LP core code on ESP32-C6 (#779)
 - Add `ECC`` peripheral driver (#785)
+- Adding async support for RSA peripheral (#790)
 
 ### Changed
 

--- a/esp-hal-common/src/rsa/esp32.rs
+++ b/esp-hal-common/src/rsa/esp32.rs
@@ -139,6 +139,20 @@ where
         Ok(())
     }
 
+    #[cfg(feature = "async")]
+    pub async fn start_step2_async(&mut self, operand_b: &T::InputType) {
+        loop {
+            if self.rsa.is_idle() {
+                self.rsa.clear_interrupt();
+                unsafe {
+                    self.rsa.write_operand_a(operand_b);
+                }
+                self.set_start();
+                break;
+            }
+        }
+    }
+
     fn set_start(&mut self) {
         self.rsa.write_multi_start();
     }

--- a/esp-hal-common/src/rsa/esp32.rs
+++ b/esp-hal-common/src/rsa/esp32.rs
@@ -127,20 +127,7 @@ where
     /// This is a non blocking function that returns without an error if
     /// operation is completed successfully. `start_step1` must be called
     /// before calling this function.
-    pub fn start_step2(&mut self, operand_b: &T::InputType) -> nb::Result<(), Infallible> {
-        if !self.rsa.is_idle() {
-            return Err(nb::Error::WouldBlock);
-        }
-        self.rsa.clear_interrupt();
-        unsafe {
-            self.rsa.write_operand_a(operand_b);
-        }
-        self.set_start();
-        Ok(())
-    }
-
-    #[cfg(feature = "async")]
-    pub async fn start_step2_async(&mut self, operand_b: &T::InputType) {
+    pub fn start_step2(&mut self, operand_b: &T::InputType) {
         loop {
             if self.rsa.is_idle() {
                 self.rsa.clear_interrupt();

--- a/esp-hal-common/src/rsa/mod.rs
+++ b/esp-hal-common/src/rsa/mod.rs
@@ -51,8 +51,6 @@ use crate::{
 #[cfg_attr(esp32, path = "esp32.rs")]
 mod rsa_spec_impl;
 
-#[cfg(feature = "async")]
-use nb::block;
 pub use rsa_spec_impl::operand_sizes;
 
 /// RSA peripheral container
@@ -266,11 +264,6 @@ where
     }
 
     #[cfg(feature = "async")]
-    pub(crate) fn inner(&self) -> &RSA {
-        &self.rsa.rsa
-    }
-
-    #[cfg(feature = "async")]
     pub async fn async_exponentiation(
         &mut self,
         base: &T::InputType,
@@ -278,8 +271,8 @@ where
         outbuf: &mut T::InputType,
     ) {
         self.start_exponentiation(&base, &r);
-        asynch::RsaFuture::new(self.inner());
-        block!(self.read_results(outbuf)).unwrap();
+        asynch::RsaFuture::new(&self.rsa.rsa);
+        nb::block!(self.read_results(outbuf)).unwrap();
     }
 }
 
@@ -311,11 +304,6 @@ where
     }
 
     #[cfg(feature = "async")]
-    pub(crate) fn inner(&self) -> &RSA {
-        &self.rsa.rsa
-    }
-
-    #[cfg(feature = "async")]
     #[cfg(not(esp32))]
     pub async fn async_modular_multiplication(
         &mut self,
@@ -324,9 +312,9 @@ where
     ) {
         self.start_modular_multiplication(r);
 
-        asynch::RsaFuture::new(self.inner());
+        asynch::RsaFuture::new(&self.rsa.rsa);
 
-        block!(self.read_results(outbuf)).unwrap();
+        nb::block!(self.read_results(outbuf)).unwrap();
     }
 
     #[cfg(feature = "async")]
@@ -339,9 +327,9 @@ where
         outbuf: &mut T::InputType,
     ) {
         self.start_step1(operand_a, r);
-        block!(self.start_step2(operand_b)).unwrap();
-        asynch::RsaFuture::new(self.inner());
-        block!(self.read_results(outbuf)).unwrap();
+        nb::block!(self.start_step2(operand_b)).unwrap();
+        asynch::RsaFuture::new(&self.rsa.rsa);
+        nb::block!(self.read_results(outbuf)).unwrap();
     }
 }
 
@@ -380,11 +368,6 @@ where
     }
 
     #[cfg(feature = "async")]
-    pub(crate) fn inner(&self) -> &RSA {
-        &self.rsa.rsa
-    }
-
-    #[cfg(feature = "async")]
     #[cfg(not(esp32))]
     pub async fn async_multiplication<'b, const O: usize>(
         &mut self,
@@ -395,9 +378,9 @@ where
     {
         self.start_multiplication(operand_b);
 
-        asynch::RsaFuture::new(self.inner());
+        asynch::RsaFuture::new(&self.rsa.rsa);
 
-        block!(self.read_results(outbuf)).unwrap();
+        nb::block!(self.read_results(outbuf)).unwrap();
     }
 
     #[cfg(feature = "async")]
@@ -412,8 +395,8 @@ where
     {
         self.start_multiplication(operand_a, operand_b);
 
-        asynch::RsaFuture::new(self.inner());
+        asynch::RsaFuture::new(&self.rsa.rsa);
 
-        block!(self.read_results(outbuf)).unwrap();
+        nb::block!(self.read_results(outbuf)).unwrap();
     }
 }

--- a/esp-hal-common/src/rsa/mod.rs
+++ b/esp-hal-common/src/rsa/mod.rs
@@ -271,7 +271,7 @@ where
         outbuf: &mut T::InputType,
     ) {
         self.start_exponentiation(&base, &r);
-        asynch::RsaFuture::new(&self.rsa.rsa);
+        asynch::RsaFuture::new(&self.rsa.rsa).await;
         nb::block!(self.read_results(outbuf)).unwrap();
     }
 }
@@ -312,7 +312,7 @@ where
     ) {
         self.start_modular_multiplication(r);
 
-        asynch::RsaFuture::new(&self.rsa.rsa);
+        asynch::RsaFuture::new(&self.rsa.rsa).await;
 
         nb::block!(self.read_results(outbuf)).unwrap();
     }
@@ -328,7 +328,7 @@ where
     ) {
         self.start_step1(operand_a, r);
         nb::block!(self.start_step2(operand_b)).unwrap();
-        asynch::RsaFuture::new(&self.rsa.rsa);
+        asynch::RsaFuture::new(&self.rsa.rsa).await;
         nb::block!(self.read_results(outbuf)).unwrap();
     }
 }
@@ -378,7 +378,7 @@ where
     {
         self.start_multiplication(operand_b);
 
-        asynch::RsaFuture::new(&self.rsa.rsa);
+        asynch::RsaFuture::new(&self.rsa.rsa).await;
 
         nb::block!(self.read_results(outbuf)).unwrap();
     }
@@ -395,7 +395,7 @@ where
     {
         self.start_multiplication(operand_a, operand_b);
 
-        asynch::RsaFuture::new(&self.rsa.rsa);
+        asynch::RsaFuture::new(&self.rsa.rsa).await;
 
         nb::block!(self.read_results(outbuf)).unwrap();
     }

--- a/esp-hal-common/src/rsa/mod.rs
+++ b/esp-hal-common/src/rsa/mod.rs
@@ -264,7 +264,7 @@ where
     }
 
     #[cfg(feature = "async")]
-    pub async fn read_async(&mut self, outbuf: &mut T::InputType) {
+    pub async fn read(&mut self, outbuf: &mut T::InputType) {
         loop {
             if self.rsa.is_idle() {
                 unsafe {
@@ -277,7 +277,7 @@ where
     }
 
     #[cfg(feature = "async")]
-    pub async fn async_exponentiation(
+    pub async fn exponentiation(
         &mut self,
         base: &T::InputType,
         r: &T::InputType,
@@ -285,7 +285,7 @@ where
     ) {
         self.start_exponentiation(&base, &r);
         asynch::RsaFuture::new(&self.rsa.rsa).await;
-        self.read_async(outbuf).await;
+        self.read(outbuf).await;
     }
 }
 
@@ -317,7 +317,7 @@ where
     }
 
     #[cfg(feature = "async")]
-    pub async fn read_async(&mut self, outbuf: &mut T::InputType) {
+    pub async fn read(&mut self, outbuf: &mut T::InputType) {
         loop {
             if self.rsa.is_idle() {
                 unsafe {
@@ -331,19 +331,15 @@ where
 
     #[cfg(feature = "async")]
     #[cfg(not(esp32))]
-    pub async fn async_modular_multiplication(
-        &mut self,
-        r: &T::InputType,
-        outbuf: &mut T::InputType,
-    ) {
+    pub async fn modular_multiplication(&mut self, r: &T::InputType, outbuf: &mut T::InputType) {
         self.start_modular_multiplication(r);
         asynch::RsaFuture::new(&self.rsa.rsa).await;
-        self.read_async(outbuf).await;
+        self.read(outbuf).await;
     }
 
     #[cfg(feature = "async")]
     #[cfg(esp32)]
-    pub async fn async_modular_multiplication(
+    pub async fn modular_multiplication(
         &mut self,
         operand_a: &T::InputType,
         operand_b: &T::InputType,
@@ -351,9 +347,9 @@ where
         outbuf: &mut T::InputType,
     ) {
         self.start_step1(operand_a, r);
-        self.start_step2_async(operand_b).await;
+        self.start_step2(operand_b);
         asynch::RsaFuture::new(&self.rsa.rsa).await;
-        self.read_async(outbuf).await;
+        self.read(outbuf).await;
     }
 }
 
@@ -392,7 +388,7 @@ where
     }
 
     #[cfg(feature = "async")]
-    pub async fn read_async<'b, const O: usize>(&mut self, outbuf: &mut T::OutputType)
+    pub async fn read<'b, const O: usize>(&mut self, outbuf: &mut T::OutputType)
     where
         T: Multi<OutputType = [u8; O]>,
     {
@@ -409,7 +405,7 @@ where
 
     #[cfg(feature = "async")]
     #[cfg(not(esp32))]
-    pub async fn async_multiplication<'b, const O: usize>(
+    pub async fn multiplication<'b, const O: usize>(
         &mut self,
         operand_b: &T::InputType,
         outbuf: &mut T::OutputType,
@@ -418,12 +414,12 @@ where
     {
         self.start_multiplication(operand_b);
         asynch::RsaFuture::new(&self.rsa.rsa).await;
-        self.read_async(outbuf).await;
+        self.read(outbuf).await;
     }
 
     #[cfg(feature = "async")]
     #[cfg(esp32)]
-    pub async fn async_multiplication<'b, const O: usize>(
+    pub async fn multiplication<'b, const O: usize>(
         &mut self,
         operand_a: &T::InputType,
         operand_b: &T::InputType,
@@ -433,6 +429,6 @@ where
     {
         self.start_multiplication(operand_a, operand_b);
         asynch::RsaFuture::new(&self.rsa.rsa).await;
-        self.read_async(outbuf).await;
+        self.read(outbuf).await;
     }
 }

--- a/esp-hal-common/src/rsa/mod.rs
+++ b/esp-hal-common/src/rsa/mod.rs
@@ -27,6 +27,31 @@
 //!
 //! let mut rsa = Rsa::new(peripherals.RSA);
 //! ```
+//!  
+//! ### Async (modular exponentiation)
+//! ```no_run
+//! #[embassy_executor::task]
+//! async fn mod_exp_example(mut rsa: Rsa<'static>) {
+//!     let mut outbuf = [0_u8; U512::BYTES];
+//!     let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op512>::new(
+//!         &mut rsa,
+//!         &BIGNUM_2.to_le_bytes(),
+//!         &BIGNUM_3.to_le_bytes(),
+//!         compute_mprime(&BIGNUM_3),
+//!     );
+//!     let r = compute_r(&BIGNUM_3).to_le_bytes();
+//!     let base = &BIGNUM_1.to_le_bytes();
+//!     mod_exp.exponentiation(&base, &r, &mut outbuf).await;
+//!     let residue_params = DynResidueParams::new(&BIGNUM_3);
+//!     let residue = DynResidue::new(&BIGNUM_1, residue_params);
+//!     let sw_out = residue.pow(&BIGNUM_2);
+//!     assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+//!     println!("modular exponentiation done");
+//! }
+//! ```
+
+//! This peripheral supports `async` on every available chip except of `esp32`
+//! (to be solved).
 //!
 //! ⚠️: The examples for RSA peripheral are quite extensive, so for a more
 //! detailed study of how to use this driver please visit [the repository

--- a/esp32-hal/examples/rsa.rs
+++ b/esp32-hal/examples/rsa.rs
@@ -78,7 +78,7 @@ fn mod_multi_example(rsa: &mut Rsa) {
     let r = compute_r(&BIGNUM_3).to_le_bytes();
     let pre_hw_modmul = xtensa_lx::timer::get_cycle_count();
     mod_multi.start_step1(&BIGNUM_1.to_le_bytes(), &r);
-    block!(mod_multi.start_step2(&BIGNUM_2.to_le_bytes())).unwrap();
+    mod_multi.start_step2(&BIGNUM_2.to_le_bytes());
     block!(mod_multi.read_results(&mut outbuf)).unwrap();
     let post_hw_modmul = xtensa_lx::timer::get_cycle_count();
     println!(

--- a/esp32-hal/examples/rsa.rs
+++ b/esp32-hal/examples/rsa.rs
@@ -26,7 +26,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use nb::block;
 
 const BIGNUM_1: U512 = Uint::from_be_hex(
     "c7f61058f96db3bd87dbab08ab03b4f7f2f864eac249144adea6a65f97803b719d8ca980b7b3c0389c1c7c6\
@@ -61,7 +60,7 @@ fn main() -> ! {
 
     let rsa = peripherals.RSA;
     let mut rsa = Rsa::new(rsa);
-    block!(rsa.ready()).unwrap();
+    nb::block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);
     mod_multi_example(&mut rsa);
     multiplication_example(&mut rsa);
@@ -79,7 +78,7 @@ fn mod_multi_example(rsa: &mut Rsa) {
     let pre_hw_modmul = xtensa_lx::timer::get_cycle_count();
     mod_multi.start_step1(&BIGNUM_1.to_le_bytes(), &r);
     mod_multi.start_step2(&BIGNUM_2.to_le_bytes());
-    block!(mod_multi.read_results(&mut outbuf)).unwrap();
+    mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw modular multiplication",
@@ -112,7 +111,7 @@ fn mod_exp_example(rsa: &mut Rsa) {
     let base = &BIGNUM_1.to_le_bytes();
     let pre_hw_exp = xtensa_lx::timer::get_cycle_count();
     mod_exp.start_exponentiation(base, &r);
-    block!(mod_exp.read_results(&mut outbuf)).unwrap();
+    mod_exp.read_results(&mut outbuf);
     let post_hw_exp = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw modular exponentiation",
@@ -138,7 +137,7 @@ fn multiplication_example(rsa: &mut Rsa) {
     let operand_b = &BIGNUM_2.to_le_bytes();
     let pre_hw_mul = xtensa_lx::timer::get_cycle_count();
     rsamulti.start_multiplication(&operand_a, &operand_b);
-    block!(rsamulti.read_results(&mut out)).unwrap();
+    rsamulti.read_results(&mut out);
     let post_hw_mul = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw multiplication",

--- a/esp32c3-hal/examples/rsa.rs
+++ b/esp32c3-hal/examples/rsa.rs
@@ -26,7 +26,6 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use nb::block;
 
 const BIGNUM_1: U512 = Uint::from_be_hex(
     "c7f61058f96db3bd87dbab08ab03b4f7f2f864eac249144adea6a65f97803b719d8ca980b7b3c0389c1c7c6\
@@ -61,7 +60,7 @@ fn main() -> ! {
 
     let mut rsa = Rsa::new(peripherals.RSA);
 
-    block!(rsa.ready()).unwrap();
+    nb::block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);
     mod_multi_example(&mut rsa);
     multiplication_example(&mut rsa);
@@ -80,7 +79,7 @@ fn mod_multi_example(rsa: &mut Rsa) {
     let r = compute_r(&BIGNUM_3).to_le_bytes();
     let pre_hw_modmul = SystemTimer::now();
     mod_multi.start_modular_multiplication(&r);
-    block!(mod_multi.read_results(&mut outbuf)).unwrap();
+    mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = SystemTimer::now();
     println!(
         "it took {} cycles for hw modular multiplication",
@@ -114,7 +113,7 @@ fn mod_exp_example(rsa: &mut Rsa) {
     let base = &BIGNUM_1.to_le_bytes();
     let pre_hw_exp = SystemTimer::now();
     mod_exp.start_exponentiation(&base, &r);
-    block!(mod_exp.read_results(&mut outbuf)).unwrap();
+    mod_exp.read_results(&mut outbuf);
     let post_hw_exp = SystemTimer::now();
     println!(
         "it took {} cycles for hw modular exponentiation",
@@ -140,7 +139,7 @@ fn multiplication_example(rsa: &mut Rsa) {
     let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
     let pre_hw_mul = SystemTimer::now();
     rsamulti.start_multiplication(&operand_b);
-    block!(rsamulti.read_results(&mut out)).unwrap();
+    rsamulti.read_results(&mut out);
     let post_hw_mul = SystemTimer::now();
     println!(
         "it took {} cycles for hw multiplication",

--- a/esp32c6-hal/examples/rsa.rs
+++ b/esp32c6-hal/examples/rsa.rs
@@ -26,7 +26,6 @@ use esp32c6_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use nb::block;
 
 const BIGNUM_1: U512 = Uint::from_be_hex(
     "c7f61058f96db3bd87dbab08ab03b4f7f2f864eac249144adea6a65f97803b719d8ca980b7b3c0389c1c7c6\
@@ -61,7 +60,7 @@ fn main() -> ! {
 
     let mut rsa = Rsa::new(peripherals.RSA);
 
-    block!(rsa.ready()).unwrap();
+    nb::block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);
     mod_multi_example(&mut rsa);
     multiplication_example(&mut rsa);
@@ -80,7 +79,7 @@ fn mod_multi_example(rsa: &mut Rsa) {
     let r = compute_r(&BIGNUM_3).to_le_bytes();
     let pre_hw_modmul = SystemTimer::now();
     mod_multi.start_modular_multiplication(&r);
-    block!(mod_multi.read_results(&mut outbuf)).unwrap();
+    mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = SystemTimer::now();
     println!(
         "it took {} cycles for hw modular multiplication",
@@ -114,7 +113,7 @@ fn mod_exp_example(rsa: &mut Rsa) {
     let base = &BIGNUM_1.to_le_bytes();
     let pre_hw_exp = SystemTimer::now();
     mod_exp.start_exponentiation(&base, &r);
-    block!(mod_exp.read_results(&mut outbuf)).unwrap();
+    mod_exp.read_results(&mut outbuf);
     let post_hw_exp = SystemTimer::now();
     println!(
         "it took {} cycles for hw modular exponentiation",
@@ -140,7 +139,7 @@ fn multiplication_example(rsa: &mut Rsa) {
     let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
     let pre_hw_mul = SystemTimer::now();
     rsamulti.start_multiplication(&operand_b);
-    block!(rsamulti.read_results(&mut out)).unwrap();
+    rsamulti.read_results(&mut out);
     let post_hw_mul = SystemTimer::now();
     println!(
         "it took {} cycles for hw multiplication",

--- a/esp32h2-hal/examples/rsa.rs
+++ b/esp32h2-hal/examples/rsa.rs
@@ -26,7 +26,6 @@ use esp32h2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use nb::block;
 
 const BIGNUM_1: U512 = Uint::from_be_hex(
     "c7f61058f96db3bd87dbab08ab03b4f7f2f864eac249144adea6a65f97803b719d8ca980b7b3c0389c1c7c6\
@@ -61,7 +60,7 @@ fn main() -> ! {
 
     let mut rsa = Rsa::new(peripherals.RSA);
 
-    block!(rsa.ready()).unwrap();
+    nb::block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);
     mod_multi_example(&mut rsa);
     multiplication_example(&mut rsa);
@@ -80,7 +79,7 @@ fn mod_multi_example(rsa: &mut Rsa) {
     let r = compute_r(&BIGNUM_3).to_le_bytes();
     let pre_hw_modmul = SystemTimer::now();
     mod_multi.start_modular_multiplication(&r);
-    block!(mod_multi.read_results(&mut outbuf)).unwrap();
+    mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = SystemTimer::now();
     println!(
         "it took {} cycles for hw modular multiplication",
@@ -114,7 +113,7 @@ fn mod_exp_example(rsa: &mut Rsa) {
     let base = &BIGNUM_1.to_le_bytes();
     let pre_hw_exp = SystemTimer::now();
     mod_exp.start_exponentiation(&base, &r);
-    block!(mod_exp.read_results(&mut outbuf)).unwrap();
+    mod_exp.read_results(&mut outbuf);
     let post_hw_exp = SystemTimer::now();
     println!(
         "it took {} cycles for hw modular exponentiation",
@@ -140,7 +139,7 @@ fn multiplication_example(rsa: &mut Rsa) {
     let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
     let pre_hw_mul = SystemTimer::now();
     rsamulti.start_multiplication(&operand_b);
-    block!(rsamulti.read_results(&mut out)).unwrap();
+    rsamulti.read_results(&mut out);
     let post_hw_mul = SystemTimer::now();
     println!(
         "it took {} cycles for hw multiplication",

--- a/esp32s2-hal/examples/rsa.rs
+++ b/esp32s2-hal/examples/rsa.rs
@@ -26,7 +26,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use nb::block;
 
 const BIGNUM_1: U512 = Uint::from_be_hex(
     "c7f61058f96db3bd87dbab08ab03b4f7f2f864eac249144adea6a65f97803b719d8ca980b7b3c0389c1c7c6\
@@ -61,7 +60,7 @@ fn main() -> ! {
 
     let mut rsa = Rsa::new(peripherals.RSA);
 
-    block!(rsa.ready()).unwrap();
+    nb::block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);
     mod_multi_example(&mut rsa);
     multiplication_example(&mut rsa);
@@ -81,7 +80,7 @@ fn mod_multi_example(rsa: &mut Rsa) {
     let r = compute_r(&BIGNUM_3).to_le_bytes();
     let pre_hw_modmul = xtensa_lx::timer::get_cycle_count();
     mod_multi.start_modular_multiplication(&r);
-    block!(mod_multi.read_results(&mut outbuf)).unwrap();
+    mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw modular multiplication",
@@ -115,7 +114,7 @@ fn mod_exp_example(rsa: &mut Rsa) {
     let base = &BIGNUM_1.to_le_bytes();
     let pre_hw_exp = xtensa_lx::timer::get_cycle_count();
     mod_exp.start_exponentiation(&base, &r);
-    block!(mod_exp.read_results(&mut outbuf)).unwrap();
+    mod_exp.read_results(&mut outbuf);
     let post_hw_exp = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw modular exponentiation",
@@ -141,7 +140,7 @@ fn multiplication_example(rsa: &mut Rsa) {
     let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
     let pre_hw_mul = xtensa_lx::timer::get_cycle_count();
     rsamulti.start_multiplication(&operand_b);
-    block!(rsamulti.read_results(&mut out)).unwrap();
+    rsamulti.read_results(&mut out);
     let post_hw_mul = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw multiplication",

--- a/esp32s3-hal/examples/rsa.rs
+++ b/esp32s3-hal/examples/rsa.rs
@@ -26,7 +26,6 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use nb::block;
 
 const BIGNUM_1: U512 = Uint::from_be_hex(
     "c7f61058f96db3bd87dbab08ab03b4f7f2f864eac249144adea6a65f97803b719d8ca980b7b3c0389c1c7c6\
@@ -61,7 +60,7 @@ fn main() -> ! {
 
     let mut rsa = Rsa::new(peripherals.RSA);
 
-    block!(rsa.ready()).unwrap();
+    nb::block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);
     mod_multi_example(&mut rsa);
     multiplication_example(&mut rsa);
@@ -81,7 +80,7 @@ fn mod_multi_example(rsa: &mut Rsa) {
     let r = compute_r(&BIGNUM_3).to_le_bytes();
     let pre_hw_modmul = xtensa_lx::timer::get_cycle_count();
     mod_multi.start_modular_multiplication(&r);
-    block!(mod_multi.read_results(&mut outbuf)).unwrap();
+    mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw modular multiplication",
@@ -115,7 +114,7 @@ fn mod_exp_example(rsa: &mut Rsa) {
     let base = &BIGNUM_1.to_le_bytes();
     let pre_hw_exp = xtensa_lx::timer::get_cycle_count();
     mod_exp.start_exponentiation(&base, &r);
-    block!(mod_exp.read_results(&mut outbuf)).unwrap();
+    mod_exp.read_results(&mut outbuf);
     let post_hw_exp = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw modular exponentiation",
@@ -141,7 +140,7 @@ fn multiplication_example(rsa: &mut Rsa) {
     let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
     let pre_hw_mul = xtensa_lx::timer::get_cycle_count();
     rsamulti.start_multiplication(&operand_b);
-    block!(rsamulti.read_results(&mut out)).unwrap();
+    rsamulti.read_results(&mut out);
     let post_hw_mul = xtensa_lx::timer::get_cycle_count();
     println!(
         "it took {} cycles for hw multiplication",


### PR DESCRIPTION
At this stage, `esp32` doesn't work (code hangs on [this lines](https://github.com/esp-rs/esp-hal/blob/main/esp-hal-common/src/rsa/esp32.rs#L131-L133) and similar checks in `read_results()` functions)
Other chips seems to work fine, but need to check if the order of called functions/interrupts is as expected