### PR TITLE
Support SysTimer as timebase on ESP32-S2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,11 @@ jobs:
           cd esp32s2-hal/
           cargo +esp check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
           cargo +esp check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+      - name: check esp32s2-hal (embassy, systick)
+        run: |
+          cd esp32s2-hal/
+          cargo +esp check --example=embassy_hello_world --features=embassy,embassy-time-systick,embassy-executor-thread
+          cargo +esp check --example=embassy_multiprio --features=embassy,embassy-time-systick,embassy-executor-interrupt
       - name: check esp32s2-hal (embassy, timg0, async)
         run: |
           cd esp32s2-hal/
@@ -420,6 +425,13 @@ jobs:
           cargo +esp check --example=embassy_i2s_sound --features=embassy,embassy-time-timg0,async,embassy-executor-thread
           cargo +esp check --example=embassy_rmt_rx --features=embassy,embassy-time-timg0,async,embassy-executor-thread --release
           cargo +esp check --example=embassy_rmt_tx --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+      - name: check esp32s2-hal (embassy, systick, async)
+        run: |
+          cd esp32s2-hal/
+          cargo +esp check --example=embassy_wait --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo +esp check --example=embassy_spi --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo +esp check --example=embassy_serial --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo +esp check --example=embassy_i2c --features=embassy,embassy-time-systick,async,embassy-executor-thread
       - name: check esp32s2-hal (embassy, log/defmt)
         run: |
           cd esp32s2-hal/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `embassy-time-systick` to ESP32-S2 (#827)
 - Implement enabling/disabling BLE clock on ESP32-C6 (#784)
 - Async support for RMT (#787)
 - Implement `defmt::Format` for more types (#786)

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -38,7 +38,7 @@ embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-io-async  = { version = "0.5.0", optional = true }
 embassy-executor   = { version = "0.3.0", features = ["integrated-timers"], optional = true }
 embassy-sync       = { version = "0.3.0", optional = true }
-embassy-time       = { version = "0.1.3", features = ["nightly"], optional = true }
+embassy-time       = { version = "0.1.4", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }
 
 # RISC-V

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.12.0", features = ["esp32"],   path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.3",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.4",  features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.12.0", features = ["esp32c2"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.3",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.4",  features = ["nightly"], optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 [dependencies]
 cfg-if         = "1.0.0"
 esp-hal-common = { version = "0.12.0", features = ["esp32c3"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.3",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.4",  features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.12.0", features = ["esp32c6"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.3",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.4",  features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.12.0", features = ["esp32h2"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.3",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.4",  features = ["nightly"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common               = { version = "0.12.0", features = ["esp32s2"], path = "../esp-hal-common" }
-embassy-time                 = { version = "0.1.3",  features = ["nightly"], optional = true }
+embassy-time                 = { version = "0.1.4",  features = ["nightly"], optional = true }
 xtensa-atomic-emulation-trap = "0.4.0"
 
 [dev-dependencies]
@@ -66,10 +66,7 @@ vectored  = ["esp-hal-common/vectored"]
 
 # Embassy support
 embassy = ["esp-hal-common/embassy"]
-# FIXME:
-# - add 80_000_000 support to embassy time
-# - Fix https://github.com/esp-rs/esp-hal/issues/253
-# embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-1_000_000"] 
+embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-80_000_000"] 
 embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
 embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -33,6 +33,12 @@ async fn main(spawner: Spawner) -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
     #[cfg(feature = "embassy-time-timg0")]
     {
         let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32s2-hal/examples/embassy_i2c.rs
+++ b/esp32s2-hal/examples/embassy_i2c.rs
@@ -34,6 +34,12 @@ async fn main(_spawner: Spawner) -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
     #[cfg(feature = "embassy-time-timg0")]
     {
         let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32s2-hal/examples/embassy_i2s_read.rs
+++ b/esp32s2-hal/examples/embassy_i2s_read.rs
@@ -23,7 +23,6 @@ use esp32s2_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     IO,
 };
 use esp_backtrace as _;
@@ -38,8 +37,17 @@ async fn main(_spawner: Spawner) -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32s2-hal/examples/embassy_multiprio.rs
+++ b/esp32s2-hal/examples/embassy_multiprio.rs
@@ -87,6 +87,12 @@ fn main() -> ! {
     // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
     #[cfg(feature = "embassy-time-timg0")]
     {
         let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32s2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_rx.rs
@@ -46,6 +46,12 @@ async fn main(spawner: Spawner) -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
     #[cfg(feature = "embassy-time-timg0")]
     {
         let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32s2-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_tx.rs
@@ -29,6 +29,12 @@ async fn main(_spawner: Spawner) -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
     #[cfg(feature = "embassy-time-timg0")]
     {
         let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -67,6 +67,12 @@ async fn main(spawner: Spawner) {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
     #[cfg(feature = "embassy-time-timg0")]
     {
         let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -39,6 +39,12 @@ async fn main(_spawner: Spawner) -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
     #[cfg(feature = "embassy-time-timg0")]
     {
         let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -25,6 +25,12 @@ async fn main(_spawner: Spawner) -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
     #[cfg(feature = "embassy-time-timg0")]
     {
         let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -18,6 +18,8 @@
 //!   using this feature.
 //! - `embassy-executor-interrupt` - Use the interrupt-mode embassy executor
 //! - `embassy-executor-thread` - Use the thread-mode embassy executor
+//! - `embassy-time-systick` - Enable the [embassy] time driver using the
+//!   `SYSTIMER` peripheral
 //! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
 //!   peripheral
 //! - `log` - enable log output using the `log` crate

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.12.0", features = ["esp32s3"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.3",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.1.4",  features = ["nightly"], optional = true }
 r0             = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

I'm pre-ticking the boxes, but this doesn't work until `embassy-time 0.1.4` is released, including this PR: https://github.com/embassy-rs/embassy/pull/1962

cc https://github.com/esp-rs/esp-hal/issues/253