### PR TITLE
Make SPI dma slave usable in cases when transmission is shorter than buffers

### DIFF
--- a/esp-hal-common/src/aes/mod.rs
+++ b/esp-hal-common/src/aes/mod.rs
@@ -327,7 +327,7 @@ pub mod dma {
             // Waiting for the DMA transfer is not enough. We need to wait for the
             // peripheral to finish flushing its buffers, too.
             while self.aes_dma.aes.aes.state().read().state().bits() != 2 // DMA status DONE == 2
-                && !self.aes_dma.channel.tx.is_done()
+                && !self.aes_dma.channel.tx.is_completed()
             {
                 // wait until done
             }
@@ -359,7 +359,7 @@ pub mod dma {
         /// Check if the DMA transfer is complete
         fn is_done(&self) -> bool {
             let ch = &self.aes_dma.channel;
-            ch.tx.is_done() && ch.rx.is_done()
+            ch.tx.is_completed() && ch.rx.is_completed()
         }
     }
 
@@ -453,8 +453,8 @@ pub mod dma {
             // AES has to be restarted after each calculation
             self.reset_aes();
 
-            self.channel.tx.is_done();
-            self.channel.rx.is_done();
+            self.channel.tx.is_completed();
+            self.channel.rx.is_completed();
 
             self.channel
                 .tx

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -225,7 +225,7 @@ macro_rules! impl_channel {
                     #[cfg(not(any(esp32c6, esp32h2, esp32s3)))]
                     let ret = dma.int_raw_ch($num).read().out_total_eof().bit();
                     #[cfg(any(esp32c6, esp32h2, esp32s3))]
-                    let ret = dma.out_int_raw_ch($num).read().out_total_eof().bit();
+                    let ret = dma.out_int_raw_ch($num).read().out_done().bit();
 
                     ret
                 }

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -219,11 +219,22 @@ macro_rules! impl_channel {
                     }
                 }
 
-                fn is_out_done() -> bool {
+                fn is_out_completed() -> bool {
                     let dma = unsafe { &*crate::peripherals::DMA::PTR };
 
                     #[cfg(not(any(esp32c6, esp32h2, esp32s3)))]
                     let ret = dma.int_raw_ch($num).read().out_total_eof().bit();
+                    #[cfg(any(esp32c6, esp32h2, esp32s3))]
+                    let ret = dma.out_int_raw_ch($num).read().out_total_eof().bit();
+
+                    ret
+                }
+
+                fn is_out_done() -> bool {
+                    let dma = unsafe { &*crate::peripherals::DMA::PTR };
+
+                    #[cfg(not(any(esp32c6, esp32h2, esp32s3)))]
+                    let ret = dma.int_raw_ch($num).read().out_done().bit();
                     #[cfg(any(esp32c6, esp32h2, esp32s3))]
                     let ret = dma.out_int_raw_ch($num).read().out_done().bit();
 

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -365,7 +365,7 @@ pub trait RxPrivate {
 
     fn is_listening_ch_in_done(&self) -> bool;
 
-    fn is_done(&self) -> bool;
+    fn is_completed(&self) -> bool;
 
     fn is_listening_eof(&self) -> bool;
 
@@ -467,7 +467,7 @@ where
         }
     }
 
-    fn is_done(&self) -> bool {
+    fn is_completed(&self) -> bool {
         R::is_in_done()
     }
 
@@ -563,8 +563,8 @@ where
         R::is_listening_ch_in_done()
     }
 
-    fn is_done(&self) -> bool {
-        self.rx_impl.is_done()
+    fn is_completed(&self) -> bool {
+        self.rx_impl.is_completed()
     }
 
     fn init_channel(&mut self) {
@@ -716,6 +716,8 @@ pub trait TxPrivate {
 
     fn is_listening_ch_out_done(&self) -> bool;
 
+    fn is_completed(&self) -> bool;
+
     fn is_done(&self) -> bool;
 
     fn is_listening_eof(&self) -> bool;
@@ -833,6 +835,10 @@ where
         R::is_listening_ch_out_done()
     }
 
+    fn is_completed(&self) -> bool {
+        R::is_out_completed()
+    }
+
     fn is_done(&self) -> bool {
         R::is_out_done()
     }
@@ -940,6 +946,10 @@ where
 
     fn is_listening_ch_out_done(&self) -> bool {
         self.tx_impl.is_listening_ch_out_done()
+    }
+
+    fn is_completed(&self) -> bool {
+        self.tx_impl.is_completed()
     }
 
     fn is_done(&self) -> bool {
@@ -1088,6 +1098,7 @@ pub trait RegisterAccess {
     fn unlisten_ch_out_done();
     fn is_listening_ch_out_done() -> bool;
     fn is_out_done() -> bool;
+    fn is_out_completed() -> bool;
     fn is_out_eof_interrupt_set() -> bool;
     fn reset_out_eof_interrupt();
     fn last_out_dscr_address() -> usize;
@@ -1318,7 +1329,7 @@ pub(crate) mod asynch {
                 ChannelRxImpl::waker().wake()
             }
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1350,7 +1361,7 @@ pub(crate) mod asynch {
                 ChannelRxImpl::waker().wake()
             }
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1383,7 +1394,7 @@ pub(crate) mod asynch {
                 ChannelRxImpl::waker().wake()
             }
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1416,7 +1427,7 @@ pub(crate) mod asynch {
                 ChannelRxImpl::waker().wake()
             }
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1461,7 +1472,7 @@ pub(crate) mod asynch {
         fn DMA_OUT_CH0() {
             use crate::dma::gdma::{Channel0 as Channel, Channel0TxImpl as ChannelTxImpl};
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1495,7 +1506,7 @@ pub(crate) mod asynch {
         fn DMA_OUT_CH1() {
             use crate::dma::gdma::{Channel1 as Channel, Channel1TxImpl as ChannelTxImpl};
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1529,7 +1540,7 @@ pub(crate) mod asynch {
         fn DMA_OUT_CH2() {
             use crate::dma::gdma::{Channel2 as Channel, Channel2TxImpl as ChannelTxImpl};
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1568,7 +1579,7 @@ pub(crate) mod asynch {
         fn DMA_OUT_CH0() {
             use crate::dma::gdma::{Channel0 as Channel, Channel0TxImpl as ChannelTxImpl};
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1602,7 +1613,7 @@ pub(crate) mod asynch {
         fn DMA_OUT_CH1() {
             use crate::dma::gdma::{Channel1 as Channel, Channel1TxImpl as ChannelTxImpl};
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1636,7 +1647,7 @@ pub(crate) mod asynch {
         fn DMA_OUT_CH3() {
             use crate::dma::gdma::{Channel3 as Channel, Channel3TxImpl as ChannelTxImpl};
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1670,7 +1681,7 @@ pub(crate) mod asynch {
         fn DMA_OUT_CH4() {
             use crate::dma::gdma::{Channel4 as Channel, Channel4TxImpl as ChannelTxImpl};
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1702,7 +1713,7 @@ pub(crate) mod asynch {
                 ChannelRxImpl::waker().wake()
             }
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1735,7 +1746,7 @@ pub(crate) mod asynch {
                 ChannelRxImpl::waker().wake()
             }
 
-            if Channel::is_out_done() {
+            if Channel::is_out_completed() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1768,7 +1779,7 @@ pub(crate) mod asynch {
                 ChannelRxImpl::waker().wake()
             }
 
-            if Channel::is_out_done() && Channel::is_listening_out_eof() {
+            if Channel::is_out_completed() && Channel::is_listening_out_eof() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()
@@ -1802,7 +1813,7 @@ pub(crate) mod asynch {
                 ChannelRxImpl::waker().wake()
             }
 
-            if Channel::is_out_done() && Channel::is_listening_out_eof() {
+            if Channel::is_out_completed() && Channel::is_listening_out_eof() {
                 Channel::clear_out_interrupts();
                 Channel::unlisten_out_eof();
                 ChannelTxImpl::waker().wake()

--- a/esp-hal-common/src/dma/pdma.rs
+++ b/esp-hal-common/src/dma/pdma.rs
@@ -137,10 +137,15 @@ macro_rules! ImplSpiChannel {
                     spi.dma_int_ena().read().out_done_int_ena().bit()
                 }
 
-                fn is_out_done() -> bool {
+                fn is_out_completed() -> bool {
                     let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
                     // FIXME this should be out_total_eof_int_raw? but on esp32 this interrupt doesn't seem to fire
                     spi.dma_int_raw().read().out_eof_int_raw().bit()
+                }
+
+                fn is_out_done() -> bool {
+                    let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
+                    spi.dma_int_raw().read().out_done_int_raw().bit()
                 }
 
                 fn last_out_dscr_address() -> usize {
@@ -460,9 +465,15 @@ macro_rules! ImplI2sChannel {
                     reg_block.int_ena().read().out_done_int_ena().bit()
                 }
 
+                fn is_out_completed() -> bool {
+                    let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
+                    // FIXME this should be out_total_eof_int_raw? but on esp32 this interrupt doesn't seem to fire
+                    spi.dma_int_raw().read().out_eof_int_raw().bit()
+                }
+
                 fn is_out_done() -> bool {
                     let reg_block = unsafe { &*crate::peripherals::[<$peripheral>]::PTR };
-                    reg_block.int_raw().read().out_eof_int_raw().bit()
+                    reg_block.int_raw().read().out_done_int_raw().bit()
                 }
 
                 fn last_out_dscr_address() -> usize {

--- a/esp-hal-common/src/i2s.rs
+++ b/esp-hal-common/src/i2s.rs
@@ -286,7 +286,7 @@ where
 
     /// Check if the DMA transfer is complete
     fn is_done(&self) -> bool {
-        self.i2s_tx.tx_channel.is_done()
+        self.i2s_tx.tx_channel.is_completed()
     }
 }
 
@@ -422,7 +422,7 @@ where
 
     /// Check if the DMA transfer is complete
     fn is_done(&self) -> bool {
-        self.i2s_rx.rx_channel.is_done()
+        self.i2s_rx.rx_channel.is_completed()
     }
 }
 

--- a/esp-hal-common/src/parl_io.rs
+++ b/esp-hal-common/src/parl_io.rs
@@ -1206,7 +1206,7 @@ where
         Instance::clear_tx_interrupts();
         Instance::set_tx_bytes(len as u16);
 
-        self.tx_channel.is_done();
+        self.tx_channel.is_completed();
 
         self.tx_channel
             .prepare_transfer_without_start(DmaPeripheral::ParlIo, false, ptr, len)
@@ -1396,7 +1396,7 @@ where
     /// Check if the DMA transfer is complete
     pub fn is_done(&self) -> bool {
         let ch = &self.instance.rx_channel;
-        ch.is_done()
+        ch.is_completed()
     }
 
     /// Check if the DMA transfer is completed by buffer full or source EOF

--- a/esp-hal-common/src/spi/master.rs
+++ b/esp-hal-common/src/spi/master.rs
@@ -904,7 +904,7 @@ pub mod dma {
         /// Check if the DMA transfer is complete
         fn is_done(&self) -> bool {
             let ch = &self.spi_dma.channel;
-            ch.tx.is_done() && ch.rx.is_done()
+            ch.tx.is_completed() && ch.rx.is_completed()
         }
     }
 
@@ -973,7 +973,7 @@ pub mod dma {
         /// Check if the DMA transfer is complete
         fn is_done(&self) -> bool {
             let ch = &self.spi_dma.channel;
-            ch.tx.is_done() && ch.rx.is_done()
+            ch.tx.is_completed() && ch.rx.is_completed()
         }
     }
 
@@ -1743,7 +1743,7 @@ where
                 false,
             )?;
 
-            while !tx.is_done() && !rx.is_done() {}
+            while !tx.is_completed() && !rx.is_completed() {}
             self.flush().unwrap();
         }
 
@@ -1775,7 +1775,7 @@ where
                 false,
             )?;
 
-            while !tx.is_done() && !rx.is_done() {}
+            while !tx.is_completed() && !rx.is_completed() {}
             self.flush().unwrap();
 
             idx += MAX_DMA_SIZE as isize;
@@ -1800,8 +1800,8 @@ where
         let reg_block = self.register_block();
         self.configure_datalen(usize::max(read_buffer_len, write_buffer_len) as u32 * 8);
 
-        tx.is_done();
-        rx.is_done();
+        tx.is_completed();
+        rx.is_completed();
 
         self.enable_dma();
         self.update();
@@ -1838,8 +1838,8 @@ where
         for chunk in words.chunks(MAX_DMA_SIZE) {
             self.start_write_bytes_dma(chunk.as_ptr(), chunk.len(), tx, false)?;
 
-            while !tx.is_done() {}
-            self.flush().unwrap(); // seems "is_done" doesn't work as intended?
+            while !tx.is_completed() {}
+            self.flush().unwrap(); // seems "is_completed" doesn't work as intended?
         }
 
         Ok(words)
@@ -1855,7 +1855,7 @@ where
         let reg_block = self.register_block();
         self.configure_datalen(len as u32 * 8);
 
-        tx.is_done();
+        tx.is_completed();
 
         self.enable_dma();
         self.update();
@@ -1885,7 +1885,7 @@ where
         let reg_block = self.register_block();
         self.configure_datalen(len as u32 * 8);
 
-        rx.is_done();
+        rx.is_completed();
 
         self.enable_dma();
         self.update();

--- a/esp-hal-common/src/spi/master.rs
+++ b/esp-hal-common/src/spi/master.rs
@@ -1839,7 +1839,8 @@ where
             self.start_write_bytes_dma(chunk.as_ptr(), chunk.len(), tx, false)?;
 
             while !tx.is_completed() {}
-            self.flush().unwrap(); // seems "is_completed" doesn't work as intended?
+            self.flush().unwrap(); // seems "is_completed" doesn't work as
+                                   // intended?
         }
 
         Ok(words)

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -277,7 +277,7 @@ pub mod dma {
         /// Check if the DMA transfer is complete
         fn is_done(&self) -> bool {
             let ch = &self.spi_dma.channel;
-            ch.tx.is_done() && ch.rx.is_done() && !self.spi_dma.spi.is_bus_busy()
+            ch.tx.is_done() && ch.rx.is_completed() && !self.spi_dma.spi.is_bus_busy()
         }
     }
 
@@ -341,7 +341,7 @@ pub mod dma {
         /// Check if the DMA transfer is complete
         fn is_done(&self) -> bool {
             let ch = &self.spi_dma.channel;
-            ch.rx.is_done()
+            ch.rx.is_completed()
         }
     }
 
@@ -607,7 +607,7 @@ where
         let reg_block = self.register_block();
 
         tx.is_done();
-        rx.is_done();
+        rx.is_completed();
 
         self.enable_dma();
 
@@ -672,7 +672,7 @@ where
     fn start_read_bytes_dma(&mut self, ptr: *mut u8, len: usize, rx: &mut RX) -> Result<(), Error> {
         let reg_block = self.register_block();
 
-        rx.is_done();
+        rx.is_completed();
 
         self.enable_dma();
 

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -304,6 +304,29 @@ pub mod dma {
         len: Option<&'l mut usize>,
     }
 
+    impl<'d, 'l, T, C, BUFFER> SpiDmaTransferRx<'d, 'l, T, C, BUFFER>
+    where
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+        C: ChannelTypes,
+        C::P: SpiPeripheral,
+    {
+        pub fn cancel(
+            self,
+        ) -> Result<(BUFFER, SpiDma<'d, T, C>), (DmaError, BUFFER, SpiDma<'d, T, C>)> {
+            let err = self.spi_dma.channel.rx.has_error() || self.spi_dma.channel.tx.has_error();
+            unsafe {
+                let buffer = core::ptr::read(&self.buffer);
+                let payload = core::ptr::read(&self.spi_dma);
+                mem::forget(self);
+                if err {
+                    Err((DmaError::DescriptorError, buffer, payload))
+                } else {
+                    Ok((buffer, payload))
+                }
+            }
+        }
+    }
+
     impl<'d, 'l, T, C, BUFFER> DmaTransfer<BUFFER, SpiDma<'d, T, C>>
         for SpiDmaTransferRx<'d, 'l, T, C, BUFFER>
     where
@@ -375,6 +398,29 @@ pub mod dma {
         spi_dma: SpiDma<'d, T, C>,
         buffer: BUFFER,
         len: Option<&'l mut usize>,
+    }
+
+    impl<'d, 'l, T, C, BUFFER> SpiDmaTransferTx<'d, 'l, T, C, BUFFER>
+    where
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+        C: ChannelTypes,
+        C::P: SpiPeripheral,
+    {
+        pub fn cancel(
+            self,
+        ) -> Result<(BUFFER, SpiDma<'d, T, C>), (DmaError, BUFFER, SpiDma<'d, T, C>)> {
+            let err = self.spi_dma.channel.rx.has_error() || self.spi_dma.channel.tx.has_error();
+            unsafe {
+                let buffer = core::ptr::read(&self.buffer);
+                let payload = core::ptr::read(&self.spi_dma);
+                mem::forget(self);
+                if err {
+                    Err((DmaError::DescriptorError, buffer, payload))
+                } else {
+                    Ok((buffer, payload))
+                }
+            }
+        }
     }
 
     impl<'d, 'l, T, C, BUFFER> DmaTransfer<BUFFER, SpiDma<'d, T, C>>

--- a/esp-hal-common/src/spi/slave.rs
+++ b/esp-hal-common/src/spi/slave.rs
@@ -377,7 +377,8 @@ pub mod dma {
         len: Option<&'l mut usize>,
     }
 
-    impl<'d, 'l, T, C, BUFFER> DmaTransfer<BUFFER, SpiDma<'d, T, C>> for SpiDmaTransferTx<'d, 'l, T, C, BUFFER>
+    impl<'d, 'l, T, C, BUFFER> DmaTransfer<BUFFER, SpiDma<'d, T, C>>
+        for SpiDmaTransferTx<'d, 'l, T, C, BUFFER>
     where
         T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
         C: ChannelTypes,

--- a/esp32c2-hal/examples/spi_slave_dma.rs
+++ b/esp32c2-hal/examples/spi_slave_dma.rs
@@ -149,7 +149,7 @@ fn main() -> ! {
         delay.delay_ms(250u32);
 
         slave_receive.fill(0xff);
-        let transfer = spi.dma_read(slave_receive).unwrap();
+        let transfer = spi.dma_read_all(slave_receive).unwrap();
         master_cs.set_high().unwrap();
 
         master_cs.set_low().unwrap();
@@ -175,7 +175,7 @@ fn main() -> ! {
         );
 
         delay.delay_ms(250u32);
-        let transfer = spi.dma_write(slave_send).unwrap();
+        let transfer = spi.dma_write_all(slave_send).unwrap();
 
         master_receive.fill(0);
 

--- a/esp32c3-hal/examples/spi_slave_dma.rs
+++ b/esp32c3-hal/examples/spi_slave_dma.rs
@@ -148,7 +148,7 @@ fn main() -> ! {
         delay.delay_ms(250u32);
 
         slave_receive.fill(0xff);
-        let transfer = spi.dma_read(slave_receive).unwrap();
+        let transfer = spi.dma_read_all(slave_receive).unwrap();
         master_cs.set_high().unwrap();
 
         master_cs.set_low().unwrap();
@@ -174,7 +174,7 @@ fn main() -> ! {
         );
 
         delay.delay_ms(250u32);
-        let transfer = spi.dma_write(slave_send).unwrap();
+        let transfer = spi.dma_write_all(slave_send).unwrap();
 
         master_receive.fill(0);
 

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -148,7 +148,7 @@ fn main() -> ! {
         delay.delay_ms(250u32);
 
         slave_receive.fill(0xff);
-        let transfer = spi.dma_read(slave_receive).unwrap();
+        let transfer = spi.dma_read_all(slave_receive).unwrap();
         master_cs.set_high().unwrap();
 
         master_cs.set_low().unwrap();
@@ -174,7 +174,7 @@ fn main() -> ! {
         );
 
         delay.delay_ms(250u32);
-        let transfer = spi.dma_write(slave_send).unwrap();
+        let transfer = spi.dma_write_all(slave_send).unwrap();
 
         master_receive.fill(0);
 

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -148,7 +148,7 @@ fn main() -> ! {
         delay.delay_ms(250u32);
 
         slave_receive.fill(0xff);
-        let transfer = spi.dma_read(slave_receive).unwrap();
+        let transfer = spi.dma_read_all(slave_receive).unwrap();
         master_cs.set_high().unwrap();
 
         master_cs.set_low().unwrap();
@@ -174,7 +174,7 @@ fn main() -> ! {
         );
 
         delay.delay_ms(250u32);
-        let transfer = spi.dma_write(slave_send).unwrap();
+        let transfer = spi.dma_write_all(slave_send).unwrap();
 
         master_receive.fill(0);
 

--- a/esp32s3-hal/examples/spi_slave_dma.rs
+++ b/esp32s3-hal/examples/spi_slave_dma.rs
@@ -148,7 +148,7 @@ fn main() -> ! {
         delay.delay_ms(250u32);
 
         slave_receive.fill(0xff);
-        let transfer = spi.dma_read(slave_receive).unwrap();
+        let transfer = spi.dma_read_all(slave_receive).unwrap();
         master_cs.set_high().unwrap();
 
         master_cs.set_low().unwrap();
@@ -174,7 +174,7 @@ fn main() -> ! {
         );
 
         delay.delay_ms(250u32);
-        let transfer = spi.dma_write(slave_send).unwrap();
+        let transfer = spi.dma_write_all(slave_send).unwrap();
 
         master_receive.fill(0);
 


### PR DESCRIPTION
### Read 

After a little bit of testing, I figured out that `dma_read` works fine when received data is shorter than buffer- it does so by leaving the rest of values in buffer untouched. But there is no way to determine from given buffer, what actual transmission length was. 

I added method `wait_with_len`, which returns dma transmission length in bits. Current declaration seems sketchy and out of place, but I cannot think of a way to introduce this feature without major trait changes. 

### Write

`dma_write` is not working well when transmission is shorter than buffer, because it is waiting for another transmission to complete write operation. So I changed `out_total_eof` to `out_done`, and now it works.
The question is, could this change result in some unexpected behavior of other parts of the library?

I think, we could also add `wait_with_len` for `SpiDmaTransferTx` in order to be able to check, if all needed data was sent. 

---

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
