### PR TITLE
Improve SmartLED init

### DIFF
--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -14,7 +14,8 @@
 //! let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 //! let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
 //!
-//! let led = <smartLedAdapter!(0, 1)>::new(rmt.channel0, io.pins.gpio0);
+//! let mut rmt_buffer = smartLedBuffer!(1);
+//! let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, &mut rmt_buffer);
 //! ```
 
 #![no_std]
@@ -70,35 +71,35 @@ pub enum LedAdapterError {
     TransmissionError(RmtError),
 }
 
-/// Macro to generate adapters with an arbitrary buffer size fitting for a
-/// specific number of `$buffer_size` LEDs to be addressed.
+/// Macro to allocate a buffer sized for a specific number of LEDs to be
+/// addressed.
 ///
 /// Attempting to use more LEDs that the buffer is configured for will result in
 /// an `LedAdapterError:BufferSizeExceeded` error.
 #[macro_export]
-macro_rules! smartLedAdapter {
-    ( $channel: literal, $buffer_size: literal ) => {
+macro_rules! smartLedBuffer {
+    ( $buffer_size: literal ) => {
         // The size we're assigning here is calculated as following
         //  (
         //   Nr. of LEDs
         //   * channels (r,g,b -> 3)
         //   * pulses per channel 8)
         //  ) + 1 additional pulse for the end delimiter
-        SmartLedsAdapter::<_, $channel, { $buffer_size * 24 + 1 }>
+        [0u32; $buffer_size * 24 + 1]
     };
 }
 
 /// Adapter taking an RMT channel and a specific pin and providing RGB LED
 /// interaction functionality using the `smart-leds` crate
-pub struct SmartLedsAdapter<TX, const CHANNEL: u8, const BUFFER_SIZE: usize>
+pub struct SmartLedsAdapter<'d, TX, const CHANNEL: u8>
 where
     TX: TxChannel<CHANNEL>,
 {
     channel: Option<TX>,
-    rmt_buffer: [u32; BUFFER_SIZE],
+    rmt_buffer: &'d mut [u32],
 }
 
-impl<'d, TX, const CHANNEL: u8, const BUFFER_SIZE: usize> SmartLedsAdapter<TX, CHANNEL, BUFFER_SIZE>
+impl<'d, TX, const CHANNEL: u8> SmartLedsAdapter<'d, TX, CHANNEL>
 where
     TX: TxChannel<CHANNEL>,
 {
@@ -106,7 +107,8 @@ where
     pub fn new<C, O>(
         channel: C,
         pin: impl Peripheral<P = O> + 'd,
-    ) -> SmartLedsAdapter<TX, CHANNEL, BUFFER_SIZE>
+        rmt_buffer: &'d mut [u32],
+    ) -> SmartLedsAdapter<TX, CHANNEL>
     where
         O: OutputPin + 'd,
         C: TxChannelCreator<'d, TX, O, CHANNEL>,
@@ -124,7 +126,7 @@ where
 
         Self {
             channel: Some(channel),
-            rmt_buffer: [0; BUFFER_SIZE],
+            rmt_buffer,
         }
     }
 
@@ -167,8 +169,7 @@ where
     }
 }
 
-impl<TX, const CHANNEL: u8, const BUFFER_SIZE: usize> SmartLedsWrite
-    for SmartLedsAdapter<TX, CHANNEL, BUFFER_SIZE>
+impl<'d, TX, const CHANNEL: u8> SmartLedsWrite for SmartLedsAdapter<'d, TX, CHANNEL>
 where
     TX: TxChannel<CHANNEL>,
 {

--- a/esp32-hal/examples/hello_rgb.rs
+++ b/esp32-hal/examples/hello_rgb.rs
@@ -15,7 +15,7 @@
 
 use esp32_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
-use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
+use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness,
     gamma,
@@ -36,10 +36,11 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    // -> We need to use the macro `smartLedAdapter!` with the number of addressed
+    // -> We need to use the macro `smartLedBuffer!` with the number of addressed
     // LEDs here to initialize the internal LED pulse buffer to the correct
     // size!
-    let mut led = <smartLedAdapter!(0, 12)>::new(rmt.channel0, io.pins.gpio33);
+    let mut rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio33, &mut rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -13,7 +13,7 @@
 
 use esp32c3_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
-use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
+use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness,
     gamma,
@@ -34,7 +34,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut led = <smartLedAdapter!(0, 1)>::new(rmt.channel0, io.pins.gpio8);
+    let mut rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, &mut rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c6-hal/examples/hello_rgb.rs
+++ b/esp32c6-hal/examples/hello_rgb.rs
@@ -12,7 +12,7 @@
 
 use esp32c6_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
-use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
+use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness,
     gamma,
@@ -33,7 +33,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut led = <smartLedAdapter!(0, 1)>::new(rmt.channel0, io.pins.gpio8);
+    let mut rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, &mut rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32h2-hal/examples/hello_rgb.rs
+++ b/esp32h2-hal/examples/hello_rgb.rs
@@ -12,7 +12,7 @@
 
 use esp32h2_hal::{clock::ClockControl, peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
-use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
+use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness,
     gamma,
@@ -29,11 +29,12 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Configure RMT peripheral globally
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 32u32.MHz(), &clocks).unwrap();
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut led = <smartLedAdapter!(0, 1)>::new(rmt.channel0, io.pins.gpio8);
+    let mut rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, &mut rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -13,7 +13,7 @@
 
 use esp32s2_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
-use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
+use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness,
     gamma,
@@ -34,7 +34,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut led = <smartLedAdapter!(0, 1)>::new(rmt.channel0, io.pins.gpio18);
+    let mut rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio18, &mut rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32s3-hal/examples/hello_rgb.rs
+++ b/esp32s3-hal/examples/hello_rgb.rs
@@ -13,7 +13,7 @@
 
 use esp32s3_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, rmt::Rmt, Delay, IO};
 use esp_backtrace as _;
-use esp_hal_smartled::{smartLedAdapter, SmartLedsAdapter};
+use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness,
     gamma,
@@ -34,7 +34,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut led = <smartLedAdapter!(0, 1)>::new(rmt.channel0, io.pins.gpio48);
+    let mut rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio48, &mut rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.


### PR DESCRIPTION
This slightly improves how the SmartLED adapter is used.

Before that macro took the channel number which was confusing and usage of the macro looked a bit odd.

Skipping changelog since this doesn't change anything in esp-hal(-common) besides adapting the `hello_rgb` example
