### PR TITLE
Dma convenience macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RtcClock::get_xtal_freq`, `RtcClock::get_slow_freq` (#957)
 - Added Rx Timeout functionality to async Uart (#911)
 - RISC-V: Thread-mode and interrupt-mode executors, `#[main]` macro (#947)
+- A macro to make it easier to create DMA buffers and descriptors (#935)
 
 ### Changed
 

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -84,7 +84,7 @@ const CHUNK_SIZE: usize = 4092;
 ///
 /// ## Usage
 /// ```rust,no_run
-/// // TX and RX buffers are 32000 bytes
+/// // TX and RX buffers are 32000 bytes - passing only one parameter makes TX and RX the same size
 /// let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 /// ```
 #[macro_export]
@@ -103,13 +103,28 @@ macro_rules! dma_buffers {
             )
         }
     }};
+
+    ($size:expr) => {{
+        static mut TX_BUFFER: [u8; $size] = [0u8; $size];
+        static mut RX_BUFFER: [u8; $size] = [0u8; $size];
+        let tx_descriptors = [0u32; (($size + 4091) / 4092) * 3];
+        let rx_descriptors = [0u32; (($size + 4091) / 4092) * 3];
+        unsafe {
+            (
+                &mut TX_BUFFER,
+                tx_descriptors,
+                &mut RX_BUFFER,
+                rx_descriptors,
+            )
+        }
+    }};
 }
 
 /// Convenience macro to create DMA descriptors
 ///
 /// ## Usage
 /// ```rust,no_run
-/// // Create TX and RX descriptors for transactions up to 32000 bytes
+/// // Create TX and RX descriptors for transactions up to 32000 bytes - passing only one parameter assumes TX and RX are the same size
 /// let (mut tx_descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
 /// ```
 #[macro_export]
@@ -117,6 +132,12 @@ macro_rules! dma_descriptors {
     ($tx_size:expr, $rx_size:expr) => {{
         let tx_descriptors = [0u32; (($tx_size + 4091) / 4092) * 3];
         let rx_descriptors = [0u32; (($rx_size + 4091) / 4092) * 3];
+        (tx_descriptors, rx_descriptors)
+    }};
+
+    ($size:expr) => {{
+        let tx_descriptors = [0u32; (($size + 4091) / 4092) * 3];
+        let rx_descriptors = [0u32; (($size + 4091) / 4092) * 3];
         (tx_descriptors, rx_descriptors)
     }};
 }

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -80,6 +80,47 @@ pub mod pdma;
 
 const CHUNK_SIZE: usize = 4092;
 
+/// Convenience macro to create DMA buffers and descriptors
+///
+/// ## Usage
+/// ```rust,no_run
+/// // TX and RX buffers are 32000 bytes
+/// let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+/// ```
+#[macro_export]
+macro_rules! dma_buffers {
+    ($tx_size:expr, $rx_size:expr) => {{
+        static mut TX_BUFFER: [u8; $tx_size] = [0u8; $tx_size];
+        static mut RX_BUFFER: [u8; $rx_size] = [0u8; $rx_size];
+        let tx_descriptors = [0u32; (($tx_size + 4091) / 4092) * 3];
+        let rx_descriptors = [0u32; (($rx_size + 4091) / 4092) * 3];
+        (unsafe {
+            (
+                &mut TX_BUFFER,
+                tx_descriptors,
+                &mut RX_BUFFER,
+                rx_descriptors,
+            )
+        })
+    }};
+}
+
+/// Convenience macro to create DMA descriptors
+///
+/// ## Usage
+/// ```rust,no_run
+/// // Create TX and RX descriptors for transactions up to 32000 bytes
+/// let (mut tx_descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
+/// ```
+#[macro_export]
+macro_rules! dma_descriptors {
+    ($tx_size:expr, $rx_size:expr) => {{
+        let tx_descriptors = [0u32; (($tx_size + 4091) / 4092) * 3];
+        let rx_descriptors = [0u32; (($rx_size + 4091) / 4092) * 3];
+        (unsafe { (tx_descriptors, rx_descriptors) })
+    }};
+}
+
 /// DMA Errors
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -94,14 +94,14 @@ macro_rules! dma_buffers {
         static mut RX_BUFFER: [u8; $rx_size] = [0u8; $rx_size];
         let tx_descriptors = [0u32; (($tx_size + 4091) / 4092) * 3];
         let rx_descriptors = [0u32; (($rx_size + 4091) / 4092) * 3];
-        (unsafe {
+        unsafe {
             (
                 &mut TX_BUFFER,
                 tx_descriptors,
                 &mut RX_BUFFER,
                 rx_descriptors,
             )
-        })
+        }
     }};
 }
 
@@ -117,7 +117,7 @@ macro_rules! dma_descriptors {
     ($tx_size:expr, $rx_size:expr) => {{
         let tx_descriptors = [0u32; (($tx_size + 4091) / 4092) * 3];
         let rx_descriptors = [0u32; (($rx_size + 4091) / 4092) * 3];
-        (unsafe { (tx_descriptors, rx_descriptors) })
+        (tx_descriptors, rx_descriptors)
     }};
 }
 

--- a/esp32-hal/examples/embassy_i2s_read.rs
+++ b/esp32-hal/examples/embassy_i2s_read.rs
@@ -18,6 +18,7 @@ use embassy_executor::Spawner;
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy::{self},
     i2s::{asynch::*, DataFormat, I2s, Standard},
     pdma::Dma,
@@ -46,8 +47,7 @@ async fn main(_spawner: Spawner) {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -77,7 +77,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
     println!("Start");
 
     let mut data = [0u8; 5000];
@@ -94,9 +94,4 @@ async fn main(_spawner: Spawner) {
             &data[count - 10..count]
         );
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -23,6 +23,7 @@ use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_descriptors,
     embassy::{self},
     pdma::*,
     peripherals::Peripherals,
@@ -61,8 +62,7 @@ async fn main(_spawner: Spawner) {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -62,7 +62,7 @@ async fn main(_spawner: Spawner) {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32-hal/examples/i2s_read.rs
+++ b/esp32-hal/examples/i2s_read.rs
@@ -16,6 +16,7 @@
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     pdma::Dma,
     peripherals::Peripherals,
@@ -36,8 +37,7 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -60,7 +60,7 @@ fn main() -> ! {
         .with_din(io.pins.gpio14)
         .build();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
 
     let mut transfer = i2s_rx.read_dma_circular(buffer).unwrap();
     println!("Started transfer");
@@ -74,9 +74,4 @@ fn main() -> ! {
             println!("Received {:x?}...", &rcv[..30]);
         }
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -20,6 +20,7 @@
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gpio::IO,
     pdma::Dma,
     peripherals::Peripherals,
@@ -51,8 +52,7 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);
 
     let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
@@ -65,17 +65,16 @@ fn main() -> ! {
         )
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
 
     let mut delay = Delay::new(&clocks);
 
-    // DMA buffer require a static life-time
-    let send = send_buffer();
-    let mut receive = receive_buffer();
     let mut zero_buf = zero_buffer();
+    let send = tx_buffer;
+    let mut receive = rx_buffer;
 
     // write enable
     let transfer = spi
@@ -164,15 +163,5 @@ fn main() -> ! {
 
 fn zero_buffer() -> &'static mut [u8; 0] {
     static mut BUFFER: [u8; 0] = [0u8; 0];
-    unsafe { &mut BUFFER }
-}
-
-fn send_buffer() -> &'static mut [u8; 256] {
-    static mut BUFFER: [u8; 256] = [0u8; 256];
-    unsafe { &mut BUFFER }
-}
-
-fn receive_buffer() -> &'static mut [u8; 320] {
-    static mut BUFFER: [u8; 320] = [0u8; 320];
     unsafe { &mut BUFFER }
 }

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -19,6 +19,7 @@
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gpio::IO,
     pdma::Dma,
     peripherals::Peripherals,
@@ -47,14 +48,13 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -62,8 +62,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let mut send = buffer1();
-    let mut receive = buffer2();
+    let mut send = tx_buffer;
+    let mut receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in send.iter_mut().enumerate() {
@@ -95,14 +95,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -70,7 +70,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -23,6 +23,7 @@ use embassy_time::{Duration, Timer};
 use esp32c2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_descriptors,
     embassy,
     gdma::*,
     peripherals::Peripherals,
@@ -69,8 +70,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -20,6 +20,7 @@
 use esp32c2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -51,8 +52,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);
 
     let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
@@ -65,7 +65,7 @@ fn main() -> ! {
         )
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -73,9 +73,9 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let send = send_buffer();
-    let mut receive = receive_buffer();
     let mut zero_buf = zero_buffer();
+    let send = tx_buffer;
+    let mut receive = rx_buffer;
 
     // write enable
     let transfer = spi
@@ -164,15 +164,5 @@ fn main() -> ! {
 
 fn zero_buffer() -> &'static mut [u8; 0] {
     static mut BUFFER: [u8; 0] = [0u8; 0];
-    unsafe { &mut BUFFER }
-}
-
-fn send_buffer() -> &'static mut [u8; 256] {
-    static mut BUFFER: [u8; 256] = [0u8; 256];
-    unsafe { &mut BUFFER }
-}
-
-fn receive_buffer() -> &'static mut [u8; 320] {
-    static mut BUFFER: [u8; 320] = [0u8; 320];
     unsafe { &mut BUFFER }
 }

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -19,6 +19,7 @@
 use esp32c2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -47,14 +48,13 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -62,8 +62,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let mut send = buffer1();
-    let mut receive = buffer2();
+    let mut send = tx_buffer;
+    let mut receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in send.iter_mut().enumerate() {
@@ -95,14 +95,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c2-hal/examples/spi_slave_dma.rs
+++ b/esp32c2-hal/examples/spi_slave_dma.rs
@@ -64,7 +64,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(3200, 3200);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(3200);
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/esp32c2-hal/examples/spi_slave_dma.rs
+++ b/esp32c2-hal/examples/spi_slave_dma.rs
@@ -37,9 +37,7 @@ use esp32c2_hal::{
         slave::{prelude::*, Spi},
         SpiMode,
     },
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -49,16 +47,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C2, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDT.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt0 = timer_group0.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let slave_sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/embassy_i2s_read.rs
+++ b/esp32c3-hal/examples/embassy_i2s_read.rs
@@ -19,6 +19,7 @@ use embassy_executor::Spawner;
 use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
@@ -55,8 +56,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -87,7 +87,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
     println!("Start");
 
     let mut data = [0u8; 5000];
@@ -104,9 +104,4 @@ async fn main(_spawner: Spawner) {
             &data[count - 10..count]
         );
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c3-hal/examples/embassy_i2s_sound.rs
@@ -35,6 +35,7 @@ use embassy_executor::Spawner;
 use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
@@ -79,8 +80,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -114,7 +114,7 @@ async fn main(_spawner: Spawner) {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -141,9 +141,4 @@ async fn main(_spawner: Spawner) {
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -70,7 +70,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -23,6 +23,7 @@ use embassy_time::{Duration, Timer};
 use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_descriptors,
     embassy,
     gdma::*,
     peripherals::Peripherals,
@@ -69,8 +70,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c3-hal/examples/i2s_read.rs
+++ b/esp32c3-hal/examples/i2s_read.rs
@@ -17,6 +17,7 @@
 use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
@@ -37,8 +38,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -62,7 +62,7 @@ fn main() -> ! {
         .with_din(io.pins.gpio5)
         .build();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
 
     let mut transfer = i2s_rx.read_dma_circular(buffer).unwrap();
     println!("Started transfer");
@@ -76,9 +76,4 @@ fn main() -> ! {
             println!("Received {:x?}...", &rcv[..30]);
         }
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c3-hal/examples/i2s_sound.rs
+++ b/esp32c3-hal/examples/i2s_sound.rs
@@ -33,6 +33,7 @@
 use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
@@ -60,8 +61,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -88,7 +88,7 @@ fn main() -> ! {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -118,9 +118,4 @@ fn main() -> ! {
             transfer.push(&filler[0..avail]).unwrap();
         }
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -20,6 +20,7 @@
 use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -51,8 +52,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);
 
     let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
@@ -65,7 +65,7 @@ fn main() -> ! {
         )
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -73,9 +73,9 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let send = send_buffer();
-    let mut receive = receive_buffer();
     let mut zero_buf = zero_buffer();
+    let send = tx_buffer;
+    let mut receive = rx_buffer;
 
     // write enable
     let transfer = spi
@@ -164,15 +164,5 @@ fn main() -> ! {
 
 fn zero_buffer() -> &'static mut [u8; 0] {
     static mut BUFFER: [u8; 0] = [0u8; 0];
-    unsafe { &mut BUFFER }
-}
-
-fn send_buffer() -> &'static mut [u8; 256] {
-    static mut BUFFER: [u8; 256] = [0u8; 256];
-    unsafe { &mut BUFFER }
-}
-
-fn receive_buffer() -> &'static mut [u8; 320] {
-    static mut BUFFER: [u8; 320] = [0u8; 320];
     unsafe { &mut BUFFER }
 }

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c3-hal/examples/spi_slave_dma.rs
+++ b/esp32c3-hal/examples/spi_slave_dma.rs
@@ -37,9 +37,7 @@ use esp32c3_hal::{
         slave::{prelude::*, Spi},
         SpiMode,
     },
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -49,19 +47,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let slave_sclk = io.pins.gpio6;

--- a/esp32c3-hal/examples/spi_slave_dma.rs
+++ b/esp32c3-hal/examples/spi_slave_dma.rs
@@ -64,7 +64,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/esp32c6-hal/examples/embassy_i2s_read.rs
+++ b/esp32c6-hal/examples/embassy_i2s_read.rs
@@ -19,6 +19,7 @@ use embassy_executor::Spawner;
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
@@ -55,8 +56,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -87,7 +87,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
     println!("Start");
 
     let mut data = [0u8; 5000];
@@ -104,9 +104,4 @@ async fn main(_spawner: Spawner) {
             &data[count - 10..count]
         );
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c6-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c6-hal/examples/embassy_i2s_sound.rs
@@ -35,6 +35,7 @@ use embassy_executor::Spawner;
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
@@ -79,8 +80,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -114,7 +114,7 @@ async fn main(_spawner: Spawner) {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -141,9 +141,4 @@ async fn main(_spawner: Spawner) {
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c6-hal/examples/embassy_parl_io_tx.rs
+++ b/esp32c6-hal/examples/embassy_parl_io_tx.rs
@@ -16,6 +16,7 @@ use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     gpio::IO,
@@ -56,8 +57,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -99,7 +99,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     for i in 0..buffer.len() {
         buffer[i] = (i % 255) as u8;
     }
@@ -110,9 +110,4 @@ async fn main(_spawner: Spawner) {
 
         Timer::after(Duration::from_millis(500)).await;
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -75,7 +75,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -23,6 +23,7 @@ use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_descriptors,
     embassy,
     gdma::*,
     peripherals::Peripherals,
@@ -74,8 +75,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c6-hal/examples/i2s_sound.rs
+++ b/esp32c6-hal/examples/i2s_sound.rs
@@ -33,6 +33,7 @@
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
@@ -60,8 +61,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -88,7 +88,7 @@ fn main() -> ! {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -118,9 +118,4 @@ fn main() -> ! {
             transfer.push(&filler[0..avail]).unwrap();
         }
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c6-hal/examples/parl_io_rx.rs
+++ b/esp32c6-hal/examples/parl_io_rx.rs
@@ -9,6 +9,7 @@
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
@@ -41,8 +42,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -67,7 +67,7 @@ fn main() -> ! {
         .with_config(rx_pins, NoClkPin, BitPackOrder::Msb, Some(0xfff))
         .unwrap();
 
-    let mut buffer = dma_buffer();
+    let mut buffer = rx_buffer;
     buffer.fill(0u8);
 
     let mut delay = Delay::new(&clocks);
@@ -82,9 +82,4 @@ fn main() -> ! {
 
         delay.delay_ms(500u32);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c6-hal/examples/parl_io_rx.rs
+++ b/esp32c6-hal/examples/parl_io_rx.rs
@@ -15,9 +15,7 @@ use esp32c6_hal::{
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -27,18 +25,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32c6-hal/examples/parl_io_tx.rs
+++ b/esp32c6-hal/examples/parl_io_tx.rs
@@ -13,6 +13,7 @@
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     parl_io::{
@@ -38,8 +39,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -74,7 +74,7 @@ fn main() -> ! {
         )
         .unwrap();
 
-    let mut buffer = dma_buffer();
+    let mut buffer = tx_buffer;
     for i in 0..buffer.len() {
         buffer[i] = (i % 255) as u8;
     }
@@ -91,9 +91,4 @@ fn main() -> ! {
 
         delay.delay_ms(500u32);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -19,6 +19,7 @@
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -47,14 +48,13 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -62,8 +62,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let mut send = buffer1();
-    let mut receive = buffer2();
+    let mut send = tx_buffer;
+    let mut receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in send.iter_mut().enumerate() {
@@ -95,14 +95,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -64,7 +64,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -37,9 +37,7 @@ use esp32c6_hal::{
         slave::{prelude::*, Spi},
         SpiMode,
     },
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -49,19 +47,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let slave_sclk = io.pins.gpio6;

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -28,6 +28,7 @@
 use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -78,8 +79,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(
         peripherals.SPI2,
@@ -91,7 +91,7 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        &mut descriptors,
+        &mut tx_descriptors,
         &mut rx_descriptors,
         DmaPriority::Priority0,
     ));
@@ -101,8 +101,8 @@ fn main() -> ! {
     // DMA buffer require a static life-time
     let master_send = &mut [0u8; 32000];
     let master_receive = &mut [0u8; 32000];
-    let mut slave_send = buffer1();
-    let mut slave_receive = buffer2();
+    let mut slave_send = tx_buffer;
+    let mut slave_receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in master_send.iter_mut().enumerate() {
@@ -162,14 +162,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/embassy_i2s_read.rs
+++ b/esp32h2-hal/examples/embassy_i2s_read.rs
@@ -19,6 +19,7 @@ use embassy_executor::Spawner;
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
@@ -55,8 +56,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -87,7 +87,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
     println!("Start");
 
     let mut data = [0u8; 5000];
@@ -104,9 +104,4 @@ async fn main(_spawner: Spawner) {
             &data[count - 10..count]
         );
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32h2-hal/examples/embassy_i2s_sound.rs
@@ -35,6 +35,7 @@ use embassy_executor::Spawner;
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
@@ -79,8 +80,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -114,7 +114,7 @@ async fn main(_spawner: Spawner) {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -141,9 +141,4 @@ async fn main(_spawner: Spawner) {
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/embassy_parl_io_rx.rs
+++ b/esp32h2-hal/examples/embassy_parl_io_rx.rs
@@ -12,6 +12,7 @@ use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     gpio::IO,
@@ -45,8 +46,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -78,16 +78,11 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
     loop {
         parl_io_rx.read_dma_async(buffer).await.unwrap();
         println!("Received: {:02x?} ...", &buffer[..30]);
 
         Timer::after(Duration::from_millis(500)).await;
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/embassy_parl_io_tx.rs
+++ b/esp32h2-hal/examples/embassy_parl_io_tx.rs
@@ -16,6 +16,7 @@ use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy,
     gdma::Gdma,
     gpio::IO,
@@ -56,8 +57,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -99,7 +99,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     for i in 0..buffer.len() {
         buffer[i] = (i % 255) as u8;
     }
@@ -110,9 +110,4 @@ async fn main(_spawner: Spawner) {
 
         Timer::after(Duration::from_millis(500)).await;
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -75,7 +75,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -23,6 +23,7 @@ use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_descriptors,
     embassy,
     gdma::*,
     peripherals::Peripherals,
@@ -74,8 +75,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32h2-hal/examples/i2s_read.rs
+++ b/esp32h2-hal/examples/i2s_read.rs
@@ -17,6 +17,7 @@
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
@@ -37,8 +38,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4 * 4092);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -62,7 +62,7 @@ fn main() -> ! {
         .with_din(io.pins.gpio5)
         .build();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
 
     let mut transfer = i2s_rx.read_dma_circular(buffer).unwrap();
     println!("Started transfer");
@@ -76,9 +76,4 @@ fn main() -> ! {
             println!("Received {:x?}...", &rcv[..30]);
         }
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/i2s_sound.rs
+++ b/esp32h2-hal/examples/i2s_sound.rs
@@ -33,6 +33,7 @@
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
@@ -60,8 +61,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -88,7 +88,7 @@ fn main() -> ! {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -118,9 +118,4 @@ fn main() -> ! {
             transfer.push(&filler[0..avail]).unwrap();
         }
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/parl_io_rx.rs
+++ b/esp32h2-hal/examples/parl_io_rx.rs
@@ -15,9 +15,7 @@ use esp32h2_hal::{
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
     prelude::*,
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -27,18 +25,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/esp32h2-hal/examples/parl_io_rx.rs
+++ b/esp32h2-hal/examples/parl_io_rx.rs
@@ -9,6 +9,7 @@
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
@@ -41,8 +42,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -67,7 +67,7 @@ fn main() -> ! {
         .with_config(rx_pins, NoClkPin, BitPackOrder::Msb, Some(0xfff))
         .unwrap();
 
-    let mut buffer = dma_buffer();
+    let mut buffer = rx_buffer;
     buffer.fill(0u8);
 
     let mut delay = Delay::new(&clocks);
@@ -82,9 +82,4 @@ fn main() -> ! {
 
         delay.delay_ms(500u32);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/parl_io_tx.rs
+++ b/esp32h2-hal/examples/parl_io_tx.rs
@@ -13,6 +13,7 @@
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     parl_io::{
@@ -38,8 +39,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -74,7 +74,7 @@ fn main() -> ! {
         )
         .unwrap();
 
-    let mut buffer = dma_buffer();
+    let mut buffer = tx_buffer;
     for i in 0..buffer.len() {
         buffer[i] = (i % 255) as u8;
     }
@@ -91,9 +91,4 @@ fn main() -> ! {
 
         delay.delay_ms(500u32);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/qspi_flash.rs
+++ b/esp32h2-hal/examples/qspi_flash.rs
@@ -20,6 +20,7 @@
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -51,8 +52,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);
 
     let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
@@ -65,7 +65,7 @@ fn main() -> ! {
         )
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -73,9 +73,9 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let send = send_buffer();
-    let mut receive = receive_buffer();
     let mut zero_buf = zero_buffer();
+    let send = tx_buffer;
+    let mut receive = rx_buffer;
 
     // write enable
     let transfer = spi
@@ -164,15 +164,5 @@ fn main() -> ! {
 
 fn zero_buffer() -> &'static mut [u8; 0] {
     static mut BUFFER: [u8; 0] = [0u8; 0];
-    unsafe { &mut BUFFER }
-}
-
-fn send_buffer() -> &'static mut [u8; 256] {
-    static mut BUFFER: [u8; 256] = [0u8; 256];
-    unsafe { &mut BUFFER }
-}
-
-fn receive_buffer() -> &'static mut [u8; 320] {
-    static mut BUFFER: [u8; 320] = [0u8; 320];
     unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -19,6 +19,7 @@
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -47,14 +48,13 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -62,8 +62,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let mut send = buffer1();
-    let mut receive = buffer2();
+    let mut send = tx_buffer;
+    let mut receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in send.iter_mut().enumerate() {
@@ -88,14 +88,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -64,7 +64,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -28,6 +28,7 @@
 use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -78,8 +79,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(
         peripherals.SPI2,
@@ -91,7 +91,7 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        &mut descriptors,
+        &mut tx_descriptors,
         &mut rx_descriptors,
         DmaPriority::Priority0,
     ));
@@ -101,8 +101,8 @@ fn main() -> ! {
     // DMA buffer require a static life-time
     let master_send = &mut [0u8; 32000];
     let master_receive = &mut [0u8; 32000];
-    let mut slave_send = buffer1();
-    let mut slave_receive = buffer2();
+    let mut slave_send = tx_buffer;
+    let mut slave_receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in master_send.iter_mut().enumerate() {
@@ -162,14 +162,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -37,9 +37,7 @@ use esp32h2_hal::{
         slave::{prelude::*, Spi},
         SpiMode,
     },
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -49,19 +47,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C6, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.LP_CLKRST);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let slave_sclk = io.pins.gpio4;

--- a/esp32s2-hal/examples/embassy_i2s_read.rs
+++ b/esp32s2-hal/examples/embassy_i2s_read.rs
@@ -18,6 +18,7 @@ use embassy_executor::Spawner;
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy::{self},
     i2s::{asynch::*, DataFormat, I2s, Standard},
     pdma::Dma,
@@ -54,8 +55,7 @@ async fn main(_spawner: Spawner) {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -85,7 +85,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
     println!("Start");
 
     let mut data = [0u8; 5000];
@@ -102,9 +102,4 @@ async fn main(_spawner: Spawner) {
             &data[count - 10..count]
         );
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s2-hal/examples/embassy_i2s_sound.rs
@@ -35,6 +35,7 @@ use embassy_executor::Spawner;
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy::{self},
     i2s::{asynch::*, DataFormat, I2s, Standard},
     pdma::Dma,
@@ -79,8 +80,7 @@ async fn main(_spawner: Spawner) {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -113,7 +113,7 @@ async fn main(_spawner: Spawner) {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -141,9 +141,4 @@ async fn main(_spawner: Spawner) {
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -23,6 +23,7 @@ use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_descriptors,
     embassy::{self},
     pdma::*,
     peripherals::Peripherals,
@@ -69,8 +70,7 @@ async fn main(_spawner: Spawner) {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -70,7 +70,7 @@ async fn main(_spawner: Spawner) {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32s2-hal/examples/i2s_sound.rs
+++ b/esp32s2-hal/examples/i2s_sound.rs
@@ -33,6 +33,7 @@
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     pdma::Dma,
     peripherals::Peripherals,
@@ -60,8 +61,7 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.i2s0channel;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -88,7 +88,7 @@ fn main() -> ! {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -118,9 +118,4 @@ fn main() -> ! {
             transfer.push(&filler[0..avail]).unwrap();
         }
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -20,6 +20,7 @@
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gpio::IO,
     pdma::Dma,
     peripherals::Peripherals,
@@ -51,8 +52,7 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);
 
     let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
@@ -65,7 +65,7 @@ fn main() -> ! {
         )
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -73,9 +73,9 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let send = send_buffer();
-    let mut receive = receive_buffer();
     let mut zero_buf = zero_buffer();
+    let send = tx_buffer;
+    let mut receive = rx_buffer;
 
     // write enable
     let transfer = spi
@@ -164,15 +164,5 @@ fn main() -> ! {
 
 fn zero_buffer() -> &'static mut [u8; 0] {
     static mut BUFFER: [u8; 0] = [0u8; 0];
-    unsafe { &mut BUFFER }
-}
-
-fn send_buffer() -> &'static mut [u8; 256] {
-    static mut BUFFER: [u8; 256] = [0u8; 256];
-    unsafe { &mut BUFFER }
-}
-
-fn receive_buffer() -> &'static mut [u8; 320] {
-    static mut BUFFER: [u8; 320] = [0u8; 320];
     unsafe { &mut BUFFER }
 }

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -19,6 +19,7 @@
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gpio::IO,
     pdma::Dma,
     peripherals::Peripherals,
@@ -47,14 +48,13 @@ fn main() -> ! {
     let dma = Dma::new(system.dma);
     let dma_channel = dma.spi2channel;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -62,8 +62,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let mut send = buffer1();
-    let mut receive = buffer2();
+    let mut send = tx_buffer;
+    let mut receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in send.iter_mut().enumerate() {
@@ -95,14 +95,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s3-hal/examples/embassy_i2s_read.rs
+++ b/esp32s3-hal/examples/embassy_i2s_read.rs
@@ -19,6 +19,7 @@ use embassy_executor::Spawner;
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy::{self},
     gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
@@ -55,8 +56,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -87,7 +87,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
     println!("Start");
 
     let mut data = [0u8; 5000];
@@ -104,9 +104,4 @@ async fn main(_spawner: Spawner) {
             &data[count - 10..count]
         );
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s3-hal/examples/embassy_i2s_sound.rs
@@ -35,6 +35,7 @@ use embassy_executor::Spawner;
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     embassy::{self},
     gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
@@ -79,8 +80,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 20 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
@@ -114,7 +114,7 @@ async fn main(_spawner: Spawner) {
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };
 
-    let buffer = dma_buffer();
+    let buffer = tx_buffer;
     let mut idx = 0;
     for i in 0..usize::min(data.len(), buffer.len()) {
         buffer[i] = data[idx];
@@ -141,9 +141,4 @@ async fn main(_spawner: Spawner) {
         idx = (idx + written) % data.len();
         println!("written {}", written);
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -23,6 +23,7 @@ use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_descriptors,
     embassy::{self},
     gdma::*,
     peripherals::Peripherals,
@@ -74,8 +75,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI3, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -75,7 +75,7 @@ async fn main(_spawner: Spawner) {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000, 32000);
+    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
 
     let mut spi = Spi::new(peripherals.SPI3, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32s3-hal/examples/i2s_read.rs
+++ b/esp32s3-hal/examples/i2s_read.rs
@@ -17,6 +17,7 @@
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
@@ -37,8 +38,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut tx_descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4 * 4092);
 
     // Here we test that the type is
     // 1) reasonably simple (or at least this will flag changes that may make it
@@ -66,7 +66,7 @@ fn main() -> ! {
         .with_din(io.pins.gpio5)
         .build();
 
-    let buffer = dma_buffer();
+    let buffer = rx_buffer;
 
     let mut transfer = i2s_rx.read_dma_circular(buffer).unwrap();
     println!("Started transfer");
@@ -80,9 +80,4 @@ fn main() -> ! {
             println!("Received {:x?}...", &rcv[..30]);
         }
     }
-}
-
-fn dma_buffer() -> &'static mut [u8; 4092 * 4] {
-    static mut BUFFER: [u8; 4092 * 4] = [0u8; 4092 * 4];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -20,6 +20,7 @@
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -51,8 +52,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);
 
     let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
@@ -65,7 +65,7 @@ fn main() -> ! {
         )
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -73,9 +73,9 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let send = send_buffer();
-    let mut receive = receive_buffer();
     let mut zero_buf = zero_buffer();
+    let send = tx_buffer;
+    let mut receive = rx_buffer;
 
     // write enable
     let transfer = spi
@@ -164,15 +164,5 @@ fn main() -> ! {
 
 fn zero_buffer() -> &'static mut [u8; 0] {
     static mut BUFFER: [u8; 0] = [0u8; 0];
-    unsafe { &mut BUFFER }
-}
-
-fn send_buffer() -> &'static mut [u8; 256] {
-    static mut BUFFER: [u8; 256] = [0u8; 256];
-    unsafe { &mut BUFFER }
-}
-
-fn receive_buffer() -> &'static mut [u8; 320] {
-    static mut BUFFER: [u8; 320] = [0u8; 320];
     unsafe { &mut BUFFER }
 }

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -19,6 +19,7 @@
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -47,14 +48,13 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
         .with_dma(dma_channel.configure(
             false,
-            &mut descriptors,
+            &mut tx_descriptors,
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ));
@@ -62,8 +62,8 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     // DMA buffer require a static life-time
-    let mut send = buffer1();
-    let mut receive = buffer2();
+    let mut send = tx_buffer;
+    let mut receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in send.iter_mut().enumerate() {
@@ -95,14 +95,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))

--- a/esp32s3-hal/examples/spi_slave_dma.rs
+++ b/esp32s3-hal/examples/spi_slave_dma.rs
@@ -64,7 +64,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/esp32s3-hal/examples/spi_slave_dma.rs
+++ b/esp32s3-hal/examples/spi_slave_dma.rs
@@ -28,6 +28,7 @@
 use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
+    dma_buffers,
     gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
@@ -78,8 +79,7 @@ fn main() -> ! {
     let dma = Gdma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut descriptors = [0u32; 8 * 3];
-    let mut rx_descriptors = [0u32; 8 * 3];
+    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000, 32000);
 
     let mut spi = Spi::new(
         peripherals.SPI2,
@@ -91,7 +91,7 @@ fn main() -> ! {
     )
     .with_dma(dma_channel.configure(
         false,
-        &mut descriptors,
+        &mut tx_descriptors,
         &mut rx_descriptors,
         DmaPriority::Priority0,
     ));
@@ -101,8 +101,8 @@ fn main() -> ! {
     // DMA buffer require a static life-time
     let master_send = &mut [0u8; 32000];
     let master_receive = &mut [0u8; 32000];
-    let mut slave_send = buffer1();
-    let mut slave_receive = buffer2();
+    let mut slave_send = tx_buffer;
+    let mut slave_receive = rx_buffer;
     let mut i = 0;
 
     for (i, v) in master_send.iter_mut().enumerate() {
@@ -162,14 +162,4 @@ fn main() -> ! {
 
         delay.delay_ms(250u32);
     }
-}
-
-fn buffer1() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
-}
-
-fn buffer2() -> &'static mut [u8; 32000] {
-    static mut BUFFER: [u8; 32000] = [0u8; 32000];
-    unsafe { &mut BUFFER }
 }

--- a/esp32s3-hal/examples/spi_slave_dma.rs
+++ b/esp32s3-hal/examples/spi_slave_dma.rs
@@ -37,9 +37,7 @@ use esp32s3_hal::{
         slave::{prelude::*, Spi},
         SpiMode,
     },
-    timer::TimerGroup,
     Delay,
-    Rtc,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -49,19 +47,6 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
-    // Disable the watchdog timers. For the ESP32-C3, this includes the Super WDT,
-    // the RTC WDT, and the TIMG WDTs.
-    let mut rtc = Rtc::new(peripherals.RTC_CNTL);
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt0 = timer_group0.wdt;
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-    let mut wdt1 = timer_group1.wdt;
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let slave_sclk = io.pins.gpio6;


### PR DESCRIPTION
This (optionally) makes it more convenient to setup DMA buffers and DMA descriptors. 
It can still be done as before as shown by the `aes_dma` example

