### PR TITLE
Panic when DefaultHandler gets invoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reworked construction of I2S driver instances (#983)
 - S2 / S3: Don't require GPIO 18 to create a USB peripheral driver instance (#990)
 - Updated to latest release candidate (`1.0.0-rc.2`) for `embedded-hal{-async,-nb}` (#994)
+- Explicit panic when hitting the `DefaultHandler` (#1005)
 
 ### Fixed
 

--- a/esp-hal-common/ld/esp32c2/esp32c2.x
+++ b/esp-hal-common/ld/esp32c2/esp32c2.x
@@ -14,7 +14,6 @@ PROVIDE(UserExternal = DefaultHandler);
 PROVIDE(SupervisorExternal = DefaultHandler);
 PROVIDE(MachineExternal = DefaultHandler);
 
-PROVIDE(DefaultHandler = DefaultInterruptHandler);
 PROVIDE(ExceptionHandler = DefaultExceptionHandler);
 
 PROVIDE(__post_init = default_post_init);

--- a/esp-hal-common/ld/esp32c3/esp32c3.x
+++ b/esp-hal-common/ld/esp32c3/esp32c3.x
@@ -14,7 +14,6 @@ PROVIDE(UserExternal = DefaultHandler);
 PROVIDE(SupervisorExternal = DefaultHandler);
 PROVIDE(MachineExternal = DefaultHandler);
 
-PROVIDE(DefaultHandler = DefaultInterruptHandler);
 PROVIDE(ExceptionHandler = DefaultExceptionHandler);
 
 PROVIDE(__post_init = default_post_init);

--- a/esp-hal-common/ld/esp32c6/esp32c6.x
+++ b/esp-hal-common/ld/esp32c6/esp32c6.x
@@ -14,7 +14,6 @@ PROVIDE(UserExternal = DefaultHandler);
 PROVIDE(SupervisorExternal = DefaultHandler);
 PROVIDE(MachineExternal = DefaultHandler);
 
-PROVIDE(DefaultHandler = DefaultInterruptHandler);
 PROVIDE(ExceptionHandler = DefaultExceptionHandler);
 
 /* The ESP32-C2 and ESP32-C3 have interrupt IDs 1-31, while the ESP32-C6 has

--- a/esp-hal-common/ld/esp32h2/esp32h2.x
+++ b/esp-hal-common/ld/esp32h2/esp32h2.x
@@ -14,7 +14,6 @@ PROVIDE(UserExternal = DefaultHandler);
 PROVIDE(SupervisorExternal = DefaultHandler);
 PROVIDE(MachineExternal = DefaultHandler);
 
-PROVIDE(DefaultHandler = DefaultInterruptHandler);
 PROVIDE(ExceptionHandler = DefaultExceptionHandler);
 
 /* The ESP32-C2 and ESP32-C3 have interrupt IDs 1-31, while the ESP32-C6 and ESP32-H2 have

--- a/esp-hal-common/ld/riscv/hal-defaults.x
+++ b/esp-hal-common/ld/riscv/hal-defaults.x
@@ -1,3 +1,5 @@
+PROVIDE(DefaultHandler = EspDefaultHandler);
+
 PROVIDE(interrupt1 = DefaultHandler);
 PROVIDE(interrupt2 = DefaultHandler);
 PROVIDE(interrupt3 = DefaultHandler);

--- a/esp-hal-common/ld/xtensa/hal-defaults.x
+++ b/esp-hal-common/ld/xtensa/hal-defaults.x
@@ -1,3 +1,5 @@
+PROVIDE(DefaultHandler = EspDefaultHandler);
+
 PROVIDE(level1_interrupt = DefaultHandler);
 PROVIDE(level2_interrupt = DefaultHandler);
 PROVIDE(level3_interrupt = DefaultHandler);

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -161,22 +161,16 @@ pub mod trapframe {
 // be directly exposed.
 mod soc;
 
+#[cfg(xtensa)]
 #[no_mangle]
-extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {
-    #[cfg(feature = "log")]
-    warn!("Unhandled level {} interrupt: {:?}", _level, _interrupt);
-
-    #[cfg(feature = "defmt")]
-    warn!(
-        "Unhandled level {} interrupt: {:?}",
-        _level,
-        defmt::Debug2Format(&_interrupt)
-    );
+extern "C" fn EspDefaultHandler(level: u32, interrupt: peripherals::Interrupt) {
+    panic!("Unhandled level {} interrupt: {:?}", level, interrupt);
 }
 
+#[cfg(riscv)]
 #[no_mangle]
-extern "C" fn DefaultHandler() {
-    panic!("DefaultHandler invoked");
+extern "C" fn EspDefaultHandler(interrupt: peripherals::Interrupt) {
+    panic!("Unhandled interrupt: {:?}", interrupt);
 }
 
 /// Available CPU cores

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -174,9 +174,10 @@ extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt)
     );
 }
 
-#[cfg(xtensa)]
 #[no_mangle]
-extern "C" fn DefaultHandler() {}
+extern "C" fn DefaultHandler() {
+    panic!("DefaultHandler invoked");
+}
 
 /// Available CPU cores
 ///

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -163,14 +163,29 @@ mod soc;
 
 #[cfg(xtensa)]
 #[no_mangle]
-extern "C" fn EspDefaultHandler(level: u32, interrupt: peripherals::Interrupt) {
-    panic!("Unhandled level {} interrupt: {:?}", level, interrupt);
+extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {
+    #[cfg(not(feature = "defmt"))]
+    panic!("Unhandled level {} interrupt: {:?}", _level, _interrupt);
+
+    #[cfg(feature = "defmt")]
+    panic!(
+        "Unhandled level {} interrupt: {:?}",
+        _level,
+        defmt::Debug2Format(&_interrupt)
+    );
 }
 
 #[cfg(riscv)]
 #[no_mangle]
-extern "C" fn EspDefaultHandler(interrupt: peripherals::Interrupt) {
-    panic!("Unhandled interrupt: {:?}", interrupt);
+extern "C" fn EspDefaultHandler(_interrupt: peripherals::Interrupt) {
+    #[cfg(not(feature = "defmt"))]
+    panic!("Unhandled interrupt: {:?}", _interrupt);
+
+    #[cfg(feature = "defmt")]
+    panic!(
+        "Unhandled interrupt: {:?}",
+        defmt::Debug2Format(&_interrupt)
+    );
 }
 
 /// Available CPU cores


### PR DESCRIPTION
The `DefaultHandler` can never do something much more useful than panicking

Fixes #1001 

Easy check: Use the `gpio_interrupt.rs` example and remove the interrupt handler. Pressing the boot button will now panic instead of silently do nothing anymore
