### PR TITLE
efuse: allow overriding base mac

### DIFF
--- a/esp-hal-common/src/soc/esp32/efuse.rs
+++ b/esp-hal-common/src/soc/esp32/efuse.rs
@@ -51,7 +51,7 @@ pub enum ChipType {
 }
 
 impl Efuse {
-    pub fn get_mac_address() -> [u8; 6] {
+    pub fn read_base_mac_address() -> [u8; 6] {
         Self::read_field_be(MAC_FACTORY)
     }
 

--- a/esp-hal-common/src/soc/esp32c2/efuse.rs
+++ b/esp-hal-common/src/soc/esp32c2/efuse.rs
@@ -40,7 +40,7 @@ pub struct Efuse;
 
 impl Efuse {
     /// Reads chip's MAC address from the eFuse storage.
-    pub fn get_mac_address() -> [u8; 6] {
+    pub fn read_base_mac_address() -> [u8; 6] {
         Self::read_field_be(MAC_FACTORY)
     }
 

--- a/esp-hal-common/src/soc/esp32c3/efuse.rs
+++ b/esp-hal-common/src/soc/esp32c3/efuse.rs
@@ -40,7 +40,7 @@ pub struct Efuse;
 
 impl Efuse {
     /// Reads chip's MAC address from the eFuse storage.
-    pub fn get_mac_address() -> [u8; 6] {
+    pub fn read_base_mac_address() -> [u8; 6] {
         Self::read_field_be(MAC_FACTORY)
     }
 

--- a/esp-hal-common/src/soc/esp32c6/efuse.rs
+++ b/esp-hal-common/src/soc/esp32c6/efuse.rs
@@ -40,7 +40,7 @@ pub struct Efuse;
 
 impl Efuse {
     /// Reads chip's MAC address from the eFuse storage.
-    pub fn get_mac_address() -> [u8; 6] {
+    pub fn read_base_mac_address() -> [u8; 6] {
         Self::read_field_be(MAC_FACTORY)
     }
 

--- a/esp-hal-common/src/soc/esp32h2/efuse.rs
+++ b/esp-hal-common/src/soc/esp32h2/efuse.rs
@@ -40,7 +40,7 @@ pub struct Efuse;
 
 impl Efuse {
     /// Reads chip's MAC address from the eFuse storage.
-    pub fn get_mac_address() -> [u8; 6] {
+    pub fn read_base_mac_address() -> [u8; 6] {
         Self::read_field_be(MAC_FACTORY)
     }
 

--- a/esp-hal-common/src/soc/esp32s2/efuse.rs
+++ b/esp-hal-common/src/soc/esp32s2/efuse.rs
@@ -56,7 +56,7 @@ impl Efuse {
     ///     mac_address[5]
     /// );
     /// ```
-    pub fn get_mac_address() -> [u8; 6] {
+    pub fn read_base_mac_address() -> [u8; 6] {
         Self::read_field_be(MAC_FACTORY)
     }
 

--- a/esp-hal-common/src/soc/esp32s3/efuse.rs
+++ b/esp-hal-common/src/soc/esp32s3/efuse.rs
@@ -40,7 +40,7 @@ pub struct Efuse;
 
 impl Efuse {
     /// Reads chip's MAC address from the eFuse storage.
-    pub fn get_mac_address() -> [u8; 6] {
+    pub fn read_base_mac_address() -> [u8; 6] {
         Self::read_field_be(MAC_FACTORY)
     }
 

--- a/esp-hal-common/src/soc/mod.rs
+++ b/esp-hal-common/src/soc/mod.rs
@@ -1,3 +1,5 @@
+use core::sync::atomic::{AtomicU8, Ordering};
+
 pub use self::soc::*;
 
 #[cfg_attr(esp32, path = "esp32/mod.rs")]
@@ -8,6 +10,54 @@ pub use self::soc::*;
 #[cfg_attr(esp32s2, path = "esp32s2/mod.rs")]
 #[cfg_attr(esp32s3, path = "esp32s3/mod.rs")]
 mod soc;
+
+// Indicates the state of setting the mac address
+// 0 -- unset
+// 1 -- in the process of being set
+// 2 -- set
+//
+// Values other than 0 indicate that we cannot attempt setting the mac address again,
+// and values other than 2 indicate that we should read the mac address from efuse.
+static MAC_OVERRIDE_STATE: AtomicU8 = AtomicU8::new(0);
+static mut MAC_OVERRIDE: [u8; 6] = [0; 6];
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum SetMacError {
+    AlreadySet,
+}
+
+impl soc::efuse::Efuse {
+    /// Set the base mac address
+    ///
+    /// The new value will be returned by `read_mac_address` instead of the one hard-coded
+    /// in Efuse. This does not persist across device resets.
+    ///
+    /// Can only be called once. Returns `Err(`[`SetMacError::AlreadySet`]`)` otherwise.
+    pub fn set_mac_address(mac: [u8; 6]) -> Result<(), SetMacError> {
+        if MAC_OVERRIDE_STATE
+            .compare_exchange(0, 1, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return Err(SetMacError::AlreadySet);
+        }
+
+        unsafe {
+            MAC_OVERRIDE = mac;
+        }
+
+        MAC_OVERRIDE_STATE.store(2, Ordering::Relaxed);
+
+        Ok(())
+    }
+
+    pub fn get_mac_address() -> [u8; 6] {
+        if MAC_OVERRIDE_STATE.load(Ordering::Relaxed) == 2 {
+            unsafe { MAC_OVERRIDE }
+        } else {
+            Self::read_base_mac_address()
+        }
+    }
+}
 
 mod efuse_field;
 


### PR DESCRIPTION
ESP-IDF defines several kinds of mac addresses, but this doesn't map well to the esp-hal design, because:
1. This isn't actually required by hardware.
2. Wifi / Ble drivers are external to esp-hal.

Hence this patch only allows overriding the base mac and does not introduce the concept of other types of mac addresses.

Resolves https://github.com/esp-rs/esp-hal/issues/971

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [x] You added proper docs for your newly added features and code.
