### PR TITLE
Fix stack-top calculation for app-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-H2: Fix used RAM (#1003)
 - Fix SPI slave DMA dma\_read and dma\_write (#1013)
 - ESP32-C6/H2: Fix disabling of interrupts (#1040)
+- ESP32/ESP32-S3: Fix stack-top calculation for app-core (#1081)
 
 ### Removed
 

--- a/esp-hal-common/src/soc/esp32/cpu_control.rs
+++ b/esp-hal-common/src/soc/esp32/cpu_control.rs
@@ -98,7 +98,7 @@ impl<const SIZE: usize> Stack<SIZE> {
     }
 
     pub fn top(&mut self) -> *mut u32 {
-        unsafe { self.bottom().add(SIZE) }
+        unsafe { self.bottom().add(SIZE / 4) }
     }
 }
 

--- a/esp-hal-common/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal-common/src/soc/esp32s3/cpu_control.rs
@@ -98,7 +98,7 @@ impl<const SIZE: usize> Stack<SIZE> {
     }
 
     pub fn top(&mut self) -> *mut u32 {
-        unsafe { self.bottom().add(SIZE) }
+        unsafe { self.bottom().add(SIZE / 4) }
     }
 }
 


### PR DESCRIPTION
Fixes stack-top calculation for app-core.

Since the pointer is `*mut u32` we need to divide the stack size (in bytes) by 4
