### PR TITLE
No longer publicly expose the `PeripheralClockControl` struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Uart::new_with_config` takes an `Config` instead of `Option<Config>`. (#808)
 - `Alarm::set_period` takes a period (duration) instead of a frequency (#812)
 - `Alarm::interrupt_clear` is now `Alarm::clear_interrupt` to be consistent (#812)
+- The `PeripheralClockControl` struct is no longer public, drivers no longer take this as a parameter (#817)
 
 ## [0.12.0]
 

--- a/esp-hal-common/src/aes/esp32.rs
+++ b/esp-hal-common/src/aes/esp32.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 
 impl<'d> Aes<'d> {
-    pub(super) fn init(&mut self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(PeripheralEnable::Aes);
+    pub(super) fn init(&mut self) {
+        PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_endianness(
             Endianness::BigEndian,
             Endianness::BigEndian,

--- a/esp-hal-common/src/aes/esp32cX.rs
+++ b/esp-hal-common/src/aes/esp32cX.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 
 impl<'d> Aes<'d> {
-    pub(super) fn init(&mut self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(PeripheralEnable::Aes);
+    pub(super) fn init(&mut self) {
+        PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_dma(false);
     }
 

--- a/esp-hal-common/src/aes/esp32s2.rs
+++ b/esp-hal-common/src/aes/esp32s2.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 
 impl<'d> Aes<'d> {
-    pub(super) fn init(&mut self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(PeripheralEnable::Aes);
+    pub(super) fn init(&mut self) {
+        PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_dma(false);
         self.write_endianness(
             Endianness::BigEndian,

--- a/esp-hal-common/src/aes/esp32s3.rs
+++ b/esp-hal-common/src/aes/esp32s3.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 
 impl<'d> Aes<'d> {
-    pub(super) fn init(&mut self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(PeripheralEnable::Aes);
+    pub(super) fn init(&mut self) {
+        PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_dma(false);
     }
 

--- a/esp-hal-common/src/aes/mod.rs
+++ b/esp-hal-common/src/aes/mod.rs
@@ -11,7 +11,7 @@
 //! ## Example
 //! ### Initialization
 //! ```no_run
-//! let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
+//! let mut aes = Aes::new(peripherals.AES);
 //! ```
 //! ### Creating key and block Buffer
 //! ```no_run
@@ -65,7 +65,6 @@ use crate::{
         generic::{Readable, Reg, RegisterSpec, Resettable, Writable},
         AES,
     },
-    system::PeripheralClockControl,
 };
 
 #[cfg_attr(esp32, path = "esp32.rs")]
@@ -84,13 +83,12 @@ pub struct Aes<'d> {
 }
 
 impl<'d> Aes<'d> {
-    pub fn new(
-        aes: impl Peripheral<P = AES> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(aes: impl Peripheral<P = AES> + 'd) -> Self {
         crate::into_ref!(aes);
-        let mut ret = Self { aes: aes };
-        ret.init(peripheral_clock_control);
+
+        let mut ret = Self { aes };
+        ret.init();
+
         ret
     }
 

--- a/esp-hal-common/src/analog/adc/riscv.rs
+++ b/esp-hal-common/src/analog/adc/riscv.rs
@@ -556,11 +556,10 @@ where
     ADCI: RegisterAccess + 'd,
 {
     pub fn adc(
-        peripheral_clock_controller: &mut PeripheralClockControl,
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
     ) -> Result<Self, ()> {
-        peripheral_clock_controller.enable(Peripheral::ApbSarAdc);
+        PeripheralClockControl::enable(Peripheral::ApbSarAdc);
 
         let sar_adc = unsafe { &*APB_SARADC::PTR };
         sar_adc.ctrl.modify(|_, w| unsafe {
@@ -718,12 +717,7 @@ mod implementation {
     //!
     //! let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
     //!
-    //! let mut adc1 = ADC::<ADC1>::adc(
-    //!     &mut system.peripheral_clock_control,
-    //!     analog.adc1,
-    //!     adc1_config,
-    //! )
-    //! .unwrap();
+    //! let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
     //!
     //! let mut delay = Delay::new(&clocks);
     //!
@@ -770,12 +764,7 @@ mod implementation {
     //!
     //! let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
     //!
-    //! let mut adc1 = ADC::<ADC1>::adc(
-    //!     &mut system.peripheral_clock_control,
-    //!     analog.adc1,
-    //!     adc1_config,
-    //! )
-    //! .unwrap();
+    //! let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
     //!
     //! let mut delay = Delay::new(&clocks);
     //!
@@ -827,12 +816,7 @@ mod implementation {
     //!
     //! let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
     //!
-    //! let mut adc1 = ADC::<ADC1>::adc(
-    //!     &mut system.peripheral_clock_control,
-    //!     analog.adc1,
-    //!     adc1_config,
-    //! )
-    //! .unwrap();
+    //! let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
     //!
     //! let mut delay = Delay::new(&clocks);
     //!
@@ -880,12 +864,7 @@ mod implementation {
     //!
     //! let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
     //!
-    //! let mut adc1 = ADC::<ADC1>::adc(
-    //!     &mut system.peripheral_clock_control,
-    //!     analog.adc1,
-    //!     adc1_config,
-    //! )
-    //! .unwrap();
+    //! let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
     //!
     //! let mut delay = Delay::new(&clocks);
     //!

--- a/esp-hal-common/src/analog/mod.rs
+++ b/esp-hal-common/src/analog/mod.rs
@@ -46,12 +46,7 @@
 //!
 //! let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
 //!
-//! let mut adc1 = ADC::<ADC1>::adc(
-//!     &mut system.peripheral_clock_control,
-//!     analog.adc1,
-//!     adc1_config,
-//! )
-//! .unwrap();
+//! let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
 //!
 //! let mut delay = Delay::new(&clocks);
 //!

--- a/esp-hal-common/src/assist_debug.rs
+++ b/esp-hal-common/src/assist_debug.rs
@@ -18,22 +18,19 @@
 
 use crate::{
     peripheral::{Peripheral, PeripheralRef},
-    system::PeripheralClockControl,
+    peripherals::ASSIST_DEBUG,
 };
 
 pub struct DebugAssist<'d> {
-    debug_assist: PeripheralRef<'d, crate::peripherals::ASSIST_DEBUG>,
+    debug_assist: PeripheralRef<'d, ASSIST_DEBUG>,
 }
 
 impl<'d> DebugAssist<'d> {
-    pub fn new(
-        debug_assist: impl Peripheral<P = crate::peripherals::ASSIST_DEBUG> + 'd,
-        _peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(debug_assist: impl Peripheral<P = ASSIST_DEBUG> + 'd) -> Self {
         crate::into_ref!(debug_assist);
 
-        // we should use peripheral clock control to enable the debug assist however
-        // it's always enabled in ROM code already
+        // NOTE: We should enable the debug assist, however, it's always enabled in ROM
+        //       code already.
 
         DebugAssist { debug_assist }
     }

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -16,7 +16,7 @@
 //!
 //! GDMA peripheral can be initializes using the `new` function, which requires
 //! a DMA peripheral instance and a clock control reference. ```no_run
-//! let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+//! let dma = Gdma::new(peripherals.DMA);
 //! ```
 //! 
 //! <em>PS: Note that the number of DMA channels is chip-specific.</em>
@@ -643,11 +643,10 @@ impl<'d> Gdma<'d> {
     /// Create a DMA instance.
     pub fn new(
         dma: impl crate::peripheral::Peripheral<P = crate::peripherals::DMA> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
     ) -> Gdma<'d> {
         crate::into_ref!(dma);
 
-        peripheral_clock_control.enable(Peripheral::Gdma);
+        PeripheralClockControl::enable(Peripheral::Gdma);
         dma.misc_conf.modify(|_, w| w.ahbm_rst_inter().set_bit());
         dma.misc_conf.modify(|_, w| w.ahbm_rst_inter().clear_bit());
         dma.misc_conf.modify(|_, w| w.clk_en().set_bit());

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -36,11 +36,11 @@
 //! ## Example
 //! #### Initialize and utilize DMA controller in `SPI`
 //! ```no_run
-//! let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+//! let dma = Gdma::new(peripherals.DMA);
 //! let dma_channel = dma.channel0;
 //!
 //! // For `ESP32` and `ESP32-S2` chips use `Pdma` controller instead:
-//! // let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+//! // let dma = Dma::new(system.dma);
 //! // let dma_channel = dma.spi2channel;
 //!
 //! let mut descriptors = [0u32; 8 * 3];
@@ -54,7 +54,6 @@
 //!     cs,
 //!     100u32.kHz(),
 //!     SpiMode::Mode0,
-//!     &mut system.peripheral_clock_control,
 //!     &clocks,
 //! )
 //! .with_dma(dma_channel.configure(

--- a/esp-hal-common/src/dma/pdma.rs
+++ b/esp-hal-common/src/dma/pdma.rs
@@ -711,11 +711,8 @@ pub struct Dma<'d> {
 
 impl<'d> Dma<'d> {
     /// Create a DMA instance.
-    pub fn new(
-        dma: impl crate::peripheral::Peripheral<P = crate::system::Dma> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Dma<'d> {
-        peripheral_clock_control.enable(Peripheral::Dma);
+    pub fn new(dma: impl crate::peripheral::Peripheral<P = crate::system::Dma> + 'd) -> Dma<'d> {
+        PeripheralClockControl::enable(Peripheral::Dma);
 
         Dma {
             _inner: dma.into_ref(),

--- a/esp-hal-common/src/ecc.rs
+++ b/esp-hal-common/src/ecc.rs
@@ -77,13 +77,10 @@ pub enum WorkMode {
 }
 
 impl<'d> Ecc<'d> {
-    pub fn new(
-        ecc: impl Peripheral<P = ECC> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(ecc: impl Peripheral<P = ECC> + 'd) -> Self {
         crate::into_ref!(ecc);
 
-        peripheral_clock_control.enable(PeripheralEnable::Ecc);
+        PeripheralClockControl::enable(PeripheralEnable::Ecc);
 
         Self {
             ecc,

--- a/esp-hal-common/src/etm.rs
+++ b/esp-hal-common/src/etm.rs
@@ -31,7 +31,7 @@
 //! let led_task = gpio_ext.channel0_task.toggle(&mut led);
 //! let button_event = gpio_ext.channel0_event.falling_edge(button);
 //!
-//! let etm = Etm::new(peripherals.SOC_ETM, &mut system.peripheral_clock_control);
+//! let etm = Etm::new(peripherals.SOC_ETM);
 //! let channel0 = etm.channel0;
 //!
 //! // make sure the configured channel doesn't get dropped - dropping it will
@@ -241,12 +241,10 @@ macro_rules! create_etm_constructor {
     ($($num:literal),+) => {
         paste::paste! {
             impl<'d> Etm<'d> {
-                pub fn new(
-                    peripheral: impl Peripheral<P = crate::peripherals::SOC_ETM> + 'd,
-                    peripheral_clock_control: &mut PeripheralClockControl,
-                ) -> Self {
+                pub fn new(peripheral: impl Peripheral<P = crate::peripherals::SOC_ETM> + 'd) -> Self {
                     crate::into_ref!(peripheral);
-                    peripheral_clock_control.enable(crate::system::Peripheral::Etm);
+
+                    PeripheralClockControl::enable(crate::system::Peripheral::Etm);
 
                     Self {
                         _peripheral: peripheral,

--- a/esp-hal-common/src/hmac.rs
+++ b/esp-hal-common/src/hmac.rs
@@ -93,14 +93,11 @@ enum NextCommand {
 }
 
 impl<'d> Hmac<'d> {
-    pub fn new(
-        hmac: impl Peripheral<P = HMAC> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(hmac: impl Peripheral<P = HMAC> + 'd) -> Self {
         crate::into_ref!(hmac);
 
-        peripheral_clock_control.enable(PeripheralEnable::Sha);
-        peripheral_clock_control.enable(PeripheralEnable::Hmac);
+        PeripheralClockControl::enable(PeripheralEnable::Sha);
+        PeripheralClockControl::enable(PeripheralEnable::Hmac);
 
         Self {
             hmac,

--- a/esp-hal-common/src/i2s.rs
+++ b/esp-hal-common/src/i2s.rs
@@ -35,7 +35,6 @@
 //!         &mut rx_descriptors,
 //!         DmaPriority::Priority0,
 //!     ),
-//!     &mut system.peripheral_clock_control,
 //!     &clocks,
 //! );
 //! ```
@@ -629,7 +628,6 @@ where
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
         mut channel: Channel<'d, CH>,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self {
         // on ESP32-C3 / ESP32-S3 and later RX and TX are independent and
@@ -640,7 +638,7 @@ where
         let mut register_access = i2s.register_access();
 
         channel.tx.init_channel();
-        peripheral_clock_control.enable(register_access.get_peripheral());
+        PeripheralClockControl::enable(register_access.get_peripheral());
         pins.configure(&mut register_access);
         register_access.set_clock(calculate_clock(
             sample_rate,
@@ -682,7 +680,6 @@ where
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
         channel: Channel<'d, CH>,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self;
 }
@@ -701,7 +698,6 @@ where
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
         channel: Channel<'d, CH>,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self {
         Self::new_internal(
@@ -711,7 +707,6 @@ where
             data_format,
             sample_rate,
             channel,
-            peripheral_clock_control,
             clocks,
         )
     }
@@ -733,7 +728,6 @@ where
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
         channel: Channel<'d, CH>,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self;
 }
@@ -753,7 +747,6 @@ where
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
         channel: Channel<'d, CH>,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Self {
         Self::new_internal(
@@ -763,7 +756,6 @@ where
             data_format,
             sample_rate,
             channel,
-            peripheral_clock_control,
             clocks,
         )
     }

--- a/esp-hal-common/src/ledc/mod.rs
+++ b/esp-hal-common/src/ledc/mod.rs
@@ -10,11 +10,7 @@
 //! 10% duty using the ABPClock
 //!
 //! ```no_run
-//! let mut ledc = LEDC::new(
-//!     peripherals.LEDC,
-//!     &clock_control,
-//!     &mut system.peripheral_clock_control,
-//! );
+//! let mut ledc = LEDC::new(peripherals.LEDC, &clock_control);
 //! ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 //!
 //! let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer0);
@@ -41,11 +37,7 @@
 //! 10% duty using the ABPClock
 //!
 //! ```no_run
-//! let ledc = LEDC::new(
-//!     peripherals.LEDC,
-//!     &clock_control,
-//!     &mut system.peripheral_clock_control,
-//! );
+//! let ledc = LEDC::new(peripherals.LEDC, &clock_control);
 //!
 //! let mut hstimer0 = ledc.get_timer::<HighSpeed>(timer::Number::Timer0);
 //! hstimer0
@@ -116,10 +108,9 @@ impl<'d> LEDC<'d> {
     pub fn new(
         _instance: impl Peripheral<P = crate::peripherals::LEDC> + 'd,
         clock_control_config: &'d Clocks,
-        system: &mut PeripheralClockControl,
     ) -> Self {
         crate::into_ref!(_instance);
-        system.enable(PeripheralEnable::Ledc);
+        PeripheralClockControl::enable(PeripheralEnable::Ledc);
 
         let ledc = unsafe { &*crate::peripherals::LEDC::ptr() };
         LEDC {

--- a/esp-hal-common/src/mcpwm/mod.rs
+++ b/esp-hal-common/src/mcpwm/mod.rs
@@ -33,11 +33,7 @@
 //!
 //! // initialize peripheral
 //! let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40u32.MHz()).unwrap();
-//! let mut mcpwm = MCPWM::new(
-//!     peripherals.PWM0,
-//!     clock_cfg,
-//!     &mut system.peripheral_clock_control,
-//! );
+//! let mut mcpwm = MCPWM::new(peripherals.PWM0, clock_cfg);
 //!
 //! // connect operator0 to timer0
 //! mcpwm.operator0.set_timer(&mcpwm.timer0);
@@ -102,11 +98,10 @@ impl<'d, PWM: PwmPeripheral> MCPWM<'d, PWM> {
     pub fn new(
         peripheral: impl Peripheral<P = PWM> + 'd,
         peripheral_clock: PeripheralClockConfig,
-        system: &mut PeripheralClockControl,
     ) -> Self {
         crate::into_ref!(peripheral);
 
-        PWM::enable(system);
+        PWM::enable();
 
         #[cfg(not(esp32c6))]
         {
@@ -289,7 +284,7 @@ pub struct FrequencyError;
 /// A MCPWM peripheral
 pub unsafe trait PwmPeripheral: Deref<Target = RegisterBlock> {
     /// Enable peripheral
-    fn enable(system: &mut PeripheralClockControl);
+    fn enable();
     /// Get a pointer to the peripheral RegisterBlock
     fn block() -> *const RegisterBlock;
     /// Get operator GPIO mux output signal
@@ -298,8 +293,8 @@ pub unsafe trait PwmPeripheral: Deref<Target = RegisterBlock> {
 
 #[cfg(mcpwm0)]
 unsafe impl PwmPeripheral for crate::peripherals::MCPWM0 {
-    fn enable(system: &mut PeripheralClockControl) {
-        system.enable(PeripheralEnable::Mcpwm0)
+    fn enable() {
+        PeripheralClockControl::enable(PeripheralEnable::Mcpwm0)
     }
 
     fn block() -> *const RegisterBlock {
@@ -321,8 +316,8 @@ unsafe impl PwmPeripheral for crate::peripherals::MCPWM0 {
 
 #[cfg(mcpwm1)]
 unsafe impl PwmPeripheral for crate::peripherals::MCPWM1 {
-    fn enable(system: &mut PeripheralClockControl) {
-        system.enable(PeripheralEnable::Mcpwm1)
+    fn enable() {
+        PeripheralClockControl::enable(PeripheralEnable::Mcpwm1)
     }
 
     fn block() -> *const RegisterBlock {

--- a/esp-hal-common/src/otg_fs.rs
+++ b/esp-hal-common/src/otg_fs.rs
@@ -68,10 +68,11 @@ where
         usb_sel: impl Peripheral<P = S> + 'd,
         usb_dp: impl Peripheral<P = P> + 'd,
         usb_dm: impl Peripheral<P = M> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
     ) -> Self {
         crate::into_ref!(usb_sel, usb_dp, usb_dm);
-        peripheral_clock_control.enable(PeripheralEnable::Usb);
+
+        PeripheralClockControl::enable(PeripheralEnable::Usb);
+
         Self {
             _usb0: usb0.into_ref(),
             _usb_sel: usb_sel,

--- a/esp-hal-common/src/parl_io.rs
+++ b/esp-hal-common/src/parl_io.rs
@@ -28,7 +28,6 @@
 //!         DmaPriority::Priority0,
 //!     ),
 //!     1u32.MHz(),
-//!     &mut system.peripheral_clock_control,
 //!     &clocks,
 //! )
 //! .unwrap();
@@ -64,7 +63,6 @@
 //!         DmaPriority::Priority0,
 //!     ),
 //!     1u32.MHz(),
-//!     &mut system.peripheral_clock_control,
 //!     &clocks,
 //! )
 //! .unwrap();
@@ -1034,11 +1032,10 @@ where
         parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
         mut dma_channel: Channel<'d, CH>,
         frequency: HertzU32,
-        peripheral_clock_control: &mut PeripheralClockControl,
         _clocks: &Clocks,
     ) -> Result<Self, Error> {
         crate::into_ref!(parl_io);
-        internal_init(&mut dma_channel, frequency, peripheral_clock_control)?;
+        internal_init(&mut dma_channel, frequency)?;
 
         Ok(Self {
             _parl_io: parl_io,
@@ -1071,11 +1068,10 @@ where
         parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
         mut dma_channel: Channel<'d, CH>,
         frequency: HertzU32,
-        peripheral_clock_control: &mut PeripheralClockControl,
         _clocks: &Clocks,
     ) -> Result<Self, Error> {
         crate::into_ref!(parl_io);
-        internal_init(&mut dma_channel, frequency, peripheral_clock_control)?;
+        internal_init(&mut dma_channel, frequency)?;
 
         Ok(Self {
             _parl_io: parl_io,
@@ -1105,11 +1101,10 @@ where
         parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
         mut dma_channel: Channel<'d, CH>,
         frequency: HertzU32,
-        peripheral_clock_control: &mut PeripheralClockControl,
         _clocks: &Clocks,
     ) -> Result<Self, Error> {
         crate::into_ref!(parl_io);
-        internal_init(&mut dma_channel, frequency, peripheral_clock_control)?;
+        internal_init(&mut dma_channel, frequency)?;
 
         Ok(Self {
             _parl_io: parl_io,
@@ -1123,7 +1118,6 @@ where
 fn internal_init<'d, CH>(
     dma_channel: &mut Channel<'d, CH>,
     frequency: HertzU32,
-    peripheral_clock_control: &mut PeripheralClockControl,
 ) -> Result<(), Error>
 where
     CH: ChannelTypes,
@@ -1133,7 +1127,7 @@ where
         return Err(Error::UnreachableClockRate);
     }
 
-    peripheral_clock_control.enable(crate::system::Peripheral::ParlIo);
+    PeripheralClockControl::enable(crate::system::Peripheral::ParlIo);
 
     let pcr = unsafe { &*crate::peripherals::PCR::PTR };
 

--- a/esp-hal-common/src/pcnt/mod.rs
+++ b/esp-hal-common/src/pcnt/mod.rs
@@ -34,7 +34,7 @@
 //!
 //! // setup a pulse couter
 //! println!("setup pulse counter unit 0");
-//! let pcnt = PCNT::new(peripherals.PCNT, &mut system.peripheral_clock_control);
+//! let pcnt = PCNT::new(peripherals.PCNT);
 //! let mut u0 = pcnt.get_unit(unit_number);
 //! u0.configure(unit::Config {
 //!     low_limit: -100,
@@ -147,13 +147,11 @@ pub struct PCNT<'d> {
 
 impl<'d> PCNT<'d> {
     /// Return a new PCNT
-    pub fn new(
-        _instance: impl Peripheral<P = crate::peripherals::PCNT> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(_instance: impl Peripheral<P = crate::peripherals::PCNT> + 'd) -> Self {
         crate::into_ref!(_instance);
         // Enable the PCNT peripherals clock in the system peripheral
-        peripheral_clock_control.enable(crate::system::Peripheral::Pcnt);
+        PeripheralClockControl::enable(crate::system::Peripheral::Pcnt);
+
         PCNT { _instance }
     }
 

--- a/esp-hal-common/src/rmt.rs
+++ b/esp-hal-common/src/rmt.rs
@@ -206,7 +206,6 @@ impl<'d> Rmt<'d> {
     pub fn new(
         peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
         frequency: HertzU32,
-        peripheral_clock_control: &mut PeripheralClockControl,
         _clocks: &Clocks,
     ) -> Result<Self, Error> {
         let me = Rmt::create(peripheral);
@@ -216,7 +215,7 @@ impl<'d> Rmt<'d> {
             return Err(Error::UnreachableTargetFrequency);
         }
 
-        peripheral_clock_control.enable(crate::system::Peripheral::Rmt);
+        PeripheralClockControl::enable(crate::system::Peripheral::Rmt);
 
         #[cfg(not(any(esp32, esp32s2)))]
         me.configure_clock(frequency, _clocks)?;

--- a/esp-hal-common/src/rsa/mod.rs
+++ b/esp-hal-common/src/rsa/mod.rs
@@ -25,7 +25,7 @@
 //! let peripherals = Peripherals::take();
 //! let mut system = peripherals.PCR.split();
 //!
-//! let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
+//! let mut rsa = Rsa::new(peripherals.RSA);
 //! ```
 //!
 //! ⚠️: The examples for RSA peripheral are quite extensive, so for a more
@@ -59,18 +59,12 @@ pub struct Rsa<'d> {
 }
 
 impl<'d> Rsa<'d> {
-    pub fn new(
-        rsa: impl Peripheral<P = RSA> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(rsa: impl Peripheral<P = RSA> + 'd) -> Self {
         crate::into_ref!(rsa);
-        let mut ret = Self { rsa };
-        ret.init(peripheral_clock_control);
-        ret
-    }
 
-    fn init(&mut self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(PeripheralEnable::Rsa);
+        PeripheralClockControl::enable(PeripheralEnable::Rsa);
+
+        Self { rsa }
     }
 
     unsafe fn write_operand_b<const N: usize>(&mut self, operand_b: &[u8; N]) {

--- a/esp-hal-common/src/sha.rs
+++ b/esp-hal-common/src/sha.rs
@@ -31,11 +31,7 @@
 //! ```no_run
 //! let source_data = "HELLO, ESPRESSIF!".as_bytes();
 //! let mut remaining = source_data.clone();
-//! let mut hasher = Sha::new(
-//!     peripherals.SHA,
-//!     ShaMode::SHA256,
-//!     &mut system.peripheral_clock_control,
-//! );
+//! let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA256);
 //!
 //! // Short hashes can be created by decreasing the output buffer to the desired
 //! // length
@@ -149,13 +145,10 @@ fn mode_as_bits(mode: ShaMode) -> u8 {
 // This implementation might fail after u32::MAX/8 bytes, to increase please see
 // ::finish() length/self.cursor usage
 impl<'d> Sha<'d> {
-    pub fn new(
-        sha: impl Peripheral<P = SHA> + 'd,
-        mode: ShaMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(sha: impl Peripheral<P = SHA> + 'd, mode: ShaMode) -> Self {
         crate::into_ref!(sha);
-        peripheral_clock_control.enable(crate::system::Peripheral::Sha);
+
+        PeripheralClockControl::enable(crate::system::Peripheral::Sha);
 
         // Setup SHA Mode
         #[cfg(not(esp32))]

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -434,7 +434,6 @@ where
         cs: impl Peripheral<P = CS> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Spi<'d, T, FullDuplexMode> {
         crate::into_ref!(spi, sck, mosi, miso, cs);
@@ -450,7 +449,7 @@ where
         cs.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.cs_signal());
 
-        Self::new_internal(spi, frequency, mode, peripheral_clock_control, clocks)
+        Self::new_internal(spi, frequency, mode, clocks)
     }
 
     /// Constructs an SPI instance in 8bit dataframe mode without CS pin.
@@ -461,7 +460,6 @@ where
         miso: impl Peripheral<P = MISO> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Spi<'d, T, FullDuplexMode> {
         crate::into_ref!(spi, sck, mosi, miso);
@@ -474,7 +472,7 @@ where
         miso.set_to_input()
             .connect_input_to_peripheral(spi.miso_signal());
 
-        Self::new_internal(spi, frequency, mode, peripheral_clock_control, clocks)
+        Self::new_internal(spi, frequency, mode, clocks)
     }
 
     /// Constructs an SPI instance in 8bit dataframe mode without MISO pin.
@@ -485,7 +483,6 @@ where
         cs: impl Peripheral<P = CS> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Spi<'d, T, FullDuplexMode> {
         crate::into_ref!(spi, sck, mosi, cs);
@@ -498,7 +495,7 @@ where
         cs.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.cs_signal());
 
-        Self::new_internal(spi, frequency, mode, peripheral_clock_control, clocks)
+        Self::new_internal(spi, frequency, mode, clocks)
     }
 
     /// Constructs an SPI instance in 8bit dataframe mode without CS and MISO
@@ -509,7 +506,6 @@ where
         mosi: impl Peripheral<P = MOSI> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Spi<'d, T, FullDuplexMode> {
         crate::into_ref!(spi, sck, mosi);
@@ -519,7 +515,7 @@ where
         mosi.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.mosi_signal());
 
-        Self::new_internal(spi, frequency, mode, peripheral_clock_control, clocks)
+        Self::new_internal(spi, frequency, mode, clocks)
     }
 
     /// Constructs an SPI instance in 8bit dataframe mode with only MOSI
@@ -531,24 +527,22 @@ where
         mosi: impl Peripheral<P = MOSI> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Spi<'d, T, FullDuplexMode> {
         crate::into_ref!(spi, mosi);
         mosi.set_to_push_pull_output()
             .connect_peripheral_to_output(spi.mosi_signal());
 
-        Self::new_internal(spi, frequency, mode, peripheral_clock_control, clocks)
+        Self::new_internal(spi, frequency, mode, clocks)
     }
 
     pub(crate) fn new_internal(
         spi: PeripheralRef<'d, T>,
         frequency: HertzU32,
         mode: SpiMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Spi<'d, T, FullDuplexMode> {
-        spi.enable_peripheral(peripheral_clock_control);
+        spi.enable_peripheral();
 
         let mut spi = Spi {
             spi,
@@ -591,7 +585,6 @@ where
         cs: Option<impl Peripheral<P = CS> + 'd>,
         frequency: HertzU32,
         mode: SpiMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Spi<'d, T, HalfDuplexMode> {
         crate::into_ref!(spi);
@@ -639,17 +632,16 @@ where
                 .connect_peripheral_to_output(spi.cs_signal());
         }
 
-        Self::new_internal(spi, frequency, mode, peripheral_clock_control, clocks)
+        Self::new_internal(spi, frequency, mode, clocks)
     }
 
     pub(crate) fn new_internal(
         spi: PeripheralRef<'d, T>,
         frequency: HertzU32,
         mode: SpiMode,
-        peripheral_clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
     ) -> Spi<'d, T, HalfDuplexMode> {
-        spi.enable_peripheral(peripheral_clock_control);
+        spi.enable_peripheral();
 
         let mut spi = Spi {
             spi,
@@ -2138,7 +2130,7 @@ pub trait Instance {
 
     fn cs_signal(&self) -> OutputSignal;
 
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl);
+    fn enable_peripheral(&self);
 
     fn spi_num(&self) -> u8;
 
@@ -2996,8 +2988,8 @@ impl Instance for crate::peripherals::SPI2 {
     }
 
     #[inline(always)]
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(crate::system::Peripheral::Spi2);
+    fn enable_peripheral(&self) {
+        PeripheralClockControl::enable(crate::system::Peripheral::Spi2);
     }
 
     #[inline(always)]
@@ -3067,8 +3059,8 @@ impl Instance for crate::peripherals::SPI2 {
     }
 
     #[inline(always)]
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(crate::system::Peripheral::Spi2);
+    fn enable_peripheral(&self) {
+        PeripheralClockControl::enable(crate::system::Peripheral::Spi2);
     }
 
     #[inline(always)]
@@ -3132,8 +3124,8 @@ impl Instance for crate::peripherals::SPI3 {
     }
 
     #[inline(always)]
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(crate::system::Peripheral::Spi3)
+    fn enable_peripheral(&self) {
+        PeripheralClockControl::enable(crate::system::Peripheral::Spi3)
     }
 
     #[inline(always)]
@@ -3170,8 +3162,8 @@ impl Instance for crate::peripherals::SPI2 {
     }
 
     #[inline(always)]
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(crate::system::Peripheral::Spi2)
+    fn enable_peripheral(&self) {
+        PeripheralClockControl::enable(crate::system::Peripheral::Spi2)
     }
 
     #[inline(always)]
@@ -3241,8 +3233,8 @@ impl Instance for crate::peripherals::SPI3 {
     }
 
     #[inline(always)]
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(crate::system::Peripheral::Spi3)
+    fn enable_peripheral(&self) {
+        PeripheralClockControl::enable(crate::system::Peripheral::Spi3)
     }
 
     #[inline(always)]

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -202,7 +202,7 @@ impl PeripheralClockControl {
         #[cfg(any(esp32c2, esp32c3, esp32s2, esp32s3))]
         let (perip_clk_en1, perip_rst_en1) = { (&system.perip_clk_en1, &system.perip_rst_en1) };
 
-        match peripheral {
+        critical_section::with(|_cs| match peripheral {
             #[cfg(spi2)]
             Peripheral::Spi2 => {
                 perip_clk_en0.modify(|_, w| w.spi2_clk_en().set_bit());
@@ -385,7 +385,7 @@ impl PeripheralClockControl {
                 perip_clk_en1.modify(|_, w| w.crypto_ecc_clk_en().set_bit());
                 perip_rst_en1.modify(|_, w| w.crypto_ecc_rst().clear_bit());
             }
-        }
+        });
     }
 }
 

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -179,14 +179,14 @@ impl SoftwareInterruptControl {
 }
 
 /// Controls the enablement of peripheral clocks.
-pub struct PeripheralClockControl {
+pub(crate) struct PeripheralClockControl {
     _private: (),
 }
 
 #[cfg(not(any(esp32c6, esp32h2)))]
 impl PeripheralClockControl {
     /// Enables and resets the given peripheral
-    pub fn enable(&mut self, peripheral: Peripheral) {
+    pub(crate) fn enable(peripheral: Peripheral) {
         let system = unsafe { &*SystemPeripheral::PTR };
 
         #[cfg(not(esp32))]
@@ -394,7 +394,7 @@ impl PeripheralClockControl {
 #[cfg(any(esp32c6, esp32h2))]
 impl PeripheralClockControl {
     /// Enables and resets the given peripheral
-    pub fn enable(&mut self, peripheral: Peripheral) {
+    pub(crate) fn enable(peripheral: Peripheral) {
         let system = unsafe { &*SystemPeripheral::PTR };
 
         match peripheral {
@@ -618,7 +618,6 @@ pub trait RadioClockController {
 /// The SYSTEM/DPORT splitted into it's different logical parts.
 pub struct SystemParts<'d> {
     _private: PeripheralRef<'d, SystemPeripheral>,
-    pub peripheral_clock_control: PeripheralClockControl,
     pub clock_control: SystemClockControl,
     pub cpu_control: CpuControl,
     #[cfg(pdma)]
@@ -642,7 +641,6 @@ impl<'d, T: crate::peripheral::Peripheral<P = SystemPeripheral> + 'd> SystemExt<
     fn split(self) -> Self::Parts {
         Self::Parts {
             _private: self.into_ref(),
-            peripheral_clock_control: PeripheralClockControl { _private: () },
             clock_control: SystemClockControl { _private: () },
             cpu_control: CpuControl { _private: () },
             #[cfg(pdma)]

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -46,7 +46,7 @@ pub enum SoftwareInterrupt {
     SoftwareInterrupt3,
 }
 
-/// Peripherals which can be enabled via [PeripheralClockControl]
+/// Peripherals which can be enabled via `PeripheralClockControl`
 pub enum Peripheral {
     #[cfg(spi2)]
     Spi2,
@@ -179,9 +179,7 @@ impl SoftwareInterruptControl {
 }
 
 /// Controls the enablement of peripheral clocks.
-pub(crate) struct PeripheralClockControl {
-    _private: (),
-}
+pub(crate) struct PeripheralClockControl;
 
 #[cfg(not(any(esp32c6, esp32h2)))]
 impl PeripheralClockControl {

--- a/esp-hal-common/src/timer.rs
+++ b/esp-hal-common/src/timer.rs
@@ -21,18 +21,10 @@
 //! let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 //!
 //! // Create timer groups
-//! let timer_group0 = TimerGroup::new(
-//!     peripherals.TIMG0,
-//!     &clocks,
-//!     &mut system.peripheral_clock_control,
-//! );
+//! let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
 //! // Get watchdog timers of timer groups
 //! let mut wdt0 = timer_group0.wdt;
-//! let timer_group1 = TimerGroup::new(
-//!     peripherals.TIMG1,
-//!     &clocks,
-//!     &mut system.peripheral_clock_control,
-//! );
+//! let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
 //! let mut wdt1 = timer_group1.wdt;
 //!
 //! // Disable watchdog timers
@@ -189,11 +181,7 @@ impl<'d, T> TimerGroup<'d, T>
 where
     T: TimerGroupInstance,
 {
-    pub fn new(
-        timer_group: impl Peripheral<P = T> + 'd,
-        clocks: &Clocks,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(timer_group: impl Peripheral<P = T> + 'd, clocks: &Clocks) -> Self {
         crate::into_ref!(timer_group);
 
         T::configure_src_clk();
@@ -207,7 +195,6 @@ where
             clocks.apb_clock,
             #[cfg(esp32h2)]
             clocks.pll_48m_clock,
-            peripheral_clock_control,
         );
 
         #[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2)))]
@@ -216,17 +203,14 @@ where
                 phantom: PhantomData::default(),
             },
             clocks.apb_clock,
-            peripheral_clock_control,
         );
-
-        let wdt = Wdt::new(peripheral_clock_control);
 
         Self {
             _timer_group: timer_group,
             timer0,
             #[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2)))]
             timer1,
-            wdt,
+            wdt: Wdt::new(),
         }
     }
 }
@@ -242,15 +226,12 @@ where
     T: Instance,
 {
     /// Create a new timer instance
-    pub fn new(
-        timg: T,
-        apb_clk_freq: HertzU32,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(timg: T, apb_clk_freq: HertzU32) -> Self {
         // TODO: this currently assumes APB_CLK is being used, as we don't yet have a
         //       way to select the XTAL_CLK.
 
-        timg.enable_peripheral(peripheral_clock_control);
+        timg.enable_peripheral();
+
         Self { timg, apb_clk_freq }
     }
 
@@ -312,7 +293,7 @@ pub trait Instance {
 
     fn is_interrupt_set(&self) -> bool;
 
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl);
+    fn enable_peripheral(&self);
 }
 
 pub struct Timer0<TG> {
@@ -469,8 +450,8 @@ where
             .modify(|_, w| unsafe { w.divider().bits(divider) })
     }
 
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(crate::system::Peripheral::Timg0);
+    fn enable_peripheral(&self) {
+        PeripheralClockControl::enable(crate::system::Peripheral::Timg0);
     }
 }
 
@@ -631,8 +612,8 @@ where
             .modify(|_, w| unsafe { w.divider().bits(divider) })
     }
 
-    fn enable_peripheral(&self, peripheral_clock_control: &mut PeripheralClockControl) {
-        peripheral_clock_control.enable(crate::system::Peripheral::Timg1);
+    fn enable_peripheral(&self) {
+        PeripheralClockControl::enable(crate::system::Peripheral::Timg1);
     }
 }
 
@@ -726,9 +707,9 @@ where
     TG: TimerGroupInstance,
 {
     /// Create a new watchdog timer instance
-    pub fn new(_peripheral_clock_control: &mut PeripheralClockControl) -> Self {
+    pub fn new() -> Self {
         #[cfg(lp_wdt)]
-        _peripheral_clock_control.enable(crate::system::Peripheral::Wdt);
+        PeripheralClockControl::enable(crate::system::Peripheral::Wdt);
 
         TG::configure_wdt_src_clk();
 

--- a/esp-hal-common/src/twai/mod.rs
+++ b/esp-hal-common/src/twai/mod.rs
@@ -32,7 +32,6 @@
 //!     peripherals.TWAI0,
 //!     can_tx_pin,
 //!     can_rx_pin,
-//!     &mut system.peripheral_clock_control,
 //!     &clocks,
 //!     CAN_BAUDRATE,
 //! );
@@ -274,12 +273,11 @@ where
         peripheral: impl Peripheral<P = T> + 'd,
         tx_pin: impl Peripheral<P = TX> + 'd,
         rx_pin: impl Peripheral<P = RX> + 'd,
-        clock_control: &mut PeripheralClockControl,
         clocks: &Clocks,
         baud_rate: BaudRate,
     ) -> Self {
         // Enable the peripheral clock for the TWAI peripheral.
-        clock_control.enable(T::SYSTEM_PERIPHERAL);
+        PeripheralClockControl::enable(T::SYSTEM_PERIPHERAL);
 
         // Set up the GPIO pins.
         crate::into_ref!(tx_pin, rx_pin);

--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -11,12 +11,9 @@
 //! ## Example
 //! ```no_run
 //! let peripherals = Peripherals::take();
-//! let mut system = peripherals.SYSTEM.split();
-//! let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 //! ...
 //! // Initialize USB Serial/JTAG peripheral
-//! let mut usb_serial =
-//!    UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);
+//! let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
 
 use core::convert::Infallible;
 
@@ -26,23 +23,20 @@ use crate::{
     system::PeripheralClockControl,
 };
 
+/// Custom USB serial error type
+type Error = Infallible;
+
 /// USB Serial JTAG driver
 pub struct UsbSerialJtag<'d> {
     usb_serial: PeripheralRef<'d, USB_DEVICE>,
 }
 
-/// Custom USB serial error type
-type Error = Infallible;
-
 impl<'d> UsbSerialJtag<'d> {
     /// Create a new USB serial/JTAG instance with defaults
-    pub fn new(
-        usb_serial: impl Peripheral<P = USB_DEVICE> + 'd,
-        peripheral_clock_control: &mut PeripheralClockControl,
-    ) -> Self {
+    pub fn new(usb_serial: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         crate::into_ref!(usb_serial);
 
-        peripheral_clock_control.enable(crate::system::Peripheral::Sha);
+        PeripheralClockControl::enable(crate::system::Peripheral::UsbDevice);
 
         let mut dev = Self { usb_serial };
         dev.usb_serial.disable_rx_interrupts();

--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -12,13 +12,7 @@
 //!
 //! ```rust,ignore
 //! let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let rmt = Rmt::new(
-//!     peripherals.RMT,
-//!     80u32.MHz(),
-//!     &mut system.peripheral_clock_control,
-//!     &clocks,
-//! )
-//! .unwrap();
+//! let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 //!
 //! let led = <smartLedAdapter!(0, 1)>::new(rmt.channel0, io.pins.gpio0);
 //! ```

--- a/esp32-hal/examples/advanced_serial.rs
+++ b/esp32-hal/examples/advanced_serial.rs
@@ -29,7 +29,7 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let config = Config {
@@ -45,13 +45,7 @@ fn main() -> ! {
         io.pins.gpio17.into_floating_input(),
     );
 
-    let mut serial1 = Uart::new_with_config(
-        peripherals.UART1,
-        config,
-        Some(pins),
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32-hal/examples/aes.rs
+++ b/esp32-hal/examples/aes.rs
@@ -19,10 +19,10 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
+    let mut aes = Aes::new(peripherals.AES);
 
     let keytext = "SUp4SeCp@sSw0rd".as_bytes();
     let plaintext = "message".as_bytes();

--- a/esp32-hal/examples/crc.rs
+++ b/esp32-hal/examples/crc.rs
@@ -19,20 +19,12 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
     timer0.start(1u64.secs());
 

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -38,14 +38,10 @@ async fn run2() {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     let executor = make_static!(Executor::new());

--- a/esp32-hal/examples/embassy_i2c.rs
+++ b/esp32-hal/examples/embassy_i2c.rs
@@ -45,14 +45,10 @@ async fn run(i2c: I2C<'static, I2C0>) {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -62,7 +58,6 @@ fn main() -> ! {
         io.pins.gpio32,
         io.pins.gpio33,
         400u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/embassy_i2s_read.rs
+++ b/esp32-hal/examples/embassy_i2s_read.rs
@@ -68,19 +68,15 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -98,7 +94,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/embassy_i2s_sound.rs
+++ b/esp32-hal/examples/embassy_i2s_sound.rs
@@ -106,19 +106,15 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -136,7 +132,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/embassy_multicore.rs
+++ b/esp32-hal/examples/embassy_multicore.rs
@@ -65,14 +65,10 @@ async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bo
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     // Set GPIO2 as an output, and set its state high initially.

--- a/esp32-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32-hal/examples/embassy_multicore_interrupt.rs
@@ -82,14 +82,10 @@ async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bo
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     // Set GPIO2 as an output, and set its state high initially.

--- a/esp32-hal/examples/embassy_multiprio.rs
+++ b/esp32-hal/examples/embassy_multiprio.rs
@@ -82,14 +82,10 @@ async fn low_prio_async() {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     // Set GPIO2 as an output, and set its state high initially.

--- a/esp32-hal/examples/embassy_rmt_rx.rs
+++ b/esp32-hal/examples/embassy_rmt_rx.rs
@@ -94,18 +94,16 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 =
-            esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        let timer_group0 = esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     let channel = rmt
         .channel2

--- a/esp32-hal/examples/embassy_rmt_tx.rs
+++ b/esp32-hal/examples/embassy_rmt_tx.rs
@@ -50,18 +50,16 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 =
-            esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        let timer_group0 = esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     let channel = rmt
         .channel0

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -68,18 +68,10 @@ fn main() -> ! {
     let mut system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -53,14 +53,10 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     esp32_hal::interrupt::enable(
@@ -75,7 +71,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio23;
     let cs = io.pins.gpio22;
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
     let descriptors = make_static!([0u32; 8 * 3]);
@@ -89,7 +85,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -34,14 +34,10 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32-hal/examples/hello_rgb.rs
+++ b/esp32-hal/examples/hello_rgb.rs
@@ -26,19 +26,13 @@ use smart_leds::{
 #[entry]
 fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Configure RMT peripheral globally
-    let rmt = Rmt::new(
-        peripherals.RMT,
-        80u32.MHz(),
-        &mut system.peripheral_clock_control,
-        &clocks,
-    )
-    .unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations

--- a/esp32-hal/examples/hello_world.rs
+++ b/esp32-hal/examples/hello_world.rs
@@ -19,20 +19,12 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
     timer0.start(1u64.secs());
 

--- a/esp32-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32-hal/examples/i2c_bmp180_calibration_data.rs
@@ -16,7 +16,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -28,7 +28,6 @@ fn main() -> ! {
         io.pins.gpio32,
         io.pins.gpio33,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/i2c_display.rs
+++ b/esp32-hal/examples/i2c_display.rs
@@ -34,14 +34,10 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -53,7 +49,6 @@ fn main() -> ! {
         io.pins.gpio32,
         io.pins.gpio33,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/i2s_read.rs
+++ b/esp32-hal/examples/i2s_read.rs
@@ -28,12 +28,12 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
     let mut tx_descriptors = [0u32; 8 * 3];
@@ -51,7 +51,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/i2s_sound.rs
+++ b/esp32-hal/examples/i2s_sound.rs
@@ -51,12 +51,12 @@ const SINE: [i16; 64] = [
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
     let mut tx_descriptors = [0u32; 20 * 3];
@@ -74,7 +74,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/ledc.rs
+++ b/esp32-hal/examples/ledc.rs
@@ -23,17 +23,13 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    let ledc = LEDC::new(
-        peripherals.LEDC,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let ledc = LEDC::new(peripherals.LEDC, &clocks);
     let mut hstimer0 = ledc.get_timer::<HighSpeed>(timer::Number::Timer0);
 
     hstimer0

--- a/esp32-hal/examples/mcpwm.rs
+++ b/esp32-hal/examples/mcpwm.rs
@@ -18,7 +18,7 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -26,11 +26,7 @@ fn main() -> ! {
 
     // initialize peripheral
     let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40u32.MHz()).unwrap();
-    let mut mcpwm = MCPWM::new(
-        peripherals.MCPWM0,
-        clock_cfg,
-        &mut system.peripheral_clock_control,
-    );
+    let mut mcpwm = MCPWM::new(peripherals.MCPWM0, clock_cfg);
 
     // connect operator0 to timer0
     mcpwm.operator0.set_timer(&mcpwm.timer0);

--- a/esp32-hal/examples/multicore.rs
+++ b/esp32-hal/examples/multicore.rs
@@ -24,21 +24,13 @@ static mut APP_CORE_STACK: Stack<8192> = Stack::new();
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut timer1 = timer_group1.timer0;
 
     timer0.start(1u64.secs());

--- a/esp32-hal/examples/pcnt_encoder.rs
+++ b/esp32-hal/examples/pcnt_encoder.rs
@@ -33,7 +33,7 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -42,7 +42,7 @@ fn main() -> ! {
 
     // setup a pulse couter
     println!("setup pulse counter unit 0");
-    let pcnt = PCNT::new(peripherals.PCNT, &mut system.peripheral_clock_control);
+    let pcnt = PCNT::new(peripherals.PCNT);
     let mut u0 = pcnt.get_unit(unit_number);
     u0.configure(unit::Config {
         low_limit: -100,

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -44,7 +44,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio16;
     let cs = io.pins.gpio4;
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -60,7 +60,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32-hal/examples/ram.rs
+++ b/esp32-hal/examples/ram.rs
@@ -32,14 +32,10 @@ static mut SOME_ZEROED_DATA: [u8; 8] = [0; 8];
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     // The RWDT flash boot protection must be enabled, as it is triggered as part of

--- a/esp32-hal/examples/rmt_rx.rs
+++ b/esp32-hal/examples/rmt_rx.rs
@@ -21,12 +21,11 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut out = io.pins.gpio15.into_push_pull_output();
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel0

--- a/esp32-hal/examples/rmt_tx.rs
+++ b/esp32-hal/examples/rmt_tx.rs
@@ -20,11 +20,10 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel0

--- a/esp32-hal/examples/rsa.rs
+++ b/esp32-hal/examples/rsa.rs
@@ -56,11 +56,11 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let rsa = peripherals.RSA;
-    let mut rsa = Rsa::new(rsa, &mut system.peripheral_clock_control);
+    let mut rsa = Rsa::new(rsa);
     block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);
     mod_multi_example(&mut rsa);

--- a/esp32-hal/examples/serial_interrupts.rs
+++ b/esp32-hal/examples/serial_interrupts.rs
@@ -25,21 +25,13 @@ static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(Non
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     uart0.set_rx_fifo_full_threshold(30).unwrap();
     uart0.listen_at_cmd();

--- a/esp32-hal/examples/sha.rs
+++ b/esp32-hal/examples/sha.rs
@@ -19,16 +19,12 @@ use sha2::{Digest, Sha512};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data.clone();
-    let mut hasher = Sha::new(
-        peripherals.SHA,
-        ShaMode::SHA512,
-        &mut system.peripheral_clock_control,
-    );
+    let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA512);
 
     // Short hashes can be created by decreasing the output buffer to the desired
     // length

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         miso,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     ));
     let mut spi_device_1 = spi_controller.add_device(io.pins.gpio12);

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -31,7 +31,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         cs,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -31,7 +31,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -52,7 +52,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -30,7 +30,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -47,7 +47,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -32,7 +32,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio23;
     let cs = io.pins.gpio22;
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -55,7 +55,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32-hal/examples/timer_interrupt.rs
+++ b/esp32-hal/examples/timer_interrupt.rs
@@ -26,22 +26,14 @@ static TIMER11: Mutex<RefCell<Option<Timer<Timer1<TIMG1>>>>> = Mutex::new(RefCel
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer00 = timer_group0.timer0;
     let mut timer01 = timer_group0.timer1;
 
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut timer10 = timer_group1.timer0;
     let mut timer11 = timer_group1.timer1;
 

--- a/esp32-hal/examples/watchdog.rs
+++ b/esp32-hal/examples/watchdog.rs
@@ -13,14 +13,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
 

--- a/esp32c2-hal/examples/adc.rs
+++ b/esp32c2-hal/examples/adc.rs
@@ -19,7 +19,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -31,12 +31,7 @@ fn main() -> ! {
 
     let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
 
-    let mut adc1 = ADC::<ADC1>::adc(
-        &mut system.peripheral_clock_control,
-        analog.adc1,
-        adc1_config,
-    )
-    .unwrap();
+    let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c2-hal/examples/adc_cal.rs
+++ b/esp32c2-hal/examples/adc_cal.rs
@@ -20,7 +20,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -39,12 +39,7 @@ fn main() -> ! {
 
     let mut pin = adc1_config.enable_pin_with_cal::<_, AdcCal>(io.pins.gpio2.into_analog(), atten);
 
-    let mut adc1 = ADC::<ADC1>::adc(
-        &mut system.peripheral_clock_control,
-        analog.adc1,
-        adc1_config,
-    )
-    .unwrap();
+    let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c2-hal/examples/advanced_serial.rs
+++ b/esp32c2-hal/examples/advanced_serial.rs
@@ -29,14 +29,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let config = Config {
@@ -52,13 +48,7 @@ fn main() -> ! {
         io.pins.gpio2.into_floating_input(),
     );
 
-    let mut serial1 = Uart::new_with_config(
-        peripherals.UART1,
-        config,
-        Some(pins),
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
 
     timer0.start(250u64.millis());
 

--- a/esp32c2-hal/examples/crc.rs
+++ b/esp32c2-hal/examples/crc.rs
@@ -19,19 +19,11 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     timer0.start(1u64.secs());
 

--- a/esp32c2-hal/examples/debug_assist.rs
+++ b/esp32c2-hal/examples/debug_assist.rs
@@ -22,13 +22,10 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut da = DebugAssist::new(
-        peripherals.ASSIST_DEBUG,
-        &mut system.peripheral_clock_control,
-    );
+    let mut da = DebugAssist::new(peripherals.ASSIST_DEBUG);
 
     da.enable_sp_monitor(0x3fccee00, 0x3fcd0000);
 

--- a/esp32c2-hal/examples/direct-vectoring.rs
+++ b/esp32c2-hal/examples/direct-vectoring.rs
@@ -16,10 +16,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 unsafe fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
-    let clocks = ClockControl::boot_defaults(clockctrl).freeze();
+    let _clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
     unsafe {

--- a/esp32c2-hal/examples/ecc.rs
+++ b/esp32c2-hal/examples/ecc.rs
@@ -42,13 +42,13 @@ const TEST_PARAMS_VECTOR: TestParams = TestParams {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let _system = peripherals.SYSTEM.split();
 
     let mut rng = Rng::new(peripherals.RNG);
 
     println!("ECC example");
 
-    let mut hw_ecc = Ecc::new(peripherals.ECC, &mut system.peripheral_clock_control);
+    let mut hw_ecc = Ecc::new(peripherals.ECC);
 
     println!("Beginning stress tests...");
     test_affine_point_multiplication(&mut hw_ecc, &mut rng);

--- a/esp32c2-hal/examples/embassy_hello_world.rs
+++ b/esp32c2-hal/examples/embassy_hello_world.rs
@@ -33,7 +33,7 @@ async fn run2() {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -45,12 +45,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let executor = make_static!(Executor::new());

--- a/esp32c2-hal/examples/embassy_i2c.rs
+++ b/esp32c2-hal/examples/embassy_i2c.rs
@@ -45,7 +45,7 @@ async fn run(i2c: I2C<'static, I2C0>) {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -57,12 +57,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -72,7 +67,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         400u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -65,7 +65,7 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -77,19 +77,10 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -54,7 +54,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -66,12 +66,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     esp32c2_hal::interrupt::enable(
@@ -86,7 +81,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let descriptors = make_static!([0u32; 8 * 3]);
@@ -100,7 +95,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c2-hal/examples/embassy_wait.rs
+++ b/esp32c2-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -46,12 +46,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c2-hal/examples/hello_world.rs
+++ b/esp32c2-hal/examples/hello_world.rs
@@ -19,19 +19,11 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     timer0.start(1u64.secs());

--- a/esp32c2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -16,7 +16,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -28,7 +28,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c2-hal/examples/i2c_display.rs
+++ b/esp32c2-hal/examples/i2c_display.rs
@@ -34,14 +34,10 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -53,7 +49,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c2-hal/examples/interrupt_preemption.rs
+++ b/esp32c2-hal/examples/interrupt_preemption.rs
@@ -17,8 +17,6 @@ use esp32c2_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,10 +25,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
-    let clocks = ClockControl::boot_defaults(clockctrl).freeze();
+    let _clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32c2-hal/examples/ledc.rs
+++ b/esp32c2-hal/examples/ledc.rs
@@ -24,17 +24,13 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    let mut ledc = LEDC::new(
-        peripherals.LEDC,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut ledc = LEDC::new(peripherals.LEDC, &clocks);
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
     let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer2);
 

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -44,7 +44,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio8;
     let cs = io.pins.gpio9;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -60,7 +60,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c2-hal/examples/serial_interrupts.rs
+++ b/esp32c2-hal/examples/serial_interrupts.rs
@@ -27,19 +27,11 @@ static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(Non
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));

--- a/esp32c2-hal/examples/sha.rs
+++ b/esp32c2-hal/examples/sha.rs
@@ -18,16 +18,12 @@ use sha2::{Digest, Sha256};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data;
-    let mut hasher = Sha::new(
-        peripherals.SHA,
-        ShaMode::SHA256,
-        &mut system.peripheral_clock_control,
-    );
+    let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA256);
 
     // Short hashes can be created by decreasing the output buffer to the desired
     // length

--- a/esp32c2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_device_loopback.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         miso,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     ));
     let mut spi_device_1 = spi_controller.add_device(io.pins.gpio3);

--- a/esp32c2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_loopback.rs
@@ -31,7 +31,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         cs,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -31,7 +31,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -52,7 +52,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c2-hal/examples/spi_loopback.rs
+++ b/esp32c2-hal/examples/spi_loopback.rs
@@ -30,7 +30,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -47,7 +47,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -32,7 +32,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -55,7 +55,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c2-hal/examples/timer_interrupt.rs
+++ b/esp32c2-hal/examples/timer_interrupt.rs
@@ -22,14 +22,10 @@ static TIMER0: Mutex<RefCell<Option<Timer<Timer0<TIMG0>>>>> = Mutex::new(RefCell
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     interrupt::enable(

--- a/esp32c2-hal/examples/watchdog.rs
+++ b/esp32c2-hal/examples/watchdog.rs
@@ -13,14 +13,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
 

--- a/esp32c3-hal/examples/adc.rs
+++ b/esp32c3-hal/examples/adc.rs
@@ -19,7 +19,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -31,12 +31,7 @@ fn main() -> ! {
 
     let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
 
-    let mut adc1 = ADC::<ADC1>::adc(
-        &mut system.peripheral_clock_control,
-        analog.adc1,
-        adc1_config,
-    )
-    .unwrap();
+    let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c3-hal/examples/adc_cal.rs
+++ b/esp32c3-hal/examples/adc_cal.rs
@@ -20,7 +20,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -40,12 +40,7 @@ fn main() -> ! {
 
     let mut pin = adc1_config.enable_pin_with_cal::<_, AdcCal>(io.pins.gpio2.into_analog(), atten);
 
-    let mut adc1 = ADC::<ADC1>::adc(
-        &mut system.peripheral_clock_control,
-        analog.adc1,
-        adc1_config,
-    )
-    .unwrap();
+    let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c3-hal/examples/advanced_serial.rs
+++ b/esp32c3-hal/examples/advanced_serial.rs
@@ -29,14 +29,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let config = Config {
@@ -52,13 +48,7 @@ fn main() -> ! {
         io.pins.gpio2.into_floating_input(),
     );
 
-    let mut serial1 = Uart::new_with_config(
-        peripherals.UART1,
-        config,
-        Some(pins),
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
 
     timer0.start(250u64.millis());
 

--- a/esp32c3-hal/examples/aes.rs
+++ b/esp32c3-hal/examples/aes.rs
@@ -19,10 +19,10 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
+    let mut aes = Aes::new(peripherals.AES);
 
     let keytext = "SUp4SeCp@sSw0rd".as_bytes();
     let plaintext = "message".as_bytes();

--- a/esp32c3-hal/examples/crc.rs
+++ b/esp32c3-hal/examples/crc.rs
@@ -19,19 +19,11 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     timer0.start(1u64.secs());
 

--- a/esp32c3-hal/examples/debug_assist.rs
+++ b/esp32c3-hal/examples/debug_assist.rs
@@ -24,13 +24,10 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _ = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut da = DebugAssist::new(
-        peripherals.ASSIST_DEBUG,
-        &mut system.peripheral_clock_control,
-    );
+    let mut da = DebugAssist::new(peripherals.ASSIST_DEBUG);
 
     // uncomment the functionality you want to test
 

--- a/esp32c3-hal/examples/direct-vectoring.rs
+++ b/esp32c3-hal/examples/direct-vectoring.rs
@@ -20,10 +20,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 unsafe fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
-    let clocks = ClockControl::boot_defaults(clockctrl).freeze();
+    let _clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
     interrupt::enable(

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -33,7 +33,7 @@ async fn run2() {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -45,12 +45,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let executor = make_static!(Executor::new());

--- a/esp32c3-hal/examples/embassy_i2c.rs
+++ b/esp32c3-hal/examples/embassy_i2c.rs
@@ -45,7 +45,7 @@ async fn run(i2c: I2C<'static, I2C0>) {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -57,12 +57,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -72,7 +67,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         400u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/embassy_i2s_read.rs
+++ b/esp32c3-hal/examples/embassy_i2s_read.rs
@@ -81,17 +81,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -109,7 +104,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c3-hal/examples/embassy_i2s_sound.rs
@@ -118,17 +118,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -146,7 +141,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -65,7 +65,7 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -77,19 +77,10 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -54,7 +54,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -66,12 +66,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     esp32c3_hal::interrupt::enable(
@@ -86,7 +81,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let descriptors = make_static!([0u32; 8 * 3]);
@@ -100,7 +95,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -46,12 +46,7 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -24,19 +24,13 @@ use smart_leds::{
 #[entry]
 fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Configure RMT peripheral globally
-    let rmt = Rmt::new(
-        peripherals.RMT,
-        80u32.MHz(),
-        &mut system.peripheral_clock_control,
-        &clocks,
-    )
-    .unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations

--- a/esp32c3-hal/examples/hello_world.rs
+++ b/esp32c3-hal/examples/hello_world.rs
@@ -19,19 +19,11 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     timer0.start(1u64.secs());

--- a/esp32c3-hal/examples/hmac.rs
+++ b/esp32c3-hal/examples/hmac.rs
@@ -74,7 +74,7 @@ type HmacSha256 = HmacSw<Sha256>;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
@@ -82,7 +82,7 @@ fn main() -> ! {
     // Set sw key
     let key = [0_u8; 32].as_ref();
 
-    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+    let mut hw_hmac = Hmac::new(peripherals.HMAC);
 
     let mut src = [0_u8; 1024];
     rng.read(src.as_mut_slice()).unwrap();

--- a/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -16,7 +16,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -28,7 +28,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/i2c_display.rs
+++ b/esp32c3-hal/examples/i2c_display.rs
@@ -34,14 +34,10 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -53,7 +49,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/i2s_read.rs
+++ b/esp32c3-hal/examples/i2s_read.rs
@@ -29,12 +29,12 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [0u32; 8 * 3];
@@ -52,7 +52,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/i2s_sound.rs
+++ b/esp32c3-hal/examples/i2s_sound.rs
@@ -52,12 +52,12 @@ const SINE: [i16; 64] = [
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [0u32; 20 * 3];
@@ -75,7 +75,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/interrupt_preemption.rs
+++ b/esp32c3-hal/examples/interrupt_preemption.rs
@@ -17,8 +17,6 @@ use esp32c3_hal::{
     prelude::*,
     riscv,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    timer::TimerGroup,
-    Rtc,
 };
 use esp_backtrace as _;
 
@@ -27,10 +25,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
-    let clocks = ClockControl::boot_defaults(clockctrl).freeze();
+    let _clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32c3-hal/examples/ledc.rs
+++ b/esp32c3-hal/examples/ledc.rs
@@ -24,17 +24,13 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    let mut ledc = LEDC::new(
-        peripherals.LEDC,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut ledc = LEDC::new(peripherals.LEDC, &clocks);
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
     let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer2);
 

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -44,7 +44,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio5;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -60,7 +60,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c3-hal/examples/ram.rs
+++ b/esp32c3-hal/examples/ram.rs
@@ -32,14 +32,10 @@ static mut SOME_ZEROED_DATA: [u8; 8] = [0; 8];
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     // The RWDT flash boot protection must be enabled, as it is triggered as part of

--- a/esp32c3-hal/examples/rmt_rx.rs
+++ b/esp32c3-hal/examples/rmt_rx.rs
@@ -25,11 +25,10 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 1u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 1u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel2

--- a/esp32c3-hal/examples/rmt_tx.rs
+++ b/esp32c3-hal/examples/rmt_tx.rs
@@ -20,11 +20,10 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel0

--- a/esp32c3-hal/examples/rsa.rs
+++ b/esp32c3-hal/examples/rsa.rs
@@ -56,10 +56,10 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
+    let mut rsa = Rsa::new(peripherals.RSA);
 
     block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);

--- a/esp32c3-hal/examples/serial_interrupts.rs
+++ b/esp32c3-hal/examples/serial_interrupts.rs
@@ -27,19 +27,11 @@ static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(Non
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));

--- a/esp32c3-hal/examples/sha.rs
+++ b/esp32c3-hal/examples/sha.rs
@@ -18,16 +18,12 @@ use sha2::{Digest, Sha256};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data;
-    let mut hasher = Sha::new(
-        peripherals.SHA,
-        ShaMode::SHA256,
-        &mut system.peripheral_clock_control,
-    );
+    let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA256);
 
     // Short hashes can be created by decreasing the output buffer to the desired
     // length

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         miso,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     ));
     let mut spi_device_1 = spi_controller.add_device(io.pins.gpio3);

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -31,7 +31,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         cs,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -31,7 +31,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -52,7 +52,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -30,7 +30,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -47,7 +47,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -32,7 +32,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -55,7 +55,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c3-hal/examples/timer_interrupt.rs
+++ b/esp32c3-hal/examples/timer_interrupt.rs
@@ -24,20 +24,12 @@ static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut timer1 = timer_group1.timer0;
 
     interrupt::enable(

--- a/esp32c3-hal/examples/twai.rs
+++ b/esp32c3-hal/examples/twai.rs
@@ -18,7 +18,7 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -37,7 +37,6 @@ fn main() -> ! {
         peripherals.TWAI0,
         can_tx_pin,
         can_rx_pin,
-        &mut system.peripheral_clock_control,
         &clocks,
         CAN_BAUDRATE,
     );

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -27,18 +27,13 @@ static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag>>> = Mutex::new(RefCell::n
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut usb_serial =
-        UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);
+    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
 
     usb_serial.listen_rx_packet_recv_interrupt();
 

--- a/esp32c3-hal/examples/watchdog.rs
+++ b/esp32c3-hal/examples/watchdog.rs
@@ -13,14 +13,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
 

--- a/esp32c6-hal/examples/adc.rs
+++ b/esp32c6-hal/examples/adc.rs
@@ -19,7 +19,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -31,12 +31,7 @@ fn main() -> ! {
 
     let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
 
-    let mut adc1 = ADC::<ADC1>::adc(
-        &mut system.peripheral_clock_control,
-        analog.adc1,
-        adc1_config,
-    )
-    .unwrap();
+    let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c6-hal/examples/adc_cal.rs
+++ b/esp32c6-hal/examples/adc_cal.rs
@@ -20,7 +20,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -40,12 +40,7 @@ fn main() -> ! {
 
     let mut pin = adc1_config.enable_pin_with_cal::<_, AdcCal>(io.pins.gpio2.into_analog(), atten);
 
-    let mut adc1 = ADC::<ADC1>::adc(
-        &mut system.peripheral_clock_control,
-        analog.adc1,
-        adc1_config,
-    )
-    .unwrap();
+    let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c6-hal/examples/advanced_serial.rs
+++ b/esp32c6-hal/examples/advanced_serial.rs
@@ -29,14 +29,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let config = Config {
@@ -52,13 +48,7 @@ fn main() -> ! {
         io.pins.gpio2.into_floating_input(),
     );
 
-    let mut serial1 = Uart::new_with_config(
-        peripherals.UART1,
-        config,
-        Some(pins),
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
 
     timer0.start(250u64.millis());
 

--- a/esp32c6-hal/examples/aes.rs
+++ b/esp32c6-hal/examples/aes.rs
@@ -19,10 +19,10 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
+    let mut aes = Aes::new(peripherals.AES);
 
     let keytext = "SUp4SeCp@sSw0rd".as_bytes();
     let plaintext = "message".as_bytes();

--- a/esp32c6-hal/examples/crc.rs
+++ b/esp32c6-hal/examples/crc.rs
@@ -19,20 +19,12 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     timer0.start(1u64.secs());
 

--- a/esp32c6-hal/examples/debug_assist.rs
+++ b/esp32c6-hal/examples/debug_assist.rs
@@ -24,13 +24,10 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut da = DebugAssist::new(
-        peripherals.ASSIST_DEBUG,
-        &mut system.peripheral_clock_control,
-    );
+    let mut da = DebugAssist::new(peripherals.ASSIST_DEBUG);
 
     // uncomment the functionality you want to test
 

--- a/esp32c6-hal/examples/direct-vectoring.rs
+++ b/esp32c6-hal/examples/direct-vectoring.rs
@@ -21,10 +21,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
-    let clocks = ClockControl::boot_defaults(clockctrl).freeze();
+    let _clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
     unsafe {

--- a/esp32c6-hal/examples/ecc.rs
+++ b/esp32c6-hal/examples/ecc.rs
@@ -40,13 +40,13 @@ const TEST_PARAMS_VECTOR: TestParams = TestParams {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let _system = peripherals.PCR.split();
 
     let mut rng = Rng::new(peripherals.RNG);
 
     println!("ECC example");
 
-    let mut hw_ecc = Ecc::new(peripherals.ECC, &mut system.peripheral_clock_control);
+    let mut hw_ecc = Ecc::new(peripherals.ECC);
 
     println!("Beginning stress tests...");
     test_affine_point_multiplication(&mut hw_ecc, &mut rng);

--- a/esp32c6-hal/examples/embassy_hello_world.rs
+++ b/esp32c6-hal/examples/embassy_hello_world.rs
@@ -33,7 +33,7 @@ async fn run2() {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -44,11 +44,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32c6-hal/examples/embassy_i2c.rs
+++ b/esp32c6-hal/examples/embassy_i2c.rs
@@ -45,7 +45,7 @@ async fn run(i2c: I2C<'static, I2C0>) {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -56,11 +56,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -71,7 +67,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         400u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/embassy_i2s_read.rs
+++ b/esp32c6-hal/examples/embassy_i2s_read.rs
@@ -81,17 +81,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -109,7 +104,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c6-hal/examples/embassy_i2s_sound.rs
@@ -118,17 +118,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -146,7 +141,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/embassy_parl_io_rx.rs
+++ b/esp32c6-hal/examples/embassy_parl_io_rx.rs
@@ -64,11 +64,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -77,7 +73,7 @@ fn main() -> ! {
     let tx_descriptors = make_static!([0u32; 8 * 3]);
     let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
@@ -91,7 +87,6 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .unwrap();

--- a/esp32c6-hal/examples/embassy_parl_io_tx.rs
+++ b/esp32c6-hal/examples/embassy_parl_io_tx.rs
@@ -84,11 +84,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -97,7 +93,7 @@ fn main() -> ! {
     let tx_descriptors = make_static!([0u32; 8 * 3]);
     let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
@@ -113,7 +109,6 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .unwrap();

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -65,7 +65,7 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -76,19 +76,11 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -54,7 +54,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -65,11 +65,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -90,7 +86,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let descriptors = make_static!([0u32; 8 * 3]);
@@ -104,7 +100,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c6-hal/examples/embassy_wait.rs
+++ b/esp32c6-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -45,11 +45,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32c6-hal/examples/etm_gpio.rs
+++ b/esp32c6-hal/examples/etm_gpio.rs
@@ -16,7 +16,7 @@ use esp_backtrace as _;
 fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -30,7 +30,7 @@ fn main() -> ! {
     let led_task = gpio_ext.channel0_task.toggle(&mut led);
     let button_event = gpio_ext.channel0_event.falling_edge(button);
 
-    let etm = Etm::new(peripherals.SOC_ETM, &mut system.peripheral_clock_control);
+    let etm = Etm::new(peripherals.SOC_ETM);
     let channel0 = etm.channel0;
 
     // make sure the configured channel doesn't get dropped - dropping it will

--- a/esp32c6-hal/examples/hello_rgb.rs
+++ b/esp32c6-hal/examples/hello_rgb.rs
@@ -23,19 +23,13 @@ use smart_leds::{
 #[entry]
 fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Configure RMT peripheral globally
-    let rmt = Rmt::new(
-        peripherals.RMT,
-        80u32.MHz(),
-        &mut system.peripheral_clock_control,
-        &clocks,
-    )
-    .unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations

--- a/esp32c6-hal/examples/hello_world.rs
+++ b/esp32c6-hal/examples/hello_world.rs
@@ -19,20 +19,12 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     timer0.start(1u64.secs());
 

--- a/esp32c6-hal/examples/hmac.rs
+++ b/esp32c6-hal/examples/hmac.rs
@@ -74,7 +74,7 @@ type HmacSha256 = HmacSw<Sha256>;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
@@ -82,7 +82,7 @@ fn main() -> ! {
     // Set sw key
     let key = [0_u8; 32].as_ref();
 
-    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+    let mut hw_hmac = Hmac::new(peripherals.HMAC);
 
     let mut src = [0_u8; 1024];
     rng.read(src.as_mut_slice()).unwrap();

--- a/esp32c6-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32c6-hal/examples/i2c_bmp180_calibration_data.rs
@@ -16,7 +16,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -28,7 +28,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/i2c_display.rs
+++ b/esp32c6-hal/examples/i2c_display.rs
@@ -34,14 +34,10 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -53,7 +49,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/i2s_read.rs
+++ b/esp32c6-hal/examples/i2s_read.rs
@@ -29,12 +29,12 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [0u32; 8 * 3];
@@ -52,7 +52,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/i2s_sound.rs
+++ b/esp32c6-hal/examples/i2s_sound.rs
@@ -52,12 +52,12 @@ const SINE: [i16; 64] = [
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [0u32; 20 * 3];
@@ -75,7 +75,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/interrupt_preemption.rs
+++ b/esp32c6-hal/examples/interrupt_preemption.rs
@@ -25,10 +25,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
-    let clocks = ClockControl::boot_defaults(clockctrl).freeze();
+    let _clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32c6-hal/examples/ledc.rs
+++ b/esp32c6-hal/examples/ledc.rs
@@ -24,17 +24,13 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    let mut ledc = LEDC::new(
-        peripherals.LEDC,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut ledc = LEDC::new(peripherals.LEDC, &clocks);
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
     let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer2);
 

--- a/esp32c6-hal/examples/mcpwm.rs
+++ b/esp32c6-hal/examples/mcpwm.rs
@@ -18,7 +18,7 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -26,11 +26,7 @@ fn main() -> ! {
 
     // initialize peripheral
     let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40u32.MHz()).unwrap();
-    let mut mcpwm = MCPWM::new(
-        peripherals.MCPWM0,
-        clock_cfg,
-        &mut system.peripheral_clock_control,
-    );
+    let mut mcpwm = MCPWM::new(peripherals.MCPWM0, clock_cfg);
 
     // connect operator0 to timer0
     mcpwm.operator0.set_timer(&mcpwm.timer0);

--- a/esp32c6-hal/examples/parl_io_rx.rs
+++ b/esp32c6-hal/examples/parl_io_rx.rs
@@ -24,22 +24,14 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers.
     let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
 
     rtc.swd.disable();
@@ -52,7 +44,7 @@ fn main() -> ! {
     let mut tx_descriptors = [0u32; 8 * 3];
     let mut rx_descriptors = [0u32; 8 * 3];
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
@@ -66,7 +58,6 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .unwrap();

--- a/esp32c6-hal/examples/parl_io_tx.rs
+++ b/esp32c6-hal/examples/parl_io_tx.rs
@@ -33,7 +33,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mut tx_descriptors = [0u32; 8 * 3];
     let mut rx_descriptors = [0u32; 8 * 3];
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
@@ -57,7 +57,6 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .unwrap();

--- a/esp32c6-hal/examples/pcnt_encoder.rs
+++ b/esp32c6-hal/examples/pcnt_encoder.rs
@@ -33,14 +33,14 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let unit_number = unit::Number::Unit1;
 
     // setup a pulse couter
     println!("setup pulse counter unit 0");
-    let pcnt = PCNT::new(peripherals.PCNT, &mut system.peripheral_clock_control);
+    let pcnt = PCNT::new(peripherals.PCNT);
     let mut u0 = pcnt.get_unit(unit_number);
     u0.configure(unit::Config {
         low_limit: -100,

--- a/esp32c6-hal/examples/qspi_flash.rs
+++ b/esp32c6-hal/examples/qspi_flash.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -44,7 +44,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio0;
     let cs = io.pins.gpio1;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -60,7 +60,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c6-hal/examples/ram.rs
+++ b/esp32c6-hal/examples/ram.rs
@@ -32,14 +32,10 @@ static mut SOME_ZEROED_DATA: [u8; 8] = [0; 8];
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     // The RWDT flash boot protection must be enabled, as it is triggered as part of

--- a/esp32c6-hal/examples/rmt_rx.rs
+++ b/esp32c6-hal/examples/rmt_rx.rs
@@ -24,12 +24,11 @@ const WIDTH: usize = 80;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.PCR.split();
-    let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 1u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 1u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel2

--- a/esp32c6-hal/examples/rmt_tx.rs
+++ b/esp32c6-hal/examples/rmt_tx.rs
@@ -19,12 +19,11 @@ use esp_backtrace as _;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.PCR.split();
-    let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel0

--- a/esp32c6-hal/examples/rsa.rs
+++ b/esp32c6-hal/examples/rsa.rs
@@ -56,10 +56,10 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
+    let mut rsa = Rsa::new(peripherals.RSA);
 
     block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);

--- a/esp32c6-hal/examples/serial_interrupts.rs
+++ b/esp32c6-hal/examples/serial_interrupts.rs
@@ -27,21 +27,13 @@ static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(Non
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     uart0.set_rx_fifo_full_threshold(30).unwrap();
     uart0.listen_at_cmd();

--- a/esp32c6-hal/examples/sha.rs
+++ b/esp32c6-hal/examples/sha.rs
@@ -18,16 +18,12 @@ use sha2::{Digest, Sha256};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data;
-    let mut hasher = Sha::new(
-        peripherals.SHA,
-        ShaMode::SHA256,
-        &mut system.peripheral_clock_control,
-    );
+    let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA256);
 
     // Short hashes can be created by decreasing the output buffer to the desired
     // length

--- a/esp32c6-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_device_loopback.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         miso,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     ));
     let mut spi_device_1 = spi_controller.add_device(io.pins.gpio3);

--- a/esp32c6-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_loopback.rs
@@ -31,7 +31,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         cs,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -31,7 +31,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -52,7 +52,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/spi_loopback.rs
+++ b/esp32c6-hal/examples/spi_loopback.rs
@@ -30,7 +30,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -47,7 +47,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -32,7 +32,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -55,7 +55,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32c6-hal/examples/timer_interrupt.rs
+++ b/esp32c6-hal/examples/timer_interrupt.rs
@@ -24,21 +24,13 @@ static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut timer1 = timer_group1.timer0;
 
     interrupt::enable(

--- a/esp32c6-hal/examples/usb_serial_jtag.rs
+++ b/esp32c6-hal/examples/usb_serial_jtag.rs
@@ -26,18 +26,13 @@ static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag>>> = Mutex::new(RefCell::n
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut usb_serial =
-        UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);
+    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
 
     usb_serial.listen_rx_packet_recv_interrupt();
 

--- a/esp32c6-hal/examples/watchdog.rs
+++ b/esp32c6-hal/examples/watchdog.rs
@@ -13,14 +13,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
 

--- a/esp32h2-hal/examples/adc.rs
+++ b/esp32h2-hal/examples/adc.rs
@@ -19,7 +19,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -31,12 +31,7 @@ fn main() -> ! {
 
     let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
 
-    let mut adc1 = ADC::<ADC1>::adc(
-        &mut system.peripheral_clock_control,
-        analog.adc1,
-        adc1_config,
-    )
-    .unwrap();
+    let mut adc1 = ADC::<ADC1>::adc(analog.adc1, adc1_config).unwrap();
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32h2-hal/examples/advanced_serial.rs
+++ b/esp32h2-hal/examples/advanced_serial.rs
@@ -29,14 +29,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let config = Config {
@@ -52,13 +48,7 @@ fn main() -> ! {
         io.pins.gpio2.into_floating_input(),
     );
 
-    let mut serial1 = Uart::new_with_config(
-        peripherals.UART1,
-        config,
-        Some(pins),
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
 
     timer0.start(250u64.millis());
 

--- a/esp32h2-hal/examples/aes.rs
+++ b/esp32h2-hal/examples/aes.rs
@@ -19,10 +19,10 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
+    let mut aes = Aes::new(peripherals.AES);
 
     let keytext = "SUp4SeCp@sSw0rd".as_bytes();
     let plaintext = "message".as_bytes();

--- a/esp32h2-hal/examples/crc.rs
+++ b/esp32h2-hal/examples/crc.rs
@@ -19,20 +19,12 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     timer0.start(1u64.secs());
 

--- a/esp32h2-hal/examples/debug_assist.rs
+++ b/esp32h2-hal/examples/debug_assist.rs
@@ -24,13 +24,10 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut da = DebugAssist::new(
-        peripherals.ASSIST_DEBUG,
-        &mut system.peripheral_clock_control,
-    );
+    let mut da = DebugAssist::new(peripherals.ASSIST_DEBUG);
 
     // Uncomment the functionality you want to test
     // We use a 0x1200 wide SP and 0x100 regions, and RAM ends at 0x40850000

--- a/esp32h2-hal/examples/direct-vectoring.rs
+++ b/esp32h2-hal/examples/direct-vectoring.rs
@@ -21,10 +21,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
-    let clocks = ClockControl::boot_defaults(clockctrl).freeze();
+    let _clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
     unsafe {

--- a/esp32h2-hal/examples/ecc.rs
+++ b/esp32h2-hal/examples/ecc.rs
@@ -41,13 +41,13 @@ const TEST_PARAMS_VECTOR: TestParams = TestParams {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let _system = peripherals.PCR.split();
 
     let mut rng = Rng::new(peripherals.RNG);
 
     println!("ECC example");
 
-    let mut hw_ecc = Ecc::new(peripherals.ECC, &mut system.peripheral_clock_control);
+    let mut hw_ecc = Ecc::new(peripherals.ECC);
 
     println!("Beginning stress tests...");
     test_affine_point_multiplication(&mut hw_ecc, &mut rng);

--- a/esp32h2-hal/examples/embassy_hello_world.rs
+++ b/esp32h2-hal/examples/embassy_hello_world.rs
@@ -33,7 +33,7 @@ async fn run2() {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -44,11 +44,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32h2-hal/examples/embassy_i2c.rs
+++ b/esp32h2-hal/examples/embassy_i2c.rs
@@ -45,7 +45,7 @@ async fn run(i2c: I2C<'static, I2C0>) {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -56,11 +56,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -71,7 +67,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         400u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/embassy_i2s_read.rs
+++ b/esp32h2-hal/examples/embassy_i2s_read.rs
@@ -81,17 +81,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -109,7 +104,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32h2-hal/examples/embassy_i2s_sound.rs
@@ -118,17 +118,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -146,7 +141,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/embassy_parl_io_rx.rs
+++ b/esp32h2-hal/examples/embassy_parl_io_rx.rs
@@ -64,11 +64,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -77,7 +73,7 @@ fn main() -> ! {
     let tx_descriptors = make_static!([0u32; 8 * 3]);
     let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
@@ -91,7 +87,6 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .unwrap();

--- a/esp32h2-hal/examples/embassy_parl_io_tx.rs
+++ b/esp32h2-hal/examples/embassy_parl_io_tx.rs
@@ -84,11 +84,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -97,7 +93,7 @@ fn main() -> ! {
     let tx_descriptors = make_static!([0u32; 8 * 3]);
     let rx_descriptors = make_static!([0u32; 8 * 3]);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
@@ -113,7 +109,6 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .unwrap();

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -65,7 +65,7 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -76,19 +76,11 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -54,7 +54,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -65,11 +65,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -90,7 +86,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio3;
     let cs = io.pins.gpio11;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let descriptors = make_static!([0u32; 8 * 3]);
@@ -104,7 +100,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32h2-hal/examples/embassy_wait.rs
+++ b/esp32h2-hal/examples/embassy_wait.rs
@@ -34,7 +34,7 @@ async fn ping(mut pin: Gpio9<Input<PullDown>>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -45,11 +45,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32h2-hal/examples/etm_gpio.rs
+++ b/esp32h2-hal/examples/etm_gpio.rs
@@ -16,7 +16,7 @@ use esp_backtrace as _;
 fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -30,7 +30,7 @@ fn main() -> ! {
     let led_task = gpio_ext.channel0_task.toggle(&mut led);
     let button_event = gpio_ext.channel0_event.falling_edge(button);
 
-    let etm = Etm::new(peripherals.SOC_ETM, &mut system.peripheral_clock_control);
+    let etm = Etm::new(peripherals.SOC_ETM);
     let channel0 = etm.channel0;
 
     // make sure the configured channel doesn't get dropped - dropping it will

--- a/esp32h2-hal/examples/hello_rgb.rs
+++ b/esp32h2-hal/examples/hello_rgb.rs
@@ -23,19 +23,13 @@ use smart_leds::{
 #[entry]
 fn main() -> ! {
     let peripherals = peripherals::Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Configure RMT peripheral globally
-    let rmt = Rmt::new(
-        peripherals.RMT,
-        80u32.MHz(),
-        &mut system.peripheral_clock_control,
-        &clocks,
-    )
-    .unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations

--- a/esp32h2-hal/examples/hello_world.rs
+++ b/esp32h2-hal/examples/hello_world.rs
@@ -19,20 +19,12 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     timer0.start(1u64.secs());
 

--- a/esp32h2-hal/examples/hmac.rs
+++ b/esp32h2-hal/examples/hmac.rs
@@ -74,7 +74,7 @@ type HmacSha256 = HmacSw<Sha256>;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
@@ -82,7 +82,7 @@ fn main() -> ! {
     // Set sw key
     let key = [0_u8; 32].as_ref();
 
-    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+    let mut hw_hmac = Hmac::new(peripherals.HMAC);
 
     let mut src = [0_u8; 1024];
     rng.read(src.as_mut_slice()).unwrap();

--- a/esp32h2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32h2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -16,7 +16,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -28,7 +28,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/i2c_display.rs
+++ b/esp32h2-hal/examples/i2c_display.rs
@@ -34,14 +34,10 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -53,7 +49,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/i2s_read.rs
+++ b/esp32h2-hal/examples/i2s_read.rs
@@ -29,12 +29,12 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [0u32; 8 * 3];
@@ -52,7 +52,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/i2s_sound.rs
+++ b/esp32h2-hal/examples/i2s_sound.rs
@@ -52,12 +52,12 @@ const SINE: [i16; 64] = [
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [0u32; 20 * 3];
@@ -75,7 +75,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/interrupt_preemption.rs
+++ b/esp32h2-hal/examples/interrupt_preemption.rs
@@ -25,10 +25,10 @@ static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefC
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clockctrl = system.clock_control;
     let sw_int = system.software_interrupt_control;
-    let clocks = ClockControl::boot_defaults(clockctrl).freeze();
+    let _clocks = ClockControl::boot_defaults(clockctrl).freeze();
 
     critical_section::with(|cs| SWINT.borrow_ref_mut(cs).replace(sw_int));
 

--- a/esp32h2-hal/examples/ledc.rs
+++ b/esp32h2-hal/examples/ledc.rs
@@ -24,17 +24,13 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    let mut ledc = LEDC::new(
-        peripherals.LEDC,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut ledc = LEDC::new(peripherals.LEDC, &clocks);
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
     let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer2);
 

--- a/esp32h2-hal/examples/mcpwm.rs
+++ b/esp32h2-hal/examples/mcpwm.rs
@@ -18,7 +18,7 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -26,11 +26,7 @@ fn main() -> ! {
 
     // initialize peripheral
     let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 32u32.MHz()).unwrap();
-    let mut mcpwm = MCPWM::new(
-        peripherals.MCPWM0,
-        clock_cfg,
-        &mut system.peripheral_clock_control,
-    );
+    let mut mcpwm = MCPWM::new(peripherals.MCPWM0, clock_cfg);
 
     // connect operator0 to timer0
     mcpwm.operator0.set_timer(&mcpwm.timer0);

--- a/esp32h2-hal/examples/parl_io_rx.rs
+++ b/esp32h2-hal/examples/parl_io_rx.rs
@@ -24,22 +24,14 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers.
     let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut wdt1 = timer_group1.wdt;
 
     rtc.swd.disable();
@@ -52,7 +44,7 @@ fn main() -> ! {
     let mut tx_descriptors = [0u32; 8 * 3];
     let mut rx_descriptors = [0u32; 8 * 3];
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
@@ -66,7 +58,6 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .unwrap();

--- a/esp32h2-hal/examples/parl_io_tx.rs
+++ b/esp32h2-hal/examples/parl_io_tx.rs
@@ -33,7 +33,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mut tx_descriptors = [0u32; 8 * 3];
     let mut rx_descriptors = [0u32; 8 * 3];
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
@@ -57,7 +57,6 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .unwrap();

--- a/esp32h2-hal/examples/pcnt_encoder.rs
+++ b/esp32h2-hal/examples/pcnt_encoder.rs
@@ -33,14 +33,14 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let unit_number = unit::Number::Unit1;
 
     // setup a pulse couter
     println!("setup pulse counter unit 0");
-    let pcnt = PCNT::new(peripherals.PCNT, &mut system.peripheral_clock_control);
+    let pcnt = PCNT::new(peripherals.PCNT);
     let mut u0 = pcnt.get_unit(unit_number);
     u0.configure(unit::Config {
         low_limit: -100,

--- a/esp32h2-hal/examples/qspi_flash.rs
+++ b/esp32h2-hal/examples/qspi_flash.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -44,7 +44,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio5;
     let cs = io.pins.gpio11;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -60,7 +60,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32h2-hal/examples/ram.rs
+++ b/esp32h2-hal/examples/ram.rs
@@ -32,14 +32,10 @@ static mut SOME_ZEROED_DATA: [u8; 8] = [0; 8];
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     // The RWDT flash boot protection must be enabled, as it is triggered as part of

--- a/esp32h2-hal/examples/rmt_rx.rs
+++ b/esp32h2-hal/examples/rmt_rx.rs
@@ -24,12 +24,11 @@ const WIDTH: usize = 80;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.PCR.split();
-    let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 1u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 1u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel2

--- a/esp32h2-hal/examples/rmt_tx.rs
+++ b/esp32h2-hal/examples/rmt_tx.rs
@@ -19,12 +19,11 @@ use esp_backtrace as _;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.PCR.split();
-    let mut clock_control = system.peripheral_clock_control;
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel0

--- a/esp32h2-hal/examples/rsa.rs
+++ b/esp32h2-hal/examples/rsa.rs
@@ -56,10 +56,10 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
+    let mut rsa = Rsa::new(peripherals.RSA);
 
     block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);

--- a/esp32h2-hal/examples/serial_interrupts.rs
+++ b/esp32h2-hal/examples/serial_interrupts.rs
@@ -27,21 +27,13 @@ static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(Non
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     uart0.set_rx_fifo_full_threshold(30).unwrap();
     uart0.listen_at_cmd();

--- a/esp32h2-hal/examples/sha.rs
+++ b/esp32h2-hal/examples/sha.rs
@@ -18,16 +18,12 @@ use sha2::{Digest, Sha256};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data;
-    let mut hasher = Sha::new(
-        peripherals.SHA,
-        ShaMode::SHA256,
-        &mut system.peripheral_clock_control,
-    );
+    let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA256);
 
     // Short hashes can be created by decreasing the output buffer to the desired
     // length

--- a/esp32h2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_device_loopback.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         miso,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     ));
     let mut spi_device_1 = spi_controller.add_device(io.pins.gpio11);

--- a/esp32h2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_loopback.rs
@@ -31,7 +31,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         cs,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -31,7 +31,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -52,7 +52,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/spi_loopback.rs
+++ b/esp32h2-hal/examples/spi_loopback.rs
@@ -30,7 +30,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -47,7 +47,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -32,7 +32,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio3;
     let cs = io.pins.gpio11;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -55,7 +55,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32h2-hal/examples/timer_interrupt.rs
+++ b/esp32h2-hal/examples/timer_interrupt.rs
@@ -24,21 +24,13 @@ static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut timer1 = timer_group1.timer0;
 
     interrupt::enable(

--- a/esp32h2-hal/examples/usb_serial_jtag.rs
+++ b/esp32h2-hal/examples/usb_serial_jtag.rs
@@ -26,18 +26,13 @@ static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag>>> = Mutex::new(RefCell::n
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut usb_serial =
-        UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);
+    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
 
     usb_serial.listen_rx_packet_recv_interrupt();
 

--- a/esp32h2-hal/examples/watchdog.rs
+++ b/esp32h2-hal/examples/watchdog.rs
@@ -13,14 +13,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.PCR.split();
+    let system = peripherals.PCR.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt0 = timer_group0.wdt;
 

--- a/esp32s2-hal/examples/advanced_serial.rs
+++ b/esp32s2-hal/examples/advanced_serial.rs
@@ -29,7 +29,7 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let config = Config {
@@ -45,13 +45,7 @@ fn main() -> ! {
         io.pins.gpio2.into_floating_input(),
     );
 
-    let mut serial1 = Uart::new_with_config(
-        peripherals.UART1,
-        config,
-        Some(pins),
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32s2-hal/examples/aes.rs
+++ b/esp32s2-hal/examples/aes.rs
@@ -19,10 +19,10 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
+    let mut aes = Aes::new(peripherals.AES);
 
     let keytext = "SUp4SeCp@sSw0rd".as_bytes();
     let plaintext = "message".as_bytes();

--- a/esp32s2-hal/examples/crc.rs
+++ b/esp32s2-hal/examples/crc.rs
@@ -19,21 +19,13 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
     timer0.start(1u64.secs());
 

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -38,16 +38,12 @@ async fn run2() {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s2-hal/examples/embassy_i2c.rs
+++ b/esp32s2-hal/examples/embassy_i2c.rs
@@ -44,16 +44,12 @@ async fn run(i2c: I2C<'static, I2C0>) {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -64,7 +60,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         400u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/embassy_i2s_read.rs
+++ b/esp32s2-hal/examples/embassy_i2s_read.rs
@@ -68,19 +68,15 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -98,7 +94,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s2-hal/examples/embassy_i2s_sound.rs
@@ -107,19 +107,15 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -137,7 +133,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/embassy_multiprio.rs
+++ b/esp32s2-hal/examples/embassy_multiprio.rs
@@ -81,7 +81,7 @@ async fn low_prio_async() {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Set GPIO2 as an output, and set its state high initially.
@@ -89,11 +89,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_rx.rs
@@ -95,18 +95,16 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 =
-            esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     let channel = rmt
         .channel2

--- a/esp32s2-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_tx.rs
@@ -51,18 +51,16 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 =
-            esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     let channel = rmt
         .channel0

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -64,24 +64,16 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -52,16 +52,12 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -77,7 +73,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio35;
     let cs = io.pins.gpio34;
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
     let descriptors = make_static!([0u32; 8 * 3]);
@@ -91,7 +87,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -33,16 +33,12 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -24,19 +24,13 @@ use smart_leds::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Configure RMT peripheral globally
-    let rmt = Rmt::new(
-        peripherals.RMT,
-        80u32.MHz(),
-        &mut system.peripheral_clock_control,
-        &clocks,
-    )
-    .unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations

--- a/esp32s2-hal/examples/hello_world.rs
+++ b/esp32s2-hal/examples/hello_world.rs
@@ -19,21 +19,13 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
     timer0.start(1u64.secs());
 

--- a/esp32s2-hal/examples/hmac.rs
+++ b/esp32s2-hal/examples/hmac.rs
@@ -74,7 +74,7 @@ type HmacSha256 = HmacSw<Sha256>;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
@@ -82,7 +82,7 @@ fn main() -> ! {
     // Set sw key
     let key = [0_u8; 32].as_ref();
 
-    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+    let mut hw_hmac = Hmac::new(peripherals.HMAC);
 
     let mut src = [0_u8; 1024];
     rng.read(src.as_mut_slice()).unwrap();

--- a/esp32s2-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32s2-hal/examples/i2c_bmp180_calibration_data.rs
@@ -16,7 +16,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -28,7 +28,6 @@ fn main() -> ! {
         io.pins.gpio35,
         io.pins.gpio36,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -35,14 +35,10 @@ use xtensa_atomic_emulation_trap as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -54,7 +50,6 @@ fn main() -> ! {
         io.pins.gpio35,
         io.pins.gpio36,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/i2s_read.rs
+++ b/esp32s2-hal/examples/i2s_read.rs
@@ -28,12 +28,12 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
     let mut tx_descriptors = [0u32; 8 * 3];
@@ -51,7 +51,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/i2s_sound.rs
+++ b/esp32s2-hal/examples/i2s_sound.rs
@@ -52,12 +52,12 @@ const SINE: [i16; 64] = [
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
     let mut tx_descriptors = [0u32; 20 * 3];
@@ -75,7 +75,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -25,17 +25,13 @@ use xtensa_atomic_emulation_trap as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    let mut ledc = LEDC::new(
-        peripherals.LEDC,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut ledc = LEDC::new(peripherals.LEDC, &clocks);
 
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 

--- a/esp32s2-hal/examples/pcnt_encoder.rs
+++ b/esp32s2-hal/examples/pcnt_encoder.rs
@@ -33,7 +33,7 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -42,7 +42,7 @@ fn main() -> ! {
 
     // setup a pulse couter
     println!("setup pulse counter unit 0");
-    let pcnt = PCNT::new(peripherals.PCNT, &mut system.peripheral_clock_control);
+    let pcnt = PCNT::new(peripherals.PCNT);
     let mut u0 = pcnt.get_unit(unit_number);
     u0.configure(unit::Config {
         low_limit: -100,

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -44,7 +44,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio15;
     let cs = io.pins.gpio16;
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -60,7 +60,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32s2-hal/examples/ram.rs
+++ b/esp32s2-hal/examples/ram.rs
@@ -32,14 +32,10 @@ static mut SOME_ZEROED_DATA: [u8; 8] = [0; 8];
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     // The RWDT flash boot protection must be enabled, as it is triggered as part of

--- a/esp32s2-hal/examples/rmt_rx.rs
+++ b/esp32s2-hal/examples/rmt_rx.rs
@@ -21,12 +21,11 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut out = io.pins.gpio15.into_push_pull_output();
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel0

--- a/esp32s2-hal/examples/rmt_tx.rs
+++ b/esp32s2-hal/examples/rmt_tx.rs
@@ -20,12 +20,11 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut delay = Delay::new(&clocks);
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel2

--- a/esp32s2-hal/examples/rsa.rs
+++ b/esp32s2-hal/examples/rsa.rs
@@ -56,10 +56,10 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
+    let mut rsa = Rsa::new(peripherals.RSA);
 
     block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);

--- a/esp32s2-hal/examples/serial_interrupts.rs
+++ b/esp32s2-hal/examples/serial_interrupts.rs
@@ -25,22 +25,14 @@ static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(Non
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the TIMG watchdog timer.
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     uart0.set_rx_fifo_full_threshold(30).unwrap();
     uart0.listen_at_cmd();

--- a/esp32s2-hal/examples/sha.rs
+++ b/esp32s2-hal/examples/sha.rs
@@ -19,16 +19,12 @@ use sha2::{Digest, Sha512};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data.clone();
-    let mut hasher = Sha::new(
-        peripherals.SHA,
-        ShaMode::SHA512,
-        &mut system.peripheral_clock_control,
-    );
+    let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA512);
 
     // Short hashes can be created by decreasing the output buffer to the desired
     // length

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         miso,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     ));
     let mut spi_device_1 = spi_controller.add_device(io.pins.gpio1);

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -31,7 +31,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -48,7 +48,6 @@ fn main() -> ! {
         cs,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -31,7 +31,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -52,7 +52,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -30,7 +30,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -47,7 +47,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -32,7 +32,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio35;
     let cs = io.pins.gpio34;
 
-    let dma = Dma::new(system.dma, &mut system.peripheral_clock_control);
+    let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -55,7 +55,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32s2-hal/examples/timer_interrupt.rs
+++ b/esp32s2-hal/examples/timer_interrupt.rs
@@ -27,23 +27,15 @@ static TIMER11: Mutex<RefCell<Option<Timer<Timer1<TIMG1>>>>> = Mutex::new(RefCel
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the TIMG watchdog timer.
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer00 = timer_group0.timer0;
     let mut timer01 = timer_group0.timer1;
 
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut timer10 = timer_group1.timer0;
     let mut timer11 = timer_group1.timer1;
 

--- a/esp32s2-hal/examples/usb_serial.rs
+++ b/esp32s2-hal/examples/usb_serial.rs
@@ -20,7 +20,7 @@ static mut EP_MEMORY: [u32; 1024] = [0; 1024];
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -30,7 +30,6 @@ fn main() -> ! {
         io.pins.gpio18,
         io.pins.gpio19,
         io.pins.gpio20,
-        &mut system.peripheral_clock_control,
     );
 
     let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });

--- a/esp32s2-hal/examples/watchdog.rs
+++ b/esp32s2-hal/examples/watchdog.rs
@@ -13,14 +13,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
 

--- a/esp32s3-hal/examples/advanced_serial.rs
+++ b/esp32s3-hal/examples/advanced_serial.rs
@@ -29,7 +29,7 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let config = Config {
@@ -45,13 +45,7 @@ fn main() -> ! {
         io.pins.gpio2.into_floating_input(),
     );
 
-    let mut serial1 = Uart::new_with_config(
-        peripherals.UART1,
-        config,
-        Some(pins),
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32s3-hal/examples/aes.rs
+++ b/esp32s3-hal/examples/aes.rs
@@ -19,10 +19,10 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut aes = Aes::new(peripherals.AES, &mut system.peripheral_clock_control);
+    let mut aes = Aes::new(peripherals.AES);
 
     let keytext = "SUp4SeCp@sSw0rd".as_bytes();
     let plaintext = "message".as_bytes();

--- a/esp32s3-hal/examples/crc.rs
+++ b/esp32s3-hal/examples/crc.rs
@@ -19,21 +19,13 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
     timer0.start(1u64.secs());
 

--- a/esp32s3-hal/examples/debug_assist.rs
+++ b/esp32s3-hal/examples/debug_assist.rs
@@ -23,13 +23,10 @@ static DA: Mutex<RefCell<Option<DebugAssist>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut da = DebugAssist::new(
-        peripherals.ASSIST_DEBUG,
-        &mut system.peripheral_clock_control,
-    );
+    let mut da = DebugAssist::new(peripherals.ASSIST_DEBUG);
 
     // uncomment the functionality you want to test
 

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -48,11 +48,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s3-hal/examples/embassy_i2c.rs
+++ b/esp32s3-hal/examples/embassy_i2c.rs
@@ -55,11 +55,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -70,7 +66,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         400u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/embassy_i2s_read.rs
+++ b/esp32s3-hal/examples/embassy_i2s_read.rs
@@ -80,17 +80,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -108,7 +103,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s3-hal/examples/embassy_i2s_sound.rs
@@ -117,17 +117,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        )
-        .timer0,
+        esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_descriptors = make_static!([0u32; 20 * 3]);
@@ -145,7 +140,6 @@ fn main() -> ! {
             rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/embassy_multicore.rs
+++ b/esp32s3-hal/examples/embassy_multicore.rs
@@ -78,11 +78,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s3-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32s3-hal/examples/embassy_multicore_interrupt.rs
@@ -95,11 +95,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s3-hal/examples/embassy_multiprio.rs
+++ b/esp32s3-hal/examples/embassy_multiprio.rs
@@ -95,11 +95,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s3-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s3-hal/examples/embassy_rmt_rx.rs
@@ -81,7 +81,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
@@ -91,14 +90,13 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 =
-            esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control);
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
 
     let channel = rmt
         .channel4

--- a/esp32s3-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s3-hal/examples/embassy_rmt_tx.rs
@@ -50,7 +50,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
@@ -61,12 +60,12 @@ fn main() -> ! {
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
+        esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
 
     let channel = rmt
         .channel0

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -75,19 +75,11 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -65,11 +65,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 
@@ -90,7 +86,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let descriptors = make_static!([0u32; 8 * 3]);
@@ -104,7 +100,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -44,11 +44,7 @@ fn main() -> ! {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(
-            peripherals.TIMG0,
-            &clocks,
-            &mut system.peripheral_clock_control,
-        );
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s3-hal/examples/hello_rgb.rs
+++ b/esp32s3-hal/examples/hello_rgb.rs
@@ -24,19 +24,13 @@ use smart_leds::{
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Configure RMT peripheral globally
-    let rmt = Rmt::new(
-        peripherals.RMT,
-        80u32.MHz(),
-        &mut system.peripheral_clock_control,
-        &clocks,
-    )
-    .unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations

--- a/esp32s3-hal/examples/hello_world.rs
+++ b/esp32s3-hal/examples/hello_world.rs
@@ -19,21 +19,13 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
 
     timer0.start(1u64.secs());
 

--- a/esp32s3-hal/examples/hmac.rs
+++ b/esp32s3-hal/examples/hmac.rs
@@ -74,7 +74,7 @@ type HmacSha256 = HmacSw<Sha256>;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rng = Rng::new(peripherals.RNG);
@@ -82,7 +82,7 @@ fn main() -> ! {
     // Set sw key
     let key = [0_u8; 32].as_ref();
 
-    let mut hw_hmac = Hmac::new(peripherals.HMAC, &mut system.peripheral_clock_control);
+    let mut hw_hmac = Hmac::new(peripherals.HMAC);
 
     let mut src = [0_u8; 1024];
     rng.read(src.as_mut_slice()).unwrap();

--- a/esp32s3-hal/examples/i2c_bmp180_calibration_data.rs
+++ b/esp32s3-hal/examples/i2c_bmp180_calibration_data.rs
@@ -16,7 +16,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -28,7 +28,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/i2c_display.rs
+++ b/esp32s3-hal/examples/i2c_display.rs
@@ -34,14 +34,10 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -53,7 +49,6 @@ fn main() -> ! {
         io.pins.gpio1,
         io.pins.gpio2,
         100u32.kHz(),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/i2s_read.rs
+++ b/esp32s3-hal/examples/i2s_read.rs
@@ -31,12 +31,12 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [0u32; 8 * 3];
@@ -58,7 +58,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/i2s_sound.rs
+++ b/esp32s3-hal/examples/i2s_sound.rs
@@ -52,12 +52,12 @@ const SINE: [i16; 64] = [
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [0u32; 20 * 3];
@@ -75,7 +75,6 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/ledc.rs
+++ b/esp32s3-hal/examples/ledc.rs
@@ -24,17 +24,13 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let led = io.pins.gpio4.into_push_pull_output();
 
-    let mut ledc = LEDC::new(
-        peripherals.LEDC,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut ledc = LEDC::new(peripherals.LEDC, &clocks);
 
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 

--- a/esp32s3-hal/examples/mcpwm.rs
+++ b/esp32s3-hal/examples/mcpwm.rs
@@ -18,7 +18,7 @@ use esp_backtrace as _;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -26,11 +26,7 @@ fn main() -> ! {
 
     // initialize peripheral
     let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40u32.MHz()).unwrap();
-    let mut mcpwm = MCPWM::new(
-        peripherals.MCPWM0,
-        clock_cfg,
-        &mut system.peripheral_clock_control,
-    );
+    let mut mcpwm = MCPWM::new(peripherals.MCPWM0, clock_cfg);
 
     // connect operator0 to timer0
     mcpwm.operator0.set_timer(&mcpwm.timer0);

--- a/esp32s3-hal/examples/multicore.rs
+++ b/esp32s3-hal/examples/multicore.rs
@@ -24,21 +24,13 @@ static mut APP_CORE_STACK: Stack<8192> = Stack::new();
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut timer1 = timer_group1.timer0;
 
     timer0.start(1u64.secs());

--- a/esp32s3-hal/examples/pcnt_encoder.rs
+++ b/esp32s3-hal/examples/pcnt_encoder.rs
@@ -33,7 +33,7 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -42,7 +42,7 @@ fn main() -> ! {
 
     // setup a pulse couter
     println!("setup pulse counter unit 0");
-    let pcnt = PCNT::new(peripherals.PCNT, &mut system.peripheral_clock_control);
+    let pcnt = PCNT::new(peripherals.PCNT);
     let mut u0 = pcnt.get_unit(unit_number);
     u0.configure(unit::Config {
         low_limit: -100,

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -44,7 +44,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio15;
     let cs = io.pins.gpio16;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -60,7 +60,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32s3-hal/examples/ram.rs
+++ b/esp32s3-hal/examples/ram.rs
@@ -32,14 +32,10 @@ static mut SOME_ZEROED_DATA: [u8; 8] = [0; 8];
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
     // The RWDT flash boot protection must be enabled, as it is triggered as part of

--- a/esp32s3-hal/examples/rmt_rx.rs
+++ b/esp32s3-hal/examples/rmt_rx.rs
@@ -25,11 +25,10 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 1u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 1u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel7

--- a/esp32s3-hal/examples/rmt_tx.rs
+++ b/esp32s3-hal/examples/rmt_tx.rs
@@ -16,11 +16,10 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
 
     let mut channel = rmt
         .channel0

--- a/esp32s3-hal/examples/rsa.rs
+++ b/esp32s3-hal/examples/rsa.rs
@@ -56,10 +56,10 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rsa = Rsa::new(peripherals.RSA, &mut system.peripheral_clock_control);
+    let mut rsa = Rsa::new(peripherals.RSA);
 
     block!(rsa.ready()).unwrap();
     mod_exp_example(&mut rsa);

--- a/esp32s3-hal/examples/serial_interrupts.rs
+++ b/esp32s3-hal/examples/serial_interrupts.rs
@@ -25,21 +25,13 @@ static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(Non
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut uart0 = Uart::new(
-        peripherals.UART0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
     uart0.set_rx_fifo_full_threshold(30).unwrap();
     uart0.listen_at_cmd();

--- a/esp32s3-hal/examples/sha.rs
+++ b/esp32s3-hal/examples/sha.rs
@@ -19,16 +19,12 @@ use sha2::{Digest, Sha512};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
     let mut remaining = source_data.clone();
-    let mut hasher = Sha::new(
-        peripherals.SHA,
-        ShaMode::SHA512,
-        &mut system.peripheral_clock_control,
-    );
+    let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA512);
 
     // Short hashes can be created by decreasing the output buffer to the desired
     // length

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -48,7 +48,6 @@ fn main() -> ! {
         miso,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     ));
     let mut spi_device_1 = spi_controller.add_device(io.pins.gpio4);

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -48,7 +48,6 @@ fn main() -> ! {
         cs,
         1000u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -31,7 +31,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -52,7 +52,6 @@ fn main() -> ! {
         Some(cs),
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -30,7 +30,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -47,7 +47,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     );
 

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -32,7 +32,7 @@ use esp_println::println;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -41,7 +41,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA, &mut system.peripheral_clock_control);
+    let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [0u32; 8 * 3];
@@ -55,7 +55,6 @@ fn main() -> ! {
         cs,
         100u32.kHz(),
         SpiMode::Mode0,
-        &mut system.peripheral_clock_control,
         &clocks,
     )
     .with_dma(dma_channel.configure(

--- a/esp32s3-hal/examples/timer_interrupt.rs
+++ b/esp32s3-hal/examples/timer_interrupt.rs
@@ -27,22 +27,14 @@ static TIMER11: Mutex<RefCell<Option<Timer<Timer1<TIMG1>>>>> = Mutex::new(RefCel
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer00 = timer_group0.timer0;
     let mut timer01 = timer_group0.timer1;
 
-    let timer_group1 = TimerGroup::new(
-        peripherals.TIMG1,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
     let mut timer10 = timer_group1.timer0;
     let mut timer11 = timer_group1.timer1;
 

--- a/esp32s3-hal/examples/twai.rs
+++ b/esp32s3-hal/examples/twai.rs
@@ -33,7 +33,7 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -51,7 +51,6 @@ fn main() -> ! {
         peripherals.TWAI0,
         can_tx_pin,
         can_rx_pin,
-        &mut system.peripheral_clock_control,
         &clocks,
         CAN_BAUDRATE,
     );

--- a/esp32s3-hal/examples/usb_serial.rs
+++ b/esp32s3-hal/examples/usb_serial.rs
@@ -20,7 +20,7 @@ static mut EP_MEMORY: [u32; 1024] = [0; 1024];
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -30,7 +30,6 @@ fn main() -> ! {
         io.pins.gpio18,
         io.pins.gpio19,
         io.pins.gpio20,
-        &mut system.peripheral_clock_control,
     );
 
     let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -26,18 +26,13 @@ static USB_SERIAL: Mutex<RefCell<Option<UsbSerialJtag>>> = Mutex::new(RefCell::n
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
 
-    let mut usb_serial =
-        UsbSerialJtag::new(peripherals.USB_DEVICE, &mut system.peripheral_clock_control);
+    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
 
     usb_serial.listen_rx_packet_recv_interrupt();
 

--- a/esp32s3-hal/examples/watchdog.rs
+++ b/esp32s3-hal/examples/watchdog.rs
@@ -13,14 +13,10 @@ use nb::block;
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(
-        peripherals.TIMG0,
-        &clocks,
-        &mut system.peripheral_clock_control,
-    );
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timer_group0.timer0;
     let mut wdt = timer_group0.wdt;
 


### PR DESCRIPTION
I have been meaning to do this for some time now, finally got around to it.

Rather than exposing the `PeripheralClockControl` struck via the `SystemParts` struct, the drivers just handle this all internally. Since `PeripheralClockControl` was already a ZST, I've just removed the `&mut self` argument of the `enable` function and instead converted it to an associated function. This type's scope was also limited to the crate-level.

This is obviously a pretty breaking change, but it's more than worth it IMO.

These changes were pretty straight forward, but also fairly invasive, so hopefully I haven't broken anything! If anybody has any questions/concerns/suggestions please let me know!

Closes #776 
