### PR TITLE
fix: esp32-hal-common - interrupt riscv `_pc` variable typo for `atomic-emulation`

### DIFF
--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -535,7 +535,7 @@ unsafe fn handle_exception(_pc: usize, trap_frame: *mut TrapFrame) {
             (*trap_frame).t4 = frame[29];
             (*trap_frame).t5 = frame[30];
             (*trap_frame).t6 = frame[31];
-            (*trap_frame).pc = pc + 4;
+            (*trap_frame).pc = _pc + 4;
 
             return;
         }


### PR DESCRIPTION
Fixes a typo made #904 which broke `atomic-emulation` feature.

>    Compiling esp-hal-common v0.13.1 (https://github.com/esp-rs/esp-hal?rev=07ed22d#07ed22df)
> error[E0425]: cannot find value `pc` in this scope
>    --> /home/elpiel/.cargo/git/checkouts/esp-hal-42ec44e8c6943228/07ed22d/esp-hal-common/src/interrupt/riscv.rs:538:32
>     |
> 538 |             (*trap_frame).pc = pc + 4;
>     |                                ^^ help: a local variable with a similar name exists: `_pc`
> 

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] ~You updated existing examples or added examples (if applicable).~
- [x] ~Added examples are checked in CI~

### Nice to have

- [x] You add a description of your work to this PR.
- [x] ~You added proper docs for your newly added features and code.~
