### PR TITLE
Fix/esp32s3 direct boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples should now work with the `defmt` feature (#810)
 - Fixed a race condition causing SpiDma to stop working unexpectedly (#869)
 - Fixed async uart serial, and updated the embassy_serial examples (#871).
+- Fix ESP32-S3 direct-boot (#873)
 
 ### Removed
 

--- a/esp32s3-hal/ld/db-esp32s3.x
+++ b/esp32s3-hal/ld/db-esp32s3.x
@@ -75,13 +75,13 @@ SECTIONS {
   .pre_header (NOLOAD) : AT(0)
   {
     . = . + 0x400;
-  }
+  } > irom_seg
 
-  .header ORIGIN(ROTEXT) : AT(0x400)
+  .header ORIGIN(ROTEXT) + 0x400 : AT(0x400)
   {
     LONG(0xaedb041d)
     LONG(0xaedb041d)
-  }
+  } > irom_seg
 
   .text ORIGIN(ROTEXT) + 0x408 : AT(0x408)
   {
@@ -94,17 +94,17 @@ SECTIONS {
     . = ALIGN (4);
     _text_end = ABSOLUTE(.);
     _etext = .;
-  }
+  } > REGION_TEXT
   _text_size = _etext - _stext;
 
   .rodata ORIGIN(RODATA) + 0x408 + _text_size : AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header))
   {
-    _rodata_start = ABSOLUTE(.);
     . = ALIGN (4);
+    _rodata_start = ABSOLUTE(.);
     *(.rodata .rodata.*)
     . = ALIGN (4);
     _rodata_end = ABSOLUTE(.);
-  }
+  } > REGION_RODATA
 
   .rwtext ORIGIN(RWTEXT) + 0x408 + _text_size + SIZEOF(.rodata) : 
       AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata))
@@ -153,7 +153,7 @@ SECTIONS {
 
     . = ALIGN (4);
     _erwtext = .;
-  }
+  } > REGION_RWTEXT
 
   .data ORIGIN(RWDATA) : 
       AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext))
@@ -163,7 +163,7 @@ SECTIONS {
     *(.data .data.*)
     . = ALIGN (4);
     _data_end = ABSOLUTE(.);
-  }
+  } > REGION_DATA
  
 
   /* LMA of .data */
@@ -176,21 +176,21 @@ SECTIONS {
     *(.bss .bss.* COMMON)
     . = ALIGN (4);
     _bss_end = ABSOLUTE(.);
-  } > RWDATA
+  } > REGION_BSS
 
   .noinit (NOLOAD) : ALIGN(4)
   {
     . = ALIGN(4);
     *(.noinit .noinit.*)
     . = ALIGN (4);
-  } > RWDATA
+  } > REGION_BSS
 
   /* must be last segment using RWDATA */
   .stack_end (NOLOAD) : ALIGN(4)
   {
     . = ALIGN (4);
     _stack_end = ABSOLUTE(.);
-  } > RWDATA
+  } > REGION_STACK
   
   .rtc_fast.text ORIGIN(rtc_fast_seg) : 
       AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit))
@@ -200,7 +200,7 @@ SECTIONS {
     *(.rtc_fast.literal .rtc_fast.text .rtc_fast.literal.* .rtc_fast.text.*)
    . = ALIGN(4);
    _rtc_fast_text_end = ABSOLUTE(.);
-  }
+  } > REGION_RTC_FAST
   _irtc_fast_text = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit);
  
   .rtc_fast.data ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) : 
@@ -211,7 +211,7 @@ SECTIONS {
     *(.rtc_fast.data .rtc_fast.data.*)
    . = ALIGN(4);
     _rtc_fast_data_end = ABSOLUTE(.);
-  }
+  } > REGION_RTC_FAST
   _irtc_fast_data = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit) + SIZEOF(.rtc_fast.text);
 
  .rtc_fast.bss ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) (NOLOAD) : 
@@ -222,14 +222,14 @@ SECTIONS {
     *(.rtc_fast.bss .rtc_fast.bss.*)
     . = ALIGN (4);
     _rtc_fast_bss_end = ABSOLUTE(.);
-  }
+  } > REGION_RTC_FAST
 
  .rtc_fast.noinit ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss) (NOLOAD)  :
   {
     . = ALIGN(4);
     *(.rtc_fast.noinit .rtc_fast.noinit.*)
     . = ALIGN (4);
-  }
+  } > REGION_RTC_FAST
 
  .rtc_slow.text ORIGIN(rtc_slow_seg) : 
     AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
@@ -240,7 +240,7 @@ SECTIONS {
     *(.rtc_slow.literal .rtc_slow.text .rtc_slow.literal.* .rtc_slow.text.*)
    . = ALIGN(4);
    _rtc_slow_text_end = ABSOLUTE(.);
-  }
+  } > REGION_RTC_SLOW
   _irtc_slow_text = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
       SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss);
 
@@ -253,7 +253,7 @@ SECTIONS {
     *(.rtc_slow.data .rtc_slow.data.*)
     . = ALIGN(4);
     _rtc_slow_data_end = ABSOLUTE(.);
-  }
+  } > REGION_RTC_SLOW
   _irtc_slow_data = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
         SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss) + SIZEOF(.rtc_slow.text);
 
@@ -266,12 +266,12 @@ SECTIONS {
     *(.rtc_slow.bss .rtc_slow.bss.*)
     . = ALIGN (4);
     _rtc_slow_bss_end = ABSOLUTE(.);
-  }
+  } > REGION_RTC_SLOW
 
  .rtc_slow.noinit ORIGIN(rtc_slow_seg) + SIZEOF(.rtc_slow.text) + SIZEOF(.rtc_slow.data) + SIZEOF(.rtc_slow.bss) (NOLOAD) :
   {
     . = ALIGN(4);
     *(.rtc_slow.noinit .rtc_slow.noinit.*)
     . = ALIGN (4);
-  }
+  } > REGION_RTC_SLOW
 }

--- a/esp32s3-hal/ld/db-esp32s3.x
+++ b/esp32s3-hal/ld/db-esp32s3.x
@@ -97,7 +97,7 @@ SECTIONS {
   }
   _text_size = _etext - _stext;
 
-  .rodata ORIGIN(RODATA) + 0x408 + _text_size :
+  .rodata ORIGIN(RODATA) + 0x408 + _text_size : AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header))
   {
     _rodata_start = ABSOLUTE(.);
     . = ALIGN (4);
@@ -106,7 +106,8 @@ SECTIONS {
     _rodata_end = ABSOLUTE(.);
   }
 
-  .rwtext ORIGIN(RWTEXT) + 0x408 + _text_size + SIZEOF(.rodata) :
+  .rwtext ORIGIN(RWTEXT) + 0x408 + _text_size + SIZEOF(.rodata) : 
+      AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata))
   {
     _irwtext = ORIGIN(RODATA) + 0x408 + _text_size + SIZEOF(.rodata);
     _srwtext = .;
@@ -155,6 +156,7 @@ SECTIONS {
   }
 
   .data ORIGIN(RWDATA) : 
+      AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext))
   {
     _data_start = ABSOLUTE(.);
     . = ALIGN (4);
@@ -162,9 +164,10 @@ SECTIONS {
     . = ALIGN (4);
     _data_end = ABSOLUTE(.);
   }
+ 
 
   /* LMA of .data */
-  _sidata = _erwtext - ORIGIN(RWTEXT) + ORIGIN(RODATA);
+  _sidata = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext);
 
   .bss (NOLOAD) : ALIGN(4)
   {
@@ -190,6 +193,7 @@ SECTIONS {
   } > RWDATA
   
   .rtc_fast.text ORIGIN(rtc_fast_seg) : 
+      AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit))
   {
    . = ALIGN(4);
    _rtc_fast_text_start = ABSOLUTE(.);
@@ -197,9 +201,10 @@ SECTIONS {
    . = ALIGN(4);
    _rtc_fast_text_end = ABSOLUTE(.);
   }
-  _irtc_fast_text = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext);
-
+  _irtc_fast_text = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit);
+ 
   .rtc_fast.data ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) : 
+      AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit) + SIZEOF(.rtc_fast.text) )
   {
     . = ALIGN(4);
     _rtc_fast_data_start = ABSOLUTE(.);
@@ -207,9 +212,10 @@ SECTIONS {
    . = ALIGN(4);
     _rtc_fast_data_end = ABSOLUTE(.);
   }
-  _irtc_fast_data = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.rtc_fast.text);
+  _irtc_fast_data = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit) + SIZEOF(.rtc_fast.text);
 
- .rtc_fast.bss ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) (NOLOAD) : 
+ .rtc_fast.bss ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) (NOLOAD) : 
+    AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data))
   {
     . = ALIGN(4);
     _rtc_fast_bss_start = ABSOLUTE(.);
@@ -218,7 +224,7 @@ SECTIONS {
     _rtc_fast_bss_end = ABSOLUTE(.);
   }
 
- .rtc_fast.noinit ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.bss) (NOLOAD)  :
+ .rtc_fast.noinit ORIGIN(rtc_fast_seg) + SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss) (NOLOAD)  :
   {
     . = ALIGN(4);
     *(.rtc_fast.noinit .rtc_fast.noinit.*)
@@ -226,6 +232,8 @@ SECTIONS {
   }
 
  .rtc_slow.text ORIGIN(rtc_slow_seg) : 
+    AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
+      SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss)) 
   {
    . = ALIGN(4);
    _rtc_slow_text_start = ABSOLUTE(.);
@@ -234,9 +242,11 @@ SECTIONS {
    _rtc_slow_text_end = ABSOLUTE(.);
   }
   _irtc_slow_text = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
-      SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.bss);
+      SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss);
 
   .rtc_slow.data ORIGIN(rtc_slow_seg) + SIZEOF(.rtc_slow.text) : 
+      AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
+        SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss) + SIZEOF(.rtc_slow.text))
   {
     . = ALIGN(4);
     _rtc_slow_data_start = ABSOLUTE(.);
@@ -245,9 +255,11 @@ SECTIONS {
     _rtc_slow_data_end = ABSOLUTE(.);
   }
   _irtc_slow_data = ORIGIN(RODATA) + _text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
-        SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.bss) + SIZEOF(.rtc_slow.text);
+        SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss) + SIZEOF(.rtc_slow.text);
 
  .rtc_slow.bss ORIGIN(rtc_slow_seg) + SIZEOF(.rtc_slow.text) + SIZEOF(.rtc_slow.data) (NOLOAD) : 
+    AT(_text_size + SIZEOF(.header) + SIZEOF(.pre_header) + SIZEOF(.rodata) + SIZEOF(.rwtext) + 
+      SIZEOF(.rtc_fast.text) + SIZEOF(.rtc_fast.data) + SIZEOF(.rtc_fast.bss) + SIZEOF(.rtc_slow.text) + SIZEOF(.rtc_slow.data))
   {
     . = ALIGN(4);
     _rtc_slow_bss_start = ABSOLUTE(.);

--- a/esp32s3-hal/ld/db-memory.x
+++ b/esp32s3-hal/ld/db-memory.x
@@ -29,3 +29,14 @@ MEMORY
   /* RTC slow memory (data accessible). Persists over deep sleep. */
   rtc_slow_seg(RW)       : ORIGIN = 0x50000000, len = 8k
 }
+
+REGION_ALIAS("REGION_TEXT", irom_seg);
+REGION_ALIAS("REGION_RODATA", drom_seg);
+
+REGION_ALIAS("REGION_DATA", dram_seg);
+REGION_ALIAS("REGION_BSS", dram_seg);
+REGION_ALIAS("REGION_STACK", dram_seg);
+
+REGION_ALIAS("REGION_RWTEXT", iram_seg);
+REGION_ALIAS("REGION_RTC_FAST", rtc_fast_seg);
+REGION_ALIAS("REGION_RTC_SLOW", rtc_slow_seg);


### PR DESCRIPTION
Fixes #824 

Also works with LLD now.
At least `hello_world` and `ram` examples work fine now - especially having the `ram` example work again makes me believe it's good
