### PR TITLE
Fix RISC-V stack allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Async RMT channels can be used concurrently (#925)
 - Xtensa: Allow using `embassy-executor`'s thread-mode executor if neither `embassy-executor-thread`, nor `embassy-executor-interrupt` is enabled. (#937)
 - Uart Async: Improve interrupt handling and irq <--> future communication (#977)
+- RISC-V: Fix stack allocation (#988)
 
 ### Removed
 

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -427,8 +427,9 @@ _abs_start:
 
     // Allocate stack
     la sp, _stack_start
-    lui t0, 16
+    li t0, 4 // make sure stack start is in RAM
     sub sp, sp, t0
+    andi sp, sp, -16 // Force 16-byte alignment
 
     // Set frame pointer
     add s0, sp, zero


### PR DESCRIPTION
Originally in #716 (and #721) the intention was to save 2k of stack memory. But in #721 we took away 0x10000 instead of 0x10 bytes from the stack 🤦‍♂️ 
