### PR TITLE
remove double &mut for SetDutyCycle impl on PwmPin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix SHA for all targets (#1021)
+- Fix double &mut for the `SetDutyCycle` impl on `PwmPin` (#1033)
 
 ## [0.14.0] - 2023-12-12
 

--- a/esp-hal-common/src/mcpwm/operator.rs
+++ b/esp-hal-common/src/mcpwm/operator.rs
@@ -673,7 +673,7 @@ impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> emb
 /// Implement no error type for the PwmPin because the method are infallible
 #[cfg(feature = "eh1")]
 impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    embedded_hal_1::pwm::ErrorType for &mut PwmPin<'d, Pin, PWM, OP, IS_A>
+    embedded_hal_1::pwm::ErrorType for PwmPin<'d, Pin, PWM, OP, IS_A>
 {
     type Error = core::convert::Infallible;
 }
@@ -681,7 +681,7 @@ impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
 /// Implement the trait SetDutyCycle for PwmPin
 #[cfg(feature = "eh1")]
 impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    embedded_hal_1::pwm::SetDutyCycle for &mut PwmPin<'d, Pin, PWM, OP, IS_A>
+    embedded_hal_1::pwm::SetDutyCycle for PwmPin<'d, Pin, PWM, OP, IS_A>
 {
     /// Get the max duty of the PwmPin
     fn max_duty_cycle(&self) -> u16 {


### PR DESCRIPTION
There is no need for the double `&mut` since the relevant trait methods like `set_duty_cycle` already give `&mut`.