### PR TITLE
Enable defmt feature on PACs

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -154,4 +154,12 @@ defmt = [
     "embedded-hal-1?/defmt-03",
     "embedded-io/defmt-03",
     "embedded-io-async?/defmt-03",
+
+    "esp32?/defmt",
+    "esp32c2?/defmt",
+    "esp32c3?/defmt",
+    "esp32c6?/defmt",
+    "esp32h2?/defmt",
+    "esp32s2?/defmt",
+    "esp32s3?/defmt",
 ]


### PR DESCRIPTION
This should fix the issue I accidentally made Scott introduce in https://github.com/esp-rs/esp-hal/pull/808#discussion_r1333174043 (sorry!).

Depends on https://github.com/esp-rs/esp-pacs/pull/161

I have no idea why CI didn't fail here, on when I try to build examples.