### PR TITLE
Fix `dma_read` and `dma_write` for SPI slave dma driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- ESP32-S3: Fix SPI slave DMA read and write (#469)
 - ESP32-C2/C3 examples: fix build error (#899)
 - ESP32-S3: Fix GPIO interrupt handler crashing when using GPIO48. (#898)
 - Fixed short wait times in embassy causing hangs (#906)
@@ -47,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RISC-V: Fix stack allocation (#988)
 - ESP32-C6: Fix used RAM (#997)
 - ESP32-H2: Fix used RAM (#1003)
+- Fix SPI slave DMA dma\_read and dma\_write (#1013)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ESP32-S3: Fix SPI slave DMA read and write (#469)
 - ESP32-C2/C3 examples: fix build error (#899)
 - ESP32-S3: Fix GPIO interrupt handler crashing when using GPIO48. (#898)
 - Fixed short wait times in embassy causing hangs (#906)

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -295,7 +295,7 @@ pub mod dma {
 
     pub struct SpiDmaTransferRx<'d, T, C, BUFFER>
     where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>, 
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
         C: ChannelTypes,
         C::P: SpiPeripheral,
     {
@@ -303,13 +303,12 @@ pub mod dma {
         buffer: BUFFER,
     }
 
-    impl <'d, T, C, BUFFER> DmaTransfer<BUFFER, SpiDma<'d, T, C>> for SpiDmaTransferRx<'d, T, C, BUFFER>
+    impl<'d, T, C, BUFFER> DmaTransfer<BUFFER, SpiDma<'d, T, C>> for SpiDmaTransferRx<'d, T, C, BUFFER>
     where
         T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
         C: ChannelTypes,
         C::P: SpiPeripheral,
     {
-
         /// Wait for the DMA transfer to complete and return the buffers and the
         /// SPI instance.
         fn wait(
@@ -455,8 +454,8 @@ pub mod dma {
     {
         /// Register a buffer for a DMA write.
         ///
-        /// This will return a [SpiDmaTransferTx] owning the buffer(s) and the SPI
-        /// instance. The maximum amount of data to be sent is 32736
+        /// This will return a [SpiDmaTransferTx] owning the buffer(s) and the
+        /// SPI instance. The maximum amount of data to be sent is 32736
         /// bytes.
         ///
         /// The write is driven by the SPI master's sclk signal and cs line.
@@ -483,9 +482,9 @@ pub mod dma {
 
         /// Register a buffer for a DMA read.
         ///
-        /// This will return a [SpiDmaTransferRx] owning the buffer(s) and the SPI
-        /// instance. The maximum amount of data to be received is 32736
-        /// bytes.
+        /// This will return a [SpiDmaTransferRx] owning the buffer(s) and the
+        /// SPI instance. The maximum amount of data to be received is
+        /// 32736 bytes.
         ///
         /// The read is driven by the SPI master's sclk signal and cs line.
         pub fn dma_read<RXBUF>(
@@ -511,9 +510,9 @@ pub mod dma {
 
         /// Register buffers for a DMA transfer.
         ///
-        /// This will return a [SpiDmaTransferRxTx] owning the buffer(s) and the SPI
-        /// instance. The maximum amount of data to be sent/received is
-        /// 32736 bytes.
+        /// This will return a [SpiDmaTransferRxTx] owning the buffer(s) and the
+        /// SPI instance. The maximum amount of data to be sent/received
+        /// is 32736 bytes.
         ///
         /// The data transfer is driven by the SPI master's sclk signal and cs
         /// line.

--- a/esp32c2-hal/examples/spi_slave_dma.rs
+++ b/esp32c2-hal/examples/spi_slave_dma.rs
@@ -147,5 +147,59 @@ fn main() -> ! {
         );
 
         delay.delay_ms(250u32);
+
+        slave_receive.fill(0xff);
+        let transfer = spi.dma_read(slave_receive).unwrap();
+        master_cs.set_high().unwrap();
+
+        master_cs.set_low().unwrap();
+        for v in master_send.iter() {
+            let mut b = *v;
+            for _ in 0..8 {
+                if b & 128 != 0 {
+                    master_mosi.set_high().unwrap();
+                } else {
+                    master_mosi.set_low().unwrap();
+                }
+                b <<= 1;
+                master_sclk.set_low().unwrap();
+                master_sclk.set_high().unwrap();
+            }
+        }
+        master_cs.set_high().unwrap();
+        (slave_receive, spi) = transfer.wait().unwrap();
+        println!(
+            "slave got {:x?} .. {:x?}",
+            &slave_receive[..10],
+            &slave_receive[slave_receive.len() - 10..],
+        );
+
+        delay.delay_ms(250u32);
+        let transfer = spi.dma_write(slave_send).unwrap();
+
+        master_receive.fill(0);
+
+        master_cs.set_low().unwrap();
+        for (j, _) in master_send.iter().enumerate() {
+            let mut rb = 0u8;
+            for _ in 0..8 {
+                master_sclk.set_low().unwrap();
+                rb <<= 1;
+                master_sclk.set_high().unwrap();
+                if master_miso.is_high().unwrap() {
+                    rb |= 1;
+                }
+            }
+            master_receive[j] = rb;
+        }
+        master_cs.set_high().unwrap();
+        (slave_send, spi) = transfer.wait().unwrap();
+
+        println!(
+            "master got {:x?} .. {:x?}",
+            &master_receive[..10],
+            &master_receive[master_receive.len() - 10..],
+        );
+        println!();
     }
 }


### PR DESCRIPTION
`dma_read` and `dma_write` are not working properly due to excessive checks (checking `rx.is_done()` for write, and `tx.is_done()` for read). 
So I splitted `SpiDmaTransfer` into `SpiDmaTransferRx` and `SpiDmaTransferTx` in order to remove unneeded checks.

I've also included `dma_read` and `dma_write` in `spi_slave_dma` example in order to confirm, that all available methods work properly.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
