### PR TITLE
uFmt: Remove implementation of provided method

### DIFF
--- a/esp-hal-common/src/uart.rs
+++ b/esp-hal-common/src/uart.rs
@@ -1018,14 +1018,6 @@ where
         self.write_bytes(s.as_bytes())?;
         Ok(())
     }
-
-    #[inline]
-    fn write_char(&mut self, ch: char) -> Result<(), Self::Error> {
-        let mut buffer = [0u8; 4];
-        self.write_bytes(ch.encode_utf8(&mut buffer).as_bytes())?;
-
-        Ok(())
-    }
 }
 
 impl<T> core::fmt::Write for Uart<'_, T>


### PR DESCRIPTION
`uWrite` already implements `write_char` almost the same way as written here. This PR removes this redundant implementation.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
