### PR TITLE
Clean up and simplify build scripts

### DIFF
--- a/esp32c2-hal/build.rs
+++ b/esp32c2-hal/build.rs
@@ -1,84 +1,50 @@
-use std::{env, fs::File, io::Write, path::PathBuf};
+use std::{env, error::Error, fs, path::PathBuf};
 
 #[cfg(feature = "direct-boot")]
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     check_features();
 
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-esp32c2-memory.x"))
-        .unwrap();
-
-    File::create(out.join("esp32c2-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-esp32c2-link.x"))
-        .unwrap();
-
-    File::create(out.join("riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-linkall.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/db-esp32c2-memory.x", out.join("memory.x")).unwrap();
+    fs::copy("ld/db-esp32c2-link.x", out.join("esp32c2-link.x")).unwrap();
+    fs::copy("ld/db-riscv-link.x", out.join("riscv-link.x")).unwrap();
+    fs::copy("ld/db-linkall.x", out.join("linkall.x")).unwrap();
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
-    add_defaults();
+    Ok(())
 }
 
 #[cfg(not(feature = "direct-boot"))]
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     check_features();
 
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-esp32c2-memory.x"))
-        .unwrap();
-
-    File::create(out.join("bl-riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-linkall.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/bl-esp32c2-memory.x", out.join("memory.x")).unwrap();
+    fs::copy("ld/bl-riscv-link.x", out.join("bl-riscv-link.x")).unwrap();
+    fs::copy("ld/bl-linkall.x", out.join("linkall.x")).unwrap();
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
-    add_defaults();
+    Ok(())
 }
 
 fn check_features() {
     if cfg!(feature = "xtal-40mhz") && cfg!(feature = "xtal-26mhz") {
         panic!("Only one xtal speed feature can be selected");
     }
-}
-
-fn add_defaults() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("rom-functions.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/rom-functions.x"))
-        .unwrap();
-
-    println!("cargo:rustc-link-search={}", out.display());
 }

--- a/esp32c3-hal/build.rs
+++ b/esp32c3-hal/build.rs
@@ -1,124 +1,75 @@
-use std::{env, fs::File, io::Write, path::PathBuf};
+use std::{env, error::Error, fs, path::PathBuf};
 
-// Thanks to kennytm and TheDan64 for the assert_used_features macro.
-// Source:
-// https://github.com/TheDan64/inkwell/blob/36c3b106e61b1b45295a35f94023d93d9328c76f/src/lib.rs#L81-L110
+// Given some features, assert that AT MOST one of the features is enabled.
 macro_rules! assert_unique_features {
     () => {};
-    ($first:tt $(,$rest:tt)*) => {
+
+    ( $first:tt $(,$rest:tt)* ) => {
         $(
             #[cfg(all(feature = $first, feature = $rest))]
             compile_error!(concat!("Features \"", $first, "\" and \"", $rest, "\" cannot be used together"));
         )*
         assert_unique_features!($($rest),*);
-    }
+    };
 }
 
-assert_unique_features! {"mcu-boot", "direct-boot"}
+assert_unique_features! {"direct-boot", "mcu-boot"}
+
+#[cfg(not(any(feature = "direct-boot", feature = "mcu-boot")))]
+fn main() -> Result<(), Box<dyn Error>> {
+    // Put the linker script somewhere the linker can find it
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/bl-esp32c3-memory.x", out.join("memory.x"))?;
+    fs::copy("ld/bl-riscv-link.x", out.join("bl-riscv-link.x"))?;
+    fs::copy("ld/bl-linkall.x", out.join("linkall.x"))?;
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
+
+    // Only re-run the build script when memory.x is changed,
+    // instead of when any part of the source code changes.
+    println!("cargo:rerun-if-changed=ld/memory.x");
+
+    Ok(())
+}
 
 #[cfg(feature = "direct-boot")]
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-esp32c3-memory.x"))
-        .unwrap();
-
-    File::create(out.join("esp32c3-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-esp32c3-link.x"))
-        .unwrap();
-
-    File::create(out.join("riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-linkall.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/db-esp32c3-memory.x", out.join("memory.x"))?;
+    fs::copy("ld/db-esp32c3-link.x", out.join("esp32c3-link.x"))?;
+    fs::copy("ld/db-riscv-link.x", out.join("riscv-link.x"))?;
+    fs::copy("ld/db-linkall.x", out.join("linkall.x"))?;
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
-    add_defaults();
-}
-
-#[cfg(not(any(feature = "mcu-boot", feature = "direct-boot")))]
-fn main() {
-    // Put the linker script somewhere the linker can find it
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-esp32c3-memory.x"))
-        .unwrap();
-
-    File::create(out.join("bl-riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-linkall.x"))
-        .unwrap();
-
-    println!("cargo:rustc-link-search={}", out.display());
-
-    // Only re-run the build script when memory.x is changed,
-    // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=ld/memory.x");
-
-    add_defaults();
+    Ok(())
 }
 
 #[cfg(feature = "mcu-boot")]
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/mb-esp32c3-memory.x"))
-        .unwrap();
-
-    File::create(out.join("esp32c3-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/mb-esp32c3-link.x"))
-        .unwrap();
-
-    File::create(out.join("riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/mb-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/mb-linkall.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/mb-esp32c3-memory.x", out.join("memory.x"))?;
+    fs::copy("ld/mb-esp32c3-link.x", out.join("esp32c3-link.x"))?;
+    fs::copy("ld/mb-riscv-link.x", out.join("riscv-link.x"))?;
+    fs::copy("ld/mb-linkall.x", out.join("linkall.x"))?;
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
-    add_defaults();
-}
-
-fn add_defaults() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("rom-functions.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/rom-functions.x"))
-        .unwrap();
-
-    println!("cargo:rustc-link-search={}", out.display());
+    Ok(())
 }

--- a/esp32c6-hal/build.rs
+++ b/esp32c6-hal/build.rs
@@ -1,74 +1,40 @@
-use std::{env, fs::File, io::Write, path::PathBuf};
-
-#[cfg(feature = "direct-boot")]
-fn main() {
-    // Put the linker script somewhere the linker can find it
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-esp32c6-memory.x"))
-        .unwrap();
-
-    File::create(out.join("esp32c6-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-esp32c6-link.x"))
-        .unwrap();
-
-    File::create(out.join("riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-linkall.x"))
-        .unwrap();
-
-    println!("cargo:rustc-link-search={}", out.display());
-
-    // Only re-run the build script when memory.x is changed,
-    // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=ld/memory.x");
-
-    add_defaults();
-}
+use std::{env, error::Error, fs, path::PathBuf};
 
 #[cfg(not(feature = "direct-boot"))]
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-esp32c6-memory.x"))
-        .unwrap();
-
-    File::create(out.join("bl-riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-linkall.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/bl-esp32c6-memory.x", out.join("memory.x"))?;
+    fs::copy("ld/bl-riscv-link.x", out.join("bl-riscv-link.x"))?;
+    fs::copy("ld/bl-linkall.x", out.join("linkall.x"))?;
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
-    add_defaults();
+    Ok(())
 }
 
-fn add_defaults() {
+#[cfg(feature = "direct-boot")]
+fn main() -> Result<(), Box<dyn Error>> {
+    // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("rom-functions.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/rom-functions.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/db-esp32c6-memory.x", out.join("memory.x"))?;
+    fs::copy("ld/db-esp32c6-link.x", out.join("esp32c6-link.x"))?;
+    fs::copy("ld/db-riscv-link.x", out.join("riscv-link.x"))?;
+    fs::copy("ld/db-linkall.x", out.join("linkall.x"))?;
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
+
+    // Only re-run the build script when memory.x is changed,
+    // instead of when any part of the source code changes.
+    println!("cargo:rerun-if-changed=ld/memory.x");
+
+    Ok(())
 }

--- a/esp32c6-lp-hal/build.rs
+++ b/esp32c6-lp-hal/build.rs
@@ -1,17 +1,15 @@
-use std::{env, fs::File, io::Write, path::PathBuf};
+use std::{env, error::Error, fs, path::PathBuf};
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/link.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/link.x", out.join("link.x"))?;
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
+
+    Ok(())
 }

--- a/esp32h2-hal/build.rs
+++ b/esp32h2-hal/build.rs
@@ -1,74 +1,40 @@
-use std::{env, fs::File, io::Write, path::PathBuf};
-
-#[cfg(feature = "direct-boot")]
-fn main() {
-    // Put the linker script somewhere the linker can find it
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-esp32h2-memory.x"))
-        .unwrap();
-
-    File::create(out.join("esp32h2-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-esp32h2-link.x"))
-        .unwrap();
-
-    File::create(out.join("riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/db-linkall.x"))
-        .unwrap();
-
-    println!("cargo:rustc-link-search={}", out.display());
-
-    // Only re-run the build script when memory.x is changed,
-    // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=ld/memory.x");
-
-    add_defaults();
-}
+use std::{env, error::Error, fs, path::PathBuf};
 
 #[cfg(not(feature = "direct-boot"))]
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-esp32h2-memory.x"))
-        .unwrap();
-
-    File::create(out.join("bl-riscv-link.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-riscv-link.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/bl-linkall.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/bl-esp32h2-memory.x", out.join("memory.x"))?;
+    fs::copy("ld/bl-riscv-link.x", out.join("bl-riscv-link.x"))?;
+    fs::copy("ld/bl-linkall.x", out.join("linkall.x"))?;
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
 
-    add_defaults();
+    Ok(())
 }
 
-fn add_defaults() {
+#[cfg(feature = "direct-boot")]
+fn main() -> Result<(), Box<dyn Error>> {
+    // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    File::create(out.join("rom-functions.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/rom-functions.x"))
-        .unwrap();
-
     println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/db-esp32h2-memory.x", out.join("memory.x"))?;
+    fs::copy("ld/db-esp32h2-link.x", out.join("esp32h2-link.x"))?;
+    fs::copy("ld/db-riscv-link.x", out.join("riscv-link.x"))?;
+    fs::copy("ld/db-linkall.x", out.join("linkall.x"))?;
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
+
+    // Only re-run the build script when memory.x is changed,
+    // instead of when any part of the source code changes.
+    println!("cargo:rerun-if-changed=ld/memory.x");
+
+    Ok(())
 }

--- a/esp32s2-hal/build.rs
+++ b/esp32s2-hal/build.rs
@@ -1,39 +1,30 @@
-use std::{env, fs::File, io::Write, path::PathBuf};
+use std::{
+    env,
+    error::Error,
+    fs::{self, File},
+    io::Write,
+    path::PathBuf,
+};
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/memory.x"))
-        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    fs::copy("ld/memory.x", out.join("memory.x"))?;
+    fs::copy("ld/link-esp32s2.x", out.join("link-esp32s2.x"))?;
+    fs::copy("ld/linkall.x", out.join("linkall.x"))?;
+
+    fs::copy("ld/rom-functions.x", out.join("rom-functions.x"))?;
 
     let memory_extras = generate_memory_extras();
-    File::create(out.join("memory_extras.x"))
-        .unwrap()
-        .write_all(&memory_extras)
-        .unwrap();
-
-    File::create(out.join("rom-functions.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/rom-functions.x"))
-        .unwrap();
-
-    File::create(out.join("linkall.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/linkall.x"))
-        .unwrap();
-
-    File::create(out.join("link-esp32s2.x"))
-        .unwrap()
-        .write_all(include_bytes!("ld/link-esp32s2.x"))
-        .unwrap();
-
-    println!("cargo:rustc-link-search={}", out.display());
+    File::create(out.join("memory_extras.x"))?.write_all(&memory_extras)?;
 
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=ld/memory.x");
+
+    Ok(())
 }
 
 fn generate_memory_extras() -> Vec<u8> {


### PR DESCRIPTION
For whatever reason (years of copy-pasting, most likely) our build scripts were needlessly verbose. I've simplified and re-organized them mostly just to reduce visual clutter and make it more clear what's going on. None of this really matters much, honestly; there are no actual changes to the build process, but less code is always a plus.