### PR TITLE
C6/H2: flip-link feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RISC-V: Thread-mode and interrupt-mode executors, `#[main]` macro (#947)
 - A macro to make it easier to create DMA buffers and descriptors (#935)
 - I2C timeout is configurable (#1011)
+- ESP32-C6/ESP32-H2: `flip-link` feature gives zero-cost stack overflow protection (#1008)
 
 ### Changed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -89,6 +89,9 @@ esp32s3 = ["xtensa", "esp32s3/rt", "procmacros/esp32s3", "xtensa-lx/esp32s3", "x
 xtal-26mhz = []
 xtal-40mhz = []
 
+# Only certain chips support flip-link
+flip-link = ["esp-riscv-rt/fix-sp"]
+
 # PSRAM support
 psram-2m = []
 psram-4m = []

--- a/esp-hal-common/ld/esp32/esp32.x
+++ b/esp-hal-common/ld/esp32/esp32.x
@@ -21,6 +21,7 @@ INCLUDE "rwtext.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"
+INCLUDE "stack.x"
 /* End of Shared sections */
 
 /* an uninitialized section for use as the wifi-heap in esp-wifi */
@@ -29,15 +30,6 @@ SECTIONS {
         *(.dram2_uninit)
     } > dram2_seg
 }
-
-_stack_region_top = ABSOLUTE(ORIGIN(dram_seg))+LENGTH(dram_seg);
-_stack_region_bottom = _stack_end;
-
-/*
- use the whole remaining memory as core-0's stack
-*/
-_stack_start_cpu0 = _stack_region_top;
-_stack_end_cpu0 = _stack_region_bottom;
 
 EXTERN(DefaultHandler);
 

--- a/esp-hal-common/ld/esp32c2/esp32c2.x
+++ b/esp-hal-common/ld/esp32c2/esp32c2.x
@@ -1,7 +1,6 @@
 ENTRY(_start)
 
 PROVIDE(_stext = ORIGIN(ROTEXT));
-PROVIDE(_stack_start = ORIGIN(RWDATA) + LENGTH(RWDATA));
 PROVIDE(_max_hart_id = 0);
 
 PROVIDE(UserSoft = DefaultHandler);
@@ -104,6 +103,7 @@ INCLUDE "text.x"
 INCLUDE "rodata.x"
 INCLUDE "rwtext.x"
 INCLUDE "rwdata.x"
+INCLUDE "stack.x"
 /* End of Shared sections */
 
 INCLUDE "debug.x"

--- a/esp-hal-common/ld/esp32c3/esp32c3.x
+++ b/esp-hal-common/ld/esp32c3/esp32c3.x
@@ -1,7 +1,6 @@
 ENTRY(_start)
 
 PROVIDE(_stext = ORIGIN(ROTEXT));
-PROVIDE(_stack_start = ORIGIN(RWDATA) + LENGTH(RWDATA));
 PROVIDE(_max_hart_id = 0);
 
 PROVIDE(UserSoft = DefaultHandler);
@@ -105,6 +104,7 @@ INCLUDE "rodata.x"
 INCLUDE "rwtext.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
+INCLUDE "stack.x"
 /* End of Shared sections */
 
 INCLUDE "debug.x"

--- a/esp-hal-common/ld/esp32c6/esp32c6.x
+++ b/esp-hal-common/ld/esp32c6/esp32c6.x
@@ -1,7 +1,6 @@
 ENTRY(_start)
 
 PROVIDE(_stext = ORIGIN(ROTEXT));
-PROVIDE(_stack_start = ORIGIN(RWDATA) + LENGTH(RWDATA));
 PROVIDE(_max_hart_id = 0);
 
 PROVIDE(UserSoft = DefaultHandler);
@@ -89,6 +88,7 @@ INCLUDE "rwtext.x"
 INCLUDE "rodata.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
+INCLUDE "stack.x"
 /* End of Shared sections */
 
 INCLUDE "debug.x"

--- a/esp-hal-common/ld/esp32c6/memory.x
+++ b/esp-hal-common/ld/esp32c6/memory.x
@@ -15,12 +15,11 @@ MEMORY
     ] */
 
     /* 512K of on soc RAM, 32K reserved for cache */
-    ICACHE : ORIGIN = 0x40800000,  LENGTH = 32K
     /* Instruction and Data RAM 
     0x4086E610 = 2nd stage bootloader iram_loader_seg start address
     see https://github.com/espressif/esp-idf/blob/03414a15508036c8fc0f51642aed7a264e9527df/components/esp_system/ld/esp32c6/memory.ld.in#L26
     */
-    RAM : ORIGIN = 0x40800000 + 32K, LENGTH = 0x6E610 - 32K
+    RAM : ORIGIN = 0x40800000 , LENGTH = 0x6E610
 
     /* External flash */
     /* Instruction and Data ROM */

--- a/esp-hal-common/ld/esp32h2/esp32h2.x
+++ b/esp-hal-common/ld/esp32h2/esp32h2.x
@@ -1,7 +1,6 @@
 ENTRY(_start)
 
 PROVIDE(_stext = ORIGIN(ROTEXT));
-PROVIDE(_stack_start = ORIGIN(RWDATA) + LENGTH(RWDATA));
 PROVIDE(_max_hart_id = 0);
 
 PROVIDE(UserSoft = DefaultHandler);
@@ -82,6 +81,7 @@ INCLUDE "rwtext.x"
 INCLUDE "rodata.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
+INCLUDE "stack.x"
 /* End of Shared sections */
 
 INCLUDE "debug.x"

--- a/esp-hal-common/ld/esp32h2/memory.x
+++ b/esp-hal-common/ld/esp32h2/memory.x
@@ -16,12 +16,11 @@ MEMORY
 
 
     /* 320K of on soc RAM, 16K reserved for cache */
-    ICACHE : ORIGIN = 0x40800000,  LENGTH = 16K
     /* Instruction and Data RAM 
     0x4086E610 = 2nd stage bootloader iram_loader_seg start address
     see https://github.com/espressif/esp-idf/blob/03414a15508036c8fc0f51642aed7a264e9527df/components/esp_system/ld/esp32h2/memory.ld.in#L26
     */
-    RAM : ORIGIN = 0x40800000 + 16K, LENGTH = 0x3EFD0 - 16K
+    RAM : ORIGIN = 0x40800000, LENGTH = 0x3EFD0
 
     /* External flash */
     /* Instruction and Data ROM */

--- a/esp-hal-common/ld/esp32s2/esp32s2.x
+++ b/esp-hal-common/ld/esp32s2/esp32s2.x
@@ -29,13 +29,8 @@ INCLUDE "rwtext.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"
+INCLUDE "stack.x"
 /* End of Shared sections */
-
-_stack_region_top = ABSOLUTE(ORIGIN(dram_seg))+LENGTH(dram_seg);
-_stack_region_bottom = _stack_end;
-
-_stack_start_cpu0 = _stack_region_top;
-_stack_end_cpu0 = _stack_region_bottom;
 
 EXTERN(DefaultHandler);
 

--- a/esp-hal-common/ld/esp32s3/esp32s3.x
+++ b/esp-hal-common/ld/esp32s3/esp32s3.x
@@ -43,16 +43,8 @@ INCLUDE "rwtext.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"
+INCLUDE "stack.x"
 /* End of Shared sections */
-
-_stack_region_top = ABSOLUTE(ORIGIN(dram_seg))+LENGTH(dram_seg);
-_stack_region_bottom = _stack_end;
-
-/*
- use the whole remaining memory as core-0's stack
-*/
-_stack_start_cpu0 = _stack_region_top;
-_stack_end_cpu0 = _stack_region_bottom;
 
 EXTERN(DefaultHandler);
 

--- a/esp-hal-common/ld/sections/rwdata.x
+++ b/esp-hal-common/ld/sections/rwdata.x
@@ -49,11 +49,4 @@ SECTIONS {
     *( .dram1 .dram1.*)
     . = ALIGN(4);
   } > RWDATA AT > RODATA
-
-  /* must be last segment using RWDATA */
-  .stack_end (NOLOAD) : ALIGN(4)
-  {
-    . = ALIGN (4);
-    _stack_end = ABSOLUTE(.);
-  } > RWDATA
 }

--- a/esp-hal-common/ld/sections/rwtext.x
+++ b/esp-hal-common/ld/sections/rwtext.x
@@ -17,6 +17,7 @@ SECTIONS {
     *( .wifislpiram  .wifislpiram.*)
     *( .phyiram  .phyiram.*)
     *( .iram1  .iram1.*)
+    *( .wifiextrairam.* )
     . = ALIGN(4);
   } > RWTEXT AT > RODATA
 }

--- a/esp-hal-common/ld/sections/stack.x
+++ b/esp-hal-common/ld/sections/stack.x
@@ -1,0 +1,36 @@
+#IF flip-link
+/* no Xtensa chip is supported - so we can assume RISC-V */
+SECTIONS {
+  /* must be last segment using RWDATA */
+  .stack (NOLOAD) : ALIGN(4)
+  {
+    _stack_end = ABSOLUTE(.);
+    _stack_end_cpu0 = ABSOLUTE(.);
+
+    /* Since we cannot know how much the alignment padding of the sections will add we shrink the stack for "the worst case"
+    */
+    . = . + LENGTH(RWDATA) -  (SIZEOF(.trap) + SIZEOF(.rwtext) + SIZEOF(.rwtext.wifi) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit) + SIZEOF(.data.wifi)) - 304;
+
+    . = ALIGN (4);
+    _stack_start = ABSOLUTE(.);
+    _stack_start_cpu0 = ABSOLUTE(.);
+  } > RWDATA
+}
+INSERT BEFORE .trap;
+
+#ELSE
+
+SECTIONS {
+  /* must be last segment using RWDATA */
+  .stack (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN (4);
+    _stack_end = ABSOLUTE(.);
+    _stack_end_cpu0 = ABSOLUTE(.);
+  } > RWDATA
+}
+
+PROVIDE(_stack_start = ORIGIN(RWDATA) + LENGTH(RWDATA));
+PROVIDE(_stack_start_cpu0 = ORIGIN(RWDATA) + LENGTH(RWDATA));
+
+#ENDIF

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -26,6 +26,7 @@ init-data = []
 init-rw-text = []
 init-rtc-fast-data = []
 init-rtc-fast-text = []
+fix-sp = []
 
 # This feature is intended for testing; you probably don't want to enable it:
 ci = [
@@ -38,4 +39,5 @@ ci = [
     "init-rw-text",
     "init-rtc-fast-data",
     "init-rtc-fast-text",
+    "fix-sp",
 ]

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -672,7 +672,27 @@ _start_trap31:
 
 "#,
 r#"
-_start_trap: 
+_start_trap:
+"#,
+#[cfg(feature="fix-sp")]
+r#"
+    // move SP to some save place if it's pointing below the RAM
+    // most probably we will just print something and halt in this case
+    // we actually can't do anything else
+    csrw mscratch, t0
+    la t0, _stack_end
+    bge sp, t0, 1f
+
+    la sp, _stack_start
+    li t0, 4 // make sure stack start is in RAM
+    sub sp, sp, t0
+    andi sp, sp, -16 // Force 16-byte alignment
+
+    1:
+    csrr t0, mscratch
+    // now SP is probably in RAM - continue
+"#,
+r#"
     addi sp, sp, -40*4
     sw ra, 0*4(sp)"#,
 #[cfg(feature="direct-vectoring")] //for the directly vectored handlers the above is stacked beforehand

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -68,6 +68,7 @@ log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
+flip-link            = ["esp-hal-common/flip-link"]
 
 # Initialize / clear data sections and RTC memory
 zero-rtc-bss         = ["esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -35,6 +35,8 @@
 //! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
 //!   Serial JTAG drivers
 //! - `vectored` - Enable interrupt vectoring
+//! - `flip-link` - move the stack to the start of RAM to get zero-cost stack
+//!   overflow protection
 //!
 //! #### Default Features
 //!

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -68,6 +68,7 @@ log                  = ["esp-hal-common/log", "esp-println/log"]
 rt                   = []
 ufmt                 = ["esp-hal-common/ufmt"]
 vectored             = ["esp-hal-common/vectored"]
+flip-link            = ["esp-hal-common/flip-link"]
 
 # Initialize / clear data sections and RTC memory
 zero-rtc-bss         = ["esp-hal-common/rv-zero-rtc-bss"]

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -35,6 +35,8 @@
 //! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
 //!   Serial JTAG drivers
 //! - `vectored` - Enable interrupt vectoring
+//! - `flip-link` - move the stack to the start of RAM to get zero-cost stack
+//!   overflow protection
 //!
 //! #### Default Features
 //!


### PR DESCRIPTION
Since on C6/H2 the caches are not residing in the start of RAM we can move the stack to start of RAM to get zero-cost stack overflow protection (inspired by flip-link)

I will probably add some code in esp-backtrace to give a hint when there is an access fault slightly below `_stack_end` to make things a bit more obvious.

Currently a stack overflow with the flip-link feature looks like this
```
Exception 'Store/AMO access fault' mepc=0x4080c0ca, mtval=0x407ffee0
```

An access fault trying to access memory near the start of RAM indicates a stack overflow


_This needs a lot of testing before it's fine to merge._
