### PR TITLE
Allow reading xtal and slow clock frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A way to configure inverted pins (#912)
 - Added API to check a GPIO-pin's interrupt status bit (#929)
 - A `embedded_io_async::Read` implementation for `UsbSerialJtag` (#889)
+- `RtcClock::get_xtal_freq`, `RtcClock::get_slow_freq` (#957)
 
 ### Changed
 

--- a/esp-hal-common/src/clock/mod.rs
+++ b/esp-hal-common/src/clock/mod.rs
@@ -114,9 +114,9 @@ impl Clock for CpuClock {
     }
 }
 
-#[allow(unused)]
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum XtalClock {
+#[non_exhaustive]
+pub enum XtalClock {
     #[cfg(esp32)]
     RtcXtalFreq24M,
     #[cfg(any(esp32, esp32c2))]

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -145,10 +145,10 @@ impl Clock for RtcFastClock {
 }
 
 #[cfg(not(any(esp32c6, esp32h2)))]
-#[allow(unused)]
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 /// RTC SLOW_CLK frequency values
-pub(crate) enum RtcSlowClock {
+pub enum RtcSlowClock {
     /// Internal slow RC oscillator
     RtcSlowClockRtc     = 0,
     /// External 32 KHz XTAL
@@ -369,7 +369,7 @@ impl RtcClock {
     /// Get main XTAL frequency
     /// This is the value stored in RTC register RTC_XTAL_FREQ_REG by the
     /// bootloader, as passed to rtc_clk_init function.
-    fn get_xtal_freq() -> XtalClock {
+    pub fn get_xtal_freq() -> XtalClock {
         let xtal_freq_reg = unsafe { &*RTC_CNTL::PTR }.store4.read().bits();
 
         // Values of RTC_XTAL_FREQ_REG and RTC_APB_FREQ_REG are stored as two copies in
@@ -398,7 +398,7 @@ impl RtcClock {
 
     /// Get the RTC_SLOW_CLK source
     #[cfg(not(any(esp32c6, esp32h2)))]
-    fn get_slow_freq() -> RtcSlowClock {
+    pub fn get_slow_freq() -> RtcSlowClock {
         let rtc_cntl = unsafe { &*RTC_CNTL::PTR };
         let slow_freq = rtc_cntl.clk_conf.read().ana_clk_rtc_sel().bits();
         match slow_freq {


### PR DESCRIPTION
In esp-wifi, we have the clock frequencies hard-coded, in the case of ESP32 to 40MHz. This causes issues for users that have a 26MHz module. It is possible to read the xtal frequency configured by the project from `ClockControl` via some unsafe code, but this PR adds a safe way for accessing the value applied by the bootloader.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
