### PR TITLE
Linker script adjustments needed for wifi drivers

### DIFF
--- a/esp-hal-common/ld/sections/rwtext.x
+++ b/esp-hal-common/ld/sections/rwtext.x
@@ -18,6 +18,7 @@ SECTIONS {
     *( .phyiram  .phyiram.*)
     *( .iram1  .iram1.*)
     *( .wifiextrairam.* )
+    *( .coexiram.* )
     . = ALIGN(4);
   } > RWTEXT AT > RODATA
 }


### PR DESCRIPTION
Add ".coexiram.*" to `.rwtext.wifi` segment
(This is needed for the upcoming esp-wifi driver update)

I guess we don't need a changelog entry for this
