### PR TITLE
fix: wrong clear of RMT interrupts (esp-rs/esp-hal#925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S3: Fix GPIO interrupt handler crashing when using GPIO48. (#898)
 - Fixed short wait times in embassy causing hangs (#906)
 - Make sure to clear LP/RTC RAM before loading code (#916)
+- Async RMT channels can be used concurrently (#925)
 
 ### Removed
 

--- a/esp-hal-common/src/rmt.rs
+++ b/esp-hal-common/src/rmt.rs
@@ -1123,9 +1123,6 @@ pub mod asynch {
                 _ => unreachable!(),
             }
 
-            let rmt = unsafe { &*crate::peripherals::RMT::PTR };
-            rmt.int_ena.write(|w| unsafe { w.bits(0) });
-
             WAKER[channel].wake();
         }
     }
@@ -1254,9 +1251,6 @@ pub mod asynch {
 
                 _ => unreachable!(),
             }
-
-            let rmt = unsafe { &*crate::peripherals::RMT::PTR };
-            rmt.int_ena.write(|w| unsafe { w.bits(0) });
 
             WAKER[channel].wake();
         }


### PR DESCRIPTION
Removed the offending lines that were clearing all the enabled interrupts for all RMT channels
