### PR TITLE
Add support for 16MB octal PS-RAM (ESP32-S3)

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -89,6 +89,7 @@ psram-8m = []
 opsram-2m = []
 opsram-4m = []
 opsram-8m = []
+opsram-16m = []
 
 # USB OTG support (ESP32-S2 and ESP32-S3 only! Enabled by default)
 usb-otg = ["esp-synopsys-usb-otg", "usb-device"]

--- a/esp-hal-common/src/soc/esp32s3/psram.rs
+++ b/esp-hal-common/src/soc/esp32s3/psram.rs
@@ -35,7 +35,9 @@ cfg_if::cfg_if! {
         const PSRAM_SIZE: u32 = 4;
     } else if #[cfg(feature = "opsram-8m")] {
         const PSRAM_SIZE: u32 = 8;
-    } else {
+    } else if #[cfg(feature = "opsram-16m")] {
+        const PSRAM_SIZE: u32 = 16;
+    }else {
         const PSRAM_SIZE: u32 = 0;
     }
 }
@@ -51,7 +53,8 @@ pub const PSRAM_BYTES: usize = PSRAM_SIZE as usize * 1024 * 1024;
     feature = "psram-8m",
     feature = "opsram-2m",
     feature = "opsram-4m",
-    feature = "opsram-8m"
+    feature = "opsram-8m",
+    feature = "opsram-16m"
 ))]
 pub fn init_psram(_peripheral: impl crate::peripheral::Peripheral<P = crate::peripherals::PSRAM>) {
     const CONFIG_ESP32S3_INSTRUCTION_CACHE_SIZE: u32 = 0x4000;
@@ -779,7 +782,12 @@ pub(crate) mod utils {
     }
 }
 
-#[cfg(any(feature = "opsram-2m", feature = "opsram-4m", feature = "opsram-8m"))]
+#[cfg(any(
+    feature = "opsram-2m",
+    feature = "opsram-4m",
+    feature = "opsram-8m",
+    feature = "opsram-16m"
+))]
 pub(crate) mod utils {
     use procmacros::ram;
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -84,6 +84,7 @@ psram-8m  = ["esp-hal-common/psram-8m", "psram"]
 opsram-2m  = ["esp-hal-common/opsram-2m", "psram"]
 opsram-4m  = ["esp-hal-common/opsram-4m", "psram"]
 opsram-8m  = ["esp-hal-common/opsram-8m", "psram"]
+opsram-16m = ["esp-hal-common/opsram-16m", "psram"]
 
 [profile.release]
 debug = true

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -29,6 +29,7 @@
 //! - `opsram-2m` - Use externally connected Octal PSRAM (2MB)
 //! - `opsram-4m` - Use externally connected Octal PSRAM (4MB)
 //! - `opsram-8m` - Use externally connected Octal PSRAM (8MB)
+//! - `opsram-16m`- Use externally connected Octal PSRAM (16MB)
 //! - `psram-2m` - Use externally connected PSRAM (2MB)
 //! - `psram-4m` - Use externally connected PSRAM (4MB)
 //! - `psram-8m` - Use externally connected PSRAM (8MB)


### PR DESCRIPTION
This adds support for 16MB (octal) PS-RAM (ESP32-S3)
Adds a new feature `opsram-16m`
