### PR TITLE
Allow for splitting of the USB Serial JTAG peripheral into tx/rx components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow for splitting of the USB Serial JTAG peripheral into tx/rx components (#1024)
+
 ### Fixed
 
 ### Removed

--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -508,8 +508,9 @@ mod asynch {
     use super::{Error, UsbSerialJtag, UsbSerialJtagRx, UsbSerialJtagTx};
     use crate::peripherals::USB_DEVICE;
 
-    // Single static instance of the waker
-    static WAKER: AtomicWaker = AtomicWaker::new();
+    // Static instance of the waker for each component of the peripheral:
+    static WAKER_TX: AtomicWaker = AtomicWaker::new();
+    static WAKER_RX: AtomicWaker = AtomicWaker::new();
 
     pub(crate) struct UsbSerialJtagWriteFuture<'d> {
         phantom: PhantomData<&'d mut USB_DEVICE>,
@@ -544,7 +545,7 @@ mod asynch {
             self: core::pin::Pin<&mut Self>,
             cx: &mut core::task::Context<'_>,
         ) -> core::task::Poll<Self::Output> {
-            WAKER.register(cx.waker());
+            WAKER_TX.register(cx.waker());
             if self.event_bit_is_clear() {
                 Poll::Ready(())
             } else {
@@ -586,7 +587,7 @@ mod asynch {
             self: core::pin::Pin<&mut Self>,
             cx: &mut core::task::Context<'_>,
         ) -> core::task::Poll<Self::Output> {
-            WAKER.register(cx.waker());
+            WAKER_RX.register(cx.waker());
             if self.event_bit_is_clear() {
                 Poll::Ready(())
             } else {
@@ -730,6 +731,11 @@ mod asynch {
                 .set_bit()
         });
 
-        WAKER.wake();
+        if in_empty {
+            WAKER_RX.wake();
+        }
+        if out_recv {
+            WAKER_TX.wake();
+        }
     }
 }


### PR DESCRIPTION
Still needs more testing, and I plan to update the `embassy_usb_serial_jtag` examples to use reader/writer tasks like the UART examples do, so leaving as draft for now. However, the actual changes to the driver shouldn't change I don't think, so can get some eyes on that for now.

Closes #1006