### PR TITLE
feat(SHA): Add initial interleaving calculation support.

### DIFF
--- a/esp-hal-common/src/reg_access.rs
+++ b/esp-hal-common/src/reg_access.rs
@@ -28,7 +28,7 @@ const U32_TO_BYTES: fn(u32) -> [u8; 4] = u32::to_ne_bytes;
 // It assumes incoming `dst` are aligned to desired layout (in future
 // ptr.is_aligned can be used). It also assumes that writes are done in FIFO
 // order.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct AlignmentHelper {
     buf: [u8; U32_ALIGN_SIZE],
     buf_fill: usize,

--- a/esp32s3-hal/examples/sha_save.rs
+++ b/esp32s3-hal/examples/sha_save.rs
@@ -1,0 +1,105 @@
+//! Demonstrates the use of the SHA peripheral and compares the speed of
+//! hardware-accelerated and pure software hashing.
+
+#![no_std]
+#![no_main]
+
+use esp32s3_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    sha::{Sha, ShaMode},
+    xtensa_lx,
+};
+use esp_backtrace as _;
+use esp_println::println;
+use nb::block;
+use sha2::{Digest, Sha256};
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+    let mut remaining = source_data.clone();
+    let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA256);
+
+    // Short hashes can be created by decreasing the output buffer to the desired
+    // length
+    let mut output = [0u8; 32];
+
+    let pre_calc = xtensa_lx::timer::get_cycle_count();
+    // The hardware implementation takes a subslice of the input, and returns the
+    // unprocessed parts The unprocessed parts can be input in the next
+    // iteration, you can always add more data until finish() is called. After
+    // finish() is called update()'s will contribute to a new hash which
+    // can be extracted again with finish().
+
+    // Number of runs of the hasher
+    let mut number_of_runs = 0;
+
+    // Saved state of the hasher, to restore from
+    let mut saved_state = None;
+
+    // Saved remaining slice, to resume with
+    let mut saved_remaining = None;
+
+    while remaining.len() > 0 {
+        // Can add println to view progress, however println takes a few orders of
+        // magnitude longer than the Sha function itself so not useful for
+        // comparing processing time println!("Remaining len: {}",
+        // remaining.len());
+
+        // All the HW Sha functions are infallible so unwrap is fine to use if you use
+        // block!
+        remaining = block!(hasher.update(remaining)).unwrap();
+
+        number_of_runs += 1;
+        // Run 1 works
+        // Run 2 works
+        // Run 3 works
+        // Run 4 fails
+        println!("Run: {}", number_of_runs);
+        if number_of_runs == 3 {
+            println!("Run #{} saved", number_of_runs);
+            saved_state = Some(hasher.save_digest::<32>());
+            saved_remaining = Some(remaining);
+        }
+
+    }
+
+    // Finish can be called as many times as desired to get mutliple copies of the
+    // output.
+    block!(hasher.finish(output.as_mut_slice())).unwrap();
+    let post_calc = xtensa_lx::timer::get_cycle_count();
+    let hw_time = post_calc - pre_calc;
+    println!("Took {} cycles", hw_time);
+    println!("SHA256 Hash output {:02x?}", output);
+
+    // Restore SHA digest
+    hasher.restore_digest(saved_state.unwrap());
+    remaining = saved_remaining.unwrap();
+
+    while remaining.len() > 0 {
+        remaining = block!(hasher.update(remaining)).unwrap();
+    }
+
+    block!(hasher.finish(output.as_mut_slice())).unwrap();
+    println!("SHA256 Hash output from saved state {:02x?}", output);
+
+    let pre_calc = xtensa_lx::timer::get_cycle_count();
+    let mut hasher = Sha256::new();
+    hasher.update(source_data);
+    let soft_result = hasher.finalize();
+    let post_calc = xtensa_lx::timer::get_cycle_count();
+    let soft_time = post_calc - pre_calc;
+    println!("Took {} cycles", soft_time);
+    println!("SHA256 Hash output {:02x?}", soft_result);
+
+    println!("HW SHA is {}x faster", soft_time / hw_time);
+
+    loop {}
+}


### PR DESCRIPTION
## Description
I tried to take a look at #842 and I came up with the following implementation. I am not sure it is the best. 

Main goals:
- Be the fastest possible in save and restore. This is critical to make sure that the hardware driver gives us the best results.
- Use the least possible data to save a state. This is quality of life because this will be used with C bindings in https://github.com/esp-rs/esp-mbedtls and the least amount of data we deal with, the easier and safer it is.

I've provided the example `sha_save.rs` for `esp32s3` to test this. What it does is that you can decide at which cycle of the operation you want to save the state, and the remaining data, and then continue the operation later. This currently works for every operation except the 4th one, which is the last one, and I don't know why. This is what I'm stuck on. 

I've also left the software SHA to compare if the hash is correct, and the overall speed of the operation.
*Note: Using println!() will greatly increase the speed it takes for HW Sha. It must be commented or removed to get the most accurate benchmark in a real-case scenario.

This is still very WIP, I haven't tested it on any other chips, nor with other SHA modes.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
