### PR TITLE
Provide ADC values in mV instead of requiring the user to scale them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped MSRV to 1.67 (#798)
 - Optimised multi-core critical section implementation (#797)
+- Changed linear-calibrated ADC to provide readings in mV (#836)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped MSRV to 1.67 (#798)
 - Optimised multi-core critical section implementation (#797)
-- Changed linear-calibrated ADC to provide readings in mV (#836)
+- Changed linear- and curve-calibrated ADC to provide readings in mV (#836)
 
 ### Fixed
 

--- a/esp-hal-common/src/analog/adc/cal_basic.rs
+++ b/esp-hal-common/src/analog/adc/cal_basic.rs
@@ -11,10 +11,14 @@ use crate::adc::{
 
 /// Basic ADC calibration scheme
 ///
-/// Basic calibration is related to setting some initial bias value in ADC.
-/// Such values usually is stored in efuse bit fields but also can be measured
-/// in runtime by connecting ADC input to ground internally a fallback when
-/// it is not available.
+/// Basic calibration sets the initial ADC bias value so that a zero voltage
+/// gives a reading of zero. The correct bias value is usually stored in efuse,
+/// but can also be measured at runtime by connecting the ADC input to ground
+/// internally.
+///
+/// Failing to apply basic calibration can substantially reduce the ADC's output
+/// range because bias correction is done *before* the ADC's output is truncated
+/// to 12 bits.
 #[derive(Clone, Copy)]
 pub struct AdcCalBasic<ADCI> {
     /// Calibration value to set to ADC unit

--- a/esp-hal-common/src/analog/adc/cal_curve.rs
+++ b/esp-hal-common/src/analog/adc/cal_curve.rs
@@ -37,8 +37,8 @@ pub trait AdcHasCurveCal {
 
 /// Curve fitting ADC calibration scheme
 ///
-/// This scheme implements final polynomial error correction using predefined
-/// coefficient sets for each attenuation.
+/// This scheme implements polynomial error correction using predefined
+/// coefficient sets for each attenuation. It returns readings in mV.
 ///
 /// This scheme also includes basic calibration ([`super::AdcCalBasic`]) and
 /// line fitting ([`AdcCalLine`]).

--- a/esp-hal-common/src/analog/adc/cal_line.rs
+++ b/esp-hal-common/src/analog/adc/cal_line.rs
@@ -21,7 +21,8 @@ const GAIN_SCALE: u32 = 1 << 16;
 
 /// Line fitting ADC calibration scheme
 ///
-/// This scheme implements gain correction based on reference points.
+/// This scheme implements gain correction based on reference points, and
+/// returns readings in mV.
 ///
 /// A reference point is a pair of a reference voltage and the corresponding
 /// mean raw digital ADC value. Such values are usually stored in efuse bit

--- a/esp-hal-common/src/analog/adc/cal_line.rs
+++ b/esp-hal-common/src/analog/adc/cal_line.rs
@@ -37,7 +37,11 @@ const GAIN_SCALE: u32 = 1 << 16;
 pub struct AdcCalLine<ADCI> {
     basic: AdcCalBasic<ADCI>,
 
-    /// Gain of ADC-value
+    /// ADC gain.
+    ///
+    /// After being de-biased by the basic calibration, the reading is
+    /// multiplied by this value. Despite the type, it is a fixed-point
+    /// number with 16 fractional bits.
     gain: u32,
 
     _phantom: PhantomData<ADCI>,

--- a/esp-hal-common/src/analog/adc/cal_line.rs
+++ b/esp-hal-common/src/analog/adc/cal_line.rs
@@ -16,8 +16,7 @@ use crate::adc::{
 /// See also [`AdcCalLine`].
 pub trait AdcHasLineCal {}
 
-/// Coefficients is actually a fixed-point numbers.
-/// It is scaled to put them into integer.
+/// We store the gain as a u32, but it's really a fixed-point number.
 const GAIN_SCALE: u32 = 1 << 16;
 
 /// Line fitting ADC calibration scheme
@@ -57,8 +56,8 @@ where
             .map(|code| (code, ADCI::get_cal_mv(atten)))
             .unwrap_or_else(|| {
                 // As a fallback try to calibrate using reference voltage source.
-                // This methos is no to good because actual reference voltage may varies
-                // in range 1000..=1200 mV and this value currently cannot be given from efuse.
+                // This method is not too good because actual reference voltage may varies
+                // in range 1000..=1200 mV and this value currently cannot be read from efuse.
                 (
                     AdcConfig::<ADCI>::adc_calibrate(atten, AdcCalSource::Ref),
                     1100, // use 1100 mV as a middle of typical reference voltage range
@@ -69,10 +68,9 @@ where
         // the voltage with the previously done measurement when the chip was
         // manufactured.
         //
-        // Rounding formula: R = (OP(A * 2) + 1) / 2
-        // where R - result, A - argument, O - operation
-        let gain =
-            ((mv as u32 * GAIN_SCALE * 2 / code as u32 + 1) * 4096 / atten.ref_mv() as u32 + 1) / 2;
+        // Note that the constant term is zero because the basic calibration takes care
+        // of it already.
+        let gain = mv as u32 * GAIN_SCALE / code as u32;
 
         Self {
             basic,
@@ -88,7 +86,6 @@ where
     fn adc_val(&self, val: u16) -> u16 {
         let val = self.basic.adc_val(val);
 
-        // pointers are checked in the upper layer
         (val as u32 * self.gain / GAIN_SCALE) as u16
     }
 }

--- a/esp-hal-common/src/analog/adc/riscv.rs
+++ b/esp-hal-common/src/analog/adc/riscv.rs
@@ -149,25 +149,6 @@ impl Attenuation {
         Attenuation::Attenuation6dB,
         Attenuation::Attenuation11dB,
     ];
-
-    /// Reference voltage in millivolts
-    ///
-    /// Vref = 10 ^ (Att / 20) * Vref0
-    /// where Vref0 = 1.1 V, Att - attenuation in dB
-    ///
-    /// To convert raw value to millivolts use formula:
-    /// V = D * Vref / 2 ^ R
-    /// where D - raw ADC value, R - resolution in bits
-    pub const fn ref_mv(&self) -> u16 {
-        match self {
-            Attenuation::Attenuation0dB => 1100,
-            #[cfg(not(esp32c2))]
-            Attenuation::Attenuation2p5dB => 1467,
-            #[cfg(not(esp32c2))]
-            Attenuation::Attenuation6dB => 2195,
-            Attenuation::Attenuation11dB => 3903,
-        }
-    }
 }
 
 pub struct AdcPin<PIN, ADCI, CS = ()> {

--- a/esp-hal-common/src/analog/adc/xtensa.rs
+++ b/esp-hal-common/src/analog/adc/xtensa.rs
@@ -112,23 +112,6 @@ impl Attenuation {
         Attenuation::Attenuation6dB,
         Attenuation::Attenuation11dB,
     ];
-
-    /// Reference voltage in millivolts
-    ///
-    /// Vref = 10 ^ (Att / 20) * Vref0
-    /// where Vref0 = 1.1 V, Att - attenuation in dB
-    ///
-    /// To convert raw value to millivolts use formula:
-    /// V = D * Vref / 2 ^ R
-    /// where D - raw ADC value, R - resolution in bits
-    pub const fn ref_mv(&self) -> u16 {
-        match self {
-            Attenuation::Attenuation0dB => 1100,
-            Attenuation::Attenuation2p5dB => 1467,
-            Attenuation::Attenuation6dB => 2195,
-            Attenuation::Attenuation11dB => 3903,
-        }
-    }
 }
 
 pub struct AdcPin<PIN, ADCI, CS = ()> {

--- a/esp-hal-common/src/analog/mod.rs
+++ b/esp-hal-common/src/analog/mod.rs
@@ -84,12 +84,17 @@ pub mod adc;
 #[cfg(dac)]
 pub mod dac;
 
-/// A helper trait to do calibrated samples fitting
+/// A trait abstracting over calibration methods.
+///
+/// The methods in this trait are mostly for internal use. To get
+/// calibrated ADC reads, all you need to do is call `enable_pin_with_cal`
+/// and specify some implementor of this trait.
 pub trait AdcCalScheme<ADCI>: Sized {
-    /// Instantiate scheme
+    /// Create a new calibration scheme for the given attenuation.
     fn new_cal(atten: adc::Attenuation) -> Self;
 
-    /// Get ADC calibration value to set to ADC unit
+    /// Return the basic ADC bias value. See [`adc::AdcCalBasic`] for
+    /// details.
     fn adc_cal(&self) -> u16 {
         0
     }

--- a/esp32c2-hal/examples/adc_cal.rs
+++ b/esp32c2-hal/examples/adc_cal.rs
@@ -32,14 +32,13 @@ fn main() -> ! {
 
     let atten = Attenuation::Attenuation11dB;
 
-    // You can try any of the following calibration methods by uncommenting them.
-    // Note that only AdcCalLine and AdcCalCurve return readings in mV; the other
-    // two return raw readings in some unspecified scale.
+    // You can try any of the following calibration methods by uncommenting
+    // them. Note that only AdcCalLine returns readings in mV; the other two
+    // return raw readings in some unspecified scale.
     //
     // type AdcCal = ();
     // type AdcCal = adc::AdcCalBasic<ADC1>;
-    // type AdcCal = adc::AdcCalLine<ADC1>;
-    type AdcCal = adc::AdcCalCurve<ADC1>;
+    type AdcCal = adc::AdcCalLine<ADC1>;
 
     let mut pin = adc1_config.enable_pin_with_cal::<_, AdcCal>(io.pins.gpio2.into_analog(), atten);
 

--- a/esp32c2-hal/examples/adc_cal.rs
+++ b/esp32c2-hal/examples/adc_cal.rs
@@ -32,10 +32,14 @@ fn main() -> ! {
 
     let atten = Attenuation::Attenuation11dB;
 
-    // You can try any of the following calibration methods by uncommenting them
+    // You can try any of the following calibration methods by uncommenting them.
+    // Note that only AdcCalLine and AdcCalCurve return readings in mV; the other
+    // two return raw readings in some unspecified scale.
+    //
     // type AdcCal = ();
     // type AdcCal = adc::AdcCalBasic<ADC1>;
-    type AdcCal = adc::AdcCalLine<ADC1>;
+    // type AdcCal = adc::AdcCalLine<ADC1>;
+    type AdcCal = adc::AdcCalCurve<ADC1>;
 
     let mut pin = adc1_config.enable_pin_with_cal::<_, AdcCal>(io.pins.gpio2.into_analog(), atten);
 
@@ -44,9 +48,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     loop {
-        let pin_value: u16 = nb::block!(adc1.read(&mut pin)).unwrap();
-        let pin_value_mv = pin_value as u32 * atten.ref_mv() as u32 / 4096;
-        println!("PIN2 ADC reading = {pin_value} ({pin_value_mv} mV)");
+        let pin_mv = nb::block!(adc1.read(&mut pin)).unwrap();
+        println!("PIN2 ADC reading = {pin_mv} mV");
         delay.delay_ms(1500u32);
     }
 }

--- a/esp32c3-hal/examples/adc_cal.rs
+++ b/esp32c3-hal/examples/adc_cal.rs
@@ -32,7 +32,10 @@ fn main() -> ! {
 
     let atten = Attenuation::Attenuation11dB;
 
-    // You can try any of the following calibration methods by uncommenting them
+    // You can try any of the following calibration methods by uncommenting them.
+    // Note that only AdcCalLine and AdcCalCurve return readings in mV; the other
+    // two return raw readings in some unspecified scale.
+    //
     // type AdcCal = ();
     // type AdcCal = adc::AdcCalBasic<ADC1>;
     // type AdcCal = adc::AdcCalLine<ADC1>;
@@ -45,8 +48,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     loop {
-        let pin_value = nb::block!(adc1.read(&mut pin)).unwrap();
-        println!("PIN2 ADC reading = {pin_value}");
+        let pin_mv = nb::block!(adc1.read(&mut pin)).unwrap();
+        println!("PIN2 ADC reading = {pin_mv} mV");
         delay.delay_ms(1500u32);
     }
 }

--- a/esp32c3-hal/examples/adc_cal.rs
+++ b/esp32c3-hal/examples/adc_cal.rs
@@ -46,8 +46,7 @@ fn main() -> ! {
 
     loop {
         let pin_value = nb::block!(adc1.read(&mut pin)).unwrap();
-        let pin_value_mv = pin_value as u32 * atten.ref_mv() as u32 / 4096;
-        println!("PIN2 ADC reading = {pin_value} ({pin_value_mv} mV)");
+        println!("PIN2 ADC reading = {pin_value}");
         delay.delay_ms(1500u32);
     }
 }

--- a/esp32c6-hal/examples/adc_cal.rs
+++ b/esp32c6-hal/examples/adc_cal.rs
@@ -32,7 +32,10 @@ fn main() -> ! {
 
     let atten = Attenuation::Attenuation11dB;
 
-    // You can try any of the following calibration methods by uncommenting them
+    // You can try any of the following calibration methods by uncommenting them.
+    // Note that only AdcCalLine and AdcCalCurve return readings in mV; the other
+    // two return raw readings in some unspecified scale.
+    //
     // type AdcCal = ();
     // type AdcCal = adc::AdcCalBasic<ADC1>;
     // type AdcCal = adc::AdcCalLine<ADC1>;
@@ -45,9 +48,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     loop {
-        let pin_value: u16 = nb::block!(adc1.read(&mut pin)).unwrap();
-        let pin_value_mv = pin_value as u32 * atten.ref_mv() as u32 / 4096;
-        println!("PIN2 ADC reading = {pin_value} ({pin_value_mv} mV)");
+        let pin_mv = nb::block!(adc1.read(&mut pin)).unwrap();
+        println!("PIN2 ADC reading = {pin_mv} mV");
         delay.delay_ms(1500u32);
     }
 }

--- a/esp32s3-hal/examples/adc_cal.rs
+++ b/esp32s3-hal/examples/adc_cal.rs
@@ -31,7 +31,10 @@ fn main() -> ! {
 
     let atten = Attenuation::Attenuation11dB;
 
-    // You can try any of the following calibration methods by uncommenting them
+    // You can try any of the following calibration methods by uncommenting them.
+    // Note that only AdcCalLine and AdcCalCurve return readings in mV; the other
+    // two return raw readings in some unspecified scale.
+    //
     // type AdcCal = ();
     // type AdcCal = adc::AdcCalBasic<ADC1>;
     // type AdcCal = adc::AdcCalLine<ADC1>;
@@ -44,9 +47,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     loop {
-        let pin_value: u16 = nb::block!(adc1.read(&mut pin)).unwrap();
-        let pin_value_mv = pin_value as u32 * atten.ref_mv() as u32 / 4096;
-        println!("PIN2 ADC reading = {pin_value} ({pin_value_mv} mV)");
+        let pin_mv = nb::block!(adc1.read(&mut pin)).unwrap();
+        println!("PIN2 ADC reading = {pin_mv} mV");
         delay.delay_ms(1500u32);
     }
 }


### PR DESCRIPTION
I don't understand why the adc reading provides values in some undefined units instead of in mV directly. At first I thought it was for extra precision (because `ref_mv / 4096` is less than 1, and so you lose some of the lower bits when converting to mV), but in fact the calibration code is getting the reading in mV first and then *multiplying* by `4096 / ref_mv` so the precision was never there and it all just seems like wasted work.

I've only done it for esp32c3 so far, but if it sounds like a reasonable change then I'll do it for the others.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
