### PR TITLE
Do not invert ADC readings when using ESP32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix double &mut for the `SetDutyCycle` impl on `PwmPin` (#1033)
 - ESP32/ESP32-S3: Fix stack-top calculation for app-core (#1081)
 - ESP32/ESP32-S2/ESP32-S3: Fix embassy-time-timg0 driver (#1091)
+- ESP32: ADC readings are no longer inverted (#1093)
 
 ### Removed
 

--- a/esp-hal-common/src/analog/adc/esp32.rs
+++ b/esp-hal-common/src/analog/adc/esp32.rs
@@ -336,6 +336,12 @@ where
             .sar_meas_wait2()
             .modify(|_, w| unsafe { w.sar_amp_wait3().bits(1) });
 
+        // Do *not* invert the output
+        // NOTE: This seems backwards, but was verified experimentally.
+        sensors
+            .sar_read_ctrl2()
+            .modify(|_, w| w.sar2_data_inv().set_bit());
+
         let adc = ADC {
             _adc: adc_instance.into_ref(),
             attenuations: config.attenuations,


### PR DESCRIPTION
Fixes #1077

This feels backwards to me (I would expect that the bit needs clearing, instead) however I did confirm that this fixes the issue on hardware. @MabezDev @bjoernQ would one of you mind just verifying this, please?