### PR TITLE
Gate the `embedded-io` trait impls behind a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only allow a single version of `esp-hal-common` to be present in an application (#934)
 - C3, C6 and H2 can now use the `zero-rtc-bss` feature to enable `esp-hal-common/rv-zero-rtc-bss` (#867)
 - Reuse `ieee802154_clock_enable/disable()` functions for BLE and rename `ble_ieee802154_clock_enable()` (#953)
+- The `embedded-io` trait implementations are now gated behind the `embedded-io` feature (#964)
 
 ### Fixed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -29,7 +29,7 @@ embedded-dma         = "0.2.0"
 embedded-hal         = { version = "0.2.7", features = ["unproven"] }
 embedded-hal-1       = { version = "=1.0.0-rc.1", optional = true, package = "embedded-hal" }
 embedded-hal-nb      = { version = "=1.0.0-rc.1", optional = true }
-embedded-io          = "0.6.1"
+embedded-io          = { version = "0.6.1", optional = true }
 esp-synopsys-usb-otg = { version = "0.3.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
 log                  = { version = "0.4.20", optional = true }
@@ -117,16 +117,25 @@ log = ["dep:log"]
 
 # Trait implementation features:
 #  - Implement the `embedded-hal@1.0.0-rc.x` traits (and friends)
+#  - Implement the `embedded-io` traits where able
 #  - Implement the `ufmt_write::Write` trait where able
-eh1  = ["embedded-hal-1", "embedded-hal-nb", "embedded-can"]
-ufmt = ["ufmt-write"]
+eh1         = ["embedded-hal-1", "embedded-hal-nb", "embedded-can"]
+embedded-io = ["dep:embedded-io"]
+ufmt        = ["ufmt-write"]
 
 # Support for asynchronous operation, implementing traits from
 # `embedded-hal-async` and `embedded-io-async`
-async = ["embedded-hal-async", "eh1", "embassy-sync", "embassy-futures", "embedded-io-async"]
+async = [
+    "embedded-hal-async",
+    "eh1",
+    "embassy-sync",
+    "embassy-futures",
+    "embedded-io",
+    "embedded-io-async",
+]
 
 # Embassy support
-embassy = ["embassy-time","procmacros/embassy"]
+embassy = ["embassy-time", "procmacros/embassy"]
 
 embassy-executor-interrupt = ["embassy", "embassy-executor"]
 embassy-executor-thread    = ["embassy", "embassy-executor"]

--- a/esp-hal-common/src/uart.rs
+++ b/esp-hal-common/src/uart.rs
@@ -71,6 +71,7 @@ impl embedded_hal_nb::serial::Error for Error {
     }
 }
 
+#[cfg(feature = "embedded-io")]
 impl embedded_io::Error for Error {
     fn kind(&self) -> embedded_io::ErrorKind {
         embedded_io::ErrorKind::Other
@@ -1157,18 +1158,22 @@ where
     }
 }
 
+#[cfg(feature = "embedded-io")]
 impl<T> embedded_io::ErrorType for Uart<'_, T> {
     type Error = Error;
 }
 
+#[cfg(feature = "embedded-io")]
 impl<T> embedded_io::ErrorType for UartTx<'_, T> {
     type Error = Error;
 }
 
+#[cfg(feature = "embedded-io")]
 impl<T> embedded_io::ErrorType for UartRx<'_, T> {
     type Error = Error;
 }
 
+#[cfg(feature = "embedded-io")]
 impl<T> embedded_io::Read for Uart<'_, T>
 where
     T: Instance,
@@ -1178,6 +1183,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-io")]
 impl<T> embedded_io::Read for UartRx<'_, T>
 where
     T: Instance,
@@ -1208,6 +1214,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-io")]
 impl<T> embedded_io::Write for Uart<'_, T>
 where
     T: Instance,
@@ -1221,6 +1228,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-io")]
 impl<T> embedded_io::Write for UartTx<'_, T>
 where
     T: Instance,

--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -296,10 +296,12 @@ impl embedded_hal_nb::serial::Write for UsbSerialJtag<'_> {
     }
 }
 
+#[cfg(feature = "embedded-io")]
 impl embedded_io::ErrorType for UsbSerialJtag<'_> {
     type Error = Error;
 }
 
+#[cfg(feature = "embedded-io")]
 impl embedded_io::Read for UsbSerialJtag<'_> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         let mut count = 0;
@@ -327,6 +329,7 @@ impl embedded_io::Read for UsbSerialJtag<'_> {
     }
 }
 
+#[cfg(feature = "embedded-io")]
 impl embedded_io::Write for UsbSerialJtag<'_> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.write_bytes(buf)?;


### PR DESCRIPTION
Should have been this way from the start, was my mistake.

I've enabled the `embedded-io` feature via the `async` feature as well, as trying to get the `Error` and `ErrorType` traits implemented was pretty frustrating otherwise. I think this is reasonable.