### PR TITLE
fix!: Use u32 words instead of u8 bytes for the RSA driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Direct boot support has been removed (#903).
 - `Spi::new`/`Spi::new_half_duplex` takes no gpio pin now, instead you need to call `with_pins` to setup those (#901).
 - ESP32C2, ESP32C3: atomic emulation trap is now opt-in. When upgrading you must either remove [these lines](https://github.com/esp-rs/riscv-atomic-emulation-trap#usage) from your `.cargo/config.toml` or opt back in by enabling the feature. (#904)
+- RSA driver now takes u32 words instead of u8 bytes. The expected slice length is now 4 times shorter. (#981)
 
 ## [0.13.1] - 2023-11-02
 

--- a/esp-hal-common/src/rsa/esp32.rs
+++ b/esp-hal-common/src/rsa/esp32.rs
@@ -49,20 +49,20 @@ impl<'d> Rsa<'d> {
         self.rsa.interrupt.read().bits() == 1
     }
 
-    unsafe fn write_multi_operand_a<const N: usize>(&mut self, operand_a: &[u8; N]) {
+    unsafe fn write_multi_operand_a<const N: usize>(&mut self, operand_a: &[u32; N]) {
         copy_nonoverlapping(
             operand_a.as_ptr(),
-            self.rsa.x_mem.as_mut_ptr() as *mut u8,
+            self.rsa.x_mem.as_mut_ptr() as *mut u32,
             N,
         );
-        write_bytes(self.rsa.x_mem.as_mut_ptr().add(N), 0, N);
+        write_bytes(self.rsa.x_mem.as_mut_ptr().add(N * 4), 0, N * 4);
     }
 
-    unsafe fn write_multi_operand_b<const N: usize>(&mut self, operand_b: &[u8; N]) {
-        write_bytes(self.rsa.z_mem.as_mut_ptr(), 0, N);
+    unsafe fn write_multi_operand_b<const N: usize>(&mut self, operand_b: &[u32; N]) {
+        write_bytes(self.rsa.z_mem.as_mut_ptr(), 0, N * 4);
         copy_nonoverlapping(
             operand_b.as_ptr(),
-            self.rsa.z_mem.as_mut_ptr().add(N) as *mut u8,
+            self.rsa.z_mem.as_mut_ptr().add(N * 4) as *mut u32,
             N,
         );
     }
@@ -88,7 +88,7 @@ pub mod operand_sizes {
 
 impl<'a, 'd, T: RsaMode, const N: usize> RsaModularMultiplication<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// Creates an Instance of `RsaMultiplication`.  
     /// `m_prime` could be calculated using `-(modular multiplicative inverse of
@@ -108,7 +108,7 @@ where
     }
 
     fn set_mode(rsa: &mut Rsa) {
-        rsa.write_multi_mode((N / 64 - 1) as u32)
+        rsa.write_multi_mode((N / 16 - 1) as u32)
     }
 
     /// Starts the first step of modular multiplication operation. `r` could be
@@ -147,7 +147,7 @@ where
 
 impl<'a, 'd, T: RsaMode, const N: usize> RsaModularExponentiation<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// Creates an Instance of `RsaModularExponentiation`.  
     /// `m_prime` could be calculated using `-(modular multiplicative inverse of
@@ -172,7 +172,7 @@ where
     }
 
     pub(super) fn set_mode(rsa: &mut Rsa) {
-        rsa.write_modexp_mode((N / 64 - 1) as u32)
+        rsa.write_modexp_mode((N / 16 - 1) as u32)
     }
 
     pub(super) fn set_start(&mut self) {
@@ -182,7 +182,7 @@ where
 
 impl<'a, 'd, T: RsaMode + Multi, const N: usize> RsaMultiplication<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// Creates an Instance of `RsaMultiplication`.
     pub fn new(rsa: &'a mut Rsa<'d>) -> Self {
@@ -203,7 +203,7 @@ where
     }
 
     pub(super) fn set_mode(rsa: &mut Rsa) {
-        rsa.write_multi_mode((N / 32 - 1 + 8) as u32)
+        rsa.write_multi_mode(((N * 2) / 16 + 7) as u32)
     }
 
     pub(super) fn set_start(&mut self) {

--- a/esp-hal-common/src/rsa/esp32sX.rs
+++ b/esp-hal-common/src/rsa/esp32sX.rs
@@ -109,10 +109,10 @@ impl<'d> Rsa<'d> {
         self.rsa.idle.read().idle().bit_is_set()
     }
 
-    unsafe fn write_multi_operand_b<const N: usize>(&mut self, operand_b: &[u8; N]) {
+    unsafe fn write_multi_operand_b<const N: usize>(&mut self, operand_b: &[u32; N]) {
         copy_nonoverlapping(
             operand_b.as_ptr(),
-            self.rsa.z_mem.as_mut_ptr().add(N) as *mut u8,
+            self.rsa.z_mem.as_mut_ptr().add(N * 4) as *mut u32,
             N,
         );
     }
@@ -261,7 +261,7 @@ pub mod operand_sizes {
 
 impl<'a, 'd, T: RsaMode, const N: usize> RsaModularExponentiation<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// Creates an Instance of `RsaModularExponentiation`.  
     /// `m_prime` could be calculated using `-(modular multiplicative inverse of
@@ -293,13 +293,13 @@ where
             if *byte == 0 {
                 continue;
             }
-            return (exponent.len() * 8) as u32 - (byte.leading_zeros() + i as u32 * 8) - 1;
+            return (exponent.len() * 32) as u32 - (byte.leading_zeros() + i as u32 * 32) - 1;
         }
         0
     }
 
     pub(super) fn set_mode(rsa: &mut Rsa) {
-        rsa.write_mode((N / 4 - 1) as u32)
+        rsa.write_mode((N - 1) as u32)
     }
 
     pub(super) fn set_start(&mut self) {
@@ -309,7 +309,7 @@ where
 
 impl<'a, 'd, T: RsaMode, const N: usize> RsaModularMultiplication<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// Creates an Instance of `RsaModularMultiplication`.  
     /// `m_prime` could be calculated using `-(modular multiplicative inverse of
@@ -336,7 +336,7 @@ where
     }
 
     fn write_mode(rsa: &mut Rsa) {
-        rsa.write_mode((N / 4 - 1) as u32)
+        rsa.write_mode((N - 1) as u32)
     }
 
     /// Starts the modular multiplication operation. `r` could be calculated
@@ -356,7 +356,7 @@ where
 
 impl<'a, 'd, T: RsaMode + Multi, const N: usize> RsaMultiplication<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// Creates an Instance of `RsaMultiplication`.
     pub fn new(rsa: &'a mut Rsa<'d>, operand_a: &T::InputType) -> Self {
@@ -379,7 +379,7 @@ where
     }
 
     pub(super) fn set_mode(rsa: &mut Rsa) {
-        rsa.write_mode((N / 2 - 1) as u32)
+        rsa.write_mode((N * 2 - 1) as u32)
     }
 
     pub(super) fn set_start(&mut self) {

--- a/esp-hal-common/src/rsa/mod.rs
+++ b/esp-hal-common/src/rsa/mod.rs
@@ -32,20 +32,22 @@
 //! ```no_run
 //! #[embassy_executor::task]
 //! async fn mod_exp_example(mut rsa: Rsa<'static>) {
-//!     let mut outbuf = [0_u8; U512::BYTES];
+//!     let mut outbuf = [0_u32; U512::LIMBS];
 //!     let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op512>::new(
 //!         &mut rsa,
-//!         &BIGNUM_2.to_le_bytes(),
-//!         &BIGNUM_3.to_le_bytes(),
+//!         BIGNUM_2.as_words(),
+//!         BIGNUM_3.as_words(),
 //!         compute_mprime(&BIGNUM_3),
 //!     );
-//!     let r = compute_r(&BIGNUM_3).to_le_bytes();
-//!     let base = &BIGNUM_1.to_le_bytes();
-//!     mod_exp.exponentiation(&base, &r, &mut outbuf).await;
+//!     let r = compute_r(&BIGNUM_3);
+//!     let base = &BIGNUM_1.as_words();
+//!     mod_exp
+//!         .exponentiation(base, r.as_words(), &mut outbuf)
+//!         .await;
 //!     let residue_params = DynResidueParams::new(&BIGNUM_3);
 //!     let residue = DynResidue::new(&BIGNUM_1, residue_params);
 //!     let sw_out = residue.pow(&BIGNUM_2);
-//!     assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+//!     assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
 //!     println!("modular exponentiation done");
 //! }
 //! ```
@@ -92,36 +94,40 @@ impl<'d> Rsa<'d> {
         Self { rsa }
     }
 
-    unsafe fn write_operand_b<const N: usize>(&mut self, operand_b: &[u8; N]) {
+    unsafe fn write_operand_b<const N: usize>(&mut self, operand_b: &[u32; N]) {
         copy_nonoverlapping(
             operand_b.as_ptr(),
-            self.rsa.y_mem.as_mut_ptr() as *mut u8,
+            self.rsa.y_mem.as_mut_ptr() as *mut u32,
             N,
         );
     }
 
-    unsafe fn write_modulus<const N: usize>(&mut self, modulus: &[u8; N]) {
-        copy_nonoverlapping(modulus.as_ptr(), self.rsa.m_mem.as_mut_ptr() as *mut u8, N);
+    unsafe fn write_modulus<const N: usize>(&mut self, modulus: &[u32; N]) {
+        copy_nonoverlapping(modulus.as_ptr(), self.rsa.m_mem.as_mut_ptr() as *mut u32, N);
     }
 
     fn write_mprime(&mut self, m_prime: u32) {
         self.rsa.m_prime.write(|w| unsafe { w.bits(m_prime) });
     }
 
-    unsafe fn write_operand_a<const N: usize>(&mut self, operand_a: &[u8; N]) {
+    unsafe fn write_operand_a<const N: usize>(&mut self, operand_a: &[u32; N]) {
         copy_nonoverlapping(
             operand_a.as_ptr(),
-            self.rsa.x_mem.as_mut_ptr() as *mut u8,
+            self.rsa.x_mem.as_mut_ptr() as *mut u32,
             N,
         );
     }
 
-    unsafe fn write_r<const N: usize>(&mut self, r: &[u8; N]) {
-        copy_nonoverlapping(r.as_ptr(), self.rsa.z_mem.as_mut_ptr() as *mut u8, N);
+    unsafe fn write_r<const N: usize>(&mut self, r: &[u32; N]) {
+        copy_nonoverlapping(r.as_ptr(), self.rsa.z_mem.as_mut_ptr() as *mut u32, N);
     }
 
-    unsafe fn read_out<const N: usize>(&mut self, outbuf: &mut [u8; N]) {
-        copy_nonoverlapping(self.rsa.z_mem.as_ptr() as *const u8, outbuf.as_mut_ptr(), N);
+    unsafe fn read_out<const N: usize>(&mut self, outbuf: &mut [u32; N]) {
+        copy_nonoverlapping(
+            self.rsa.z_mem.as_ptr() as *const u32,
+            outbuf.as_mut_ptr(),
+            N,
+        );
     }
 }
 
@@ -142,11 +148,11 @@ macro_rules! implement_op {
     paste! {pub struct [<Op $x>];}
     paste! {
         impl Multi for [<Op $x>] {
-        type OutputType = [u8; $x*2 / 8];
+        type OutputType = [u32; $x*2 / 32];
     }}
     paste!{
     impl RsaMode for [<Op $x>] {
-        type InputType = [u8; $x / 8];
+        type InputType = [u32; $x / 32];
     }}
     };
 
@@ -154,7 +160,7 @@ macro_rules! implement_op {
         paste! {pub struct [<Op $x>];}
     paste!{
     impl RsaMode for [<Op $x>] {
-        type InputType =  [u8; $x / 8];
+        type InputType =  [u32; $x / 32];
     }}
      };
 
@@ -177,7 +183,7 @@ pub struct RsaModularExponentiation<'a, 'd, T: RsaMode> {
 
 impl<'a, 'd, T: RsaMode, const N: usize> RsaModularExponentiation<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// starts the modular exponentiation operation. `r` could be calculated
     /// using `2 ^ ( bitlength * 2 ) mod modulus`, for more information
@@ -218,7 +224,7 @@ pub struct RsaModularMultiplication<'a, 'd, T: RsaMode> {
 
 impl<'a, 'd, T: RsaMode, const N: usize> RsaModularMultiplication<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// Reads the result to the given buffer.
     /// This is a non blocking function that returns without an error if
@@ -247,7 +253,7 @@ pub struct RsaMultiplication<'a, 'd, T: RsaMode + Multi> {
 
 impl<'a, 'd, T: RsaMode + Multi, const N: usize> RsaMultiplication<'a, 'd, T>
 where
-    T: RsaMode<InputType = [u8; N]>,
+    T: RsaMode<InputType = [u32; N]>,
 {
     /// Reads the result to the given buffer.
     /// This is a non blocking function that returns without an error if
@@ -255,7 +261,7 @@ where
     /// called before calling this function.
     pub fn read_results<'b, const O: usize>(&mut self, outbuf: &mut T::OutputType)
     where
-        T: Multi<OutputType = [u8; O]>,
+        T: Multi<OutputType = [u32; O]>,
     {
         loop {
             if self.rsa.is_idle() {
@@ -341,7 +347,7 @@ pub(crate) mod asynch {
 
     impl<'a, 'd, T: RsaMode, const N: usize> RsaModularExponentiation<'a, 'd, T>
     where
-        T: RsaMode<InputType = [u8; N]>,
+        T: RsaMode<InputType = [u32; N]>,
     {
         pub async fn exponentiation(
             &mut self,
@@ -357,7 +363,7 @@ pub(crate) mod asynch {
 
     impl<'a, 'd, T: RsaMode, const N: usize> RsaModularMultiplication<'a, 'd, T>
     where
-        T: RsaMode<InputType = [u8; N]>,
+        T: RsaMode<InputType = [u32; N]>,
     {
         #[cfg(not(esp32))]
         pub async fn modular_multiplication(
@@ -387,7 +393,7 @@ pub(crate) mod asynch {
 
     impl<'a, 'd, T: RsaMode + Multi, const N: usize> RsaMultiplication<'a, 'd, T>
     where
-        T: RsaMode<InputType = [u8; N]>,
+        T: RsaMode<InputType = [u32; N]>,
     {
         #[cfg(not(esp32))]
         pub async fn multiplication<'b, const O: usize>(
@@ -395,7 +401,7 @@ pub(crate) mod asynch {
             operand_b: &T::InputType,
             outbuf: &mut T::OutputType,
         ) where
-            T: Multi<OutputType = [u8; O]>,
+            T: Multi<OutputType = [u32; O]>,
         {
             self.start_multiplication(operand_b);
             RsaFuture::new(&self.rsa.rsa).await;
@@ -409,7 +415,7 @@ pub(crate) mod asynch {
             operand_b: &T::InputType,
             outbuf: &mut T::OutputType,
         ) where
-            T: Multi<OutputType = [u8; O]>,
+            T: Multi<OutputType = [u32; O]>,
         {
             self.start_multiplication(operand_a, operand_b);
             RsaFuture::new(&self.rsa.rsa).await;

--- a/esp32c3-hal/examples/rsa.rs
+++ b/esp32c3-hal/examples/rsa.rs
@@ -6,7 +6,6 @@
 
 use crypto_bigint::{
     modular::runtime_mod::{DynResidue, DynResidueParams},
-    Encoding,
     Uint,
     U1024,
     U512,
@@ -68,17 +67,17 @@ fn main() -> ! {
 }
 
 fn mod_multi_example(rsa: &mut Rsa) {
-    let mut outbuf = [0_u8; U512::BYTES];
+    let mut outbuf = [0_u32; U512::LIMBS];
     let mut mod_multi = RsaModularMultiplication::<operand_sizes::Op512>::new(
         rsa,
-        &BIGNUM_1.to_le_bytes(),
-        &BIGNUM_2.to_le_bytes(),
-        &BIGNUM_3.to_le_bytes(),
+        BIGNUM_1.as_words(),
+        BIGNUM_2.as_words(),
+        BIGNUM_3.as_words(),
         compute_mprime(&BIGNUM_3),
     );
-    let r = compute_r(&BIGNUM_3).to_le_bytes();
+    let r = compute_r(&BIGNUM_3);
     let pre_hw_modmul = SystemTimer::now();
-    mod_multi.start_modular_multiplication(&r);
+    mod_multi.start_modular_multiplication(r.as_words());
     mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = SystemTimer::now();
     println!(
@@ -95,24 +94,24 @@ fn mod_multi_example(rsa: &mut Rsa) {
         "it took {} cycles for sw modular multiplication",
         post_sw_exp - pre_sw_exp
     );
-    assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+    assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
     println!("modular multiplication done");
 }
 
 fn mod_exp_example(rsa: &mut Rsa) {
     rsa.enable_disable_constant_time_acceleration(true);
     rsa.enable_disable_search_acceleration(true);
-    let mut outbuf = [0_u8; U512::BYTES];
+    let mut outbuf = [0_u32; U512::LIMBS];
     let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op512>::new(
         rsa,
-        &BIGNUM_2.to_le_bytes(),
-        &BIGNUM_3.to_le_bytes(),
+        BIGNUM_2.as_words(),
+        BIGNUM_3.as_words(),
         compute_mprime(&BIGNUM_3),
     );
-    let r = compute_r(&BIGNUM_3).to_le_bytes();
-    let base = &BIGNUM_1.to_le_bytes();
+    let r = compute_r(&BIGNUM_3);
+    let base = &BIGNUM_1.as_words();
     let pre_hw_exp = SystemTimer::now();
-    mod_exp.start_exponentiation(&base, &r);
+    mod_exp.start_exponentiation(&base, r.as_words());
     mod_exp.read_results(&mut outbuf);
     let post_hw_exp = SystemTimer::now();
     println!(
@@ -128,17 +127,17 @@ fn mod_exp_example(rsa: &mut Rsa) {
         "it took {} cycles for sw modular exponentiation",
         post_sw_exp - pre_sw_exp
     );
-    assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+    assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
     println!("modular exponentiation done");
 }
 
 fn multiplication_example(rsa: &mut Rsa) {
-    let mut out = [0_u8; U1024::BYTES];
-    let operand_a = &BIGNUM_1.to_le_bytes();
-    let operand_b = &BIGNUM_2.to_le_bytes();
-    let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
+    let mut out = [0_u32; U1024::LIMBS];
+    let operand_a = BIGNUM_1;
+    let operand_b = BIGNUM_2;
+    let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, operand_a.as_words());
     let pre_hw_mul = SystemTimer::now();
-    rsamulti.start_multiplication(&operand_b);
+    rsamulti.start_multiplication(operand_b.as_words());
     rsamulti.read_results(&mut out);
     let post_hw_mul = SystemTimer::now();
     println!(
@@ -152,6 +151,6 @@ fn multiplication_example(rsa: &mut Rsa) {
         "it took {} cycles for sw multiplication",
         post_sw_mul - pre_sw_mul
     );
-    assert_eq!(U1024::from_le_bytes(out), sw_out.1.concat(&sw_out.0));
+    assert_eq!(U1024::from_words(out), sw_out.1.concat(&sw_out.0));
     println!("multiplication done");
 }

--- a/esp32c6-hal/examples/rsa.rs
+++ b/esp32c6-hal/examples/rsa.rs
@@ -6,7 +6,6 @@
 
 use crypto_bigint::{
     modular::runtime_mod::{DynResidue, DynResidueParams},
-    Encoding,
     Uint,
     U1024,
     U512,
@@ -68,17 +67,17 @@ fn main() -> ! {
 }
 
 fn mod_multi_example(rsa: &mut Rsa) {
-    let mut outbuf = [0_u8; U512::BYTES];
+    let mut outbuf = [0_u32; U512::LIMBS];
     let mut mod_multi = RsaModularMultiplication::<operand_sizes::Op512>::new(
         rsa,
-        &BIGNUM_1.to_le_bytes(),
-        &BIGNUM_2.to_le_bytes(),
-        &BIGNUM_3.to_le_bytes(),
+        BIGNUM_1.as_words(),
+        BIGNUM_2.as_words(),
+        BIGNUM_3.as_words(),
         compute_mprime(&BIGNUM_3),
     );
-    let r = compute_r(&BIGNUM_3).to_le_bytes();
+    let r = compute_r(&BIGNUM_3);
     let pre_hw_modmul = SystemTimer::now();
-    mod_multi.start_modular_multiplication(&r);
+    mod_multi.start_modular_multiplication(r.as_words());
     mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = SystemTimer::now();
     println!(
@@ -95,24 +94,24 @@ fn mod_multi_example(rsa: &mut Rsa) {
         "it took {} cycles for sw modular multiplication",
         post_sw_exp - pre_sw_exp
     );
-    assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+    assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
     println!("modular multiplication done");
 }
 
 fn mod_exp_example(rsa: &mut Rsa) {
     rsa.enable_disable_constant_time_acceleration(true);
     rsa.enable_disable_search_acceleration(true);
-    let mut outbuf = [0_u8; U512::BYTES];
+    let mut outbuf = [0_u32; U512::LIMBS];
     let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op512>::new(
         rsa,
-        &BIGNUM_2.to_le_bytes(),
-        &BIGNUM_3.to_le_bytes(),
+        BIGNUM_2.as_words(),
+        BIGNUM_3.as_words(),
         compute_mprime(&BIGNUM_3),
     );
-    let r = compute_r(&BIGNUM_3).to_le_bytes();
-    let base = &BIGNUM_1.to_le_bytes();
+    let r = compute_r(&BIGNUM_3);
+    let base = BIGNUM_1.as_words();
     let pre_hw_exp = SystemTimer::now();
-    mod_exp.start_exponentiation(&base, &r);
+    mod_exp.start_exponentiation(base, r.as_words());
     mod_exp.read_results(&mut outbuf);
     let post_hw_exp = SystemTimer::now();
     println!(
@@ -128,17 +127,17 @@ fn mod_exp_example(rsa: &mut Rsa) {
         "it took {} cycles for sw modular exponentiation",
         post_sw_exp - pre_sw_exp
     );
-    assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+    assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
     println!("modular exponentiation done");
 }
 
 fn multiplication_example(rsa: &mut Rsa) {
-    let mut out = [0_u8; U1024::BYTES];
-    let operand_a = &BIGNUM_1.to_le_bytes();
-    let operand_b = &BIGNUM_2.to_le_bytes();
-    let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
+    let mut out = [0_u32; U1024::LIMBS];
+    let operand_a = BIGNUM_1.as_words();
+    let operand_b = BIGNUM_2.as_words();
+    let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, operand_a);
     let pre_hw_mul = SystemTimer::now();
-    rsamulti.start_multiplication(&operand_b);
+    rsamulti.start_multiplication(operand_b);
     rsamulti.read_results(&mut out);
     let post_hw_mul = SystemTimer::now();
     println!(
@@ -152,6 +151,6 @@ fn multiplication_example(rsa: &mut Rsa) {
         "it took {} cycles for sw multiplication",
         post_sw_mul - pre_sw_mul
     );
-    assert_eq!(U1024::from_le_bytes(out), sw_out.1.concat(&sw_out.0));
+    assert_eq!(U1024::from_words(out), sw_out.1.concat(&sw_out.0));
     println!("multiplication done");
 }

--- a/esp32h2-hal/examples/rsa.rs
+++ b/esp32h2-hal/examples/rsa.rs
@@ -6,7 +6,6 @@
 
 use crypto_bigint::{
     modular::runtime_mod::{DynResidue, DynResidueParams},
-    Encoding,
     Uint,
     U1024,
     U512,
@@ -68,17 +67,17 @@ fn main() -> ! {
 }
 
 fn mod_multi_example(rsa: &mut Rsa) {
-    let mut outbuf = [0_u8; U512::BYTES];
+    let mut outbuf = [0_u32; U512::LIMBS];
     let mut mod_multi = RsaModularMultiplication::<operand_sizes::Op512>::new(
         rsa,
-        &BIGNUM_1.to_le_bytes(),
-        &BIGNUM_2.to_le_bytes(),
-        &BIGNUM_3.to_le_bytes(),
+        BIGNUM_1.as_words(),
+        BIGNUM_2.as_words(),
+        BIGNUM_3.as_words(),
         compute_mprime(&BIGNUM_3),
     );
-    let r = compute_r(&BIGNUM_3).to_le_bytes();
+    let r = compute_r(&BIGNUM_3);
     let pre_hw_modmul = SystemTimer::now();
-    mod_multi.start_modular_multiplication(&r);
+    mod_multi.start_modular_multiplication(r.as_words());
     mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = SystemTimer::now();
     println!(
@@ -95,24 +94,24 @@ fn mod_multi_example(rsa: &mut Rsa) {
         "it took {} cycles for sw modular multiplication",
         post_sw_exp - pre_sw_exp
     );
-    assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+    assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
     println!("modular multiplication done");
 }
 
 fn mod_exp_example(rsa: &mut Rsa) {
     rsa.enable_disable_constant_time_acceleration(true);
     rsa.enable_disable_search_acceleration(true);
-    let mut outbuf = [0_u8; U512::BYTES];
+    let mut outbuf = [0_u32; U512::LIMBS];
     let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op512>::new(
         rsa,
-        &BIGNUM_2.to_le_bytes(),
-        &BIGNUM_3.to_le_bytes(),
+        BIGNUM_2.as_words(),
+        BIGNUM_3.as_words(),
         compute_mprime(&BIGNUM_3),
     );
-    let r = compute_r(&BIGNUM_3).to_le_bytes();
-    let base = &BIGNUM_1.to_le_bytes();
+    let r = compute_r(&BIGNUM_3);
+    let base = BIGNUM_1.as_words();
     let pre_hw_exp = SystemTimer::now();
-    mod_exp.start_exponentiation(&base, &r);
+    mod_exp.start_exponentiation(base, r.as_words());
     mod_exp.read_results(&mut outbuf);
     let post_hw_exp = SystemTimer::now();
     println!(
@@ -128,17 +127,17 @@ fn mod_exp_example(rsa: &mut Rsa) {
         "it took {} cycles for sw modular exponentiation",
         post_sw_exp - pre_sw_exp
     );
-    assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+    assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
     println!("modular exponentiation done");
 }
 
 fn multiplication_example(rsa: &mut Rsa) {
-    let mut out = [0_u8; U1024::BYTES];
-    let operand_a = &BIGNUM_1.to_le_bytes();
-    let operand_b = &BIGNUM_2.to_le_bytes();
-    let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
+    let mut out = [0_u32; U1024::LIMBS];
+    let operand_a = BIGNUM_1.as_words();
+    let operand_b = BIGNUM_2.as_words();
+    let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, operand_a);
     let pre_hw_mul = SystemTimer::now();
-    rsamulti.start_multiplication(&operand_b);
+    rsamulti.start_multiplication(operand_b);
     rsamulti.read_results(&mut out);
     let post_hw_mul = SystemTimer::now();
     println!(
@@ -152,6 +151,6 @@ fn multiplication_example(rsa: &mut Rsa) {
         "it took {} cycles for sw multiplication",
         post_sw_mul - pre_sw_mul
     );
-    assert_eq!(U1024::from_le_bytes(out), sw_out.1.concat(&sw_out.0));
+    assert_eq!(U1024::from_words(out), sw_out.1.concat(&sw_out.0));
     println!("multiplication done");
 }

--- a/esp32s2-hal/examples/rsa.rs
+++ b/esp32s2-hal/examples/rsa.rs
@@ -6,7 +6,6 @@
 
 use crypto_bigint::{
     modular::runtime_mod::{DynResidue, DynResidueParams},
-    Encoding,
     Uint,
     U1024,
     U512,
@@ -69,17 +68,17 @@ fn main() -> ! {
 }
 
 fn mod_multi_example(rsa: &mut Rsa) {
-    let mut outbuf = [0_u8; U512::BYTES];
+    let mut outbuf = [0_u32; U512::LIMBS];
     let mut mod_multi = RsaModularMultiplication::<operand_sizes::Op512>::new(
         rsa,
-        &BIGNUM_1.to_le_bytes(),
-        &BIGNUM_2.to_le_bytes(),
-        &BIGNUM_3.to_le_bytes(),
+        BIGNUM_1.as_words(),
+        BIGNUM_2.as_words(),
+        BIGNUM_3.as_words(),
         compute_mprime(&BIGNUM_3),
     );
-    let r = compute_r(&BIGNUM_3).to_le_bytes();
+    let r = compute_r(&BIGNUM_3);
     let pre_hw_modmul = xtensa_lx::timer::get_cycle_count();
-    mod_multi.start_modular_multiplication(&r);
+    mod_multi.start_modular_multiplication(r.as_words());
     mod_multi.read_results(&mut outbuf);
     let post_hw_modmul = xtensa_lx::timer::get_cycle_count();
     println!(
@@ -96,24 +95,24 @@ fn mod_multi_example(rsa: &mut Rsa) {
         "it took {} cycles for sw modular multiplication",
         post_sw_exp - pre_sw_exp
     );
-    assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+    assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
     println!("modular multiplication done");
 }
 
 fn mod_exp_example(rsa: &mut Rsa) {
     rsa.enable_disable_constant_time_acceleration(true);
     rsa.enable_disable_search_acceleration(true);
-    let mut outbuf = [0_u8; U512::BYTES];
+    let mut outbuf = [0_u32; U512::LIMBS];
     let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op512>::new(
         rsa,
-        &BIGNUM_2.to_le_bytes(),
-        &BIGNUM_3.to_le_bytes(),
+        BIGNUM_2.as_words(),
+        BIGNUM_3.as_words(),
         compute_mprime(&BIGNUM_3),
     );
-    let r = compute_r(&BIGNUM_3).to_le_bytes();
-    let base = &BIGNUM_1.to_le_bytes();
+    let r = compute_r(&BIGNUM_3);
+    let base = BIGNUM_1.as_words();
     let pre_hw_exp = xtensa_lx::timer::get_cycle_count();
-    mod_exp.start_exponentiation(&base, &r);
+    mod_exp.start_exponentiation(base, r.as_words());
     mod_exp.read_results(&mut outbuf);
     let post_hw_exp = xtensa_lx::timer::get_cycle_count();
     println!(
@@ -129,17 +128,17 @@ fn mod_exp_example(rsa: &mut Rsa) {
         "it took {} cycles for sw modular exponentiation",
         post_sw_exp - pre_sw_exp
     );
-    assert_eq!(U512::from_le_bytes(outbuf), sw_out.retrieve());
+    assert_eq!(U512::from_words(outbuf), sw_out.retrieve());
     println!("modular exponentiation done");
 }
 
 fn multiplication_example(rsa: &mut Rsa) {
-    let mut out = [0_u8; U1024::BYTES];
-    let operand_a = &BIGNUM_1.to_le_bytes();
-    let operand_b = &BIGNUM_2.to_le_bytes();
-    let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, &operand_a);
+    let mut out = [0_u32; U1024::LIMBS];
+    let operand_a = BIGNUM_1.as_words();
+    let operand_b = BIGNUM_2.as_words();
+    let mut rsamulti = RsaMultiplication::<operand_sizes::Op512>::new(rsa, operand_a);
     let pre_hw_mul = xtensa_lx::timer::get_cycle_count();
-    rsamulti.start_multiplication(&operand_b);
+    rsamulti.start_multiplication(operand_b);
     rsamulti.read_results(&mut out);
     let post_hw_mul = xtensa_lx::timer::get_cycle_count();
     println!(
@@ -153,6 +152,6 @@ fn multiplication_example(rsa: &mut Rsa) {
         "it took {} cycles for sw multiplication",
         post_sw_mul - pre_sw_mul
     );
-    assert_eq!(U1024::from_le_bytes(out), sw_out.1.concat(&sw_out.0));
+    assert_eq!(U1024::from_words(out), sw_out.1.concat(&sw_out.0));
     println!("multiplication done");
 }


### PR DESCRIPTION
This fixes a bug that was happening when using 8 bytes or less for an operation. This also greatly reduce the processing time for data coming from mbedtls or any kind of u32 words used for RSA.

BREAKING CHANGE: The RSA driver now takes u32 slices instead of u8

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
