### PR TITLE
Disallow multiple esp-hal-common versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - C2, C3: atomic emulation trap is now opt-in (#904)
 - Improve DMA documentation & clean up module (#915)
+- Only allow a single version of `esp-hal-common` to be present in an application (#934)
 
 ### Fixed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -11,6 +11,13 @@ description  = "HAL implementations for peripherals common among Espressif devic
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 
+# Prevent multiple copies of this crate in the same binary.
+# Needed because different copies might get different features, causing
+# confusing build errors due to expected features not getting enabled
+# on the unintentional copy.
+# This is especially common when mixing crates from crates.io and git.
+links = "esp-hal-common"
+
 [dependencies]
 bitflags             = "2.4.1"
 bitfield             = "0.14.0"


### PR DESCRIPTION
Closes #932

We disallow multiple copies of esp-hal-common in the same dependency graph. This replaces cryptic `One of the feature flags must be provided` and similar errors, which can be very confusing when the user thinks they provide the required features (just not for the duplicate crate).

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
