### PR TITLE
Use `--examples` in most cases in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,21 +87,11 @@ jobs:
       - name: check esp32-hal (embassy)
         run: |
           cd esp32-hal/
-          cargo check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
-          cargo check --example=embassy_multicore --features=embassy,embassy-time-timg0,embassy-executor-thread
-          cargo check --example=embassy_multicore_interrupt --features=embassy,embassy-time-timg0,embassy-executor-interrupt
-          cargo check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+          cargo check --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
       - name: check esp32-hal (embassy, async)
         run: |
           cd esp32-hal/
-          cargo check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo check --example=embassy_i2s_read --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo check --example=embassy_i2s_sound --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo check --example=embassy_rmt_rx --features=embassy,embassy-time-timg0,async,embassy-executor-thread --release
-          cargo check --example=embassy_rmt_tx --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo check --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       - name: check esp32-hal (embassy, log/defmt)
         run: |
           cd esp32-hal/
@@ -141,21 +131,13 @@ jobs:
           cargo +nightly build --examples --features=eh1,ufmt,log
           cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c2-hal (async, systick)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
+        run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32c2-hal (async, timg0)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-timg0
-      - name: check esp32c2-hal (async, gpio)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_wait --features=embassy,embassy-time-systick,async
-      - name: check esp32c2-hal (async, spi)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_spi --features=embassy,embassy-time-systick,async
-      - name: check esp32c2-hal (async, serial)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_serial --features=embassy,embassy-time-systick,async
-      - name: check esp32c2-hal (async, i2c)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
+        run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0,async
       - name: check esp32c2-hal (interrupt-preemption)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=interrupt-preemption
       - name: check esp32c2-hal (direct-vectoring)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=direct-vectoring
       - name: check esp32c2-hal (embassy, log/defmt)
         run: |
           cd esp32c2-hal/
@@ -195,21 +177,15 @@ jobs:
           cargo +nightly build --examples --features=eh1,ufmt,log
           cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c3-hal (async, systick)
-        run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
+        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick
       - name: check esp32c3-hal (async, timg0)
-        run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-timg0
-      - name: check esp32c3-hal (async, gpio)
-        run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_wait --features=embassy,embassy-time-systick,async
-      - name: check esp32c3-hal (async, spi)
-        run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_spi --features=embassy,embassy-time-systick,async
-      - name: check esp32c3-hal (async, serial)
-        run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_serial --features=embassy,embassy-time-systick,async
-      - name: check esp32c3-hal (async, i2c)
-        run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
+        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0
+      - name: check esp32c3-hal (async)
+        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32c3-hal (interrupt-preemption)
-        run: cd esp32c3-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=interrupt-preemption
       - name: check esp32c3-hal (direct-vectoring)
-        run: cd esp32c3-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=direct-vectoring
       - name: check esp32c3-hal (embassy, log/defmt)
         run: |
           cd esp32c3-hal/
@@ -252,21 +228,15 @@ jobs:
           cargo +nightly build --examples --features=eh1,ufmt,log
           cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c6-hal (async, systick)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
+        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick
       - name: check esp32c6-hal (async, timg0)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-timg0
-      - name: check esp32c6-hal (async, gpio)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_wait --features=embassy,embassy-time-systick,async
-      - name: check esp32c6-hal (async, spi)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_spi --features=embassy,embassy-time-systick,async
-      - name: check esp32c6-hal (async, serial)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_serial --features=embassy,embassy-time-systick,async
-      - name: check esp32c6-hal (async, i2c)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
+        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0
+      - name: check esp32c6-hal (async)
+        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (interrupt-preemption)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=interrupt-preemption
       - name: check esp32c6-hal (direct-vectoring)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=direct-vectoring
       - name: check esp32c6-hal (embassy, log/defmt)
         run: |
           cd esp32c6-hal/
@@ -324,21 +294,15 @@ jobs:
           cargo +nightly build --examples --features=eh1,ufmt,log
           cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32h2-hal (async, systick)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-systick
+        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick
       - name: check esp32h2-hal (async, timg0)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_hello_world --features=embassy,embassy-time-timg0
-      - name: check esp32h2-hal (async, gpio)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_wait --features=embassy,embassy-time-systick,async
-      - name: check esp32h2-hal (async, spi)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_spi --features=embassy,embassy-time-systick,async
-      - name: check esp32h2-hal (async, serial)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_serial --features=embassy,embassy-time-systick,async
-      - name: check esp32h2-hal (async, i2c)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
+        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0
+      - name: check esp32h2-hal (async)
+        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32h2-hal (interrupt-preemption)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=interrupt-preemption
       - name: check esp32h2-hal (direct-vectoring)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=direct-vectoring
       - name: check esp32h2-hal (embassy, log/defmt)
         run: |
           cd esp32h2-hal/
@@ -407,31 +371,19 @@ jobs:
       - name: check esp32s2-hal (embassy, timg0)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
-          cargo +esp check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+          cargo +esp check --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
       - name: check esp32s2-hal (embassy, systick)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --example=embassy_hello_world --features=embassy,embassy-time-systick,embassy-executor-thread
-          cargo +esp check --example=embassy_multiprio --features=embassy,embassy-time-systick,embassy-executor-interrupt
+          cargo +esp check --examples --release --features=embassy,embassy-time-systick,embassy-executor-thread
       - name: check esp32s2-hal (embassy, timg0, async)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_i2s_read --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_i2s_sound --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_rmt_rx --features=embassy,embassy-time-timg0,async,embassy-executor-thread --release
-          cargo +esp check --example=embassy_rmt_tx --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo +esp check --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       - name: check esp32s2-hal (embassy, systick, async)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --example=embassy_wait --features=embassy,embassy-time-systick,async,embassy-executor-thread
-          cargo +esp check --example=embassy_spi --features=embassy,embassy-time-systick,async,embassy-executor-thread
-          cargo +esp check --example=embassy_serial --features=embassy,embassy-time-systick,async,embassy-executor-thread
-          cargo +esp check --example=embassy_i2c --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo +esp check --examples --release --features=embassy,embassy-time-systick,async,embassy-executor-thread
       - name: check esp32s2-hal (embassy, log/defmt)
         run: |
           cd esp32s2-hal/
@@ -483,35 +435,19 @@ jobs:
       - name: check esp32s3-hal (embassy, timg0)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --example=embassy_hello_world --features=embassy,embassy-time-timg0,embassy-executor-thread
-          cargo +esp check --example=embassy_multicore --features=embassy,embassy-time-timg0,embassy-executor-thread
-          cargo +esp check --example=embassy_multicore_interrupt --features=embassy,embassy-time-timg0,embassy-executor-interrupt
-          cargo +esp check --example=embassy_multiprio --features=embassy,embassy-time-timg0,embassy-executor-interrupt
+          cargo +esp check --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
       - name: check esp32s3-hal (embassy, systick)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --example=embassy_hello_world --features=embassy,embassy-time-systick,embassy-executor-thread
-          cargo +esp check --example=embassy_multicore --features=embassy,embassy-time-systick,embassy-executor-thread
-          cargo +esp check --example=embassy_multicore_interrupt --features=embassy,embassy-time-systick,embassy-executor-interrupt
-          cargo +esp check --example=embassy_multiprio --features=embassy,embassy-time-systick,embassy-executor-interrupt
+          cargo +esp check --examples --release --features=embassy,embassy-time-systick,embassy-executor-thread
       - name: check esp32s3-hal (embassy, timg0, async)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --example=embassy_wait --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_spi --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_serial --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_i2c --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_i2s_read --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_i2s_sound --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_rmt_rx --features=embassy,embassy-time-timg0,async,embassy-executor-thread
-          cargo +esp check --example=embassy_rmt_tx --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo +esp check --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       - name: check esp32s3-hal (embassy, systick, async)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --example=embassy_wait --features=embassy,embassy-time-systick,async,embassy-executor-thread
-          cargo +esp check --example=embassy_spi --features=embassy,embassy-time-systick,async,embassy-executor-thread
-          cargo +esp check --example=embassy_serial --features=embassy,embassy-time-systick,async,embassy-executor-thread
-          cargo +esp check --example=embassy_i2c --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo +esp check --examples --release --features=embassy,embassy-time-systick,async,embassy-executor-thread
       - name: check esp32s3-hal (octal psram and psram)
         run: | # This examples require release!
           cd esp32s3-hal/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,18 @@ jobs:
 
       # Check all RISC-V targets:
       - name: check (esp32c3)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c3
+        run: cd esp-hal-smartled/ && cargo +nightly build --features=esp32c3
       - name: check (esp32c6)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32c6
+        run: cd esp-hal-smartled/ && cargo +nightly build --features=esp32c6
       - name: check (esp32h2)
-        run: cd esp-hal-smartled/ && cargo +nightly check --features=esp32h2
+        run: cd esp-hal-smartled/ && cargo +nightly build --features=esp32h2
       # Check all Xtensa targets:
       - name: check (esp32)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32,xtal-40mhz
+        run: cd esp-hal-smartled/ && cargo +esp build --features=esp32,xtal-40mhz
       - name: check (esp32s2)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s2
+        run: cd esp-hal-smartled/ && cargo +esp build --features=esp32s2
       - name: check (esp32s3)
-        run: cd esp-hal-smartled/ && cargo +esp check --features=esp32s3
+        run: cd esp-hal-smartled/ && cargo +esp build --features=esp32s3
       # Ensure documentation can be built (requires a chip feature!)
       - name: rustdoc
         run: cd esp-hal-smartled/ && cargo doc --features=esp32c3,esp-hal-common/eh1
@@ -87,18 +87,18 @@ jobs:
       - name: check esp32-hal (embassy)
         run: |
           cd esp32-hal/
-          cargo check --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
+          cargo build --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
       - name: check esp32-hal (embassy, async)
         run: |
           cd esp32-hal/
-          cargo check --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo build --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       - name: check esp32-hal (embassy, log/defmt)
         run: |
           cd esp32-hal/
-          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
-          cargo check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
+          cargo build --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
+          cargo build --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
       - name: check esp32-hal (psram)
-        run: cd esp32-hal/ && cargo check --example=psram --features=psram-2m --release # This example requires release!
+        run: cd esp32-hal/ && cargo build --example=psram --features=psram-2m --release # This example requires release!
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32-hal/ && cargo doc --features=eh1
@@ -131,18 +131,18 @@ jobs:
           cargo +nightly build --examples --features=eh1,ufmt,log
           cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c2-hal (async, systick)
-        run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
+        run: cd esp32c2-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32c2-hal (async, timg0)
-        run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0,async
+        run: cd esp32c2-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-timg0,async
       - name: check esp32c2-hal (interrupt-preemption)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c2-hal/ && cargo +nightly build --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c2-hal (direct-vectoring)
-        run: cd esp32c2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c2-hal/ && cargo +nightly build --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c2-hal (embassy, log/defmt)
         run: |
           cd esp32c2-hal/
-          cargo +nightly check --examples --features=embassy,embassy-time-timg0,defmt
-          cargo +nightly check --examples --features=embassy,embassy-time-timg0,log
+          cargo +nightly build --examples --features=embassy,embassy-time-timg0,defmt
+          cargo +nightly build --examples --features=embassy,embassy-time-timg0,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c2-hal/ && cargo doc --features=eh1
@@ -177,20 +177,20 @@ jobs:
           cargo +nightly build --examples --features=eh1,ufmt,log
           cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c3-hal (async, systick)
-        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick
+        run: cd esp32c3-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-systick
       - name: check esp32c3-hal (async, timg0)
-        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0
+        run: cd esp32c3-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-timg0
       - name: check esp32c3-hal (async)
-        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
+        run: cd esp32c3-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (interrupt-preemption)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c6-hal/ && cargo +nightly build --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c6-hal (direct-vectoring)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c6-hal/ && cargo +nightly build --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c3-hal (embassy, log/defmt)
         run: |
           cd esp32c3-hal/
-          cargo +nightly check --examples --features=embassy,embassy-time-timg0,defmt
-          cargo +nightly check --examples --features=embassy,embassy-time-timg0,log
+          cargo +nightly build --examples --features=embassy,embassy-time-timg0,defmt
+          cargo +nightly build --examples --features=embassy,embassy-time-timg0,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c3-hal/ && cargo doc --features=eh1
@@ -228,20 +228,20 @@ jobs:
           cargo +nightly build --examples --features=eh1,ufmt,log
           cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32c6-hal (async, systick)
-        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick
+        run: cd esp32c6-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-systick
       - name: check esp32c6-hal (async, timg0)
-        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0
+        run: cd esp32c6-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-timg0
       - name: check esp32c6-hal (async)
-        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
+        run: cd esp32c6-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (interrupt-preemption)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32c6-hal/ && cargo +nightly build --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c6-hal (direct-vectoring)
-        run: cd esp32c6-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32c6-hal/ && cargo +nightly build --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c6-hal (embassy, log/defmt)
         run: |
           cd esp32c6-hal/
-          cargo +nightly check --examples --features=embassy,embassy-time-timg0,defmt
-          cargo +nightly check --examples --features=embassy,embassy-time-timg0,log
+          cargo +nightly build --examples --features=embassy,embassy-time-timg0,defmt
+          cargo +nightly build --examples --features=embassy,embassy-time-timg0,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32c6-hal/ && cargo doc --features=eh1
@@ -294,20 +294,20 @@ jobs:
           cargo +nightly build --examples --features=eh1,ufmt,log
           cargo +nightly build --examples --features=eh1,ufmt,defmt
       - name: check esp32h2-hal (async, systick)
-        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick
+        run: cd esp32h2-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-systick
       - name: check esp32h2-hal (async, timg0)
-        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0
+        run: cd esp32h2-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-timg0
       - name: check esp32h2-hal (async)
-        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
+        run: cd esp32h2-hal/ && cargo +nightly build --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32h2-hal (interrupt-preemption)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+        run: cd esp32h2-hal/ && cargo +nightly build --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32h2-hal (direct-vectoring)
-        run: cd esp32h2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
+        run: cd esp32h2-hal/ && cargo +nightly build --example=direct-vectoring --features=direct-vectoring
       - name: check esp32h2-hal (embassy, log/defmt)
         run: |
           cd esp32h2-hal/
-          cargo +nightly check --examples --features=embassy,embassy-time-timg0,defmt
-          cargo +nightly check --examples --features=embassy,embassy-time-timg0,log
+          cargo +nightly build --examples --features=embassy,embassy-time-timg0,defmt
+          cargo +nightly build --examples --features=embassy,embassy-time-timg0,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32h2-hal/ && cargo doc --features=eh1
@@ -367,30 +367,30 @@ jobs:
           cargo +esp build --examples --features=eh1,ufmt,defmt
       # FIXME: `time-systick` feature disabled for now, see 'esp32s2-hal/Cargo.toml'.
       # - name: check esp32s2-hal (async, systick)
-      #   run: cd esp32s2-hal/ && cargo check --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
+      #   run: cd esp32s2-hal/ && cargo build --example=embassy_hello_world --features=embassy,embassy-time-systick,executor
       - name: check esp32s2-hal (embassy, timg0)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
+          cargo +esp build --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
       - name: check esp32s2-hal (embassy, systick)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --examples --release --features=embassy,embassy-time-systick,embassy-executor-thread
+          cargo +esp build --examples --release --features=embassy,embassy-time-systick,embassy-executor-thread
       - name: check esp32s2-hal (embassy, timg0, async)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo +esp build --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       - name: check esp32s2-hal (embassy, systick, async)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --examples --release --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo +esp build --examples --release --features=embassy,embassy-time-systick,async,embassy-executor-thread
       - name: check esp32s2-hal (embassy, log/defmt)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
-          cargo +esp check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
+          cargo +esp build --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
+          cargo +esp build --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
       - name: check esp32s2-hal (psram)
-        run: cd esp32s2-hal/ && cargo +esp check --example=psram --features=psram-2m --release # This example requires release!
+        run: cd esp32s2-hal/ && cargo +esp build --example=psram --features=psram-2m --release # This example requires release!
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32s2-hal/ && cargo +esp doc --features=eh1
@@ -435,29 +435,29 @@ jobs:
       - name: check esp32s3-hal (embassy, timg0)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
+          cargo +esp build --examples --release --features=embassy,embassy-time-timg0,embassy-executor-thread
       - name: check esp32s3-hal (embassy, systick)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --examples --release --features=embassy,embassy-time-systick,embassy-executor-thread
+          cargo +esp build --examples --release --features=embassy,embassy-time-systick,embassy-executor-thread
       - name: check esp32s3-hal (embassy, timg0, async)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
+          cargo +esp build --examples --release --features=embassy,embassy-time-timg0,async,embassy-executor-thread
       - name: check esp32s3-hal (embassy, systick, async)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --examples --release --features=embassy,embassy-time-systick,async,embassy-executor-thread
+          cargo +esp build --examples --release --features=embassy,embassy-time-systick,async,embassy-executor-thread
       - name: check esp32s3-hal (octal psram and psram)
         run: | # This examples require release!
           cd esp32s3-hal/
-          cargo +esp check --example=octal_psram --features=opsram-2m --release
-          cargo +esp check --example=psram --features=psram-2m --release
+          cargo +esp build --example=octal_psram --features=opsram-2m --release
+          cargo +esp build --example=psram --features=psram-2m --release
       - name: check esp32s3-hal (embassy, log/defmt)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
-          cargo +esp check --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
+          cargo +esp build --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,defmt
+          cargo +esp build --examples --features=embassy,embassy-time-timg0,embassy-executor-interrupt,embassy-executor-thread,log
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp32s3-hal/ && cargo doc --features=eh1
@@ -475,9 +475,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check esp-riscv-rt (imc)
-        run: cd esp-riscv-rt/ && cargo check --target=riscv32imc-unknown-none-elf -Zbuild-std=core
+        run: cd esp-riscv-rt/ && cargo build --target=riscv32imc-unknown-none-elf -Zbuild-std=core
       - name: Check esp-riscv-rt (imac)
-        run: cd esp-riscv-rt/ && cargo check --target=riscv32imac-unknown-none-elf -Zbuild-std=core
+        run: cd esp-riscv-rt/ && cargo build --target=riscv32imac-unknown-none-elf -Zbuild-std=core
       # Ensure documentation can be built
       - name: rustdoc
         run: cd esp-riscv-rt/ && cargo doc
@@ -506,25 +506,25 @@ jobs:
       - name: msrv (esp32c2-hal)
         run: |
           cd esp32c2-hal/
-          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
-          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
+          RUSTC_BOOTSTRAP=1 cargo build --features=eh1,ufmt,log
+          RUSTC_BOOTSTRAP=1 cargo build --features=defmt
       - name: msrv (esp32c3-hal)
         run: |
           cd esp32c3-hal/
-          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
-          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
+          RUSTC_BOOTSTRAP=1 cargo build --features=eh1,ufmt,log
+          RUSTC_BOOTSTRAP=1 cargo build --features=defmt
       - name: msrv (esp32c6-hal)
         run: |
           cd esp32c6-hal/
-          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
-          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
+          RUSTC_BOOTSTRAP=1 cargo build --features=eh1,ufmt,log
+          RUSTC_BOOTSTRAP=1 cargo build --features=defmt
       - name: msrv (esp32c6-lp-hal)
         run: cd esp32c6-lp-hal/ && RUSTC_BOOTSTRAP=1 cargo check
       - name: msrv (esp32h2-hal)
         run: |
           cd esp32h2-hal/
-          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
-          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
+          RUSTC_BOOTSTRAP=1 cargo build --features=eh1,ufmt,log
+          RUSTC_BOOTSTRAP=1 cargo build --features=defmt
 
   msrv-xtensa:
     runs-on: ubuntu-latest
@@ -551,18 +551,18 @@ jobs:
       - name: msrv (esp32-hal)
         run: |
           cd esp32-hal/
-          cargo +esp check --features=eh1,ufmt,log
-          cargo +esp check --features=defmt
+          cargo +esp build --features=eh1,ufmt,log
+          cargo +esp build --features=defmt
       - name: msrv (esp32s2-hal)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --features=eh1,ufmt,log
-          cargo +esp check --features=defmt
+          cargo +esp build --features=eh1,ufmt,log
+          cargo +esp build --features=defmt
       - name: msrv (esp32s3-hal)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --features=eh1,ufmt,log
-          cargo +esp check --features=defmt
+          cargo +esp build --features=eh1,ufmt,log
+          cargo +esp build --features=defmt
 
   # --------------------------------------------------------------------------
   # Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,9 @@ jobs:
       - name: check esp32c2-hal (async, timg0)
         run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0,async
       - name: check esp32c2-hal (interrupt-preemption)
-        run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=interrupt-preemption
+        run: cd esp32c2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c2-hal (direct-vectoring)
-        run: cd esp32c2-hal/ && cargo +nightly check --examples --release --features=direct-vectoring
+        run: cd esp32c2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c2-hal (embassy, log/defmt)
         run: |
           cd esp32c2-hal/
@@ -182,10 +182,10 @@ jobs:
         run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-timg0
       - name: check esp32c3-hal (async)
         run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
-      - name: check esp32c3-hal (interrupt-preemption)
-        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=interrupt-preemption
-      - name: check esp32c3-hal (direct-vectoring)
-        run: cd esp32c3-hal/ && cargo +nightly check --examples --release --features=direct-vectoring
+      - name: check esp32c6-hal (interrupt-preemption)
+        run: cd esp32c6-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
+      - name: check esp32c6-hal (direct-vectoring)
+        run: cd esp32c6-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c3-hal (embassy, log/defmt)
         run: |
           cd esp32c3-hal/
@@ -234,9 +234,9 @@ jobs:
       - name: check esp32c6-hal (async)
         run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32c6-hal (interrupt-preemption)
-        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=interrupt-preemption
+        run: cd esp32c6-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c6-hal (direct-vectoring)
-        run: cd esp32c6-hal/ && cargo +nightly check --examples --release --features=direct-vectoring
+        run: cd esp32c6-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       - name: check esp32c6-hal (embassy, log/defmt)
         run: |
           cd esp32c6-hal/
@@ -300,9 +300,9 @@ jobs:
       - name: check esp32h2-hal (async)
         run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=embassy,embassy-time-systick,async
       - name: check esp32h2-hal (interrupt-preemption)
-        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=interrupt-preemption
+        run: cd esp32h2-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32h2-hal (direct-vectoring)
-        run: cd esp32h2-hal/ && cargo +nightly check --examples --release --features=direct-vectoring
+        run: cd esp32h2-hal/ && cargo +nightly check --example=direct-vectoring --features=direct-vectoring
       - name: check esp32h2-hal (embassy, log/defmt)
         run: |
           cd esp32h2-hal/

--- a/esp32c3-hal/examples/twai.rs
+++ b/esp32c3-hal/examples/twai.rs
@@ -4,11 +4,12 @@
 // Run this example with the eh1 feature enabled to use embedded-can instead of
 // embedded-hal-0.2.7. embedded-can was split off from embedded-hal before it's
 // upgrade to 1.0.0. cargo run --example twai --features eh1 --release
-#[cfg(feature = "eh1")]
+// Note: `async` also activates `eh1`
+#[cfg(any(feature = "eh1", feature = "async"))]
 use embedded_can::{nb::Can, Frame, Id};
 // Run this example without the eh1 flag to use the embedded-hal 0.2.7 CAN traits.
 // cargo run --example twai --release
-#[cfg(not(feature = "eh1"))]
+#[cfg(not(any(feature = "eh1", feature = "async")))]
 use embedded_hal::can::{Can, Frame, Id};
 use esp32c3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, twai};
 use esp_backtrace as _;

--- a/esp32s3-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s3-hal/examples/embassy_rmt_tx.rs
@@ -31,7 +31,7 @@ async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]

--- a/esp32s3-hal/examples/twai.rs
+++ b/esp32s3-hal/examples/twai.rs
@@ -19,11 +19,12 @@ const IS_FIRST_SENDER: bool = true;
 // Run this example with the eh1 feature enabled to use embedded-can instead of
 // embedded-hal-0.2.7. embedded-can was split off from embedded-hal before it's
 // upgrade to 1.0.0. cargo run --example twai --features eh1 --release
-#[cfg(feature = "eh1")]
+// Note: `async` also activates `eh1`
+#[cfg(any(feature = "eh1", feature = "async"))]
 use embedded_can::{nb::Can, Frame, StandardId};
 // Run this example without the eh1 flag to use the embedded-hal 0.2.7 CAN traits.
 // cargo run --example twai --release
-#[cfg(not(feature = "eh1"))]
+#[cfg(not(any(feature = "eh1", feature = "async")))]
 use embedded_hal::can::{Can, Frame, StandardId};
 use esp32s3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, twai};
 use esp_backtrace as _;


### PR DESCRIPTION
It's easy to forget to add an example to CI (I always forget that) - so instead of checking each `embassy_*` example separately use `--examples`. This might result in checking some examples multiple times (we do that already) I guess it's better for maintainance
