### PR TITLE
Replace `SpiNInstance` marker traits with concrete types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified the ESP32's and ESP32-C2's xtal frequency features (#831)
 - Replace any underscores in feature names with dashes (#833)
 - The `spi` and `spi_slave` modules have been refactored into the `spi`, `spi::master`, and `spi::slave` modules (#843)
+- The `WithDmaSpi2`/`WithDmaSpi3` structs are no longer generic around the inner peripheral type (#853)
 
 ## [0.12.0]
 

--- a/esp-hal-common/src/spi/master.rs
+++ b/esp-hal-common/src/spi/master.rs
@@ -709,21 +709,7 @@ pub mod dma {
     use embedded_dma::{ReadBuffer, WriteBuffer};
     use fugit::HertzU32;
 
-    #[cfg(spi3)]
-    use super::Spi3Instance;
-    use super::{
-        Address,
-        Command,
-        DuplexMode,
-        Instance,
-        InstanceDma,
-        IsFullDuplex,
-        IsHalfDuplex,
-        Spi,
-        Spi2Instance,
-        SpiDataMode,
-        MAX_DMA_SIZE,
-    };
+    use super::*;
     #[cfg(spi3)]
     use crate::dma::Spi3Peripheral;
     use crate::{
@@ -743,35 +729,35 @@ pub mod dma {
         FlashSafeDma,
     };
 
-    pub trait WithDmaSpi2<'d, T, C, M>
+    pub trait WithDmaSpi2<'d, C, M>
     where
-        T: Instance + Spi2Instance,
         C: ChannelTypes,
         C::P: SpiPeripheral,
         M: DuplexMode,
     {
-        fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, T, C, M>;
+        fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, crate::peripherals::SPI2, C, M>;
     }
 
     #[cfg(spi3)]
-    pub trait WithDmaSpi3<'d, T, C, M>
+    pub trait WithDmaSpi3<'d, C, M>
     where
-        T: Instance + Spi3Instance,
         C: ChannelTypes,
         C::P: SpiPeripheral,
         M: DuplexMode,
     {
-        fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, T, C, M>;
+        fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, crate::peripherals::SPI3, C, M>;
     }
 
-    impl<'d, T, C, M> WithDmaSpi2<'d, T, C, M> for Spi<'d, T, M>
+    impl<'d, C, M> WithDmaSpi2<'d, C, M> for Spi<'d, crate::peripherals::SPI2, M>
     where
-        T: Instance + Spi2Instance,
         C: ChannelTypes,
         C::P: SpiPeripheral + Spi2Peripheral,
         M: DuplexMode,
     {
-        fn with_dma(self, mut channel: Channel<'d, C>) -> SpiDma<'d, T, C, M> {
+        fn with_dma(
+            self,
+            mut channel: Channel<'d, C>,
+        ) -> SpiDma<'d, crate::peripherals::SPI2, C, M> {
             channel.tx.init_channel(); // no need to call this for both, TX and RX
 
             SpiDma {
@@ -783,14 +769,16 @@ pub mod dma {
     }
 
     #[cfg(spi3)]
-    impl<'d, T, C, M> WithDmaSpi3<'d, T, C, M> for Spi<'d, T, M>
+    impl<'d, C, M> WithDmaSpi3<'d, C, M> for Spi<'d, crate::peripherals::SPI3, M>
     where
-        T: Instance + Spi3Instance,
         C: ChannelTypes,
         C::P: SpiPeripheral + Spi3Peripheral,
         M: DuplexMode,
     {
-        fn with_dma(self, mut channel: Channel<'d, C>) -> SpiDma<'d, T, C, M> {
+        fn with_dma(
+            self,
+            mut channel: Channel<'d, C>,
+        ) -> SpiDma<'d, crate::peripherals::SPI3, C, M> {
             channel.tx.init_channel(); // no need to call this for both, TX and RX
 
             SpiDma {
@@ -3234,13 +3222,3 @@ impl ExtendedInstance for crate::peripherals::SPI3 {
         InputSignal::SPI3_HD
     }
 }
-
-pub trait Spi2Instance {}
-
-#[cfg(spi3)]
-pub trait Spi3Instance {}
-
-impl Spi2Instance for crate::peripherals::SPI2 {}
-
-#[cfg(spi3)]
-impl Spi3Instance for crate::peripherals::SPI3 {}

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -148,32 +148,29 @@ pub mod dma {
         peripheral::PeripheralRef,
     };
 
-    pub trait WithDmaSpi2<'d, T, C>
+    pub trait WithDmaSpi2<'d, C>
     where
-        T: Instance + Spi2Instance,
         C: ChannelTypes,
         C::P: SpiPeripheral,
     {
-        fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, T, C>;
+        fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, crate::peripherals::SPI2, C>;
     }
 
     #[cfg(spi3)]
-    pub trait WithDmaSpi3<'d, T, C>
+    pub trait WithDmaSpi3<'d, C>
     where
-        T: Instance + Spi3Instance,
         C: ChannelTypes,
         C::P: SpiPeripheral,
     {
-        fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, T, C>;
+        fn with_dma(self, channel: Channel<'d, C>) -> SpiDma<'d, crate::peripherals::SPI3, C>;
     }
 
-    impl<'d, T, C> WithDmaSpi2<'d, T, C> for Spi<'d, T, FullDuplexMode>
+    impl<'d, C> WithDmaSpi2<'d, C> for Spi<'d, crate::peripherals::SPI2, FullDuplexMode>
     where
-        T: Instance + Spi2Instance,
         C: ChannelTypes,
         C::P: SpiPeripheral + Spi2Peripheral,
     {
-        fn with_dma(self, mut channel: Channel<'d, C>) -> SpiDma<'d, T, C> {
+        fn with_dma(self, mut channel: Channel<'d, C>) -> SpiDma<'d, crate::peripherals::SPI2, C> {
             channel.tx.init_channel(); // no need to call this for both, TX and RX
 
             #[cfg(esp32)]
@@ -192,13 +189,12 @@ pub mod dma {
     }
 
     #[cfg(spi3)]
-    impl<'d, T, C> WithDmaSpi3<'d, T, C> for Spi<'d, T, FullDuplexMode>
+    impl<'d, C> WithDmaSpi3<'d, C> for Spi<'d, crate::peripherals::SPI3, FullDuplexMode>
     where
-        T: Instance + Spi3Instance,
         C: ChannelTypes,
         C::P: SpiPeripheral + Spi3Peripheral,
     {
-        fn with_dma(self, mut channel: Channel<'d, C>) -> SpiDma<'d, T, C> {
+        fn with_dma(self, mut channel: Channel<'d, C>) -> SpiDma<'d, crate::peripherals::SPI3, C> {
             channel.tx.init_channel(); // no need to call this for both, TX and RX
 
             #[cfg(esp32)]
@@ -1075,13 +1071,3 @@ impl Instance for crate::peripherals::SPI3 {
         3
     }
 }
-
-pub trait Spi2Instance {}
-
-#[cfg(spi3)]
-pub trait Spi3Instance {}
-
-impl Spi2Instance for crate::peripherals::SPI2 {}
-
-#[cfg(spi3)]
-impl Spi3Instance for crate::peripherals::SPI3 {}


### PR DESCRIPTION
Not sure why the `WithDmaSpi2` and `WithDmaSpi3` traits were generic around the inner peripheral in the first place, as these traits are specific to each peripheral. Regardless, moved the unnecessary generic type and replaced them with concrete types, eliminating the previous marker traits in the process.