### PR TITLE
Fix Async UART

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,12 @@
   ],
 
   "[toml]": {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": false,
+  },
+  "[markdown]": {
+    "editor.formatOnSave": false,
+  },
+  "[jsonc]": {
+    "editor.formatOnSave": false,
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Xtensa targets: Use ESP32Reset - not Reset (#823)
 - Examples should now work with the `defmt` feature (#810)
 - Fixed a race condition causing SpiDma to stop working unexpectedly (#869)
+- Fixed async uart serial, and updated the embassy_serial examples (#871).
 
 ### Removed
 

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -8,18 +8,18 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32_hal::{
     clock::ClockControl,
-    embassy::{self},
+    embassy,
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
-    timer::TimerGroup,
     Uart,
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
-use heapless::Vec;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -27,8 +27,8 @@ const READ_BUF_SIZE: usize = 64;
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
-async fn writer(mut tx: UartTx<'static, UART0>) {
-    esp_println::println!("writing...");
+async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+    use core::fmt::Write;
     embedded_io_async::Write::write(
         &mut tx,
         b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -36,27 +36,30 @@ async fn writer(mut tx: UartTx<'static, UART0>) {
     .await
     .unwrap();
     embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    loop {
+        let bytes_read = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "\r\n-- received {} bytes --\r\n", bytes_read).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
 }
 
 #[embassy_executor::task]
-async fn reader(mut rx: UartRx<'static, UART0>) {
-    esp_println::println!("reading...");
-    // max message size to receive
-    // leave some extra space for AT-CMD characters
+async fn reader(mut rx: UartRx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
     const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
 
-    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut rbuf: [u8; MAX_BUFFER_SIZE] = [0u8; MAX_BUFFER_SIZE];
     let mut offset = 0;
-    while let Ok(len) = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await {
-        offset += len;
-        if offset == 0 {
-            rbuf.truncate(0);
-            break;
-        }
-        // if set_at_cmd is used than stop reading
-        if len < READ_BUF_SIZE {
-            rbuf.truncate(offset);
-            break;
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await;
+        match r {
+            Ok(len) => {
+                offset += len;
+                esp_println::println!("Read: {len}, data: {:?}", &rbuf[..offset]);
+                offset = 0;
+                signal.signal(len);
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
         }
     }
 }
@@ -68,8 +71,17 @@ async fn main(spawner: Spawner) {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    {
+        let timer_group0 = esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
@@ -80,6 +92,8 @@ async fn main(spawner: Spawner) {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    spawner.spawn(reader(rx)).ok();
-    spawner.spawn(writer(tx)).ok();
+    let signal = &*make_static!(Signal::new());
+
+    spawner.spawn(reader(rx, &signal)).ok();
+    spawner.spawn(writer(tx, &signal)).ok();
 }

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -47,6 +47,7 @@ crypto-bigint     = {version = "0.5.1", default-features = false }
 elliptic-curve    = {version = "0.13.4", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256              = {version = "0.13.2", default-features = false, features = ["arithmetic"] }
+embassy-sync       = "0.2.0"
 
 [features]
 default              = ["rt", "vectored", "xtal-40mhz"]

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -8,6 +8,7 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32c2_hal::{
     clock::ClockControl,
     embassy,
@@ -18,7 +19,7 @@ use esp32c2_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
-use heapless::Vec;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -26,8 +27,8 @@ const READ_BUF_SIZE: usize = 64;
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
-async fn writer(mut tx: UartTx<'static, UART0>) {
-    esp_println::println!("writing...");
+async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+    use core::fmt::Write;
     embedded_io_async::Write::write(
         &mut tx,
         b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -35,27 +36,30 @@ async fn writer(mut tx: UartTx<'static, UART0>) {
     .await
     .unwrap();
     embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    loop {
+        let bytes_read = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "\r\n-- received {} bytes --\r\n", bytes_read).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
 }
 
 #[embassy_executor::task]
-async fn reader(mut rx: UartRx<'static, UART0>) {
-    esp_println::println!("reading...");
-    // max message size to receive
-    // leave some extra space for AT-CMD characters
+async fn reader(mut rx: UartRx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
     const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
 
-    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut rbuf: [u8; MAX_BUFFER_SIZE] = [0u8; MAX_BUFFER_SIZE];
     let mut offset = 0;
-    while let Ok(len) = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await {
-        offset += len;
-        if offset == 0 {
-            rbuf.truncate(0);
-            break;
-        }
-        // if set_at_cmd is used than stop reading
-        if len < READ_BUF_SIZE {
-            rbuf.truncate(offset);
-            break;
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await;
+        match r {
+            Ok(len) => {
+                offset += len;
+                esp_println::println!("Read: {len}, data: {:?}", &rbuf[..offset]);
+                offset = 0;
+                signal.signal(len);
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
         }
     }
 }
@@ -74,10 +78,10 @@ async fn main(spawner: Spawner) {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
-    );
+    {
+        let timer_group0 = esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
@@ -88,6 +92,8 @@ async fn main(spawner: Spawner) {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    spawner.spawn(reader(rx)).ok();
-    spawner.spawn(writer(tx)).ok();
+    let signal = &*make_static!(Signal::new());
+
+    spawner.spawn(reader(rx, &signal)).ok();
+    spawner.spawn(writer(tx, &signal)).ok();
 }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -50,6 +50,7 @@ sha2               = { version = "0.10.7", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.1"
 static_cell        = { version = "1.2.0", features = ["nightly"] }
+embassy-sync       = "0.2.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -8,6 +8,7 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32c3_hal::{
     clock::ClockControl,
     embassy,
@@ -18,7 +19,7 @@ use esp32c3_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
-use heapless::Vec;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -26,8 +27,8 @@ const READ_BUF_SIZE: usize = 64;
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
-async fn writer(mut tx: UartTx<'static, UART0>) {
-    esp_println::println!("writing...");
+async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+    use core::fmt::Write;
     embedded_io_async::Write::write(
         &mut tx,
         b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -35,27 +36,30 @@ async fn writer(mut tx: UartTx<'static, UART0>) {
     .await
     .unwrap();
     embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    loop {
+        let bytes_read = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "\r\n-- received {} bytes --\r\n", bytes_read).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
 }
 
 #[embassy_executor::task]
-async fn reader(mut rx: UartRx<'static, UART0>) {
-    esp_println::println!("reading...");
-    // max message size to receive
-    // leave some extra space for AT-CMD characters
+async fn reader(mut rx: UartRx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
     const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
 
-    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut rbuf: [u8; MAX_BUFFER_SIZE] = [0u8; MAX_BUFFER_SIZE];
     let mut offset = 0;
-    while let Ok(len) = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await {
-        offset += len;
-        if offset == 0 {
-            rbuf.truncate(0);
-            break;
-        }
-        // if set_at_cmd is used than stop reading
-        if len < READ_BUF_SIZE {
-            rbuf.truncate(offset);
-            break;
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await;
+        match r {
+            Ok(len) => {
+                offset += len;
+                esp_println::println!("Read: {len}, data: {:?}", &rbuf[..offset]);
+                offset = 0;
+                signal.signal(len);
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
         }
     }
 }
@@ -74,10 +78,10 @@ async fn main(spawner: Spawner) {
     );
 
     #[cfg(feature = "embassy-time-timg0")]
-    embassy::init(
-        &clocks,
-        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
-    );
+    {
+        let timer_group0 = esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        embassy::init(&clocks, timer_group0.timer0);
+    }
 
     let mut uart0 = Uart::new(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
@@ -88,6 +92,8 @@ async fn main(spawner: Spawner) {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    spawner.spawn(reader(rx)).ok();
-    spawner.spawn(writer(tx)).ok();
+    let signal = &*make_static!(Signal::new());
+
+    spawner.spawn(reader(rx, &signal)).ok();
+    spawner.spawn(writer(tx, &signal)).ok();
 }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -53,6 +53,7 @@ hex-literal       = "0"
 elliptic-curve    = {version = "0.13.4", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256              = {version = "0.13.2", default-features = false, features = ["arithmetic"] }
+embassy-sync       = "0.2.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -8,6 +8,7 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32c6_hal::{
     clock::ClockControl,
     embassy,
@@ -18,7 +19,7 @@ use esp32c6_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
-use heapless::Vec;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -26,8 +27,8 @@ const READ_BUF_SIZE: usize = 64;
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
-async fn writer(mut tx: UartTx<'static, UART0>) {
-    esp_println::println!("writing...");
+async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+    use core::fmt::Write;
     embedded_io_async::Write::write(
         &mut tx,
         b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -35,33 +36,36 @@ async fn writer(mut tx: UartTx<'static, UART0>) {
     .await
     .unwrap();
     embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    loop {
+        let bytes_read = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "\r\n-- received {} bytes --\r\n", bytes_read).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
 }
 
 #[embassy_executor::task]
-async fn reader(mut rx: UartRx<'static, UART0>) {
-    esp_println::println!("reading...");
-    // max message size to receive
-    // leave some extra space for AT-CMD characters
+async fn reader(mut rx: UartRx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
     const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
 
-    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut rbuf: [u8; MAX_BUFFER_SIZE] = [0u8; MAX_BUFFER_SIZE];
     let mut offset = 0;
-    while let Ok(len) = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await {
-        offset += len;
-        if offset == 0 {
-            rbuf.truncate(0);
-            break;
-        }
-        // if set_at_cmd is used than stop reading
-        if len < READ_BUF_SIZE {
-            rbuf.truncate(offset);
-            break;
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await;
+        match r {
+            Ok(len) => {
+                offset += len;
+                esp_println::println!("Read: {len}, data: {:?}", &rbuf[..offset]);
+                offset = 0;
+                signal.signal(len);
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
         }
     }
 }
 
 #[main]
-async fn main(spawner: Spawner) -> ! {
+async fn main(spawner: Spawner) {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -88,6 +92,8 @@ async fn main(spawner: Spawner) -> ! {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    spawner.spawn(reader(rx)).ok();
-    spawner.spawn(writer(tx)).ok();
+    let signal = &*make_static!(Signal::new());
+
+    spawner.spawn(reader(rx, &signal)).ok();
+    spawner.spawn(writer(tx, &signal)).ok();
 }

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -53,6 +53,7 @@ hex-literal       = "0"
 elliptic-curve    = {version = "0.13.4", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256              = {version = "0.13.2", default-features = false, features = ["arithmetic"] }
+embassy-sync       = "0.2.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -8,6 +8,7 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32h2_hal::{
     clock::ClockControl,
     embassy,
@@ -18,7 +19,7 @@ use esp32h2_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
-use heapless::Vec;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -26,8 +27,8 @@ const READ_BUF_SIZE: usize = 64;
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
-async fn writer(mut tx: UartTx<'static, UART0>) {
-    esp_println::println!("writing...");
+async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+    use core::fmt::Write;
     embedded_io_async::Write::write(
         &mut tx,
         b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -35,27 +36,30 @@ async fn writer(mut tx: UartTx<'static, UART0>) {
     .await
     .unwrap();
     embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    loop {
+        let bytes_read = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "\r\n-- received {} bytes --\r\n", bytes_read).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
 }
 
 #[embassy_executor::task]
-async fn reader(mut rx: UartRx<'static, UART0>) {
-    esp_println::println!("reading...");
-    // max message size to receive
-    // leave some extra space for AT-CMD characters
+async fn reader(mut rx: UartRx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
     const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
 
-    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut rbuf: [u8; MAX_BUFFER_SIZE] = [0u8; MAX_BUFFER_SIZE];
     let mut offset = 0;
-    while let Ok(len) = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await {
-        offset += len;
-        if offset == 0 {
-            rbuf.truncate(0);
-            break;
-        }
-        // if set_at_cmd is used than stop reading
-        if len < READ_BUF_SIZE {
-            rbuf.truncate(offset);
-            break;
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await;
+        match r {
+            Ok(len) => {
+                offset += len;
+                esp_println::println!("Read: {len}, data: {:?}", &rbuf[..offset]);
+                offset = 0;
+                signal.signal(len);
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
         }
     }
 }
@@ -88,6 +92,8 @@ async fn main(spawner: Spawner) {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    spawner.spawn(reader(rx)).ok();
-    spawner.spawn(writer(tx)).ok();
+    let signal = &*make_static!(Signal::new());
+
+    spawner.spawn(reader(rx, &signal)).ok();
+    spawner.spawn(writer(tx, &signal)).ok();
 }

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -8,9 +8,10 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32s2_hal::{
     clock::ClockControl,
-    embassy::{self},
+    embassy,
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
@@ -18,7 +19,7 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
-use heapless::Vec;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -26,8 +27,8 @@ const READ_BUF_SIZE: usize = 64;
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
-async fn writer(mut tx: UartTx<'static, UART0>) {
-    esp_println::println!("writing...");
+async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+    use core::fmt::Write;
     embedded_io_async::Write::write(
         &mut tx,
         b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -35,27 +36,30 @@ async fn writer(mut tx: UartTx<'static, UART0>) {
     .await
     .unwrap();
     embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    loop {
+        let bytes_read = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "\r\n-- received {} bytes --\r\n", bytes_read).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
 }
 
 #[embassy_executor::task]
-async fn reader(mut rx: UartRx<'static, UART0>) {
-    esp_println::println!("reading...");
-    // max message size to receive
-    // leave some extra space for AT-CMD characters
+async fn reader(mut rx: UartRx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
     const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
 
-    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut rbuf: [u8; MAX_BUFFER_SIZE] = [0u8; MAX_BUFFER_SIZE];
     let mut offset = 0;
-    while let Ok(len) = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await {
-        offset += len;
-        if offset == 0 {
-            rbuf.truncate(0);
-            break;
-        }
-        // if set_at_cmd is used than stop reading
-        if len < READ_BUF_SIZE {
-            rbuf.truncate(offset);
-            break;
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await;
+        match r {
+            Ok(len) => {
+                offset += len;
+                esp_println::println!("Read: {len}, data: {:?}", &rbuf[..offset]);
+                offset = 0;
+                signal.signal(len);
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
         }
     }
 }
@@ -88,6 +92,8 @@ async fn main(spawner: Spawner) {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    spawner.spawn(reader(rx)).ok();
-    spawner.spawn(writer(tx)).ok();
+    let signal = &*make_static!(Signal::new());
+
+    spawner.spawn(reader(rx, &signal)).ok();
+    spawner.spawn(writer(tx, &signal)).ok();
 }

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -8,9 +8,10 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32s3_hal::{
     clock::ClockControl,
-    embassy::{self},
+    embassy,
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
@@ -18,7 +19,7 @@ use esp32s3_hal::{
 };
 use esp_backtrace as _;
 use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
-use heapless::Vec;
+use static_cell::make_static;
 
 // rx_fifo_full_threshold
 const READ_BUF_SIZE: usize = 64;
@@ -26,8 +27,8 @@ const READ_BUF_SIZE: usize = 64;
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
-async fn writer(mut tx: UartTx<'static, UART0>) {
-    esp_println::println!("writing...");
+async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+    use core::fmt::Write;
     embedded_io_async::Write::write(
         &mut tx,
         b"Hello async serial. Enter something ended with EOT (CTRL-D).\r\n",
@@ -35,27 +36,30 @@ async fn writer(mut tx: UartTx<'static, UART0>) {
     .await
     .unwrap();
     embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    loop {
+        let bytes_read = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "\r\n-- received {} bytes --\r\n", bytes_read).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
 }
 
 #[embassy_executor::task]
-async fn reader(mut rx: UartRx<'static, UART0>) {
-    esp_println::println!("reading...");
-    // max message size to receive
-    // leave some extra space for AT-CMD characters
+async fn reader(mut rx: UartRx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
     const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
 
-    let mut rbuf: Vec<u8, MAX_BUFFER_SIZE> = Vec::new();
+    let mut rbuf: [u8; MAX_BUFFER_SIZE] = [0u8; MAX_BUFFER_SIZE];
     let mut offset = 0;
-    while let Ok(len) = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await {
-        offset += len;
-        if offset == 0 {
-            rbuf.truncate(0);
-            break;
-        }
-        // if set_at_cmd is used than stop reading
-        if len < READ_BUF_SIZE {
-            rbuf.truncate(offset);
-            break;
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf[offset..]).await;
+        match r {
+            Ok(len) => {
+                offset += len;
+                esp_println::println!("Read: {len}, data: {:?}", &rbuf[..offset]);
+                offset = 0;
+                signal.signal(len);
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
         }
     }
 }
@@ -88,6 +92,8 @@ async fn main(spawner: Spawner) {
 
     interrupt::enable(Interrupt::UART0, interrupt::Priority::Priority1).unwrap();
 
-    spawner.spawn(reader(rx)).ok();
-    spawner.spawn(writer(tx)).ok();
+    let signal = &*make_static!(Signal::new());
+
+    spawner.spawn(reader(rx, &signal)).ok();
+    spawner.spawn(writer(tx, &signal)).ok();
 }


### PR DESCRIPTION
The uart handler was `writing` to the enable register instead of `modify`, which meant any wake would see the cleared enabled bit and think the event had occurred. This wasn't seen before the split of uart because it was only possible to listen to one thing at a time.

This PR also removes the ReadBufferFull error in favour of returning the max bytes in the buffer.

The serial examples have been updated actually to have some cross-task communication.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

Closes #850 