### PR TITLE
Implement embedded_hal 1 pwm traits for ledc channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add initial support for the ESP32-P4 (#1101)
+- Implement `embedded_hal::pwm::SetDutyCycle` trait for `ledc::channel::Channel` (#1097) 
 
 ### Fixed
 
@@ -23,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Implement `embedded_hal::pwm::SetDutyCycle` trait for `ledc::channel::Channel` (#1097) 
 - ESP32-C6: Properly initialize PMU (#974)
 - Implement overriding base mac address (#1044)
 - Add `rt-riscv` and `rt-xtensa` features to enable/disable runtime support (#1057)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implement `embedded_hal::pwm::SetDutyCycle` trait for `ledc::channel::Channel` (#1097) 
 - ESP32-C6: Properly initialize PMU (#974)
 - Implement overriding base mac address (#1044)
 - Add `rt-riscv` and `rt-xtensa` features to enable/disable runtime support (#1057)


### PR DESCRIPTION
Implements [embedded_hal_1::pwm::SetDutyCycle](https://docs.rs/embedded-hal/latest/embedded_hal/pwm/trait.SetDutyCycle.html) for `ledc::channel::Channel`.

Tries to handle max duty cycle resolution differences between embedded_hal and esp32 (16, 20).

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable). (Would only be a rough copy of the ledc example?)
- [ ] Added examples are checked in CI

### Nice to have

- [X] You add a description of your work to this PR.
- [X] You added proper docs for your newly added features and code. (embedded_hal provides it)
