### PR TITLE
Assorted analog-related simplifications/clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace any underscores in feature names with dashes (#833)
 - The `spi` and `spi_slave` modules have been refactored into the `spi`, `spi::master`, and `spi::slave` modules (#843)
 - The `WithDmaSpi2`/`WithDmaSpi3` structs are no longer generic around the inner peripheral type (#853)
+- The `SarAdcExt`/`SensExt` traits are now collectively named `AnalogExt` instead (#857)
 
 ## [0.12.0]
 

--- a/esp-hal-common/src/analog/mod.rs
+++ b/esp-hal-common/src/analog/mod.rs
@@ -195,10 +195,13 @@ impl crate::peripheral::Peripheral for DAC2 {
 
 impl crate::peripheral::sealed::Sealed for DAC2 {}
 
+/// Extension trait to split a SENS peripheral in independent parts
+pub trait AnalogExt {
+    fn split(self) -> AvailableAnalog;
+}
+
 cfg_if::cfg_if! {
     if #[cfg(xtensa)] {
-        use crate::peripherals::SENS;
-
         pub struct AvailableAnalog {
             pub adc1: ADC1,
             pub adc2: ADC2,
@@ -206,12 +209,7 @@ cfg_if::cfg_if! {
             pub dac2: DAC2,
         }
 
-        /// Extension trait to split a SENS peripheral in independent parts
-        pub trait AnalogExt {
-            fn split(self) -> AvailableAnalog;
-        }
-
-        impl AnalogExt for SENS {
+        impl AnalogExt for crate::peripherals::SENS {
             fn split(self) -> AvailableAnalog {
                 AvailableAnalog {
                     adc1: ADC1 {
@@ -234,20 +232,13 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(riscv)] {
-        use crate::peripherals::APB_SARADC;
-
         pub struct AvailableAnalog {
             pub adc1: ADC1,
             #[cfg(esp32c3)]
             pub adc2: ADC2,
         }
 
-        /// Extension trait to split a APB_SARADC peripheral in independent parts
-        pub trait AnalogExt {
-            fn split(self) -> AvailableAnalog;
-        }
-
-        impl<'d, T: crate::peripheral::Peripheral<P = APB_SARADC> + 'd> AnalogExt for T {
+        impl AnalogExt for crate::peripherals::APB_SARADC {
             fn split(self) -> AvailableAnalog {
                 AvailableAnalog {
                     adc1: ADC1 {

--- a/esp-hal-common/src/analog/mod.rs
+++ b/esp-hal-common/src/analog/mod.rs
@@ -21,8 +21,8 @@
 //! #### Xtensa architecture
 //! For ESP microcontrollers using the `Xtensa` architecture, the driver
 //! provides access to the `SENS` peripheral, allowing users to split it into
-//! independent parts using the [`SensExt`] trait. This extension trait provides
-//! access to the following analog peripherals:
+//! independent parts using the [`AnalogExt`] trait. This extension trait
+//! provides access to the following analog peripherals:
 //!   * ADC1
 //!   * ADC2
 //!   * DAC1
@@ -30,7 +30,7 @@
 //!
 //! #### RISC-V architecture
 //! For ESP microcontrollers using the `RISC-V` architecture, the driver
-//! provides access to the `APB_SARADC` peripheral. The `SarAdcExt` trait allows
+//! provides access to the `APB_SARADC` peripheral. The `AnalogExt` trait allows
 //! users to split this peripheral into independent parts, providing access to
 //! the following analog peripheral:
 //!   * ADC1
@@ -207,11 +207,11 @@ cfg_if::cfg_if! {
         }
 
         /// Extension trait to split a SENS peripheral in independent parts
-        pub trait SensExt {
+        pub trait AnalogExt {
             fn split(self) -> AvailableAnalog;
         }
 
-        impl SensExt for SENS {
+        impl AnalogExt for SENS {
             fn split(self) -> AvailableAnalog {
                 AvailableAnalog {
                     adc1: ADC1 {
@@ -243,11 +243,11 @@ cfg_if::cfg_if! {
         }
 
         /// Extension trait to split a APB_SARADC peripheral in independent parts
-        pub trait SarAdcExt {
+        pub trait AnalogExt {
             fn split(self) -> AvailableAnalog;
         }
 
-        impl<'d, T: crate::peripheral::Peripheral<P = APB_SARADC> + 'd> SarAdcExt for T {
+        impl<'d, T: crate::peripheral::Peripheral<P = APB_SARADC> + 'd> AnalogExt for T {
             fn split(self) -> AvailableAnalog {
                 AvailableAnalog {
                     adc1: ADC1 {

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -35,10 +35,8 @@ pub use fugit::{
 };
 pub use nb;
 
-#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2))]
-pub use crate::analog::SarAdcExt as _esp_hal_analog_SarAdcExt;
-#[cfg(sens)]
-pub use crate::analog::SensExt as _esp_hal_analog_SensExt;
+#[cfg(any(apb_saradc, sens))]
+pub use crate::analog::AnalogExt as _esp_hal_analog_AnalogExt;
 #[cfg(any(gdma, pdma))]
 pub use crate::dma::{
     DmaTransfer as _esp_hal_dma_DmaTransfer,
@@ -62,7 +60,7 @@ pub use crate::ledc::{
 };
 #[cfg(radio)]
 pub use crate::radio::RadioExt as _esp_hal_RadioExt;
-#[cfg(any(esp32, esp32s2, esp32s3))]
+#[cfg(spi3)]
 pub use crate::spi::master::dma::WithDmaSpi3 as _esp_hal_spi_dma_WithDmaSpi3;
 #[cfg(any(spi0, spi1, spi2, spi3))]
 pub use crate::spi::master::{

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -53,11 +53,6 @@
 
 pub use esp_hal_common::*;
 
-/// Common module for analog functions
-pub mod analog {
-    pub use esp_hal_common::analog::{AvailableAnalog, SensExt};
-}
-
 /// Function initializes ESP32 specific memories (RTC slow and fast) and
 /// then calls original Reset function
 ///

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -75,11 +75,6 @@
 
 pub use esp_hal_common::*;
 
-/// Common module for analog functions
-pub mod analog {
-    pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
-}
-
 #[export_name = "__post_init"]
 unsafe fn post_init() {
     use esp_hal_common::{

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -81,11 +81,6 @@
 
 pub use esp_hal_common::*;
 
-/// Common module for analog functions
-pub mod analog {
-    pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
-}
-
 extern "C" {
     cfg_if::cfg_if! {
         if #[cfg(feature = "mcu-boot")] {

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -73,11 +73,6 @@
 
 pub use esp_hal_common::*;
 
-/// Common module for analog functions
-pub mod analog {
-    pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
-}
-
 #[export_name = "__post_init"]
 unsafe fn post_init() {
     use esp_hal_common::{

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -73,11 +73,6 @@
 
 pub use esp_hal_common::*;
 
-/// Common module for analog functions
-pub mod analog {
-    pub use esp_hal_common::analog::{AvailableAnalog, SarAdcExt};
-}
-
 #[export_name = "__post_init"]
 unsafe fn post_init() {
     use esp_hal_common::{

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -51,11 +51,6 @@ pub use esp_hal_common::*;
 // Always enable atomic emulation on ESP32-S2
 use xtensa_atomic_emulation_trap as _;
 
-/// Common module for analog functions
-pub mod analog {
-    pub use esp_hal_common::analog::{AvailableAnalog, SensExt};
-}
-
 /// Function initializes ESP32 specific memories (RTC slow and fast) and
 /// then calls original Reset function
 ///

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -85,11 +85,6 @@
 
 pub use esp_hal_common::*;
 
-/// Common module for analog functions
-pub mod analog {
-    pub use esp_hal_common::analog::{AvailableAnalog, SensExt};
-}
-
 #[cfg(all(feature = "rt", feature = "direct-boot"))]
 #[doc(hidden)]
 #[no_mangle]


### PR DESCRIPTION
Just some small changes, cleaning things up a bit. Part of my prelude-simplification-yak-shaving adventure (more fun to come!).

- Remove the `analog` modules from the chip-specific HAL packages
    - Not sure why these existed in the first place? Historical reasons? Regardless, not necessary
- Merge the `SarAdcExt` and `SensExt` traits into a single `AnalogExt` trait
    - There was no reason for these to be different traits
- A bit of clean up and simplification in the `analog` module
