### PR TITLE
Fix ESP32-H2 memory size

### DIFF
--- a/esp-hal-common/ld/esp32h2/memory.x
+++ b/esp-hal-common/ld/esp32h2/memory.x
@@ -17,8 +17,11 @@ MEMORY
 
     /* 320K of on soc RAM, 16K reserved for cache */
     ICACHE : ORIGIN = 0x40800000,  LENGTH = 16K
-    /* Instruction and Data RAM */
-    RAM : ORIGIN = 0x40800000 + 16K, LENGTH = 320K - 16K
+    /* Instruction and Data RAM 
+    0x4086E610 = 2nd stage bootloader iram_loader_seg start address
+    see https://github.com/espressif/esp-idf/blob/03414a15508036c8fc0f51642aed7a264e9527df/components/esp_system/ld/esp32h2/memory.ld.in#L26
+    */
+    RAM : ORIGIN = 0x40800000 + 16K, LENGTH = 0x3EFD0 - 16K
 
     /* External flash */
     /* Instruction and Data ROM */


### PR DESCRIPTION
Like we had to do for C6 before we also need to adapt the memory size for H2

Fixes #999 
