### PR TITLE
Fix/c6 h2 interrupt disabling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-C6: Fix used RAM (#997)
 - ESP32-H2: Fix used RAM (#1003)
 - Fix SPI slave DMA dma\_read and dma\_write (#1013)
+- ESP32-C6/H2: Fix disabling of interrupts (#1040)
 
 ### Removed
 

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -292,7 +292,6 @@ fn preprocess_file(
 
     for line in std::io::BufReader::new(file).lines() {
         let line = line?;
-        println!("{} >> {}", *take.last().unwrap(), line);
         let trimmed = line.trim();
 
         if trimmed.starts_with("#IF ") {


### PR DESCRIPTION
Fixes #1039 

While I cannot completely explain #1039 this fixes the issue (also in esp-wifi where this was discovered first)

It's probably better to not use CPU INT 0 when trying to disable an interrupt since that one is reserved for the CLIC

From TRM

> The interrupts numbered 0, 3, 4, and 7 are used by the CPU for core-local interrupts (CLINT) ...

> These properties (_Enable State,  Type, Priority_) can be configured for the 28 external interrupts (1-2, 5-6, 8-31), but are static (except mode) for the 4 local CLINT interrupts (0, 3, 4, 7).
