### PR TITLE
RISC-V: Make atomic emulation opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,25 +628,26 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
+          target: riscv32imc-unknown-none-elf, riscv32imac-unknown-none-elf
           toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@v2
 
       # Run clippy on all packages targeting RISC-V.
       - name: clippy (esp-riscv-rt)
-        run: cargo +stable clippy --manifest-path=esp-riscv-rt/Cargo.toml -- -D warnings
+        run: cd esp-riscv-rt && cargo +stable clippy -- -D warnings
       - name: clippy (esp32c2-hal)
-        run: cargo +stable clippy --manifest-path=esp32c2-hal/Cargo.toml -- -D warnings
+        run: cd esp32c2-hal && cargo +stable clippy -- -D warnings
       - name: clippy (esp32c3-hal)
-        run: cargo +stable clippy --manifest-path=esp32c3-hal/Cargo.toml -- -D warnings
+        run: cd esp32c3-hal && cargo +stable clippy -- -D warnings
       - name: clippy (esp32c6-hal)
-        run: cargo +stable clippy --manifest-path=esp32c6-hal/Cargo.toml -- -D warnings
+        run: cd esp32c6-hal && cargo +stable clippy -- -D warnings
       - name: clippy (esp32c6-lp-hal)
-        run: cargo +stable clippy --manifest-path=esp32c6-lp-hal/Cargo.toml -- -D warnings -A asm-sub-register
+        run: cd esp32c6-lp-hal && cargo +stable clippy -- -D warnings -A asm-sub-register
       - name: clippy (esp32h2-hal)
-        run: cargo +stable clippy --manifest-path=esp32h2-hal/Cargo.toml -- -D warnings
+        run: cd esp32h2-hal && cargo +stable clippy -- -D warnings
       - name: clippy (esp-ulp-riscv-hal)
-        run: cargo +stable clippy --manifest-path=esp-ulp-riscv-hal/Cargo.toml --features=esp32s3 -- -D warnings -A asm-sub-register
+        run: cd esp-ulp-riscv-hal && cargo +stable clippy --features=esp32s3 -- -D warnings -A asm-sub-register
 
   clippy-xtensa:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- C2, C3: atomic emulation trap is now opt-in and `esp-hal` now uses `portable-atomic` by default (#904)
+- C2, C3: atomic emulation trap is now opt-in (#904)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- C2, C3: atomic emulation trap is now opt-in and `esp-hal` now uses `portable-atomic` by default (#904)
+
 ### Fixed
 
 - ESP32-C2/C3 examples: fix build error (#899)

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -40,9 +40,9 @@ riscv-atomic-emulation-trap  = { version = "0.4.1", optional = true }
 # async
 embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-io-async  = { version = "0.6.0", optional = true }
-embassy-executor   = { version = "0.3.0", optional = true, features = ["integrated-timers"] }
+embassy-executor   = { version = "0.3.2", optional = true, features = ["integrated-timers"] }
 embassy-futures    = { version = "0.1.0", optional = true }
-embassy-sync       = { version = "0.3.0", optional = true }
+embassy-sync       = { version = "0.4.0", optional = true }
 embassy-time       = { version = "0.1.5", optional = true, features = ["nightly"] }
 
 # RISC-V

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -33,6 +33,10 @@ strum                = { version = "0.25.0", default-features = false, features 
 void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
 
+# atomic polyfill options
+portable-atomic              = { version = "1.5.1", default-features = false, optional = true }
+riscv-atomic-emulation-trap  = { version = "0.4.1", optional = true }
+
 # async
 embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
 embedded-io-async  = { version = "0.6.0", optional = true }
@@ -43,7 +47,6 @@ embassy-time       = { version = "0.1.5", optional = true, features = ["nightly"
 
 # RISC-V
 esp-riscv-rt                = { version = "0.5.0", optional = true, path = "../esp-riscv-rt" }
-riscv-atomic-emulation-trap = { version = "0.4.1", optional = true }
 
 # Xtensa
 xtensa-lx    = { version = "0.8.0",  optional = true }
@@ -125,8 +128,12 @@ embassy-time-systick = []
 embassy-time-timg0   = []
 
 # Architecture-specific features (intended for internal use)
-riscv  = ["critical-section/restore-state-u8", "esp-riscv-rt", "esp-riscv-rt/zero-bss", "riscv-atomic-emulation-trap"]
+riscv  = ["critical-section/restore-state-u8", "esp-riscv-rt", "esp-riscv-rt/zero-bss"]
 xtensa = ["critical-section/restore-state-u32"]
+
+portable-atomic = ["dep:portable-atomic"]
+riscv-atomic-emulation = ["dep:riscv-atomic-emulation-trap", "atomic-emulation"]
+atomic-emulation = []
 
 # Initialize / clear data sections and RTC memory
 rv-init-data     = ["esp-riscv-rt/init-data", "esp-riscv-rt/init-rw-text"]

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -72,11 +72,11 @@ serde      = { version = "1.0.190", features = ["derive"] }
 
 [features]
 esp32   = ["xtensa", "esp32/rt",   "procmacros/esp32",   "xtensa-lx/esp32",   "xtensa-lx-rt/esp32"]
-esp32c2 = ["riscv",  "esp32c2/rt", "procmacros/esp32c2"]
-esp32c3 = ["riscv",  "esp32c3/rt", "procmacros/esp32c3"]
+esp32c2 = ["riscv",  "esp32c2/rt", "procmacros/esp32c2", "portable-atomic?/unsafe-assume-single-core"]
+esp32c3 = ["riscv",  "esp32c3/rt", "procmacros/esp32c3", "portable-atomic?/unsafe-assume-single-core"]
 esp32c6 = ["riscv",  "esp32c6/rt", "procmacros/esp32c6"]
 esp32h2 = ["riscv",  "esp32h2/rt", "procmacros/esp32h2"]
-esp32s2 = ["xtensa", "esp32s2/rt", "procmacros/esp32s2", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2", "usb-otg"]
+esp32s2 = ["xtensa", "esp32s2/rt", "procmacros/esp32s2", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2", "usb-otg", "portable-atomic?/unsafe-assume-single-core"]
 esp32s3 = ["xtensa", "esp32s3/rt", "procmacros/esp32s3", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "usb-otg"]
 
 # Crystal frequency selection (ESP32 and ESP32-C2 only!)

--- a/esp-hal-common/src/analog/adc/riscv.rs
+++ b/esp-hal-common/src/analog/adc/riscv.rs
@@ -687,8 +687,6 @@ macro_rules! impl_adc_interface {
     }
 }
 
-pub use implementation::*;
-
 #[cfg(esp32c2)]
 mod implementation {
     //! # Analog to digital (ADC) conversion support.
@@ -722,7 +720,7 @@ mod implementation {
     //! }
     //! ```
 
-    pub use crate::analog::ADC1;
+    use crate::analog::ADC1;
 
     impl_adc_interface! {
         ADC1 [
@@ -769,7 +767,7 @@ mod implementation {
     //! }
     //! ```
 
-    pub use crate::analog::{ADC1, ADC2};
+    use crate::analog::{ADC1, ADC2};
 
     impl_adc_interface! {
         ADC1 [
@@ -821,7 +819,7 @@ mod implementation {
     //! }
     //! ```
 
-    pub use crate::analog::ADC1;
+    use crate::analog::ADC1;
 
     impl_adc_interface! {
         ADC1 [
@@ -869,7 +867,7 @@ mod implementation {
     //! }
     //! ```
 
-    pub use crate::analog::ADC1;
+    use crate::analog::ADC1;
 
     impl_adc_interface! {
         ADC1 [

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -1153,11 +1153,13 @@ pub(crate) mod asynch {
         }
     }
 
+    #[cfg(any(i2s0, i2s1))]
     pub struct DmaTxDoneChFuture<'a, TX> {
         pub(crate) tx: &'a mut TX,
         _a: (),
     }
 
+    #[cfg(any(i2s0, i2s1))]
     impl<'a, TX> DmaTxDoneChFuture<'a, TX>
     where
         TX: Tx,
@@ -1168,6 +1170,7 @@ pub(crate) mod asynch {
         }
     }
 
+    #[cfg(any(i2s0, i2s1))]
     impl<'a, TX> core::future::Future for DmaTxDoneChFuture<'a, TX>
     where
         TX: Tx,
@@ -1187,11 +1190,13 @@ pub(crate) mod asynch {
         }
     }
 
+    #[cfg(any(i2s0, i2s1))]
     pub struct DmaRxDoneChFuture<'a, RX> {
         pub(crate) rx: &'a mut RX,
         _a: (),
     }
 
+    #[cfg(any(i2s0, i2s1))]
     impl<'a, RX> DmaRxDoneChFuture<'a, RX>
     where
         RX: Rx,
@@ -1202,6 +1207,7 @@ pub(crate) mod asynch {
         }
     }
 
+    #[cfg(any(i2s0, i2s1))]
     impl<'a, RX> core::future::Future for DmaRxDoneChFuture<'a, RX>
     where
         RX: Rx,

--- a/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/interrupt.rs
@@ -1,14 +1,14 @@
 //! Multicore-aware interrupt-mode executor.
-use core::{
-    cell::UnsafeCell,
-    marker::PhantomData,
-    mem::MaybeUninit,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use core::{cell::UnsafeCell, marker::PhantomData, mem::MaybeUninit};
 
 use embassy_executor::{raw, SendSpawner};
 
-use crate::{get_core, interrupt, peripherals, peripherals::SYSTEM};
+use crate::{
+    atomic::{AtomicUsize, Ordering},
+    get_core,
+    interrupt,
+    peripherals::{self, SYSTEM},
+};
 
 static FROM_CPU_IRQ_USED: AtomicUsize = AtomicUsize::new(0);
 

--- a/esp-hal-common/src/embassy/executor/xtensa/thread.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/thread.rs
@@ -1,12 +1,13 @@
 //! Multicore-aware thread-mode embassy executor.
-use core::{
-    marker::PhantomData,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use core::marker::PhantomData;
 
 use embassy_executor::{raw, Spawner};
 
-use crate::{get_core, prelude::interrupt};
+use crate::{
+    atomic::{AtomicBool, Ordering},
+    get_core,
+    prelude::interrupt,
+};
 #[cfg(multi_core)]
 use crate::{
     interrupt,

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -86,15 +86,15 @@ impl EmbassyTimer {
 
     pub(crate) fn set_alarm(
         &self,
-        alarm: embassy_time::driver::AlarmHandle,
+        _alarm: embassy_time::driver::AlarmHandle,
         timestamp: u64,
     ) -> bool {
-        critical_section::with(|cs| {
+        critical_section::with(|_cs| {
             // The hardware fires the alarm even if timestamp is lower than the current
             // time. In this case the interrupt handler will pend a wakeup when we exit the
             // critical section.
             #[cfg(any(esp32, esp32s2, esp32s3))]
-            if alarm.id() == 1 {
+            if _alarm.id() == 1 {
                 let mut tg = unsafe { Timer1::<TIMG0>::steal() };
                 Self::arm(&mut tg, timestamp);
                 return;

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -463,85 +463,89 @@ pub unsafe extern "C" fn start_trap_rust_hal(trap_frame: *mut TrapFrame) {
 /// This function is called from an trap handler.
 #[doc(hidden)]
 unsafe fn handle_exception(pc: usize, trap_frame: *mut TrapFrame) {
-    let insn: usize = *(pc as *const _);
-    let needs_atomic_emulation = (insn & 0b1111111) == 0b0101111;
-    if !needs_atomic_emulation {
-        extern "C" {
-            fn ExceptionHandler(tf: *mut TrapFrame);
-        }
-        ExceptionHandler(trap_frame);
+    #[cfg(feature = "atomic-emulation")]
+    {
+        let insn: usize = *(pc as *const _);
+        let needs_atomic_emulation = (insn & 0b1111111) == 0b0101111;
+        if needs_atomic_emulation {
+            let mut frame = [
+                0,
+                (*trap_frame).ra,
+                (*trap_frame).sp,
+                (*trap_frame).gp,
+                (*trap_frame).tp,
+                (*trap_frame).t0,
+                (*trap_frame).t1,
+                (*trap_frame).t2,
+                (*trap_frame).s0,
+                (*trap_frame).s1,
+                (*trap_frame).a0,
+                (*trap_frame).a1,
+                (*trap_frame).a2,
+                (*trap_frame).a3,
+                (*trap_frame).a4,
+                (*trap_frame).a5,
+                (*trap_frame).a6,
+                (*trap_frame).a7,
+                (*trap_frame).s2,
+                (*trap_frame).s3,
+                (*trap_frame).s4,
+                (*trap_frame).s5,
+                (*trap_frame).s6,
+                (*trap_frame).s7,
+                (*trap_frame).s8,
+                (*trap_frame).s9,
+                (*trap_frame).s10,
+                (*trap_frame).s11,
+                (*trap_frame).t3,
+                (*trap_frame).t4,
+                (*trap_frame).t5,
+                (*trap_frame).t6,
+            ];
 
-        return;
+            riscv_atomic_emulation_trap::atomic_emulation((*trap_frame).pc, &mut frame);
+
+            (*trap_frame).ra = frame[1];
+            (*trap_frame).sp = frame[2];
+            (*trap_frame).gp = frame[3];
+            (*trap_frame).tp = frame[4];
+            (*trap_frame).t0 = frame[5];
+            (*trap_frame).t1 = frame[6];
+            (*trap_frame).t2 = frame[7];
+            (*trap_frame).s0 = frame[8];
+            (*trap_frame).s1 = frame[9];
+            (*trap_frame).a0 = frame[10];
+            (*trap_frame).a1 = frame[11];
+            (*trap_frame).a2 = frame[12];
+            (*trap_frame).a3 = frame[13];
+            (*trap_frame).a4 = frame[14];
+            (*trap_frame).a5 = frame[15];
+            (*trap_frame).a6 = frame[16];
+            (*trap_frame).a7 = frame[17];
+            (*trap_frame).s2 = frame[18];
+            (*trap_frame).s3 = frame[19];
+            (*trap_frame).s4 = frame[20];
+            (*trap_frame).s5 = frame[21];
+            (*trap_frame).s6 = frame[22];
+            (*trap_frame).s7 = frame[23];
+            (*trap_frame).s8 = frame[24];
+            (*trap_frame).s9 = frame[25];
+            (*trap_frame).s10 = frame[26];
+            (*trap_frame).s11 = frame[27];
+            (*trap_frame).t3 = frame[28];
+            (*trap_frame).t4 = frame[29];
+            (*trap_frame).t5 = frame[30];
+            (*trap_frame).t6 = frame[31];
+            (*trap_frame).pc = pc + 4;
+
+            return;
+        }
     }
 
-    let mut frame = [
-        0,
-        (*trap_frame).ra,
-        (*trap_frame).sp,
-        (*trap_frame).gp,
-        (*trap_frame).tp,
-        (*trap_frame).t0,
-        (*trap_frame).t1,
-        (*trap_frame).t2,
-        (*trap_frame).s0,
-        (*trap_frame).s1,
-        (*trap_frame).a0,
-        (*trap_frame).a1,
-        (*trap_frame).a2,
-        (*trap_frame).a3,
-        (*trap_frame).a4,
-        (*trap_frame).a5,
-        (*trap_frame).a6,
-        (*trap_frame).a7,
-        (*trap_frame).s2,
-        (*trap_frame).s3,
-        (*trap_frame).s4,
-        (*trap_frame).s5,
-        (*trap_frame).s6,
-        (*trap_frame).s7,
-        (*trap_frame).s8,
-        (*trap_frame).s9,
-        (*trap_frame).s10,
-        (*trap_frame).s11,
-        (*trap_frame).t3,
-        (*trap_frame).t4,
-        (*trap_frame).t5,
-        (*trap_frame).t6,
-    ];
-    riscv_atomic_emulation_trap::atomic_emulation((*trap_frame).pc, &mut frame);
-
-    (*trap_frame).ra = frame[1];
-    (*trap_frame).sp = frame[2];
-    (*trap_frame).gp = frame[3];
-    (*trap_frame).tp = frame[4];
-    (*trap_frame).t0 = frame[5];
-    (*trap_frame).t1 = frame[6];
-    (*trap_frame).t2 = frame[7];
-    (*trap_frame).s0 = frame[8];
-    (*trap_frame).s1 = frame[9];
-    (*trap_frame).a0 = frame[10];
-    (*trap_frame).a1 = frame[11];
-    (*trap_frame).a2 = frame[12];
-    (*trap_frame).a3 = frame[13];
-    (*trap_frame).a4 = frame[14];
-    (*trap_frame).a5 = frame[15];
-    (*trap_frame).a6 = frame[16];
-    (*trap_frame).a7 = frame[17];
-    (*trap_frame).s2 = frame[18];
-    (*trap_frame).s3 = frame[19];
-    (*trap_frame).s4 = frame[20];
-    (*trap_frame).s5 = frame[21];
-    (*trap_frame).s6 = frame[22];
-    (*trap_frame).s7 = frame[23];
-    (*trap_frame).s8 = frame[24];
-    (*trap_frame).s9 = frame[25];
-    (*trap_frame).s10 = frame[26];
-    (*trap_frame).s11 = frame[27];
-    (*trap_frame).t3 = frame[28];
-    (*trap_frame).t4 = frame[29];
-    (*trap_frame).t5 = frame[30];
-    (*trap_frame).t6 = frame[31];
-    (*trap_frame).pc = pc + 4;
+    extern "C" {
+        fn ExceptionHandler(tf: *mut TrapFrame);
+    }
+    ExceptionHandler(trap_frame);
 }
 
 #[doc(hidden)]

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -461,11 +461,10 @@ pub unsafe extern "C" fn start_trap_rust_hal(trap_frame: *mut TrapFrame) {
 /// # Safety
 ///
 /// This function is called from an trap handler.
-#[doc(hidden)]
-unsafe fn handle_exception(pc: usize, trap_frame: *mut TrapFrame) {
+unsafe fn handle_exception(_pc: usize, trap_frame: *mut TrapFrame) {
     #[cfg(feature = "atomic-emulation")]
     {
-        let insn: usize = *(pc as *const _);
+        let insn: usize = *(_pc as *const _);
         let needs_atomic_emulation = (insn & 0b1111111) == 0b0101111;
         if needs_atomic_emulation {
             let mut frame = [

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -161,11 +161,14 @@ pub mod trapframe {
 // be directly exposed.
 mod soc;
 
-#[cfg(any(has_native_atomic_support, feature = "atomic-emulation"))]
-use core::sync::atomic;
+#[allow(unused_imports)]
+mod atomic {
+    #[cfg(any(has_native_atomic_support, feature = "atomic-emulation"))]
+    pub use core::sync::atomic::*;
 
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
+    #[cfg(feature = "portable-atomic")]
+    pub use portable_atomic::*;
+}
 
 #[no_mangle]
 extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -26,7 +26,7 @@
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]
 #![cfg_attr(
     feature = "async",
-    allow(incomplete_features),
+    allow(incomplete_features, stable_features, unknown_lints, async_fn_in_trait),
     feature(async_fn_in_trait),
     feature(impl_trait_projections)
 )]

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -161,6 +161,12 @@ pub mod trapframe {
 // be directly exposed.
 mod soc;
 
+#[cfg(any(has_native_atomic_support, feature = "atomic-emulation"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
 #[no_mangle]
 extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {
     #[cfg(feature = "log")]
@@ -317,7 +323,7 @@ mod critical_section_impl {
 
     #[cfg(multi_core)]
     mod multicore {
-        use core::sync::atomic::{AtomicUsize, Ordering};
+        use crate::atomic::{AtomicUsize, Ordering};
 
         // We're using a value that we know get_raw_core() will never return. This
         // avoids an unnecessary increment of the core ID.

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -32,8 +32,8 @@ embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.0", features = ["nightly"] }
-embassy-sync       = "0.3.0"
+embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-sync       = "0.4.0"
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -47,7 +47,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "=1.2.0", features = ["nightly"] }
+static_cell        = { version = "2.0.0", features = ["nightly"] }
 
 [features]
 default            = ["rt", "vectored", "xtal-40mhz"]

--- a/esp32-hal/examples/embassy_i2c.rs
+++ b/esp32-hal/examples/embassy_i2c.rs
@@ -21,7 +21,7 @@ use esp32_hal::{
     embassy::{self},
     i2c::I2C,
     interrupt,
-    peripherals::{Interrupt, Peripherals, I2C0},
+    peripherals::{Interrupt, Peripherals},
     prelude::*,
     timer::TimerGroup,
     IO,

--- a/esp32-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Spi, SpiBusController},
+        master::{Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32-hal/examples/spi_eh1_loopback.rs
+++ b/esp32-hal/examples/spi_eh1_loopback.rs
@@ -22,10 +22,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32-hal/examples/spi_loopback.rs
+++ b/esp32-hal/examples/spi_loopback.rs
@@ -21,10 +21,7 @@ use esp32_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/.cargo/config.toml
+++ b/esp32c2-hal/.cargo/config.toml
@@ -3,22 +3,6 @@ runner = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "force-frame-pointers",
-
-  # comment the cfgs below if you do _not_ wish to emulate atomics.
-  # enable the atomic codegen option for RISCV
-  "-C", "target-feature=+a",
-  # tell the core library have atomics even though it's not specified in the target definition
-  "--cfg", "target_has_atomic_load_store",
-  "--cfg", 'target_has_atomic_load_store="8"',
-  "--cfg", 'target_has_atomic_load_store="16"',
-  "--cfg", 'target_has_atomic_load_store="32"',
-  "--cfg", 'target_has_atomic_load_store="ptr"',
-  # enable cas
-  "--cfg", "target_has_atomic",
-  "--cfg", 'target_has_atomic="8"',
-  "--cfg", 'target_has_atomic="16"',
-  "--cfg", 'target_has_atomic="32"',
-  "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [build]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -27,6 +27,7 @@ categories = [
 [dependencies]
 esp-hal-common = { version = "0.13.0", features = ["esp32c2"], path = "../esp-hal-common" }
 embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
+portable-atomic = { version = "1.5.1",  features = ["unsafe-assume-single-core"], optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"
@@ -41,7 +42,7 @@ heapless           = "0.7.16"
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 ssd1306            = "0.8.4"
-static_cell        = { version = "=1.2.0", features = ["nightly"] }
+static_cell        = { version = "2.0.0", features = ["nightly"] }
 hex-literal       = "0.4.1"
 crypto-bigint     = {version = "0.5.3", default-features = false }
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
@@ -50,7 +51,7 @@ p256              = {version = "0.13.2", default-features = false, features = ["
 embassy-sync       = "0.3.0"
 
 [features]
-default              = ["rt", "vectored", "xtal-40mhz"]
+default              = ["rt", "vectored", "xtal-40mhz", "portable-atomic"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
 defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
@@ -68,6 +69,9 @@ xtal-40mhz           = ["esp-hal-common/xtal-40mhz"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]
+
+portable-atomic  = ["dep:portable-atomic", "esp-hal-common/portable-atomic"]
+atomic-emulation = ["esp-hal-common/riscv-atomic-emulation"]
 
 [profile.release]
 debug = true

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -31,7 +31,7 @@ portable-atomic = { version = "1.5.1",  features = ["unsafe-assume-single-core"]
 
 [dev-dependencies]
 critical-section   = "1.1.2"
-embassy-executor   = { version = "0.3.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-executor   = { version = "0.3.2", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
@@ -48,7 +48,7 @@ crypto-bigint     = {version = "0.5.3", default-features = false }
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256              = {version = "0.13.2", default-features = false, features = ["arithmetic"] }
-embassy-sync       = "0.3.0"
+embassy-sync       = "0.4.0"
 
 [features]
 default              = ["rt", "vectored", "xtal-40mhz", "portable-atomic"]

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -27,7 +27,6 @@ categories = [
 [dependencies]
 esp-hal-common = { version = "0.13.0", features = ["esp32c2"], path = "../esp-hal-common" }
 embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
-portable-atomic = { version = "1.5.1",  features = ["unsafe-assume-single-core"], optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"
@@ -42,7 +41,9 @@ heapless           = "0.7.16"
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 ssd1306            = "0.8.4"
+portable-atomic    = "1.5.1"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
+esp-hal-common     = { features = ["portable-atomic"], path = "../esp-hal-common" } # enable portable-atomic by default for examples
 hex-literal       = "0.4.1"
 crypto-bigint     = {version = "0.5.3", default-features = false }
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
@@ -51,7 +52,7 @@ p256              = {version = "0.13.2", default-features = false, features = ["
 embassy-sync       = "0.4.0"
 
 [features]
-default              = ["rt", "vectored", "xtal-40mhz", "portable-atomic"]
+default              = ["rt", "vectored", "xtal-40mhz"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
 defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
@@ -70,7 +71,7 @@ embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]
 
-portable-atomic  = ["dep:portable-atomic", "esp-hal-common/portable-atomic"]
+portable-atomic  = ["esp-hal-common/portable-atomic"]
 atomic-emulation = ["esp-hal-common/riscv-atomic-emulation"]
 
 [profile.release]

--- a/esp32c2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Spi, SpiBusController},
+        master::{Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32c2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c2-hal/examples/spi_eh1_loopback.rs
@@ -22,10 +22,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32c2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c2-hal/examples/spi_loopback.rs
+++ b/esp32c2-hal/examples/spi_loopback.rs
@@ -21,10 +21,7 @@ use esp32c2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/.cargo/config.toml
+++ b/esp32c3-hal/.cargo/config.toml
@@ -3,22 +3,6 @@ runner = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "force-frame-pointers",
-
-  # comment the cfgs below if you do _not_ wish to emulate atomics.
-  # enable the atomic codegen option for RISCV
-  "-C", "target-feature=+a",
-  # tell the core library have atomics even though it's not specified in the target definition
-  "--cfg", "target_has_atomic_load_store",
-  "--cfg", 'target_has_atomic_load_store="8"',
-  "--cfg", 'target_has_atomic_load_store="16"',
-  "--cfg", 'target_has_atomic_load_store="32"',
-  "--cfg", 'target_has_atomic_load_store="ptr"',
-  # enable cas
-  "--cfg", "target_has_atomic",
-  "--cfg", 'target_has_atomic="8"',
-  "--cfg", 'target_has_atomic="16"',
-  "--cfg", 'target_has_atomic="32"',
-  "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [build]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -28,6 +28,7 @@ categories = [
 cfg-if         = "1.0.0"
 esp-hal-common = { version = "0.13.0", features = ["esp32c3"], path = "../esp-hal-common" }
 embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
+portable-atomic = { version = "1.5.1",  features = ["unsafe-assume-single-core"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -49,11 +50,11 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "=1.2.0", features = ["nightly"] }
+static_cell        = { version = "2.0.0", features = ["nightly"] }
 embassy-sync       = "0.3.0"
 
 [features]
-default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
+default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss", "portable-atomic"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
 defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
@@ -70,6 +71,9 @@ vectored             = ["esp-hal-common/vectored"]
 embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
+
+portable-atomic  = ["dep:portable-atomic", "esp-hal-common/portable-atomic"]
+atomic-emulation = ["esp-hal-common/riscv-atomic-emulation"]
 
 [profile.release]
 debug = true

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -28,7 +28,6 @@ categories = [
 cfg-if         = "1.0.0"
 esp-hal-common = { version = "0.13.0", features = ["esp32c3"], path = "../esp-hal-common" }
 embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
-portable-atomic = { version = "1.5.1",  features = ["unsafe-assume-single-core"], optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -50,11 +49,13 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
+portable-atomic    = "1.5.1"
+esp-hal-common     = { features = ["portable-atomic"], path = "../esp-hal-common" } # enable portable-atomic by default for examples
 static_cell        = { version = "2.0.0", features = ["nightly"] }
 embassy-sync       = "0.4.0"
 
 [features]
-default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss", "portable-atomic"]
+default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]
 async                = ["esp-hal-common/async"]
 debug                = ["esp-hal-common/debug"]
 defmt                = ["esp-hal-common/defmt", "esp-println/defmt"]
@@ -72,7 +73,7 @@ embassy              = ["esp-hal-common/embassy"]
 embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
 embassy-time-timg0   = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
-portable-atomic  = ["dep:portable-atomic", "esp-hal-common/portable-atomic"]
+portable-atomic  = ["esp-hal-common/portable-atomic"]
 atomic-emulation = ["esp-hal-common/riscv-atomic-emulation"]
 
 [profile.release]

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -34,7 +34,7 @@ portable-atomic = { version = "1.5.1",  features = ["unsafe-assume-single-core"]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-executor   = { version = "0.3.2", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-can       = "0.4.1"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
@@ -51,7 +51,7 @@ sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
-embassy-sync       = "0.3.0"
+embassy-sync       = "0.4.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss", "portable-atomic"]

--- a/esp32c3-hal/examples/embassy_hello_world.rs
+++ b/esp32c3-hal/examples/embassy_hello_world.rs
@@ -11,7 +11,6 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c3_hal::{clock::ClockControl, embassy, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
-use static_cell::make_static;
 
 #[embassy_executor::task]
 async fn run() {

--- a/esp32c3-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Spi, SpiBusController},
+        master::{Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32c3-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c3-hal/examples/spi_eh1_loopback.rs
@@ -22,10 +22,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c3-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c3-hal/examples/spi_loopback.rs
+++ b/esp32c3-hal/examples/spi_loopback.rs
@@ -21,10 +21,7 @@ use esp32c3_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -48,7 +48,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "=1.2.0", features = ["nightly"] }
+static_cell        = { version = "2.0.0", features = ["nightly"] }
 hex-literal       = "0.4.1"
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -33,7 +33,7 @@ embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false}
-embassy-executor   = { version = "0.3.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-executor   = { version = "0.3.2", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
@@ -53,7 +53,7 @@ hex-literal       = "0.4.1"
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256              = {version = "0.13.2", default-features = false, features = ["arithmetic"] }
-embassy-sync       = "0.3.0"
+embassy-sync       = "0.4.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c6-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Spi, SpiBusController},
+        master::{Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32c6-hal/examples/spi_eh1_loopback.rs
+++ b/esp32c6-hal/examples/spi_eh1_loopback.rs
@@ -22,10 +22,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32c6-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32c6_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32c6-hal/examples/spi_loopback.rs
+++ b/esp32c6-hal/examples/spi_loopback.rs
@@ -21,10 +21,7 @@ use esp32c6_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -48,7 +48,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "=1.2.0", features = ["nightly"] }
+static_cell        = { version = "2.0.0", features = ["nightly"] }
 hex-literal       = "0.4.1"
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -33,7 +33,7 @@ embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.0", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
+embassy-executor   = { version = "0.3.2", features = ["nightly", "integrated-timers", "arch-riscv32", "executor-thread"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"
@@ -53,7 +53,7 @@ hex-literal       = "0.4.1"
 elliptic-curve    = {version = "0.13.6", default-features = false, features = ["sec1"] }
 p192              = {version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256              = {version = "0.13.2", default-features = false, features = ["arithmetic"] }
-embassy-sync       = "0.3.0"
+embassy-sync       = "0.4.0"
 
 [features]
 default              = ["rt", "vectored", "esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32h2-hal/examples/spi_eh1_device_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_device_loopback.rs
@@ -25,7 +25,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Spi, SpiBusController},
+        master::{Spi, SpiBusController},
         SpiMode,
     },
     Delay,

--- a/esp32h2-hal/examples/spi_eh1_loopback.rs
+++ b/esp32h2-hal/examples/spi_eh1_loopback.rs
@@ -22,10 +22,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
+++ b/esp32h2-hal/examples/spi_halfduplex_read_manufacturer_id.rs
@@ -23,7 +23,7 @@ use esp32h2_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Address, Command, HalfDuplexReadWrite, Spi},
+        master::{Address, Command, HalfDuplexReadWrite, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/esp32h2-hal/examples/spi_loopback.rs
+++ b/esp32h2-hal/examples/spi_loopback.rs
@@ -21,10 +21,7 @@ use esp32h2_hal::{
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     Delay,
 };
 use esp_backtrace as _;

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -49,7 +49,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "=1.2.0", features = ["nightly"] }
+static_cell        = { version = "2.0.0", features = ["nightly"] }
 usb-device         = "0.2.9"
 usbd-serial        = "0.1.1"
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -33,8 +33,8 @@ xtensa-atomic-emulation-trap = "0.4.0"
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.0", features = ["nightly"] }
-embassy-sync       = "0.3.0"
+embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-sync       = "0.4.0"
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.1"

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -64,6 +64,8 @@ rt        = []
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
 
+portable-atomic  = ["esp-hal-common/portable-atomic"]
+
 # Embassy support
 embassy = ["esp-hal-common/embassy"]
 embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-80_000_000"] 

--- a/esp32s2-hal/examples/clock_monitor.rs
+++ b/esp32s2-hal/examples/clock_monitor.rs
@@ -17,7 +17,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_atomic_emulation_trap as _;
 
 static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
 

--- a/esp32s2-hal/examples/embassy_hello_world.rs
+++ b/esp32s2-hal/examples/embassy_hello_world.rs
@@ -16,7 +16,6 @@ use esp32s2_hal::{
     prelude::*,
 };
 use esp_backtrace as _;
-use xtensa_atomic_emulation_trap as _;
 
 #[embassy_executor::task]
 async fn run() {

--- a/esp32s2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_rx.rs
@@ -19,7 +19,6 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use esp_hal_common::gpio::{Gpio15, Output, PushPull};
 use esp_println::{print, println};
-use xtensa_atomic_emulation_trap as _;
 
 const WIDTH: usize = 80;
 

--- a/esp32s2-hal/examples/embassy_rmt_tx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_tx.rs
@@ -18,7 +18,6 @@ use esp32s2_hal::{
 };
 use esp_backtrace as _;
 use esp_println::println;
-use xtensa_atomic_emulation_trap as _;
 
 #[main]
 async fn main(_spawner: Spawner) -> ! {

--- a/esp32s2-hal/examples/i2c_display.rs
+++ b/esp32s2-hal/examples/i2c_display.rs
@@ -30,7 +30,6 @@ use esp32s2_hal::{
 use esp_backtrace as _;
 use nb::block;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
-use xtensa_atomic_emulation_trap as _;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s2-hal/examples/ledc.rs
+++ b/esp32s2-hal/examples/ledc.rs
@@ -20,7 +20,6 @@ use esp32s2_hal::{
     prelude::*,
 };
 use esp_backtrace as _;
-use xtensa_atomic_emulation_trap as _;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -48,8 +48,6 @@
 
 use esp_hal_common::xtensa_lx_rt::exception::ExceptionCause;
 pub use esp_hal_common::*;
-// Always enable atomic emulation on ESP32-S2
-use xtensa_atomic_emulation_trap as _;
 
 /// Function initializes ESP32 specific memories (RTC slow and fast) and
 /// then calls original Reset function

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -51,7 +51,7 @@ lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-static_cell        = { version = "=1.2.0", features = ["nightly"] }
+static_cell        = { version = "2.0.0", features = ["nightly"] }
 usb-device         = "0.2.9"
 usbd-serial        = "0.1.1"
 

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -33,8 +33,8 @@ r0             = { version = "1.0.0",  optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.0", features = ["nightly"] }
-embassy-sync       = "0.3.0"
+embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-sync       = "0.4.0"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
 embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.

Let's try to make portable-atomic work by default and demote atomic emulation traps on risc-v. Xtensa is left untouched because, due to a happy accident, it works with atomic-polyfill and trying to remove emulation causes a bunch of problems in multiple crates.

I've updated CI so Clippy now runs on the target folder, using the correct target. This is required because otherwise `portable-atomic` doesn't allow enabling the `unstable-assume-single-core` feature - which is annoying, but fair when clippy wants to target the host architecture.

The current idea is, that neither atomic emulation, nor portable-atomic is enabled by default. The portable-atomic feature in esp-hal isn't very useful for RISC-V, but we may (barring ULP...) enable `unsafe-assume-single-core` or other default features. Besides that, I've kept the feature just to detect mutual exclusivity with the emulation trap. I may be overthinking this part, though, I'm not sure.