### PR TITLE
H2: prepare modem clocks for BLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve DMA documentation & clean up module (#915)
 - Only allow a single version of `esp-hal-common` to be present in an application (#934)
 - C3, C6 and H2 can now use the `zero-rtc-bss` feature to enable `esp-hal-common/rv-zero-rtc-bss` (#867)
+- Reuse `ieee802154_clock_enable/disable()` functions for BLE and rename `ble_ieee802154_clock_enable()` (#953)
 
 ### Fixed
 

--- a/esp-hal-common/src/soc/esp32h2/radio_clocks.rs
+++ b/esp-hal-common/src/soc/esp32h2/radio_clocks.rs
@@ -17,16 +17,14 @@ impl RadioClockController for RadioClockControl {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),
-            RadioPeripherals::Bt => todo!("BLE not yet supported"),
-            RadioPeripherals::Ieee802154 => ieee802154_clock_enable(),
+            RadioPeripherals::Bt | RadioPeripherals::Ieee802154 => ble_ieee802154_clock_enable(),
         }
     }
 
     fn disable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => disable_phy(),
-            RadioPeripherals::Bt => todo!("BLE not yet supported"),
-            RadioPeripherals::Ieee802154 => ieee802154_clock_disable(),
+            RadioPeripherals::Bt | RadioPeripherals::Ieee802154 => ble_ieee802154_clock_disable(),
         }
     }
 
@@ -59,7 +57,7 @@ fn disable_phy() {
         .modify(|_, w| w.clk_i2c_mst_en().clear_bit());
 }
 
-fn ieee802154_clock_enable() {
+fn ble_ieee802154_clock_enable() {
     let modem_lpcon = unsafe { &*esp32h2::MODEM_LPCON::PTR };
     let modem_syscon = unsafe { &*esp32h2::MODEM_SYSCON::PTR };
 
@@ -89,7 +87,7 @@ fn ieee802154_clock_enable() {
         .modify(|_, w| w.clk_coex_en().set_bit());
 }
 
-fn ieee802154_clock_disable() {
+fn ble_ieee802154_clock_disable() {
     let modem_lpcon = unsafe { &*esp32h2::MODEM_LPCON::PTR };
     let modem_syscon = unsafe { &*esp32h2::MODEM_SYSCON::PTR };
 


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.

Reuse `ieee802154_clock_enable/disable()` functions for BLE and rename `ble_ieee802154_clock_enable()`