### PR TITLE
Make sure examples can actually build with defmt enabled, build some examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,6 @@ jobs:
           cargo check --example=embassy_multicore --features=embassy,embassy-time-timg0,embassy-executor-thread
           cargo check --example=embassy_multicore_interrupt --features=embassy,embassy-time-timg0,embassy-executor-interrupt
           cargo check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
-          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
-          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
       - name: check esp32-hal (embassy, async)
         run: |
           cd esp32-hal/
@@ -155,9 +153,9 @@ jobs:
       - name: check esp32c2-hal (async, i2c)
         run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c2-hal (interrupt-preemption)
-        run: cd esp32c2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c2-hal (direct-vectoring)
-        run: cd esp32c2-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c2-hal (embassy, log/defmt)
         run: |
           cd esp32c2-hal/
@@ -209,9 +207,9 @@ jobs:
       - name: check esp32c3-hal (async, i2c)
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c3-hal (interrupt-preemption)
-        run: cd esp32c3-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c3-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c3-hal (direct-vectoring)
-        run: cd esp32c3-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c3-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c3-hal (embassy, log/defmt)
         run: |
           cd esp32c3-hal/
@@ -266,9 +264,9 @@ jobs:
       - name: check esp32c6-hal (async, i2c)
         run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (interrupt-preemption)
-        run: cd esp32c6-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c6-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c6-hal (direct-vectoring)
-        run: cd esp32c6-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c6-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c6-hal (embassy, log/defmt)
         run: |
           cd esp32c6-hal/
@@ -338,9 +336,9 @@ jobs:
       - name: check esp32h2-hal (async, i2c)
         run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
       - name: check esp32h2-hal (interrupt-preemption)
-        run: cd esp32h2-hal/ && cargo check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32h2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32h2-hal (direct-vectoring)
-        run: cd esp32h2-hal/ && cargo check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32h2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       - name: check esp32h2-hal (embassy, log/defmt)
         run: |
           cd esp32h2-hal/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
       - name: check esp32-hal (common features)
         run: |
           cd esp32-hal/
-          cargo check --examples --features=eh1,ufmt,log
-          cargo check --examples --features=eh1,ufmt,defmt
+          cargo build --examples --features=eh1,ufmt,log
+          cargo build --examples --features=eh1,ufmt,defmt
       - name: check esp32-hal (embassy)
         run: |
           cd esp32-hal/
@@ -138,8 +138,8 @@ jobs:
       - name: check esp32c2-hal (common features)
         run: |
           cd esp32c2-hal/
-          cargo +nightly check --examples --features=eh1,ufmt,log
-          cargo +nightly check --examples --features=eh1,ufmt,defmt
+          cargo +nightly build --examples --features=eh1,ufmt,log
+          cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c2-hal (async, systick)
         run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32c2-hal (async, timg0)
@@ -192,8 +192,8 @@ jobs:
       - name: check esp32c3-hal (common features)
         run: |
           cd esp32c3-hal/
-          cargo +nightly check --examples --features=eh1,ufmt,log
-          cargo +nightly check --examples --features=eh1,ufmt,defmt
+          cargo +nightly build --examples --features=eh1,ufmt,log
+          cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c3-hal (async, systick)
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32c3-hal (async, timg0)
@@ -249,8 +249,8 @@ jobs:
       - name: check esp32c6-hal (common features)
         run: |
           cd esp32c6-hal/
-          cargo +nightly check --examples --features=eh1,ufmt,log
-          cargo +nightly check --examples --features=eh1,ufmt,defmt
+          cargo +nightly build --examples --features=eh1,ufmt,log
+          cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c6-hal (async, systick)
         run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32c6-hal (async, timg0)
@@ -321,8 +321,8 @@ jobs:
       - name: check esp32h2-hal (common features)
         run: |
           cd esp32h2-hal/
-          cargo +nightly check --examples --features=eh1,ufmt,log
-          cargo +nightly check --examples --features=eh1,ufmt,defmt
+          cargo +nightly build --examples --features=eh1,ufmt,log
+          cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32h2-hal (async, systick)
         run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
       - name: check esp32h2-hal (async, timg0)
@@ -369,8 +369,8 @@ jobs:
       - name: check esp32s2-hal (common features)
         run: |
           cd esp32s2-hal/
-          cargo check --examples --features=eh1,ufmt,log
-          cargo check --examples --features=eh1,ufmt,defmt
+          cargo build --examples --features=eh1,ufmt,log
+          cargo build --examples --features=eh1,ufmt,defmt
       # FIXME: `time-systick` feature disabled for now, see 'esp32s2-hal/Cargo.toml'.
       # - name: check esp32s2-hal (async, systick)
       #   run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
@@ -426,8 +426,8 @@ jobs:
       - name: check esp32s3-hal (common features)
         run: |
           cd esp32s3-hal/
-          cargo check --examples --features=eh1,ufmt,log
-          cargo check --examples --features=eh1,ufmt,defmt
+          cargo build --examples --features=eh1,ufmt,log
+          cargo build --examples --features=eh1,ufmt,defmt
       - name: check esp32s3-hal (embassy, timg0)
         run: |
           cd esp32s3-hal/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - S3: Allow powering down RC_FAST_CLK (#796)
 - UART/ESP32: fix calculating FIFO counter with `get_rx_fifo_count()` (#804)
 - Xtensa targets: Use ESP32Reset - not Reset (#823)
+- Examples should now work with the `defmt` feature (#810)
 
 ### Removed
 

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -183,6 +183,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     copy_dir_all("ld/sections", &out)?;
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     // Generate the eFuse table from the selected device's CSV file:
     gen_efuse_table(device_name, out)?;
 

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -183,9 +183,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     copy_dir_all("ld/sections", &out)?;
 
-    #[cfg(feature = "defmt")]
-    println!("cargo:rustc-link-arg=-Tdefmt.x");
-
     // Generate the eFuse table from the selected device's CSV file:
     gen_efuse_table(device_name, out)?;
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -41,7 +41,7 @@ embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.8.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.5.0", features = ["esp32"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.6.0", features = ["esp32", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32"] }
 heapless           = "0.7.16"
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.7", default-features = false}
@@ -54,9 +54,9 @@ default            = ["rt", "vectored", "xtal-40mhz"]
 async              = ["esp-hal-common/async"]
 bluetooth          = []
 debug              = ["esp-hal-common/debug"]
-defmt              = ["esp-hal-common/defmt"]
+defmt              = ["esp-hal-common/defmt", "esp-println/defmt"]
 eh1                = ["esp-hal-common/eh1"]
-log                = ["esp-hal-common/log"]
+log                = ["esp-hal-common/log", "esp-println/log"]
 rt                 = []
 ufmt               = ["esp-hal-common/ufmt"]
 vectored           = ["esp-hal-common/vectored"]

--- a/esp32-hal/build.rs
+++ b/esp32-hal/build.rs
@@ -24,6 +24,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     Ok(())
 }
 

--- a/esp32-hal/examples/embassy_i2s_read.rs
+++ b/esp32-hal/examples/embassy_i2s_read.rs
@@ -28,6 +28,7 @@ use esp32_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -45,16 +46,16 @@ async fn i2s_task(
     >,
 ) {
     let buffer = dma_buffer();
-    esp_println::println!("Start");
+    println!("Start");
 
     let mut data = [0u8; 5000];
     let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
     loop {
         let avail = transaction.available().await;
-        esp_println::println!("available {}", avail);
+        println!("available {}", avail);
 
         let count = transaction.pop(&mut data).await.unwrap();
-        esp_println::println!(
+        println!(
             "got {} bytes, {:x?}..{:x?}",
             count,
             &data[..10],
@@ -65,8 +66,9 @@ async fn i2s_task(
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32-hal/examples/embassy_i2s_sound.rs
+++ b/esp32-hal/examples/embassy_i2s_sound.rs
@@ -44,6 +44,7 @@ use esp32_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 const SINE: [i16; 64] = [
@@ -86,25 +87,26 @@ async fn i2s_task(
     let mut filler = [0u8; 10000];
     let mut idx = 32000 % data.len();
 
-    esp_println::println!("Start");
+    println!("Start");
     let mut transaction = i2s_tx.write_dma_circular_async(buffer).unwrap();
 
     loop {
         for i in 0..filler.len() {
             filler[i] = data[(idx + i) % data.len()];
         }
-        esp_println::println!("Next");
+        println!("Next");
 
         let written = transaction.push(&filler).await.unwrap();
         idx = (idx + written) % data.len();
-        esp_println::println!("written {}", written);
+        println!("written {}", written);
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32-hal/examples/embassy_rmt_rx.rs
+++ b/esp32-hal/examples/embassy_rmt_rx.rs
@@ -89,6 +89,7 @@ async fn signal_task(mut pin: Gpio15<Output<PushPull>>) {
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32-hal/examples/embassy_rmt_tx.rs
+++ b/esp32-hal/examples/embassy_rmt_tx.rs
@@ -16,6 +16,7 @@ use esp32_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -36,17 +37,18 @@ async fn rmt_task(mut channel: Channel0<0>) {
     data[data.len() - 1] = PulseCode::default();
 
     loop {
-        esp_println::println!("transmit");
+        println!("transmit");
         channel.transmit(&data).await.unwrap();
-        esp_println::println!("transmitted\n");
+        println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32-hal/examples/psram.rs
+++ b/esp32-hal/examples/psram.rs
@@ -25,6 +25,7 @@ fn main() -> ! {
     #[cfg(debug_assertions)]
     compile_error!("PSRAM on ESP32 needs to be built in release mode");
 
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
 
     let peripherals = Peripherals::take();

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -36,7 +36,7 @@ embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
 embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.8.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
-esp-println        = { version = "0.6.0", features = ["esp32c2", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32c2"] }
 heapless           = "0.7.16"
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.7", default-features = false}
@@ -52,12 +52,12 @@ p256              = {version = "0.13.2", default-features = false, features = ["
 default              = ["rt", "vectored", "xtal-40mhz"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt"]
+defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
 direct-boot          = ["esp-hal-common/rv-init-data"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 eh1                  = ["esp-hal-common/eh1"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log"]
+log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]

--- a/esp32c2-hal/build.rs
+++ b/esp32c2-hal/build.rs
@@ -19,6 +19,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     Ok(())
 }
 
@@ -39,6 +42,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
+
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 
     Ok(())
 }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -42,7 +42,7 @@ embedded-hal-async = "=1.0.0-rc.1"
 embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.8.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.5.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.6.0", features = ["esp32c3", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32c3"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
@@ -55,12 +55,12 @@ static_cell        = { version = "1.2.0", features = ["nightly"] }
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt"]
+defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 eh1                  = ["esp-hal-common/eh1"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log"]
+log                  = ["esp-hal-common/log", "esp-println/log"]
 mcu-boot             = []
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]

--- a/esp32c3-hal/build.rs
+++ b/esp32c3-hal/build.rs
@@ -31,6 +31,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     Ok(())
 }
 
@@ -51,6 +54,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     Ok(())
 }
 
@@ -70,6 +76,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
+
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 
     Ok(())
 }

--- a/esp32c3-hal/examples/embassy_i2s_read.rs
+++ b/esp32c3-hal/examples/embassy_i2s_read.rs
@@ -29,6 +29,7 @@ use esp32c3_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -46,16 +47,16 @@ async fn i2s_task(
     >,
 ) {
     let buffer = dma_buffer();
-    esp_println::println!("Start");
+    println!("Start");
 
     let mut data = [0u8; 5000];
     let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
     loop {
         let avail = transaction.available().await;
-        esp_println::println!("available {}", avail);
+        println!("available {}", avail);
 
         let count = transaction.pop(&mut data).await.unwrap();
-        esp_println::println!(
+        println!(
             "got {} bytes, {:x?}..{:x?}",
             count,
             &data[..10],
@@ -66,8 +67,9 @@ async fn i2s_task(
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32c3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c3-hal/examples/embassy_i2s_sound.rs
@@ -45,6 +45,7 @@ use esp32c3_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 const SINE: [i16; 64] = [
@@ -87,24 +88,25 @@ async fn i2s_task(
     let mut filler = [0u8; 10000];
     let mut idx = 32000 % data.len();
 
-    esp_println::println!("Start");
+    println!("Start");
     let mut transaction = i2s_tx.write_dma_circular_async(buffer).unwrap();
     loop {
         for i in 0..filler.len() {
             filler[i] = data[(idx + i) % data.len()];
         }
-        esp_println::println!("Next");
+        println!("Next");
 
         let written = transaction.push(&filler).await.unwrap();
         idx = (idx + written) % data.len();
-        esp_println::println!("written {}", written);
+        println!("written {}", written);
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32c3-hal/examples/embassy_rmt_rx.rs
+++ b/esp32c3-hal/examples/embassy_rmt_rx.rs
@@ -77,6 +77,7 @@ async fn rmt_task(mut channel: Channel2<2>) {
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32c3-hal/examples/embassy_rmt_tx.rs
+++ b/esp32c3-hal/examples/embassy_rmt_tx.rs
@@ -17,6 +17,7 @@ use esp32c3_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -37,17 +38,18 @@ async fn rmt_task(mut channel: Channel0<0>) {
     data[data.len() - 1] = PulseCode::default();
 
     loop {
-        esp_println::println!("transmit");
+        println!("transmit");
         channel.transmit(&data).await.unwrap();
-        esp_println::println!("transmitted\n");
+        println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -41,7 +41,7 @@ embedded-can       = "0.4.1"
 embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.8.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.5.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.6.0", features = ["esp32c6", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32c6"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
@@ -58,12 +58,12 @@ p256              = {version = "0.13.2", default-features = false, features = ["
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt"]
+defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 eh1                  = ["esp-hal-common/eh1"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log"]
+log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]

--- a/esp32c6-hal/build.rs
+++ b/esp32c6-hal/build.rs
@@ -16,6 +16,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     Ok(())
 }
 
@@ -35,6 +38,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
+
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 
     Ok(())
 }

--- a/esp32c6-hal/examples/embassy_i2s_read.rs
+++ b/esp32c6-hal/examples/embassy_i2s_read.rs
@@ -29,6 +29,7 @@ use esp32c6_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -46,16 +47,16 @@ async fn i2s_task(
     >,
 ) {
     let buffer = dma_buffer();
-    esp_println::println!("Start");
+    println!("Start");
 
     let mut data = [0u8; 5000];
     let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
     loop {
         let avail = transaction.available().await;
-        esp_println::println!("available {}", avail);
+        println!("available {}", avail);
 
         let count = transaction.pop(&mut data).await.unwrap();
-        esp_println::println!(
+        println!(
             "got {} bytes, {:x?}..{:x?}",
             count,
             &data[..10],
@@ -66,8 +67,9 @@ async fn i2s_task(
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32c6-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c6-hal/examples/embassy_i2s_sound.rs
@@ -45,6 +45,7 @@ use esp32c6_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 const SINE: [i16; 64] = [
@@ -87,24 +88,25 @@ async fn i2s_task(
     let mut filler = [0u8; 10000];
     let mut idx = 32000 % data.len();
 
-    esp_println::println!("Start");
+    println!("Start");
     let mut transaction = i2s_tx.write_dma_circular_async(buffer).unwrap();
     loop {
         for i in 0..filler.len() {
             filler[i] = data[(idx + i) % data.len()];
         }
-        esp_println::println!("Next");
+        println!("Next");
 
         let written = transaction.push(&filler).await.unwrap();
         idx = (idx + written) % data.len();
-        esp_println::println!("written {}", written);
+        println!("written {}", written);
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32c6-hal/examples/embassy_rmt_rx.rs
+++ b/esp32c6-hal/examples/embassy_rmt_rx.rs
@@ -77,6 +77,7 @@ async fn rmt_task(mut channel: Channel2<2>) {
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32c6-hal/examples/embassy_rmt_tx.rs
+++ b/esp32c6-hal/examples/embassy_rmt_tx.rs
@@ -17,6 +17,7 @@ use esp32c6_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -37,17 +38,18 @@ async fn rmt_task(mut channel: Channel0<0>) {
     data[data.len() - 1] = PulseCode::default();
 
     loop {
-        esp_println::println!("transmit");
+        println!("transmit");
         channel.transmit(&data).await.unwrap();
-        esp_println::println!("transmitted\n");
+        println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -41,7 +41,7 @@ embedded-can       = "0.4.1"
 embedded-io-async  = "0.5.0"
 esp-backtrace      = { version = "0.8.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.5.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.6.0", features = ["esp32h2", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32h2"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
@@ -58,12 +58,12 @@ p256              = {version = "0.13.2", default-features = false, features = ["
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt"]
+defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
 direct-boot          = ["esp-hal-common/rv-init-data", "esp-hal-common/rv-init-rtc-data"]
 direct-vectoring     = ["esp-hal-common/direct-vectoring"]
 eh1                  = ["esp-hal-common/eh1"]
 interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log"]
+log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]

--- a/esp32h2-hal/build.rs
+++ b/esp32h2-hal/build.rs
@@ -16,6 +16,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     Ok(())
 }
 
@@ -35,6 +38,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
+
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 
     Ok(())
 }

--- a/esp32h2-hal/examples/embassy_i2s_read.rs
+++ b/esp32h2-hal/examples/embassy_i2s_read.rs
@@ -29,6 +29,7 @@ use esp32h2_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -46,16 +47,16 @@ async fn i2s_task(
     >,
 ) {
     let buffer = dma_buffer();
-    esp_println::println!("Start");
+    println!("Start");
 
     let mut data = [0u8; 5000];
     let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
     loop {
         let avail = transaction.available().await;
-        esp_println::println!("available {}", avail);
+        println!("available {}", avail);
 
         let count = transaction.pop(&mut data).await.unwrap();
-        esp_println::println!(
+        println!(
             "got {} bytes, {:x?}..{:x?}",
             count,
             &data[..10],
@@ -66,8 +67,9 @@ async fn i2s_task(
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32h2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32h2-hal/examples/embassy_i2s_sound.rs
@@ -45,6 +45,7 @@ use esp32h2_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 const SINE: [i16; 64] = [
@@ -87,24 +88,25 @@ async fn i2s_task(
     let mut filler = [0u8; 10000];
     let mut idx = 32000 % data.len();
 
-    esp_println::println!("Start");
+    println!("Start");
     let mut transaction = i2s_tx.write_dma_circular_async(buffer).unwrap();
     loop {
         for i in 0..filler.len() {
             filler[i] = data[(idx + i) % data.len()];
         }
-        esp_println::println!("Next");
+        println!("Next");
 
         let written = transaction.push(&filler).await.unwrap();
         idx = (idx + written) % data.len();
-        esp_println::println!("written {}", written);
+        println!("written {}", written);
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32h2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32h2-hal/examples/embassy_rmt_rx.rs
@@ -77,6 +77,7 @@ async fn rmt_task(mut channel: Channel2<2>) {
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32h2-hal/examples/embassy_rmt_tx.rs
+++ b/esp32h2-hal/examples/embassy_rmt_tx.rs
@@ -17,6 +17,7 @@ use esp32h2_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -37,17 +38,18 @@ async fn rmt_task(mut channel: Channel0<0>) {
     data[data.len() - 1] = PulseCode::default();
 
     loop {
-        esp_println::println!("transmit");
+        println!("transmit");
         channel.transmit(&data).await.unwrap();
-        esp_println::println!("transmitted\n");
+        println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -42,7 +42,7 @@ embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.8.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled   = { version = "0.5.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.6.0", features = ["esp32s2", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32s2"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
@@ -57,9 +57,9 @@ usbd-serial        = "0.1.1"
 default   = ["rt", "vectored"]
 async     = ["esp-hal-common/async"]
 debug     = ["esp-hal-common/debug"]
-defmt     = ["esp-hal-common/defmt"]
+defmt     = ["esp-hal-common/defmt", "esp-println/defmt"]
 eh1       = ["esp-hal-common/eh1"]
-log       = ["esp-hal-common/log"]
+log       = ["esp-hal-common/log", "esp-println/log"]
 rt        = []
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]

--- a/esp32s2-hal/build.rs
+++ b/esp32s2-hal/build.rs
@@ -24,6 +24,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     Ok(())
 }
 

--- a/esp32s2-hal/examples/embassy_i2s_read.rs
+++ b/esp32s2-hal/examples/embassy_i2s_read.rs
@@ -28,6 +28,7 @@ use esp32s2_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -45,16 +46,16 @@ async fn i2s_task(
     >,
 ) {
     let buffer = dma_buffer();
-    esp_println::println!("Start");
+    println!("Start");
 
     let mut data = [0u8; 5000];
     let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
     loop {
         let avail = transaction.available().await;
-        esp_println::println!("available {}", avail);
+        println!("available {}", avail);
 
         let count = transaction.pop(&mut data).await.unwrap();
-        esp_println::println!(
+        println!(
             "got {} bytes, {:x?}..{:x?}",
             count,
             &data[..10],
@@ -65,8 +66,9 @@ async fn i2s_task(
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32s2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s2-hal/examples/embassy_i2s_sound.rs
@@ -45,6 +45,7 @@ use esp32s2_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 const SINE: [i16; 64] = [
@@ -87,25 +88,26 @@ async fn i2s_task(
     let mut filler = [0u8; 10000];
     let mut idx = 32000 % data.len();
 
-    esp_println::println!("Start");
+    println!("Start");
     let mut transaction = i2s_tx.write_dma_circular_async(buffer).unwrap();
 
     loop {
         for i in 0..filler.len() {
             filler[i] = data[(idx + i) % data.len()];
         }
-        esp_println::println!("Next");
+        println!("Next");
 
         let written = transaction.push(&filler).await.unwrap();
         idx = (idx + written) % data.len();
-        esp_println::println!("written {}", written);
+        println!("written {}", written);
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32s2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_rx.rs
@@ -90,6 +90,7 @@ async fn signal_task(mut pin: Gpio15<Output<PushPull>>) {
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32s2-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_tx.rs
@@ -16,6 +16,7 @@ use esp32s2_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 use xtensa_atomic_emulation_trap as _;
 
@@ -37,17 +38,18 @@ async fn rmt_task(mut channel: Channel0<0>) {
     data[data.len() - 1] = PulseCode::default();
 
     loop {
-        esp_println::println!("transmit");
+        println!("transmit");
         channel.transmit(&data).await.unwrap();
-        esp_println::println!("transmitted\n");
+        println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -44,7 +44,7 @@ embedded-io-async  = "0.5.0"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.8.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.5.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
-esp-println        = { version = "0.6.0", features = ["esp32s3", "log"] }
+esp-println        = { version = "0.6.0", features = ["esp32s3"] }
 heapless           = "0.7.16"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
@@ -59,10 +59,10 @@ usbd-serial        = "0.1.1"
 default              = ["rt", "vectored"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt"]
+defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
 direct-boot          = ["r0"]
 eh1                  = ["esp-hal-common/eh1"]
-log                  = ["esp-hal-common/log"]
+log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]

--- a/esp32s3-hal/build.rs
+++ b/esp32s3-hal/build.rs
@@ -16,6 +16,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
     Ok(())
 }
 
@@ -34,6 +37,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
+
+    #[cfg(feature = "defmt")]
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
 
     Ok(())
 }

--- a/esp32s3-hal/examples/embassy_i2s_read.rs
+++ b/esp32s3-hal/examples/embassy_i2s_read.rs
@@ -28,6 +28,7 @@ use esp32s3_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -45,16 +46,16 @@ async fn i2s_task(
     >,
 ) {
     let buffer = dma_buffer();
-    esp_println::println!("Start");
+    println!("Start");
 
     let mut data = [0u8; 5000];
     let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
     loop {
         let avail = transaction.available().await;
-        esp_println::println!("available {}", avail);
+        println!("available {}", avail);
 
         let count = transaction.pop(&mut data).await.unwrap();
-        esp_println::println!(
+        println!(
             "got {} bytes, {:x?}..{:x?}",
             count,
             &data[..10],
@@ -65,8 +66,9 @@ async fn i2s_task(
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32s3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s3-hal/examples/embassy_i2s_sound.rs
@@ -44,6 +44,7 @@ use esp32s3_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 const SINE: [i16; 64] = [
@@ -86,24 +87,25 @@ async fn i2s_task(
     let mut filler = [0u8; 10000];
     let mut idx = 32000 % data.len();
 
-    esp_println::println!("Start");
+    println!("Start");
     let mut transaction = i2s_tx.write_dma_circular_async(buffer).unwrap();
     loop {
         for i in 0..filler.len() {
             filler[i] = data[(idx + i) % data.len()];
         }
-        esp_println::println!("Next");
+        println!("Next");
 
         let written = transaction.push(&filler).await.unwrap();
         idx = (idx + written) % data.len();
-        esp_println::println!("written {}", written);
+        println!("written {}", written);
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32s3-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s3-hal/examples/embassy_rmt_rx.rs
@@ -76,6 +76,7 @@ async fn rmt_task(mut channel: Channel4<4>) {
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();

--- a/esp32s3-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s3-hal/examples/embassy_rmt_tx.rs
@@ -16,6 +16,7 @@ use esp32s3_hal::{
     IO,
 };
 use esp_backtrace as _;
+use esp_println::println;
 use static_cell::make_static;
 
 #[embassy_executor::task]
@@ -36,17 +37,18 @@ async fn rmt_task(mut channel: Channel0<0>) {
     data[data.len() - 1] = PulseCode::default();
 
     loop {
-        esp_println::println!("transmit");
+        println!("transmit");
         channel.transmit(&data).await.unwrap();
-        esp_println::println!("transmitted\n");
+        println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
 }
 
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
-    esp_println::println!("Init!");
+    println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

--- a/esp32s3-hal/examples/octal_psram.rs
+++ b/esp32s3-hal/examples/octal_psram.rs
@@ -25,6 +25,7 @@ fn main() -> ! {
     #[cfg(debug_assertions)]
     compile_error!("PSRAM on ESP32-S3 needs to be built in release mode");
 
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
 
     let peripherals = Peripherals::take();

--- a/esp32s3-hal/examples/psram.rs
+++ b/esp32s3-hal/examples/psram.rs
@@ -25,6 +25,7 @@ fn main() -> ! {
     #[cfg(debug_assertions)]
     compile_error!("PSRAM on ESP32-S3 needs to be built in release mode");
 
+    #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
 
     let peripherals = Peripherals::take();


### PR DESCRIPTION
This PR:
 - removes duplicate example checks
 - adds stuff to make sure the `defmt` feature not only passes `cargo check` but actually builds
 - adds `+nightly` toolchain spec for consistency
 - don't enable `esp-println/log` by default
 - fixes examples to work with `log` disabled