### PR TITLE
Decouple default features from esp-hal-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C2, C3: atomic emulation trap is now opt-in (#904)
 - Improve DMA documentation & clean up module (#915)
 - Only allow a single version of `esp-hal-common` to be present in an application (#934)
+- C3, C6 and H2 can now use the `zero-rtc-bss` feature to enable `esp-hal-common/rv-zero-rtc-bss` (#867)
 
 ### Fixed
 

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -55,7 +55,7 @@ static_cell        = { version = "2.0.0", features = ["nightly"] }
 embassy-sync       = "0.4.0"
 
 [features]
-default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
+default              = ["rt", "vectored", "zero-rtc-bss"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
 defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
@@ -66,6 +66,11 @@ log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
+
+# Initialize / clear data sections and RTC memory
+zero-rtc-bss         = ["esp-hal-common/rv-zero-rtc-bss"]
+init-data            = ["esp-hal-common/rv-init-data"]
+init-rtc-data        = ["esp-hal-common/rv-init-rtc-data"]
 
 # Embassy support
 embassy              = ["esp-hal-common/embassy"]

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -56,7 +56,7 @@ p256              = {version = "0.13.2", default-features = false, features = ["
 embassy-sync       = "0.4.0"
 
 [features]
-default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
+default              = ["rt", "vectored", "zero-rtc-bss"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
 defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
@@ -67,6 +67,11 @@ log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
+
+# Initialize / clear data sections and RTC memory
+zero-rtc-bss         = ["esp-hal-common/rv-zero-rtc-bss"]
+init-data            = ["esp-hal-common/rv-init-data"]
+init-rtc-data        = ["esp-hal-common/rv-init-rtc-data"]
 
 # Embassy support
 embassy              = ["esp-hal-common/embassy"]

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -56,7 +56,7 @@ p256              = {version = "0.13.2", default-features = false, features = ["
 embassy-sync       = "0.4.0"
 
 [features]
-default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
+default              = ["rt", "vectored", "zero-rtc-bss"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
 defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
@@ -67,6 +67,11 @@ log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
+
+# Initialize / clear data sections and RTC memory
+zero-rtc-bss         = ["esp-hal-common/rv-zero-rtc-bss"]
+init-data            = ["esp-hal-common/rv-init-data"]
+init-rtc-data        = ["esp-hal-common/rv-init-rtc-data"]
 
 # Embassy support
 embassy              = ["esp-hal-common/embassy"]


### PR DESCRIPTION
There are more assumptions in this PR than I'd like but the point is the same: esp-wifi will no longer enable default features. To prevent depending on esp-hal-common, I'm introducing a new feature in place of `esp-hal-common/rv-zero-rtc-bss` to clear up esp-wifi examples.

cc https://github.com/esp-rs/esp-wifi/pull/303 that uncovered the need for this.