### PR TITLE
Remove unnecessary `riscv::interrupt::enable()` from examples

### DIFF
--- a/esp32c2-hal/examples/clock_monitor.rs
+++ b/esp32c2-hal/examples/clock_monitor.rs
@@ -13,7 +13,6 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Rtc,
 };
 use esp_backtrace as _;
@@ -45,10 +44,6 @@ fn main() -> ! {
     critical_section::with(|cs| {
         RTC.borrow_ref_mut(cs).replace(rtc);
     });
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32c2-hal/examples/gpio_interrupt.rs
+++ b/esp32c2-hal/examples/gpio_interrupt.rs
@@ -15,7 +15,6 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Delay,
 };
 use esp_backtrace as _;
@@ -39,10 +38,6 @@ fn main() -> ! {
     critical_section::with(|cs| BUTTON.borrow_ref_mut(cs).replace(button));
 
     interrupt::enable(peripherals::Interrupt::GPIO, interrupt::Priority::Priority3).unwrap();
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     let mut delay = Delay::new(&clocks);
     loop {

--- a/esp32c2-hal/examples/rtc_watchdog.rs
+++ b/esp32c2-hal/examples/rtc_watchdog.rs
@@ -14,7 +14,6 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Rtc,
     Rwdt,
 };
@@ -39,10 +38,6 @@ fn main() -> ! {
     .unwrap();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32c2-hal/examples/serial_interrupts.rs
+++ b/esp32c2-hal/examples/serial_interrupts.rs
@@ -13,7 +13,6 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals, UART0},
     prelude::*,
-    riscv,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
@@ -53,10 +52,6 @@ fn main() -> ! {
         interrupt::CpuInterrupt::Interrupt1, // Interrupt 1 handles priority one interrupts
         interrupt::InterruptKind::Edge,
     );
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {
         critical_section::with(|cs| {

--- a/esp32c2-hal/examples/timer_interrupt.rs
+++ b/esp32c2-hal/examples/timer_interrupt.rs
@@ -12,7 +12,6 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{self, Peripherals, TIMG0},
     prelude::*,
-    riscv,
     timer::{Timer, Timer0, TimerGroup},
 };
 use esp_backtrace as _;
@@ -39,10 +38,6 @@ fn main() -> ! {
     critical_section::with(|cs| {
         TIMER0.borrow_ref_mut(cs).replace(timer0);
     });
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32c3-hal/examples/clock_monitor.rs
+++ b/esp32c3-hal/examples/clock_monitor.rs
@@ -13,7 +13,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Rtc,
 };
 use esp_backtrace as _;
@@ -45,10 +44,6 @@ fn main() -> ! {
     critical_section::with(|cs| {
         RTC.borrow_ref_mut(cs).replace(rtc);
     });
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32c3-hal/examples/debug_assist.rs
+++ b/esp32c3-hal/examples/debug_assist.rs
@@ -14,7 +14,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
 };
 use esp_backtrace as _;
 use esp_println::println;
@@ -29,11 +28,21 @@ fn main() -> ! {
 
     let mut da = DebugAssist::new(peripherals.ASSIST_DEBUG);
 
+    extern "C" {
+        // top of stack
+        static mut _stack_start: u32;
+        // bottom of stack
+        static mut _stack_end: u32;
+    }
+
+    let stack_top = unsafe { &mut _stack_start } as *mut _ as u32;
+    let stack_bottom = unsafe { &mut _stack_end } as *mut _ as u32;
+
     // uncomment the functionality you want to test
 
-    // da.enable_sp_monitor(0x3fcce000, 0x3fccffff);
-    // da.enable_region0_monitor(0x3fcce000, 0x3fcce100, true, true);
-    da.enable_region1_monitor(0x3fcce000, 0x3fcce100, true, true);
+    da.enable_sp_monitor(stack_bottom + 4096, stack_top);
+    // da.enable_region0_monitor(stack_bottom, stack_bottom + 4096, true, true);
+    // da.enable_region1_monitor(stack_bottom, stack_bottom + 4096, true, true);
 
     critical_section::with(|cs| DA.borrow_ref_mut(cs).replace(da));
 
@@ -42,10 +51,6 @@ fn main() -> ! {
         interrupt::Priority::Priority3,
     )
     .unwrap();
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     eat_up_stack(0);
 

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -15,7 +15,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Delay,
 };
 use esp_backtrace as _;
@@ -39,10 +38,6 @@ fn main() -> ! {
     critical_section::with(|cs| BUTTON.borrow_ref_mut(cs).replace(button));
 
     interrupt::enable(peripherals::Interrupt::GPIO, interrupt::Priority::Priority3).unwrap();
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     let mut delay = Delay::new(&clocks);
     loop {

--- a/esp32c3-hal/examples/rtc_watchdog.rs
+++ b/esp32c3-hal/examples/rtc_watchdog.rs
@@ -14,7 +14,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Rtc,
     Rwdt,
 };
@@ -39,10 +38,6 @@ fn main() -> ! {
     .unwrap();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32c3-hal/examples/serial_interrupts.rs
+++ b/esp32c3-hal/examples/serial_interrupts.rs
@@ -13,7 +13,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals, UART0},
     prelude::*,
-    riscv,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
@@ -53,10 +52,6 @@ fn main() -> ! {
         interrupt::CpuInterrupt::Interrupt1, // Interrupt 1 handles priority one interrupts
         interrupt::InterruptKind::Edge,
     );
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {
         critical_section::with(|cs| {

--- a/esp32c3-hal/examples/timer_interrupt.rs
+++ b/esp32c3-hal/examples/timer_interrupt.rs
@@ -13,7 +13,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals, TIMG0, TIMG1},
     prelude::*,
-    riscv,
     timer::{Timer, Timer0, TimerGroup},
 };
 use esp_backtrace as _;
@@ -52,10 +51,6 @@ fn main() -> ! {
         TIMER0.borrow_ref_mut(cs).replace(timer0);
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32c3-hal/examples/usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/usb_serial_jtag.rs
@@ -14,7 +14,6 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     timer::TimerGroup,
     Cpu,
     UsbSerialJtag,
@@ -52,10 +51,6 @@ fn main() -> ! {
         interrupt::CpuInterrupt::Interrupt1,
         interrupt::InterruptKind::Edge,
     );
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {
         critical_section::with(|cs| {

--- a/esp32c6-hal/examples/gpio_interrupt.rs
+++ b/esp32c6-hal/examples/gpio_interrupt.rs
@@ -15,7 +15,6 @@ use esp32c6_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Delay,
 };
 use esp_backtrace as _;
@@ -39,10 +38,6 @@ fn main() -> ! {
     critical_section::with(|cs| BUTTON.borrow_ref_mut(cs).replace(button));
 
     interrupt::enable(peripherals::Interrupt::GPIO, interrupt::Priority::Priority3).unwrap();
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     let mut delay = Delay::new(&clocks);
     loop {

--- a/esp32c6-hal/examples/rtc_watchdog.rs
+++ b/esp32c6-hal/examples/rtc_watchdog.rs
@@ -14,7 +14,6 @@ use esp32c6_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Rtc,
     Rwdt,
 };
@@ -39,10 +38,6 @@ fn main() -> ! {
     .unwrap();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32c6-hal/examples/serial_interrupts.rs
+++ b/esp32c6-hal/examples/serial_interrupts.rs
@@ -13,7 +13,6 @@ use esp32c6_hal::{
     interrupt,
     peripherals::{self, Peripherals, UART0},
     prelude::*,
-    riscv,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
@@ -53,10 +52,6 @@ fn main() -> ! {
         interrupt::CpuInterrupt::Interrupt1, // Interrupt 1 handles priority one interrupts
         interrupt::InterruptKind::Edge,
     );
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {
         critical_section::with(|cs| {

--- a/esp32c6-hal/examples/timer_interrupt.rs
+++ b/esp32c6-hal/examples/timer_interrupt.rs
@@ -13,7 +13,6 @@ use esp32c6_hal::{
     interrupt,
     peripherals::{self, Peripherals, TIMG0, TIMG1},
     prelude::*,
-    riscv,
     timer::{Timer, Timer0, TimerGroup},
 };
 use esp_backtrace as _;
@@ -56,10 +55,6 @@ fn main() -> ! {
         TIMER0.borrow_ref_mut(cs).replace(timer0);
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32c6-hal/examples/usb_serial_jtag.rs
+++ b/esp32c6-hal/examples/usb_serial_jtag.rs
@@ -13,7 +13,6 @@ use esp32c6_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     timer::TimerGroup,
     Cpu,
     UsbSerialJtag,
@@ -51,10 +50,6 @@ fn main() -> ! {
         interrupt::CpuInterrupt::Interrupt1,
         interrupt::InterruptKind::Edge,
     );
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {
         critical_section::with(|cs| {

--- a/esp32h2-hal/examples/gpio_interrupt.rs
+++ b/esp32h2-hal/examples/gpio_interrupt.rs
@@ -15,7 +15,6 @@ use esp32h2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Delay,
 };
 use esp_backtrace as _;
@@ -39,10 +38,6 @@ fn main() -> ! {
     critical_section::with(|cs| BUTTON.borrow_ref_mut(cs).replace(button));
 
     interrupt::enable(peripherals::Interrupt::GPIO, interrupt::Priority::Priority3).unwrap();
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     let mut delay = Delay::new(&clocks);
     loop {

--- a/esp32h2-hal/examples/rtc_watchdog.rs
+++ b/esp32h2-hal/examples/rtc_watchdog.rs
@@ -14,7 +14,6 @@ use esp32h2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     Rtc,
     Rwdt,
 };
@@ -39,10 +38,6 @@ fn main() -> ! {
     .unwrap();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32h2-hal/examples/serial_interrupts.rs
+++ b/esp32h2-hal/examples/serial_interrupts.rs
@@ -13,7 +13,6 @@ use esp32h2_hal::{
     interrupt,
     peripherals::{self, Peripherals, UART0},
     prelude::*,
-    riscv,
     timer::TimerGroup,
     uart::config::AtCmdConfig,
     Cpu,
@@ -53,10 +52,6 @@ fn main() -> ! {
         interrupt::CpuInterrupt::Interrupt1, // Interrupt 1 handles priority one interrupts
         interrupt::InterruptKind::Edge,
     );
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {
         critical_section::with(|cs| {

--- a/esp32h2-hal/examples/timer_interrupt.rs
+++ b/esp32h2-hal/examples/timer_interrupt.rs
@@ -13,7 +13,6 @@ use esp32h2_hal::{
     interrupt,
     peripherals::{self, Peripherals, TIMG0, TIMG1},
     prelude::*,
-    riscv,
     timer::{Timer, Timer0, TimerGroup},
 };
 use esp_backtrace as _;
@@ -56,10 +55,6 @@ fn main() -> ! {
         TIMER0.borrow_ref_mut(cs).replace(timer0);
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {}
 }

--- a/esp32h2-hal/examples/usb_serial_jtag.rs
+++ b/esp32h2-hal/examples/usb_serial_jtag.rs
@@ -13,7 +13,6 @@ use esp32h2_hal::{
     interrupt,
     peripherals::{self, Peripherals},
     prelude::*,
-    riscv,
     timer::TimerGroup,
     Cpu,
     UsbSerialJtag,
@@ -51,10 +50,6 @@ fn main() -> ! {
         interrupt::CpuInterrupt::Interrupt1,
         interrupt::InterruptKind::Edge,
     );
-
-    unsafe {
-        riscv::interrupt::enable();
-    }
 
     loop {
         critical_section::with(|cs| {


### PR DESCRIPTION
Fixes #924 

Additionally, the debug_assist example (for RISC-V chips) doesn't use magic hardcoded numbers anymore.
