### PR TITLE
Only implement `__pender` if a hal-provided executor is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed short wait times in embassy causing hangs (#906)
 - Make sure to clear LP/RTC RAM before loading code (#916)
 - Async RMT channels can be used concurrently (#925)
+- Xtensa: Allow using `embassy-executor`'s thread-mode executor if neither `embassy-executor-thread`, nor `embassy-executor-interrupt` is enabled. (#937)
 
 ### Removed
 

--- a/esp-hal-common/src/embassy/executor/xtensa/mod.rs
+++ b/esp-hal-common/src/embassy/executor/xtensa/mod.rs
@@ -12,6 +12,10 @@ pub mod thread;
 #[cfg(feature = "embassy-executor-thread")]
 pub use thread::*;
 
+#[cfg(any(
+    feature = "embassy-executor-thread",
+    feature = "embassy-executor-interrupt",
+))]
 #[export_name = "__pender"]
 fn __pender(context: *mut ()) {
     let context = (context as usize).to_le_bytes();


### PR DESCRIPTION
This PR should allow using the xtensa-arch thread-mode executor in embassy-executor.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
