### PR TITLE
Make sure BLE and WiFi are not powered down when esp-wifi needs them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- ESP32-C3: Make sure BLE and WiFi are not powered down when esp-wifi needs them (#891)
 
 ### Removed
 

--- a/esp-hal-common/src/soc/esp32c3/radio_clocks.rs
+++ b/esp-hal-common/src/soc/esp32c3/radio_clocks.rs
@@ -89,6 +89,16 @@ fn reset_mac() {
 }
 
 fn init_clocks() {
+    // undo the power down in base_settings (esp32c3_sleep)
+    let rtc_cntl = unsafe { crate::peripherals::RTC_CNTL::steal() };
+    rtc_cntl
+        .dig_iso
+        .modify(|_, w| w.wifi_force_iso().clear_bit().bt_force_iso().clear_bit());
+
+    rtc_cntl
+        .dig_pwc
+        .modify(|_, w| w.wifi_force_pd().clear_bit().bt_force_pd().clear_bit());
+
     // from `esp_perip_clk_init`
     const SYSTEM_WIFI_CLK_I2C_CLK_EN: u32 = 1 << 5;
     const SYSTEM_WIFI_CLK_UNUSED_BIT12: u32 = 1 << 12;


### PR DESCRIPTION
In https://github.com/esp-rs/esp-wifi/pull/296#issuecomment-1788479618 it was discovered that BLE on ESP32-C3 doesn't work anymore.

This fixes the problem
