### PR TITLE
Fix UART to handle CPU/APB clock changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new_no_miso to Spi FullDuplexMode (#794)
 - Add UART support for splitting into TX and RX (#754)
 - Async support for I2S (#801)
-- UART/ESP32: fix calculating FIFO counter with `get_rx_fifo_count()` (#804)
 
 ### Changed
 
@@ -26,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - S3: Allow powering down RC_FAST_CLK (#796)
+- UART/ESP32: fix calculating FIFO counter with `get_rx_fifo_count()` (#804)
 
 ### Removed
 
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Pin::is_acore_interrupt_set` (#793)
 - `Pin::is_acore_non_maskable_interrupt_set` (#793)
 - `Pin::enable_hold` (#793)
+
+### Breaking
+
+- `Uart::new` now takes the `&Clocks` struct to ensure baudrate is correct for CPU/APB speed. (#808)
+- `Uart::new_with_config` takes an `Config` instead of `Option<Config>`. (#808)
 
 ## [0.12.0]
 

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -162,7 +162,9 @@ pub mod trapframe {
 mod soc;
 
 #[no_mangle]
-extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {}
+extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {
+    warn!("Unhandled level {} interrupt: {:?}", _level, _interrupt);
+}
 
 #[cfg(xtensa)]
 #[no_mangle]

--- a/esp-hal-common/src/uart.rs
+++ b/esp-hal-common/src/uart.rs
@@ -26,7 +26,7 @@
 //!
 //! let mut serial1 = Uart::new_with_config(
 //!     peripherals.UART1,
-//!     Some(config),
+//!     config,
 //!     Some(pins),
 //!     &clocks,
 //!     &mut system.peripheral_clock_control,
@@ -456,7 +456,13 @@ where
         use crate::gpio::*;
         // not real, just to satify the type
         type Pins<'a> = TxRxPins<'a, GpioPin<Output<PushPull>, 2>, GpioPin<Input<Floating>, 0>>;
-        Self::new_with_config(uart, Default::default(),  None::<Pins<'_>>, clocks,  peripheral_clock_control)
+        Self::new_with_config(
+            uart,
+            Default::default(),
+            None::<Pins<'_>>,
+            clocks,
+            peripheral_clock_control,
+        )
     }
 
     /// Split the Uart into a transmitter and receiver, which is

--- a/esp-hal-common/src/uart.rs
+++ b/esp-hal-common/src/uart.rs
@@ -413,7 +413,7 @@ where
     /// Create a new UART instance with defaults
     pub fn new_with_config<P>(
         _uart: impl Peripheral<P = T> + 'd,
-        config: Option<Config>,
+        config: Config,
         mut pins: Option<P>,
         clocks: &Clocks,
         peripheral_clock_control: &mut PeripheralClockControl,
@@ -439,28 +439,24 @@ where
             rx: UartRx::new_inner(),
         };
 
-        config.map(|config| {
-            serial.change_data_bits(config.data_bits);
-            serial.change_parity(config.parity);
-            serial.change_stop_bits(config.stop_bits);
-            serial.change_baud(config.baudrate, clocks);
-        });
+        serial.change_data_bits(config.data_bits);
+        serial.change_parity(config.parity);
+        serial.change_stop_bits(config.stop_bits);
+        serial.change_baud(config.baudrate, clocks);
 
         serial
     }
 
     /// Create a new UART instance with defaults
     pub fn new(
-        _uart: impl Peripheral<P = T> + 'd,
+        uart: impl Peripheral<P = T> + 'd,
+        clocks: &Clocks,
         peripheral_clock_control: &mut PeripheralClockControl,
     ) -> Self {
-        T::enable_peripheral(peripheral_clock_control);
-        T::disable_rx_interrupts();
-        T::disable_tx_interrupts();
-        Uart {
-            tx: UartTx::new_inner(),
-            rx: UartRx::new_inner(),
-        }
+        use crate::gpio::*;
+        // not real, just to satify the type
+        type Pins<'a> = TxRxPins<'a, GpioPin<Output<PushPull>, 2>, GpioPin<Input<Floating>, 0>>;
+        Self::new_with_config(uart, Default::default(),  None::<Pins<'_>>, clocks,  peripheral_clock_control)
     }
 
     /// Split the Uart into a transmitter and receiver, which is

--- a/esp32-hal/examples/advanced_serial.rs
+++ b/esp32-hal/examples/advanced_serial.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
 
     let mut serial1 = Uart::new_with_config(
         peripherals.UART1,
-        Some(config),
+        config,
         Some(pins),
         &clocks,
         &mut system.peripheral_clock_control,

--- a/esp32-hal/examples/crc.rs
+++ b/esp32-hal/examples/crc.rs
@@ -28,7 +28,11 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     timer0.start(1u64.secs());
 
@@ -36,7 +40,7 @@ fn main() -> ! {
     let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
-        serial0,
+        uart0,
         "Performing CRC calculations on test string \"{data}\""
     )
     .unwrap();
@@ -81,7 +85,7 @@ fn main() -> ! {
         );
 
         writeln!(
-            serial0,
+            uart0,
             "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
             crc_hdlc,
             crc_bzip2,

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -75,7 +75,11 @@ fn main() -> ! {
     );
     embassy::init(&clocks, timer_group0.timer0);
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32-hal/examples/hello_world.rs
+++ b/esp32-hal/examples/hello_world.rs
@@ -1,4 +1,4 @@
-//! This shows how to write text to serial0.
+//! This shows how to write text to uart0.
 //! You can see the output with `espflash` if you provide the `--monitor` option
 
 #![no_std]
@@ -28,12 +28,16 @@ fn main() -> ! {
         &mut system.peripheral_clock_control,
     );
     let mut timer0 = timer_group0.timer0;
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     timer0.start(1u64.secs());
 
     loop {
-        writeln!(serial0, "Hello world!").unwrap();
+        writeln!(uart0, "Hello world!").unwrap();
         block!(timer0.wait()).unwrap();
     }
 }

--- a/esp32-hal/examples/serial_interrupts.rs
+++ b/esp32-hal/examples/serial_interrupts.rs
@@ -35,11 +35,15 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
-    serial0.set_rx_fifo_full_threshold(30).unwrap();
-    serial0.listen_at_cmd();
-    serial0.listen_rx_fifo_full();
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
+    uart0.set_rx_fifo_full_threshold(30).unwrap();
+    uart0.listen_at_cmd();
+    uart0.listen_rx_fifo_full();
 
     interrupt::enable(
         peripherals::Interrupt::UART0,
@@ -49,7 +53,7 @@ fn main() -> ! {
 
     timer0.start(1u64.secs());
 
-    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(serial0));
+    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(uart0));
 
     loop {
         critical_section::with(|cs| {

--- a/esp32c2-hal/examples/advanced_serial.rs
+++ b/esp32c2-hal/examples/advanced_serial.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
 
     let mut serial1 = Uart::new_with_config(
         peripherals.UART1,
-        Some(config),
+        config,
         Some(pins),
         &clocks,
         &mut system.peripheral_clock_control,

--- a/esp32c2-hal/examples/crc.rs
+++ b/esp32c2-hal/examples/crc.rs
@@ -22,7 +22,11 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -85,7 +85,11 @@ fn main() -> ! {
         .timer0,
     );
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32c2-hal/examples/hello_world.rs
+++ b/esp32c2-hal/examples/hello_world.rs
@@ -22,7 +22,11 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,

--- a/esp32c2-hal/examples/serial_interrupts.rs
+++ b/esp32c2-hal/examples/serial_interrupts.rs
@@ -30,7 +30,11 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -38,14 +42,14 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
-    serial0.set_rx_fifo_full_threshold(30).unwrap();
-    serial0.listen_at_cmd();
-    serial0.listen_rx_fifo_full();
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
+    uart0.set_rx_fifo_full_threshold(30).unwrap();
+    uart0.listen_at_cmd();
+    uart0.listen_rx_fifo_full();
 
     timer0.start(1u64.secs());
 
-    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(serial0));
+    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(uart0));
 
     interrupt::enable(
         peripherals::Interrupt::UART0,

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
 
     let mut serial1 = Uart::new_with_config(
         peripherals.UART1,
-        Some(config),
+        config,
         Some(pins),
         &clocks,
         &mut system.peripheral_clock_control,

--- a/esp32c3-hal/examples/crc.rs
+++ b/esp32c3-hal/examples/crc.rs
@@ -22,7 +22,11 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -85,7 +85,11 @@ fn main() -> ! {
         .timer0,
     );
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32c3-hal/examples/hello_world.rs
+++ b/esp32c3-hal/examples/hello_world.rs
@@ -22,7 +22,11 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,

--- a/esp32c3-hal/examples/serial_interrupts.rs
+++ b/esp32c3-hal/examples/serial_interrupts.rs
@@ -30,7 +30,11 @@ fn main() -> ! {
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,
         &clocks,
@@ -38,14 +42,14 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
-    serial0.set_rx_fifo_full_threshold(30).unwrap();
-    serial0.listen_at_cmd();
-    serial0.listen_rx_fifo_full();
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
+    uart0.set_rx_fifo_full_threshold(30).unwrap();
+    uart0.listen_at_cmd();
+    uart0.listen_rx_fifo_full();
 
     timer0.start(1u64.secs());
 
-    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(serial0));
+    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(uart0));
 
     interrupt::enable(
         peripherals::Interrupt::UART0,

--- a/esp32c6-hal/examples/advanced_serial.rs
+++ b/esp32c6-hal/examples/advanced_serial.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
 
     let mut serial1 = Uart::new_with_config(
         peripherals.UART1,
-        Some(config),
+        config,
         Some(pins),
         &clocks,
         &mut system.peripheral_clock_control,

--- a/esp32c6-hal/examples/crc.rs
+++ b/esp32c6-hal/examples/crc.rs
@@ -22,7 +22,11 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -84,7 +84,11 @@ fn main() -> ! {
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32c6-hal/examples/hello_world.rs
+++ b/esp32c6-hal/examples/hello_world.rs
@@ -22,7 +22,11 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/esp32c6-hal/examples/serial_interrupts.rs
+++ b/esp32c6-hal/examples/serial_interrupts.rs
@@ -37,15 +37,19 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
-    serial0.set_rx_fifo_full_threshold(30).unwrap();
-    serial0.listen_at_cmd();
-    serial0.listen_rx_fifo_full();
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
+    uart0.set_rx_fifo_full_threshold(30).unwrap();
+    uart0.listen_at_cmd();
+    uart0.listen_rx_fifo_full();
 
     timer0.start(1u64.secs());
 
-    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(serial0));
+    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(uart0));
 
     interrupt::enable(
         peripherals::Interrupt::UART0,

--- a/esp32h2-hal/examples/advanced_serial.rs
+++ b/esp32h2-hal/examples/advanced_serial.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
 
     let mut serial1 = Uart::new_with_config(
         peripherals.UART1,
-        Some(config),
+        config,
         Some(pins),
         &clocks,
         &mut system.peripheral_clock_control,

--- a/esp32h2-hal/examples/crc.rs
+++ b/esp32h2-hal/examples/crc.rs
@@ -22,7 +22,11 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -84,7 +84,11 @@ fn main() -> ! {
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32h2-hal/examples/hello_world.rs
+++ b/esp32h2-hal/examples/hello_world.rs
@@ -22,7 +22,11 @@ fn main() -> ! {
     let mut system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/esp32h2-hal/examples/serial_interrupts.rs
+++ b/esp32h2-hal/examples/serial_interrupts.rs
@@ -37,15 +37,19 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
-    serial0.set_rx_fifo_full_threshold(30).unwrap();
-    serial0.listen_at_cmd();
-    serial0.listen_rx_fifo_full();
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
+    uart0.set_rx_fifo_full_threshold(30).unwrap();
+    uart0.listen_at_cmd();
+    uart0.listen_rx_fifo_full();
 
     timer0.start(1u64.secs());
 
-    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(serial0));
+    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(uart0));
 
     interrupt::enable(
         peripherals::Interrupt::UART0,

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
 
     let mut serial1 = Uart::new_with_config(
         peripherals.UART1,
-        Some(config),
+        config,
         Some(pins),
         &clocks,
         &mut system.peripheral_clock_control,

--- a/esp32s2-hal/examples/crc.rs
+++ b/esp32s2-hal/examples/crc.rs
@@ -29,7 +29,11 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     timer0.start(1u64.secs());
 
@@ -37,7 +41,7 @@ fn main() -> ! {
     let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
-        serial0,
+        uart0,
         "Performing CRC calculations on test string \"{data}\""
     )
     .unwrap();
@@ -82,7 +86,7 @@ fn main() -> ! {
         );
 
         writeln!(
-            serial0,
+            uart0,
             "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
             crc_hdlc,
             crc_bzip2,

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -77,7 +77,11 @@ fn main() -> ! {
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -1,4 +1,4 @@
-//! This shows how to write text to serial0.
+//! This shows how to write text to uart0.
 //! You can see the output with `espflash` if you provide the `--monitor` option
 
 #![no_std]
@@ -29,12 +29,16 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     timer0.start(1u64.secs());
 
     loop {
-        writeln!(serial0, "Hello world!").unwrap();
+        writeln!(uart0, "Hello world!").unwrap();
         block!(timer0.wait()).unwrap();
     }
 }

--- a/esp32s2-hal/examples/serial_interrupts.rs
+++ b/esp32s2-hal/examples/serial_interrupts.rs
@@ -36,11 +36,15 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
-    serial0.set_rx_fifo_full_threshold(30).unwrap();
-    serial0.listen_at_cmd();
-    serial0.listen_rx_fifo_full();
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
+    uart0.set_rx_fifo_full_threshold(30).unwrap();
+    uart0.listen_at_cmd();
+    uart0.listen_rx_fifo_full();
 
     interrupt::enable(
         peripherals::Interrupt::UART0,
@@ -50,7 +54,7 @@ fn main() -> ! {
 
     timer0.start(1u64.secs());
 
-    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(serial0));
+    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(uart0));
 
     loop {
         critical_section::with(|cs| {

--- a/esp32s3-hal/examples/advanced_serial.rs
+++ b/esp32s3-hal/examples/advanced_serial.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
 
     let mut serial1 = Uart::new_with_config(
         peripherals.UART1,
-        Some(config),
+        config,
         Some(pins),
         &clocks,
         &mut system.peripheral_clock_control,

--- a/esp32s3-hal/examples/crc.rs
+++ b/esp32s3-hal/examples/crc.rs
@@ -29,7 +29,11 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     timer0.start(1u64.secs());
 
@@ -37,7 +41,7 @@ fn main() -> ! {
     let sentence = "The quick brown fox jumps over a lazy dog";
 
     writeln!(
-        serial0,
+        uart0,
         "Performing CRC calculations on test string \"{data}\""
     )
     .unwrap();
@@ -82,7 +86,7 @@ fn main() -> ! {
         );
 
         writeln!(
-            serial0,
+            uart0,
             "{:08x} {:08x} {:08x} {:08x} {:04x} {:04x} {:02x} {:02x} {}",
             crc_hdlc,
             crc_bzip2,

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -83,7 +83,11 @@ fn main() -> ! {
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let mut uart0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32s3-hal/examples/hello_world.rs
+++ b/esp32s3-hal/examples/hello_world.rs
@@ -1,4 +1,4 @@
-//! This shows how to write text to serial0.
+//! This shows how to write text to uart0.
 //! You can see the output with `espflash` if you provide the `--monitor` option
 
 #![no_std]
@@ -29,12 +29,16 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
 
     timer0.start(1u64.secs());
 
     loop {
-        writeln!(serial0, "Hello world!").unwrap();
+        writeln!(uart0, "Hello world!").unwrap();
         block!(timer0.wait()).unwrap();
     }
 }

--- a/esp32s3-hal/examples/serial_interrupts.rs
+++ b/esp32s3-hal/examples/serial_interrupts.rs
@@ -35,11 +35,15 @@ fn main() -> ! {
     );
     let mut timer0 = timer_group0.timer0;
 
-    let mut serial0 = Uart::new(peripherals.UART0, &mut system.peripheral_clock_control);
-    serial0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
-    serial0.set_rx_fifo_full_threshold(30).unwrap();
-    serial0.listen_at_cmd();
-    serial0.listen_rx_fifo_full();
+    let mut uart0 = Uart::new(
+        peripherals.UART0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
+    uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
+    uart0.set_rx_fifo_full_threshold(30).unwrap();
+    uart0.listen_at_cmd();
+    uart0.listen_rx_fifo_full();
 
     interrupt::enable(
         peripherals::Interrupt::UART0,
@@ -49,7 +53,7 @@ fn main() -> ! {
 
     timer0.start(1u64.secs());
 
-    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(serial0));
+    critical_section::with(|cs| SERIAL.borrow_ref_mut(cs).replace(uart0));
 
     loop {
         critical_section::with(|cs| {


### PR DESCRIPTION
For the ESP32 and ESP32-S2, baud rate can be affected by CPU speed, which was causing issues in the stub: https://github.com/esp-rs/esp-flasher-stub/issues/29 ( and perhaps some esp-wifi projects?). `new` now takes a reference to the CPU clock and adjusts its baud calculations accordingly.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
