### PR TITLE
Remove unnecessary pin required by USB peripheral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `embedded-io` trait implementations are now gated behind the `embedded-io` feature (#964)
 - Simplifed RMT channels and channel creators (#958)
 - Reworked construction of I2S driver instances (#983)
+- S2 / S3: Don't require GPIO 18 to create a USB peripheral driver instance (#990)
 
 ### Fixed
 

--- a/esp-hal-common/src/otg_fs.rs
+++ b/esp-hal-common/src/otg_fs.rs
@@ -37,62 +37,52 @@ use crate::{
 };
 
 #[doc(hidden)]
-pub trait UsbSel {}
-
-#[doc(hidden)]
 pub trait UsbDp {}
 
 #[doc(hidden)]
 pub trait UsbDm {}
 
-pub struct USB<'d, S, P, M>
+pub struct USB<'d, P, M>
 where
-    S: UsbSel + Send + Sync,
     P: UsbDp + Send + Sync,
     M: UsbDm + Send + Sync,
 {
     _usb0: PeripheralRef<'d, peripherals::USB0>,
-    _usb_sel: PeripheralRef<'d, S>,
     _usb_dp: PeripheralRef<'d, P>,
     _usb_dm: PeripheralRef<'d, M>,
 }
 
-impl<'d, S, P, M> USB<'d, S, P, M>
+impl<'d, P, M> USB<'d, P, M>
 where
-    S: UsbSel + Send + Sync,
     P: UsbDp + Send + Sync,
     M: UsbDm + Send + Sync,
 {
     pub fn new(
         usb0: impl Peripheral<P = peripherals::USB0> + 'd,
-        usb_sel: impl Peripheral<P = S> + 'd,
         usb_dp: impl Peripheral<P = P> + 'd,
         usb_dm: impl Peripheral<P = M> + 'd,
     ) -> Self {
-        crate::into_ref!(usb_sel, usb_dp, usb_dm);
+        crate::into_ref!(usb_dp, usb_dm);
 
         PeripheralClockControl::enable(PeripheralEnable::Usb);
 
         Self {
             _usb0: usb0.into_ref(),
-            _usb_sel: usb_sel,
             _usb_dp: usb_dp,
             _usb_dm: usb_dm,
         }
     }
 }
 
-unsafe impl<'d, S, P, M> Sync for USB<'d, S, P, M>
+unsafe impl<'d, P, M> Sync for USB<'d, P, M>
 where
-    S: UsbSel + Send + Sync,
     P: UsbDp + Send + Sync,
     M: UsbDm + Send + Sync,
 {
 }
 
-unsafe impl<'d, S, P, M> UsbPeripheral for USB<'d, S, P, M>
+unsafe impl<'d, P, M> UsbPeripheral for USB<'d, P, M>
 where
-    S: UsbSel + Send + Sync,
     P: UsbDp + Send + Sync,
     M: UsbDm + Send + Sync,
 {

--- a/esp-hal-common/src/soc/esp32s2/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s2/gpio.rs
@@ -429,6 +429,5 @@ impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
 }
 
 // implement marker traits on USB pins
-impl<T> crate::otg_fs::UsbSel for Gpio18<T> {}
 impl<T> crate::otg_fs::UsbDp for Gpio19<T> {}
 impl<T> crate::otg_fs::UsbDm for Gpio20<T> {}

--- a/esp-hal-common/src/soc/esp32s3/gpio.rs
+++ b/esp-hal-common/src/soc/esp32s3/gpio.rs
@@ -439,6 +439,5 @@ impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
 }
 
 // implement marker traits on USB pins
-impl<T> crate::otg_fs::UsbSel for Gpio18<T> {}
 impl<T> crate::otg_fs::UsbDp for Gpio19<T> {}
 impl<T> crate::otg_fs::UsbDm for Gpio20<T> {}

--- a/esp32s2-hal/examples/usb_serial.rs
+++ b/esp32s2-hal/examples/usb_serial.rs
@@ -25,12 +25,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let usb = USB::new(
-        peripherals.USB0,
-        io.pins.gpio18,
-        io.pins.gpio19,
-        io.pins.gpio20,
-    );
+    let usb = USB::new(peripherals.USB0, io.pins.gpio19, io.pins.gpio20);
 
     let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
 

--- a/esp32s3-hal/examples/usb_serial.rs
+++ b/esp32s3-hal/examples/usb_serial.rs
@@ -25,12 +25,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let usb = USB::new(
-        peripherals.USB0,
-        io.pins.gpio18,
-        io.pins.gpio19,
-        io.pins.gpio20,
-    );
+    let usb = USB::new(peripherals.USB0, io.pins.gpio19, io.pins.gpio20);
 
     let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
 


### PR DESCRIPTION
For some reason we required an additional pin to construct the USB peripheral driver. Let's remove that
