### PR TITLE
Add more input trait impls for open drain outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a `defmt` feature to the `esp-hal-smartled` package (#846)
 - Support 16MB octal PS-RAM for ESP32-S3 (#858)
 - RISCV TRACE Encoder driver for ESP32-C6 / ESP32-H2 (#864)
+- `embedded_hal` 1 `InputPin` and `embedded_hal_async` `Wait` impls for open drain outputs (#905)
 
 ### Changed
 


### PR DESCRIPTION
This adds `embedded_hal_1::digital::InputPin` and `embedded_hal_async::Wait` implementations for `GpioPin<Output<OpenDrain>, _>`. Previously, there was only an impl of `embedded_hal::digital::v2::InputPin`, so I'm assuming that the others were just left out unintentionally.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
