### PR TITLE
Pin PACs to a commit for `esp-ulp-riscv-hal`

### DIFF
--- a/esp-ulp-riscv-hal/Cargo.toml
+++ b/esp-ulp-riscv-hal/Cargo.toml
@@ -25,9 +25,8 @@ categories = [
 embedded-hal      = { version = "0.2.7", features = ["unproven"] }
 procmacros        = { package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 paste             = "1.0.14"
-esp32s2-ulp       = { git = "https://github.com/esp-rs/esp-pacs", package = "esp32s2-ulp", optional = true }
-esp32s3-ulp       = { git = "https://github.com/esp-rs/esp-pacs", package = "esp32s3-ulp", optional = true }
-
+esp32s2-ulp       = { git = "https://github.com/esp-rs/esp-pacs", rev = "a7066cf", package = "esp32s2-ulp", optional = true }
+esp32s3-ulp       = { git = "https://github.com/esp-rs/esp-pacs", rev = "a7066cf", package = "esp32s3-ulp", optional = true }
 
 [dev-dependencies]
 panic-halt       = "0.2.0"


### PR DESCRIPTION
Updates to `esp-pacs` caused the CI workflow to fail due to changes in the ULP PACs. Pinning to the previous commit hash until new releases are available.