### PR TITLE
Refactor the `spi` and `spi_slave` modules into a common `spi` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding async support for RSA peripheral(doesn't work properly for `esp32` chip - issue will be created)(#790)
 - Added sleep support for ESP32-C3 with timer and GPIO wakeups (#795)
 - Support for ULP-RISCV including Delay and GPIO (#840)
-- Add bare-bones SPI slave support, DMA only (#580)
+- Add bare-bones SPI slave support, DMA only (#580, #843)
 - Embassy `#[main]` convenience macro
 
 ### Changed
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unify the system peripheral, `SYSTEM`, `DPORT` and `PCR` are now all exposed as `SYSTEM` (#832).
 - Unified the ESP32's and ESP32-C2's xtal frequency features (#831)
 - Replace any underscores in feature names with dashes (#833)
+- The `spi` and `spi_slave` modules have been refactored into the `spi`, `spi::master`, and `spi::slave` modules (#843)
 
 ## [0.12.0]
 

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -398,7 +398,7 @@ mod critical_section_impl {
 /// needs to transmit data from flash (ROM) via the embedded-hal traits. This is
 /// often a `const` variable.
 ///
-/// Example usage using [`spi::dma::SpiDma`]
+/// Example usage using [`spi::master::dma::SpiDma`]
 /// ```no_run
 /// const ARRAY_IN_FLASH = [0xAA; 128]
 ///

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -72,8 +72,6 @@ pub use self::soc::peripherals;
 pub use self::soc::psram;
 #[cfg(ulp_riscv_core)]
 pub use self::soc::ulp_core;
-#[cfg(any(spi0, spi1, spi2, spi3))]
-pub use self::spi::Spi;
 #[cfg(any(timg0, timg1))]
 pub use self::timer::Timer;
 #[cfg(any(uart0, uart1, uart2))]
@@ -138,8 +136,6 @@ pub mod rtc_cntl;
 pub mod sha;
 #[cfg(any(spi0, spi1, spi2, spi3))]
 pub mod spi;
-#[cfg(all(any(spi0, spi1, spi2, spi3), not(pdma)))]
-pub mod spi_slave;
 #[cfg(any(dport, pcr, system))]
 pub mod system;
 #[cfg(systimer)]

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -63,15 +63,15 @@ pub use crate::ledc::{
 #[cfg(radio)]
 pub use crate::radio::RadioExt as _esp_hal_RadioExt;
 #[cfg(any(esp32, esp32s2, esp32s3))]
-pub use crate::spi::dma::WithDmaSpi3 as _esp_hal_spi_dma_WithDmaSpi3;
+pub use crate::spi::master::dma::WithDmaSpi3 as _esp_hal_spi_dma_WithDmaSpi3;
 #[cfg(any(spi0, spi1, spi2, spi3))]
-pub use crate::spi::{
+pub use crate::spi::master::{
     dma::WithDmaSpi2 as _esp_hal_spi_dma_WithDmaSpi2,
     Instance as _esp_hal_spi_Instance,
     InstanceDma as _esp_hal_spi_InstanceDma,
 };
 #[cfg(all(any(spi0, spi1, spi2, spi3), not(pdma)))]
-pub use crate::spi_slave::{
+pub use crate::spi::slave::{
     dma::WithDmaSpi2 as _esp_hal_spi_slave_dma_WithDmaSpi2,
     Instance as _esp_hal_spi_slave_Instance,
     InstanceDma as _esp_hal_spi_slave_InstanceDma,

--- a/esp-hal-common/src/spi/master.rs
+++ b/esp-hal-common/src/spi/master.rs
@@ -1,6 +1,7 @@
-//! # Serial Peripheral Interface
+//! # Serial Peripheral Interface - Master Mode
 //!
 //! ## Overview
+//!
 //! There are multiple ways to use SPI, depending on your needs. Regardless of
 //! which way you choose, you must first create an SPI instance with
 //! [`Spi::new`].
@@ -708,7 +709,7 @@ pub mod dma {
     use embedded_dma::{ReadBuffer, WriteBuffer};
     use fugit::HertzU32;
 
-    #[cfg(any(esp32, esp32s2, esp32s3))]
+    #[cfg(spi3)]
     use super::Spi3Instance;
     use super::{
         Address,
@@ -723,7 +724,7 @@ pub mod dma {
         SpiDataMode,
         MAX_DMA_SIZE,
     };
-    #[cfg(any(esp32, esp32s2, esp32s3))]
+    #[cfg(spi3)]
     use crate::dma::Spi3Peripheral;
     use crate::{
         clock::Clocks,
@@ -752,7 +753,7 @@ pub mod dma {
         fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, T, C, M>;
     }
 
-    #[cfg(any(esp32, esp32s2, esp32s3))]
+    #[cfg(spi3)]
     pub trait WithDmaSpi3<'d, T, C, M>
     where
         T: Instance + Spi3Instance,
@@ -781,7 +782,7 @@ pub mod dma {
         }
     }
 
-    #[cfg(any(esp32, esp32s2, esp32s3))]
+    #[cfg(spi3)]
     impl<'d, T, C, M> WithDmaSpi3<'d, T, C, M> for Spi<'d, T, M>
     where
         T: Instance + Spi3Instance,
@@ -1944,7 +1945,7 @@ where
     fn dma_peripheral(&self) -> DmaPeripheral {
         match self.spi_num() {
             2 => DmaPeripheral::Spi2,
-            #[cfg(any(esp32, esp32s2, esp32s3))]
+            #[cfg(spi3)]
             3 => DmaPeripheral::Spi3,
             _ => panic!("Illegal SPI instance"),
         }
@@ -2055,7 +2056,7 @@ where
 {
 }
 
-#[cfg(any(esp32, esp32s2, esp32s3))]
+#[cfg(spi3)]
 impl<TX, RX> InstanceDma<TX, RX> for crate::peripherals::SPI3
 where
     TX: Tx,
@@ -3236,10 +3237,10 @@ impl ExtendedInstance for crate::peripherals::SPI3 {
 
 pub trait Spi2Instance {}
 
-#[cfg(any(esp32, esp32s2, esp32s3))]
+#[cfg(spi3)]
 pub trait Spi3Instance {}
 
 impl Spi2Instance for crate::peripherals::SPI2 {}
 
-#[cfg(any(esp32, esp32s2, esp32s3))]
+#[cfg(spi3)]
 impl Spi3Instance for crate::peripherals::SPI3 {}

--- a/esp-hal-common/src/spi/master.rs
+++ b/esp-hal-common/src/spi/master.rs
@@ -1510,8 +1510,8 @@ pub mod dma {
     mod ehal1 {
         use embedded_hal_1::spi::SpiBus;
 
-        use super::{super::InstanceDma, SpiDma, SpiPeripheral};
-        use crate::{dma::ChannelTypes, spi::IsFullDuplex, FlashSafeDma};
+        use super::{super::InstanceDma, *};
+        use crate::{dma::ChannelTypes, FlashSafeDma};
 
         impl<'d, T, C, M> embedded_hal_1::spi::ErrorType for SpiDma<'d, T, C, M>
         where
@@ -2803,8 +2803,8 @@ pub trait Instance {
 
     fn write_bytes_half_duplex(
         &mut self,
-        cmd: crate::spi::Command,
-        address: crate::spi::Address,
+        cmd: Command,
+        address: Address,
         dummy: u8,
         buffer: &[u8],
     ) -> Result<(), Error> {
@@ -2866,8 +2866,8 @@ pub trait Instance {
 
     fn read_bytes_half_duplex(
         &mut self,
-        cmd: crate::spi::Command,
-        address: crate::spi::Address,
+        cmd: Command,
+        address: Address,
         dummy: u8,
         buffer: &mut [u8],
     ) -> Result<(), Error> {

--- a/esp-hal-common/src/spi/master.rs
+++ b/esp-hal-common/src/spi/master.rs
@@ -53,9 +53,19 @@ use core::marker::PhantomData;
 
 use fugit::HertzU32;
 
+use super::{
+    DuplexMode,
+    Error,
+    FullDuplexMode,
+    HalfDuplexMode,
+    IsFullDuplex,
+    IsHalfDuplex,
+    SpiDataMode,
+    SpiMode,
+};
 use crate::{
     clock::Clocks,
-    dma::{DmaError, DmaPeripheral, Rx, Tx},
+    dma::{DmaPeripheral, Rx, Tx},
     gpio::{InputPin, InputSignal, OutputPin, OutputSignal},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::spi2::RegisterBlock,
@@ -67,68 +77,12 @@ use crate::{
 const FIFO_SIZE: usize = 64;
 #[cfg(esp32s2)]
 const FIFO_SIZE: usize = 72;
+
 /// Padding byte for empty write transfers
 const EMPTY_WRITE_PAD: u8 = 0x00u8;
 
 #[allow(unused)]
 const MAX_DMA_SIZE: usize = 32736;
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Error {
-    DmaError(DmaError),
-    MaxDmaTransferSizeExceeded,
-    FifoSizeExeeded,
-    Unsupported,
-    Unknown,
-}
-
-impl From<DmaError> for Error {
-    fn from(value: DmaError) -> Self {
-        Error::DmaError(value)
-    }
-}
-
-#[cfg(feature = "eh1")]
-impl embedded_hal_1::spi::Error for Error {
-    fn kind(&self) -> embedded_hal_1::spi::ErrorKind {
-        embedded_hal_1::spi::ErrorKind::Other
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SpiMode {
-    Mode0,
-    Mode1,
-    Mode2,
-    Mode3,
-}
-
-pub trait DuplexMode {}
-pub trait IsFullDuplex: DuplexMode {}
-pub trait IsHalfDuplex: DuplexMode {}
-
-/// SPI data mode
-///
-/// Single = 1 bit, 2 wires
-/// Dual = 2 bit, 2 wires
-/// Quad = 4 bit, 4 wires
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SpiDataMode {
-    Single,
-    Dual,
-    Quad,
-}
-
-pub struct FullDuplexMode {}
-impl DuplexMode for FullDuplexMode {}
-impl IsFullDuplex for FullDuplexMode {}
-
-pub struct HalfDuplexMode {}
-impl DuplexMode for HalfDuplexMode {}
-impl IsHalfDuplex for HalfDuplexMode {}
 
 /// SPI command, 1 to 16 bits.
 ///

--- a/esp-hal-common/src/spi/mod.rs
+++ b/esp-hal-common/src/spi/mod.rs
@@ -1,0 +1,3 @@
+pub mod master;
+#[cfg(all(any(spi0, spi1, spi2, spi3), not(pdma)))]
+pub mod slave;

--- a/esp-hal-common/src/spi/mod.rs
+++ b/esp-hal-common/src/spi/mod.rs
@@ -1,9 +1,16 @@
+//! Serial Peripheral Interface
+//!
+//! This peripheral is capable of operating in either master or slave mode. For
+//! more information on these modes, please refer to the documentation in their
+//! respective modules.
+
 use crate::dma::DmaError;
 
 pub mod master;
 #[cfg(all(any(spi0, spi1, spi2, spi3), not(pdma)))]
 pub mod slave;
 
+/// SPI errors
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
@@ -27,6 +34,7 @@ impl embedded_hal_1::spi::Error for Error {
     }
 }
 
+/// SPI modes
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SpiMode {
@@ -53,10 +61,12 @@ pub enum SpiDataMode {
     Quad,
 }
 
+/// Full-duplex operation
 pub struct FullDuplexMode {}
 impl DuplexMode for FullDuplexMode {}
 impl IsFullDuplex for FullDuplexMode {}
 
+/// Half-duplex operation
 pub struct HalfDuplexMode {}
 impl DuplexMode for HalfDuplexMode {}
 impl IsHalfDuplex for HalfDuplexMode {}

--- a/esp-hal-common/src/spi/mod.rs
+++ b/esp-hal-common/src/spi/mod.rs
@@ -1,3 +1,62 @@
+use crate::dma::DmaError;
+
 pub mod master;
 #[cfg(all(any(spi0, spi1, spi2, spi3), not(pdma)))]
 pub mod slave;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    DmaError(DmaError),
+    MaxDmaTransferSizeExceeded,
+    FifoSizeExeeded,
+    Unsupported,
+    Unknown,
+}
+
+impl From<DmaError> for Error {
+    fn from(value: DmaError) -> Self {
+        Error::DmaError(value)
+    }
+}
+
+#[cfg(feature = "eh1")]
+impl embedded_hal_1::spi::Error for Error {
+    fn kind(&self) -> embedded_hal_1::spi::ErrorKind {
+        embedded_hal_1::spi::ErrorKind::Other
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SpiMode {
+    Mode0,
+    Mode1,
+    Mode2,
+    Mode3,
+}
+
+pub trait DuplexMode {}
+pub trait IsFullDuplex: DuplexMode {}
+pub trait IsHalfDuplex: DuplexMode {}
+
+/// SPI data mode
+///
+/// Single = 1 bit, 2 wires
+/// Dual = 2 bit, 2 wires
+/// Quad = 4 bit, 4 wires
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SpiDataMode {
+    Single,
+    Dual,
+    Quad,
+}
+
+pub struct FullDuplexMode {}
+impl DuplexMode for FullDuplexMode {}
+impl IsFullDuplex for FullDuplexMode {}
+
+pub struct HalfDuplexMode {}
+impl DuplexMode for HalfDuplexMode {}
+impl IsHalfDuplex for HalfDuplexMode {}

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -13,7 +13,7 @@
 //! let mosi = io.pins.gpio13;
 //! let cs = io.pins.gpio10;
 //!
-//! let mut spi = hal::spi_slave::Spi::new(peripherals.SPI2, sclk, mosi, miso, cs, SpiMode::Mode0);
+//! let mut spi = hal::spi::slave::Spi::new(peripherals.SPI2, sclk, mosi, miso, cs, SpiMode::Mode0);
 //! ```
 //!
 //! There are several options for working with the SPI peripheral in slave mode,
@@ -66,7 +66,7 @@ use crate::{
 };
 
 const MAX_DMA_SIZE: usize = 32768 - 32;
-pub use crate::spi::{Error, FullDuplexMode, SpiMode};
+pub use crate::spi::master::{Error, FullDuplexMode, SpiMode};
 
 /// SPI peripheral driver
 pub struct Spi<'d, T, M> {

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -1,11 +1,13 @@
-//! # Serial Peripheral Interface, slave mode
+//! # Serial Peripheral Interface - Slave Mode
 //!
 //! ## Overview
+//!
 //! There are multiple ways to use SPI, depending on your needs. Regardless of
 //! which way you choose, you must first create an SPI instance with
 //! [`Spi::new`].
 //!
 //! ## Example
+//!
 //! ```rust
 //! let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 //! let sclk = io.pins.gpio12;

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -59,7 +59,7 @@
 
 use core::marker::PhantomData;
 
-pub use super::{Error, FullDuplexMode, SpiMode};
+use super::{Error, FullDuplexMode, SpiMode};
 use crate::{
     dma::{DmaPeripheral, Rx, Tx},
     gpio::{InputPin, InputSignal, OutputPin, OutputSignal},

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32_hal::{
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     timer::TimerGroup,
     IO,
 };

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32_hal::{
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     timer::TimerGroup,
     IO,
 };

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -24,7 +24,7 @@ use esp32_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -24,7 +24,11 @@ use esp32_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,10 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiBusController, SpiMode},
+    spi::{
+        master::{Spi, SpiBusController},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiBusController, SpiMode},
+    spi::master::{Spi, SpiBusController, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,11 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32c2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32c2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -24,7 +24,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -24,7 +24,11 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,10 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiBusController, SpiMode},
+    spi::{
+        master::{Spi, SpiBusController},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiBusController, SpiMode},
+    spi::master::{Spi, SpiBusController, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,11 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_loopback.rs
+++ b/esp32c2-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_loopback.rs
+++ b/esp32c2-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_slave_dma.rs
+++ b/esp32c2-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi_slave::{Spi, SpiMode},
+    spi::slave::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32c2-hal/examples/spi_slave_dma.rs
+++ b/esp32c2-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::slave::{Spi, SpiMode},
+    spi::{slave::Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32c3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32c3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -24,7 +24,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -24,7 +24,11 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,10 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiBusController, SpiMode},
+    spi::{
+        master::{Spi, SpiBusController},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiBusController, SpiMode},
+    spi::master::{Spi, SpiBusController, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,11 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_slave_dma.rs
+++ b/esp32c3-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi_slave::{Spi, SpiMode},
+    spi::slave::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32c3-hal/examples/spi_slave_dma.rs
+++ b/esp32c3-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::slave::{Spi, SpiMode},
+    spi::{slave::Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32c6_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32c6_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/qspi_flash.rs
+++ b/esp32c6-hal/examples/qspi_flash.rs
@@ -24,7 +24,11 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/qspi_flash.rs
+++ b/esp32c6-hal/examples/qspi_flash.rs
@@ -24,7 +24,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiBusController, SpiMode},
+    spi::master::{Spi, SpiBusController, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,10 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiBusController, SpiMode},
+    spi::{
+        master::{Spi, SpiBusController},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,11 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_loopback.rs
+++ b/esp32c6-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_loopback.rs
+++ b/esp32c6-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi_slave::{Spi, SpiMode},
+    spi::slave::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::slave::{Spi, SpiMode},
+    spi::{slave::Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32h2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32h2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/qspi_flash.rs
+++ b/esp32h2-hal/examples/qspi_flash.rs
@@ -24,7 +24,11 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/qspi_flash.rs
+++ b/esp32h2-hal/examples/qspi_flash.rs
@@ -24,7 +24,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiBusController, SpiMode},
+    spi::master::{Spi, SpiBusController, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,10 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiBusController, SpiMode},
+    spi::{
+        master::{Spi, SpiBusController},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,11 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_loopback.rs
+++ b/esp32h2-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_loopback.rs
+++ b/esp32h2-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::slave::{Spi, SpiMode},
+    spi::{slave::Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi_slave::{Spi, SpiMode},
+    spi::slave::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32s2_hal::{
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32s2_hal::{
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -24,7 +24,7 @@ use esp32s2_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -24,7 +24,11 @@ use esp32s2_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,7 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiBusController, SpiMode},
+    spi::master::{Spi, SpiBusController, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,10 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiBusController, SpiMode},
+    spi::{
+        master::{Spi, SpiBusController},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,7 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,11 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32s2_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32s2_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32s3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp32s3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     IO,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -24,7 +24,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -24,7 +24,11 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiBusController, SpiMode},
+    spi::master::{Spi, SpiBusController, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -24,7 +24,10 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiBusController, SpiMode},
+    spi::{
+        master::{Spi, SpiBusController},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,11 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::{
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        SpiDataMode,
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
+    spi::master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDataMode, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -21,7 +21,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::master::{Spi, SpiMode},
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{Spi, SpiMode},
+    spi::master::{Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_slave_dma.rs
+++ b/esp32s3-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi_slave::{Spi, SpiMode},
+    spi::slave::{Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32s3-hal/examples/spi_slave_dma.rs
+++ b/esp32s3-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,7 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::slave::{Spi, SpiMode},
+    spi::{slave::Spi, SpiMode},
     timer::TimerGroup,
     Delay,
     Rtc,


### PR DESCRIPTION
I've extracted any types which are used by both operational modes into the root `spi` module, while any mode-specific types and implementations are in their respective modules. Pretty self-explanatory, I think, but let me know if you have any questions/concerns.