### PR TITLE
Completely remove atomic emulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: cd esp-hal-smartled/ && cargo +esp build -Zbuild-std=core --target=xtensa-esp32s3-none-elf --features=esp32s3
       # Ensure documentation can be built (requires a chip feature!)
       - name: rustdoc
-        run: cd esp-hal-smartled/ && cargo doc --features=esp32c3
+        run: cd esp-hal-smartled/ && cargo doc -Zbuild-std=core --target=riscv32imc-unknown-none-elf --features=esp32c3
 
   esp32-hal:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 - Direct boot support has been removed (#903).
 - `Spi::new`/`Spi::new_half_duplex` takes no gpio pin now, instead you need to call `with_pins` to setup those (#901).
-- ESP32C2, ESP32C3: atomic emulation trap is now opt-in. When upgrading you must either remove [these lines](https://github.com/esp-rs/riscv-atomic-emulation-trap#usage) from your `.cargo/config.toml` or opt back in by enabling the feature. (#904)
+- ESP32C2, ESP32C3, ESP32S2: atomic emulation trap has been removed. When upgrading you must either remove [these lines](https://github.com/esp-rs/riscv-atomic-emulation-trap#usage) from your `.cargo/config.toml`. Usage of `core::sync::atomic::*` in dependent crates should be replaced with [portable-atomic](https://github.com/taiki-e/portable-atomic). (#904) (#985)
 - RSA driver now takes u32 words instead of u8 bytes. The expected slice length is now 4 times shorter. (#981)
 
 ## [0.13.1] - 2023-11-02

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -32,7 +32,7 @@ embedded-hal-nb      = { version = "=1.0.0-rc.1", optional = true }
 embedded-io          = { version = "0.6.1", optional = true }
 esp-synopsys-usb-otg = { version = "0.3.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
-heapless             = "0.8.0"
+heapless             = "0.8"
 log                  = { version = "0.4.20", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.14"
@@ -41,10 +41,7 @@ strum                = { version = "0.25.0", default-features = false, features 
 void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
 enumset              = "1.1.3"
-
-# atomic polyfill options
-portable-atomic              = { version = "1.5.1", default-features = false, optional = true }
-riscv-atomic-emulation-trap  = { version = "0.4.1", optional = true }
+portable-atomic              = { version = "1.5.1", default-features = false }
 
 # async
 embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
@@ -81,11 +78,11 @@ serde      = { version = "1.0.190", features = ["derive"] }
 
 [features]
 esp32   = ["xtensa", "esp32/rt",   "procmacros/esp32",   "xtensa-lx/esp32",   "xtensa-lx-rt/esp32"]
-esp32c2 = ["riscv",  "esp32c2/rt", "procmacros/esp32c2", "portable-atomic?/unsafe-assume-single-core"]
-esp32c3 = ["riscv",  "esp32c3/rt", "procmacros/esp32c3", "portable-atomic?/unsafe-assume-single-core"]
+esp32c2 = ["riscv",  "esp32c2/rt", "procmacros/esp32c2", "portable-atomic/unsafe-assume-single-core"]
+esp32c3 = ["riscv",  "esp32c3/rt", "procmacros/esp32c3", "portable-atomic/unsafe-assume-single-core"]
 esp32c6 = ["riscv",  "esp32c6/rt", "procmacros/esp32c6"]
 esp32h2 = ["riscv",  "esp32h2/rt", "procmacros/esp32h2"]
-esp32s2 = ["xtensa", "esp32s2/rt", "procmacros/esp32s2", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2", "usb-otg", "portable-atomic?/unsafe-assume-single-core"]
+esp32s2 = ["xtensa", "esp32s2/rt", "procmacros/esp32s2", "xtensa-lx/esp32s2", "xtensa-lx-rt/esp32s2", "usb-otg", "portable-atomic/critical-section"]
 esp32s3 = ["xtensa", "esp32s3/rt", "procmacros/esp32s3", "xtensa-lx/esp32s3", "xtensa-lx-rt/esp32s3", "usb-otg"]
 
 # Crystal frequency selection (ESP32 and ESP32-C2 only!)
@@ -156,10 +153,6 @@ embassy-generic-queue-128 = ["embassy-time/generic-queue-128"]
 # Architecture-specific features (intended for internal use)
 riscv  = ["critical-section/restore-state-u8", "esp-riscv-rt", "esp-riscv-rt/zero-bss"]
 xtensa = ["critical-section/restore-state-u32"]
-
-portable-atomic = ["dep:portable-atomic"]
-riscv-atomic-emulation = ["dep:riscv-atomic-emulation-trap", "atomic-emulation"]
-atomic-emulation = []
 
 # Initialize / clear data sections and RTC memory
 rv-init-data     = ["esp-riscv-rt/init-data", "esp-riscv-rt/init-rw-text"]

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -145,30 +145,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         unreachable!() // We've confirmed exactly one known device was selected
     };
 
-    // The C6 has an "atomic" peripheral but it's an exception, not the rule
-    // For S2, we just keep lying for now. The target has emulation support
-    // force-enabled.
-    let has_native_atomic_support = matches!(
-        device_name,
-        "esp32" | "esp32s2" | "esp32s3" | "esp32c6" | "esp32h2"
-    );
-
-    let atomic_emulation_enabled = cfg!(feature = "atomic-emulation");
-    let portable_atomic_enabled = cfg!(feature = "portable-atomic");
-
-    if !atomic_emulation_enabled && detect_atomic_extension("a") {
-        panic!("Atomic emulation flags detected in `.cargo/config.toml` but `atomic-emulation` feature is not enabled!");
-    }
-
-    if atomic_emulation_enabled && portable_atomic_enabled {
-        panic!("The `atomic-emulation` and `portable-atomic` features cannot be used together");
-    }
-
-    if has_native_atomic_support {
-        if atomic_emulation_enabled {
-            println!("cargo:warning={} has native atomic instructions, the `atomic-emulation` feature is not needed", device_name);
-        }
-        println!("cargo:rustc-cfg=has_native_atomic_support");
+    if detect_atomic_extension("a") || detect_atomic_extension("s32c1i") {
+        panic!(
+            "Atomic emulation flags detected in `.cargo/config.toml`, this is no longer supported!"
+        );
     }
 
     // Load the configuration file for the configured device:

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -12,7 +12,7 @@
 //! interrupt15() => Priority::Priority15
 //! ```
 
-use esp_riscv_rt::riscv::register::{mcause, mepc, mtvec};
+use esp_riscv_rt::riscv::register::{mcause, mtvec};
 pub use esp_riscv_rt::TrapFrame;
 
 #[cfg(not(plic))]
@@ -408,8 +408,10 @@ pub unsafe extern "C" fn start_trap_rust_hal(trap_frame: *mut TrapFrame) {
 
     let cause = mcause::read();
     if cause.is_exception() {
-        let pc = mepc::read();
-        handle_exception(pc, trap_frame);
+        extern "C" {
+            fn ExceptionHandler(tf: *mut TrapFrame);
+        }
+        ExceptionHandler(trap_frame);
     } else {
         #[cfg(feature = "interrupt-preemption")]
         let interrupt_priority = _handle_priority();
@@ -453,98 +455,6 @@ pub unsafe extern "C" fn start_trap_rust_hal(trap_frame: *mut TrapFrame) {
         #[cfg(feature = "interrupt-preemption")]
         _restore_priority(interrupt_priority);
     }
-}
-
-/// Apply atomic emulation if needed. Call the default exception handler
-/// otherwise.
-///
-/// # Safety
-///
-/// This function is called from an trap handler.
-unsafe fn handle_exception(_pc: usize, trap_frame: *mut TrapFrame) {
-    #[cfg(feature = "atomic-emulation")]
-    {
-        let insn: usize = *(_pc as *const _);
-        let needs_atomic_emulation = (insn & 0b1111111) == 0b0101111;
-        if needs_atomic_emulation {
-            let mut frame = [
-                0,
-                (*trap_frame).ra,
-                (*trap_frame).sp,
-                (*trap_frame).gp,
-                (*trap_frame).tp,
-                (*trap_frame).t0,
-                (*trap_frame).t1,
-                (*trap_frame).t2,
-                (*trap_frame).s0,
-                (*trap_frame).s1,
-                (*trap_frame).a0,
-                (*trap_frame).a1,
-                (*trap_frame).a2,
-                (*trap_frame).a3,
-                (*trap_frame).a4,
-                (*trap_frame).a5,
-                (*trap_frame).a6,
-                (*trap_frame).a7,
-                (*trap_frame).s2,
-                (*trap_frame).s3,
-                (*trap_frame).s4,
-                (*trap_frame).s5,
-                (*trap_frame).s6,
-                (*trap_frame).s7,
-                (*trap_frame).s8,
-                (*trap_frame).s9,
-                (*trap_frame).s10,
-                (*trap_frame).s11,
-                (*trap_frame).t3,
-                (*trap_frame).t4,
-                (*trap_frame).t5,
-                (*trap_frame).t6,
-            ];
-
-            riscv_atomic_emulation_trap::atomic_emulation((*trap_frame).pc, &mut frame);
-
-            (*trap_frame).ra = frame[1];
-            (*trap_frame).sp = frame[2];
-            (*trap_frame).gp = frame[3];
-            (*trap_frame).tp = frame[4];
-            (*trap_frame).t0 = frame[5];
-            (*trap_frame).t1 = frame[6];
-            (*trap_frame).t2 = frame[7];
-            (*trap_frame).s0 = frame[8];
-            (*trap_frame).s1 = frame[9];
-            (*trap_frame).a0 = frame[10];
-            (*trap_frame).a1 = frame[11];
-            (*trap_frame).a2 = frame[12];
-            (*trap_frame).a3 = frame[13];
-            (*trap_frame).a4 = frame[14];
-            (*trap_frame).a5 = frame[15];
-            (*trap_frame).a6 = frame[16];
-            (*trap_frame).a7 = frame[17];
-            (*trap_frame).s2 = frame[18];
-            (*trap_frame).s3 = frame[19];
-            (*trap_frame).s4 = frame[20];
-            (*trap_frame).s5 = frame[21];
-            (*trap_frame).s6 = frame[22];
-            (*trap_frame).s7 = frame[23];
-            (*trap_frame).s8 = frame[24];
-            (*trap_frame).s9 = frame[25];
-            (*trap_frame).s10 = frame[26];
-            (*trap_frame).s11 = frame[27];
-            (*trap_frame).t3 = frame[28];
-            (*trap_frame).t4 = frame[29];
-            (*trap_frame).t5 = frame[30];
-            (*trap_frame).t6 = frame[31];
-            (*trap_frame).pc = _pc + 4;
-
-            return;
-        }
-    }
-
-    extern "C" {
-        fn ExceptionHandler(tf: *mut TrapFrame);
-    }
-    ExceptionHandler(trap_frame);
 }
 
 #[doc(hidden)]

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -163,10 +163,6 @@ mod soc;
 
 #[allow(unused_imports)]
 mod atomic {
-    #[cfg(any(has_native_atomic_support, feature = "atomic-emulation"))]
-    pub use core::sync::atomic::*;
-
-    #[cfg(feature = "portable-atomic")]
     pub use portable_atomic::*;
 }
 

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -43,7 +43,7 @@ esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.9.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32"] }
-heapless           = "0.8.0"
+heapless           = "0.8"
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 smart-leds         = "0.3.0"

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -38,13 +38,11 @@ embedded-io-async  = "0.6.0"
 embedded-hal-bus   = "0.1.0-rc.1"
 esp-backtrace      = { version = "0.9.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println        = { version = "0.7.0", features = ["esp32c2"] }
-heapless           = "0.8.0"
+heapless           = "0.8"
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}
 ssd1306            = "0.8.4"
-portable-atomic    = "1.5.1"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
-esp-hal-common     = { features = ["portable-atomic"], path = "../esp-hal-common" } # enable portable-atomic by default for examples
 hex-literal        = "0.4.1"
 crypto-bigint      = { version = "0.5.3", default-features = false }
 elliptic-curve     = { version = "0.13.6", default-features = false, features = ["sec1"] }
@@ -81,9 +79,6 @@ embassy-generic-queue-16  = ["esp-hal-common/embassy-generic-queue-16"]
 embassy-generic-queue-32  = ["esp-hal-common/embassy-generic-queue-32"]
 embassy-generic-queue-64  = ["esp-hal-common/embassy-generic-queue-64"]
 embassy-generic-queue-128 = ["esp-hal-common/embassy-generic-queue-128"]
-
-portable-atomic  = ["esp-hal-common/portable-atomic"]
-atomic-emulation = ["esp-hal-common/riscv-atomic-emulation"]
 
 [profile.release]
 debug = true

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -44,14 +44,12 @@ embedded-hal-bus   = "0.1.0-rc.1"
 esp-backtrace      = { version = "0.9.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32c3"] }
-heapless           = "0.8.0"
+heapless           = "0.8"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
-portable-atomic    = "1.5.1"
-esp-hal-common     = { features = ["portable-atomic"], path = "../esp-hal-common" } # enable portable-atomic by default for examples
 static_cell        = { version = "2.0.0", features = ["nightly"] }
 embassy-sync       = "0.4.0"
 
@@ -87,9 +85,6 @@ embassy-generic-queue-16  = ["esp-hal-common/embassy-generic-queue-16"]
 embassy-generic-queue-32  = ["esp-hal-common/embassy-generic-queue-32"]
 embassy-generic-queue-64  = ["esp-hal-common/embassy-generic-queue-64"]
 embassy-generic-queue-128 = ["esp-hal-common/embassy-generic-queue-128"]
-
-portable-atomic  = ["esp-hal-common/portable-atomic"]
-atomic-emulation = ["esp-hal-common/riscv-atomic-emulation"]
 
 [profile.release]
 debug = true

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -43,7 +43,7 @@ embedded-hal-bus   = "0.1.0-rc.1"
 esp-backtrace      = { version = "0.9.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32c6"] }
-heapless           = "0.8.0"
+heapless           = "0.8"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -43,7 +43,7 @@ embedded-hal-bus   = "0.1.0-rc.1"
 esp-backtrace      = { version = "0.9.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32h2"] }
-heapless           = "0.8.0"
+heapless           = "0.8"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false}

--- a/esp32s2-hal/.cargo/config.toml
+++ b/esp32s2-hal/.cargo/config.toml
@@ -10,22 +10,6 @@ rustflags = [
   # LLD
   # "-C", "linker=rust-lld",
   # "-C", "link-arg=-Tlinkall.x",
-
-  # enable the atomic codegen option for Xtensa
-  "-C", "target-feature=+s32c1i",
-
-  # tell the core library have atomics even though it's not specified in the target definition
-  "--cfg", "target_has_atomic_load_store",
-  "--cfg", 'target_has_atomic_load_store="8"',
-  "--cfg", 'target_has_atomic_load_store="16"',
-  "--cfg", 'target_has_atomic_load_store="32"',
-  "--cfg", 'target_has_atomic_load_store="ptr"',
-  # enable cas
-  "--cfg", "target_has_atomic",
-  "--cfg", 'target_has_atomic="8"',
-  "--cfg", 'target_has_atomic="16"',
-  "--cfg", 'target_has_atomic="32"',
-  "--cfg", 'target_has_atomic="ptr"',
 ]
 target = "xtensa-esp32s2-none-elf"
 

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -27,7 +27,6 @@ categories = [
 [dependencies]
 esp-hal-common               = { version = "0.13.0", features = ["esp32s2"], path = "../esp-hal-common" }
 embassy-time                 = { version = "0.1.5",  features = ["nightly"], optional = true }
-xtensa-atomic-emulation-trap = "0.4.0"
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -44,7 +43,10 @@ esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.9.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32s2"] }
-heapless           = "0.8.0"
+heapless           = { version = "0.8", features = ["portable-atomic"] }
+# xtensa targets are not auto detected to need atomic emulation in the futures-* crates.
+# see https://github.com/rust-lang/futures-rs/pull/2805 as to how to remove this dep for good
+futures-util = { version = "0.3.17", default-features = false, features = ["portable-atomic"] }
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }
@@ -64,8 +66,6 @@ log       = ["esp-hal-common/log", "esp-println/log"]
 rt        = []
 ufmt      = ["esp-hal-common/ufmt"]
 vectored  = ["esp-hal-common/vectored"]
-
-portable-atomic  = ["esp-hal-common/portable-atomic"]
 
 # Embassy support
 embassy = ["esp-hal-common/embassy"]

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -59,7 +59,6 @@
 #![no_std]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-use esp_hal_common::xtensa_lx_rt::exception::ExceptionCause;
 pub use esp_hal_common::*;
 
 /// Function initializes ESP32 specific memories (RTC slow and fast) and
@@ -104,63 +103,6 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 #[rustfmt::skip]
 pub extern "Rust" fn __init_data() -> bool {
     false
-}
-
-/// Atomic Emulation is always enabled on ESP32-S2
-#[doc(hidden)]
-#[no_mangle]
-#[export_name = "__exception"] // this overrides the exception handler in xtensa_lx_rt
-#[link_section = ".rwtext"]
-unsafe fn exception(cause: ExceptionCause, save_frame: &mut trapframe::TrapFrame) {
-    if let ExceptionCause::Illegal = cause {
-        let mut regs = [
-            save_frame.A0,
-            save_frame.A1,
-            save_frame.A2,
-            save_frame.A3,
-            save_frame.A4,
-            save_frame.A5,
-            save_frame.A6,
-            save_frame.A7,
-            save_frame.A8,
-            save_frame.A9,
-            save_frame.A10,
-            save_frame.A11,
-            save_frame.A12,
-            save_frame.A13,
-            save_frame.A14,
-            save_frame.A15,
-        ];
-
-        if xtensa_atomic_emulation_trap::atomic_emulation(save_frame.PC, &mut regs) {
-            save_frame.PC += 3; // 24bit instruction
-
-            save_frame.A0 = regs[0];
-            save_frame.A1 = regs[1];
-            save_frame.A2 = regs[2];
-            save_frame.A3 = regs[3];
-            save_frame.A4 = regs[4];
-            save_frame.A5 = regs[5];
-            save_frame.A6 = regs[6];
-            save_frame.A7 = regs[7];
-            save_frame.A8 = regs[8];
-            save_frame.A9 = regs[9];
-            save_frame.A10 = regs[10];
-            save_frame.A11 = regs[11];
-            save_frame.A12 = regs[12];
-            save_frame.A13 = regs[13];
-            save_frame.A14 = regs[14];
-            save_frame.A15 = regs[15];
-
-            return;
-        }
-    }
-
-    extern "C" {
-        fn __user_exception(cause: ExceptionCause, save_frame: &mut trapframe::TrapFrame);
-    }
-
-    __user_exception(cause, save_frame);
 }
 
 #[export_name = "__post_init"]

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -46,7 +46,7 @@ esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.9.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32s3"] }
-heapless           = "0.8.0"
+heapless           = "0.8"
 hmac               = { version = "0.12.1", default-features = false }
 lis3dh-async       = "0.8.0"
 sha2               = { version = "0.10.8", default-features = false }


### PR DESCRIPTION
This PR completely removes atomic emulation. Now that the `+forced-atomics` feature is enabled on `-a` RISCV targets, the trap is less useful. Most crates in the embedded ecosystem that need cas will opt to use portable-atomic to support targets without cas.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [~] You added proper docs for your newly added features and code.
