### PR TITLE
Update to latest release candidate of `embedded-hal{-async,-nb}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplifed RMT channels and channel creators (#958)
 - Reworked construction of I2S driver instances (#983)
 - S2 / S3: Don't require GPIO 18 to create a USB peripheral driver instance (#990)
+- Updated to latest release candidate (`1.0.0-rc.2`) for `embedded-hal{-async,-nb}` (#994)
 
 ### Fixed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -41,7 +41,7 @@ portable-atomic      = { version = "1.5.1", default-features = false }
 procmacros           = { version = "0.7.0", features = ["enum-dispatch", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 strum                = { version = "0.25.0", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
-usb-device           = { version = "0.2.9", optional = true }
+usb-device           = { version = "0.3.1", optional = true }
 
 # async
 embedded-hal-async = { version = "=1.0.0-rc.2", optional = true }

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -27,32 +27,32 @@ defmt                = { version = "=0.3.5", optional = true }
 embedded-can         = { version = "0.4.1", optional = true }
 embedded-dma         = "0.2.0"
 embedded-hal         = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1       = { version = "=1.0.0-rc.1", optional = true, package = "embedded-hal" }
-embedded-hal-nb      = { version = "=1.0.0-rc.1", optional = true }
+embedded-hal-1       = { version = "=1.0.0-rc.2", optional = true, package = "embedded-hal" }
+embedded-hal-nb      = { version = "=1.0.0-rc.2", optional = true }
 embedded-io          = { version = "0.6.1", optional = true }
+enumset              = "1.1.3"
 esp-synopsys-usb-otg = { version = "0.3.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
 heapless             = "0.8"
 log                  = { version = "0.4.20", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.14"
+portable-atomic      = { version = "1.5.1", default-features = false }
 procmacros           = { version = "0.7.0", features = ["enum-dispatch", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 strum                = { version = "0.25.0", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
 usb-device           = { version = "0.2.9", optional = true }
-enumset              = "1.1.3"
-portable-atomic              = { version = "1.5.1", default-features = false }
 
 # async
-embedded-hal-async = { version = "=1.0.0-rc.1", optional = true }
-embedded-io-async  = { version = "0.6.0", optional = true }
-embassy-executor   = { version = "0.3.2", optional = true }
-embassy-futures    = { version = "0.1.0", optional = true }
-embassy-sync       = { version = "0.4.0", optional = true }
-embassy-time       = { version = "0.1.5", optional = true, features = ["nightly"] }
+embedded-hal-async = { version = "=1.0.0-rc.2", optional = true }
+embedded-io-async  = { version = "0.6.1", optional = true }
+embassy-executor   = { version = "0.3.3", optional = true }
+embassy-futures    = { version = "0.1.1", optional = true }
+embassy-sync       = { version = "0.5.0", optional = true }
+embassy-time       = { version = "0.2.0", optional = true }
 
 # RISC-V
-esp-riscv-rt                = { version = "0.5.0", optional = true, path = "../esp-riscv-rt" }
+esp-riscv-rt = { version = "0.5.0", optional = true, path = "../esp-riscv-rt" }
 
 # Xtensa
 xtensa-lx    = { version = "0.8.0",  optional = true }
@@ -74,7 +74,7 @@ esp32s3 = { version = "0.23.0", features = ["critical-section"], optional = true
 
 [build-dependencies]
 basic-toml = "0.1.7"
-serde      = { version = "1.0.190", features = ["derive"] }
+serde      = { version = "1.0.193", features = ["derive"] }
 
 [features]
 esp32   = ["xtensa", "esp32/rt",   "procmacros/esp32",   "xtensa-lx/esp32",   "xtensa-lx-rt/esp32"]
@@ -181,3 +181,9 @@ defmt = [
     "embedded-io/defmt-03",
     "embedded-io-async?/defmt-03",
 ]
+
+[patch.crates-io]
+embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -46,7 +46,7 @@ usb-device           = { version = "0.3.1", optional = true }
 # async
 embedded-hal-async = { version = "=1.0.0-rc.2", optional = true }
 embedded-io-async  = { version = "0.6.1", optional = true }
-embassy-executor   = { version = "0.3.3", optional = true }
+embassy-executor   = { version = "0.4.0", optional = true }
 embassy-futures    = { version = "0.1.1", optional = true }
 embassy-sync       = { version = "0.5.0", optional = true }
 embassy-time       = { version = "0.2.0", optional = true }
@@ -181,9 +181,3 @@ defmt = [
     "embedded-io/defmt-03",
     "embedded-io-async?/defmt-03",
 ]
-
-[patch.crates-io]
-embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp-hal-common/src/mcpwm/operator.rs
+++ b/esp-hal-common/src/mcpwm/operator.rs
@@ -684,9 +684,10 @@ impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
     embedded_hal_1::pwm::SetDutyCycle for &mut PwmPin<'d, Pin, PWM, OP, IS_A>
 {
     /// Get the max duty of the PwmPin
-    fn get_max_duty_cycle(&self) -> u16 {
+    fn max_duty_cycle(&self) -> u16 {
         self.get_period()
     }
+
     /// Set the max duty of the PwmPin
     fn set_duty_cycle(&mut self, duty: u16) -> Result<(), core::convert::Infallible> {
         self.set_timestamp(duty);

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -32,7 +32,7 @@ embassy-time   = { version = "0.2.0",  optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-executor   = { version = "0.4.0", features = ["nightly"] }
 embassy-sync       = "0.5.0"
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
@@ -146,9 +146,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2s_read"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -25,20 +25,20 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.13.0", features = ["esp32"],   path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
+esp-hal-common = { version = "0.13.0", features = ["esp32"], path = "../esp-hal-common" }
+embassy-time   = { version = "0.2.0",  optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
 embassy-executor   = { version = "0.3.2", features = ["nightly"] }
-embassy-sync       = "0.4.0"
+embassy-sync       = "0.5.0"
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
-embedded-hal-async = "=1.0.0-rc.1"
+embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.2"
 embedded-io-async  = "0.6.0"
-embedded-hal-bus   = "0.1.0-rc.1"
+embedded-hal-bus   = "0.1.0-rc.2"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.9.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32"], path = "../esp-hal-smartled" }
@@ -146,3 +146,9 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2s_read"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -26,16 +26,16 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.13.0", features = ["esp32c2"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"
 embassy-executor   = { version = "0.3.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
-embedded-hal-async = "=1.0.0-rc.1"
+embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.2"
 embedded-io-async  = "0.6.0"
-embedded-hal-bus   = "0.1.0-rc.1"
+embedded-hal-bus   = "0.1.0-rc.2"
 esp-backtrace      = { version = "0.9.0", features = ["esp32c2", "panic-handler", "exception-handler", "print-uart"] }
 esp-println        = { version = "0.7.0", features = ["esp32c2"] }
 heapless           = "0.8"
@@ -48,7 +48,7 @@ crypto-bigint      = { version = "0.5.3", default-features = false }
 elliptic-curve     = { version = "0.13.6", default-features = false, features = ["sec1"] }
 p192               = { version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256               = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
-embassy-sync       = "0.4.0"
+embassy-sync       = "0.5.0"
 
 [features]
 default              = ["rt", "vectored", "xtal-40mhz", "embassy-integrated-timers"]
@@ -122,3 +122,9 @@ required-features = ["embassy", "async", "embassy-executor-thread"]
 [[example]]
 name              = "direct-vectoring"
 required-features = ["direct-vectoring"]
+
+[patch.crates-io]
+embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -30,7 +30,7 @@ embassy-time   = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 critical-section   = "1.1.2"
-embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-executor   = { version = "0.4.0", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.2"
@@ -122,9 +122,3 @@ required-features = ["embassy", "async", "embassy-executor-thread"]
 [[example]]
 name              = "direct-vectoring"
 required-features = ["direct-vectoring"]
-
-[patch.crates-io]
-embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -33,7 +33,7 @@ embassy-time   = { version = "0.2.0", optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-executor   = { version = "0.4.0", features = ["nightly"] }
 embedded-can       = "0.4.1"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
@@ -148,9 +148,3 @@ required-features = ["embassy", "async", "embassy-executor-thread"]
 [[example]]
 name              = "direct-vectoring"
 required-features = ["direct-vectoring"]
-
-[patch.crates-io]
-embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 [dependencies]
 cfg-if         = "1.0.0"
 esp-hal-common = { version = "0.13.0", features = ["esp32c3"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -37,10 +37,10 @@ embassy-executor   = { version = "0.3.2", features = ["nightly"] }
 embedded-can       = "0.4.1"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7", features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
-embedded-hal-async = "=1.0.0-rc.1"
+embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.2"
 embedded-io-async  = "0.6.0"
-embedded-hal-bus   = "0.1.0-rc.1"
+embedded-hal-bus   = "0.1.0-rc.2"
 esp-backtrace      = { version = "0.9.0", features = ["esp32c3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32c3"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32c3"] }
@@ -51,7 +51,7 @@ sha2               = { version = "0.10.8", default-features = false }
 smart-leds         = "0.3.0"
 ssd1306            = "0.8.4"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
-embassy-sync       = "0.4.0"
+embassy-sync       = "0.5.0"
 
 [features]
 default              = ["rt", "vectored", "zero-rtc-bss", "embassy-integrated-timers"]
@@ -148,3 +148,9 @@ required-features = ["embassy", "async", "embassy-executor-thread"]
 [[example]]
 name              = "direct-vectoring"
 required-features = ["direct-vectoring"]
+
+[patch.crates-io]
+embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.13.0", features = ["esp32c6"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -35,11 +35,11 @@ critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false}
 embassy-executor   = { version = "0.3.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
-embedded-hal-async = "=1.0.0-rc.1"
+embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.2"
 embedded-can       = "0.4.1"
 embedded-io-async  = "0.6.0"
-embedded-hal-bus   = "0.1.0-rc.1"
+embedded-hal-bus   = "0.1.0-rc.2"
 esp-backtrace      = { version = "0.9.0", features = ["esp32c6", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32c6"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32c6"] }
@@ -54,7 +54,7 @@ hex-literal        = "0.4.1"
 elliptic-curve     = { version = "0.13.6", default-features = false, features = ["sec1"] }
 p192               = { version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256               = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
-embassy-sync       = "0.4.0"
+embassy-sync       = "0.5.0"
 
 [features]
 default              = ["rt", "vectored", "zero-rtc-bss", "embassy-integrated-timers"]
@@ -159,3 +159,9 @@ required-features = ["embassy", "async", "embassy-executor-thread"]
 [[example]]
 name              = "embassy_usb_serial_jtag"
 required-features = ["embassy", "async", "embassy-executor-thread"]
+
+[patch.crates-io]
+embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -33,7 +33,7 @@ embassy-time   = { version = "0.2.0", optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false}
-embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-executor   = { version = "0.4.0", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.2"
@@ -159,9 +159,3 @@ required-features = ["embassy", "async", "embassy-executor-thread"]
 [[example]]
 name              = "embassy_usb_serial_jtag"
 required-features = ["embassy", "async", "embassy-executor-thread"]
-
-[patch.crates-io]
-embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -33,7 +33,7 @@ embassy-time   = { version = "0.2.0", optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-executor   = { version = "0.4.0", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
 embedded-hal-async = "=1.0.0-rc.2"
@@ -159,9 +159,3 @@ required-features = ["embassy", "async", "embassy-executor-thread"]
 [[example]]
 name              = "embassy_usb_serial_jtag"
 required-features = ["embassy", "async", "embassy-executor-thread"]
-
-[patch.crates-io]
-embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -27,7 +27,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.13.0", features = ["esp32h2"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
@@ -35,11 +35,11 @@ critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
 embassy-executor   = { version = "0.3.2", features = ["nightly"] }
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
-embedded-hal-async = "=1.0.0-rc.1"
+embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.2"
 embedded-can       = "0.4.1"
 embedded-io-async  = "0.6.0"
-embedded-hal-bus   = "0.1.0-rc.1"
+embedded-hal-bus   = "0.1.0-rc.2"
 esp-backtrace      = { version = "0.9.0", features = ["esp32h2", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32h2"], path = "../esp-hal-smartled" }
 esp-println        = { version = "0.7.0", features = ["esp32h2"] }
@@ -54,7 +54,7 @@ hex-literal        = "0.4.1"
 elliptic-curve     = { version = "0.13.6", default-features = false, features = ["sec1"] }
 p192               = { version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256               = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
-embassy-sync       = "0.4.0"
+embassy-sync       = "0.5.0"
 
 [features]
 default              = ["rt", "vectored", "zero-rtc-bss", "embassy-integrated-timers"]
@@ -159,3 +159,9 @@ required-features = ["embassy", "async", "embassy-executor-thread"]
 [[example]]
 name              = "embassy_usb_serial_jtag"
 required-features = ["embassy", "async", "embassy-executor-thread"]
+
+[patch.crates-io]
+embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -32,7 +32,7 @@ embassy-time                 = { version = "0.2.0", optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-executor   = { version = "0.4.0", features = ["nightly"] }
 embassy-sync       = "0.5.0"
 embedded-graphics  = "0.8.1"
 embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
@@ -142,9 +142,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2s_read"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -26,19 +26,19 @@ categories = [
 
 [dependencies]
 esp-hal-common               = { version = "0.13.0", features = ["esp32s2"], path = "../esp-hal-common" }
-embassy-time                 = { version = "0.1.5",  features = ["nightly"], optional = true }
+embassy-time                 = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
 embassy-executor   = { version = "0.3.2", features = ["nightly"] }
-embassy-sync       = "0.4.0"
+embassy-sync       = "0.5.0"
 embedded-graphics  = "0.8.1"
-embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
-embedded-hal-async = "=1.0.0-rc.1"
+embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.2"
 embedded-io-async  = "0.6.0"
-embedded-hal-bus   = "0.1.0-rc.1"
+embedded-hal-bus   = "0.1.0-rc.2"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.9.0", features = ["esp32s2", "panic-handler", "print-uart", "exception-handler"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32s2"], path = "../esp-hal-smartled" }
@@ -142,3 +142,9 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_i2s_read"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -26,7 +26,7 @@ categories = [
 
 [dependencies]
 esp-hal-common = { version = "0.13.0", features = ["esp32s3"], path = "../esp-hal-common" }
-embassy-time   = { version = "0.1.5",  features = ["nightly"], optional = true }
+embassy-time   = { version = "0.2.0", optional = true }
 r0             = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
@@ -34,14 +34,14 @@ aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
 embassy-executor   = { version = "0.3.2", features = ["nightly"] }
-embassy-sync       = "0.4.0"
+embassy-sync       = "0.5.0"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
-embedded-hal-1     = { version = "=1.0.0-rc.1", package = "embedded-hal" }
-embedded-hal-async = "=1.0.0-rc.1"
+embedded-hal-1     = { version = "=1.0.0-rc.2", package = "embedded-hal" }
+embedded-hal-async = "=1.0.0-rc.2"
 embedded-can       = "0.4.1"
 embedded-io-async  = "0.6.0"
-embedded-hal-bus   = "0.1.0-rc.1"
+embedded-hal-bus   = "0.1.0-rc.2"
 esp-alloc          = "0.3.0"
 esp-backtrace      = { version = "0.9.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-hal-smartled   = { version = "0.6.0", features = ["esp32s3"], path = "../esp-hal-smartled" }
@@ -164,3 +164,9 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_usb_serial_jtag"
 required-features = ["embassy", "async"]
+
+[patch.crates-io]
+embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
+embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -33,7 +33,7 @@ r0             = { version = "1.0.0",  optional = true }
 aes                = "0.8.3"
 critical-section   = "1.1.2"
 crypto-bigint      = { version = "0.5.3", default-features = false }
-embassy-executor   = { version = "0.3.2", features = ["nightly"] }
+embassy-executor   = { version = "0.4.0", features = ["nightly"] }
 embassy-sync       = "0.5.0"
 embedded-graphics  = "0.8.1"
 embedded-hal       = { version = "0.2.7",  features = ["unproven"] }
@@ -164,9 +164,3 @@ required-features = ["embassy", "async"]
 [[example]]
 name              = "embassy_usb_serial_jtag"
 required-features = ["embassy", "async"]
-
-[patch.crates-io]
-embassy-executor = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-futures  = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-sync     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }
-embassy-time     = { git = "https:/github.com/embassy-rs/embassy", rev = "3349007" }


### PR DESCRIPTION
Not really sure about the implementation of `DelayNs` as that's a pretty small time slice relative to our CPUs' frequencies, but I've just basically [copied from `riscv`](https://github.com/rust-embedded/riscv/blob/eb02f31ba1920e4c8d2d907d8279e8390cc974b7/riscv/src/delay.rs#L22-L30). Should be fine, I think.

Otherwise, pretty straight-forward change.

Waiting on a new `embassy-time` release still, so will need to update that and remove the patch when it's available.