### PR TITLE
Warnings cleanup and add missing `PSRAM` examples to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
           cd esp32-hal/
           cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
           cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
+      - name: check esp32-hal (psram)
+        run: cd esp32-hal/ && cargo check --example=psram --features=psram_2m --release # This example requires release!
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32-hal/ && cargo doc --features=eh1
@@ -395,6 +397,8 @@ jobs:
           cd esp32s2-hal/
           cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
           cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
+      - name: check esp32s2-hal (psram)
+        run: cd esp32s2-hal/ && cargo check --example=psram --features=psram_2m --release # This example requires release!
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32s2-hal/ && cargo doc --features=eh1
@@ -458,8 +462,11 @@ jobs:
           cargo check --example=embassy_spi --features=embassy,embassy-time-systick,async,embassy-executor-thread
           cargo check --example=embassy_serial --features=embassy,embassy-time-systick,async,embassy-executor-thread
           cargo check --example=embassy_i2c --features=embassy,embassy-time-systick,async,embassy-executor-thread
-      - name: check esp32s3-hal (octal psram)
-        run: cd esp32s3-hal/ && cargo check --example=octal_psram --features=opsram_2m --release # This example requires release!
+      - name: check esp32s3-hal (octal psram and psram)
+        run: |  # This examples require release!
+          cd esp32s3-hal/
+          cargo check --example=octal_psram --features=opsram_2m --release
+          cargo check --example=psram --features=psram_2m --release
       - name: check esp32s3-hal (embassy, log/defmt)
         run: |
           cd esp32s3-hal/

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -281,7 +281,7 @@ mod critical_section_impl {
             unsafe fn acquire() -> critical_section::RawRestoreState {
                 let mut mstatus = 0u32;
                 core::arch::asm!("csrrci {0}, mstatus, 8", inout(reg) mstatus);
-                let mut tkn = ((mstatus & 0b1000) != 0) as critical_section::RawRestoreState;
+                let tkn = ((mstatus & 0b1000) != 0) as critical_section::RawRestoreState;
 
                 #[cfg(multi_core)]
                 {

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -65,7 +65,7 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.DPORT.split();
+    let system = peripherals.DPORT.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32-hal/examples/psram.rs
+++ b/esp32-hal/examples/psram.rs
@@ -5,14 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    psram,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, psram};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -38,8 +31,8 @@ fn main() -> ! {
     psram::init_psram(peripherals.PSRAM);
     init_psram_heap();
 
-    let mut system = peripherals.DPORT.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let system = peripherals.DPORT.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     println!("Going to access PSRAM");
 

--- a/esp32s2-hal/examples/psram.rs
+++ b/esp32s2-hal/examples/psram.rs
@@ -26,8 +26,8 @@ fn main() -> ! {
     psram::init_psram(peripherals.PSRAM);
     init_psram_heap();
 
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     println!("Going to access PSRAM");
 

--- a/esp32s3-hal/examples/embassy_hello_world.rs
+++ b/esp32s3-hal/examples/embassy_hello_world.rs
@@ -37,7 +37,7 @@ async fn run2() {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]

--- a/esp32s3-hal/examples/embassy_i2c.rs
+++ b/esp32s3-hal/examples/embassy_i2c.rs
@@ -44,7 +44,7 @@ async fn run(i2c: I2C<'static, I2C0>) {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]

--- a/esp32s3-hal/examples/embassy_i2s_read.rs
+++ b/esp32s3-hal/examples/embassy_i2s_read.rs
@@ -68,7 +68,7 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]

--- a/esp32s3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s3-hal/examples/embassy_i2s_sound.rs
@@ -105,7 +105,7 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]

--- a/esp32s3-hal/examples/embassy_multicore.rs
+++ b/esp32s3-hal/examples/embassy_multicore.rs
@@ -64,7 +64,7 @@ async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bo
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Set GPIO2 as an output, and set its state high initially.

--- a/esp32s3-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32s3-hal/examples/embassy_multicore_interrupt.rs
@@ -81,7 +81,7 @@ async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bo
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Set GPIO2 as an output, and set its state high initially.

--- a/esp32s3-hal/examples/embassy_multiprio.rs
+++ b/esp32s3-hal/examples/embassy_multiprio.rs
@@ -81,7 +81,7 @@ async fn low_prio_async() {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Set GPIO2 as an output, and set its state high initially.

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -64,7 +64,7 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -54,7 +54,7 @@ async fn spi_task(spi: &'static mut SpiType<'static>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -33,7 +33,7 @@ async fn ping(mut pin: Gpio0<Input<PullDown>>) {
 fn main() -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]

--- a/esp32s3-hal/examples/octal_psram.rs
+++ b/esp32s3-hal/examples/octal_psram.rs
@@ -5,14 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    psram,
-    timer::TimerGroup,
-    Rtc,
-};
+use esp32s3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, psram};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -38,8 +31,8 @@ fn main() -> ! {
     psram::init_psram(peripherals.PSRAM);
     init_psram_heap();
 
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::configure(
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::configure(
         system.clock_control,
         esp_hal_common::clock::CpuClock::Clock240MHz,
     )

--- a/esp32s3-hal/examples/psram.rs
+++ b/esp32s3-hal/examples/psram.rs
@@ -5,13 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    psram,
-    timer::TimerGroup,
-};
+use esp32s3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, psram};
 use esp_backtrace as _;
 use esp_println::println;
 
@@ -37,8 +31,8 @@ fn main() -> ! {
     psram::init_psram(peripherals.PSRAM);
     init_psram_heap();
 
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::configure(
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::configure(
         system.clock_control,
         esp_hal_common::clock::CpuClock::Clock240MHz,
     )

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -33,7 +33,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -31,7 +31,7 @@ use esp_println::{print, println};
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.


There is still a warning for C2(`async I2S`), however, I'm not sure what would be the cleanest way to solve it.
The warning can be found [here](https://github.com/esp-rs/esp-hal/pull/826/checks#step:10:15)