### PR TITLE
esp-hal-common: uart/ESP32: fix get_rx_fifo_count()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new_no_miso to Spi FullDuplexMode (#794)
 - Add UART support for splitting into TX and RX (#754)
 - Async support for I2S (#801)
+- UART/ESP32: fix calculating FIFO counter with `get_rx_fifo_count()` (#804)
 
 ### Changed
 


### PR DESCRIPTION
Currently the `get_rx_fifo_count()` is using `fifo_cnt`, which is unreliable for ESP32, according to the errata:
https://www.espressif.com/sites/default/files/documentation/esp32_errata_en.pdf section 3.17

This commit is fixing the code for the ESP32 according to the workaround example.

Main discussion and my debugging results:
https://github.com/esp-rs/esp-hal/discussions/765