### PR TITLE
Update the `msrv-*`, `clippy-*`, and `rustfmt` CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,64 +624,64 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
-          target: riscv32imc-unknown-none-elf, riscv32imac-unknown-none-elf
-          toolchain: stable
-          components: clippy
+          toolchain: nightly
+          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
+          components: clippy,rust-src
       - uses: Swatinem/rust-cache@v2
 
-      # Run clippy on all packages targeting RISC-V.
+      # Run 'cargo clippy' on all packages targeting RISC-V:
       - name: clippy (esp-riscv-rt)
-        run: cd esp-riscv-rt && cargo +stable clippy -- -D warnings
+        run: cd esp-riscv-rt && cargo clippy --target=riscv32imc-unknown-none-elf -- -D warnings
+      - name: clippy (esp-ulp-riscv-hal, esp32s2)
+        run: cd esp-ulp-riscv-hal && cargo clippy --features=esp32s2 -- -D warnings
+      - name: clippy (esp-ulp-riscv-hal, esp32s3)
+        run: cd esp-ulp-riscv-hal && cargo clippy --features=esp32s3 -- -D warnings
       - name: clippy (esp32c2-hal)
-        run: cd esp32c2-hal && cargo +stable clippy -- -D warnings
+        run: cd esp32c2-hal && cargo clippy -- -D warnings
       - name: clippy (esp32c3-hal)
-        run: cd esp32c3-hal && cargo +stable clippy -- -D warnings
+        run: cd esp32c3-hal && cargo clippy -- -D warnings
       - name: clippy (esp32c6-hal)
-        run: cd esp32c6-hal && cargo +stable clippy -- -D warnings
+        run: cd esp32c6-hal && cargo clippy -- -D warnings
       - name: clippy (esp32c6-lp-hal)
-        run: cd esp32c6-lp-hal && cargo +stable clippy -- -D warnings -A asm-sub-register
+        run: cd esp32c6-lp-hal && cargo clippy -- -D warnings
       - name: clippy (esp32h2-hal)
-        run: cd esp32h2-hal && cargo +stable clippy -- -D warnings
-      - name: clippy (esp-ulp-riscv-hal)
-        run: cd esp-ulp-riscv-hal && cargo +stable clippy --features=esp32s3 -- -D warnings -A asm-sub-register
+        run: cd esp32h2-hal && cargo clippy -- -D warnings
 
   clippy-xtensa:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
 
-      # Run clippy on all packages targeting Xtensa.
+      # Run 'cargo clippy' on all packages targeting Xtensa:
       - name: clippy (esp32-hal)
-        run: cargo +esp clippy --manifest-path=esp32-hal/Cargo.toml -- -D warnings
+        run: cd esp32-hal && cargo clippy -- -D warnings
       - name: clippy (esp32s2-hal)
-        run: cargo +esp clippy --manifest-path=esp32s2-hal/Cargo.toml -- -D warnings
+        run: cd esp32s2-hal && cargo clippy -- -D warnings
       - name: clippy (esp32s3-hal)
-        run: cargo +esp clippy --manifest-path=esp32s3-hal/Cargo.toml -- -D warnings
+        run: cd esp32s3-hal && cargo clippy -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-
-      # Some of the items in 'rustfmt.toml' require the nightly release
-      # channel, so we must use this channel for the formatting checks
-      # to succeed.
+      - uses: actions/checkout@v4
+      # Some of the configuration items in 'rustfmt.toml' require the 'nightly'
+      # release channel:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
 
-      # Check the formatting of all packages.
+      # Check the formatting of all packages:
       - name: rustfmt (esp-hal-common)
         run: cargo fmt --all --manifest-path=esp-hal-common/Cargo.toml -- --check
       - name: rustfmt (esp-hal-procmacros)
@@ -690,6 +690,8 @@ jobs:
         run: cargo fmt --all --manifest-path=esp-hal-smartled/Cargo.toml -- --check
       - name: rustfmt (esp-riscv-rt)
         run: cargo fmt --all --manifest-path=esp-riscv-rt/Cargo.toml -- --check
+      - name: rustfmt (esp-ulp-riscv-hal)
+        run: cargo fmt --all --manifest-path=esp-ulp-riscv-hal/Cargo.toml -- --check
       - name: rustfmt (esp32-hal)
         run: cargo fmt --all --manifest-path=esp32-hal/Cargo.toml -- --check
       - name: rustfmt (esp32c2-hal)
@@ -706,5 +708,3 @@ jobs:
         run: cargo fmt --all --manifest-path=esp32s2-hal/Cargo.toml -- --check
       - name: rustfmt (esp32s3-hal)
         run: cargo fmt --all --manifest-path=esp32s3-hal/Cargo.toml -- --check
-      - name: rustfmt (esp-ulp-riscv-hal)
-        run: cargo fmt --all --manifest-path=esp-ulp-riscv-hal/Cargo.toml -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MSRV: "1.67.0"
 
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.
@@ -540,82 +541,88 @@ jobs:
 
   msrv-riscv:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_BOOTSTRAP: 1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
-          target: riscv32imc-unknown-none-elf, riscv32imac-unknown-none-elf
-          toolchain: "1.67"
+          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
+          toolchain: ${{ env.MSRV }}
           components: rust-src
       - uses: Swatinem/rust-cache@v2
 
-      # build the lp-hal examples first to make sure the examples which expect
-      # the ELF files to be present will compile
+      # Build the esp32c6-lp-hal examples first. This is done to ensure the
+      # examples which expect the ELF files to be present will compile:
       - name: build esp32c6-lp-hal prerequisites
-        run: cd esp32c6-lp-hal/ && RUSTC_BOOTSTRAP=1 cargo build --release --examples
+        run: cd esp32c6-lp-hal && cargo build --release --examples
 
       # Verify the MSRV for all RISC-V chips.
       - name: msrv (esp32c2-hal)
         run: |
           cd esp32c2-hal/
-          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
-          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
+          cargo build --features=eh1,ufmt,log
+          cargo build --features=defmt
       - name: msrv (esp32c3-hal)
         run: |
           cd esp32c3-hal/
-          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
-          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
+          cargo build --features=eh1,ufmt,log
+          cargo build --features=defmt
       - name: msrv (esp32c6-hal)
         run: |
           cd esp32c6-hal/
-          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
-          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
+          cargo build --features=eh1,ufmt,log
+          cargo build --features=defmt
       - name: msrv (esp32c6-lp-hal)
-        run: cd esp32c6-lp-hal/ && RUSTC_BOOTSTRAP=1 cargo check
+        run: |
+          cd esp32c6-lp-hal/
+          cargo build
       - name: msrv (esp32h2-hal)
         run: |
           cd esp32h2-hal/
-          RUSTC_BOOTSTRAP=1 cargo check --features=eh1,ufmt,log
-          RUSTC_BOOTSTRAP=1 cargo check --features=defmt
+          cargo build --features=eh1,ufmt,log
+          cargo build --features=defmt
 
   msrv-xtensa:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_BOOTSTRAP: 1
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          ldproxy: false
-          version: "1.67.0"
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
-          toolchain: "1.67"
+          toolchain: ${{ env.MSRV }}
           components: rust-src
+      - uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          ldproxy: false
+          version: ${{ env.MSRV }}
       - uses: Swatinem/rust-cache@v2
 
-      # build the esp-ulp-riscv-hal examples first to make sure the examples which expect
-      # the ELF files to be present will compile
+      # Build the `esp-ulp-riscv-hal` examples first. This is done to ensure
+      # the examples which expect the ELF files to be present will compile:
       - name: build esp-ulp-riscv-hal prerequisites
-        run: cd esp-ulp-riscv-hal/ && RUSTC_BOOTSTRAP=1 cargo +1.67 build --release --features=esp32s3 --examples
+        run: cd esp-ulp-riscv-hal && cargo build --release --features=esp32s3 --examples
 
-      # Verify the MSRV for all Xtensa chips.
+      # Verify the MSRV for all Xtensa chips:
       - name: msrv (esp32-hal)
         run: |
           cd esp32-hal/
-          cargo +esp check --features=eh1,ufmt,log
-          cargo +esp check --features=defmt
+          cargo build --features=eh1,ufmt,log
+          cargo build --features=defmt
       - name: msrv (esp32s2-hal)
         run: |
           cd esp32s2-hal/
-          cargo +esp check --features=eh1,ufmt,log
-          cargo +esp check --features=defmt
+          cargo build --features=eh1,ufmt,log
+          cargo build --features=defmt
       - name: msrv (esp32s3-hal)
         run: |
           cd esp32s3-hal/
-          cargo +esp check --features=eh1,ufmt,log
-          cargo +esp check --features=defmt
+          cargo build --features=eh1,ufmt,log
+          cargo build --features=defmt
 
   # --------------------------------------------------------------------------
   # Lint

--- a/esp-ulp-riscv-hal/src/lib.rs
+++ b/esp-ulp-riscv-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(asm_sub_register)]
 
 use core::arch::global_asm;
 

--- a/esp32c6-lp-hal/src/lib.rs
+++ b/esp32c6-lp-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(asm_sub_register)]
 
 use core::arch::global_asm;
 


### PR DESCRIPTION
Previously, due to the use of `--manifest-path`, we were not running `clippy` for the correct target. This resolves that issues, and also just cleans up and updates some other minor details.

I plan on addressing the other CI jobs as well, but will do so in another PR.