### PR TITLE
Ignore changes to `CHANGELOG.md` files for the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,13 @@ name: CI
 on:
   pull_request:
     paths-ignore:
+      - "**/CHANGELOG.md"
       - "**/README.md"
   push:
     branches-ignore:
       - "gh-readonly-queue/**"
     paths-ignore:
+      - "**/CHANGELOG.md"
       - "**/README.md"
   merge_group:
   workflow_dispatch:


### PR DESCRIPTION
This keeps annoying me, so I'm finally fixing it 😁 

Since the `CHANGELOG.md` checks are performed in their own workflow, we can just ignore these files altogether in the CI workflow. This means that updating these files will no longer require a full re-run of CI (which is completely unnecessary).