### PR TITLE
Clean up example imports

### DIFF
--- a/esp32-hal/examples/embassy_multicore.rs
+++ b/esp32-hal/examples/embassy_multicore.rs
@@ -13,13 +13,13 @@ use esp32_hal::{
     clock::ClockControl,
     cpu_control::{CpuControl, Stack},
     embassy::{self, executor::Executor},
+    get_core,
     gpio::{GpioPin, Output, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
 };
 use esp_backtrace as _;
-use esp_hal_common::get_core;
 use esp_println::println;
 use static_cell::make_static;
 

--- a/esp32-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32-hal/examples/embassy_multicore_interrupt.rs
@@ -15,6 +15,7 @@ use esp32_hal::{
         self,
         executor::{FromCpu1, FromCpu2, InterruptExecutor},
     },
+    get_core,
     gpio::{GpioPin, Output, PushPull, IO},
     interrupt::Priority,
     peripherals::Peripherals,
@@ -22,7 +23,6 @@ use esp32_hal::{
     timer::TimerGroup,
 };
 use esp_backtrace as _;
-use esp_hal_common::get_core;
 use esp_println::println;
 use static_cell::make_static;
 

--- a/esp32-hal/examples/embassy_multiprio.rs
+++ b/esp32-hal/examples/embassy_multiprio.rs
@@ -17,10 +17,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Instant, Ticker, Timer};
-use esp32_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32_hal::{
     clock::ClockControl,
     embassy::{
         self,
@@ -30,6 +27,8 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 
@@ -82,7 +81,7 @@ async fn main(low_prio_spawner: Spawner) {
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        let timer_group0 = esp32_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32-hal/examples/embassy_rmt_rx.rs
+++ b/esp32-hal/examples/embassy_rmt_rx.rs
@@ -10,6 +10,7 @@ use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
     embassy::{self},
+    gpio::{Gpio15, Output, PushPull},
     peripherals::Peripherals,
     prelude::*,
     rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
@@ -17,7 +18,6 @@ use esp32_hal::{
     IO,
 };
 use esp_backtrace as _;
-use esp_hal_common::gpio::{Gpio15, Output, PushPull};
 use esp_println::{print, println};
 
 const WIDTH: usize = 80;

--- a/esp32-hal/examples/embassy_serial.rs
+++ b/esp32-hal/examples/embassy_serial.rs
@@ -15,10 +15,10 @@ use esp32_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
+    uart::{config::AtCmdConfig, UartRx, UartTx},
     Uart,
 };
 use esp_backtrace as _;
-use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use static_cell::make_static;
 
 // rx_fifo_full_threshold

--- a/esp32-hal/examples/sleep_timer.rs
+++ b/esp32-hal/examples/sleep_timer.rs
@@ -5,18 +5,18 @@
 
 use core::time::Duration;
 
-use esp32_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32_hal::{
     clock::ClockControl,
     entry,
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, SocResetReason},
+    Cpu,
     Delay,
     Rtc,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -27,7 +27,7 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);

--- a/esp32-hal/examples/sleep_timer_ext0.rs
+++ b/esp32-hal/examples/sleep_timer_ext0.rs
@@ -5,10 +5,7 @@
 
 use core::time::Duration;
 
-use esp32_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32_hal::{
     clock::ClockControl,
     entry,
     peripherals::Peripherals,
@@ -19,10 +16,13 @@ use hal::{
         sleep::{Ext0WakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
+    Cpu,
     Delay,
     Rtc,
     IO,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -36,7 +36,7 @@ fn main() -> ! {
     let mut ext0_pin = io.pins.gpio27;
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);

--- a/esp32-hal/examples/sleep_timer_ext1.rs
+++ b/esp32-hal/examples/sleep_timer_ext1.rs
@@ -5,12 +5,10 @@
 
 use core::time::Duration;
 
-use esp32_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32_hal::{
     clock::ClockControl,
     entry,
+    gpio::{RTCPin, IO},
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{
@@ -19,10 +17,12 @@ use hal::{
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
+    Cpu,
     Delay,
     Rtc,
-    IO,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -37,7 +37,7 @@ fn main() -> ! {
     let mut pin32 = io.pins.gpio32;
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);
@@ -45,7 +45,7 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     let timer = TimerWakeupSource::new(Duration::from_secs(30));
-    let mut wakeup_pins: [&mut dyn hal::gpio::RTCPin; 2] = [&mut pin27, &mut pin32];
+    let mut wakeup_pins: [&mut dyn RTCPin; 2] = [&mut pin27, &mut pin32];
     let ext1 = Ext1WakeupSource::new(&mut wakeup_pins, WakeupLevel::High);
     println!("sleeping!");
     delay.delay_ms(100u32);

--- a/esp32c2-hal/examples/embassy_multiprio.rs
+++ b/esp32c2-hal/examples/embassy_multiprio.rs
@@ -17,10 +17,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Instant, Ticker, Timer};
-use esp32c2_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32c2_hal::{
     clock::ClockControl,
     embassy::{
         self,
@@ -30,6 +27,8 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 
@@ -83,12 +82,12 @@ async fn main(low_prio_spawner: Spawner) {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32c2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        let timer_group0 = esp32c2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32c2-hal/examples/embassy_serial.rs
+++ b/esp32c2-hal/examples/embassy_serial.rs
@@ -15,10 +15,10 @@ use esp32c2_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
+    uart::{config::AtCmdConfig, UartRx, UartTx},
     Uart,
 };
 use esp_backtrace as _;
-use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use static_cell::make_static;
 
 // rx_fifo_full_threshold

--- a/esp32c3-hal/examples/embassy_multiprio.rs
+++ b/esp32c3-hal/examples/embassy_multiprio.rs
@@ -17,10 +17,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Instant, Ticker, Timer};
-use esp32c3_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32c3_hal::{
     clock::ClockControl,
     embassy::{
         self,
@@ -30,6 +27,8 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 
@@ -83,12 +82,12 @@ async fn main(low_prio_spawner: Spawner) {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32c3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        let timer_group0 = esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32c3-hal/examples/embassy_serial.rs
+++ b/esp32c3-hal/examples/embassy_serial.rs
@@ -15,10 +15,10 @@ use esp32c3_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
+    uart::{config::AtCmdConfig, UartRx, UartTx},
     Uart,
 };
 use esp_backtrace as _;
-use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use static_cell::make_static;
 
 // rx_fifo_full_threshold

--- a/esp32c3-hal/examples/rmt_tx.rs
+++ b/esp32c3-hal/examples/rmt_tx.rs
@@ -10,10 +10,10 @@ use esp32c3_hal::{
     peripherals::Peripherals,
     prelude::*,
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
+    Delay,
     Rmt,
 };
 use esp_backtrace as _;
-use esp_hal_common::Delay;
 
 #[entry]
 fn main() -> ! {

--- a/esp32c3-hal/examples/sleep_timer.rs
+++ b/esp32c3-hal/examples/sleep_timer.rs
@@ -5,18 +5,18 @@
 
 use core::time::Duration;
 
-use esp32c3_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32c3_hal::{
     clock::ClockControl,
     entry,
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, SocResetReason},
+    Cpu,
     Delay,
     Rtc,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -27,7 +27,7 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);

--- a/esp32c3-hal/examples/sleep_timer_rtcio.rs
+++ b/esp32c3-hal/examples/sleep_timer_rtcio.rs
@@ -6,25 +6,25 @@
 
 use core::time::Duration;
 
-use esp32c3_hal as hal;
-use esp_backtrace as _;
-use esp_hal_common::{gpio::RTCPinWithResistors, rtc_cntl::sleep::RtcioWakeupSource};
-use esp_println::println;
-use hal::{
+use esp32c3_hal::{
     clock::ClockControl,
     entry,
+    gpio::RTCPinWithResistors,
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{
         get_reset_reason,
         get_wakeup_cause,
-        sleep::{TimerWakeupSource, WakeupLevel},
+        sleep::{RtcioWakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
+    Cpu,
     Delay,
     Rtc,
     IO,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -39,7 +39,7 @@ fn main() -> ! {
     let mut pin3 = io.pins.gpio3;
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);

--- a/esp32c6-hal/examples/embassy_multiprio.rs
+++ b/esp32c6-hal/examples/embassy_multiprio.rs
@@ -17,10 +17,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Instant, Ticker, Timer};
-use esp32c6_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32c6_hal::{
     clock::ClockControl,
     embassy::{
         self,
@@ -30,6 +27,8 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 
@@ -83,12 +82,12 @@ async fn main(low_prio_spawner: Spawner) {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32c6_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        let timer_group0 = esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -15,10 +15,10 @@ use esp32c6_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
+    uart::{config::AtCmdConfig, UartRx, UartTx},
     Uart,
 };
 use esp_backtrace as _;
-use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use static_cell::make_static;
 
 // rx_fifo_full_threshold

--- a/esp32h2-hal/examples/ecc.rs
+++ b/esp32h2-hal/examples/ecc.rs
@@ -14,14 +14,13 @@ use crypto_bigint::{
 };
 use elliptic_curve::sec1::ToEncodedPoint;
 use esp32h2_hal::{
-    ecc::{Ecc, EllipticCurve, Error},
+    ecc::{Ecc, EllipticCurve, Error, WorkMode},
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
     Rng,
 };
 use esp_backtrace as _;
-use esp_hal_common::ecc::WorkMode;
 use esp_println::{print, println};
 use hex_literal::hex;
 

--- a/esp32h2-hal/examples/embassy_multiprio.rs
+++ b/esp32h2-hal/examples/embassy_multiprio.rs
@@ -17,10 +17,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Instant, Ticker, Timer};
-use esp32h2_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32h2_hal::{
     clock::ClockControl,
     embassy::{
         self,
@@ -30,6 +27,8 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 
@@ -83,12 +82,12 @@ async fn main(low_prio_spawner: Spawner) {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32h2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        let timer_group0 = esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32h2-hal/examples/embassy_serial.rs
+++ b/esp32h2-hal/examples/embassy_serial.rs
@@ -15,10 +15,10 @@ use esp32h2_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
+    uart::{config::AtCmdConfig, UartRx, UartTx},
     Uart,
 };
 use esp_backtrace as _;
-use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use static_cell::make_static;
 
 // rx_fifo_full_threshold

--- a/esp32s2-hal/examples/embassy_multiprio.rs
+++ b/esp32s2-hal/examples/embassy_multiprio.rs
@@ -17,10 +17,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Instant, Ticker, Timer};
-use esp32s2_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32s2_hal::{
     clock::ClockControl,
     embassy::{
         self,
@@ -30,6 +27,8 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 
@@ -83,12 +82,12 @@ async fn main(low_prio_spawner: Spawner) {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32s2_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        let timer_group0 = esp32s2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s2-hal/examples/embassy_rmt_rx.rs
+++ b/esp32s2-hal/examples/embassy_rmt_rx.rs
@@ -10,6 +10,7 @@ use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
     embassy::{self},
+    gpio::{Gpio15, Output, PushPull},
     peripherals::Peripherals,
     prelude::*,
     rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
@@ -17,7 +18,6 @@ use esp32s2_hal::{
     IO,
 };
 use esp_backtrace as _;
-use esp_hal_common::gpio::{Gpio15, Output, PushPull};
 use esp_println::{print, println};
 
 const WIDTH: usize = 80;

--- a/esp32s2-hal/examples/embassy_serial.rs
+++ b/esp32s2-hal/examples/embassy_serial.rs
@@ -15,10 +15,10 @@ use esp32s2_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
+    uart::{config::AtCmdConfig, UartRx, UartTx},
     Uart,
 };
 use esp_backtrace as _;
-use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use static_cell::make_static;
 
 // rx_fifo_full_threshold

--- a/esp32s3-hal/examples/embassy_multicore.rs
+++ b/esp32s3-hal/examples/embassy_multicore.rs
@@ -13,12 +13,12 @@ use esp32s3_hal::{
     clock::ClockControl,
     cpu_control::{CpuControl, Stack},
     embassy::{self, executor::Executor},
+    get_core,
     gpio::{GpioPin, Output, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
 };
 use esp_backtrace as _;
-use esp_hal_common::get_core;
 use esp_println::println;
 use static_cell::make_static;
 

--- a/esp32s3-hal/examples/embassy_multicore_interrupt.rs
+++ b/esp32s3-hal/examples/embassy_multicore_interrupt.rs
@@ -15,13 +15,13 @@ use esp32s3_hal::{
         self,
         executor::{FromCpu1, FromCpu2, InterruptExecutor},
     },
+    get_core,
     gpio::{GpioPin, Output, PushPull, IO},
     interrupt::Priority,
     peripherals::Peripherals,
     prelude::*,
 };
 use esp_backtrace as _;
-use esp_hal_common::get_core;
 use esp_println::println;
 use static_cell::make_static;
 

--- a/esp32s3-hal/examples/embassy_multiprio.rs
+++ b/esp32s3-hal/examples/embassy_multiprio.rs
@@ -17,10 +17,7 @@
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Instant, Ticker, Timer};
-use esp32s3_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     embassy::{
         self,
@@ -30,6 +27,8 @@ use hal::{
     peripherals::Peripherals,
     prelude::*,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 static INT_EXECUTOR_0: InterruptExecutor<FromCpu1> = InterruptExecutor::new();
 
@@ -83,12 +82,12 @@ async fn main(low_prio_spawner: Spawner) {
     #[cfg(feature = "embassy-time-systick")]
     embassy::init(
         &clocks,
-        hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
+        esp32s3_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
     );
 
     #[cfg(feature = "embassy-time-timg0")]
     {
-        let timer_group0 = hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+        let timer_group0 = esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
         embassy::init(&clocks, timer_group0.timer0);
     }
 

--- a/esp32s3-hal/examples/embassy_serial.rs
+++ b/esp32s3-hal/examples/embassy_serial.rs
@@ -15,10 +15,10 @@ use esp32s3_hal::{
     interrupt,
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
+    uart::{config::AtCmdConfig, UartRx, UartTx},
     Uart,
 };
 use esp_backtrace as _;
-use esp_hal_common::uart::{config::AtCmdConfig, UartRx, UartTx};
 use static_cell::make_static;
 
 // rx_fifo_full_threshold

--- a/esp32s3-hal/examples/rmt_tx.rs
+++ b/esp32s3-hal/examples/rmt_tx.rs
@@ -4,12 +4,16 @@
 #![no_std]
 #![no_main]
 
-use esp32s3_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
-use esp_backtrace as _;
-use esp_hal_common::{
+use esp32s3_hal::{
+    clock::ClockControl,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
     rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
+    Delay,
     Rmt,
 };
+use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {

--- a/esp32s3-hal/examples/sleep_timer.rs
+++ b/esp32s3-hal/examples/sleep_timer.rs
@@ -5,18 +5,18 @@
 
 use core::time::Duration;
 
-use esp32s3_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     entry,
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, SocResetReason},
+    Cpu,
     Delay,
     Rtc,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -27,7 +27,7 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);

--- a/esp32s3-hal/examples/sleep_timer_ext0.rs
+++ b/esp32s3-hal/examples/sleep_timer_ext0.rs
@@ -5,10 +5,7 @@
 
 use core::time::Duration;
 
-use esp32s3_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     entry,
     peripherals::Peripherals,
@@ -19,10 +16,13 @@ use hal::{
         sleep::{Ext0WakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
+    Cpu,
     Delay,
     Rtc,
     IO,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -36,7 +36,7 @@ fn main() -> ! {
     let mut ext0_pin = io.pins.gpio18;
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);

--- a/esp32s3-hal/examples/sleep_timer_ext1.rs
+++ b/esp32s3-hal/examples/sleep_timer_ext1.rs
@@ -5,12 +5,10 @@
 
 use core::time::Duration;
 
-use esp32s3_hal as hal;
-use esp_backtrace as _;
-use esp_println::println;
-use hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     entry,
+    gpio::{RTCPin, IO},
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{
@@ -19,10 +17,12 @@ use hal::{
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
+    Cpu,
     Delay,
     Rtc,
-    IO,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -37,7 +37,7 @@ fn main() -> ! {
     let mut pin19 = io.pins.gpio19;
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);
@@ -45,7 +45,7 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
 
     let timer = TimerWakeupSource::new(Duration::from_secs(30));
-    let mut wakeup_pins: [&mut dyn hal::gpio::RTCPin; 2] = [&mut pin18, &mut pin19];
+    let mut wakeup_pins: [&mut dyn RTCPin; 2] = [&mut pin18, &mut pin19];
     let ext1 = Ext1WakeupSource::new(&mut wakeup_pins, WakeupLevel::High);
     println!("sleeping!");
     delay.delay_ms(100u32);

--- a/esp32s3-hal/examples/sleep_timer_rtcio.rs
+++ b/esp32s3-hal/examples/sleep_timer_rtcio.rs
@@ -5,28 +5,25 @@
 
 use core::time::Duration;
 
-use esp32s3_hal as hal;
-use esp_backtrace as _;
-use esp_hal_common::{
-    gpio::{RTCPin, RTCPinWithResistors},
-    rtc_cntl::sleep::RtcioWakeupSource,
-};
-use esp_println::println;
-use hal::{
+use esp32s3_hal::{
     clock::ClockControl,
     entry,
+    gpio::{RTCPin, RTCPinWithResistors},
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{
         get_reset_reason,
         get_wakeup_cause,
-        sleep::{TimerWakeupSource, WakeupLevel},
+        sleep::{RtcioWakeupSource, TimerWakeupSource, WakeupLevel},
         SocResetReason,
     },
+    Cpu,
     Delay,
     Rtc,
     IO,
 };
+use esp_backtrace as _;
+use esp_println::println;
 
 #[entry]
 fn main() -> ! {
@@ -43,7 +40,7 @@ fn main() -> ! {
     rtcio_pin18.rtcio_pullup(true);
 
     println!("up and runnning!");
-    let reason = get_reset_reason(hal::Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
     let wake_reason = get_wakeup_cause();
     println!("wake reason: {:?}", wake_reason);


### PR DESCRIPTION
Just fixing a few small issues I happened to notice:

1. We were importing from `esp-hal-common` in some examples; this is not necessary and I don't want to encourage this.
2. We were aliasing the HAL packages in some examples; again, not necessary.