### PR TITLE
embassy `#[main]` convenience for RISC-V / Xtensa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added sleep support for ESP32-C3 with timer and GPIO wakeups (#795)
 - Support for ULP-RISCV including Delay and GPIO (#840)
 - Add bare-bones SPI slave support, DMA only (#580)
+- Embassy `#[main]` convenience macro
 
 ### Changed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -115,7 +115,7 @@ ufmt = ["ufmt-write"]
 async = ["embedded-hal-async", "eh1", "embassy-sync", "embassy-futures", "embedded-io-async"]
 
 # Embassy support
-embassy = ["embassy-time"]
+embassy = ["embassy-time","procmacros/embassy"]
 
 embassy-executor-interrupt = ["embassy", "embassy-executor"]
 embassy-executor-thread    = ["embassy", "embassy-executor"]

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -40,3 +40,4 @@ esp32s3   = ["dep:object"]
 
 interrupt = []
 rtc_slow  = []
+embassy   = []

--- a/esp-hal-procmacros/src/embassy_xtensa.rs
+++ b/esp-hal-procmacros/src/embassy_xtensa.rs
@@ -1,0 +1,191 @@
+use darling::ast::NestedMeta;
+use syn::{
+    parse::{Parse, ParseBuffer},
+    punctuated::Punctuated,
+    Token,
+};
+
+pub(crate) struct Args {
+    pub(crate) meta: Vec<NestedMeta>,
+}
+
+impl Parse for Args {
+    fn parse(input: &ParseBuffer) -> syn::Result<Self> {
+        let meta = Punctuated::<NestedMeta, Token![,]>::parse_terminated(input)?;
+        Ok(Args {
+            meta: meta.into_iter().collect(),
+        })
+    }
+}
+
+pub(crate) mod main {
+    use std::{cell::RefCell, fmt::Display, thread};
+
+    use darling::{export::NestedMeta, FromMeta};
+    use proc_macro2::{Ident, Span, TokenStream};
+    use proc_macro_crate::FoundCrate;
+    use quote::{quote, ToTokens};
+    use syn::{ReturnType, Type};
+
+    #[derive(Debug, FromMeta)]
+    struct Args {}
+
+    pub fn run(
+        args: &[NestedMeta],
+        f: syn::ItemFn,
+        main: TokenStream,
+    ) -> Result<TokenStream, TokenStream> {
+        #[allow(unused_variables)]
+        let args = Args::from_list(args).map_err(|e| e.write_errors())?;
+
+        let fargs = f.sig.inputs.clone();
+
+        let ctxt = Ctxt::new();
+
+        if f.sig.asyncness.is_none() {
+            ctxt.error_spanned_by(&f.sig, "main function must be async");
+        }
+        if !f.sig.generics.params.is_empty() {
+            ctxt.error_spanned_by(&f.sig, "main function must not be generic");
+        }
+        if !f.sig.generics.where_clause.is_none() {
+            ctxt.error_spanned_by(&f.sig, "main function must not have `where` clauses");
+        }
+        if !f.sig.abi.is_none() {
+            ctxt.error_spanned_by(&f.sig, "main function must not have an ABI qualifier");
+        }
+        if !f.sig.variadic.is_none() {
+            ctxt.error_spanned_by(&f.sig, "main function must not be variadic");
+        }
+        match &f.sig.output {
+            ReturnType::Default => {}
+            ReturnType::Type(_, ty) => match &**ty {
+                Type::Tuple(tuple) if tuple.elems.is_empty() => {}
+                Type::Never(_) => {}
+                _ => ctxt.error_spanned_by(
+                    &f.sig,
+                    "main function must either not return a value, return `()` or return `!`",
+                ),
+            },
+        }
+
+        if fargs.len() != 1 {
+            ctxt.error_spanned_by(&f.sig, "main function must have 1 argument: the spawner.");
+        }
+
+        ctxt.check()?;
+
+        let f_body = f.block;
+        let out = &f.sig.output;
+
+        let result = quote! {
+            #[::embassy_executor::task()]
+            async fn __embassy_main(#fargs) #out {
+                #f_body
+            }
+
+            unsafe fn __make_static<T>(t: &mut T) -> &'static mut T {
+                ::core::mem::transmute(t)
+            }
+
+            #main
+        };
+
+        Ok(result)
+    }
+
+    /// A type to collect errors together and format them.
+    ///
+    /// Dropping this object will cause a panic. It must be consumed using
+    /// `check`.
+    ///
+    /// References can be shared since this type uses run-time exclusive mut
+    /// checking.
+    #[derive(Default)]
+    pub struct Ctxt {
+        // The contents will be set to `None` during checking. This is so that checking can be
+        // enforced.
+        errors: RefCell<Option<Vec<syn::Error>>>,
+    }
+
+    impl Ctxt {
+        /// Create a new context object.
+        ///
+        /// This object contains no errors, but will still trigger a panic if it
+        /// is not `check`ed.
+        pub fn new() -> Self {
+            Ctxt {
+                errors: RefCell::new(Some(Vec::new())),
+            }
+        }
+
+        /// Add an error to the context object with a tokenenizable object.
+        ///
+        /// The object is used for spanning in error messages.
+        pub fn error_spanned_by<A: ToTokens, T: Display>(&self, obj: A, msg: T) {
+            self.errors
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                // Curb monomorphization from generating too many identical methods.
+                .push(syn::Error::new_spanned(obj.into_token_stream(), msg));
+        }
+
+        /// Add one of Syn's parse errors.
+        #[allow(unused)]
+        pub fn syn_error(&self, err: syn::Error) {
+            self.errors.borrow_mut().as_mut().unwrap().push(err);
+        }
+
+        /// Consume this object, producing a formatted error string if there are
+        /// errors.
+        pub fn check(self) -> Result<(), TokenStream> {
+            let errors = self.errors.borrow_mut().take().unwrap();
+            match errors.len() {
+                0 => Ok(()),
+                _ => Err(to_compile_errors(errors)),
+            }
+        }
+    }
+
+    fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {
+        let compile_errors = errors.iter().map(syn::Error::to_compile_error);
+        quote!(#(#compile_errors)*)
+    }
+
+    impl Drop for Ctxt {
+        fn drop(&mut self) {
+            if !thread::panicking() && self.errors.borrow().is_some() {
+                panic!("forgot to check for errors");
+            }
+        }
+    }
+
+    pub fn main() -> TokenStream {
+        let (hal_crate, hal_crate_name) = crate::get_hal_crate();
+
+        let executor = match hal_crate {
+            Ok(FoundCrate::Itself) => {
+                quote!( #hal_crate_name::embassy::executor::Executor )
+            }
+            Ok(FoundCrate::Name(ref name)) => {
+                let ident = Ident::new(&name, Span::call_site().into());
+                quote!( #ident::embassy::executor::Executor )
+            }
+            Err(_) => {
+                quote!(crate::embassy::executor::Executor)
+            }
+        };
+
+        quote! {
+            #[entry]
+            fn main() -> ! {
+                let mut executor = #executor::new();
+                let executor = unsafe { __make_static(&mut executor) };
+                executor.run(|spawner| {
+                    spawner.must_spawn(__embassy_main(spawner));
+                })
+            }
+        }
+    }
+}

--- a/esp32-hal/examples/embassy_hello_world.rs
+++ b/esp32-hal/examples/embassy_hello_world.rs
@@ -7,35 +7,27 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
 #[embassy_executor::task]
-async fn run1() {
+async fn run() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
         Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
-#[embassy_executor::task]
-async fn run2() {
-    loop {
-        esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -44,9 +36,10 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run1()).ok();
-        spawner.spawn(run2()).ok();
-    });
+    spawner.spawn(run()).ok();
+
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32-hal/examples/embassy_i2c.rs
+++ b/esp32-hal/examples/embassy_i2c.rs
@@ -14,10 +14,11 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     i2c::I2C,
     interrupt,
     peripherals::{Interrupt, Peripherals, I2C0},
@@ -27,23 +28,9 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn run(i2c: I2C<'static, I2C0>) {
-    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
-    lis3dh.set_range(Range::G8).await.unwrap();
-
-    loop {
-        let norm = lis3dh.accel_norm().await.unwrap();
-        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
-
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -63,8 +50,13 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run(i2c0)).ok();
-    });
+    let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32-hal/examples/embassy_i2s_read.rs
+++ b/esp32-hal/examples/embassy_i2s_read.rs
@@ -14,13 +14,12 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy::{self, executor::Executor},
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sRx, NoMclk, PinsBclkWsDin, Standard},
+    embassy::{self},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, NoMclk, PinsBclkWsDin, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -29,22 +28,55 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_rx: I2sRx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDin<
-            'static,
-            GpioPin<esp32_hal::gpio::Unknown, 12>,
-            GpioPin<esp32_hal::gpio::Unknown, 13>,
-            GpioPin<esp32_hal::gpio::Unknown, 14>,
-        >,
-        esp32_hal::pdma::I2s0DmaChannel,
-    >,
-) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let dma = Dma::new(system.dma);
+    let dma_channel = dma.i2s0channel;
+
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let i2s = I2s::new(
+        peripherals.I2S0,
+        NoMclk {},
+        Standard::Philips,
+        DataFormat::Data16Channel16,
+        44100u32.Hz(),
+        dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ),
+        &clocks,
+    );
+
+    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
+        io.pins.gpio12,
+        io.pins.gpio13,
+        io.pins.gpio14,
+    ));
+
+    // you need to manually enable the DMA channel's interrupt!
+    esp32_hal::interrupt::enable(
+        esp32_hal::peripherals::Interrupt::I2S0,
+        esp32_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let buffer = dma_buffer();
     println!("Start");
 
@@ -62,60 +94,6 @@ async fn i2s_task(
             &data[count - 10..count]
         );
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let dma = Dma::new(system.dma);
-    let dma_channel = dma.i2s0channel;
-
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
-
-    let i2s = I2s::new(
-        peripherals.I2S0,
-        NoMclk {},
-        Standard::Philips,
-        DataFormat::Data16Channel16,
-        44100u32.Hz(),
-        dma_channel.configure(
-            false,
-            tx_descriptors,
-            rx_descriptors,
-            DmaPriority::Priority0,
-        ),
-        &clocks,
-    );
-
-    let i2s_tx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio12,
-        io.pins.gpio13,
-        io.pins.gpio14,
-    ));
-
-    // you need to manually enable the DMA channel's interrupt!
-    esp32_hal::interrupt::enable(
-        esp32_hal::peripherals::Interrupt::I2S0,
-        esp32_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_tx)).ok();
-    });
 }
 
 fn dma_buffer() -> &'static mut [u8; 4092 * 4] {

--- a/esp32-hal/examples/embassy_i2s_sound.rs
+++ b/esp32-hal/examples/embassy_i2s_sound.rs
@@ -30,13 +30,12 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy::{self, executor::Executor},
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sTx, NoMclk, PinsBclkWsDout, Standard},
+    embassy::{self},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, NoMclk, PinsBclkWsDout, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -45,7 +44,6 @@ use esp32_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,
@@ -55,20 +53,54 @@ const SINE: [i16; 64] = [
     -28897, -27244, -25329, -23169, -20787, -18204, -15446, -12539, -9511, -6392, -3211,
 ];
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_tx: I2sTx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDout<
-            'static,
-            GpioPin<esp32_hal::gpio::Unknown, 12>,
-            GpioPin<esp32_hal::gpio::Unknown, 13>,
-            GpioPin<esp32_hal::gpio::Unknown, 14>,
-        >,
-        esp32_hal::pdma::I2s0DmaChannel,
-    >,
-) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let dma = Dma::new(system.dma);
+    let dma_channel = dma.i2s0channel;
+
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let i2s = I2s::new(
+        peripherals.I2S0,
+        NoMclk {},
+        Standard::Philips,
+        DataFormat::Data16Channel16,
+        44100u32.Hz(),
+        dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ),
+        &clocks,
+    );
+
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio12,
+        io.pins.gpio13,
+        io.pins.gpio14,
+    ));
+
+    // you need to manually enable the DMA channel's interrupt!
+    esp32_hal::interrupt::enable(
+        esp32_hal::peripherals::Interrupt::I2S0,
+        esp32_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
@@ -100,60 +132,6 @@ async fn i2s_task(
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let dma = Dma::new(system.dma);
-    let dma_channel = dma.i2s0channel;
-
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
-
-    let i2s = I2s::new(
-        peripherals.I2S0,
-        NoMclk {},
-        Standard::Philips,
-        DataFormat::Data16Channel16,
-        44100u32.Hz(),
-        dma_channel.configure(
-            false,
-            tx_descriptors,
-            rx_descriptors,
-            DmaPriority::Priority0,
-        ),
-        &clocks,
-    );
-
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio12,
-        io.pins.gpio13,
-        io.pins.gpio14,
-    ));
-
-    // you need to manually enable the DMA channel's interrupt!
-    esp32_hal::interrupt::enable(
-        esp32_hal::peripherals::Interrupt::I2S0,
-        esp32_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_tx)).ok();
-    });
 }
 
 fn dma_buffer() -> &'static mut [u8; 32000] {

--- a/esp32-hal/examples/embassy_multicore.rs
+++ b/esp32-hal/examples/embassy_multicore.rs
@@ -6,6 +6,7 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Duration, Ticker};
 use esp32_hal::{
@@ -43,27 +44,8 @@ async fn control_led(
     }
 }
 
-/// Sends periodic messages to control_led, enabling or disabling it.
-#[embassy_executor::task]
-async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bool>) {
-    println!(
-        "Starting enable_disable_led() on core {}",
-        get_core() as usize
-    );
-    let mut ticker = Ticker::every(Duration::from_secs(1));
-    loop {
-        esp_println::println!("Sending LED on");
-        control.signal(true);
-        ticker.next().await;
-
-        esp_println::println!("Sending LED off");
-        control.signal(false);
-        ticker.next().await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -89,8 +71,19 @@ fn main() -> ! {
         .start_app_core(unsafe { &mut APP_CORE_STACK }, cpu1_fnctn)
         .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(enable_disable_led(led_ctrl_signal)).ok();
-    });
+    // Sends periodic messages to control_led, enabling or disabling it.
+    println!(
+        "Starting enable_disable_led() on core {}",
+        get_core() as usize
+    );
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        esp_println::println!("Sending LED on");
+        led_ctrl_signal.signal(true);
+        ticker.next().await;
+
+        esp_println::println!("Sending LED off");
+        led_ctrl_signal.signal(false);
+        ticker.next().await;
+    }
 }

--- a/esp32-hal/examples/embassy_rmt_rx.rs
+++ b/esp32-hal/examples/embassy_rmt_rx.rs
@@ -5,20 +5,20 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_hal_common::gpio::{Gpio15, Output, PushPull};
 use esp_println::{print, println};
-use static_cell::make_static;
 
 const WIDTH: usize = 80;
 
@@ -26,7 +26,58 @@ const WIDTH: usize = 80;
 compile_error!("Run this example in release mode");
 
 #[embassy_executor::task]
-async fn rmt_task(mut channel: Channel2<2>) {
+async fn signal_task(mut pin: Gpio15<Output<PushPull>>) {
+    loop {
+        for _ in 0..10 {
+            pin.toggle().unwrap();
+            Timer::after(Duration::from_micros(10)).await;
+        }
+        Timer::after(Duration::from_millis(1000)).await;
+    }
+}
+
+#[main]
+async fn main(spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 = esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio4,
+            RxChannelConfig {
+                clk_divider: 1,
+                idle_threshold: 0b111_1111_1111_1111,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32_hal::interrupt::enable(
+        esp32_hal::peripherals::Interrupt::RMT,
+        esp32_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    spawner
+        .spawn(signal_task(io.pins.gpio15.into_push_pull_output()))
+        .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 1,
@@ -74,62 +125,4 @@ async fn rmt_task(mut channel: Channel2<2>) {
 
         println!();
     }
-}
-
-#[embassy_executor::task]
-async fn signal_task(mut pin: Gpio15<Output<PushPull>>) {
-    loop {
-        for _ in 0..10 {
-            pin.toggle().unwrap();
-            Timer::after(Duration::from_micros(10)).await;
-        }
-        Timer::after(Duration::from_millis(1000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-timg0")]
-    {
-        let timer_group0 = esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
-        embassy::init(&clocks, timer_group0.timer0);
-    }
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
-
-    let channel = rmt
-        .channel2
-        .configure(
-            io.pins.gpio4,
-            RxChannelConfig {
-                clk_divider: 1,
-                idle_threshold: 0b111_1111_1111_1111,
-                ..RxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32_hal::interrupt::enable(
-        esp32_hal::peripherals::Interrupt::RMT,
-        esp32_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-        spawner
-            .spawn(signal_task(io.pins.gpio15.into_push_pull_output()))
-            .ok();
-    });
 }

--- a/esp32-hal/examples/embassy_rmt_tx.rs
+++ b/esp32-hal/examples/embassy_rmt_tx.rs
@@ -5,22 +5,57 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    rmt::{asynch::TxChannelAsync, PulseCode, TxChannelConfig, TxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn rmt_task(mut channel: Channel0<0>) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 = esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio4.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32_hal::interrupt::enable(
+        esp32_hal::peripherals::Interrupt::RMT,
+        esp32_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 200,
@@ -42,47 +77,4 @@ async fn rmt_task(mut channel: Channel0<0>) {
         println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-timg0")]
-    {
-        let timer_group0 = esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
-        embassy::init(&clocks, timer_group0.timer0);
-    }
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
-
-    let channel = rmt
-        .channel0
-        .configure(
-            io.pins.gpio4.into_push_pull_output(),
-            TxChannelConfig {
-                clk_divider: 255,
-                ..TxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32_hal::interrupt::enable(
-        esp32_hal::peripherals::Interrupt::RMT,
-        esp32_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-    });
 }

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -7,9 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use esp32_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
@@ -19,7 +20,6 @@ use esp32_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use heapless::Vec;
-use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -61,8 +61,8 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
     }
 }
 
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -80,9 +80,6 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(reader(rx)).ok();
-        spawner.spawn(writer(tx)).ok();
-    });
+    spawner.spawn(reader(rx)).ok();
+    spawner.spawn(writer(tx)).ok();
 }

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -18,39 +18,23 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
+    spi::{Spi, SpiMode},
     timer::TimerGroup,
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-pub type SpiType<'d> = SpiDma<'d, esp32_hal::peripherals::SPI2, Spi2DmaChannel, FullDuplexMode>;
-
-#[embassy_executor::task]
-async fn spi_task(spi: &'static mut SpiType<'static>) {
-    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
-    loop {
-        let mut buffer = [0; 8];
-        esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
-            .await
-            .unwrap();
-        esp_println::println!("Bytes recieved: {:?}", buffer);
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -74,10 +58,10 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
-    let spi = make_static!(Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -89,13 +73,19 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        descriptors,
-        rx_descriptors,
+        &mut descriptors,
+        &mut rx_descriptors,
         DmaPriority::Priority0,
-    )));
+    ));
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(spi_task(spi)).ok();
-    });
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(&mut spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32-hal/examples/embassy_wait.rs
+++ b/esp32-hal/examples/embassy_wait.rs
@@ -6,32 +6,21 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
 use esp32_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
-    gpio::{Gpio0, Input, PullDown},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn ping(mut pin: Gpio0<Input<PullDown>>) {
-    loop {
-        esp_println::println!("Waiting...");
-        pin.wait_for_rising_edge().await.unwrap();
-        esp_println::println!("Ping!");
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -42,7 +31,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 0 as input
-    let input = io.pins.gpio0.into_pull_down_input();
+    let mut input = io.pins.gpio0.into_pull_down_input();
 
     // Async requires the GPIO interrupt to wake futures
     esp32_hal::interrupt::enable(
@@ -51,8 +40,10 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(ping(input)).ok();
-    });
+    loop {
+        esp_println::println!("Waiting...");
+        input.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32c2-hal/examples/embassy_hello_world.rs
+++ b/esp32c2-hal/examples/embassy_hello_world.rs
@@ -7,30 +7,21 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c2_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
-use static_cell::make_static;
 
 #[embassy_executor::task]
-async fn run1() {
+async fn run() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
         Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
-#[embassy_executor::task]
-async fn run2() {
-    loop {
-        esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -48,9 +39,10 @@ fn main() -> ! {
         esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run1()).ok();
-        spawner.spawn(run2()).ok();
-    });
+    spawner.spawn(run()).ok();
+
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32c2-hal/examples/embassy_i2c.rs
+++ b/esp32c2-hal/examples/embassy_i2c.rs
@@ -14,36 +14,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c2_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
     interrupt,
-    peripherals::{Interrupt, Peripherals, I2C0},
+    peripherals::{Interrupt, Peripherals},
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn run(i2c: I2C<'static, I2C0>) {
-    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
-    lis3dh.set_range(Range::G8).await.unwrap();
-
-    loop {
-        let norm = lis3dh.accel_norm().await.unwrap();
-        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
-
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -72,8 +58,13 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run(i2c0)).ok();
-    });
+    let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -7,7 +7,7 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32c2_hal::{
     clock::ClockControl,
     embassy,
@@ -19,7 +19,6 @@ use esp32c2_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use heapless::Vec;
-use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -61,8 +60,8 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
     }
 }
 
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -89,9 +88,6 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(reader(rx)).ok();
-        spawner.spawn(writer(tx)).ok();
-    });
+    spawner.spawn(reader(rx)).ok();
+    spawner.spawn(writer(tx)).ok();
 }

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -18,7 +18,7 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c2_hal::{
     clock::ClockControl,
@@ -27,31 +27,13 @@ use esp32c2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
+    spi::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-pub type SpiType<'d> =
-    SpiDma<'d, esp32c2_hal::peripherals::SPI2, esp32c2_hal::gdma::Channel0, FullDuplexMode>;
-
-#[embassy_executor::task]
-async fn spi_task(spi: &'static mut SpiType<'static>) {
-    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
-    loop {
-        let mut buffer = [0; 8];
-        esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
-            .await
-            .unwrap();
-        esp_println::println!("Bytes recieved: {:?}", buffer);
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -84,10 +66,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
-    let spi = make_static!(Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -99,13 +81,19 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        descriptors,
-        rx_descriptors,
+        &mut descriptors,
+        &mut rx_descriptors,
         DmaPriority::Priority0,
-    )));
+    ));
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(spi_task(spi)).ok();
-    });
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(&mut spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32c2-hal/examples/embassy_wait.rs
+++ b/esp32c2-hal/examples/embassy_wait.rs
@@ -6,32 +6,14 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
-use esp32c2_hal::{
-    clock::ClockControl,
-    embassy,
-    gpio::{Gpio9, Input, PullDown},
-    peripherals::Peripherals,
-    prelude::*,
-    IO,
-};
+use esp32c2_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, IO};
 use esp_backtrace as _;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn ping(mut pin: Gpio9<Input<PullDown>>) {
-    loop {
-        esp_println::println!("Waiting...");
-        pin.wait_for_rising_edge().await.unwrap();
-        esp_println::println!("Ping!");
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -51,7 +33,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input
-    let input = io.pins.gpio9.into_pull_down_input();
+    let mut input = io.pins.gpio9.into_pull_down_input();
 
     // Async requires the GPIO interrupt to wake futures
     esp32c2_hal::interrupt::enable(
@@ -60,8 +42,10 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(ping(input)).ok();
-    });
+    loop {
+        esp_println::println!("Waiting...");
+        input.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -7,30 +7,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c3_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 use static_cell::make_static;
 
 #[embassy_executor::task]
-async fn run1() {
+async fn run() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
         Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
-#[embassy_executor::task]
-async fn run2() {
-    loop {
-        esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -48,9 +40,10 @@ fn main() -> ! {
         esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run1()).ok();
-        spawner.spawn(run2()).ok();
-    });
+    spawner.spawn(run()).ok();
+
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32c3-hal/examples/embassy_i2c.rs
+++ b/esp32c3-hal/examples/embassy_i2c.rs
@@ -14,36 +14,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c3_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
     interrupt,
-    peripherals::{Interrupt, Peripherals, I2C0},
+    peripherals::{Interrupt, Peripherals},
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn run(i2c: I2C<'static, I2C0>) {
-    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
-    lis3dh.set_range(Range::G8).await.unwrap();
-
-    loop {
-        let norm = lis3dh.accel_norm().await.unwrap();
-        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
-
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -72,8 +58,13 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run(i2c0)).ok();
-    });
+    let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32c3-hal/examples/embassy_i2s_read.rs
+++ b/esp32c3-hal/examples/embassy_i2s_read.rs
@@ -15,63 +15,27 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sRx, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDin, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_rx: I2sRx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDin<
-            'static,
-            GpioPin<esp32c3_hal::gpio::Unknown, 1>,
-            GpioPin<esp32c3_hal::gpio::Unknown, 2>,
-            GpioPin<esp32c3_hal::gpio::Unknown, 3>,
-        >,
-        esp32c3_hal::gdma::Channel0,
-    >,
-) {
-    let buffer = dma_buffer();
-    println!("Start");
-
-    let mut data = [0u8; 5000];
-    let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
-    loop {
-        let avail = transaction.available().await;
-        println!("available {}", avail);
-
-        let count = transaction.pop(&mut data).await.unwrap();
-        println!(
-            "got {} bytes, {:x?}..{:x?}",
-            count,
-            &data[..10],
-            &data[count - 10..count]
-        );
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -91,8 +55,8 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -102,8 +66,8 @@ fn main() -> ! {
         44100u32.Hz(),
         dma_channel.configure(
             false,
-            tx_descriptors,
-            rx_descriptors,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
         &clocks,
@@ -122,10 +86,23 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_rx)).ok();
-    });
+    let buffer = dma_buffer();
+    println!("Start");
+
+    let mut data = [0u8; 5000];
+    let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
+    loop {
+        let avail = transaction.available().await;
+        println!("available {}", avail);
+
+        let count = transaction.pop(&mut data).await.unwrap();
+        println!(
+            "got {} bytes, {:x?}..{:x?}",
+            count,
+            &data[..10],
+            &data[count - 10..count]
+        );
+    }
 }
 
 fn dma_buffer() -> &'static mut [u8; 4092 * 4] {

--- a/esp32c3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c3-hal/examples/embassy_i2s_sound.rs
@@ -31,22 +31,19 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sTx, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDout, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,
@@ -56,20 +53,63 @@ const SINE: [i16; 64] = [
     -28897, -27244, -25329, -23169, -20787, -18204, -15446, -12539, -9511, -6392, -3211,
 ];
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_tx: I2sTx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDout<
-            'static,
-            GpioPin<esp32c3_hal::gpio::Unknown, 1>,
-            GpioPin<esp32c3_hal::gpio::Unknown, 2>,
-            GpioPin<esp32c3_hal::gpio::Unknown, 3>,
-        >,
-        esp32c3_hal::gdma::Channel0,
-    >,
-) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let dma = Gdma::new(peripherals.DMA);
+    let dma_channel = dma.channel0;
+
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let i2s = I2s::new(
+        peripherals.I2S0,
+        MclkPin::new(io.pins.gpio4),
+        Standard::Philips,
+        DataFormat::Data16Channel16,
+        44100u32.Hz(),
+        dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ),
+        &clocks,
+    );
+
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio3,
+    ));
+
+    // you need to manually enable the DMA channel's interrupt!
+    esp32c3_hal::interrupt::enable(
+        esp32c3_hal::peripherals::Interrupt::DMA_CH0,
+        esp32c3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
@@ -100,69 +140,6 @@ async fn i2s_task(
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let dma = Gdma::new(peripherals.DMA);
-    let dma_channel = dma.channel0;
-
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
-
-    let i2s = I2s::new(
-        peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
-        Standard::Philips,
-        DataFormat::Data16Channel16,
-        44100u32.Hz(),
-        dma_channel.configure(
-            false,
-            tx_descriptors,
-            rx_descriptors,
-            DmaPriority::Priority0,
-        ),
-        &clocks,
-    );
-
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
-
-    // you need to manually enable the DMA channel's interrupt!
-    esp32c3_hal::interrupt::enable(
-        esp32c3_hal::peripherals::Interrupt::DMA_CH0,
-        esp32c3_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_tx)).ok();
-    });
 }
 
 fn dma_buffer() -> &'static mut [u8; 32000] {

--- a/esp32c3-hal/examples/embassy_rmt_rx.rs
+++ b/esp32c3-hal/examples/embassy_rmt_rx.rs
@@ -7,24 +7,65 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32c3_hal::{
     clock::ClockControl,
     embassy::{self},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use static_cell::make_static;
 
 const WIDTH: usize = 80;
 
-#[embassy_executor::task]
-async fn rmt_task(mut channel: Channel2<2>) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio9,
+            RxChannelConfig {
+                clk_divider: 255,
+                idle_threshold: 10000,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32c3_hal::interrupt::enable(
+        esp32c3_hal::peripherals::Interrupt::RMT,
+        esp32c3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 1,
@@ -73,55 +114,4 @@ async fn rmt_task(mut channel: Channel2<2>) {
 
         println!();
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
-
-    let channel = rmt
-        .channel2
-        .configure(
-            io.pins.gpio9,
-            RxChannelConfig {
-                clk_divider: 255,
-                idle_threshold: 10000,
-                ..RxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32c3_hal::interrupt::enable(
-        esp32c3_hal::peripherals::Interrupt::RMT,
-        esp32c3_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-    });
 }

--- a/esp32c3-hal/examples/embassy_rmt_tx.rs
+++ b/esp32c3-hal/examples/embassy_rmt_tx.rs
@@ -5,23 +5,63 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c3_hal::{
     clock::ClockControl,
     embassy,
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    rmt::{asynch::TxChannelAsync, PulseCode, TxChannelConfig, TxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn rmt_task(mut channel: Channel0<0>) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio1.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32c3_hal::interrupt::enable(
+        esp32c3_hal::peripherals::Interrupt::RMT,
+        esp32c3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 200,
@@ -43,54 +83,4 @@ async fn rmt_task(mut channel: Channel0<0>) {
         println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
-
-    let channel = rmt
-        .channel0
-        .configure(
-            io.pins.gpio1.into_push_pull_output(),
-            TxChannelConfig {
-                clk_divider: 255,
-                ..TxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32c3_hal::interrupt::enable(
-        esp32c3_hal::peripherals::Interrupt::RMT,
-        esp32c3_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-    });
 }

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -18,7 +18,7 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c3_hal::{
     clock::ClockControl,
@@ -27,31 +27,13 @@ use esp32c3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
+    spi::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-pub type SpiType<'d> =
-    SpiDma<'d, esp32c3_hal::peripherals::SPI2, esp32c3_hal::gdma::Channel0, FullDuplexMode>;
-
-#[embassy_executor::task]
-async fn spi_task(spi: &'static mut SpiType<'static>) {
-    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
-    loop {
-        let mut buffer = [0; 8];
-        esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
-            .await
-            .unwrap();
-        esp_println::println!("Bytes recieved: {:?}", buffer);
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -84,10 +66,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
-    let spi = make_static!(Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -99,13 +81,19 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        descriptors,
-        rx_descriptors,
+        &mut descriptors,
+        &mut rx_descriptors,
         DmaPriority::Priority0,
-    )));
+    ));
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(spi_task(spi)).ok();
-    });
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(&mut spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32c6-hal/examples/embassy_hello_world.rs
+++ b/esp32c6-hal/examples/embassy_hello_world.rs
@@ -7,30 +7,21 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
-use static_cell::make_static;
 
 #[embassy_executor::task]
-async fn run1() {
+async fn run() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
         Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
-#[embassy_executor::task]
-async fn run2() {
-    loop {
-        esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -48,9 +39,10 @@ fn main() -> ! {
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run1()).ok();
-        spawner.spawn(run2()).ok();
-    });
+    spawner.spawn(run()).ok();
+
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32c6-hal/examples/embassy_i2c.rs
+++ b/esp32c6-hal/examples/embassy_i2c.rs
@@ -14,36 +14,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
     interrupt,
-    peripherals::{Interrupt, Peripherals, I2C0},
+    peripherals::{Interrupt, Peripherals},
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn run(i2c: I2C<'static, I2C0>) {
-    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
-    lis3dh.set_range(Range::G8).await.unwrap();
-
-    loop {
-        let norm = lis3dh.accel_norm().await.unwrap();
-        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
-
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -72,8 +58,13 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run(i2c0)).ok();
-    });
+    let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32c6-hal/examples/embassy_i2s_read.rs
+++ b/esp32c6-hal/examples/embassy_i2s_read.rs
@@ -15,63 +15,27 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sRx, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDin, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_rx: I2sRx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDin<
-            'static,
-            GpioPin<esp32c6_hal::gpio::Unknown, 1>,
-            GpioPin<esp32c6_hal::gpio::Unknown, 2>,
-            GpioPin<esp32c6_hal::gpio::Unknown, 3>,
-        >,
-        esp32c6_hal::gdma::Channel0,
-    >,
-) {
-    let buffer = dma_buffer();
-    println!("Start");
-
-    let mut data = [0u8; 5000];
-    let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
-    loop {
-        let avail = transaction.available().await;
-        println!("available {}", avail);
-
-        let count = transaction.pop(&mut data).await.unwrap();
-        println!(
-            "got {} bytes, {:x?}..{:x?}",
-            count,
-            &data[..10],
-            &data[count - 10..count]
-        );
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -91,8 +55,8 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -102,8 +66,8 @@ fn main() -> ! {
         44100u32.Hz(),
         dma_channel.configure(
             false,
-            tx_descriptors,
-            rx_descriptors,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
         &clocks,
@@ -122,10 +86,23 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_rx)).ok();
-    });
+    let buffer = dma_buffer();
+    println!("Start");
+
+    let mut data = [0u8; 5000];
+    let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
+    loop {
+        let avail = transaction.available().await;
+        println!("available {}", avail);
+
+        let count = transaction.pop(&mut data).await.unwrap();
+        println!(
+            "got {} bytes, {:x?}..{:x?}",
+            count,
+            &data[..10],
+            &data[count - 10..count]
+        );
+    }
 }
 
 fn dma_buffer() -> &'static mut [u8; 4092 * 4] {

--- a/esp32c6-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c6-hal/examples/embassy_i2s_sound.rs
@@ -31,22 +31,19 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sTx, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDout, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,
@@ -56,20 +53,63 @@ const SINE: [i16; 64] = [
     -28897, -27244, -25329, -23169, -20787, -18204, -15446, -12539, -9511, -6392, -3211,
 ];
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_tx: I2sTx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDout<
-            'static,
-            GpioPin<esp32c6_hal::gpio::Unknown, 1>,
-            GpioPin<esp32c6_hal::gpio::Unknown, 2>,
-            GpioPin<esp32c6_hal::gpio::Unknown, 3>,
-        >,
-        esp32c6_hal::gdma::Channel0,
-    >,
-) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let dma = Gdma::new(peripherals.DMA);
+    let dma_channel = dma.channel0;
+
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let i2s = I2s::new(
+        peripherals.I2S0,
+        MclkPin::new(io.pins.gpio4),
+        Standard::Philips,
+        DataFormat::Data16Channel16,
+        44100u32.Hz(),
+        dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ),
+        &clocks,
+    );
+
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio3,
+    ));
+
+    // you need to manually enable the DMA channel's interrupt!
+    esp32c6_hal::interrupt::enable(
+        esp32c6_hal::peripherals::Interrupt::DMA_OUT_CH0,
+        esp32c6_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
@@ -100,69 +140,6 @@ async fn i2s_task(
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let dma = Gdma::new(peripherals.DMA);
-    let dma_channel = dma.channel0;
-
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
-
-    let i2s = I2s::new(
-        peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
-        Standard::Philips,
-        DataFormat::Data16Channel16,
-        44100u32.Hz(),
-        dma_channel.configure(
-            false,
-            tx_descriptors,
-            rx_descriptors,
-            DmaPriority::Priority0,
-        ),
-        &clocks,
-    );
-
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
-
-    // you need to manually enable the DMA channel's interrupt!
-    esp32c6_hal::interrupt::enable(
-        esp32c6_hal::peripherals::Interrupt::DMA_OUT_CH0,
-        esp32c6_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_tx)).ok();
-    });
 }
 
 fn dma_buffer() -> &'static mut [u8; 32000] {

--- a/esp32c6-hal/examples/embassy_parl_io_rx.rs
+++ b/esp32c6-hal/examples/embassy_parl_io_rx.rs
@@ -7,53 +7,28 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy,
-    gdma::{self, Gdma},
-    gpio::{GpioPin, Unknown, IO},
+    gdma::Gdma,
+    gpio::IO,
     interrupt,
-    parl_io::{BitPackOrder, NoClkPin, ParlIoRx, ParlIoRxOnly, RxFourBits},
+    parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals,
     peripherals::Peripherals,
     prelude::*,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn parl_io_task(
-    mut parl_io_rx: ParlIoRx<
-        'static,
-        gdma::Channel0,
-        RxFourBits<
-            'static,
-            GpioPin<Unknown, 1>,
-            GpioPin<Unknown, 2>,
-            GpioPin<Unknown, 3>,
-            GpioPin<Unknown, 4>,
-        >,
-        NoClkPin,
-    >,
-) {
-    let buffer = dma_buffer();
-    loop {
-        parl_io_rx.read_dma_async(buffer).await.unwrap();
-        println!("Received: {:02x?} ...", &buffer[..30]);
-
-        Timer::after(Duration::from_millis(500)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -70,8 +45,8 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let tx_descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut tx_descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -82,8 +57,8 @@ fn main() -> ! {
         peripherals.PARL_IO,
         dma_channel.configure(
             false,
-            tx_descriptors,
-            rx_descriptors,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
@@ -91,7 +66,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let parl_io_rx = parl_io
+    let mut parl_io_rx = parl_io
         .rx
         .with_config(rx_pins, NoClkPin, BitPackOrder::Msb, Some(0xfff))
         .unwrap();
@@ -103,10 +78,13 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(parl_io_task(parl_io_rx)).ok();
-    });
+    let buffer = dma_buffer();
+    loop {
+        parl_io_rx.read_dma_async(buffer).await.unwrap();
+        println!("Received: {:02x?} ...", &buffer[..30]);
+
+        Timer::after(Duration::from_millis(500)).await;
+    }
 }
 
 fn dma_buffer() -> &'static mut [u8; 4092 * 4] {

--- a/esp32c6-hal/examples/embassy_rmt_rx.rs
+++ b/esp32c6-hal/examples/embassy_rmt_rx.rs
@@ -7,24 +7,65 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32c6_hal::{
     clock::ClockControl,
     embassy::{self},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use static_cell::make_static;
 
 const WIDTH: usize = 80;
 
-#[embassy_executor::task]
-async fn rmt_task(mut channel: Channel2<2>) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio9,
+            RxChannelConfig {
+                clk_divider: 255,
+                idle_threshold: 10000,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32c6_hal::interrupt::enable(
+        esp32c6_hal::peripherals::Interrupt::RMT,
+        esp32c6_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 1,
@@ -73,55 +114,4 @@ async fn rmt_task(mut channel: Channel2<2>) {
 
         println!();
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
-
-    let channel = rmt
-        .channel2
-        .configure(
-            io.pins.gpio9,
-            RxChannelConfig {
-                clk_divider: 255,
-                idle_threshold: 10000,
-                ..RxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32c6_hal::interrupt::enable(
-        esp32c6_hal::peripherals::Interrupt::RMT,
-        esp32c6_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-    });
 }

--- a/esp32c6-hal/examples/embassy_rmt_tx.rs
+++ b/esp32c6-hal/examples/embassy_rmt_tx.rs
@@ -5,23 +5,63 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
     embassy,
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    rmt::{asynch::TxChannelAsync, PulseCode, TxChannelConfig, TxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn rmt_task(mut channel: Channel0<0>) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio1.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32c6_hal::interrupt::enable(
+        esp32c6_hal::peripherals::Interrupt::RMT,
+        esp32c6_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 200,
@@ -43,54 +83,4 @@ async fn rmt_task(mut channel: Channel0<0>) {
         println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
-
-    let channel = rmt
-        .channel0
-        .configure(
-            io.pins.gpio1.into_push_pull_output(),
-            TxChannelConfig {
-                clk_divider: 255,
-                ..TxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32c6_hal::interrupt::enable(
-        esp32c6_hal::peripherals::Interrupt::RMT,
-        esp32c6_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-    });
 }

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -7,7 +7,7 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32c6_hal::{
     clock::ClockControl,
     embassy,
@@ -19,7 +19,6 @@ use esp32c6_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use heapless::Vec;
-use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -61,8 +60,8 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
     }
 }
 
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -89,9 +88,6 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(reader(rx)).ok();
-        spawner.spawn(writer(tx)).ok();
-    });
+    spawner.spawn(reader(rx)).ok();
+    spawner.spawn(writer(tx)).ok();
 }

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -18,7 +18,7 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
@@ -27,31 +27,13 @@ use esp32c6_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
+    spi::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-pub type SpiType<'d> =
-    SpiDma<'d, esp32c6_hal::peripherals::SPI2, esp32c6_hal::gdma::Channel0, FullDuplexMode>;
-
-#[embassy_executor::task]
-async fn spi_task(spi: &'static mut SpiType<'static>) {
-    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
-    loop {
-        let mut buffer = [0; 8];
-        esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
-            .await
-            .unwrap();
-        esp_println::println!("Bytes recieved: {:?}", buffer);
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -89,10 +71,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
-    let spi = make_static!(Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -104,13 +86,19 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        descriptors,
-        rx_descriptors,
+        &mut descriptors,
+        &mut rx_descriptors,
         DmaPriority::Priority0,
-    )));
+    ));
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(spi_task(spi)).ok();
-    });
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(&mut spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32c6-hal/examples/embassy_wait.rs
+++ b/esp32c6-hal/examples/embassy_wait.rs
@@ -6,32 +6,14 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
-use esp32c6_hal::{
-    clock::ClockControl,
-    embassy,
-    gpio::{Gpio9, Input, PullDown},
-    peripherals::Peripherals,
-    prelude::*,
-    IO,
-};
+use esp32c6_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, IO};
 use esp_backtrace as _;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn ping(mut pin: Gpio9<Input<PullDown>>) {
-    loop {
-        esp_println::println!("Waiting...");
-        pin.wait_for_rising_edge().await.unwrap();
-        esp_println::println!("Ping!");
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -51,7 +33,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input
-    let input = io.pins.gpio9.into_pull_down_input();
+    let mut input = io.pins.gpio9.into_pull_down_input();
 
     // Async requires the GPIO interrupt to wake futures
     esp32c6_hal::interrupt::enable(
@@ -60,8 +42,10 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(ping(input)).ok();
-    });
+    loop {
+        esp_println::println!("Waiting...");
+        input.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32h2-hal/examples/embassy_hello_world.rs
+++ b/esp32h2-hal/examples/embassy_hello_world.rs
@@ -7,30 +7,21 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
-use static_cell::make_static;
 
 #[embassy_executor::task]
-async fn run1() {
+async fn run() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
         Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
-#[embassy_executor::task]
-async fn run2() {
-    loop {
-        esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -48,9 +39,10 @@ fn main() -> ! {
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run1()).ok();
-        spawner.spawn(run2()).ok();
-    });
+    spawner.spawn(run()).ok();
+
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32h2-hal/examples/embassy_i2c.rs
+++ b/esp32h2-hal/examples/embassy_i2c.rs
@@ -14,36 +14,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
     embassy,
     i2c::I2C,
     interrupt,
-    peripherals::{Interrupt, Peripherals, I2C0},
+    peripherals::{Interrupt, Peripherals},
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn run(i2c: I2C<'static, I2C0>) {
-    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
-    lis3dh.set_range(Range::G8).await.unwrap();
-
-    loop {
-        let norm = lis3dh.accel_norm().await.unwrap();
-        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
-
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -72,8 +58,13 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run(i2c0)).ok();
-    });
+    let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32h2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32h2-hal/examples/embassy_i2s_sound.rs
@@ -31,22 +31,19 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sTx, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDout, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,
@@ -56,20 +53,63 @@ const SINE: [i16; 64] = [
     -28897, -27244, -25329, -23169, -20787, -18204, -15446, -12539, -9511, -6392, -3211,
 ];
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_tx: I2sTx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDout<
-            'static,
-            GpioPin<esp32h2_hal::gpio::Unknown, 1>,
-            GpioPin<esp32h2_hal::gpio::Unknown, 2>,
-            GpioPin<esp32h2_hal::gpio::Unknown, 3>,
-        >,
-        esp32h2_hal::gdma::Channel0,
-    >,
-) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32h2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let dma = Gdma::new(peripherals.DMA);
+    let dma_channel = dma.channel0;
+
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let i2s = I2s::new(
+        peripherals.I2S0,
+        MclkPin::new(io.pins.gpio4),
+        Standard::Philips,
+        DataFormat::Data16Channel16,
+        44100u32.Hz(),
+        dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ),
+        &clocks,
+    );
+
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio3,
+    ));
+
+    // you need to manually enable the DMA channel's interrupt!
+    esp32h2_hal::interrupt::enable(
+        esp32h2_hal::peripherals::Interrupt::DMA_OUT_CH0,
+        esp32h2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
@@ -100,69 +140,6 @@ async fn i2s_task(
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32h2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let dma = Gdma::new(peripherals.DMA);
-    let dma_channel = dma.channel0;
-
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
-
-    let i2s = I2s::new(
-        peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
-        Standard::Philips,
-        DataFormat::Data16Channel16,
-        44100u32.Hz(),
-        dma_channel.configure(
-            false,
-            tx_descriptors,
-            rx_descriptors,
-            DmaPriority::Priority0,
-        ),
-        &clocks,
-    );
-
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
-
-    // you need to manually enable the DMA channel's interrupt!
-    esp32h2_hal::interrupt::enable(
-        esp32h2_hal::peripherals::Interrupt::DMA_OUT_CH0,
-        esp32h2_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_tx)).ok();
-    });
 }
 
 fn dma_buffer() -> &'static mut [u8; 32000] {

--- a/esp32h2-hal/examples/embassy_parl_io_rx.rs
+++ b/esp32h2-hal/examples/embassy_parl_io_rx.rs
@@ -7,53 +7,28 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy,
-    gdma::{self, Gdma},
-    gpio::{GpioPin, Unknown, IO},
+    gdma::Gdma,
+    gpio::IO,
     interrupt,
-    parl_io::{BitPackOrder, NoClkPin, ParlIoRx, ParlIoRxOnly, RxFourBits},
+    parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals,
     peripherals::Peripherals,
     prelude::*,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn parl_io_task(
-    mut parl_io_rx: ParlIoRx<
-        'static,
-        gdma::Channel0,
-        RxFourBits<
-            'static,
-            GpioPin<Unknown, 1>,
-            GpioPin<Unknown, 2>,
-            GpioPin<Unknown, 3>,
-            GpioPin<Unknown, 4>,
-        >,
-        NoClkPin,
-    >,
-) {
-    let buffer = dma_buffer();
-    loop {
-        parl_io_rx.read_dma_async(buffer).await.unwrap();
-        println!("Received: {:02x?} ...", &buffer[..30]);
-
-        Timer::after(Duration::from_millis(500)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -70,8 +45,8 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let tx_descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut tx_descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -82,8 +57,8 @@ fn main() -> ! {
         peripherals.PARL_IO,
         dma_channel.configure(
             false,
-            tx_descriptors,
-            rx_descriptors,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
@@ -91,7 +66,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let parl_io_rx = parl_io
+    let mut parl_io_rx = parl_io
         .rx
         .with_config(rx_pins, NoClkPin, BitPackOrder::Msb, Some(0xfff))
         .unwrap();
@@ -103,10 +78,13 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(parl_io_task(parl_io_rx)).ok();
-    });
+    let buffer = dma_buffer();
+    loop {
+        parl_io_rx.read_dma_async(buffer).await.unwrap();
+        println!("Received: {:02x?} ...", &buffer[..30]);
+
+        Timer::after(Duration::from_millis(500)).await;
+    }
 }
 
 fn dma_buffer() -> &'static mut [u8; 4092 * 4] {

--- a/esp32h2-hal/examples/embassy_parl_io_tx.rs
+++ b/esp32h2-hal/examples/embassy_parl_io_tx.rs
@@ -11,19 +11,18 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy,
-    gdma::{self, Gdma},
-    gpio::{GpioPin, Unknown, IO},
+    gdma::Gdma,
+    gpio::IO,
     interrupt,
     parl_io::{
         BitPackOrder,
         ClkOutPin,
-        ParlIoTx,
         ParlIoTxOnly,
         SampleEdge,
         TxFourBits,
@@ -35,45 +34,12 @@ use esp32h2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn parl_io_task(
-    mut parl_io_tx: ParlIoTx<
-        'static,
-        gdma::Channel0,
-        TxPinConfigWithValidPin<
-            'static,
-            TxFourBits<
-                'static,
-                GpioPin<Unknown, 1>,
-                GpioPin<Unknown, 2>,
-                GpioPin<Unknown, 3>,
-                GpioPin<Unknown, 4>,
-            >,
-            GpioPin<Unknown, 5>,
-        >,
-        ClkOutPin<'static, GpioPin<Unknown, 6>>,
-    >,
-) {
-    let buffer = dma_buffer();
-    for i in 0..buffer.len() {
-        buffer[i] = (i % 255) as u8;
-    }
-
-    loop {
-        parl_io_tx.write_dma_async(buffer).await.unwrap();
-        println!("Transferred {} bytes", buffer.len());
-
-        Timer::after(Duration::from_millis(500)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
-    let mut system = peripherals.SYSTEM.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     #[cfg(feature = "embassy-time-systick")]
@@ -90,8 +56,8 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let tx_descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut tx_descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -104,8 +70,8 @@ fn main() -> ! {
         peripherals.PARL_IO,
         dma_channel.configure(
             false,
-            tx_descriptors,
-            rx_descriptors,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
         1u32.MHz(),
@@ -115,7 +81,7 @@ fn main() -> ! {
 
     let clock_pin = ClkOutPin::new(io.pins.gpio6);
 
-    let parl_io_tx = parl_io
+    let mut parl_io_tx = parl_io
         .tx
         .with_config(
             pin_conf,
@@ -133,10 +99,17 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(parl_io_task(parl_io_tx)).ok();
-    });
+    let buffer = dma_buffer();
+    for i in 0..buffer.len() {
+        buffer[i] = (i % 255) as u8;
+    }
+
+    loop {
+        parl_io_tx.write_dma_async(buffer).await.unwrap();
+        println!("Transferred {} bytes", buffer.len());
+
+        Timer::after(Duration::from_millis(500)).await;
+    }
 }
 
 fn dma_buffer() -> &'static mut [u8; 4092 * 4] {

--- a/esp32h2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32h2-hal/examples/embassy_rmt_rx.rs
@@ -7,24 +7,65 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32h2_hal::{
     clock::ClockControl,
     embassy::{self},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use static_cell::make_static;
 
 const WIDTH: usize = 80;
 
-#[embassy_executor::task]
-async fn rmt_task(mut channel: Channel2<2>) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32h2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio9,
+            RxChannelConfig {
+                clk_divider: 255,
+                idle_threshold: 10000,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32h2_hal::interrupt::enable(
+        esp32h2_hal::peripherals::Interrupt::RMT,
+        esp32h2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 1,
@@ -73,55 +114,4 @@ async fn rmt_task(mut channel: Channel2<2>) {
 
         println!();
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    let mut clock_control = system.peripheral_clock_control;
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32h2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks, &mut clock_control).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &mut clock_control, &clocks).unwrap();
-
-    let channel = rmt
-        .channel2
-        .configure(
-            io.pins.gpio9,
-            RxChannelConfig {
-                clk_divider: 255,
-                idle_threshold: 10000,
-                ..RxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32h2_hal::interrupt::enable(
-        esp32h2_hal::peripherals::Interrupt::RMT,
-        esp32h2_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-    });
 }

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -7,7 +7,7 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use esp32h2_hal::{
     clock::ClockControl,
     embassy,
@@ -19,7 +19,6 @@ use esp32h2_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use heapless::Vec;
-use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -61,8 +60,8 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
     }
 }
 
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -89,9 +88,6 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(reader(rx)).ok();
-        spawner.spawn(writer(tx)).ok();
-    });
+    spawner.spawn(reader(rx)).ok();
+    spawner.spawn(writer(tx)).ok();
 }

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -18,7 +18,7 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
@@ -27,31 +27,13 @@ use esp32h2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
+    spi::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-pub type SpiType<'d> =
-    SpiDma<'d, esp32h2_hal::peripherals::SPI2, esp32h2_hal::gdma::Channel0, FullDuplexMode>;
-
-#[embassy_executor::task]
-async fn spi_task(spi: &'static mut SpiType<'static>) {
-    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
-    loop {
-        let mut buffer = [0; 8];
-        esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
-            .await
-            .unwrap();
-        esp_println::println!("Bytes recieved: {:?}", buffer);
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -89,10 +71,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
-    let spi = make_static!(Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -104,13 +86,19 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        descriptors,
-        rx_descriptors,
+        &mut descriptors,
+        &mut rx_descriptors,
         DmaPriority::Priority0,
-    )));
+    ));
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(spi_task(spi)).ok();
-    });
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(&mut spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32h2-hal/examples/embassy_wait.rs
+++ b/esp32h2-hal/examples/embassy_wait.rs
@@ -6,32 +6,14 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Executor;
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
-use esp32h2_hal::{
-    clock::ClockControl,
-    embassy,
-    gpio::{Gpio9, Input, PullDown},
-    peripherals::Peripherals,
-    prelude::*,
-    IO,
-};
+use esp32h2_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, IO};
 use esp_backtrace as _;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn ping(mut pin: Gpio9<Input<PullDown>>) {
-    loop {
-        esp_println::println!("Waiting...");
-        pin.wait_for_rising_edge().await.unwrap();
-        esp_println::println!("Ping!");
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -51,7 +33,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input
-    let input = io.pins.gpio9.into_pull_down_input();
+    let mut input = io.pins.gpio9.into_pull_down_input();
 
     // Async requires the GPIO interrupt to wake futures
     esp32h2_hal::interrupt::enable(
@@ -60,8 +42,10 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(ping(input)).ok();
-    });
+    loop {
+        esp_println::println!("Waiting...");
+        input.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -7,35 +7,27 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 use xtensa_atomic_emulation_trap as _;
 
 #[embassy_executor::task]
-async fn run1() {
+async fn run() {
     loop {
         esp_println::println!("Hello world from embassy using esp-hal-async!");
         Timer::after(Duration::from_millis(1_000)).await;
     }
 }
 
-#[embassy_executor::task]
-async fn run2() {
-    loop {
-        esp_println::println!("Bing!");
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -47,9 +39,10 @@ fn main() -> ! {
         embassy::init(&clocks, timer_group0.timer0);
     }
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run1()).ok();
-        spawner.spawn(run2()).ok();
-    });
+    spawner.spawn(run()).ok();
+
+    loop {
+        esp_println::println!("Bing!");
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32s2-hal/examples/embassy_i2c.rs
+++ b/esp32s2-hal/examples/embassy_i2c.rs
@@ -14,35 +14,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     i2c::I2C,
     interrupt,
-    peripherals::{Interrupt, Peripherals, I2C0},
+    peripherals::{Interrupt, Peripherals},
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn run(i2c: I2C<'static, I2C0>) {
-    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
-    lis3dh.set_range(Range::G8).await.unwrap();
-
-    loop {
-        let norm = lis3dh.accel_norm().await.unwrap();
-        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
-
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -65,8 +52,13 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run(i2c0)).ok();
-    });
+    let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32s2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s2-hal/examples/embassy_i2s_sound.rs
@@ -31,13 +31,12 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy::{self, executor::Executor},
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sTx, NoMclk, PinsBclkWsDout, Standard},
+    embassy::{self},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, NoMclk, PinsBclkWsDout, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -46,7 +45,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,
@@ -56,20 +54,54 @@ const SINE: [i16; 64] = [
     -28897, -27244, -25329, -23169, -20787, -18204, -15446, -12539, -9511, -6392, -3211,
 ];
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_tx: I2sTx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDout<
-            'static,
-            GpioPin<esp32s2_hal::gpio::Unknown, 1>,
-            GpioPin<esp32s2_hal::gpio::Unknown, 2>,
-            GpioPin<esp32s2_hal::gpio::Unknown, 3>,
-        >,
-        esp32s2_hal::pdma::I2s0DmaChannel,
-    >,
-) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let dma = Dma::new(system.dma);
+    let dma_channel = dma.i2s0channel;
+
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let i2s = I2s::new(
+        peripherals.I2S0,
+        NoMclk {},
+        Standard::Philips,
+        DataFormat::Data16Channel16,
+        44100u32.Hz(),
+        dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ),
+        &clocks,
+    );
+
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio3,
+    ));
+
+    // you need to manually enable the DMA channel's interrupt!
+    esp32s2_hal::interrupt::enable(
+        esp32s2_hal::peripherals::Interrupt::I2S0,
+        esp32s2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
@@ -101,60 +133,6 @@ async fn i2s_task(
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let dma = Dma::new(system.dma);
-    let dma_channel = dma.i2s0channel;
-
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
-
-    let i2s = I2s::new(
-        peripherals.I2S0,
-        NoMclk {},
-        Standard::Philips,
-        DataFormat::Data16Channel16,
-        44100u32.Hz(),
-        dma_channel.configure(
-            false,
-            tx_descriptors,
-            rx_descriptors,
-            DmaPriority::Priority0,
-        ),
-        &clocks,
-    );
-
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
-
-    // you need to manually enable the DMA channel's interrupt!
-    esp32s2_hal::interrupt::enable(
-        esp32s2_hal::peripherals::Interrupt::I2S0,
-        esp32s2_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_tx)).ok();
-    });
 }
 
 fn dma_buffer() -> &'static mut [u8; 32000] {

--- a/esp32s2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_rx.rs
@@ -5,20 +5,20 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::RxChannelAsync, Channel2, PulseCode, RxChannelConfig, RxChannelCreator},
+    rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_hal_common::gpio::{Gpio15, Output, PushPull};
 use esp_println::{print, println};
-use static_cell::make_static;
 use xtensa_atomic_emulation_trap as _;
 
 const WIDTH: usize = 80;
@@ -27,7 +27,57 @@ const WIDTH: usize = 80;
 compile_error!("Run this example in release mode");
 
 #[embassy_executor::task]
-async fn rmt_task(mut channel: Channel2<2>) {
+async fn signal_task(mut pin: Gpio15<Output<PushPull>>) {
+    loop {
+        for _ in 0..10 {
+            pin.toggle().unwrap();
+            Timer::after(Duration::from_micros(10)).await;
+        }
+        Timer::after(Duration::from_millis(1000)).await;
+    }
+}
+
+#[main]
+async fn main(spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel2
+        .configure(
+            io.pins.gpio4,
+            RxChannelConfig {
+                clk_divider: 1,
+                idle_threshold: 0b111_1111_1111_1111,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32s2_hal::interrupt::enable(
+        esp32s2_hal::peripherals::Interrupt::RMT,
+        esp32s2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    spawner
+        .spawn(signal_task(io.pins.gpio15.into_push_pull_output()))
+        .ok();
     let mut data = [PulseCode {
         level1: true,
         length1: 1,
@@ -75,62 +125,4 @@ async fn rmt_task(mut channel: Channel2<2>) {
 
         println!();
     }
-}
-
-#[embassy_executor::task]
-async fn signal_task(mut pin: Gpio15<Output<PushPull>>) {
-    loop {
-        for _ in 0..10 {
-            pin.toggle().unwrap();
-            Timer::after(Duration::from_micros(10)).await;
-        }
-        Timer::after(Duration::from_millis(1000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-timg0")]
-    {
-        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
-        embassy::init(&clocks, timer_group0.timer0);
-    }
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
-
-    let channel = rmt
-        .channel2
-        .configure(
-            io.pins.gpio4,
-            RxChannelConfig {
-                clk_divider: 1,
-                idle_threshold: 0b111_1111_1111_1111,
-                ..RxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32s2_hal::interrupt::enable(
-        esp32s2_hal::peripherals::Interrupt::RMT,
-        esp32s2_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-        spawner
-            .spawn(signal_task(io.pins.gpio15.into_push_pull_output()))
-            .ok();
-    });
 }

--- a/esp32s2-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_tx.rs
@@ -5,23 +5,58 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::TxChannelAsync, Channel0, PulseCode, TxChannelConfig, TxChannelCreator},
+    rmt::{asynch::TxChannelAsync, PulseCode, TxChannelConfig, TxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 use xtensa_atomic_emulation_trap as _;
 
-#[embassy_executor::task]
-async fn rmt_task(mut channel: Channel0<0>) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel0
+        .configure(
+            io.pins.gpio4.into_push_pull_output(),
+            TxChannelConfig {
+                clk_divider: 255,
+                ..TxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32s2_hal::interrupt::enable(
+        esp32s2_hal::peripherals::Interrupt::RMT,
+        esp32s2_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 200,
@@ -43,47 +78,4 @@ async fn rmt_task(mut channel: Channel0<0>) {
         println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-timg0")]
-    {
-        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
-        embassy::init(&clocks, timer_group0.timer0);
-    }
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
-
-    let channel = rmt
-        .channel0
-        .configure(
-            io.pins.gpio4.into_push_pull_output(),
-            TxChannelConfig {
-                clk_divider: 255,
-                ..TxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32s2_hal::interrupt::enable(
-        esp32s2_hal::peripherals::Interrupt::RMT,
-        esp32s2_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-    });
 }

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -18,38 +18,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
+    spi::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-pub type SpiType<'d> = SpiDma<'d, esp32s2_hal::peripherals::SPI2, Spi2DmaChannel, FullDuplexMode>;
-
-#[embassy_executor::task]
-async fn spi_task(spi: &'static mut SpiType<'static>) {
-    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
-    loop {
-        let mut buffer = [0; 8];
-        esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
-            .await
-            .unwrap();
-        esp_println::println!("Bytes recieved: {:?}", buffer);
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -76,10 +60,10 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
-    let spi = make_static!(Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI2,
         sclk,
         mosi,
@@ -91,13 +75,19 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        descriptors,
-        rx_descriptors,
+        &mut descriptors,
+        &mut rx_descriptors,
         DmaPriority::Priority0,
-    )));
+    ));
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(spi_task(spi)).ok();
-    });
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(&mut spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32s2-hal/examples/embassy_wait.rs
+++ b/esp32s2-hal/examples/embassy_wait.rs
@@ -6,31 +6,20 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
-    gpio::{Gpio0, Input, PullDown},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn ping(mut pin: Gpio0<Input<PullDown>>) {
-    loop {
-        esp_println::println!("Waiting...");
-        pin.wait_for_rising_edge().await.unwrap();
-        esp_println::println!("Ping!");
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -44,7 +33,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 0 as input
-    let input = io.pins.gpio0.into_pull_down_input();
+    let mut input = io.pins.gpio0.into_pull_down_input();
 
     // Async requires the GPIO interrupt to wake futures
     esp32s2_hal::interrupt::enable(
@@ -53,8 +42,10 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(ping(input)).ok();
-    });
+    loop {
+        esp_println::println!("Waiting...");
+        input.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32s3-hal/examples/embassy_i2c.rs
+++ b/esp32s3-hal/examples/embassy_i2c.rs
@@ -14,35 +14,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     i2c::I2C,
     interrupt,
-    peripherals::{Interrupt, Peripherals, I2C0},
+    peripherals::{Interrupt, Peripherals},
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn run(i2c: I2C<'static, I2C0>) {
-    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).await.unwrap();
-    lis3dh.set_range(Range::G8).await.unwrap();
-
-    loop {
-        let norm = lis3dh.accel_norm().await.unwrap();
-        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
-
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -71,8 +58,13 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::I2C_EXT0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(run(i2c0)).ok();
-    });
+    let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
+    lis3dh.set_range(Range::G8).await.unwrap();
+
+    loop {
+        let norm = lis3dh.accel_norm().await.unwrap();
+        esp_println::println!("X: {:+.5}  Y: {:+.5}  Z: {:+.5}", norm.x, norm.y, norm.z);
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }

--- a/esp32s3-hal/examples/embassy_i2s_read.rs
+++ b/esp32s3-hal/examples/embassy_i2s_read.rs
@@ -15,57 +15,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     gdma::Gdma,
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sRx, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDin, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_rx: I2sRx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDin<
-            'static,
-            GpioPin<esp32s3_hal::gpio::Unknown, 1>,
-            GpioPin<esp32s3_hal::gpio::Unknown, 2>,
-            GpioPin<esp32s3_hal::gpio::Unknown, 3>,
-        >,
-        esp32s3_hal::gdma::Channel0,
-    >,
-) {
-    let buffer = dma_buffer();
-    println!("Start");
-
-    let mut data = [0u8; 5000];
-    let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
-    loop {
-        let avail = transaction.available().await;
-        println!("available {}", avail);
-
-        let count = transaction.pop(&mut data).await.unwrap();
-        println!(
-            "got {} bytes, {:x?}..{:x?}",
-            count,
-            &data[..10],
-            &data[count - 10..count]
-        );
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "log")]
     esp_println::logger::init_logger_from_env();
     println!("Init!");
@@ -90,8 +55,8 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -101,8 +66,8 @@ fn main() -> ! {
         44100u32.Hz(),
         dma_channel.configure(
             false,
-            tx_descriptors,
-            rx_descriptors,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
         &clocks,
@@ -121,10 +86,23 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_rx)).ok();
-    });
+    let buffer = dma_buffer();
+    println!("Start");
+
+    let mut data = [0u8; 5000];
+    let mut transaction = i2s_rx.read_dma_circular_async(buffer).unwrap();
+    loop {
+        let avail = transaction.available().await;
+        println!("available {}", avail);
+
+        let count = transaction.pop(&mut data).await.unwrap();
+        println!(
+            "got {} bytes, {:x?}..{:x?}",
+            count,
+            &data[..10],
+            &data[count - 10..count]
+        );
+    }
 }
 
 fn dma_buffer() -> &'static mut [u8; 4092 * 4] {

--- a/esp32s3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s3-hal/examples/embassy_i2s_sound.rs
@@ -31,21 +31,19 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     gdma::Gdma,
-    gpio::GpioPin,
-    i2s,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, I2sTx, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDout, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::println;
-use static_cell::make_static;
 
 const SINE: [i16; 64] = [
     0, 3211, 6392, 9511, 12539, 15446, 18204, 20787, 23169, 25329, 27244, 28897, 30272, 31356,
@@ -55,20 +53,63 @@ const SINE: [i16; 64] = [
     -28897, -27244, -25329, -23169, -20787, -18204, -15446, -12539, -9511, -6392, -3211,
 ];
 
-#[embassy_executor::task]
-async fn i2s_task(
-    i2s_tx: I2sTx<
-        'static,
-        i2s::I2sPeripheral0,
-        PinsBclkWsDout<
-            'static,
-            GpioPin<esp32s3_hal::gpio::Unknown, 1>,
-            GpioPin<esp32s3_hal::gpio::Unknown, 2>,
-            GpioPin<esp32s3_hal::gpio::Unknown, 3>,
-        >,
-        esp32s3_hal::gdma::Channel0,
-    >,
-) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let dma = Gdma::new(peripherals.DMA);
+    let dma_channel = dma.channel0;
+
+    let mut tx_descriptors = [0u32; 20 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let i2s = I2s::new(
+        peripherals.I2S0,
+        MclkPin::new(io.pins.gpio4),
+        Standard::Philips,
+        DataFormat::Data16Channel16,
+        44100u32.Hz(),
+        dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ),
+        &clocks,
+    );
+
+    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
+        io.pins.gpio1,
+        io.pins.gpio2,
+        io.pins.gpio3,
+    ));
+
+    // you need to manually enable the DMA channel's interrupt!
+    esp32s3_hal::interrupt::enable(
+        esp32s3_hal::peripherals::Interrupt::DMA_OUT_CH0,
+        esp32s3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
@@ -99,69 +140,6 @@ async fn i2s_task(
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
-    );
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let dma = Gdma::new(peripherals.DMA);
-    let dma_channel = dma.channel0;
-
-    let tx_descriptors = make_static!([0u32; 20 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
-
-    let i2s = I2s::new(
-        peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
-        Standard::Philips,
-        DataFormat::Data16Channel16,
-        44100u32.Hz(),
-        dma_channel.configure(
-            false,
-            tx_descriptors,
-            rx_descriptors,
-            DmaPriority::Priority0,
-        ),
-        &clocks,
-    );
-
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
-
-    // you need to manually enable the DMA channel's interrupt!
-    esp32s3_hal::interrupt::enable(
-        esp32s3_hal::peripherals::Interrupt::DMA_OUT_CH0,
-        esp32s3_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(i2s_task(i2s_tx)).ok();
-    });
 }
 
 fn dma_buffer() -> &'static mut [u8; 32000] {

--- a/esp32s3-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s3-hal/examples/embassy_rmt_rx.rs
@@ -7,23 +7,65 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::RxChannelAsync, Channel4, PulseCode, RxChannelConfig, RxChannelCreator},
+    rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
     Rmt,
     IO,
 };
 use esp_backtrace as _;
 use esp_println::{print, println};
-use static_cell::make_static;
 
 const WIDTH: usize = 80;
 
-#[embassy_executor::task]
-async fn rmt_task(mut channel: Channel4<4>) {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
+    println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+
+    let mut channel = rmt
+        .channel4
+        .configure(
+            io.pins.gpio0,
+            RxChannelConfig {
+                clk_divider: 255,
+                idle_threshold: 10000,
+                ..RxChannelConfig::default()
+            },
+        )
+        .unwrap();
+
+    // you have to enable the interrupt for async to work
+    esp32s3_hal::interrupt::enable(
+        esp32s3_hal::peripherals::Interrupt::RMT,
+        esp32s3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
     let mut data = [PulseCode {
         level1: true,
         length1: 1,
@@ -72,54 +114,4 @@ async fn rmt_task(mut channel: Channel4<4>) {
 
         println!();
     }
-}
-
-#[entry]
-fn main() -> ! {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
-    println!("Init!");
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    #[cfg(feature = "embassy-time-systick")]
-    embassy::init(
-        &clocks,
-        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
-
-    #[cfg(feature = "embassy-time-timg0")]
-    {
-        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
-        embassy::init(&clocks, timer_group0.timer0);
-    }
-
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
-
-    let channel = rmt
-        .channel4
-        .configure(
-            io.pins.gpio0,
-            RxChannelConfig {
-                clk_divider: 255,
-                idle_threshold: 10000,
-                ..RxChannelConfig::default()
-            },
-        )
-        .unwrap();
-
-    // you have to enable the interrupt for async to work
-    esp32s3_hal::interrupt::enable(
-        esp32s3_hal::peripherals::Interrupt::RMT,
-        esp32s3_hal::interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(rmt_task(channel)).ok();
-    });
 }

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -7,9 +7,10 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
@@ -18,7 +19,6 @@ use esp32s3_hal::{
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use heapless::Vec;
-use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -60,8 +60,8 @@ async fn reader(mut rx: UartRx<'static, UART0>) {
     }
 }
 
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(spawner: Spawner) {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -88,9 +88,6 @@ fn main() -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(reader(rx)).ok();
-        spawner.spawn(writer(tx)).ok();
-    });
+    spawner.spawn(reader(rx)).ok();
+    spawner.spawn(writer(tx)).ok();
 }

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -18,40 +18,22 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    embassy::{self, executor::Executor},
+    embassy::{self},
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{dma::SpiDma, FullDuplexMode, Spi, SpiMode},
+    spi::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-// This example uses SPI3 to test that WithDmaSpi3 is included in the prelude.
-pub type SpiType<'d> =
-    SpiDma<'d, esp32s3_hal::peripherals::SPI3, esp32s3_hal::gdma::Channel0, FullDuplexMode>;
-
-#[embassy_executor::task]
-async fn spi_task(spi: &'static mut SpiType<'static>) {
-    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
-    loop {
-        let mut buffer = [0; 8];
-        esp_println::println!("Sending bytes");
-        embedded_hal_async::spi::SpiBus::transfer(spi, &mut buffer, &send_buffer)
-            .await
-            .unwrap();
-        esp_println::println!("Bytes recieved: {:?}", buffer);
-        Timer::after(Duration::from_millis(5_000)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -89,10 +71,10 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let descriptors = make_static!([0u32; 8 * 3]);
-    let rx_descriptors = make_static!([0u32; 8 * 3]);
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
 
-    let spi = make_static!(Spi::new(
+    let mut spi = Spi::new(
         peripherals.SPI3,
         sclk,
         mosi,
@@ -104,13 +86,19 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        descriptors,
-        rx_descriptors,
+        &mut descriptors,
+        &mut rx_descriptors,
         DmaPriority::Priority0,
-    )));
+    ));
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(spi_task(spi)).ok();
-    });
+    let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
+    loop {
+        let mut buffer = [0; 8];
+        esp_println::println!("Sending bytes");
+        embedded_hal_async::spi::SpiBus::transfer(&mut spi, &mut buffer, &send_buffer)
+            .await
+            .unwrap();
+        esp_println::println!("Bytes recieved: {:?}", buffer);
+        Timer::after(Duration::from_millis(5_000)).await;
+    }
 }

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -6,31 +6,20 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::digital::Wait;
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy::{self, executor::Executor},
-    gpio::{Gpio0, Input, PullDown},
+    embassy::{self},
     peripherals::Peripherals,
     prelude::*,
     IO,
 };
 use esp_backtrace as _;
-use static_cell::make_static;
 
-#[embassy_executor::task]
-async fn ping(mut pin: Gpio0<Input<PullDown>>) {
-    loop {
-        esp_println::println!("Waiting...");
-        pin.wait_for_rising_edge().await.unwrap();
-        esp_println::println!("Ping!");
-        Timer::after(Duration::from_millis(100)).await;
-    }
-}
-
-#[entry]
-fn main() -> ! {
+#[main]
+async fn main(_spawner: Spawner) -> ! {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -50,7 +39,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 0 as input
-    let input = io.pins.gpio0.into_pull_down_input();
+    let mut input = io.pins.gpio0.into_pull_down_input();
 
     // Async requires the GPIO interrupt to wake futures
     esp32s3_hal::interrupt::enable(
@@ -59,8 +48,10 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let executor = make_static!(Executor::new());
-    executor.run(|spawner| {
-        spawner.spawn(ping(input)).ok();
-    });
+    loop {
+        esp_println::println!("Waiting...");
+        input.wait_for_rising_edge().await.unwrap();
+        esp_println::println!("Ping!");
+        Timer::after(Duration::from_millis(100)).await;
+    }
 }


### PR DESCRIPTION
This makes the `#[main]` macro easily useable.

For RISC-V it just delegates to the existing macro and passes the entry.

For Xtensa it's basically an adaption of the code found in embassy-macro. Since we bring our own executor there it probably won't make sense to have it in embassy

For now, I haven't changed the examples - wanted to wait for a first review round

Here is the _embassy_hello_world.rs_ adapted for S3:
```rust
//! embassy hello world
//!
//! This is an example of running the embassy executor with multiple tasks
//! concurrently.

#![no_std]
#![no_main]
#![feature(type_alias_impl_trait)]

use embassy_executor::Spawner;
use embassy_time::{Duration, Timer};
use esp32s3_hal::{
    clock::ClockControl,
    embassy::{self},
    peripherals::Peripherals,
    prelude::*,
};
use esp_backtrace as _;

#[embassy_executor::task]
async fn run1() {
    loop {
        esp_println::println!("Hello world from embassy using esp-hal-async!");
        Timer::after(Duration::from_millis(1_000)).await;
    }
}

#[embassy_executor::task]
async fn run2() {
    loop {
        esp_println::println!("Bing!");
        Timer::after(Duration::from_millis(5_000)).await;
    }
}

#[main]
async fn main(spawner: Spawner) {
    esp_println::println!("Init!");
    let peripherals = Peripherals::take();
    let system = peripherals.SYSTEM.split();
    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    #[cfg(feature = "embassy-time-systick")]
    embassy::init(
        &clocks,
        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
    );

    #[cfg(feature = "embassy-time-timg0")]
    {
        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
        embassy::init(&clocks, timer_group0.timer0);
    }

    spawner.spawn(run1()).ok();
    spawner.spawn(run2()).ok();

    loop {
        esp_println::println!("Tada!");
        Timer::after(Duration::from_millis(1_500)).await;
    }
}
```

It's really just a convenience - the current way of creating and using an executor can still be used unchanged.
