### PR TITLE
correct errata36() for gpio 32 and 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ESP32: correct gpio 32/33 in errata36() (#1053)
+
 ### Removed
 
 ## [0.14.1] - 2023-12-13

--- a/esp-hal-common/src/soc/esp32/gpio.rs
+++ b/esp-hal-common/src/soc/esp32/gpio.rs
@@ -683,18 +683,18 @@ pub(crate) fn errata36(pin_num: u8, pull_up: bool, pull_down: bool) {
         32 => {
             rtcio.xtal_32k_pad().modify(|r, w| unsafe {
                 w.bits(r.bits())
-                    .x32n_rue()
+                    .x32p_rue()
                     .bit(pull_up)
-                    .x32n_rde()
+                    .x32p_rde()
                     .bit(pull_down)
             });
         }
         33 => {
             rtcio.xtal_32k_pad().modify(|r, w| unsafe {
                 w.bits(r.bits())
-                    .x32p_rue()
+                    .x32n_rue()
                     .bit(pull_up)
-                    .x32p_rde()
+                    .x32n_rde()
                     .bit(pull_down)
             });
         }


### PR DESCRIPTION
The datasheet in page 14 table 2-1 lists 32K_XP as gpio32 and 32K_XN as gpio33 but these were swapped in `errata36()`.
This PR corrects that.

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
