### PR TITLE
Fix `us` waits in embassy hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ESP32-C2/C3 examples: fix build error (#899)
 - ESP32-S3: Fix GPIO interrupt handler crashing when using GPIO48. (#898)
+- Fixed short wait times in embassy causing hangs (#906)
 
 ### Removed
 

--- a/esp-hal-common/src/embassy/mod.rs
+++ b/esp-hal-common/src/embassy/mod.rs
@@ -122,18 +122,16 @@ impl Driver for EmbassyTimer {
     }
 
     unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {
-        return critical_section::with(|cs| {
-            let alarms = self.alarms.borrow(cs);
-            for i in 0..time_driver::ALARM_COUNT {
-                let c = alarms.get_unchecked(i);
-                if !c.allocated.get() {
+        critical_section::with(|cs| {
+            for (i, alarm) in self.alarms.borrow(cs).iter().enumerate() {
+                if !alarm.allocated.get() {
                     // set alarm so it is not overwritten
-                    c.allocated.set(true);
-                    return Option::Some(AlarmHandle::new(i as u8));
+                    alarm.allocated.set(true);
+                    return Some(AlarmHandle::new(i as u8));
                 }
             }
-            return Option::None;
-        });
+            None
+        })
     }
 
     fn set_alarm_callback(

--- a/esp-hal-common/src/embassy/mod.rs
+++ b/esp-hal-common/src/embassy/mod.rs
@@ -101,7 +101,6 @@ pub fn init(clocks: &Clocks, td: time_driver::TimerType) {
 }
 
 pub struct AlarmState {
-    pub timestamp: Cell<u64>,
     pub callback: Cell<Option<(fn(*mut ()), *mut ())>>,
     pub allocated: Cell<bool>,
 }
@@ -111,7 +110,6 @@ unsafe impl Send for AlarmState {}
 impl AlarmState {
     pub const fn new() -> Self {
         Self {
-            timestamp: Cell::new(0),
             callback: Cell::new(None),
             allocated: Cell::new(false),
         }

--- a/esp-hal-common/src/embassy/mod.rs
+++ b/esp-hal-common/src/embassy/mod.rs
@@ -127,6 +127,7 @@ impl Driver for EmbassyTimer {
                 if !alarm.allocated.get() {
                     // set alarm so it is not overwritten
                     alarm.allocated.set(true);
+                    self.on_alarm_allocated(i);
                     return Some(AlarmHandle::new(i as u8));
                 }
             }

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -32,11 +32,20 @@ impl EmbassyTimer {
         SystemTimer::now()
     }
 
-    pub(crate) fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
+    fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
         let alarm = &self.alarms.borrow(cs)[n];
 
         if let Some((f, ctx)) = alarm.callback.get() {
             f(ctx);
+        }
+    }
+
+    pub(super) fn on_alarm_allocated(&self, n: usize) {
+        match n {
+            0 => self.alarm0.enable_interrupt(true),
+            1 => self.alarm1.enable_interrupt(true),
+            2 => self.alarm2.enable_interrupt(true),
+            _ => {}
         }
     }
 
@@ -86,11 +95,16 @@ impl EmbassyTimer {
             let n = alarm.id() as usize;
 
             // The hardware fires the alarm even if timestamp is lower than the current
-            // time.
+            // time. In this case the interrupt handler will pend a wakeup when we exit the
+            // critical section.
             self.arm(n, timestamp);
+        });
 
-            true
-        })
+        // In theory, the above comment is true. However, in practice, we seem to be
+        // missing interrupt for very short timeouts, so let's make sure and catch
+        // timestamps that already passed. Returning `false` means embassy will
+        // run one more poll loop.
+        Self::now() < timestamp
     }
 
     fn clear_interrupt(&self, id: usize) {
@@ -104,18 +118,9 @@ impl EmbassyTimer {
 
     fn arm(&self, id: usize, timestamp: u64) {
         match id {
-            0 => {
-                self.alarm0.set_target(timestamp);
-                self.alarm0.enable_interrupt(true);
-            }
-            1 => {
-                self.alarm1.set_target(timestamp);
-                self.alarm1.enable_interrupt(true);
-            }
-            2 => {
-                self.alarm2.set_target(timestamp);
-                self.alarm2.enable_interrupt(true);
-            }
+            0 => self.alarm0.set_target(timestamp),
+            1 => self.alarm1.set_target(timestamp),
+            2 => self.alarm2.set_target(timestamp),
             _ => {}
         }
     }

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -84,7 +84,6 @@ impl EmbassyTimer {
     ) -> bool {
         critical_section::with(|cs| {
             let n = alarm.id() as usize;
-            let alarm_state = &self.alarms.borrow(cs)[n];
 
             // The hardware fires the alarm even if timestamp is lower than the current
             // time.

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -82,7 +82,7 @@ impl EmbassyTimer {
         alarm: embassy_time::driver::AlarmHandle,
         timestamp: u64,
     ) -> bool {
-        critical_section::with(|cs| {
+        critical_section::with(|_cs| {
             let n = alarm.id() as usize;
 
             // The hardware fires the alarm even if timestamp is lower than the current

--- a/esp-hal-common/src/embassy/time_driver_systimer.rs
+++ b/esp-hal-common/src/embassy/time_driver_systimer.rs
@@ -34,7 +34,6 @@ impl EmbassyTimer {
 
     pub(crate) fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
         let alarm = &self.alarms.borrow(cs)[n];
-        alarm.timestamp.set(u64::MAX);
 
         if let Some((f, ctx)) = alarm.callback.get() {
             f(ctx);
@@ -89,7 +88,6 @@ impl EmbassyTimer {
 
             // The hardware fires the alarm even if timestamp is lower than the current
             // time.
-            alarm_state.timestamp.set(timestamp);
             self.arm(n, timestamp);
 
             true

--- a/esp-hal-common/src/embassy/time_driver_timg.rs
+++ b/esp-hal-common/src/embassy/time_driver_timg.rs
@@ -35,7 +35,6 @@ impl EmbassyTimer {
 
     pub(crate) fn trigger_alarm(&self, n: usize, cs: CriticalSection) {
         let alarm = &self.alarms.borrow(cs)[n];
-        alarm.timestamp.set(u64::MAX);
 
         if let Some((f, ctx)) = alarm.callback.get() {
             f(ctx);
@@ -110,7 +109,6 @@ impl EmbassyTimer {
     ) -> bool {
         // The hardware fires the alarm even if timestamp is lower than the current
         // time.
-        alarm_state.timestamp.set(timestamp);
         Self::arm(&mut tg, timestamp);
 
         true


### PR DESCRIPTION
The check removed in https://github.com/esp-rs/esp-hal/pull/737 seems to break waits in the order of a few microseconds. In these cases, the interrupt handler does not fire even though the TRM seems to indicate it should. This PR restores the check and makes a few additional simplifications.

TIMG0 driver seems unaffected.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
