### PR TITLE
Unify the ESP32's and ESP32-C2's xtal frequency features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32h2
       # Check all Xtensa targets:
       - name: check (esp32)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32,esp32_40mhz
+        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32,xtal_40mhz
       - name: check (esp32s2)
         run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s2
       - name: check (esp32s3)
@@ -463,7 +463,7 @@ jobs:
           cargo check --example=embassy_serial --features=embassy,embassy-time-systick,async,embassy-executor-thread
           cargo check --example=embassy_i2c --features=embassy,embassy-time-systick,async,embassy-executor-thread
       - name: check esp32s3-hal (octal psram and psram)
-        run: |  # This examples require release!
+        run: | # This examples require release!
           cd esp32s3-hal/
           cargo check --example=octal_psram --features=opsram_2m --release
           cargo check --example=psram --features=psram_2m --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped MSRV to 1.67 (#798)
 - Optimised multi-core critical section implementation (#797)
+- Unified the ESP32's and ESP32-C2's xtal frequency features (#831)
 
 ### Fixed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -37,13 +37,13 @@ usb-device           = { version = "0.2.9", optional = true }
 embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-io-async  = { version = "0.5.0", optional = true }
 embassy-executor   = { version = "0.3.0", features = ["integrated-timers"], optional = true }
-embassy-sync       = { version = "0.2.0", optional = true }
+embassy-sync       = { version = "0.3.0", optional = true }
 embassy-time       = { version = "0.1.3", features = ["nightly"], optional = true }
 embassy-futures    = { version = "0.1.0", optional = true }
 
 # RISC-V
-esp-riscv-rt                = { version = "0.5.0", path = "../esp-riscv-rt", optional = true }
-riscv-atomic-emulation-trap = { version = "0.4.0", optional = true }
+esp-riscv-rt                = { version = "0.5.0", optional = true, path = "../esp-riscv-rt" }
+riscv-atomic-emulation-trap = { version = "0.4.1", optional = true }
 
 # Xtensa
 xtensa-lx    = { version = "0.8.0",  optional = true }
@@ -58,25 +58,23 @@ ufmt-write = { version = "0.1.0", optional = true }
 esp32   = { version = "0.26.0", features = ["critical-section"], optional = true }
 esp32c2 = { version = "0.14.0", features = ["critical-section"], optional = true }
 esp32c3 = { version = "0.17.0", features = ["critical-section"], optional = true }
-# until new C6 pacs are relesed, required because of a wrong base address of GPIO_SD
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", package = "esp32c6", rev = "1b1ce7ba631cb349a8255f5959e768d5c52fad40", version = "0.7.0",  features = ["critical-section"], optional = true }
-# until new H2 pacs are relesed, required because of https://github.com/esp-rs/esp-pacs/pull/156
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs.git", rev = "1b1ce7ba631cb349a8255f5959e768d5c52fad40",  features = ["critical-section"], optional = true }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1b1ce7b", features = ["critical-section"], optional = true }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1b1ce7b", features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.17.0", features = ["critical-section"], optional = true }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "c1283ca", features = ["critical-section",], optional = true }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1b1ce7b", features = ["critical-section"], optional = true }
 
 [build-dependencies]
 basic-toml = "0.1.4"
 serde      = { version = "1.0.188", features = ["derive"] }
 
 [features]
-esp32   = ["esp32/rt",   "xtensa", "xtensa-lx/esp32", "xtensa-lx-rt/esp32", "procmacros/esp32"]
-esp32c2 = ["esp32c2/rt", "riscv",  "procmacros/esp32c2"]
-esp32c3 = ["esp32c3/rt", "riscv",  "procmacros/esp32c3"]
-esp32c6 = ["esp32c6/rt", "riscv",  "procmacros/esp32c6"]
-esp32h2 = ["esp32h2/rt", "riscv",  "procmacros/esp32h2"]
-esp32s2 = ["esp32s2/rt", "xtensa", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2", "esp-synopsys-usb-otg", "usb-device", "procmacros/esp32s2"]
-esp32s3 = ["esp32s3/rt", "xtensa", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "esp-synopsys-usb-otg", "usb-device", "procmacros/esp32s3"]
+esp32   = ["xtensa", "esp32/rt",   "procmacros/esp32",   "xtensa-lx/esp32",   "xtensa-lx-rt/esp32"]
+esp32c2 = ["riscv",  "esp32c2/rt", "procmacros/esp32c2"]
+esp32c3 = ["riscv",  "esp32c3/rt", "procmacros/esp32c3"]
+esp32c6 = ["riscv",  "esp32c6/rt", "procmacros/esp32c6"]
+esp32h2 = ["riscv",  "esp32h2/rt", "procmacros/esp32h2"]
+esp32s2 = ["xtensa", "esp32s2/rt", "procmacros/esp32s2", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2", "usb-otg"]
+esp32s3 = ["xtensa", "esp32s3/rt", "procmacros/esp32s3", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "usb-otg"]
 
 # Crystal frequency selection (ESP32 and ESP32-C2 only!)
 xtal_26mhz = []
@@ -92,23 +90,25 @@ opsram_2m = []
 opsram_4m = []
 opsram_8m = []
 
-# Implement the `embedded-hal==1.0.0-alpha.x` traits
-eh1 = ["embedded-hal-1", "embedded-hal-nb", "embedded-can"]
+# USB OTG support (ESP32-S2 and ESP32-S3 only! Enabled by default)
+usb-otg = ["esp-synopsys-usb-otg", "usb-device"]
+
+# Interrupt-related feature:
+#  - Use direct interrupt vectoring (RISC-V only!)
+#  - Use interrupt preemption (RISC-V only!)
+#  - Use vectored interrupts (calling the handlers defined in the PAC)
+direct-vectoring     = ["esp-riscv-rt/direct-vectoring"]
+interrupt-preemption = ["esp-riscv-rt/interrupt-preemption"]
+vectored             = ["procmacros/interrupt"]
 
 # Enable logging
 log = ["dep:log"]
 
-# To support `ufmt`
+# Trait implementation features:
+#  - Implement the `embedded-hal@1.0.0-rc.x` traits (and friends)
+#  - Implement the `ufmt_write::Write` trait where able
+eh1  = ["embedded-hal-1", "embedded-hal-nb", "embedded-can"]
 ufmt = ["ufmt-write"]
-
-# To use vectored interrupts (calling the handlers defined in the PAC)
-vectored = ["procmacros/interrupt"]
-
-# Use direct interrupt vectoring (RISC-V only!)
-direct-vectoring = ["esp-riscv-rt/direct-vectoring"]
-
-# Use interrupt preemption (RISC-V only!)
-interrupt-preemption = ["esp-riscv-rt/interrupt-preemption"]
 
 # Support for asynchronous operation, implementing traits from
 # `embedded-hal-async` and `embedded-io-async`
@@ -147,9 +147,9 @@ debug = [
 defmt = [
     "dep:defmt",
     "embassy-executor?/defmt",
+    "embassy-futures?/defmt",
     "embassy-sync?/defmt",
     "embassy-time?/defmt",
-    "embassy-futures?/defmt",
     "embedded-hal-1?/defmt-03",
     "embedded-io/defmt-03",
     "embedded-io-async?/defmt-03",

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -79,10 +79,8 @@ esp32s2 = ["esp32s2/rt", "xtensa", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2", 
 esp32s3 = ["esp32s3/rt", "xtensa", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "esp-synopsys-usb-otg", "usb-device", "procmacros/esp32s3"]
 
 # Crystal frequency selection (ESP32 and ESP32-C2 only!)
-esp32_26mhz   = []
-esp32_40mhz   = []
-esp32c2_26mhz = []
-esp32c2_40mhz = []
+xtal_26mhz = []
+xtal_40mhz = []
 
 # PSRAM support
 psram_2m = []

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -98,16 +98,11 @@ fn main() {
         "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"
     );
 
-    // Handle the features for the ESP32's different crystal frequencies:
-    #[cfg(feature = "esp32")]
+    // Handle the features for the ESP32's and ESP32-C2's different crystal
+    // frequencies:
+    #[cfg(any(feature = "esp32", feature = "esp32c2"))]
     {
-        assert_unique_used_features!("esp32_26mhz", "esp32_40mhz");
-    }
-
-    // Handle the features for the ESP32-C2's different crystal frequencies:
-    #[cfg(feature = "esp32c2")]
-    {
-        assert_unique_used_features!("esp32c2_26mhz", "esp32c2_40mhz");
+        assert_unique_used_features!("xtal_26mhz", "xtal_40mhz");
     }
 
     // NOTE: update when adding new device support!

--- a/esp-hal-common/src/clock/mod.rs
+++ b/esp-hal-common/src/clock/mod.rs
@@ -294,7 +294,7 @@ impl<'d> ClockControl<'d> {
     pub fn boot_defaults(
         clock_control: impl Peripheral<P = SystemClockControl> + 'd,
     ) -> ClockControl<'d> {
-        #[cfg(feature = "esp32_40mhz")]
+        #[cfg(feature = "xtal_40mhz")]
         return ClockControl {
             _private: clock_control.into_ref(),
             desired_rates: RawClocks {
@@ -306,7 +306,7 @@ impl<'d> ClockControl<'d> {
             },
         };
 
-        #[cfg(feature = "esp32_26mhz")]
+        #[cfg(feature = "xtal_26mhz")]
         return ClockControl {
             _private: clock_control.into_ref(),
             desired_rates: RawClocks {
@@ -326,9 +326,9 @@ impl<'d> ClockControl<'d> {
     ) -> ClockControl<'d> {
         // like NuttX use 40M hardcoded - if it turns out to be a problem
         // we will take care then
-        #[cfg(feature = "esp32_40mhz")]
+        #[cfg(feature = "xtal_40mhz")]
         let xtal_freq = XtalClock::RtcXtalFreq40M;
-        #[cfg(feature = "esp32_26mhz")]
+        #[cfg(feature = "xtal_26mhz")]
         let xtal_freq = XtalClock::RtcXtalFreq26M;
         let pll_freq = match cpu_clock_speed {
             CpuClock::Clock80MHz => PllClock::Pll320MHz,
@@ -368,7 +368,7 @@ impl<'d> ClockControl<'d> {
     pub fn boot_defaults(
         clock_control: impl Peripheral<P = SystemClockControl> + 'd,
     ) -> ClockControl<'d> {
-        #[cfg(feature = "esp32c2_40mhz")]
+        #[cfg(feature = "xtal_40mhz")]
         return ClockControl {
             _private: clock_control.into_ref(),
             desired_rates: RawClocks {
@@ -378,7 +378,7 @@ impl<'d> ClockControl<'d> {
             },
         };
 
-        #[cfg(feature = "esp32c2_26mhz")]
+        #[cfg(feature = "xtal_26mhz")]
         return ClockControl {
             _private: clock_control.into_ref(),
             desired_rates: RawClocks {
@@ -395,9 +395,9 @@ impl<'d> ClockControl<'d> {
         cpu_clock_speed: CpuClock,
     ) -> ClockControl<'d> {
         let apb_freq;
-        #[cfg(feature = "esp32c2_40mhz")]
+        #[cfg(feature = "xtal_40mhz")]
         let xtal_freq = XtalClock::RtcXtalFreq40M;
-        #[cfg(feature = "esp32c2_26mhz")]
+        #[cfg(feature = "xtal_26mhz")]
         let xtal_freq = XtalClock::RtcXtalFreq26M;
         let pll_freq = PllClock::Pll480MHz;
 

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32.rs
@@ -9,12 +9,12 @@ use crate::{
 pub(crate) fn init() {}
 
 pub(crate) fn configure_clock() {
-    #[cfg(feature = "esp32_40mhz")]
+    #[cfg(feature = "xtal_40mhz")]
     assert!(matches!(
         RtcClock::get_xtal_freq(),
         XtalClock::RtcXtalFreq40M
     ));
-    #[cfg(feature = "esp32_26mhz")]
+    #[cfg(feature = "xtal_26mhz")]
     assert!(
         matches!(RtcClock::get_xtal_freq(), XtalClock::RtcXtalFreq26M),
         "Did you flash the right bootloader configured for 26Mhz xtal?"

--- a/esp-hal-common/src/rtc_cntl/rtc/esp32c2.rs
+++ b/esp-hal-common/src/rtc_cntl/rtc/esp32c2.rs
@@ -56,12 +56,12 @@ pub(crate) fn init() {
 }
 
 pub(crate) fn configure_clock() {
-    #[cfg(feature = "esp32c2_40mhz")]
+    #[cfg(feature = "xtal_40mhz")]
     assert!(matches!(
         RtcClock::get_xtal_freq(),
         XtalClock::RtcXtalFreq40M
     ));
-    #[cfg(feature = "esp32c2_26mhz")]
+    #[cfg(feature = "xtal_26mhz")]
     assert!(
         matches!(RtcClock::get_xtal_freq(), XtalClock::RtcXtalFreq26M),
         "Did you flash the right bootloader configured for 26MHz xtal?"

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -23,5 +23,5 @@ esp32h2 = ["esp-hal-common/esp32h2"]
 esp32s2 = ["esp-hal-common/esp32s2"]
 esp32s3 = ["esp-hal-common/esp32s3"]
 
-esp32_26mhz = ["esp-hal-common/esp32_26mhz"]
-esp32_40mhz = ["esp-hal-common/esp32_40mhz"]
+xtal_26mhz = ["esp-hal-common/xtal_26mhz"]
+xtal_40mhz = ["esp-hal-common/xtal_40mhz"]

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -50,7 +50,7 @@ ssd1306            = "0.8.1"
 static_cell        = { version = "1.2.0", features = ["nightly"] }
 
 [features]
-default            = ["rt", "vectored", "xtal40mhz"]
+default            = ["rt", "vectored", "xtal_40mhz"]
 async              = ["esp-hal-common/async"]
 bluetooth          = []
 debug              = ["esp-hal-common/debug"]
@@ -60,8 +60,8 @@ log                = ["esp-hal-common/log"]
 rt                 = []
 ufmt               = ["esp-hal-common/ufmt"]
 vectored           = ["esp-hal-common/vectored"]
-xtal40mhz          = ["esp-hal-common/esp32_40mhz"]
-xtal26mhz          = ["esp-hal-common/esp32_26mhz"]
+xtal_26mhz         = ["esp-hal-common/xtal_26mhz"]
+xtal_40mhz         = ["esp-hal-common/xtal_40mhz"]
 
 # Embassy support
 embassy                    = ["esp-hal-common/embassy"]

--- a/esp32-hal/build.rs
+++ b/esp32-hal/build.rs
@@ -59,7 +59,7 @@ fn generate_memory_extras() -> Vec<u8> {
 }
 
 fn check_features() {
-    if cfg!(feature = "xtal40mhz") && cfg!(feature = "xtal26mhz") {
+    if cfg!(feature = "xtal_40mhz") && cfg!(feature = "xtal_26mhz") {
         panic!("Only one xtal speed feature can be selected");
     }
 }

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -32,12 +32,12 @@
 //! - `rt` - Runtime support
 //! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART driver
 //! - `vectored` - Enable interrupt vectoring
-//! - `xtal26mhz` - The target device uses a 26MHz crystal
-//! - `xtal40mhz` - The target device uses a 40MHz crystal
+//! - `xtal_26mhz` - The target device uses a 26MHz crystal
+//! - `xtal_40mhz` - The target device uses a 40MHz crystal
 //!
 //! #### Default Features
 //!
-//! The `rt`, `vectored`, and `xtal40mhz` features are enabled by default.
+//! The `rt`, `vectored`, and `xtal_40mhz` features are enabled by default.
 //!
 //! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
 //! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -49,7 +49,7 @@ p192              = {version = "0.13.0", default-features = false, features = ["
 p256              = {version = "0.13.2", default-features = false, features = ["arithmetic"] }
 
 [features]
-default              = ["rt", "vectored", "xtal40mhz"]
+default              = ["rt", "vectored", "xtal_40mhz"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
 defmt                = ["esp-hal-common/defmt"]
@@ -61,8 +61,8 @@ log                  = ["esp-hal-common/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
-xtal26mhz            = ["esp-hal-common/esp32c2_26mhz"]
-xtal40mhz            = ["esp-hal-common/esp32c2_40mhz"] 
+xtal_26mhz           = ["esp-hal-common/xtal_26mhz"]
+xtal_40mhz           = ["esp-hal-common/xtal_40mhz"]
 
 # Embassy support
 embassy              = ["esp-hal-common/embassy"]

--- a/esp32c2-hal/build.rs
+++ b/esp32c2-hal/build.rs
@@ -67,7 +67,7 @@ fn main() {
 }
 
 fn check_features() {
-    if cfg!(feature = "xtal40mhz") && cfg!(feature = "xtal26mhz") {
+    if cfg!(feature = "xtal_40mhz") && cfg!(feature = "xtal_26mhz") {
         panic!("Only one xtal speed feature can be selected");
     }
 }

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -27,12 +27,12 @@
 //! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
 //!   Serial JTAG drivers
 //! - `vectored` - Enable interrupt vectoring
-//! - `xtal26mhz` - The target device uses a 26MHz crystal
-//! - `xtal40mhz` - The target device uses a 40MHz crystal
+//! - `xtal_26mhz` - The target device uses a 26MHz crystal
+//! - `xtal_40mhz` - The target device uses a 40MHz crystal
 //!
 //! #### Default Features
 //!
-//! The `rt`, `vectored`, and `xtal40mhz` features are enabled by default.
+//! The `rt`, `vectored`, and `xtal_40mhz` features are enabled by default.
 //!
 //! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
 //! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async


### PR DESCRIPTION
There's no real reason to make a distinction for each chip, so I've removed two of these features to simplify things. These features were then updated where required, and renamed in the HAL packages to be consistent (hopefully not many people are using these).

I've also done a bunch of grouping and re-organizing of features in the Cargo manifest, so apologies for the noise there, but it's a bit nicer now IMO.