### PR TITLE
Add new_no_miso to Spi FullDuplexMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement enabling/disabling BLE clock on ESP32-C6 (#784)
 - Async support for RMT (#787)
 - Implement `defmt::Format` for more types (#786)
+- Add new_no_miso to Spi FullDuplexMode (#794)
 
 ### Changed
 

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -477,6 +477,30 @@ where
         Self::new_internal(spi, frequency, mode, peripheral_clock_control, clocks)
     }
 
+    /// Constructs an SPI instance in 8bit dataframe mode without MISO pin.
+    pub fn new_no_miso<SCK: OutputPin, MOSI: OutputPin, CS: OutputPin>(
+        spi: impl Peripheral<P = T> + 'd,
+        sck: impl Peripheral<P = SCK> + 'd,
+        mosi: impl Peripheral<P = MOSI> + 'd,
+        cs: impl Peripheral<P = CS> + 'd,
+        frequency: HertzU32,
+        mode: SpiMode,
+        peripheral_clock_control: &mut PeripheralClockControl,
+        clocks: &Clocks,
+    ) -> Spi<'d, T, FullDuplexMode> {
+        crate::into_ref!(spi, sck, mosi, cs);
+        sck.set_to_push_pull_output()
+            .connect_peripheral_to_output(spi.sclk_signal());
+
+        mosi.set_to_push_pull_output()
+            .connect_peripheral_to_output(spi.mosi_signal());
+
+        cs.set_to_push_pull_output()
+            .connect_peripheral_to_output(spi.cs_signal());
+
+        Self::new_internal(spi, frequency, mode, peripheral_clock_control, clocks)
+    }
+
     /// Constructs an SPI instance in 8bit dataframe mode without CS and MISO
     /// pin.
     pub fn new_no_cs_no_miso<SCK: OutputPin, MOSI: OutputPin>(


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

Add new_no_mosi function to Spi in FullDuplexMode, this is useful for devices like spi displays with share a single bus. They don't need a Miso connection but do need CS pin for selection with display to write to. Fixes also https://github.com/esp-rs/esp-hal/issues/791
