### PR TITLE
Derive Clone and Copy for EspTwaiFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - ESP32-C6: LP core clock is configurable (#907)
+- Derive `Clone` and `Copy` for `EspTwaiFrame` (#914)
 
 ### Changed
 

--- a/esp-hal-common/src/twai/mod.rs
+++ b/esp-hal-common/src/twai/mod.rs
@@ -93,7 +93,7 @@ use crate::{
 pub mod filter;
 
 /// Structure backing the embedded_hal::can::Frame/embedded_can::Frame trait.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct EspTwaiFrame {
     id: Id,
     dlc: usize,


### PR DESCRIPTION
Fixes #914 

I want to create a queue of `EspTwaiFrame`s, but it's really awkward since it does not implement Clone or Copy.

I tested on a esp32-c3. If this small change needs extra validation, then I can go through the examples, but it really shouldn't effect existing code. `EspTwaiFrames` should be safe to clone.

- [x] The code compiles without `errors` or `warnings`.
- [ ] All examples work. **N/A?**
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable). **N/A**
- [ ] Added examples are checked in CI **N/A**
