### PR TITLE
I2S: Less generics, nicer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reuse `ieee802154_clock_enable/disable()` functions for BLE and rename `ble_ieee802154_clock_enable()` (#953)
 - The `embedded-io` trait implementations are now gated behind the `embedded-io` feature (#964)
 - Simplifed RMT channels and channel creators (#958)
+- Reworked construction of I2S driver instances (#983)
 
 ### Fixed
 

--- a/esp32-hal/examples/embassy_i2s_read.rs
+++ b/esp32-hal/examples/embassy_i2s_read.rs
@@ -19,7 +19,7 @@ use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy::{self},
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, NoMclk, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -51,7 +51,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        NoMclk {},
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -64,11 +63,12 @@ async fn main(_spawner: Spawner) {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio12,
-        io.pins.gpio13,
-        io.pins.gpio14,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio12)
+        .with_ws(io.pins.gpio13)
+        .with_din(io.pins.gpio14)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32_hal::interrupt::enable(

--- a/esp32-hal/examples/embassy_i2s_sound.rs
+++ b/esp32-hal/examples/embassy_i2s_sound.rs
@@ -35,7 +35,7 @@ use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy::{self},
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, NoMclk, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -75,7 +75,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        NoMclk {},
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -88,11 +87,12 @@ async fn main(_spawner: Spawner) {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio12,
-        io.pins.gpio13,
-        io.pins.gpio14,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio12)
+        .with_ws(io.pins.gpio13)
+        .with_dout(io.pins.gpio14)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32_hal::interrupt::enable(

--- a/esp32-hal/examples/i2s_read.rs
+++ b/esp32-hal/examples/i2s_read.rs
@@ -16,7 +16,7 @@
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    i2s::{DataFormat, I2s, I2s0New, I2sReadDma, NoMclk, PinsBclkWsDin, Standard},
+    i2s::{DataFormat, I2s, I2sReadDma, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -41,7 +41,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        NoMclk {},
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -54,11 +53,12 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio12,
-        io.pins.gpio13,
-        io.pins.gpio14,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio12)
+        .with_ws(io.pins.gpio13)
+        .with_din(io.pins.gpio14)
+        .build();
 
     let buffer = dma_buffer();
 

--- a/esp32-hal/examples/i2s_sound.rs
+++ b/esp32-hal/examples/i2s_sound.rs
@@ -32,7 +32,7 @@
 use esp32_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, NoMclk, PinsBclkWsDout, Standard},
+    i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -64,7 +64,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        NoMclk {},
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -77,11 +76,12 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio12,
-        io.pins.gpio13,
-        io.pins.gpio14,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio12)
+        .with_ws(io.pins.gpio13)
+        .with_dout(io.pins.gpio14)
+        .build();
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32c3-hal/examples/embassy_i2s_read.rs
+++ b/esp32c3-hal/examples/embassy_i2s_read.rs
@@ -21,7 +21,7 @@ use esp32c3_hal::{
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -60,7 +60,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -71,13 +70,15 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32c3_hal::interrupt::enable(

--- a/esp32c3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c3-hal/examples/embassy_i2s_sound.rs
@@ -37,7 +37,7 @@ use esp32c3_hal::{
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -84,7 +84,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -95,13 +94,15 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32c3_hal::interrupt::enable(

--- a/esp32c3-hal/examples/i2s_read.rs
+++ b/esp32c3-hal/examples/i2s_read.rs
@@ -18,7 +18,7 @@ use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     gdma::Gdma,
-    i2s::{DataFormat, I2s, I2s0New, I2sReadDma, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -42,7 +42,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -53,13 +52,15 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio5,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     let buffer = dma_buffer();
 

--- a/esp32c3-hal/examples/i2s_sound.rs
+++ b/esp32c3-hal/examples/i2s_sound.rs
@@ -34,7 +34,7 @@ use esp32c3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     gdma::Gdma,
-    i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -65,7 +65,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -76,13 +75,15 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32c6-hal/examples/embassy_i2s_read.rs
+++ b/esp32c6-hal/examples/embassy_i2s_read.rs
@@ -21,7 +21,7 @@ use esp32c6_hal::{
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -60,7 +60,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -71,13 +70,15 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32c6_hal::interrupt::enable(

--- a/esp32c6-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c6-hal/examples/embassy_i2s_sound.rs
@@ -37,7 +37,7 @@ use esp32c6_hal::{
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -84,7 +84,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -95,13 +94,15 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32c6_hal::interrupt::enable(

--- a/esp32c6-hal/examples/i2s_read.rs
+++ b/esp32c6-hal/examples/i2s_read.rs
@@ -18,7 +18,7 @@ use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     gdma::Gdma,
-    i2s::{DataFormat, I2s, I2s0New, I2sReadDma, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -42,7 +42,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -53,13 +52,15 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio5,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     let buffer = dma_buffer();
 

--- a/esp32c6-hal/examples/i2s_sound.rs
+++ b/esp32c6-hal/examples/i2s_sound.rs
@@ -34,7 +34,7 @@ use esp32c6_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     gdma::Gdma,
-    i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -65,7 +65,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -76,13 +75,15 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32h2-hal/examples/embassy_i2s_read.rs
+++ b/esp32h2-hal/examples/embassy_i2s_read.rs
@@ -21,7 +21,7 @@ use esp32h2_hal::{
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -60,7 +60,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -71,13 +70,15 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32h2_hal::interrupt::enable(

--- a/esp32h2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32h2-hal/examples/embassy_i2s_sound.rs
@@ -37,7 +37,7 @@ use esp32h2_hal::{
     dma::DmaPriority,
     embassy,
     gdma::Gdma,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -84,7 +84,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -95,13 +94,15 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32h2_hal::interrupt::enable(

--- a/esp32h2-hal/examples/i2s_read.rs
+++ b/esp32h2-hal/examples/i2s_read.rs
@@ -18,7 +18,7 @@ use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     gdma::Gdma,
-    i2s::{DataFormat, I2s, I2s0New, I2sReadDma, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -42,7 +42,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -53,13 +52,15 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio5,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     let buffer = dma_buffer();
 

--- a/esp32h2-hal/examples/i2s_sound.rs
+++ b/esp32h2-hal/examples/i2s_sound.rs
@@ -34,7 +34,7 @@ use esp32h2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     gdma::Gdma,
-    i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -65,7 +65,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -76,13 +75,15 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32s2-hal/examples/embassy_i2s_read.rs
+++ b/esp32s2-hal/examples/embassy_i2s_read.rs
@@ -19,7 +19,7 @@ use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy::{self},
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, NoMclk, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -59,7 +59,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        NoMclk {},
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -72,11 +71,12 @@ async fn main(_spawner: Spawner) {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32s2_hal::interrupt::enable(

--- a/esp32s2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s2-hal/examples/embassy_i2s_sound.rs
@@ -36,7 +36,7 @@ use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     embassy::{self},
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, NoMclk, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -84,7 +84,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        NoMclk {},
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -97,11 +96,12 @@ async fn main(_spawner: Spawner) {
         &clocks,
     );
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32s2_hal::interrupt::enable(

--- a/esp32s2-hal/examples/i2s_read.rs
+++ b/esp32s2-hal/examples/i2s_read.rs
@@ -16,7 +16,7 @@
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    i2s::{DataFormat, I2s, I2s0New, I2sReadDma, NoMclk, PinsBclkWsDin, Standard},
+    i2s::{DataFormat, I2s, I2sReadDma, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -41,7 +41,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        NoMclk {},
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -54,11 +53,12 @@ fn main() -> ! {
         &clocks,
     );
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio5,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     let buffer = dma_buffer();
 

--- a/esp32s2-hal/examples/i2s_sound.rs
+++ b/esp32s2-hal/examples/i2s_sound.rs
@@ -33,7 +33,7 @@
 use esp32s2_hal::{
     clock::ClockControl,
     dma::DmaPriority,
-    i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
@@ -65,7 +65,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -76,13 +75,15 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };

--- a/esp32s3-hal/examples/embassy_i2s_read.rs
+++ b/esp32s3-hal/examples/embassy_i2s_read.rs
@@ -21,7 +21,7 @@ use esp32s3_hal::{
     dma::DmaPriority,
     embassy::{self},
     gdma::Gdma,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDin, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -60,7 +60,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -71,13 +70,15 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_rx = i2s.i2s_rx.with_pins(PinsBclkWsDin::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_din(io.pins.gpio5)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32s3_hal::interrupt::enable(

--- a/esp32s3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s3-hal/examples/embassy_i2s_sound.rs
@@ -37,7 +37,7 @@ use esp32s3_hal::{
     dma::DmaPriority,
     embassy::{self},
     gdma::Gdma,
-    i2s::{asynch::*, DataFormat, I2s, I2s0New, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -84,7 +84,6 @@ async fn main(_spawner: Spawner) {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -95,13 +94,15 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     // you need to manually enable the DMA channel's interrupt!
     esp32s3_hal::interrupt::enable(

--- a/esp32s3-hal/examples/i2s_sound.rs
+++ b/esp32s3-hal/examples/i2s_sound.rs
@@ -34,7 +34,7 @@ use esp32s3_hal::{
     clock::ClockControl,
     dma::DmaPriority,
     gdma::Gdma,
-    i2s::{DataFormat, I2s, I2s0New, I2sWriteDma, MclkPin, PinsBclkWsDout, Standard},
+    i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -65,7 +65,6 @@ fn main() -> ! {
 
     let i2s = I2s::new(
         peripherals.I2S0,
-        MclkPin::new(io.pins.gpio4),
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
@@ -76,13 +75,15 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    );
+    )
+    .with_mclk(io.pins.gpio4);
 
-    let i2s_tx = i2s.i2s_tx.with_pins(PinsBclkWsDout::new(
-        io.pins.gpio1,
-        io.pins.gpio2,
-        io.pins.gpio3,
-    ));
+    let i2s_tx = i2s
+        .i2s_tx
+        .with_bclk(io.pins.gpio1)
+        .with_ws(io.pins.gpio2)
+        .with_dout(io.pins.gpio3)
+        .build();
 
     let data =
         unsafe { core::slice::from_raw_parts(&SINE as *const _ as *const u8, SINE.len() * 2) };


### PR DESCRIPTION
This reduces unnecessary generics, changes the constructor to better match what we want to do in #913 and some other minor improvements.

Originally, I just meant to add the `stop` function but used the opportunity to do some overdue improvements. (Yes - that additional function is also here now)

