### PR TITLE
Unify naming of `RTC_CNTL`/`LP_CLKRST` peripherals

### DIFF
--- a/esp-hal-common/devices/esp32c6/device.toml
+++ b/esp-hal-common/devices/esp32c6/device.toml
@@ -95,4 +95,7 @@ symbols = [
     "gpio_support_deepsleep_wakeup",
     "uart_support_wakeup_int",
     "pm_support_ext1_wakeup",
+
+    # We derive `RTC_CNTL` from `LP_CLKRST` for this device:
+    "rtc_cntl",
 ]

--- a/esp-hal-common/devices/esp32h2/device.toml
+++ b/esp-hal-common/devices/esp32h2/device.toml
@@ -76,4 +76,7 @@ symbols = [
     "rom_crc_le",
     "rom_crc_be",
     "rom_md5_bsd",
+
+    # We derive `RTC_CNTL` from `LP_CLKRST` for this device:
+    "rtc_cntl",
 ]

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -59,7 +59,7 @@ pub use self::gpio::IO;
 pub use self::rmt::Rmt;
 #[cfg(rng)]
 pub use self::rng::Rng;
-#[cfg(any(lp_clkrst, rtc_cntl))]
+#[cfg(rtc_cntl)]
 pub use self::rtc_cntl::{Rtc, Rwdt};
 #[cfg(any(esp32, esp32s3))]
 pub use self::soc::cpu_control;
@@ -130,7 +130,7 @@ pub mod rng;
 pub mod rom;
 #[cfg(rsa)]
 pub mod rsa;
-#[cfg(any(lp_clkrst, rtc_cntl))]
+#[cfg(rtc_cntl)]
 pub mod rtc_cntl;
 #[cfg(sha)]
 pub mod sha;

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -79,26 +79,22 @@ pub use self::rtc::SocResetReason;
 use crate::clock::XtalClock;
 #[cfg(not(esp32))]
 use crate::efuse::Efuse;
+#[cfg(not(any(esp32c6, esp32h2)))]
+use crate::peripherals::TIMG0;
 #[cfg(any(esp32c6, esp32h2))]
 use crate::peripherals::{LP_TIMER, LP_WDT};
-#[cfg(not(any(esp32c6, esp32h2)))]
-use crate::peripherals::{RTC_CNTL, TIMG0};
 #[cfg(any(esp32, esp32s3, esp32c3))]
 use crate::rtc_cntl::sleep::{RtcSleepConfig, WakeSource, WakeTriggers};
 use crate::{
     clock::Clock,
     peripheral::{Peripheral, PeripheralRef},
+    peripherals::RTC_CNTL,
     reset::{SleepSource, WakeupReason},
     Cpu,
 };
 // only include sleep where its been implemented
 #[cfg(any(esp32, esp32s3, esp32c3))]
 pub mod sleep;
-
-#[cfg(any(esp32c6, esp32h2))]
-type RtcCntl = crate::peripherals::LP_CLKRST;
-#[cfg(not(any(esp32c6, esp32h2)))]
-type RtcCntl = crate::peripherals::RTC_CNTL;
 
 #[cfg_attr(esp32, path = "rtc/esp32.rs")]
 #[cfg_attr(esp32c2, path = "rtc/esp32c2.rs")]
@@ -194,14 +190,14 @@ pub(crate) enum RtcCalSel {
 
 /// Low-power Management
 pub struct Rtc<'d> {
-    _inner: PeripheralRef<'d, RtcCntl>,
+    _inner: PeripheralRef<'d, RTC_CNTL>,
     pub rwdt: Rwdt,
     #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
     pub swd: Swd,
 }
 
 impl<'d> Rtc<'d> {
-    pub fn new(rtc_cntl: impl Peripheral<P = RtcCntl> + 'd) -> Self {
+    pub fn new(rtc_cntl: impl Peripheral<P = RTC_CNTL> + 'd) -> Self {
         rtc::init();
         rtc::configure_clock();
 

--- a/esp-hal-common/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32c6/peripherals.rs
@@ -55,7 +55,8 @@ crate::peripherals! {
     LP_AON <= LP_AON,
     LP_APM <= LP_APM,
     LP_APM0 <= LP_APM0,
-    LP_CLKRST <= LP_CLKRST,
+    // RTC_CNTL is derived from LP_CLKRST
+    RTC_CNTL <= LP_CLKRST,
     LP_I2C0 <= LP_I2C0,
     LP_I2C_ANA_MST <= LP_I2C_ANA_MST,
     LP_IO <= LP_IO,

--- a/esp-hal-common/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32h2/peripherals.rs
@@ -50,7 +50,8 @@ crate::peripherals! {
     LP_ANA <= LP_ANA,
     LP_AON <= LP_AON,
     LP_APM <= LP_APM,
-    LP_CLKRST <= LP_CLKRST,
+    // RTC_CNTL is derived from LP_CLKRST
+    RTC_CNTL <= LP_CLKRST,
     LP_PERI <= LP_PERI,
     LP_TIMER <= LP_TIMER,
     LP_WDT <= LP_WDT,

--- a/esp32c6-hal/examples/parl_io_rx.rs
+++ b/esp32c6-hal/examples/parl_io_rx.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);

--- a/esp32c6-hal/examples/ram.rs
+++ b/esp32c6-hal/examples/ram.rs
@@ -40,7 +40,7 @@ fn main() -> ! {
 
     // The RWDT flash boot protection must be enabled, as it is triggered as part of
     // the example.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     rtc.rwdt.enable();
 
     timer0.start(1u64.secs());

--- a/esp32c6-hal/examples/rtc_time.rs
+++ b/esp32c6-hal/examples/rtc_time.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let rtc = Rtc::new(peripherals.LP_CLKRST);
+    let rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32c6-hal/examples/rtc_watchdog.rs
+++ b/esp32c6-hal/examples/rtc_watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -81,12 +81,12 @@ pub mod analog {
 #[export_name = "__post_init"]
 unsafe fn post_init() {
     use esp_hal_common::{
-        peripherals::{LP_CLKRST, TIMG0, TIMG1},
+        peripherals::{RTC_CNTL, TIMG0, TIMG1},
         timer::Wdt,
     };
 
     // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LP_CLKRST::steal());
+    let mut rtc = Rtc::new(RTC_CNTL::steal());
     rtc.swd.disable();
     rtc.rwdt.disable();
 

--- a/esp32h2-hal/examples/parl_io_rx.rs
+++ b/esp32h2-hal/examples/parl_io_rx.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the watchdog timers.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);

--- a/esp32h2-hal/examples/ram.rs
+++ b/esp32h2-hal/examples/ram.rs
@@ -40,7 +40,7 @@ fn main() -> ! {
 
     // The RWDT flash boot protection must be enabled, as it is triggered as part of
     // the example.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     rtc.rwdt.enable();
 
     timer0.start(1u64.secs());

--- a/esp32h2-hal/examples/rtc_time.rs
+++ b/esp32h2-hal/examples/rtc_time.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let rtc = Rtc::new(peripherals.LP_CLKRST);
+    let rtc = Rtc::new(peripherals.RTC_CNTL);
     let mut delay = Delay::new(&clocks);
 
     loop {

--- a/esp32h2-hal/examples/rtc_watchdog.rs
+++ b/esp32h2-hal/examples/rtc_watchdog.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     rtc.rwdt.start(2000u64.millis());
     rtc.rwdt.listen();
 

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
 
     // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
     // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -81,12 +81,12 @@ pub mod analog {
 #[export_name = "__post_init"]
 unsafe fn post_init() {
     use esp_hal_common::{
-        peripherals::{LP_CLKRST, TIMG0, TIMG1},
+        peripherals::{RTC_CNTL, TIMG0, TIMG1},
         timer::Wdt,
     };
 
     // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LP_CLKRST::steal());
+    let mut rtc = Rtc::new(RTC_CNTL::steal());
     rtc.swd.disable();
     rtc.rwdt.disable();
 


### PR DESCRIPTION
Much in the same spirit as #832, unifies the `RTC_CNTL` and `LP_CLKRST` peripheral names. Wasn't sure if we want to move forward with this for sure, so leaving as a draft for now, but we had discussed this in the past.