### PR TITLE
Fix s3 RC_FAST_CLK powerdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- S3: Allow powering down RC_FAST_CLK (#796)
+
 ### Removed
 
 ## [0.12.0]

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32s3_sleep.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32s3_sleep.rs
@@ -844,7 +844,7 @@ impl RtcSleepConfig {
 
             #[rustfmt::skip]
             rtc_cntl.clk_conf.modify(|_, w| w
-                .ck8m_force_pu().bit(self.int_8m_pd_en())
+                .ck8m_force_pu().bit(!self.int_8m_pd_en())
             );
 
             // enable VDDSDIO control by state machine


### PR DESCRIPTION
Found by https://matrix.to/#/!LdaNPfUfvefOLewEIM:matrix.org/$FUWqLqPUH-bfGxi0FnjqIz2FsLID0u1wyRVKhSg6tV8?via=matrix.org&via=tchncs.de&via=mozilla.org

> Hi all, I've been digging into esp32c3 sleep, and I noticed something that I think is backwards in esp32s3 sleep: [here](https://github.com/esp-rs/esp-hal/blob/976549f44060fdb78a606dac0e8369dff196eb43/esp-hal-common/src/rtc_cntl/rtc/esp32s3_sleep.rs#L845C2-L848C15) we're setting ck8m_force_pu to be the same as self.int_8m_pd_en(), but [idf](https://github.com/espressif/esp-idf/blob/2bc1f2f574d791d6bffc1688d115a0f549e6364c/components/esp_hw_support/port/esp32s3/rtc_sleep.c#L238) seems to do the opposite. I won't make a PR as I have no way of testing which is correct, but just wanted to let y'all know...