### PR TITLE
Add USB_EXCHG_PINS efuse workarounds for esp32c3 and esp32s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `embedded-io` feature to each chip-specific HAL (#1072)
 - Add `embassy-time-driver` to `esp-hal-common` due to updating `embassy-time` to `v0.3.0` (#1075)
 - ESP32-S3: Added support for 80Mhz PSRAM (#1069)
+- ESP32-C3/S3: Add workaround for USB pin exchange on usb-serial-jtag (#1104).
 
 ### Changed
 

--- a/esp-hal-common/src/otg_fs.rs
+++ b/esp-hal-common/src/otg_fs.rs
@@ -119,19 +119,6 @@ where
             crate::gpio::connect_high_to_peripheral(InputSignal::USB_SRP_BVALID); // HIGH to force USB device mode
             crate::gpio::connect_high_to_peripheral(InputSignal::USB_OTG_VBUSVALID); // receiving a valid Vbus from device
             crate::gpio::connect_low_to_peripheral(InputSignal::USB_OTG_AVALID);
-
-            usb_wrap.otg_conf().modify(|_, w| {
-                w.pad_pull_override()
-                    .set_bit()
-                    .dp_pullup()
-                    .set_bit()
-                    .dp_pulldown()
-                    .clear_bit()
-                    .dm_pullup()
-                    .clear_bit()
-                    .dm_pulldown()
-                    .clear_bit()
-            });
         }
     }
 


### PR DESCRIPTION
If you are stupid enough ( me :smiling_face_with_tear: ) to make the mistake of swapping the pins, there is a nice EFUSE to save the day. However, on the esp32c3 and esp32s3 the EFUSE is bugged and doesn't switch the pullups as well. This PR detects the EFUSE and works around it, at least in the case of USB-SERIAL-JTAG. For USB-OTG, the work around is much simpler, just don't override the pins, the peripheral respects the EFUSE properly.
