### PR TITLE
Align stack variable names

### DIFF
--- a/esp-hal-common/ld/esp32/esp32.x
+++ b/esp-hal-common/ld/esp32/esp32.x
@@ -36,8 +36,8 @@ _stack_region_bottom = _stack_end;
 /*
  use the whole remaining memory as core-0's stack
 */
-_stack_end_cpu0 = _stack_region_top;
-_stack_start_cpu0 = _stack_region_bottom;
+_stack_start_cpu0 = _stack_region_top;
+_stack_end_cpu0 = _stack_region_bottom;
 
 EXTERN(DefaultHandler);
 

--- a/esp-hal-common/ld/esp32s2/esp32s2.x
+++ b/esp-hal-common/ld/esp32s2/esp32s2.x
@@ -34,8 +34,8 @@ INCLUDE "rtc_slow.x"
 _stack_region_top = ABSOLUTE(ORIGIN(dram_seg))+LENGTH(dram_seg);
 _stack_region_bottom = _stack_end;
 
-_stack_end_cpu0 = _stack_region_top;
-_stack_start_cpu0 = _stack_region_bottom;
+_stack_start_cpu0 = _stack_region_top;
+_stack_end_cpu0 = _stack_region_bottom;
 
 EXTERN(DefaultHandler);
 

--- a/esp-hal-common/ld/esp32s3/esp32s3.x
+++ b/esp-hal-common/ld/esp32s3/esp32s3.x
@@ -51,8 +51,8 @@ _stack_region_bottom = _stack_end;
 /*
  use the whole remaining memory as core-0's stack
 */
-_stack_end_cpu0 = _stack_region_top;
-_stack_start_cpu0 = _stack_region_bottom;
+_stack_start_cpu0 = _stack_region_top;
+_stack_end_cpu0 = _stack_region_bottom;
 
 EXTERN(DefaultHandler);
 

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -71,11 +71,11 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         static mut _rtc_slow_bss_start: u32;
         static mut _rtc_slow_bss_end: u32;
 
-        static mut _stack_end_cpu0: u32;
+        static mut _stack_start_cpu0: u32;
     }
 
     // set stack pointer to end of memory: no need to retain stack up to this point
-    esp_hal_common::xtensa_lx::set_stack_pointer(&mut _stack_end_cpu0);
+    esp_hal_common::xtensa_lx::set_stack_pointer(&mut _stack_start_cpu0);
 
     // copying data from flash to various data segments is done by the bootloader
     // initialization to zero needs to be done by the application

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -67,11 +67,11 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         static mut _rtc_slow_bss_start: u32;
         static mut _rtc_slow_bss_end: u32;
 
-        static mut _stack_end_cpu0: u32;
+        static mut _stack_start_cpu0: u32;
     }
 
     // set stack pointer to end of memory: no need to retain stack up to this point
-    esp_hal_common::xtensa_lx::set_stack_pointer(&mut _stack_end_cpu0);
+    esp_hal_common::xtensa_lx::set_stack_pointer(&mut _stack_start_cpu0);
 
     // copying data from flash to various data segments is done by the bootloader
     // initialization to zero needs to be done by the application

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -120,11 +120,11 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         static mut _rtc_slow_bss_start: u32;
         static mut _rtc_slow_bss_end: u32;
 
-        static mut _stack_end_cpu0: u32;
+        static mut _stack_start_cpu0: u32;
     }
 
     // set stack pointer to end of memory: no need to retain stack up to this point
-    esp_hal_common::xtensa_lx::set_stack_pointer(&mut _stack_end_cpu0);
+    esp_hal_common::xtensa_lx::set_stack_pointer(&mut _stack_start_cpu0);
 
     // copying data from flash to various data segments is done by the bootloader
     // initialization to zero needs to be done by the application


### PR DESCRIPTION
Closes https://github.com/esp-rs/esp-hal/issues/961

In both Xtensa and RISC-V the stack grows downwards, so the start address will have a higher value. For Xtensa the start and end addresses were flipped, but coincidently, we also set the stack pointer to the end value too. I think this was just a simple typo/confusion. 
