### PR TITLE
Configurable I2C Timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Rx Timeout functionality to async Uart (#911)
 - RISC-V: Thread-mode and interrupt-mode executors, `#[main]` macro (#947)
 - A macro to make it easier to create DMA buffers and descriptors (#935)
+- I2C timeout is configurable (#1011)
 
 ### Changed
 


### PR DESCRIPTION
Hi, similar to what has been described in #352, I have a sensor requiring a higher i2c delay.
I tried to follow the hints from the discussion and added a second constructor taking a delay value.
I did not try to use any semantic time values (second part of the discussion in the issue above) but instead just pass the raw timeout (similar to what esp-idf does).

Let me know if there are any required changes required or whether this change requires me to actually run all of the examples.

### Must

- [X] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [X] `cargo fmt` was run.
- [X] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [X] You add a description of your work to this PR.
- [X] You added proper docs for your newly added features and code.
