### PR TITLE
Remove variable from s2 linker because it no longer exists

### DIFF
--- a/esp32s2-hal/ld/memory.x
+++ b/esp32s2-hal/ld/memory.x
@@ -38,5 +38,5 @@ MEMORY
   rtc_fast_dram_seg(RW)  : ORIGIN = 0x3ff9e000, len = 8k
 
   /* RTC slow memory (data accessible). Persists over deep sleep. */
-  rtc_slow_seg(RW)       : ORIGIN = 0x50000000 + RESERVE_RTC_SLOW, len = 8k - RESERVE_RTC_SLOW
+  rtc_slow_seg(RW)       : ORIGIN = 0x50000000, len = 8k
 }


### PR DESCRIPTION
Closes #874 

Skipping changelog because it was only broken a few commits ago
