### PR TITLE
Bump the MSRV to `1.67`, check the `defmt` feature in MSRV check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,7 +488,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf, riscv32imac-unknown-none-elf
-          toolchain: "1.65"
+          toolchain: "1.67"
           components: rust-src
       - uses: Swatinem/rust-cache@v2
 
@@ -499,15 +499,27 @@ jobs:
 
       # Verify the MSRV for all RISC-V chips.
       - name: msrv (esp32c2-hal)
-        run: cd esp32c2-hal/ && RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
+        run: |
+          cd esp32c2-hal/
+          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
+          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
       - name: msrv (esp32c3-hal)
-        run: cd esp32c3-hal/ && RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
+        run: |
+          cd esp32c3-hal/
+          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
+          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
       - name: msrv (esp32c6-hal)
-        run: cd esp32c6-hal/ && RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
+        run: |
+          cd esp32c6-hal/
+          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
+          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
       - name: msrv (esp32c6-lp-hal)
         run: cd esp32c6-lp-hal/ && RUSTC_BOOTSTRAP=1 cargo check
       - name: msrv (esp32h2-hal)
-        run: cd esp32h2-hal/ && RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
+        run: |
+          cd esp32h2-hal/
+          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
+          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
 
   msrv-xtensa:
     runs-on: ubuntu-latest
@@ -517,16 +529,25 @@ jobs:
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           ldproxy: false
-          version: "1.65.0"
+          version: "1.67.0"
       - uses: Swatinem/rust-cache@v2
 
       # Verify the MSRV for all Xtensa chips.
       - name: msrv (esp32-hal)
-        run: cd esp32-hal/ && cargo check --features=eh1,ufmt,log
+        run: |
+          cd esp32-hal/
+          cargo check --features=eh1,ufmt,log
+          cargo check --features=defmt
       - name: msrv (esp32s2-hal)
-        run: cd esp32s2-hal/ && cargo check --features=eh1,ufmt,log
+        run: |
+          cd esp32s2-hal/
+          cargo check --features=eh1,ufmt,log
+          cargo check --features=defmt
       - name: msrv (esp32s3-hal)
-        run: cd esp32s3-hal/ && cargo check --features=eh1,ufmt,log
+        run: |
+          cd esp32s3-hal/
+          cargo check --features=eh1,ufmt,log
+          cargo check --features=defmt
 
   # --------------------------------------------------------------------------
   # Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped MSRV to 1.67 (#798)
+
 ### Fixed
 
 - S3: Allow powering down RC_FAST_CLK (#796)

--- a/README.md
+++ b/README.md
@@ -99,17 +99,11 @@ When using this hook, you can choose to ignore its failure on a per-commit basis
 
 ## MSRV
 
-The **M**inimum **S**upported **R**ust **V**ersions are:
+The **M**inimum **S**upported **R**ust **V**ersion is `1.67.0` for all packages.
 
-- `nightly-2022-09-16` for RISC-V devices (**ESP32-C2**, **ESP32-C3**, **ESP32-C6**, **ESP32-H2**)
-  - This corresponds to the date that the `1.65.0` release was branched from `master`
-- `1.65.0` for Xtensa devices (**ESP32**, **ESP32-S2**, **ESP32-S3**)
-- `1.67.0` for all `async` examples (`embassy_hello_world`, `embassy_wait`, etc.)
-- latest `stable` when using the `defmt` feature
+RISC-V is officially supported by the official Rust compiler, however, it should be noted that targeting the Xtensa ISA currently requires the use of the [esp-rs/rust] compiler fork. Our recommend method of installation is [espup].
 
-It should be noted that targeting the Xtensa ISA currently requires the use of the [esp-rs/rust] compiler fork. Our recommend method of installation is [espup].
-
-RISC-V is officially supported by the official Rust compiler.
+When targetting the RISC-V architecture, it is necessary to set `RUSTC_BOOTSTRAP=1` in order to build with a previous stable release; this is not required when targeting Xtensa.
 
 [esp-rs/rust]: https://github.com/esp-rs/rust
 [espup]: https://github.com/esp-rs/espup

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL implementations for peripherals common among Espressif devices; should not be used directly"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "Procedural macros for ESP-HAL"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -2,7 +2,7 @@
 name         = "esp-hal-smartled"
 version      = "0.5.0"
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "RMT adapter for smartleds"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp-hal.code-workspace
+++ b/esp-hal.code-workspace
@@ -28,6 +28,9 @@
       "path": "esp32c6-lp-hal"
     },
     {
+      "path": "esp32c6-lp-hal-procmacros"
+    },
+    {
       "path": "esp32h2-hal"
     },
     {

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL for ESP32 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL for ESP32-C2 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL for ESP32-C3 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Juraj Sadel <jurajsadel@gmail.com>",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL for ESP32-C6 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32c6-lp-hal-procmacros/Cargo.toml
+++ b/esp32c6-lp-hal-procmacros/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "esp32c6-lp-hal-procmacros"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.65.0"
-description  = "HAL for ESP32-C6's low-power coprocessor"
+name         = "esp32c6-lp-hal-procmacros"
+version      = "0.1.0"
+edition      = "2021"
+rust-version = "1.67.0"
+description  = "Procedural macros for the ESP32-C6's LP coprocessor"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 
@@ -24,11 +24,10 @@ categories = [
 proc-macro = true
 
 [dependencies]
-litrs = "0.4.0"
+litrs            = "0.4.0"
 proc-macro-crate = "1.3.1"
 proc-macro-error = "1.0.4"
 proc-macro2      = "1.0.63"
 quote            = "1.0.28"
 syn              = {version = "2.0.22", features = ["extra-traits", "full"]}
-# toml_edit is a dependency of proc-macro-crate. Unfortunately they raised their MSRV on 0.19.15 so we pin the version for now
-toml_edit        = "=0.19.14"
+toml_edit        = "0.20.0"

--- a/esp32c6-lp-hal/Cargo.toml
+++ b/esp32c6-lp-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name         = "esp32c6-lp-hal"
 version      = "0.1.0"
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL for ESP32-C6's low-power coprocessor"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Sergio Gasquez Arcos <sergio.gasquez@gmail.com",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL for ESP32-H2 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL for ESP32-S2 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Björn Quentin <bjoern.quentin@mobile-j.de>",
 ]
 edition      = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 description  = "HAL for ESP32-S3 microcontrollers"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"


### PR DESCRIPTION
- Bumps the MSRV of each package to `1.67`
- Check the `defmt` feature in the MSRV check
- Add the `esp32c6-lp-hal-procmacros` package to the VS Code workspace

This unifies the various MSRV differences between RISC-V/Xtensa/async/defmt, so I think it's a nice improvement. Much simpler now, just a single version (as it should be).

Not sure why defmt was stated as requiring the latest `stable` release previously, but it seems to build just fine in our MSRV check. If there is more to this, please provide some documentation so I can make a note of it for the future.

@bjoernQ @MabezDev please let me know if you have any questions/concerns/objections to any of this. We should probably revisit our MSRV policy in the future, but I think for now this is a good balance.

Closes #788