### PR TITLE
Async read implementation for usb serial jtag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,8 @@ jobs:
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_serial --features=embassy,embassy-time-systick,async
       - name: check esp32c3-hal (async, i2c)
         run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_i2c --features=embassy,embassy-time-systick,async
+      - name: check esp32c3-hal (async, usb_serial_jtag)
+        run: cd esp32c3-hal/ && cargo +nightly check --example=embassy_usb_serial_jtag --features=embassy,embassy-time-systick,async
       - name: check esp32c3-hal (interrupt-preemption)
         run: cd esp32c3-hal/ && cargo +nightly check --example=interrupt_preemption --features=interrupt-preemption
       - name: check esp32c3-hal (direct-vectoring)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support 16MB octal PS-RAM for ESP32-S3 (#858)
 - RISCV TRACE Encoder driver for ESP32-C6 / ESP32-H2 (#864)
 - `embedded_hal` 1 `InputPin` and `embedded_hal_async` `Wait` impls for open drain outputs (#905)
+- A `embedded_io_async::Read` implementation for `UsbSerialJtag` (#889)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Derive `Clone` and `Copy` for `EspTwaiFrame` (#914)
 - A way to configure inverted pins (#912)
 - Added API to check a GPIO-pin's interrupt status bit (#929)
+- A `embedded_io_async::Read` implementation for `UsbSerialJtag` (#889)
 
 ### Changed
 
@@ -72,7 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support 16MB octal PS-RAM for ESP32-S3 (#858)
 - RISCV TRACE Encoder driver for ESP32-C6 / ESP32-H2 (#864)
 - `embedded_hal` 1 `InputPin` and `embedded_hal_async` `Wait` impls for open drain outputs (#905)
-- A `embedded_io_async::Read` implementation for `UsbSerialJtag` (#889)
 
 ### Changed
 

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -132,5 +132,9 @@ name              = "embassy_i2s_read"
 required-features = ["embassy", "async"]
 
 [[example]]
+name              = "embassy_usb_serial_jtag"
+required-features = ["embassy", "async"]
+
+[[example]]
 name = "direct-vectoring"
 required-features = ["direct-vectoring"]

--- a/esp32c3-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/embassy_usb_serial_jtag.rs
@@ -50,12 +50,13 @@ async fn main(_spawner: Spawner) -> ! {
 
         match AsyncRead::read(&mut usb_serial, &mut read_buf).await {
             Ok(n) => {
-                AsyncWrite::write(&mut usb_serial, "echo: ".as_bytes())
+                AsyncWrite::write_all(&mut usb_serial, b"echo: ")
                     .await
                     .unwrap();
-                AsyncWrite::write(&mut usb_serial, &read_buf[..n])
+                AsyncWrite::write_all(&mut usb_serial, &read_buf[..n])
                     .await
                     .unwrap();
+                AsyncWrite::write_all(&mut usb_serial, b"\n").await.unwrap();
             }
             Err(e) => esp_println::println!("error: {e}"),
         }

--- a/esp32c3-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/embassy_usb_serial_jtag.rs
@@ -1,0 +1,63 @@
+//! This shows how to read and write text via USB Serial/JTAG using embassy.
+//! You need to connect via the Serial/JTAG interface to see any output.
+//! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
+//! This will work with the ESP32-C3-DevKit-RUST-1
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::Spawner;
+use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
+use esp32c3_hal::{
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    UsbSerialJtag,
+};
+use esp_backtrace as _;
+
+#[main]
+async fn main(_spawner: Spawner) -> ! {
+    esp_println::println!("Init!");
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    #[cfg(feature = "embassy-time-systick")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+    );
+
+    #[cfg(feature = "embassy-time-timg0")]
+    embassy::init(
+        &clocks,
+        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+    );
+
+    esp32c3_hal::interrupt::enable(
+        esp32c3_hal::peripherals::Interrupt::USB_DEVICE,
+        esp32c3_hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
+
+    loop {
+        let mut read_buf = [0; 64];
+
+        match AsyncRead::read(&mut usb_serial, &mut read_buf).await {
+            Ok(n) => {
+                AsyncWrite::write(&mut usb_serial, "echo: ".as_bytes())
+                    .await
+                    .unwrap();
+                AsyncWrite::write(&mut usb_serial, &read_buf[..n])
+                    .await
+                    .unwrap();
+            }
+            Err(e) => esp_println::println!("error: {e}"),
+        }
+    }
+}

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -140,3 +140,7 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_parl_io_rx"
 required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_usb_serial_jtag"
+required-features = ["embassy", "async"]

--- a/esp32c6-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32c6-hal/examples/embassy_usb_serial_jtag.rs
@@ -1,7 +1,6 @@
 //! This shows how to read and write text via USB Serial/JTAG using embassy.
 //! You need to connect via the Serial/JTAG interface to see any output.
 //! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
-//! This will work with the ESP32-C3-DevKit-RUST-1
 
 #![no_std]
 #![no_main]
@@ -9,7 +8,7 @@
 
 use embassy_executor::Spawner;
 use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
-use esp32c3_hal::{
+use esp32c6_hal::{
     clock::ClockControl,
     embassy,
     interrupt,
@@ -29,13 +28,13 @@ async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+        esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     interrupt::enable(

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -140,3 +140,7 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_parl_io_rx"
 required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_usb_serial_jtag"
+required-features = ["embassy", "async"]

--- a/esp32h2-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32h2-hal/examples/embassy_usb_serial_jtag.rs
@@ -1,7 +1,6 @@
 //! This shows how to read and write text via USB Serial/JTAG using embassy.
 //! You need to connect via the Serial/JTAG interface to see any output.
 //! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
-//! This will work with the ESP32-C3-DevKit-RUST-1
 
 #![no_std]
 #![no_main]
@@ -9,7 +8,7 @@
 
 use embassy_executor::Spawner;
 use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
-use esp32c3_hal::{
+use esp32h2_hal::{
     clock::ClockControl,
     embassy,
     interrupt,
@@ -29,13 +28,13 @@ async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32h2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+        esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     interrupt::enable(

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -151,3 +151,7 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2s_read"
 required-features = ["embassy", "async"]
+
+[[example]]
+name              = "embassy_usb_serial_jtag"
+required-features = ["embassy", "async"]

--- a/esp32s3-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/embassy_usb_serial_jtag.rs
@@ -1,7 +1,6 @@
 //! This shows how to read and write text via USB Serial/JTAG using embassy.
 //! You need to connect via the Serial/JTAG interface to see any output.
 //! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
-//! This will work with the ESP32-C3-DevKit-RUST-1
 
 #![no_std]
 #![no_main]
@@ -9,7 +8,7 @@
 
 use embassy_executor::Spawner;
 use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
-use esp32c3_hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     embassy,
     interrupt,
@@ -29,13 +28,13 @@ async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     embassy::init(
         &clocks,
-        esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
+        esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0,
     );
 
     interrupt::enable(

--- a/esp32s3-hal/examples/usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/usb_serial_jtag.rs
@@ -1,8 +1,6 @@
 //! This shows how to output text via USB Serial/JTAG.
 //! You need to connect via the Serial/JTAG interface to see any output.
 //! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
-//! PLEASE NOTE: USB Serial input on ESP32-S3 is not currently working
-//! See https://github.com/esp-rs/esp-hal/issues/269 for details
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
This is an attempt at adding an async read implementation for usb_serial_jtag to complement the existing async write implementation. I'm pretty unsure about whether I'm doing the interrupt handling correctly, but I did at least check that a basic implementation works.

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
