### PR TITLE
Pin static_cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ESP32-C2/C3 examples: fix build error (#899)
+
 ### Removed
 
 ## [0.13.1] - 2023-11-02

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -47,7 +47,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "1.2.0", features = ["nightly"] }
+static_cell        = { version = "=1.2.0", features = ["nightly"] }
 
 [features]
 default            = ["rt", "vectored", "xtal-40mhz"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -41,7 +41,7 @@ heapless           = "0.7.16"
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 ssd1306            = "0.8.4"
-static_cell        = { version = "1.2.0", features = ["nightly"] }
+static_cell        = { version = "=1.2.0", features = ["nightly"] }
 hex-literal       = "0.4.1"
 crypto-bigint     = {version = "0.5.3", default-features = false }
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -49,7 +49,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "1.2.0", features = ["nightly"] }
+static_cell        = { version = "=1.2.0", features = ["nightly"] }
 embassy-sync       = "0.3.0"
 
 [features]

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -48,7 +48,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "1.2.0", features = ["nightly"] }
+static_cell        = { version = "=1.2.0", features = ["nightly"] }
 hex-literal       = "0.4.1"
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -48,7 +48,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "1.2.0", features = ["nightly"] }
+static_cell        = { version = "=1.2.0", features = ["nightly"] }
 hex-literal       = "0.4.1"
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -49,7 +49,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "1.2.0", features = ["nightly"] }
+static_cell        = { version = "=1.2.0", features = ["nightly"] }
 usb-device         = "0.2.9"
 usbd-serial        = "0.1.1"
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -51,7 +51,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "1.2.0", features = ["nightly"] }
+static_cell        = { version = "=1.2.0", features = ["nightly"] }
 usb-device         = "0.2.9"
 usbd-serial        = "0.1.1"
 


### PR DESCRIPTION
static_cell 1.3 was released yesterday dropping atomic-polyfill in favour of portable-atomic. Unfortunately, portable-atomic isn't compatible with something in RISC-V atomic emulation. This PR pins the old version as a band-aid so CI can stay blissfully ignorant.

Xtensa targets should be fine without this PR but I've pinned those to stay consistent with RV.