### PR TITLE
Fix SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fix SHA for all targets (#1021)
 
 ### Removed
 

--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -61,10 +61,10 @@ ufmt-write = { version = "0.1.0", optional = true }
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
 esp32   = { version = "0.28.0", features = ["critical-section"], optional = true }
-esp32c2 = { version = "0.16.0", features = ["critical-section"], optional = true }
-esp32c3 = { version = "0.19.0", features = ["critical-section"], optional = true }
-esp32c6 = { version = "0.10.0", features = ["critical-section"], optional = true }
-esp32h2 = { version = "0.6.0",  features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.17.0", features = ["critical-section"], optional = true }
+esp32c3 = { version = "0.20.0", features = ["critical-section"], optional = true }
+esp32c6 = { version = "0.11.0", features = ["critical-section"], optional = true }
+esp32h2 = { version = "0.7.0",  features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.19.0", features = ["critical-section"], optional = true }
 esp32s3 = { version = "0.23.0", features = ["critical-section"], optional = true }
 

--- a/esp-hal-common/src/reg_access.rs
+++ b/esp-hal-common/src/reg_access.rs
@@ -80,13 +80,15 @@ impl AlignmentHelper {
         count: usize,
         offset: usize,
     ) {
+        let dst_ptr = unsafe { dst_ptr.add(offset) };
+
         let mut cursor = if self.buf_fill != 0 {
             for i in self.buf_fill..U32_ALIGN_SIZE {
                 self.buf[i] = val;
             }
 
             unsafe {
-                dst_ptr.add(offset).write_volatile(U32_FROM_BYTES(self.buf));
+                dst_ptr.write_volatile(U32_FROM_BYTES(self.buf));
             }
 
             self.buf_fill = 0;
@@ -120,6 +122,8 @@ impl AlignmentHelper {
         offset: usize,
     ) -> (&'a [u8], bool) {
         assert!(dst_bound > 0);
+
+        let dst_ptr = unsafe { dst_ptr.add(offset) };
 
         let mut nsrc = src;
         let mut cursor = 0;


### PR DESCRIPTION
It was a combination of two issues:
- `dst_ptr` was not taking into account the `offset` in all operations. [Example where it didn't add the `offset`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal-common/src/reg_access.rs#L101-L103)
- PACs had SHA H_MEM dimension wrong for many chips.
  - The thing is with the old `H_MEM`, some targets, like C6, were working fine after the `dst_prt` but some others, like C3, were still failing. With this change, all updated targets are working fine.
  
~Draft until PACs are merged (https://github.com/esp-rs/esp-pacs/pull/177).~