### PR TITLE
Miscellaneous pre-release fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add UART support for splitting into TX and RX (#754)
 - Async support for I2S (#801)
 - Async support for PARL_IO (#807)
-- Implement `embeded_hal_async::delay::DelayUs` trait for `SYSTIMER` alarms (#812)
-  - This trait is NOT implemented when the `embassy-time-systick` feature is enabled!
 - ETM driver, GPIO ETM (#819)
 - (G)DMA AES support (#821)
 - SYSTIMER ETM functionality (#828)

--- a/esp-hal-common/.gitignore
+++ b/esp-hal-common/.gitignore
@@ -1,1 +1,0 @@
-rust-toolchain.toml

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -43,7 +43,7 @@ impl EmbassyTimer {
 
     fn on_interrupt(&self, id: usize) {
         critical_section::with(|cs| {
-            self.interrupt_clear(id);
+            self.clear_interrupt(id);
             self.trigger_alarm(id, cs);
         })
     }
@@ -96,11 +96,11 @@ impl EmbassyTimer {
         })
     }
 
-    fn interrupt_clear(&self, id: usize) {
+    fn clear_interrupt(&self, id: usize) {
         match id {
-            0 => self.alarm0.interrupt_clear(),
-            1 => self.alarm1.interrupt_clear(),
-            2 => self.alarm2.interrupt_clear(),
+            0 => self.alarm0.clear_interrupt(),
+            1 => self.alarm1.clear_interrupt(),
+            2 => self.alarm2.clear_interrupt(),
             _ => {}
         }
     }

--- a/esp-hal-common/src/rtc_cntl/sleep.rs
+++ b/esp-hal-common/src/rtc_cntl/sleep.rs
@@ -21,10 +21,9 @@
 
 use core::{cell::RefCell, time::Duration};
 
-use crate::{
-    gpio::{RTCPin, RTCPinWithResistors},
-    Rtc,
-};
+#[cfg(esp32c3)]
+use crate::gpio::RTCPinWithResistors;
+use crate::{gpio::RTCPin, Rtc};
 
 #[cfg_attr(esp32, path = "rtc/esp32_sleep.rs")]
 #[cfg_attr(esp32s3, path = "rtc/esp32s3_sleep.rs")]

--- a/esp-hal-common/src/sha.rs
+++ b/esp-hal-common/src/sha.rs
@@ -30,7 +30,7 @@
 //! ## Example
 //! ```no_run
 //! let source_data = "HELLO, ESPRESSIF!".as_bytes();
-//! let mut remaining = source_data.clone();
+//! let mut remaining = source_data;
 //! let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA256);
 //!
 //! // Short hashes can be created by decreasing the output buffer to the desired

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -272,7 +272,9 @@ impl<T> Alarm<T, 2> {
 //        interferes with the embassy time driver, which also uses the
 //        `SYSTIMER` peripheral. Until we come up with a solution, do not
 //        implement this trait if the `embassy-time-systick` feature is enabled.
-#[cfg(all(feature = "async", not(feature = "embassy-time-systick")))]
+// #[cfg(all(feature = "async", not(feature = "embassy-time-systick")))]
+// HACK: disable `asynch` module *always* until we come up with a solution
+#[cfg(not(systimer))]
 mod asynch {
     use core::{
         pin::Pin,

--- a/esp-hal-common/src/systimer.rs
+++ b/esp-hal-common/src/systimer.rs
@@ -128,7 +128,7 @@ impl<T, const CHANNEL: u8> Alarm<T, CHANNEL> {
         }
     }
 
-    pub fn interrupt_clear(&self) {
+    pub fn clear_interrupt(&self) {
         let systimer = unsafe { &*SYSTIMER::ptr() };
         match CHANNEL {
             0 => systimer.int_clr.write(|w| w.target0_int_clr().set_bit()),
@@ -297,7 +297,7 @@ mod asynch {
 
     impl<'a, const N: u8> AlarmFuture<'a, N> {
         pub(crate) fn new(alarm: &'a Alarm<Periodic, N>) -> Self {
-            alarm.interrupt_clear();
+            alarm.clear_interrupt();
             alarm.enable_interrupt(true);
 
             Self {

--- a/esp-riscv-rt/build.rs
+++ b/esp-riscv-rt/build.rs
@@ -1,6 +1,0 @@
-use std::{env, path::PathBuf};
-
-fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    println!("cargo:rustc-link-search={}", out_dir.display());
-}

--- a/esp32-hal/examples/sha.rs
+++ b/esp32-hal/examples/sha.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-    let mut remaining = source_data.clone();
+    let mut remaining = source_data;
     let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA512);
 
     // Short hashes can be created by decreasing the output buffer to the desired

--- a/esp32c2-hal/examples/systimer.rs
+++ b/esp32c2-hal/examples/systimer.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
-    alarm0.interrupt_clear();
+    alarm0.clear_interrupt();
     alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
@@ -85,7 +85,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -97,7 +97,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -109,6 +109,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }

--- a/esp32c3-hal/examples/systimer.rs
+++ b/esp32c3-hal/examples/systimer.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
-    alarm0.interrupt_clear();
+    alarm0.clear_interrupt();
     alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
@@ -85,7 +85,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -97,7 +97,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -109,6 +109,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }

--- a/esp32c6-hal/examples/systimer.rs
+++ b/esp32c6-hal/examples/systimer.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
-    alarm0.interrupt_clear();
+    alarm0.clear_interrupt();
     alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
@@ -85,7 +85,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -97,7 +97,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -109,6 +109,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }

--- a/esp32h2-hal/examples/systimer.rs
+++ b/esp32h2-hal/examples/systimer.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
 
     let alarm0 = syst.alarm0.into_periodic();
     alarm0.set_period(1u32.secs());
-    alarm0.interrupt_clear();
+    alarm0.clear_interrupt();
     alarm0.enable_interrupt(true);
 
     let alarm1 = syst.alarm1;
@@ -85,7 +85,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -97,7 +97,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -109,6 +109,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }

--- a/esp32s2-hal/examples/sha.rs
+++ b/esp32s2-hal/examples/sha.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-    let mut remaining = source_data.clone();
+    let mut remaining = source_data;
     let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA512);
 
     // Short hashes can be created by decreasing the output buffer to the desired

--- a/esp32s2-hal/examples/systimer.rs
+++ b/esp32s2-hal/examples/systimer.rs
@@ -84,7 +84,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -96,7 +96,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -108,6 +108,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }

--- a/esp32s3-hal/examples/sha.rs
+++ b/esp32s3-hal/examples/sha.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-    let mut remaining = source_data.clone();
+    let mut remaining = source_data;
     let mut hasher = Sha::new(peripherals.SHA, ShaMode::SHA512);
 
     // Short hashes can be created by decreasing the output buffer to the desired

--- a/esp32s3-hal/examples/systimer.rs
+++ b/esp32s3-hal/examples/systimer.rs
@@ -84,7 +84,7 @@ fn SYSTIMER_TARGET0() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -96,7 +96,7 @@ fn SYSTIMER_TARGET1() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }
 
@@ -108,6 +108,6 @@ fn SYSTIMER_TARGET2() {
             .borrow_ref_mut(cs)
             .as_mut()
             .unwrap()
-            .interrupt_clear()
+            .clear_interrupt()
     });
 }


### PR DESCRIPTION
- Temporarily disable the `embedded_hal_async::delay::DelayMs` implementation
    - This was causing issues with `esp-wifi`
    - I've just disabled the entire `asynch` module via a `#[cfg()]`, rather than removing the implementation altogether, as it _is_ a valid implementation.
- Remove a couple of old files which are not required
- Fix build warnings for `sha` examples 
- Fix build warning when not targeting ESP32-C3
- Rename `SYSTIMER`'s `interrupt_clear` function to `clear_interrupt`

I think this should put us in decent shape for our next round of releases. @MabezDev @bjoernQ lemme know if you can think of anything I'm forgetting, please.