### PR TITLE
remove unused mod, use portable-atomic unconditionally

### DIFF
--- a/esp-hal-common/src/embassy/executor/interrupt.rs
+++ b/esp-hal-common/src/embassy/executor/interrupt.rs
@@ -6,13 +6,9 @@ use embassy_executor::{raw, SendSpawner};
 use peripherals::INTPRI as SystemPeripheral;
 #[cfg(not(any(esp32c6, esp32h2)))]
 use peripherals::SYSTEM as SystemPeripheral;
+use portable_atomic::{AtomicUsize, Ordering};
 
-use crate::{
-    atomic::{AtomicUsize, Ordering},
-    get_core,
-    interrupt,
-    peripherals,
-};
+use crate::{get_core, interrupt, peripherals};
 
 static FROM_CPU_IRQ_USED: AtomicUsize = AtomicUsize::new(0);
 

--- a/esp-hal-common/src/embassy/executor/thread.rs
+++ b/esp-hal-common/src/embassy/executor/thread.rs
@@ -2,12 +2,9 @@
 use core::marker::PhantomData;
 
 use embassy_executor::{raw, Spawner};
+use portable_atomic::{AtomicBool, Ordering};
 
-use crate::{
-    atomic::{AtomicBool, Ordering},
-    get_core,
-    prelude::interrupt,
-};
+use crate::{get_core, prelude::interrupt};
 #[cfg(multi_core)]
 use crate::{
     interrupt,

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -161,11 +161,6 @@ pub mod trapframe {
 // be directly exposed.
 mod soc;
 
-#[allow(unused_imports)]
-mod atomic {
-    pub use portable_atomic::*;
-}
-
 #[no_mangle]
 extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {
     #[cfg(feature = "log")]
@@ -322,7 +317,7 @@ mod critical_section_impl {
 
     #[cfg(multi_core)]
     mod multicore {
-        use crate::atomic::{AtomicUsize, Ordering};
+        use portable_atomic::{AtomicUsize, Ordering};
 
         // We're using a value that we know get_raw_core() will never return. This
         // avoids an unnecessary increment of the core ID.


### PR DESCRIPTION
Something I missed in #985 