### PR TITLE
Configurable LP Core clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- ESP32-C6: LP core clock is configurable (#907)
 
 ### Changed
 

--- a/esp32c6-lp-hal/src/delay.rs
+++ b/esp32c6-lp-hal/src/delay.rs
@@ -14,7 +14,7 @@ pub struct Delay {
 impl Delay {
     pub fn new() -> Self {
         Self {
-            rv_delay: riscv::delay::McycleDelay::new(CPU_CLOCK),
+            rv_delay: riscv::delay::McycleDelay::new(unsafe { CPU_CLOCK }),
         }
     }
 }


### PR DESCRIPTION
This enables the user to configure the LP core clock source. (RC_FAST or XTAL_D2)

XTAL_D2 is not only faster but apparently also more accurate
