### PR TITLE
Fix SHA registers access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix setting alarm when a timer group is used as the alarm source. (#730)
 - Fix `Instant::now()` not counting in some cases when using TIMG0 as the timebase (#737)
 - Fix number of ADC attenuations for ESP32-C6 (#771)
+- Fix SHA registers access (#805)
 
 ### Breaking
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -63,9 +63,7 @@ esp32c6 = { version = "0.7.0",  features = ["critical-section"], optional = true
 # until new H2 pacs are relesed, required because of https://github.com/esp-rs/esp-pacs/pull/156
 esp32h2 = { git = "https://github.com/esp-rs/esp-pacs.git", rev = "2545b66f4c11dd78dc02a3c77c44a78fa5893beb",  features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.17.0", features = ["critical-section"], optional = true }
-esp32s3 = { git = "https://github.com/SergioGasquez/esp-pacs", branch = "fix/sha-regs", features = [
-    "critical-section",
-], optional = true }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "c1283ca", features = ["critical-section",], optional = true }
 
 [build-dependencies]
 basic-toml = "0.1.4"

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -63,7 +63,9 @@ esp32c6 = { version = "0.7.0",  features = ["critical-section"], optional = true
 # until new H2 pacs are relesed, required because of https://github.com/esp-rs/esp-pacs/pull/156
 esp32h2 = { git = "https://github.com/esp-rs/esp-pacs.git", rev = "2545b66f4c11dd78dc02a3c77c44a78fa5893beb",  features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.17.0", features = ["critical-section"], optional = true }
-esp32s3 = { version = "0.21.0", features = ["critical-section"], optional = true }
+esp32s3 = { git = "https://github.com/SergioGasquez/esp-pacs", branch = "fix/sha-regs", features = [
+    "critical-section",
+], optional = true }
 
 [build-dependencies]
 basic-toml = "0.1.4"

--- a/esp-hal-common/src/sha.rs
+++ b/esp-hal-common/src/sha.rs
@@ -182,19 +182,13 @@ impl<'d> Sha<'d> {
 
     #[cfg(not(esp32))]
     fn process_buffer(&mut self) {
-        // FIXME: SHA_START_REG & SHA_CONTINUE_REG are wrongly marked as RO (they are
-        // WO)
         if self.first_run {
             // Set SHA_START_REG
-            unsafe {
-                self.sha.start.as_ptr().write_volatile(1u32);
-            }
+            self.sha.start.write(|w| unsafe { w.bits(1) });
             self.first_run = false;
         } else {
             // SET SHA_CONTINUE_REG
-            unsafe {
-                self.sha.continue_.as_ptr().write_volatile(1u32);
-            }
+            self.sha.continue_.write(|w| unsafe { w.bits(1) });
         }
     }
 


### PR DESCRIPTION
~Draft until https://github.com/esp-rs/esp-pacs/pull/160 is merged~

SHA esp32s3 example output:
```
Took 18142 cycles
SHA512 Hash output [ee, 8d, 0e, 15, de, dc, d8, c8, 86, a2, ef, b1, ac, 6a, 49, cf, d8, 3f, 67, 65, 64, b3, 00, ce, 48, 51, 5e, ce, 5f, 4b, ee, 10, e1, 1d, 89, c2, 1c, 21, 81, 53, c3, b2, 31, ab, 77, ca, ed, c9, 6c, 24, d7, e5, 9a, 94, 86, 80, e1, 51, 00, 1a, e1, 8c, ec, 80]
Took 1541837 cycles
SHA512 Hash output [ee, 8d, 0e, 15, de, dc, d8, c8, 86, a2, ef, b1, ac, 6a, 49, cf, d8, 3f, 67, 65, 64, b3, 00, ce, 48, 51, 5e, ce, 5f, 4b, ee, 10, e1, 1d, 89, c2, 1c, 21, 81, 53, c3, b2, 31, ab, 77, ca, ed, c9, 6c, 24, d7, e5, 9a, 94, 86, 80, e1, 51, 00, 1a, e1, 8c, ec, 80]
HW SHA is 84x faster
```