### PR TITLE
Enable GitHub Merge Queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,14 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - "**/README.md"
   push:
+    branches-ignore:
+      - "gh-readonly-queue/**"
     paths-ignore:
       - "**/README.md"
+  merge_group:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Well, shall we pull the trigger? 😁 

I believe this is all that's required in the workflow; once this is merged I can enable the `require merge queue` setting in the branch protection rules and we should be good to go I think.