### PR TITLE
Let SmartLedsAdapter take its buffer by value

### DIFF
--- a/esp32-hal/examples/hello_rgb.rs
+++ b/esp32-hal/examples/hello_rgb.rs
@@ -39,8 +39,8 @@ fn main() -> ! {
     // -> We need to use the macro `smartLedBuffer!` with the number of addressed
     // LEDs here to initialize the internal LED pulse buffer to the correct
     // size!
-    let mut rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio33, &mut rmt_buffer);
+    let rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio33, rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -34,8 +34,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, &mut rmt_buffer);
+    let rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c6-hal/examples/hello_rgb.rs
+++ b/esp32c6-hal/examples/hello_rgb.rs
@@ -33,8 +33,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, &mut rmt_buffer);
+    let rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32h2-hal/examples/hello_rgb.rs
+++ b/esp32h2-hal/examples/hello_rgb.rs
@@ -33,8 +33,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, &mut rmt_buffer);
+    let rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -34,8 +34,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio18, &mut rmt_buffer);
+    let rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio18, rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32s3-hal/examples/hello_rgb.rs
+++ b/esp32s3-hal/examples/hello_rgb.rs
@@ -34,8 +34,8 @@ fn main() -> ! {
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
-    let mut rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio48, &mut rmt_buffer);
+    let rmt_buffer = smartLedBuffer!(1);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio48, rmt_buffer);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.


### PR DESCRIPTION
This makes it possible to store a `SmartLedsAdapter` in a struct without requiring `static mut` or self-referential tactics.
Could be cleaned up once `#![feature(generic_const_exprs)]` gets stabilized.

CC #980

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
