### PR TITLE
S3: Fix the number of GPIO pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - ESP32-C2/C3 examples: fix build error (#899)
+- ESP32-S3: Fix GPIO interrupt handler crashing when using GPIO48. (#898)
 
 ### Removed
 

--- a/esp-hal-common/src/soc/esp32s3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s3/gpio.rs
@@ -52,7 +52,7 @@ use crate::{
     peripherals::GPIO,
 };
 
-pub const NUM_PINS: usize = 48;
+pub const NUM_PINS: usize = 49;
 
 pub type OutputSignalType = u16;
 pub const OUTPUT_SIGNAL_MAX: u16 = 256;


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.

Fixes #897 

Pins are numbered 0..48, with some numbers missing in the middle. Using `GPIO_NUM = 48` meant that [this array](https://github.com/esp-rs/esp-hal/blob/a8fbc03e2679a583bde27f44104015d4ff1b89dc/esp-hal-common/src/gpio.rs#L2353) had one fewer element than required.