### PR TITLE
Make sure to use ESP32Reset - not Reset as entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - S3: Allow powering down RC_FAST_CLK (#796)
 - UART/ESP32: fix calculating FIFO counter with `get_rx_fifo_count()` (#804)
+- Xtensa targets: Use ESP32Reset - not Reset (#823)
 
 ### Removed
 

--- a/esp32-hal/ld/link-esp32.x
+++ b/esp32-hal/ld/link-esp32.x
@@ -1,6 +1,6 @@
 
 /* before memory.x to allow override */
-ENTRY(Reset)
+ENTRY(ESP32Reset)
 
 /* after memory.x to allow override */
 PROVIDE(__pre_init = DefaultPreInit);

--- a/esp32s2-hal/ld/link-esp32s2.x
+++ b/esp32s2-hal/ld/link-esp32s2.x
@@ -1,6 +1,6 @@
 
 /* before memory.x to allow override */
-ENTRY(Reset)
+ENTRY(ESP32Reset)
 
 /* after memory.x to allow override */
 PROVIDE(__pre_init = DefaultPreInit);

--- a/esp32s3-hal/ld/db-esp32s3.x
+++ b/esp32s3-hal/ld/db-esp32s3.x
@@ -1,5 +1,5 @@
 /* before memory.x to allow override */
-ENTRY(Reset)
+ENTRY(ESP32Reset)
 
 _stack_region_top = ABSOLUTE(ORIGIN(dram_seg))+LENGTH(dram_seg);
 _stack_region_bottom = _stack_end;


### PR DESCRIPTION
Some Xtensa targets used `Reset` as entry but they must use `ESP32Reset` in order to set the SP.
Without setting SP, stack-allocations might overwrite memory which is reserved for the ROM functions on ESP32

Seems like direct-boot on ESP32-S3 is broken - but it was broken before: at least I'm unable to flash and run `hello_world` using direct-boot (it flashes 4MB to the chip and the app won't come up)
