### PR TITLE
Make ADC reads return u16s, not generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed the generic return type for ADC reads.
+- Removed the generic return type for ADC reads (#792)
 
 ## [0.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the generic return type for ADC reads.
+
 ## [0.12.0]
 
 ### Added

--- a/esp-hal-common/src/analog/adc/esp32.rs
+++ b/esp-hal-common/src/analog/adc/esp32.rs
@@ -352,15 +352,14 @@ impl<'d, ADC1> ADC<'d, ADC1> {
     }
 }
 
-impl<'d, ADCI, WORD, PIN> OneShot<ADCI, WORD, AdcPin<PIN, ADCI>> for ADC<'d, ADCI>
+impl<'d, ADCI, PIN> OneShot<ADCI, u16, AdcPin<PIN, ADCI>> for ADC<'d, ADCI>
 where
-    WORD: From<u16>,
     PIN: Channel<ADCI, ID = u8>,
     ADCI: RegisterAccess,
 {
     type Error = ();
 
-    fn read(&mut self, _pin: &mut AdcPin<PIN, ADCI>) -> nb::Result<WORD, Self::Error> {
+    fn read(&mut self, _pin: &mut AdcPin<PIN, ADCI>) -> nb::Result<u16, Self::Error> {
         if self.attenuations[AdcPin::<PIN, ADCI>::channel() as usize] == None {
             panic!(
                 "Channel {} is not configured reading!",
@@ -397,7 +396,7 @@ where
         // Mark that no conversions are currently in progress
         self.active_channel = None;
 
-        Ok(converted_value.into())
+        Ok(converted_value)
     }
 }
 

--- a/esp-hal-common/src/analog/adc/riscv.rs
+++ b/esp-hal-common/src/analog/adc/riscv.rs
@@ -613,16 +613,15 @@ impl AdcCalEfuse for ADC2 {
     }
 }
 
-impl<'d, ADCI, WORD, PIN, CS> OneShot<ADCI, WORD, AdcPin<PIN, ADCI, CS>> for ADC<'d, ADCI>
+impl<'d, ADCI, PIN, CS> OneShot<ADCI, u16, AdcPin<PIN, ADCI, CS>> for ADC<'d, ADCI>
 where
-    WORD: From<u16>,
     PIN: Channel<ADCI, ID = u8>,
     ADCI: RegisterAccess,
     CS: AdcCalScheme<ADCI>,
 {
     type Error = ();
 
-    fn read(&mut self, pin: &mut AdcPin<PIN, ADCI, CS>) -> nb::Result<WORD, Self::Error> {
+    fn read(&mut self, pin: &mut AdcPin<PIN, ADCI, CS>) -> nb::Result<u16, Self::Error> {
         if self.attenuations[AdcPin::<PIN, ADCI>::channel() as usize] == None {
             panic!(
                 "Channel {} is not configured reading!",
@@ -676,7 +675,7 @@ where
         // Mark that no conversions are currently in progress
         self.active_channel = None;
 
-        Ok(converted_value.into())
+        Ok(converted_value)
     }
 }
 

--- a/esp-hal-common/src/analog/adc/xtensa.rs
+++ b/esp-hal-common/src/analog/adc/xtensa.rs
@@ -679,16 +679,15 @@ impl AdcCalEfuse for ADC2 {
     }
 }
 
-impl<'d, ADCI, WORD, PIN, CS> OneShot<ADCI, WORD, AdcPin<PIN, ADCI, CS>> for ADC<'d, ADCI>
+impl<'d, ADCI, PIN, CS> OneShot<ADCI, u16, AdcPin<PIN, ADCI, CS>> for ADC<'d, ADCI>
 where
-    WORD: From<u16>,
     PIN: Channel<ADCI, ID = u8>,
     ADCI: RegisterAccess,
     CS: AdcCalScheme<ADCI>,
 {
     type Error = ();
 
-    fn read(&mut self, pin: &mut AdcPin<PIN, ADCI, CS>) -> nb::Result<WORD, Self::Error> {
+    fn read(&mut self, pin: &mut AdcPin<PIN, ADCI, CS>) -> nb::Result<u16, Self::Error> {
         if self.attenuations[AdcPin::<PIN, ADCI>::channel() as usize] == None {
             panic!(
                 "Channel {} is not configured reading!",
@@ -729,7 +728,7 @@ where
         // Mark that no conversions are currently in progress
         self.active_channel = None;
 
-        Ok(converted_value.into())
+        Ok(converted_value)
     }
 }
 

--- a/esp32c3-hal/examples/adc.rs
+++ b/esp32c3-hal/examples/adc.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     loop {
-        let pin_value: u16 = nb::block!(adc1.read(&mut pin)).unwrap();
+        let pin_value = nb::block!(adc1.read(&mut pin)).unwrap();
         println!("PIN2 ADC reading = {}", pin_value);
         delay.delay_ms(1500u32);
     }

--- a/esp32c3-hal/examples/adc_cal.rs
+++ b/esp32c3-hal/examples/adc_cal.rs
@@ -50,7 +50,7 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     loop {
-        let pin_value: u16 = nb::block!(adc1.read(&mut pin)).unwrap();
+        let pin_value = nb::block!(adc1.read(&mut pin)).unwrap();
         let pin_value_mv = pin_value as u32 * atten.ref_mv() as u32 / 4096;
         println!("PIN2 ADC reading = {pin_value} ({pin_value_mv} mV)");
         delay.delay_ms(1500u32);


### PR DESCRIPTION
The ADC read functions all return a generic `From<u16>` but I couldn't find a rationale for it: the read is always done first as a `u16`, so why not just return that and allow the user to convert it if they want?

This change allows for removing some type annotations.

