### PR TITLE
Assert that the hardware and software digests match for SHA examples

### DIFF
--- a/esp32-hal/examples/sha.rs
+++ b/esp32-hal/examples/sha.rs
@@ -66,6 +66,7 @@ fn main() -> ! {
     println!("Took {} cycles", soft_time);
     println!("SHA512 Hash output {:02x?}", soft_result);
 
+    assert_eq!(output, soft_result[..]);
     println!("HW SHA is {}x faster", soft_time / hw_time);
 
     loop {}

--- a/esp32c2-hal/examples/sha.rs
+++ b/esp32c2-hal/examples/sha.rs
@@ -64,6 +64,7 @@ fn main() -> ! {
     // println!("Took {} cycles", soft_time);
     println!("SHA256 Hash output {:02x?}", soft_result);
 
+    assert_eq!(output, soft_result[..]);
     // println!("HW SHA is {}x faster", soft_time/hw_time);
 
     loop {}

--- a/esp32c3-hal/examples/sha.rs
+++ b/esp32c3-hal/examples/sha.rs
@@ -64,6 +64,7 @@ fn main() -> ! {
     // println!("Took {} cycles", soft_time);
     println!("SHA256 Hash output {:02x?}", soft_result);
 
+    assert_eq!(output, soft_result[..]);
     // println!("HW SHA is {}x faster", soft_time/hw_time);
 
     loop {}

--- a/esp32c6-hal/examples/sha.rs
+++ b/esp32c6-hal/examples/sha.rs
@@ -64,6 +64,7 @@ fn main() -> ! {
     // println!("Took {} cycles", soft_time);
     println!("SHA256 Hash output {:02x?}", soft_result);
 
+    assert_eq!(output, soft_result[..]);
     // println!("HW SHA is {}x faster", soft_time/hw_time);
 
     loop {}

--- a/esp32h2-hal/examples/sha.rs
+++ b/esp32h2-hal/examples/sha.rs
@@ -64,6 +64,7 @@ fn main() -> ! {
     // println!("Took {} cycles", soft_time);
     println!("SHA256 Hash output {:02x?}", soft_result);
 
+    assert_eq!(output, soft_result[..]);
     // println!("HW SHA is {}x faster", soft_time/hw_time);
 
     loop {}

--- a/esp32s2-hal/examples/sha.rs
+++ b/esp32s2-hal/examples/sha.rs
@@ -65,6 +65,7 @@ fn main() -> ! {
     println!("Took {} cycles", soft_time);
     println!("SHA512 Hash output {:02x?}", soft_result);
 
+    assert_eq!(output, soft_result[..]);
     println!("HW SHA is {}x faster", soft_time / hw_time);
 
     loop {}

--- a/esp32s3-hal/examples/sha.rs
+++ b/esp32s3-hal/examples/sha.rs
@@ -65,6 +65,7 @@ fn main() -> ! {
     println!("Took {} cycles", soft_time);
     println!("SHA512 Hash output {:02x?}", soft_result);
 
+    assert_eq!(output, soft_result[..]);
     println!("HW SHA is {}x faster", soft_time / hw_time);
 
     loop {}


### PR DESCRIPTION
The examples for the other crypto accelerators all perform this assertion, however these examples do not.

I'm guessing this is how the SHA issues slipped through in the giant PAC update PR, as I didn't see a panic so probably just assumed it was fine without actually comparing the hashes 😁 