### PR TITLE
Add type for gpio::AnyPin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Implementation OutputPin and InputPin for AnyPin (#1067)
+
 ### Added
 
 - Add initial support for the ESP32-P4 (#1101)

--- a/esp-hal/src/gpio.rs
+++ b/esp-hal/src/gpio.rs
@@ -1361,7 +1361,359 @@ where
     }
 }
 
-impl<MODE> embedded_hal::digital::v2::InputPin for AnyPin<Input<MODE>> {
+impl<MODE, TYPE> From<AnyPin<MODE, TYPE>> for AnyPin<MODE>
+where
+    TYPE: PinType,
+{
+    fn from(pin: AnyPin<MODE, TYPE>) -> Self {
+        Self {
+            inner: pin.inner,
+            _type: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<MODE, TYPE> crate::peripheral::Peripheral for AnyPin<MODE, TYPE>
+where
+    TYPE: PinType,
+{
+    type P = Self;
+
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        let inner = &mut self.inner;
+        let this: AnyPin<MODE> = handle_gpio_input!(inner, target, {
+            crate::peripheral::Peripheral::clone_unchecked(target).into()
+        });
+        Self {
+            inner: this.inner,
+            _type: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<MODE, TYPE> crate::peripheral::sealed::Sealed for AnyPin<MODE, TYPE> where TYPE: PinType {}
+
+impl<MODE, TYPE> AnyPin<MODE, TYPE>
+where
+    TYPE: PinType,
+{
+    pub fn degrade(self) -> AnyPin<MODE> {
+        AnyPin {
+            inner: self.inner,
+            _type: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<MODE> AnyPin<MODE, InputOutputPinType> {
+    pub fn into_input_type(self) -> AnyPin<MODE, InputOnlyPinType> {
+        AnyPin {
+            inner: self.inner,
+            _type: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<MODE> AnyPin<MODE, InputOutputAnalogPinType> {
+    pub fn into_input_type(self) -> AnyPin<MODE, InputOnlyPinType> {
+        AnyPin {
+            inner: self.inner,
+            _type: core::marker::PhantomData,
+        }
+    }
+
+    pub fn into_input_output_type(self) -> AnyPin<MODE, InputOutputPinType> {
+        AnyPin {
+            inner: self.inner,
+            _type: core::marker::PhantomData,
+        }
+    }
+
+    pub fn into_input_only_analog_type(self) -> AnyPin<MODE, InputOnlyAnalogPinType> {
+        AnyPin {
+            inner: self.inner,
+            _type: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<MODE> AnyPin<MODE, InputOnlyAnalogPinType> {
+    pub fn into_input_type(self) -> AnyPin<MODE, InputOnlyPinType> {
+        AnyPin {
+            inner: self.inner,
+            _type: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<MODE, TYPE> Pin for AnyPin<MODE, TYPE>
+where
+    TYPE: PinType,
+{
+    fn number(&self) -> u8 {
+        let inner = &self.inner;
+        handle_gpio_input!(inner, target, { Pin::number(target) })
+    }
+
+    fn sleep_mode(&mut self, on: bool) {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, { Pin::sleep_mode(target, on) })
+    }
+
+    fn set_alternate_function(&mut self, alternate: AlternateFunction) {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, {
+            Pin::set_alternate_function(target, alternate)
+        })
+    }
+
+    fn is_listening(&self) -> bool {
+        let inner = &self.inner;
+        handle_gpio_input!(inner, target, { Pin::is_listening(target) })
+    }
+
+    fn listen_with_options(
+        &mut self,
+        event: Event,
+        int_enable: bool,
+        nmi_enable: bool,
+        wake_up_from_light_sleep: bool,
+    ) {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, {
+            Pin::listen_with_options(
+                target,
+                event,
+                int_enable,
+                nmi_enable,
+                wake_up_from_light_sleep,
+            )
+        })
+    }
+
+    fn listen(&mut self, event: Event) {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, { Pin::listen(target, event) })
+    }
+
+    fn unlisten(&mut self) {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, { Pin::unlisten(target) })
+    }
+
+    fn is_interrupt_set(&self) -> bool {
+        let inner = &self.inner;
+        handle_gpio_input!(inner, target, { Pin::is_interrupt_set(target) })
+    }
+
+    fn clear_interrupt(&mut self) {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, { Pin::clear_interrupt(target) })
+    }
+}
+
+impl<MODE, TYPE> InputPin for AnyPin<MODE, TYPE>
+where
+    MODE: InputMode,
+    TYPE: IsInputPin,
+{
+    fn set_to_input(&mut self) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, {
+            InputPin::set_to_input(target);
+        });
+        self
+    }
+
+    fn enable_input(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, {
+            InputPin::enable_input(target, on);
+        });
+        self
+    }
+
+    fn enable_input_in_sleep_mode(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, {
+            InputPin::enable_input_in_sleep_mode(target, on);
+        });
+        self
+    }
+
+    fn is_input_high(&self) -> bool {
+        let inner = &self.inner;
+        handle_gpio_input!(inner, target, { InputPin::is_input_high(target) })
+    }
+
+    fn connect_input_to_peripheral(&mut self, signal: InputSignal) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, {
+            InputPin::connect_input_to_peripheral(target, signal);
+        });
+        self
+    }
+
+    fn connect_input_to_peripheral_with_options(
+        &mut self,
+        signal: InputSignal,
+        invert: bool,
+        force_via_gpio_mux: bool,
+    ) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, {
+            InputPin::connect_input_to_peripheral_with_options(
+                target,
+                signal,
+                invert,
+                force_via_gpio_mux,
+            );
+        });
+        self
+    }
+
+    fn disconnect_input_from_peripheral(&mut self, signal: InputSignal) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_input!(inner, target, {
+            InputPin::disconnect_input_from_peripheral(target, signal);
+        });
+        self
+    }
+}
+
+impl<MODE, TYPE> OutputPin for AnyPin<MODE, TYPE>
+where
+    MODE: OutputMode,
+    TYPE: IsOutputPin,
+{
+    fn set_to_open_drain_output(&mut self) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::set_to_open_drain_output(target);
+        });
+        self
+    }
+
+    fn set_to_push_pull_output(&mut self) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::set_to_push_pull_output(target);
+        });
+        self
+    }
+
+    fn enable_output(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::enable_output(target, on);
+        });
+        self
+    }
+
+    fn set_output_high(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::set_output_high(target, on);
+        });
+        self
+    }
+
+    fn set_drive_strength(&mut self, strength: DriveStrength) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::set_drive_strength(target, strength);
+        });
+        self
+    }
+
+    fn enable_open_drain(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::enable_open_drain(target, on);
+        });
+        self
+    }
+
+    fn enable_output_in_sleep_mode(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::enable_output_in_sleep_mode(target, on);
+        });
+        self
+    }
+
+    fn internal_pull_up_in_sleep_mode(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::internal_pull_up_in_sleep_mode(target, on);
+        });
+        self
+    }
+
+    fn internal_pull_down_in_sleep_mode(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::internal_pull_down_in_sleep_mode(target, on);
+        });
+        self
+    }
+
+    fn internal_pull_up(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::internal_pull_up(target, on);
+        });
+        self
+    }
+
+    fn internal_pull_down(&mut self, on: bool) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::internal_pull_down(target, on);
+        });
+        self
+    }
+
+    fn connect_peripheral_to_output(&mut self, signal: OutputSignal) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::connect_peripheral_to_output(target, signal);
+        });
+        self
+    }
+
+    fn connect_peripheral_to_output_with_options(
+        &mut self,
+        signal: OutputSignal,
+        invert: bool,
+        invert_enable: bool,
+        enable_from_gpio: bool,
+        force_via_gpio_mux: bool,
+    ) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::connect_peripheral_to_output_with_options(
+                target,
+                signal,
+                invert,
+                invert_enable,
+                enable_from_gpio,
+                force_via_gpio_mux,
+            );
+        });
+        self
+    }
+
+    fn disconnect_peripheral_from_output(&mut self) -> &mut Self {
+        let inner = &mut self.inner;
+        handle_gpio_output!(inner, target, {
+            OutputPin::disconnect_peripheral_from_output(target);
+        });
+        self
+    }
+}
+
+impl<MODE, TYPE> embedded_hal::digital::v2::InputPin for AnyPin<Input<MODE>, TYPE> {
     type Error = core::convert::Infallible;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -1376,12 +1728,12 @@ impl<MODE> embedded_hal::digital::v2::InputPin for AnyPin<Input<MODE>> {
 }
 
 #[cfg(feature = "eh1")]
-impl<MODE> embedded_hal_1::digital::ErrorType for AnyPin<Input<MODE>> {
+impl<MODE, TYPE> embedded_hal_1::digital::ErrorType for AnyPin<Input<MODE>, TYPE> {
     type Error = Infallible;
 }
 
 #[cfg(feature = "eh1")]
-impl<MODE> embedded_hal_1::digital::InputPin for AnyPin<Input<MODE>> {
+impl<MODE, TYPE> embedded_hal_1::digital::InputPin for AnyPin<Input<MODE>, TYPE> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
         let inner = &mut self.inner;
         handle_gpio_input!(inner, target, { target.is_high() })
@@ -1393,7 +1745,7 @@ impl<MODE> embedded_hal_1::digital::InputPin for AnyPin<Input<MODE>> {
     }
 }
 
-impl<MODE> embedded_hal::digital::v2::OutputPin for AnyPin<Output<MODE>> {
+impl<MODE, TYPE> embedded_hal::digital::v2::OutputPin for AnyPin<Output<MODE>, TYPE> {
     type Error = Infallible;
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
@@ -1407,7 +1759,7 @@ impl<MODE> embedded_hal::digital::v2::OutputPin for AnyPin<Output<MODE>> {
     }
 }
 
-impl<MODE> embedded_hal::digital::v2::StatefulOutputPin for AnyPin<Output<MODE>> {
+impl<MODE, TYPE> embedded_hal::digital::v2::StatefulOutputPin for AnyPin<Output<MODE>, TYPE> {
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         let inner = &self.inner;
         handle_gpio_output!(inner, target, { target.is_set_high() })
@@ -1419,7 +1771,7 @@ impl<MODE> embedded_hal::digital::v2::StatefulOutputPin for AnyPin<Output<MODE>>
     }
 }
 
-impl<MODE> embedded_hal::digital::v2::ToggleableOutputPin for AnyPin<Output<MODE>> {
+impl<MODE, TYPE> embedded_hal::digital::v2::ToggleableOutputPin for AnyPin<Output<MODE>, TYPE> {
     type Error = Infallible;
 
     fn toggle(&mut self) -> Result<(), Self::Error> {
@@ -1429,12 +1781,12 @@ impl<MODE> embedded_hal::digital::v2::ToggleableOutputPin for AnyPin<Output<MODE
 }
 
 #[cfg(feature = "eh1")]
-impl<MODE> embedded_hal_1::digital::ErrorType for AnyPin<Output<MODE>> {
+impl<MODE, TYPE> embedded_hal_1::digital::ErrorType for AnyPin<Output<MODE>, TYPE> {
     type Error = Infallible;
 }
 
 #[cfg(feature = "eh1")]
-impl<MODE> embedded_hal_1::digital::OutputPin for AnyPin<Output<MODE>> {
+impl<MODE, TYPE> embedded_hal_1::digital::OutputPin for AnyPin<Output<MODE>, TYPE> {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         let inner = &mut self.inner;
         handle_gpio_output!(inner, target, { target.set_low() })
@@ -1447,7 +1799,7 @@ impl<MODE> embedded_hal_1::digital::OutputPin for AnyPin<Output<MODE>> {
 }
 
 #[cfg(feature = "eh1")]
-impl<MODE> embedded_hal_1::digital::StatefulOutputPin for AnyPin<Output<MODE>> {
+impl<MODE, TYPE> embedded_hal_1::digital::StatefulOutputPin for AnyPin<Output<MODE>, TYPE> {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
         let inner = &mut self.inner;
         handle_gpio_output!(inner, target, { target.is_set_high() })
@@ -1460,7 +1812,7 @@ impl<MODE> embedded_hal_1::digital::StatefulOutputPin for AnyPin<Output<MODE>> {
 }
 
 #[cfg(feature = "async")]
-impl<MODE> embedded_hal_async::digital::Wait for AnyPin<Input<MODE>> {
+impl<MODE, TYPE> embedded_hal_async::digital::Wait for AnyPin<Input<MODE>, TYPE> {
     async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
         let inner = &mut self.inner;
         handle_gpio_input!(inner, target, { target.wait_for_high().await })
@@ -1598,28 +1950,40 @@ macro_rules! gpio {
                 )+
             }
 
-            pub struct AnyPin<MODE> {
-                pub(crate) inner: ErasedPin<MODE>
+            pub struct AnyPin<MODE, TYPE = ()> {
+                pub(crate) inner: ErasedPin<MODE>,
+                pub(crate) _type: core::marker::PhantomData<TYPE>,
             }
 
             $(
+            impl<MODE> From< [<Gpio $gpionum >]<MODE> > for AnyPin<MODE, $crate::gpio::[<$type PinType>]> {
+                fn from(value: [<Gpio $gpionum >]<MODE>) -> Self {
+                    AnyPin {
+                        inner: ErasedPin::[<Gpio $gpionum >](value),
+                        _type: core::marker::PhantomData,
+                    }
+                }
+            }
+
             impl<MODE> From< [<Gpio $gpionum >]<MODE> > for AnyPin<MODE> {
                 fn from(value: [<Gpio $gpionum >]<MODE>) -> Self {
                     AnyPin {
-                        inner: ErasedPin::[<Gpio $gpionum >](value)
+                        inner: ErasedPin::[<Gpio $gpionum >](value),
+                        _type: core::marker::PhantomData,
                     }
                 }
             }
 
             impl<MODE> [<Gpio $gpionum >]<MODE> {
-                pub fn degrade(self) -> AnyPin<MODE> {
+                pub fn degrade(self) -> AnyPin<MODE, $crate::gpio::[<$type PinType>]> {
                     AnyPin {
-                        inner: ErasedPin::[<Gpio $gpionum >](self)
+                        inner: ErasedPin::[<Gpio $gpionum >](self),
+                        _type: core::marker::PhantomData,
                     }
                 }
             }
 
-            impl<MODE> TryInto<[<Gpio $gpionum >]<MODE>> for AnyPin<MODE> {
+            impl<MODE, TYPE> TryInto<[<Gpio $gpionum >]<MODE>> for AnyPin<MODE, TYPE> {
                 type Error = ();
 
                 fn try_into(self) -> Result<[<Gpio $gpionum >]<MODE>, Self::Error> {

--- a/esp32-hal/examples/blinky_erased_pins.rs
+++ b/esp32-hal/examples/blinky_erased_pins.rs
@@ -27,10 +27,10 @@ fn main() -> ! {
     let led3 = io.pins.gpio27.into_push_pull_output();
 
     // Set GPIO9 as an input.
-    let button = io.pins.gpio0.into_pull_down_input().degrade();
+    let button = io.pins.gpio0.into_pull_down_input().into();
 
     // You can use `into` or `degrade`
-    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+    let mut pins = [led1.into(), led2.into(), led3.degrade().into()];
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c2-hal/examples/blinky_erased_pins.rs
+++ b/esp32c2-hal/examples/blinky_erased_pins.rs
@@ -27,10 +27,10 @@ fn main() -> ! {
     let led3 = io.pins.gpio5.into_push_pull_output();
 
     // Set GPIO9 as an input.
-    let button = io.pins.gpio9.into_pull_down_input().degrade();
+    let button = io.pins.gpio9.into_pull_down_input().into();
 
     // You can use `into` or `degrade`
-    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+    let mut pins = [led1.into(), led2.into(), led3.degrade().into()];
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c3-hal/examples/blinky_erased_pins.rs
+++ b/esp32c3-hal/examples/blinky_erased_pins.rs
@@ -27,10 +27,10 @@ fn main() -> ! {
     let led3 = io.pins.gpio5.into_push_pull_output();
 
     // Set GPIO9 as an input.
-    let button = io.pins.gpio9.into_pull_down_input().degrade();
+    let button = io.pins.gpio9.into_pull_down_input().into();
 
     // You can use `into` or `degrade`
-    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+    let mut pins = [led1.into(), led2.into(), led3.degrade().into()];
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c6-hal/examples/blinky_erased_pins.rs
+++ b/esp32c6-hal/examples/blinky_erased_pins.rs
@@ -27,10 +27,10 @@ fn main() -> ! {
     let led3 = io.pins.gpio5.into_push_pull_output();
 
     // Set GPIO9 as an input.
-    let button = io.pins.gpio9.into_pull_down_input().degrade();
+    let button = io.pins.gpio9.into_pull_down_input().into();
 
     // You can use `into` or `degrade`
-    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+    let mut pins = [led1.into(), led2.into(), led3.degrade().into()];
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32h2-hal/examples/blinky_erased_pins.rs
+++ b/esp32h2-hal/examples/blinky_erased_pins.rs
@@ -27,10 +27,10 @@ fn main() -> ! {
     let led3 = io.pins.gpio5.into_push_pull_output();
 
     // Set GPIO9 as an input.
-    let button = io.pins.gpio9.into_pull_down_input().degrade();
+    let button = io.pins.gpio9.into_pull_down_input().into();
 
     // You can use `into` or `degrade`
-    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+    let mut pins = [led1.into(), led2.into(), led3.degrade().into()];
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32s2-hal/examples/blinky_erased_pins.rs
+++ b/esp32s2-hal/examples/blinky_erased_pins.rs
@@ -27,10 +27,10 @@ fn main() -> ! {
     let led3 = io.pins.gpio5.into_push_pull_output();
 
     // Set GPIO9 as an input.
-    let button = io.pins.gpio0.into_pull_down_input().degrade();
+    let button = io.pins.gpio0.into_pull_down_input().into();
 
     // You can use `into` or `degrade`
-    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+    let mut pins = [led1.into(), led2.into(), led3.degrade().into()];
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32s3-hal/examples/blinky_erased_pins.rs
+++ b/esp32s3-hal/examples/blinky_erased_pins.rs
@@ -27,10 +27,10 @@ fn main() -> ! {
     let led3 = io.pins.gpio5.into_push_pull_output();
 
     // Set GPIO9 as an input.
-    let button = io.pins.gpio0.into_pull_down_input().degrade();
+    let button = io.pins.gpio0.into_pull_down_input().into();
 
     // You can use `into` or `degrade`
-    let mut pins = [led1.into(), led2.into(), led3.degrade()];
+    let mut pins = [led1.into(), led2.into(), led3.degrade().into()];
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.


### PR DESCRIPTION
This makes it possible to safely implement the InputPin and OutputPin traits for AnyPin. Now you can convert any pin to AnyPin with the appropriate type and use it in other library modules

Added:
- Peripheral implementation for AnyPin
- Implementation of Pin for AnyPin
- Implementation of OutputPin for AnyPin with type IsOutputPin
- Implementation of InputPin for AnyPin with type IsInputPin
- Upgrade types for AnyPin (for example InputOutputAnalogPinType -> InputOutputPinType)
- Implementation of From<Gpio> for AnyPin with the appropriate type

Changed:
- The Gpio::degrage method returns AnyPin with the appropriate type

A small example where this can be useful:
```rust
#![no_std]
#![no_main]

use esp32s3_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
use esp_backtrace as _;
use esp_println::println;

enum BoardRevision {
    Dev,
    Release
}

// Take data about the device on which the program is running. 
// This is not known at the compilation stage, but is extracted at runtime,
// for example from the device serial number
fn get_board_revision() -> BoardRevision {
    //...
}

#[entry]
fn main() -> ! {
    let peripherals = Peripherals::take();
    let system = peripherals.SYSTEM.split();
    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
    
    // Select pins depending on BoardRevision
    let (sda, scl) = match get_board_revision() {
        BoardRevision::Dev => (io.pins.gpio43.degrade(), io.pins.gpio44.degrade()),
        BoardRevision::Release=>(io.pins.gpio41.degrade(), io.pins.gpio38.degrade()),
    }

    // Create a new peripheral object with the described wiring
    // and standard I2C clock speed
    let mut i2c = I2C::new(peripherals.I2C0, sda, scl, 100u32.kHz(), &clocks);

    loop {
        let mut data = [0u8; 22];
        i2c.write_read(0x77, &[0xaa], &mut data).ok();

        println!("{:02x?}", data);
    }
}
```
