### PR TITLE
Add LLD option for all Xtensa chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `defmt` feature to enable log output (#773)
 - A new macro to load LP core code on ESP32-C6 (#779)
 - Add `ECC`` peripheral driver (#785)
+- Initial LLD support for Xtensa chips (#861).
 
 ### Changed
 

--- a/esp-hal-common/ld/sections/fixups/rodata_dummy.x
+++ b/esp-hal-common/ld/sections/fixups/rodata_dummy.x
@@ -14,7 +14,7 @@ SECTIONS {
 
     /* Create an empty gap as big as .text section */
 
-    . = SIZEOF(.text);
+    . = . + SIZEOF(.text);
 
     /* Prepare the alignment of the section above. Few bytes (0x20) must be
      * added for the mapping header.

--- a/esp-hal-common/ld/sections/fixups/rtc_fast_rwdata_dummy.x
+++ b/esp-hal-common/ld/sections/fixups/rtc_fast_rwdata_dummy.x
@@ -7,7 +7,7 @@ SECTIONS {
   .rtc_fast.dummy (NOLOAD) :
   {
     _rtc_dummy_start = ABSOLUTE(.); /* needed to make section proper size */
-    . = SIZEOF(.rtc_fast.text);
+    . = . + SIZEOF(.rtc_fast.text);
     _rtc_dummy_end = ABSOLUTE(.); /* needed to make section proper size */
   } > RTC_FAST_RWDATA
 }

--- a/esp-hal-common/ld/sections/rodata.x
+++ b/esp-hal-common/ld/sections/rodata.x
@@ -3,12 +3,12 @@
 SECTIONS {
   .rodata : ALIGN(4)
   {
-    _rodata_start = ABSOLUTE(.);
     . = ALIGN (4);
+    _rodata_start = ABSOLUTE(.);
     *(.rodata .rodata.*)
     *(.srodata .srodata.*)
-    _rodata_end = ABSOLUTE(.);
     . = ALIGN(4);
+    _rodata_end = ABSOLUTE(.);
   } > RODATA
 
   .rodata.wifi : ALIGN(4)

--- a/esp-hal-common/ld/xtensa/rom.x
+++ b/esp-hal-common/ld/xtensa/rom.x
@@ -1,6 +1,0 @@
-REGION_ALIAS("ROTEXT", irom_seg);
-REGION_ALIAS("RWTEXT", iram_seg);
-REGION_ALIAS("RODATA", drom_seg);
-REGION_ALIAS("RWDATA", dram_seg);
-REGION_ALIAS("RTC_FAST_RWTEXT", rtc_fast_iram_seg);
-REGION_ALIAS("RTC_FAST_RWDATA", rtc_fast_dram_seg);

--- a/esp32-hal/.cargo/config.toml
+++ b/esp32-hal/.cargo/config.toml
@@ -3,13 +3,13 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
-  # GCC
-  # "-C", "link-arg=-nostartfiles",
-  # "-C", "link-arg=-Wl,-Tlinkall.x",
+  # GNU LD
+  "-C", "link-arg=-nostartfiles",
+  "-C", "link-arg=-Wl,-Tlinkall.x",
 
   # LLD
-  "-C", "linker=rust-lld",
-  "-C", "link-arg=-Tlinkall.x",
+  # "-C", "linker=rust-lld",
+  # "-C", "link-arg=-Tlinkall.x",
 ]
 target = "xtensa-esp32-none-elf"
 

--- a/esp32-hal/.cargo/config.toml
+++ b/esp32-hal/.cargo/config.toml
@@ -3,8 +3,13 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
-  "-C", "link-arg=-nostartfiles",
-  "-C", "link-arg=-Wl,-Tlinkall.x",
+  # GCC
+  # "-C", "link-arg=-nostartfiles",
+  # "-C", "link-arg=-Wl,-Tlinkall.x",
+
+  # LLD
+  "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlinkall.x",
 ]
 target = "xtensa-esp32-none-elf"
 

--- a/esp32-hal/build.rs
+++ b/esp32-hal/build.rs
@@ -41,10 +41,6 @@ fn generate_memory_extras() -> Vec<u8> {
         "
     /* reserved at the start of DRAM for e.g. the BT stack */
     RESERVE_DRAM = {reserve_dram};
-    
-    /* reserved at the start of the RTC memories for use by the ULP processor */
-    RESERVE_RTC_FAST = 0;
-    RESERVE_RTC_SLOW = 0;
         "
     )
     .as_bytes()

--- a/esp32-hal/ld/memory.x
+++ b/esp32-hal/ld/memory.x
@@ -45,9 +45,9 @@ MEMORY
   rtc_fast_iram_seg(RWX) : ORIGIN = 0x400C0000, len = 8k
 
   /* RTC fast memory (same block as above), viewed from data bus. Only for core 0 (PRO_CPU) */
-  rtc_fast_dram_seg(RW)  : ORIGIN = 0x3FF80000 + RESERVE_RTC_FAST, len = 8k - RESERVE_RTC_FAST
+  rtc_fast_dram_seg(RW)  : ORIGIN = 0x3FF80000, len = 8k
 
   /* RTC slow memory (data accessible). Persists over deep sleep. */
-  rtc_slow_seg(RW)       : ORIGIN = 0x50000000 + RESERVE_RTC_SLOW, len = 8k - RESERVE_RTC_SLOW
+  rtc_slow_seg(RW)       : ORIGIN = 0x50000000, len = 8k
 }
 

--- a/esp32s2-hal/.cargo/config.toml
+++ b/esp32s2-hal/.cargo/config.toml
@@ -3,8 +3,13 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
+  # GCC
   "-C", "link-arg=-nostartfiles",
   "-C", "link-arg=-Wl,-Tlinkall.x",
+
+  # LLD
+  # "-C", "linker=rust-lld",
+  # "-C", "link-arg=-Tlinkall.x",
 
   # enable the atomic codegen option for Xtensa
   "-C", "target-feature=+s32c1i",

--- a/esp32s2-hal/.cargo/config.toml
+++ b/esp32s2-hal/.cargo/config.toml
@@ -3,7 +3,7 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
-  # GCC
+  # GNU LD
   "-C", "link-arg=-nostartfiles",
   "-C", "link-arg=-Wl,-Tlinkall.x",
 

--- a/esp32s2-hal/ld/memory.x
+++ b/esp32s2-hal/ld/memory.x
@@ -12,10 +12,6 @@ INCLUDE "memory_extras.x"
 
 VECTORS_SIZE = 0x400;
 
-/* reserved at the start of the RTC memories for use by the ULP processor */
-RESERVE_RTC_FAST = 0;
-RESERVE_RTC_SLOW = 0;
-
 /* Specify main memory areas */
 MEMORY
 {
@@ -39,7 +35,7 @@ MEMORY
   rtc_fast_iram_seg(RWX) : ORIGIN = 0x40070000, len = 8k
 
   /* RTC fast memory (same block as above), viewed from data bus. Only for core 0 (PRO_CPU) */
-  rtc_fast_dram_seg(RW)  : ORIGIN = 0x3ff9e000 + RESERVE_RTC_FAST, len = 8k - RESERVE_RTC_FAST
+  rtc_fast_dram_seg(RW)  : ORIGIN = 0x3ff9e000, len = 8k
 
   /* RTC slow memory (data accessible). Persists over deep sleep. */
   rtc_slow_seg(RW)       : ORIGIN = 0x50000000 + RESERVE_RTC_SLOW, len = 8k - RESERVE_RTC_SLOW

--- a/esp32s3-hal/.cargo/config.toml
+++ b/esp32s3-hal/.cargo/config.toml
@@ -4,12 +4,12 @@ runner = "espflash flash --monitor"
 [build]
 rustflags = [
   # GNU LD
-  # "-C", "link-arg=-nostartfiles",
-  # "-C", "link-arg=-Wl,-Tlinkall.x",
+  "-C", "link-arg=-nostartfiles",
+  "-C", "link-arg=-Wl,-Tlinkall.x",
 
   # LLD
-  "-C", "linker=rust-lld",
-  "-C", "link-arg=-Tlinkall.x",
+  # "-C", "linker=rust-lld",
+  # "-C", "link-arg=-Tlinkall.x",
 ]
 target = "xtensa-esp32s3-none-elf"
 

--- a/esp32s3-hal/.cargo/config.toml
+++ b/esp32s3-hal/.cargo/config.toml
@@ -3,8 +3,13 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
-  "-C", "link-arg=-nostartfiles",
-  "-C", "link-arg=-Wl,-Tlinkall.x",
+  # GNU LD
+  # "-C", "link-arg=-nostartfiles",
+  # "-C", "link-arg=-Wl,-Tlinkall.x",
+
+  # LLD
+  "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlinkall.x",
 ]
 target = "xtensa-esp32s3-none-elf"
 

--- a/esp32s3-hal/ld/db-esp32s3.x
+++ b/esp32s3-hal/ld/db-esp32s3.x
@@ -189,7 +189,7 @@ SECTIONS {
     _stack_end = ABSOLUTE(.);
   } > RWDATA
   
-  .rtc_fast.text ORIGIN(rtc_fast_iram_seg) : 
+  .rtc_fast.text ORIGIN(rtc_fast_seg) : 
   {
    . = ALIGN(4);
    _rtc_fast_text_start = ABSOLUTE(.);
@@ -198,8 +198,8 @@ SECTIONS {
    _rtc_fast_text_end = ABSOLUTE(.);
   }
   _irtc_fast_text = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext);
- 
-  .rtc_fast.data ORIGIN(rtc_fast_dram_seg) + SIZEOF(.rtc_fast.text) : 
+
+  .rtc_fast.data ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) : 
   {
     . = ALIGN(4);
     _rtc_fast_data_start = ABSOLUTE(.);
@@ -209,7 +209,7 @@ SECTIONS {
   }
   _irtc_fast_data = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.rtc_fast.text);
 
- .rtc_fast.bss ORIGIN(rtc_fast_dram_seg) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) (NOLOAD) : 
+ .rtc_fast.bss ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) (NOLOAD) : 
   {
     . = ALIGN(4);
     _rtc_fast_bss_start = ABSOLUTE(.);
@@ -218,7 +218,7 @@ SECTIONS {
     _rtc_fast_bss_end = ABSOLUTE(.);
   }
 
- .rtc_fast.noinit ORIGIN(rtc_fast_dram_seg) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss) (NOLOAD)  :
+ .rtc_fast.noinit ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.bss) (NOLOAD)  :
   {
     . = ALIGN(4);
     *(.rtc_fast.noinit .rtc_fast.noinit.*)
@@ -234,7 +234,7 @@ SECTIONS {
    _rtc_slow_text_end = ABSOLUTE(.);
   }
   _irtc_slow_text = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
-      SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss);
+      SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.bss);
 
   .rtc_slow.data ORIGIN(rtc_slow_seg) + SIZEOF(.rtc_slow.text) : 
   {
@@ -245,7 +245,7 @@ SECTIONS {
     _rtc_slow_data_end = ABSOLUTE(.);
   }
   _irtc_slow_data = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
-        SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss) + SIZEOF(.rtc_slow.text);
+        SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.bss) + SIZEOF(.rtc_slow.text);
 
  .rtc_slow.bss ORIGIN(rtc_slow_seg) + SIZEOF(.rtc_slow.text) + SIZEOF(.rtc_slow.data) (NOLOAD) : 
   {

--- a/esp32s3-hal/ld/db-memory.x
+++ b/esp32s3-hal/ld/db-memory.x
@@ -4,10 +4,6 @@ ENTRY(ESP32Reset)
 /* reserved at the start of DRAM */
 RESERVE_DRAM = 0x8000;
 
-/* reserved at the start of the RTC memories for use by the ULP processor */
-RESERVE_RTC_FAST = 0;
-RESERVE_RTC_SLOW = 0;
-
 /* Specify main memory areas */
 MEMORY
 {
@@ -28,11 +24,8 @@ MEMORY
 
 
   /* RTC fast memory (executable). Persists over deep sleep. Only for core 0 (PRO_CPU) */
-  rtc_fast_iram_seg(RWX) : ORIGIN = 0x600fe000, len = 8k
-
-  /* RTC fast memory (same block as above), viewed from data bus. Only for core 0 (PRO_CPU) */
-  rtc_fast_dram_seg(RW)  : ORIGIN = 0x600fe000 + RESERVE_RTC_FAST, len = 8k - RESERVE_RTC_FAST
+  rtc_fast_seg(RWX) : ORIGIN = 0x600fe000, len = 8k
 
   /* RTC slow memory (data accessible). Persists over deep sleep. */
-  rtc_slow_seg(RW)       : ORIGIN = 0x50000000 + RESERVE_RTC_SLOW, len = 8k - RESERVE_RTC_SLOW
+  rtc_slow_seg(RW)       : ORIGIN = 0x50000000, len = 8k
 }

--- a/esp32s3-hal/ld/link-esp32s3.x
+++ b/esp32s3-hal/ld/link-esp32s3.x
@@ -34,7 +34,6 @@ SECTIONS {
 INSERT BEFORE .data;
 
 INCLUDE "fixups/rodata_dummy.x"
-INCLUDE "fixups/rtc_fast_rwdata_dummy.x"
 /* End of ESP32S3 fixups */
 
 /* Shared sections - ordering matters */

--- a/esp32s3-hal/ld/link-esp32s3.x
+++ b/esp32s3-hal/ld/link-esp32s3.x
@@ -24,7 +24,7 @@ SECTIONS {
     /*  Create an empty gap as big as .rwtext section - 32k (SRAM0) 
      *  because SRAM1 is available on the data bus and instruction bus 
      */
-    . = MAX(SIZEOF(.rwtext) + SIZEOF(.rwtext.wifi) + RESERVE_ICACHE + VECTORS_SIZE, 32k) - 32k;
+    . = . + MAX(SIZEOF(.rwtext) + SIZEOF(.rwtext.wifi) + RESERVE_ICACHE + VECTORS_SIZE, 32k) - 32k;
 
     /* Prepare the alignment of the section above. */
     . = ALIGN(4);

--- a/esp32s3-hal/ld/memory.x
+++ b/esp32s3-hal/ld/memory.x
@@ -4,10 +4,6 @@ ENTRY(ESP32Reset)
 /* reserved for ICACHE */
 RESERVE_ICACHE = 0x8000;
 
-/* reserved at the start of the RTC memories for use by the ULP processor */
-RESERVE_RTC_FAST = 0;
-RESERVE_RTC_SLOW = 0;
-
 VECTORS_SIZE = 0x400;
 
 /* Specify main memory areas
@@ -40,11 +36,8 @@ MEMORY
 
 
   /* RTC fast memory (executable). Persists over deep sleep. Only for core 0 (PRO_CPU) */
-  rtc_fast_iram_seg(RWX) : ORIGIN = 0x600fe000, len = 8k
-
-  /* RTC fast memory (same block as above), viewed from data bus. Only for core 0 (PRO_CPU) */
-  rtc_fast_dram_seg(RW)  : ORIGIN = 0x600fe000 + RESERVE_RTC_FAST, len = 8k - RESERVE_RTC_FAST
+  rtc_fast_seg(RWX) : ORIGIN = 0x600fe000, len = 8k
 
   /* RTC slow memory (data accessible). Persists over deep sleep. */
-  rtc_slow_seg(RW)       : ORIGIN = 0x50000000 + RESERVE_RTC_SLOW, len = 8k - RESERVE_RTC_SLOW
+  rtc_slow_seg(RW)       : ORIGIN = 0x50000000, len = 8k
 }


### PR DESCRIPTION
Although not yet recommended, from 1.74 it will be possible to link all esp-hal examples (esp-wifi still running into some issues). This PR makes the required changes to the linker scripts for LLD support, as well as adding the option in `.cargo/config.toml`.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
