### PR TITLE
Implement `embedded_hal_async::delay::DelayUs` trait for `SYSTIMER` alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new_no_miso to Spi FullDuplexMode (#794)
 - Add UART support for splitting into TX and RX (#754)
 - Async support for I2S (#801)
-- UART/ESP32: fix calculating FIFO counter with `get_rx_fifo_count()` (#804)
 - Async support for PARL_IO (#807)
+- Implement `embeded_hal_async::delay::DelayUs` trait for `SYSTIMER` alarms (#812)
 
 ### Changed
 
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Uart::new` now takes the `&Clocks` struct to ensure baudrate is correct for CPU/APB speed. (#808)
 - `Uart::new_with_config` takes an `Config` instead of `Option<Config>`. (#808)
+- `Alarm::set_period` takes a period (duration) instead of a frequency (#812)
+- `Alarm::interrupt_clear` is now `Alarm::clear_interrupt` to be consistent (#812)
 
 ## [0.12.0]
 

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -109,15 +109,15 @@ impl EmbassyTimer {
         match id {
             0 => {
                 self.alarm0.set_target(timestamp);
-                self.alarm0.interrupt_enable(true);
+                self.alarm0.enable_interrupt(true);
             }
             1 => {
                 self.alarm1.set_target(timestamp);
-                self.alarm1.interrupt_enable(true);
+                self.alarm1.enable_interrupt(true);
             }
             2 => {
                 self.alarm2.set_target(timestamp);
-                self.alarm2.interrupt_enable(true);
+                self.alarm2.enable_interrupt(true);
             }
             _ => {}
         }

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -43,7 +43,7 @@ impl EmbassyTimer {
 
     fn on_interrupt(&self, id: usize) {
         critical_section::with(|cs| {
-            self.clear_interrupt(id);
+            self.interrupt_clear(id);
             self.trigger_alarm(id, cs);
         })
     }
@@ -96,11 +96,11 @@ impl EmbassyTimer {
         })
     }
 
-    fn clear_interrupt(&self, id: usize) {
+    fn interrupt_clear(&self, id: usize) {
         match id {
-            0 => self.alarm0.clear_interrupt(),
-            1 => self.alarm1.clear_interrupt(),
-            2 => self.alarm2.clear_interrupt(),
+            0 => self.alarm0.interrupt_clear(),
+            1 => self.alarm1.interrupt_clear(),
+            2 => self.alarm2.interrupt_clear(),
             _ => {}
         }
     }

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -114,7 +114,7 @@ impl<T, const CHANNEL: u8> Alarm<T, CHANNEL> {
         Self { _pd: PhantomData }
     }
 
-    pub fn interrupt_enable(&self, val: bool) {
+    pub fn enable_interrupt(&self, val: bool) {
         let systimer = unsafe { &*SYSTIMER::ptr() };
         match CHANNEL {
             0 => systimer.int_ena.modify(|_, w| w.target0_int_ena().bit(val)),
@@ -288,7 +288,7 @@ mod asynch {
     impl<'a, const N: u8> AlarmFuture<'a, N> {
         pub(crate) fn new(alarm: &'a Alarm<Periodic, N>) -> Self {
             alarm.interrupt_clear();
-            alarm.interrupt_enable(true);
+            alarm.enable_interrupt(true);
 
             Self {
                 phantom: PhantomData,

--- a/esp32c2-hal/examples/systimer.rs
+++ b/esp32c2-hal/examples/systimer.rs
@@ -36,15 +36,15 @@ fn main() -> ! {
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
     alarm0.interrupt_clear();
-    alarm0.interrupt_enable(true);
+    alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.interrupt_enable(true);
+    alarm1.enable_interrupt(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.interrupt_enable(true);
+    alarm2.enable_interrupt(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32c2-hal/examples/systimer.rs
+++ b/esp32c2-hal/examples/systimer.rs
@@ -34,8 +34,8 @@ fn main() -> ! {
     println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
-    alarm0.set_period(1u32.Hz());
-    alarm0.clear_interrupt();
+    alarm0.set_period(1u32.secs());
+    alarm0.interrupt_clear();
     alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
@@ -85,7 +85,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -97,7 +97,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -109,6 +109,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -36,15 +36,15 @@ fn main() -> ! {
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
     alarm0.interrupt_clear();
-    alarm0.interrupt_enable(true);
+    alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.interrupt_enable(true);
+    alarm1.enable_interrupt(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.interrupt_enable(true);
+    alarm2.enable_interrupt(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -34,8 +34,8 @@ fn main() -> ! {
     println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
-    alarm0.set_period(1u32.Hz());
-    alarm0.clear_interrupt();
+    alarm0.set_period(1u32.secs());
+    alarm0.interrupt_clear();
     alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
@@ -85,7 +85,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -97,7 +97,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -109,6 +109,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }

--- a/esp32c6-hal/examples/systimer.rs
+++ b/esp32c6-hal/examples/systimer.rs
@@ -36,15 +36,15 @@ fn main() -> ! {
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
     alarm0.interrupt_clear();
-    alarm0.interrupt_enable(true);
+    alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.interrupt_enable(true);
+    alarm1.enable_interrupt(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.interrupt_enable(true);
+    alarm2.enable_interrupt(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32c6-hal/examples/systimer.rs
+++ b/esp32c6-hal/examples/systimer.rs
@@ -34,8 +34,8 @@ fn main() -> ! {
     println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
-    alarm0.set_period(1u32.Hz());
-    alarm0.clear_interrupt();
+    alarm0.set_period(1u32.secs());
+    alarm0.interrupt_clear();
     alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
@@ -85,7 +85,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -97,7 +97,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -109,6 +109,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }

--- a/esp32h2-hal/examples/systimer.rs
+++ b/esp32h2-hal/examples/systimer.rs
@@ -36,15 +36,15 @@ fn main() -> ! {
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
     alarm0.interrupt_clear();
-    alarm0.interrupt_enable(true);
+    alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.interrupt_enable(true);
+    alarm1.enable_interrupt(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.interrupt_enable(true);
+    alarm2.enable_interrupt(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32h2-hal/examples/systimer.rs
+++ b/esp32h2-hal/examples/systimer.rs
@@ -34,8 +34,8 @@ fn main() -> ! {
     println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
-    alarm0.set_period(1u32.Hz());
-    alarm0.clear_interrupt();
+    alarm0.set_period(1u32.secs());
+    alarm0.interrupt_clear();
     alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
@@ -85,7 +85,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -97,7 +97,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -109,6 +109,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -35,15 +35,15 @@ fn main() -> ! {
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
-    alarm0.interrupt_enable(true);
+    alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.interrupt_enable(true);
+    alarm1.enable_interrupt(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.interrupt_enable(true);
+    alarm2.enable_interrupt(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
-    alarm0.set_period(1u32.Hz());
+    alarm0.set_period(1u32.secs());
     alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
@@ -84,7 +84,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -96,7 +96,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -108,6 +108,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -35,15 +35,15 @@ fn main() -> ! {
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
-    alarm0.interrupt_enable(true);
+    alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
     alarm1.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 2));
-    alarm1.interrupt_enable(true);
+    alarm1.enable_interrupt(true);
 
     let alarm2 = syst.alarm2;
     alarm2.set_target(SystemTimer::now() + (SystemTimer::TICKS_PER_SECOND * 3));
-    alarm2.interrupt_enable(true);
+    alarm2.enable_interrupt(true);
 
     critical_section::with(|cs| {
         ALARM0.borrow_ref_mut(cs).replace(alarm0);

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     println!("SYSTIMER Current value = {}", SystemTimer::now());
 
     let alarm0 = syst.alarm0.into_periodic();
-    alarm0.set_period(1u32.Hz());
+    alarm0.set_period(1u32.secs());
     alarm0.interrupt_enable(true);
 
     let alarm1 = syst.alarm1;
@@ -84,7 +84,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -96,7 +96,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }
 
@@ -108,6 +108,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .clear_interrupt()
+            .interrupt_clear()
     });
 }


### PR DESCRIPTION
This completes one task of #752. Changes should be pretty straight-forward, though I have renamed some things for consistency as well.

The async functionality requires the `Alarm` to first be put in `Periodic` mode, but I don't think is an issue.

There isn't really an example of this, as I don't think it really makes sense, but I did test this locally by modifying the `embassy_hello_world` example as needed.