### PR TITLE
Fix ESP32-C6 memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Xtensa: Allow using `embassy-executor`'s thread-mode executor if neither `embassy-executor-thread`, nor `embassy-executor-interrupt` is enabled. (#937)
 - Uart Async: Improve interrupt handling and irq <--> future communication (#977)
 - RISC-V: Fix stack allocation (#988)
+- ESP32-C6: Fix used RAM (#997)
 
 ### Removed
 

--- a/esp-hal-common/ld/esp32c6/memory.x
+++ b/esp-hal-common/ld/esp32c6/memory.x
@@ -16,8 +16,11 @@ MEMORY
 
     /* 512K of on soc RAM, 32K reserved for cache */
     ICACHE : ORIGIN = 0x40800000,  LENGTH = 32K
-    /* Instruction and Data RAM */
-    RAM : ORIGIN = 0x40800000 + 32K, LENGTH = 512K - 32K
+    /* Instruction and Data RAM 
+    0x4086E610 = 2nd stage bootloader iram_loader_seg start address
+    see https://github.com/espressif/esp-idf/blob/03414a15508036c8fc0f51642aed7a264e9527df/components/esp_system/ld/esp32c6/memory.ld.in#L26
+    */
+    RAM : ORIGIN = 0x40800000 + 32K, LENGTH = 0x6E610 - 32K
 
     /* External flash */
     /* Instruction and Data ROM */


### PR DESCRIPTION
With the fix in #988 it becomes necessary to adapt the memory size for ESP32-C6 to make sure to not overwrite the bootloader (before it hands over control to the application)

The problem is very noticeable with esp-wifi
