### PR TITLE
Remove unused Pin methods, optimize GPIO interrupt handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- `Pin::is_pcore_interrupt_set`
-- `Pin::is_pcore_non_maskable_interrupt_set`
-- `Pin::is_acore_interrupt_set`
-- `Pin::is_acore_non_maskable_interrupt_set`
-- `Pin::enable_hold`
+- `Pin::is_pcore_interrupt_set` (#793)
+- `Pin::is_pcore_non_maskable_interrupt_set` (#793)
+- `Pin::is_acore_interrupt_set` (#793)
+- `Pin::is_acore_non_maskable_interrupt_set` (#793)
+- `Pin::enable_hold` (#793)
 
 ## [0.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `Pin::is_pcore_interrupt_set`
+- `Pin::is_pcore_non_maskable_interrupt_set`
+- `Pin::is_acore_interrupt_set`
+- `Pin::is_acore_non_maskable_interrupt_set`
+- `Pin::enable_hold`
+
 ## [0.12.0]
 
 ### Added

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -151,16 +151,6 @@ pub trait Pin {
     fn unlisten(&mut self);
 
     fn clear_interrupt(&mut self);
-
-    fn is_pcore_interrupt_set(&self) -> bool;
-
-    fn is_pcore_non_maskable_interrupt_set(&self) -> bool;
-
-    fn is_acore_interrupt_set(&self) -> bool;
-
-    fn is_acore_non_maskable_interrupt_set(&self) -> bool;
-
-    fn enable_hold(&mut self, on: bool);
 }
 
 pub trait InputPin: Pin {
@@ -701,34 +691,6 @@ where
 
     fn clear_interrupt(&mut self) {
         <Self as GpioProperties>::Bank::write_interrupt_status_clear(1 << (GPIONUM % 32));
-    }
-
-    fn is_pcore_interrupt_set(&self) -> bool {
-        (<Self as GpioProperties>::InterruptStatus::pro_cpu_interrupt_status_read()
-            & (1 << (GPIONUM % 32)))
-            != 0
-    }
-
-    fn is_pcore_non_maskable_interrupt_set(&self) -> bool {
-        (<Self as GpioProperties>::InterruptStatus::pro_cpu_nmi_status_read()
-            & (1 << (GPIONUM % 32)))
-            != 0
-    }
-
-    fn is_acore_interrupt_set(&self) -> bool {
-        (<Self as GpioProperties>::InterruptStatus::app_cpu_interrupt_status_read()
-            & (1 << (GPIONUM % 32)))
-            != 0
-    }
-
-    fn is_acore_non_maskable_interrupt_set(&self) -> bool {
-        (<Self as GpioProperties>::InterruptStatus::app_cpu_nmi_status_read()
-            & (1 << (GPIONUM % 32)))
-            != 0
-    }
-
-    fn enable_hold(&mut self, _on: bool) {
-        todo!();
     }
 }
 

--- a/esp-hal-common/src/gpio.rs
+++ b/esp-hal-common/src/gpio.rs
@@ -1845,21 +1845,6 @@ mod asynch {
         #[cfg(any(esp32, esp32s2, esp32s3))]
         let intrs_bank1 = InterruptStatusRegisterAccessBank1::interrupt_status_read();
 
-        #[cfg(not(any(esp32, esp32s2, esp32s3)))]
-        trace!(
-            "Handling interrupt on {:?} - {:032b}",
-            crate::get_core(),
-            intrs_bank0,
-        );
-
-        #[cfg(any(esp32, esp32s2, esp32s3))]
-        trace!(
-            "Handling interrupt on {:?} - {:032b}{:032b}",
-            crate::get_core(),
-            intrs_bank1,
-            intrs_bank0,
-        );
-
         let mut intr_bits = intrs_bank0;
         while intr_bits != 0 {
             let pin_nr = intr_bits.trailing_zeros();

--- a/esp-hal-common/src/soc/esp32s3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s3/gpio.rs
@@ -410,6 +410,14 @@ impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {
     fn pro_cpu_nmi_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_nmi_int.read().bits()
     }
+
+    fn interrupt_status_read() -> u32 {
+        Self::pro_cpu_interrupt_status_read()
+    }
+
+    fn nmi_status_read() -> u32 {
+        Self::pro_cpu_nmi_status_read()
+    }
 }
 
 impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
@@ -419,6 +427,14 @@ impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
 
     fn pro_cpu_nmi_status_read() -> u32 {
         unsafe { &*GPIO::PTR }.pcpu_nmi_int1.read().bits()
+    }
+
+    fn interrupt_status_read() -> u32 {
+        Self::pro_cpu_interrupt_status_read()
+    }
+
+    fn nmi_status_read() -> u32 {
+        Self::pro_cpu_nmi_status_read()
     }
 }
 


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

This PR optimizes the GPIO interrupt handler for devices that have multiple GPIO banks:

 - First commit is some cleanup, with the baseline of 105 instructions
 - Second commit removes two `RSR` instructions, 103
 - Third commit reduces instruction count to 95
 - Last commit removes the last `RSR` instruction for a final count of 94

Unfortunately it looks like `get_core` can't be optimized away by the compiler even if the read core ID isn't used, so I've removed the calls from the GPIO interrupt handler. If there is a way to make the compiler understand that RSR isn't supposed to be a volatile read, the log calls can be added back, but I don't consider this to be a big deal.

There is still an unnecessary bounds check (and panic) present in the generated code, because the compiler doesn't understand (even if masked) that the Bank1 interrupt status does not have more bits than NUM_PINS-32.

There's also a 16-byte stack reduction but I don't really know why.