### PR TITLE
DMA cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - C2, C3: atomic emulation trap is now opt-in (#904)
+- Improve DMA documentation & clean up module (#915)
 
 ### Fixed
 


### PR DESCRIPTION
This PR:
 - cleans up documentation, uses same constant name as it appears in code
 - moves % 3 check to setup time and makes it blatantly obvious to the user that descriptor number should be a multiple of 3
 - cleans up code around `DmaLinkedListDw0`
 - avoids random pointer operations, use `addr_of!`, `cast` and `cast_mut`
 - adds a missing doc comment

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
