### PR TITLE
Prelude improvements/fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `WithDmaSpi2`/`WithDmaSpi3` structs are no longer generic around the inner peripheral type (#853)
 - The `SarAdcExt`/`SensExt` traits are now collectively named `AnalogExt` instead (#857)
 - Replace the `radio` module with peripheral singleton structs (#852)
+- The SPI traits are no longer re-exported in the main prelude, but from preludes in `spi::master`/`spi::slave` instead (#860)
+- The `embedded-hal-1` and `embedded-hal-async` traits are no longer re-exported in the prelude (#860)
 
 ## [0.12.0]
 

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -19,14 +19,6 @@ pub use embedded_hal::{
     },
     prelude::*,
 };
-#[cfg(feature = "async")]
-pub use embedded_hal_async::{
-    delay::DelayUs as _embedded_hal_async_delay_DelayUs,
-    digital::Wait as _embedded_hal_async_digital_Wait,
-    i2c::I2c as _embedded_hal_async_i2c_I2c,
-    spi::SpiBus as _embedded_hal_async_spi_SpiBus,
-    spi::SpiDevice as _embedded_hal_async_spi_SpiDevice,
-};
 pub use fugit::{
     ExtU32 as _fugit_ExtU32,
     ExtU64 as _fugit_ExtU64,
@@ -68,32 +60,3 @@ pub use crate::timer::{
 #[cfg(any(uart0, uart1, uart2))]
 pub use crate::uart::{Instance as _esp_hal_uart_Instance, UartPins as _esp_hal_uart_UartPins};
 pub use crate::{clock::Clock as _esp_hal_clock_Clock, entry, macros::*};
-
-/// All traits required for using the 1.0.0-alpha.x release of embedded-hal
-#[cfg(feature = "eh1")]
-pub mod eh1 {
-    #[cfg(any(twai0, twai1))]
-    pub use embedded_can::{
-        blocking::Can as _embedded_can_blocking_Can,
-        nb::Can as _embedded_can_nb_Can,
-        Error as _embedded_can_Error,
-        Frame as _embedded_can_Frame,
-    };
-    pub use embedded_hal_1::{
-        delay::DelayUs as _embedded_hal_1_delay_DelayUs,
-        digital::{
-            InputPin as _embedded_hal_1_digital_InputPin,
-            OutputPin as _embedded_hal_1_digital_OutputPin,
-            StatefulOutputPin as _embedded_hal_1_digital_StatefulOutputPin,
-            ToggleableOutputPin as _embedded_hal_1_digital_ToggleableOutputPin,
-        },
-        i2c::I2c as _embedded_hal_1_i2c_I2c,
-        spi::{SpiBus as _embedded_hal_1_spi_SpiBus, SpiDevice as _embedded_hal_1_spi_SpiDevice},
-    };
-    pub use embedded_hal_nb::{
-        serial::{Read as _embedded_hal_nb_serial_Read, Write as _embedded_hal_nb_serial_Write},
-        spi::FullDuplex as _embedded_hal_nb_spi_FullDuplex,
-    };
-
-    pub use super::*;
-}

--- a/esp-hal-common/src/prelude.rs
+++ b/esp-hal-common/src/prelude.rs
@@ -58,20 +58,6 @@ pub use crate::ledc::{
     },
     timer::{TimerHW as _esp_hal_ledc_timer_TimerHW, TimerIFace as _esp_hal_ledc_timer_TimerIFace},
 };
-#[cfg(spi3)]
-pub use crate::spi::master::dma::WithDmaSpi3 as _esp_hal_spi_dma_WithDmaSpi3;
-#[cfg(any(spi0, spi1, spi2, spi3))]
-pub use crate::spi::master::{
-    dma::WithDmaSpi2 as _esp_hal_spi_dma_WithDmaSpi2,
-    Instance as _esp_hal_spi_Instance,
-    InstanceDma as _esp_hal_spi_InstanceDma,
-};
-#[cfg(all(any(spi0, spi1, spi2, spi3), not(pdma)))]
-pub use crate::spi::slave::{
-    dma::WithDmaSpi2 as _esp_hal_spi_slave_dma_WithDmaSpi2,
-    Instance as _esp_hal_spi_slave_Instance,
-    InstanceDma as _esp_hal_spi_slave_InstanceDma,
-};
 #[cfg(any(dport, pcr, system))]
 pub use crate::system::SystemExt as _esp_hal_system_SystemExt;
 #[cfg(any(timg0, timg1))]

--- a/esp-hal-common/src/spi/master.rs
+++ b/esp-hal-common/src/spi/master.rs
@@ -73,6 +73,17 @@ use crate::{
     system::PeripheralClockControl,
 };
 
+/// Prelude for the SPI (Master) driver
+pub mod prelude {
+    #[cfg(spi3)]
+    pub use super::dma::WithDmaSpi3 as _esp_hal_spi_master_dma_WithDmaSpi3;
+    pub use super::{
+        dma::WithDmaSpi2 as _esp_hal_spi_master_dma_WithDmaSpi2,
+        Instance as _esp_hal_spi_master_Instance,
+        InstanceDma as _esp_hal_spi_master_InstanceDma,
+    };
+}
+
 /// The size of the FIFO buffer for SPI
 #[cfg(not(esp32s2))]
 const FIFO_SIZE: usize = 64;

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -68,6 +68,17 @@ use crate::{
     system::PeripheralClockControl,
 };
 
+/// Prelude for the SPI (Slave) driver
+pub mod prelude {
+    #[cfg(spi3)]
+    pub use super::dma::WithDmaSpi3 as _esp_hal_spi_slave_dma_WithDmaSpi3;
+    pub use super::{
+        dma::WithDmaSpi2 as _esp_hal_spi_slave_dma_WithDmaSpi2,
+        Instance as _esp_hal_spi_slave_Instance,
+        InstanceDma as _esp_hal_spi_slave_InstanceDma,
+    };
+}
+
 const MAX_DMA_SIZE: usize = 32768 - 32;
 
 /// SPI peripheral driver

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -27,7 +27,10 @@ use esp32_hal::{
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     timer::TimerGroup,
     IO,
 };

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -25,7 +25,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, Spi},
+        master::{prelude::*, Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Spi, SpiBusController},
+        master::{prelude::*, Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,10 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -21,7 +21,10 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,10 @@ use esp32_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -27,7 +27,10 @@ use esp32c2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -25,7 +25,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, Spi},
+        master::{prelude::*, Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Spi, SpiBusController},
+        master::{prelude::*, Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32c2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,10 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c2-hal/examples/spi_loopback.rs
+++ b/esp32c2-hal/examples/spi_loopback.rs
@@ -21,7 +21,10 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,10 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_slave_dma.rs
+++ b/esp32c2-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,10 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{slave::Spi, SpiMode},
+    spi::{
+        slave::{prelude::*, Spi},
+        SpiMode,
+    },
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -27,7 +27,10 @@ use esp32c3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -25,7 +25,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, Spi},
+        master::{prelude::*, Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Spi, SpiBusController},
+        master::{prelude::*, Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,10 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -21,7 +21,10 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,10 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_slave_dma.rs
+++ b/esp32c3-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,10 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{slave::Spi, SpiMode},
+    spi::{
+        slave::{prelude::*, Spi},
+        SpiMode,
+    },
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -27,7 +27,10 @@ use esp32c6_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     IO,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/qspi_flash.rs
+++ b/esp32c6-hal/examples/qspi_flash.rs
@@ -25,7 +25,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, Spi},
+        master::{prelude::*, Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c6-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Spi, SpiBusController},
+        master::{prelude::*, Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32c6-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,10 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c6-hal/examples/spi_loopback.rs
+++ b/esp32c6-hal/examples/spi_loopback.rs
@@ -21,7 +21,10 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,10 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,10 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{slave::Spi, SpiMode},
+    spi::{
+        slave::{prelude::*, Spi},
+        SpiMode,
+    },
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -27,7 +27,10 @@ use esp32h2_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     IO,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/qspi_flash.rs
+++ b/esp32h2-hal/examples/qspi_flash.rs
@@ -25,7 +25,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, Spi},
+        master::{prelude::*, Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32h2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Spi, SpiBusController},
+        master::{prelude::*, Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32h2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,10 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32h2-hal/examples/spi_loopback.rs
+++ b/esp32h2-hal/examples/spi_loopback.rs
@@ -21,7 +21,10 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,10 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,10 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{slave::Spi, SpiMode},
+    spi::{
+        slave::{prelude::*, Spi},
+        SpiMode,
+    },
     timer::TimerGroup,
     Delay,
     Rtc,

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -27,7 +27,10 @@ use esp32s2_hal::{
     pdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     IO,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -25,7 +25,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, Spi},
+        master::{prelude::*, Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32s2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Spi, SpiBusController},
+        master::{prelude::*, Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32s2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s2-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,10 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32s2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32s2-hal/examples/spi_loopback.rs
+++ b/esp32s2-hal/examples/spi_loopback.rs
@@ -21,7 +21,10 @@ use esp32s2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,10 @@ use esp32s2_hal::{
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -27,7 +27,10 @@ use esp32s3_hal::{
     gdma::*,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     IO,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -25,7 +25,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, Spi},
+        master::{prelude::*, Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32s3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Spi, SpiBusController},
+        master::{prelude::*, Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32s3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32s3-hal/examples/spi_eh1_loopback.rs
@@ -22,7 +22,10 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32s3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32s3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32s3-hal/examples/spi_loopback.rs
+++ b/esp32s3-hal/examples/spi_loopback.rs
@@ -21,7 +21,10 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -23,7 +23,10 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{master::Spi, SpiMode},
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/spi_slave_dma.rs
+++ b/esp32s3-hal/examples/spi_slave_dma.rs
@@ -32,7 +32,10 @@ use esp32s3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{slave::Spi, SpiMode},
+    spi::{
+        slave::{prelude::*, Spi},
+        SpiMode,
+    },
     timer::TimerGroup,
     Delay,
     Rtc,


### PR DESCRIPTION
As discussed previously with @bjoernQ and @MabezDev:

- Move the SPI traits into their own preludes in the `spi::master`/`spi::slave` modules
- Remove the `embedded-hal-async` trait re-exports
- Remove the `eh` module, and in turn the `embedded-hal@1.0.0-rc.1` trait re-exports

I will deal with `embedded-hal` in a following PR, then I think we should be okay here.