### PR TITLE
Use the `document-features` crate instead of manually writing package feature docs

### DIFF
--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -21,7 +21,8 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.15.0", features = ["esp32"], path = "../esp-hal-common" }
+document-features = "0.2.7"
+esp-hal-common    = { version = "0.15.0", features = ["esp32"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32-hal/Cargo.toml
+++ b/esp32-hal/Cargo.toml
@@ -48,32 +48,60 @@ ssd1306            = "0.8.4"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
 
 [features]
-default     = ["rt", "vectored", "xtal-40mhz", "embassy-integrated-timers"]
-async       = ["esp-hal-common/async"]
-bluetooth   = []
-debug       = ["esp-hal-common/debug"]
-defmt       = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
-eh1         = ["esp-hal-common/eh1"]
+default = ["embassy-integrated-timers", "rt", "vectored", "xtal-40mhz"]
+
+## Enable support for using the Bluetooth radio.
+bluetooth = []
+## Enable debug features in the HAL (used for development).
+debug = ["esp-hal-common/debug"]
+## Enable logging output using the `log` crate.
+log = ["esp-hal-common/log", "esp-println/log"]
+## Enable runtime support.
+rt = ["esp-hal-common/rt-xtensa"]
+## Enable interrupt vectoring.
+vectored = ["esp-hal-common/vectored"]
+## Target device has a 26MHz crystal.
+xtal-26mhz = ["esp-hal-common/xtal-26mhz"]
+## Target device has a 40MHz crystal.
+xtal-40mhz = ["esp-hal-common/xtal-40mhz"]
+
+#! ### Trait Implementation Feature Flags
+## Enable support for asynchronous operation, with interfaces provided by
+## `embedded-hal-async` and `embedded-io-async`.
+async = ["esp-hal-common/async"]
+## Implement `defmt::Format` on certain types.
+defmt = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
+## `embedded-hal-nb` for the relevant peripherals.
+eh1 = ["esp-hal-common/eh1"]
+## Implement the traits defined in `embedded-io` for certain peripherals.
 embedded-io = ["esp-hal-common/embedded-io"]
-log         = ["esp-hal-common/log", "esp-println/log"]
-rt          = ["esp-hal-common/rt-xtensa"]
-ufmt        = ["esp-hal-common/ufmt"]
-vectored    = ["esp-hal-common/vectored"]
-xtal-26mhz  = ["esp-hal-common/xtal-26mhz"]
-xtal-40mhz  = ["esp-hal-common/xtal-40mhz"]
+## Implement the `ufmt_write::uWrite` trait for certain peripherals.
+ufmt = ["esp-hal-common/ufmt"]
 
-# Embassy support
-embassy                    = ["esp-hal-common/embassy"]
-embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
+#! ### PSRAM Feature Flags
+psram = []
+## Use externally connected PSRAM (2MB).
+psram-2m = ["esp-hal-common/psram-2m", "psram"]
+## Use externally connected PSRAM (4MB).
+psram-4m = ["esp-hal-common/psram-4m", "psram"]
+## Use externally connected PSRAM (8MB).
+psram-8m = ["esp-hal-common/psram-8m", "psram"]
+
+#! ### Embassy Feature Flags
+## Enable support for `embassy`, a modern asynchronous embedded framework.
+embassy = ["esp-hal-common/embassy"]
+## Use the interrupt-mode embassy executor.
 embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
-embassy-integrated-timers  = ["esp-hal-common/embassy-integrated-timers"]
-embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
-
-# PSRAM support
-psram     = []
-psram-2m  = ["esp-hal-common/psram-2m", "psram"]
-psram-4m  = ["esp-hal-common/psram-4m", "psram"]
-psram-8m  = ["esp-hal-common/psram-8m", "psram"]
+## Use the thread-mode embassy executor.
+embassy-executor-thread = ["esp-hal-common/embassy-executor-thread"]
+## Uses hardware timers as alarms for the executors. Using this feature
+## limits the number of executors to the number of hardware alarms provided
+## by the time driver.
+embassy-integrated-timers = ["esp-hal-common/embassy-integrated-timers"]
+## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
+## peripheral has two alarms available for use.
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [profile.release]
 debug = true

--- a/esp32-hal/src/lib.rs
+++ b/esp32-hal/src/lib.rs
@@ -1,62 +1,9 @@
-//! `no_std` HAL for the ESP32 from Espressif.
+//! A bare-metal (`no_std`) Hardware Abstraction Layer for the ESP32 from
+//! Espressif.
 //!
-//! Implements a number of the traits defined by the various packages in the
-//! [embedded-hal] repository.
-//!
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-//!
-//! ### Cargo Features
-//!
-//! The available cargo features for this package are listed below, along with a
-//! brief description of each feature.
-//!
-//! - `async` - Enable support for asynchronous operation, with interfaces
-//!   provided by [embedded-hal-async] and [embedded-io-async]
-//! - `bluetooth` - Enable support for using the Bluetooth radio
-//! - `debug` - Enable debug features in the HAL (used for development)
-//! - `defmt` - Enable [`defmt::Format`] on certain types
-//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
-//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
-//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
-//!   framework
-//! - `embassy-executor-interrupt` - Use the multicore-aware interrupt-mode
-//!   embassy executor
-//! - `embassy-executor-thread` - Use the multicore-aware thread-mode embassy
-//!   executor
-//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
-//!   peripheral. The `TIMG0` peripheral has two alarms available for use
-//! - `embassy-integrated-timers` - Uses hardware timers as alarms for the
-//!   executors. Using this feature limits the number of executors to the number
-//!   of hardware alarms provided by the time driver
-//! - `embassy-generic-queue-N` (where `N` can be `8`, `16`, `32`, `64` or
-//!   `128`) - Use a generic timer queue of size `N` for the executors' timer
-//!   queues. Using this feature can expand the number of executors you can use
-//!   to `N`
-//! - `log` - enable log output using the `log` crate
-//! - `psram-2m` - Use externally connected PSRAM (2MB)
-//! - `psram-4m` - Use externally connected PSRAM (4MB)
-//! - `psram-8m` - Use externally connected PSRAM (8MB)
-//! - `rt` - Runtime support
-//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART driver
-//! - `vectored` - Enable interrupt vectoring
-//! - `xtal-26mhz` - The target device uses a 26MHz crystal
-//! - `xtal-40mhz` - The target device uses a 40MHz crystal
-//!
-//! #### Default Features
-//!
-//! The `rt`, `vectored`, `xtal-40mhz` and `embassy-integrated-timers` features
-//! are enabled by default.
-//!
-//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
-//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
-//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
-//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
-//! [embassy]: https://github.com/embassy-rs/embassy
-//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
-//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
-
-#![no_std]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![no_std]
 
 pub use esp_hal_common::*;

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -48,28 +48,56 @@ ssd1306            = "0.8.4"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
 
 [features]
-default              = ["rt", "vectored", "xtal-40mhz", "embassy-integrated-timers"]
-async                = ["esp-hal-common/async"]
-debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
-direct-vectoring     = ["esp-hal-common/direct-vectoring"]
-eh1                  = ["esp-hal-common/eh1"]
-embedded-io          = ["esp-hal-common/embedded-io"]
-interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log", "esp-println/log"]
-rt                   = ["esp-hal-common/rt-riscv"]
-ufmt                 = ["esp-hal-common/ufmt"]
-vectored             = ["esp-hal-common/vectored"]
-xtal-26mhz           = ["esp-hal-common/xtal-26mhz"]
-xtal-40mhz           = ["esp-hal-common/xtal-40mhz"]
+default = ["embassy-integrated-timers", "rt", "vectored", "xtal-40mhz"]
 
-# Embassy support
-embassy                    = ["esp-hal-common/embassy"]
+## Enable debug features in the HAL (used for development).
+debug = ["esp-hal-common/debug"]
+## Enable direct interrupt vectoring.
+direct-vectoring = ["esp-hal-common/direct-vectoring"]
+## Enable interrupt preemption.
+interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
+## Enable logging output using the `log` crate.
+log = ["esp-hal-common/log", "esp-println/log"]
+## Enable runtime support.
+rt = ["esp-hal-common/rt-riscv"]
+## Enable interrupt vectoring.
+vectored = ["esp-hal-common/vectored"]
+## Target device has a 26MHz crystal.
+xtal-26mhz = ["esp-hal-common/xtal-26mhz"]
+## Target device has a 40MHz crystal.
+xtal-40mhz = ["esp-hal-common/xtal-40mhz"]
+
+#! ### Trait Implementation Feature Flags
+## Enable support for asynchronous operation, with interfaces provided by
+## `embedded-hal-async` and `embedded-io-async`.
+async = ["esp-hal-common/async"]
+## Implement `defmt::Format` on certain types.
+defmt = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
+## `embedded-hal-nb` for the relevant peripherals.
+eh1 = ["esp-hal-common/eh1"]
+## Implement the traits defined in `embedded-io` for certain peripherals.
+embedded-io = ["esp-hal-common/embedded-io"]
+## Implement the `ufmt_write::uWrite` trait for certain peripherals.
+ufmt = ["esp-hal-common/ufmt"]
+
+#! ### Embassy Feature Flags
+## Enable support for `embassy`, a modern asynchronous embedded framework.
+embassy = ["esp-hal-common/embassy"]
+## Use the interrupt-mode embassy executor.
 embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
-embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
-embassy-integrated-timers  = ["esp-hal-common/embassy-integrated-timers"]
-embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]
+## Use the thread-mode embassy executor.
+embassy-executor-thread = ["esp-hal-common/embassy-executor-thread"]
+## Uses hardware timers as alarms for the executors. Using this feature
+## limits the number of executors to the number of hardware alarms provided
+## by the time driver.
+embassy-integrated-timers = ["esp-hal-common/embassy-integrated-timers"]
+## Enable the embassy time driver using the `SYSTIMER` peripheral. The
+## `SYSTIMER` peripheral has three alarams available for use.
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
+## peripheral has two alarms available for use.
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [profile.release]
 debug = true

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -21,7 +21,8 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.15.0", features = ["esp32c2"], path = "../esp-hal-common" }
+document-features = "0.2.7"
+esp-hal-common    = { version = "0.15.0", features = ["esp32c2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 critical-section   = "1.1.2"

--- a/esp32c2-hal/src/lib.rs
+++ b/esp32c2-hal/src/lib.rs
@@ -1,57 +1,9 @@
-//! `no_std` HAL for the ESP32-C2/ESP8684 from Espressif.
+//! A bare-metal (`no_std`) Hardware Abstraction Layer for the ESP32-C2 from
+//! Espressif.
 //!
-//! Implements a number of the traits defined by the various packages in the
-//! [embedded-hal] repository.
-//!
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-//!
-//! ### Cargo Features
-//!
-//! - `async` - Enable support for asynchronous operation, with interfaces
-//!   provided by [embedded-hal-async] and [embedded-io-async]
-//! - `debug` - Enable debug features in the HAL (used for development)
-//! - `defmt` - Enable [`defmt::Format`] on certain types
-//! - `direct-vectoring` - Enable direct vector table hooking support
-//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
-//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
-//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
-//!   framework. One of `embassy-time-*` features must also be enabled when
-//!   using this feature.
-//! - `embassy-time-systick` - Enable the [embassy] time driver using the
-//!   `SYSTIMER` peripheral. The `SYSTIMER` peripheral has three alarms
-//!   available for use
-//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
-//!   peripheral. The `TIMG0` peripheral has a single alarm available for use
-//! - `embassy-integrated-timers` - Uses hardware timers as alarms for the
-//!   executors. Using this feature limits the number of executors to the number
-//!   of hardware alarms provided by the time driver
-//! - `embassy-generic-queue-N` (where `N` can be `8`, `16`, `32`, `64` or
-//!   `128`) - Use a generic timer queue of size `N` for the executors' timer
-//!   queues. Using this feature can expand the number of executors you can use
-//!   to `N`
-//! - `interrupt-preemption` - Enable priority-based interrupt preemption
-//! - `log` - enable log output using the `log` crate
-//! - `rt` - Runtime support
-//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
-//!   Serial JTAG drivers
-//! - `vectored` - Enable interrupt vectoring
-//! - `xtal-26mhz` - The target device uses a 26MHz crystal
-//! - `xtal-40mhz` - The target device uses a 40MHz crystal
-//!
-//! #### Default Features
-//!
-//! The `rt`, `vectored`, `xtal-40mhz` and `embassy-integrated-timers` features
-//! are enabled by default.
-//!
-//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
-//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
-//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
-//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
-//! [embassy]: https://github.com/embassy-rs/embassy
-//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
-//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
-#![no_std]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![no_std]
 
 pub use esp_hal_common::*;

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -21,7 +21,8 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.15.0", features = ["esp32c3"], path = "../esp-hal-common" }
+document-features = "0.2.7"
+esp-hal-common    = { version = "0.15.0", features = ["esp32c3"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -50,31 +50,60 @@ ssd1306            = "0.8.4"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
 
 [features]
-default              = ["rt", "vectored", "zero-rtc-bss", "embassy-integrated-timers"]
-async                = ["esp-hal-common/async"]
-debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
-direct-vectoring     = ["esp-hal-common/direct-vectoring"]
-eh1                  = ["esp-hal-common/eh1"]
-embedded-io          = ["esp-hal-common/embedded-io"]
-interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log", "esp-println/log"]
-rt                   = ["esp-hal-common/rt-riscv"]
-ufmt                 = ["esp-hal-common/ufmt"]
-vectored             = ["esp-hal-common/vectored"]
+default = ["embassy-integrated-timers", "rt", "vectored", "zero-rtc-bss"]
 
-# Initialize / clear data sections and RTC memory
-zero-rtc-bss  = ["esp-hal-common/rv-zero-rtc-bss"]
-init-data     = ["esp-hal-common/rv-init-data"]
+## Enable debug features in the HAL (used for development).
+debug = ["esp-hal-common/debug"]
+## Enable direct interrupt vectoring.
+direct-vectoring = ["esp-hal-common/direct-vectoring"]
+## Enable interrupt preemption.
+interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
+## Enable logging output using the `log` crate.
+log = ["esp-hal-common/log", "esp-println/log"]
+## Enable runtime support.
+rt = ["esp-hal-common/rt-riscv"]
+## Enable interrupt vectoring.
+vectored = ["esp-hal-common/vectored"]
+
+#! ### Trait Implementation Feature Flags
+## Enable support for asynchronous operation, with interfaces provided by
+## `embedded-hal-async` and `embedded-io-async`.
+async = ["esp-hal-common/async"]
+## Implement `defmt::Format` on certain types.
+defmt = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
+## `embedded-hal-nb` for the relevant peripherals.
+eh1 = ["esp-hal-common/eh1"]
+## Implement the traits defined in `embedded-io` for certain peripherals.
+embedded-io = ["esp-hal-common/embedded-io"]
+## Implement the `ufmt_write::uWrite` trait for certain peripherals.
+ufmt = ["esp-hal-common/ufmt"]
+
+#! ### Memory Initialization Feature Flags
+## Zero the `.bss` section of low-power memory.
+zero-rtc-bss = ["esp-hal-common/rv-zero-rtc-bss"]
+## Initialize the `.data` section of memory.
+init-data = ["esp-hal-common/rv-init-data"]
+## Initialize the `.data` section of low-power memory.
 init-rtc-data = ["esp-hal-common/rv-init-rtc-data"]
 
-# Embassy support
-embassy                    = ["esp-hal-common/embassy"]
+#! ### Embassy Feature Flags
+## Enable support for `embassy`, a modern asynchronous embedded framework.
+embassy = ["esp-hal-common/embassy"]
+## Use the interrupt-mode embassy executor.
 embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
-embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
-embassy-integrated-timers  = ["esp-hal-common/embassy-integrated-timers"]
-embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
+## Use the thread-mode embassy executor.
+embassy-executor-thread = ["esp-hal-common/embassy-executor-thread"]
+## Uses hardware timers as alarms for the executors. Using this feature
+## limits the number of executors to the number of hardware alarms provided
+## by the time driver.
+embassy-integrated-timers = ["esp-hal-common/embassy-integrated-timers"]
+## Enable the embassy time driver using the `SYSTIMER` peripheral. The
+## `SYSTIMER` peripheral has three alarams available for use.
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
+## peripheral has two alarms available for use.
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [profile.release]
 debug = true

--- a/esp32c3-hal/src/lib.rs
+++ b/esp32c3-hal/src/lib.rs
@@ -1,56 +1,9 @@
-//! `no_std` HAL for the ESP32-C3/ESP8685 from Espressif.
+//! A bare-metal (`no_std`) Hardware Abstraction Layer for the ESP32-C3 from
+//! Espressif.
 //!
-//! Implements a number of the traits defined by the various packages in the
-//! [embedded-hal] repository.
-//!
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-//!
-//! ### Cargo Features
-//!
-//! - `async` - Enable support for asynchronous operation, with interfaces
-//!   provided by [embedded-hal-async] and [embedded-io-async]
-//! - `debug` - Enable debug features in the HAL (used for development)
-//! - `defmt` - Enable [`defmt::Format`] on certain types
-//! - `direct-vectoring` - Enable direct vector table hooking support
-//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
-//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
-//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
-//!   framework. One of `embassy-time-*` features must also be enabled when
-//!   using this feature.
-//! - `embassy-time-systick` - Enable the [embassy] time driver using the
-//!   `SYSTIMER` peripheral. The `SYSTIMER` peripheral has three alarms
-//!   available for use
-//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
-//!   peripheral. The `TIMG0` peripheral has a single alarm available for use
-//! - `embassy-integrated-timers` - Uses hardware timers as alarms for the
-//!   executors. Using this feature limits the number of executors to the number
-//!   of hardware alarms provided by the time driver
-//! - `embassy-generic-queue-N` (where `N` can be `8`, `16`, `32`, `64` or
-//!   `128`) - Use a generic timer queue of size `N` for the executors' timer
-//!   queues. Using this feature can expand the number of executors you can use
-//!   to `N`
-//! - `interrupt-preemption` - Enable priority-based interrupt preemption
-//! - `log` - enable log output using the `log` crate
-//! - `rt` - Runtime support
-//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
-//!   Serial JTAG drivers
-//! - `vectored` - Enable interrupt vectoring
-//!
-//! #### Default Features
-//!
-//! The `rt`, `vectored` and `embassy-integrated-timers` features are enabled by
-//! default.
-//!
-//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
-//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
-//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
-//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
-//! [embassy]: https://github.com/embassy-rs/embassy
-//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
-//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
-
-#![no_std]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![no_std]
 
 pub use esp_hal_common::*;

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -21,7 +21,8 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.15.0", features = ["esp32c6"], path = "../esp-hal-common" }
+document-features = "0.2.7"
+esp-hal-common    = { version = "0.15.0", features = ["esp32c6"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -53,32 +53,62 @@ ssd1306            = "0.8.4"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
 
 [features]
-default              = ["rt", "vectored", "zero-rtc-bss", "embassy-integrated-timers"]
-async                = ["esp-hal-common/async"]
-debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
-direct-vectoring     = ["esp-hal-common/direct-vectoring"]
-eh1                  = ["esp-hal-common/eh1"]
-embedded-io          = ["esp-hal-common/embedded-io"]
-interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log", "esp-println/log"]
-rt                   = ["esp-hal-common/rt-riscv"]
-ufmt                 = ["esp-hal-common/ufmt"]
-vectored             = ["esp-hal-common/vectored"]
-flip-link            = ["esp-hal-common/flip-link"]
+default = ["embassy-integrated-timers", "rt", "vectored", "zero-rtc-bss"]
 
-# Initialize / clear data sections and RTC memory
-zero-rtc-bss  = ["esp-hal-common/rv-zero-rtc-bss"]
-init-data     = ["esp-hal-common/rv-init-data"]
+## Enable debug features in the HAL (used for development).
+debug = ["esp-hal-common/debug"]
+## Enable direct interrupt vectoring.
+direct-vectoring = ["esp-hal-common/direct-vectoring"]
+## TODO: ???
+flip-link = ["esp-hal-common/flip-link"]
+## Enable interrupt preemption.
+interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
+## Enable logging output using the `log` crate.
+log = ["esp-hal-common/log", "esp-println/log"]
+## Enable runtime support.
+rt = ["esp-hal-common/rt-riscv"]
+## Enable interrupt vectoring.
+vectored = ["esp-hal-common/vectored"]
+
+#! ### Trait Implementation Feature Flags
+## Enable support for asynchronous operation, with interfaces provided by
+## `embedded-hal-async` and `embedded-io-async`.
+async = ["esp-hal-common/async"]
+## Implement `defmt::Format` on certain types.
+defmt = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
+## `embedded-hal-nb` for the relevant peripherals.
+eh1 = ["esp-hal-common/eh1"]
+## Implement the traits defined in `embedded-io` for certain peripherals.
+embedded-io = ["esp-hal-common/embedded-io"]
+## Implement the `ufmt_write::uWrite` trait for certain peripherals.
+ufmt = ["esp-hal-common/ufmt"]
+
+#! ### Memory Initialization Feature Flags
+## Zero the `.bss` section of low-power memory.
+zero-rtc-bss = ["esp-hal-common/rv-zero-rtc-bss"]
+## Initialize the `.data` section of memory.
+init-data = ["esp-hal-common/rv-init-data"]
+## Initialize the `.data` section of low-power memory.
 init-rtc-data = ["esp-hal-common/rv-init-rtc-data"]
 
-# Embassy support
-embassy                    = ["esp-hal-common/embassy"]
+#! ### Embassy Feature Flags
+## Enable support for `embassy`, a modern asynchronous embedded framework.
+embassy = ["esp-hal-common/embassy"]
+## Use the interrupt-mode embassy executor.
 embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
-embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
-embassy-integrated-timers  = ["esp-hal-common/embassy-integrated-timers"]
-embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]
+## Use the thread-mode embassy executor.
+embassy-executor-thread = ["esp-hal-common/embassy-executor-thread"]
+## Uses hardware timers as alarms for the executors. Using this feature
+## limits the number of executors to the number of hardware alarms provided
+## by the time driver.
+embassy-integrated-timers = ["esp-hal-common/embassy-integrated-timers"]
+## Enable the embassy time driver using the `SYSTIMER` peripheral. The
+## `SYSTIMER` peripheral has three alarams available for use.
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
+## peripheral has two alarms available for use.
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [profile.release]
 debug = true

--- a/esp32c6-hal/src/lib.rs
+++ b/esp32c6-hal/src/lib.rs
@@ -1,57 +1,9 @@
-//! `no_std` HAL for the ESP32-C6 from Espressif.
+//! A bare-metal (`no_std`) Hardware Abstraction Layer for the ESP32-C6 from
+//! Espressif.
 //!
-//! Implements a number of the traits defined by the various packages in the
-//! [embedded-hal] repository.
-//!
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-//!
-//! ### Cargo Features
-//!
-//! - `async` - Enable support for asynchronous operation, with interfaces
-//!   provided by [embedded-hal-async] and [embedded-io-async]
-//! - `debug` - Enable debug features in the HAL (used for development)
-//! - `defmt` - Enable [`defmt::Format`] on certain types
-//! - `direct-vectoring` - Enable direct vector table hooking support
-//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
-//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
-//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
-//!   framework. One of `embassy-time-*` features must also be enabled when
-//!   using this feature.
-//! - `embassy-time-systick` - Enable the [embassy] time driver using the
-//!   `SYSTIMER` peripheral. The `SYSTIMER` peripheral has three alarms
-//!   available for use
-//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
-//!   peripheral. The `TIMG0` peripheral has a single alarm available for use
-//! - `embassy-integrated-timers` - Uses hardware timers as alarms for the
-//!   executors. Using this feature limits the number of executors to the number
-//!   of hardware alarms provided by the time driver
-//! - `embassy-generic-queue-N` (where `N` can be `8`, `16`, `32`, `64` or
-//!   `128`) - Use a generic timer queue of size `N` for the executors' timer
-//!   queues. Using this feature can expand the number of executors you can use
-//!   to `N`
-//! - `interrupt-preemption` - Enable priority-based interrupt preemption
-//! - `log` - enable log output using the `log` crate
-//! - `rt` - Runtime support
-//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
-//!   Serial JTAG drivers
-//! - `vectored` - Enable interrupt vectoring
-//! - `flip-link` - move the stack to the start of RAM to get zero-cost stack
-//!   overflow protection
-//!
-//! #### Default Features
-//!
-//! The `rt`, `vectored` and `embassy-integrated-timers` features are enabled by
-//! default.
-//!
-//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
-//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
-//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
-//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
-//! [embassy]: https://github.com/embassy-rs/embassy
-//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
-//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
-#![no_std]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![no_std]
 
 pub use esp_hal_common::*;

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -21,7 +21,8 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.15.0", features = ["esp32h2"], path = "../esp-hal-common" }
+document-features = "0.2.7"
+esp-hal-common    = { version = "0.15.0", features = ["esp32h2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -53,32 +53,62 @@ ssd1306            = "0.8.4"
 static_cell        = { version = "2.0.0", features = ["nightly"] }
 
 [features]
-default              = ["rt", "vectored", "zero-rtc-bss", "embassy-integrated-timers"]
-async                = ["esp-hal-common/async"]
-debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
-direct-vectoring     = ["esp-hal-common/direct-vectoring"]
-eh1                  = ["esp-hal-common/eh1"]
-embedded-io          = ["esp-hal-common/embedded-io"]
-interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log", "esp-println/log"]
-rt                   = ["esp-hal-common/rt-riscv"]
-ufmt                 = ["esp-hal-common/ufmt"]
-vectored             = ["esp-hal-common/vectored"]
-flip-link            = ["esp-hal-common/flip-link"]
+default = ["embassy-integrated-timers", "rt", "vectored", "zero-rtc-bss"]
 
-# Initialize / clear data sections and RTC memory
-zero-rtc-bss  = ["esp-hal-common/rv-zero-rtc-bss"]
-init-data     = ["esp-hal-common/rv-init-data"]
+## Enable debug features in the HAL (used for development).
+debug = ["esp-hal-common/debug"]
+## Enable direct interrupt vectoring.
+direct-vectoring = ["esp-hal-common/direct-vectoring"]
+## TODO: ???
+flip-link = ["esp-hal-common/flip-link"]
+## Enable interrupt preemption.
+interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
+## Enable logging output using the `log` crate.
+log = ["esp-hal-common/log", "esp-println/log"]
+## Enable runtime support.
+rt = ["esp-hal-common/rt-riscv"]
+## Enable interrupt vectoring.
+vectored = ["esp-hal-common/vectored"]
+
+#! ### Trait Implementation Feature Flags
+## Enable support for asynchronous operation, with interfaces provided by
+## `embedded-hal-async` and `embedded-io-async`.
+async = ["esp-hal-common/async"]
+## Implement `defmt::Format` on certain types.
+defmt = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
+## `embedded-hal-nb` for the relevant peripherals.
+eh1 = ["esp-hal-common/eh1"]
+## Implement the traits defined in `embedded-io` for certain peripherals.
+embedded-io = ["esp-hal-common/embedded-io"]
+## Implement the `ufmt_write::uWrite` trait for certain peripherals.
+ufmt = ["esp-hal-common/ufmt"]
+
+#! ### Memory Initialization Feature Flags
+## Zero the `.bss` section of low-power memory.
+zero-rtc-bss = ["esp-hal-common/rv-zero-rtc-bss"]
+## Initialize the `.data` section of memory.
+init-data = ["esp-hal-common/rv-init-data"]
+## Initialize the `.data` section of low-power memory.
 init-rtc-data = ["esp-hal-common/rv-init-rtc-data"]
 
-# Embassy support
-embassy                    = ["esp-hal-common/embassy"]
+#! ### Embassy Feature Flags
+## Enable support for `embassy`, a modern asynchronous embedded framework.
+embassy = ["esp-hal-common/embassy"]
+## Use the interrupt-mode embassy executor.
 embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
-embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
-embassy-integrated-timers  = ["esp-hal-common/embassy-integrated-timers"]
-embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]
+## Use the thread-mode embassy executor.
+embassy-executor-thread = ["esp-hal-common/embassy-executor-thread"]
+## Uses hardware timers as alarms for the executors. Using this feature
+## limits the number of executors to the number of hardware alarms provided
+## by the time driver.
+embassy-integrated-timers = ["esp-hal-common/embassy-integrated-timers"]
+## Enable the embassy time driver using the `SYSTIMER` peripheral. The
+## `SYSTIMER` peripheral has three alarams available for use.
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
+## peripheral has two alarms available for use.
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [profile.release]
 debug = true

--- a/esp32h2-hal/src/lib.rs
+++ b/esp32h2-hal/src/lib.rs
@@ -1,57 +1,9 @@
-//! `no_std` HAL for the ESP32-H2 from Espressif.
+//! A bare-metal (`no_std`) Hardware Abstraction Layer for the ESP32-H2 from
+//! Espressif.
 //!
-//! Implements a number of the traits defined by the various packages in the
-//! [embedded-hal] repository.
-//!
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-//!
-//! ### Cargo Features
-//!
-//! - `async` - Enable support for asynchronous operation, with interfaces
-//!   provided by [embedded-hal-async] and [embedded-io-async]
-//! - `debug` - Enable debug features in the HAL (used for development)
-//! - `defmt` - Enable [`defmt::Format`] on certain types
-//! - `direct-vectoring` - Enable direct vector table hooking support
-//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
-//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
-//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
-//!   framework. One of `embassy-time-*` features must also be enabled when
-//!   using this feature.
-//! - `embassy-time-systick` - Enable the [embassy] time driver using the
-//!   `SYSTIMER` peripheral. The `SYSTIMER` peripheral has three alarms
-//!   available for use
-//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
-//!   peripheral. The `TIMG0` peripheral has a single alarm available for use
-//! - `embassy-integrated-timers` - Uses hardware timers as alarms for the
-//!   executors. Using this feature limits the number of executors to the number
-//!   of hardware alarms provided by the time driver
-//! - `embassy-generic-queue-N` (where `N` can be `8`, `16`, `32`, `64` or
-//!   `128`) - Use a generic timer queue of size `N` for the executors' timer
-//!   queues. Using this feature can expand the number of executors you can use
-//!   to `N`
-//! - `interrupt-preemption` - Enable priority-based interrupt preemption
-//! - `log` - enable log output using the `log` crate
-//! - `rt` - Runtime support
-//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART and USB
-//!   Serial JTAG drivers
-//! - `vectored` - Enable interrupt vectoring
-//! - `flip-link` - move the stack to the start of RAM to get zero-cost stack
-//!   overflow protection
-//!
-//! #### Default Features
-//!
-//! The `rt`, `vectored` and `embassy-integrated-timers` features are enabled by
-//! default.
-//!
-//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
-//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
-//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
-//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
-//! [embassy]: https://github.com/embassy-rs/embassy
-//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
-//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
-#![no_std]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![no_std]
 
 pub use esp_hal_common::*;

--- a/esp32p4-hal/Cargo.toml
+++ b/esp32p4-hal/Cargo.toml
@@ -21,7 +21,8 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.15.0", features = ["esp32p4"], path = "../esp-hal-common" }
+document-features = "0.2.7"
+esp-hal-common    = { version = "0.15.0", features = ["esp32p4"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 embassy-time  = "0.3.0"

--- a/esp32p4-hal/Cargo.toml
+++ b/esp32p4-hal/Cargo.toml
@@ -30,31 +30,60 @@ esp-backtrace = { version = "0.10.0", features = ["esp32p4", "exception-handler"
 esp-println   = { version = "0.8.0",  features = ["esp32p4"] }
 
 [features]
-default              = ["rt", "vectored", "zero-rtc-bss"]
-async                = ["esp-hal-common/async"]
-debug                = ["esp-hal-common/debug"]
-defmt                = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
-direct-vectoring     = ["esp-hal-common/direct-vectoring"]
-eh1                  = ["esp-hal-common/eh1"]
-embedded-io          = ["esp-hal-common/embedded-io"]
-interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
-log                  = ["esp-hal-common/log", "esp-println/log"]
-rt                   = ["esp-hal-common/rt-riscv"]
-ufmt                 = ["esp-hal-common/ufmt"]
-vectored             = ["esp-hal-common/vectored"]
+default = ["embassy-integrated-timers", "rt", "vectored", "zero-rtc-bss"]
 
-# Initialize / clear data sections and RTC memory
-zero-rtc-bss  = ["esp-hal-common/rv-zero-rtc-bss"]
-init-data     = ["esp-hal-common/rv-init-data"]
+## Enable debug features in the HAL (used for development).
+debug = ["esp-hal-common/debug"]
+## Enable direct interrupt vectoring.
+direct-vectoring = ["esp-hal-common/direct-vectoring"]
+## Enable interrupt preemption.
+interrupt-preemption = ["esp-hal-common/interrupt-preemption"]
+## Enable logging output using the `log` crate.
+log = ["esp-hal-common/log", "esp-println/log"]
+## Enable runtime support.
+rt = ["esp-hal-common/rt-riscv"]
+## Enable interrupt vectoring.
+vectored = ["esp-hal-common/vectored"]
+
+#! ### Trait Implementation Feature Flags
+## Enable support for asynchronous operation, with interfaces provided by
+## `embedded-hal-async` and `embedded-io-async`.
+async = ["esp-hal-common/async"]
+## Implement `defmt::Format` on certain types.
+defmt = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
+## `embedded-hal-nb` for the relevant peripherals.
+eh1 = ["esp-hal-common/eh1"]
+## Implement the traits defined in `embedded-io` for certain peripherals.
+embedded-io = ["esp-hal-common/embedded-io"]
+## Implement the `ufmt_write::uWrite` trait for certain peripherals.
+ufmt = ["esp-hal-common/ufmt"]
+
+#! ### Memory Initialization Feature Flags
+## Zero the `.bss` section of low-power memory.
+zero-rtc-bss = ["esp-hal-common/rv-zero-rtc-bss"]
+## Initialize the `.data` section of memory.
+init-data = ["esp-hal-common/rv-init-data"]
+## Initialize the `.data` section of low-power memory.
 init-rtc-data = ["esp-hal-common/rv-init-rtc-data"]
 
-# Embassy support
-embassy                    = ["esp-hal-common/embassy"]
+#! ### Embassy Feature Flags
+## Enable support for `embassy`, a modern asynchronous embedded framework.
+embassy = ["esp-hal-common/embassy"]
+## Use the interrupt-mode embassy executor.
 embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
-embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
-embassy-integrated-timers  = ["esp-hal-common/embassy-integrated-timers"]
-embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0",   "embassy-time/tick-hz-1_000_000"]
+## Use the thread-mode embassy executor.
+embassy-executor-thread = ["esp-hal-common/embassy-executor-thread"]
+## Uses hardware timers as alarms for the executors. Using this feature
+## limits the number of executors to the number of hardware alarms provided
+## by the time driver.
+embassy-integrated-timers = ["esp-hal-common/embassy-integrated-timers"]
+## Enable the embassy time driver using the `SYSTIMER` peripheral. The
+## `SYSTIMER` peripheral has three alarams available for use.
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
+## peripheral has two alarms available for use.
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [profile.release]
 debug = true

--- a/esp32p4-hal/src/lib.rs
+++ b/esp32p4-hal/src/lib.rs
@@ -1,11 +1,9 @@
-//! `no_std` HAL for the ESP32-P4 from Espressif.
+//! A bare-metal (`no_std`) Hardware Abstraction Layer for the ESP32-P4 from
+//! Espressif.
 //!
-//! Implements a number of the traits defined by the various packages in the
-//! [embedded-hal] repository.
-//!
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-
-#![no_std]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![no_std]
 
 pub use esp_hal_common::*;

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -51,30 +51,57 @@ usb-device         = "0.3.1"
 usbd-serial        = "0.2.0"
 
 [features]
-default     = ["rt", "vectored", "embassy-integrated-timers"]
-async       = ["esp-hal-common/async"]
-debug       = ["esp-hal-common/debug"]
-defmt       = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
-eh1         = ["esp-hal-common/eh1"]
+default = ["embassy-integrated-timers", "rt", "vectored"]
+
+## Enable debug features in the HAL (used for development).
+debug = ["esp-hal-common/debug"]
+## Enable logging output using the `log` crate.
+log = ["esp-hal-common/log", "esp-println/log"]
+## Enable runtime support.
+rt = ["esp-hal-common/rt-xtensa"]
+## Enable interrupt vectoring.
+vectored = ["esp-hal-common/vectored"]
+
+#! ### Trait Implementation Feature Flags
+## Enable support for asynchronous operation, with interfaces provided by
+## `embedded-hal-async` and `embedded-io-async`.
+async = ["esp-hal-common/async"]
+## Implement `defmt::Format` on certain types.
+defmt = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
+## `embedded-hal-nb` for the relevant peripherals.
+eh1 = ["esp-hal-common/eh1"]
+## Implement the traits defined in `embedded-io` for certain peripherals.
 embedded-io = ["esp-hal-common/embedded-io"]
-log         = ["esp-hal-common/log", "esp-println/log"]
-rt          = ["esp-hal-common/rt-xtensa"]
-ufmt        = ["esp-hal-common/ufmt"]
-vectored    = ["esp-hal-common/vectored"]
+## Implement the `ufmt_write::uWrite` trait for certain peripherals.
+ufmt = ["esp-hal-common/ufmt"]
 
-# Embassy support
-embassy                    = ["esp-hal-common/embassy"]
-embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
-embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
-embassy-integrated-timers  = ["esp-hal-common/embassy-integrated-timers"]
-embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-80_000_000"] 
-embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
-
-# PSRAM support
-psram    = []
+#! ### PSRAM Feature Flags
+psram = []
+## Use externally connected PSRAM (2MB).
 psram-2m = ["esp-hal-common/psram-2m", "psram"]
+## Use externally connected PSRAM (4MB).
 psram-4m = ["esp-hal-common/psram-4m", "psram"]
+## Use externally connected PSRAM (8MB).
 psram-8m = ["esp-hal-common/psram-8m", "psram"]
+
+#! ### Embassy Feature Flags
+## Enable support for `embassy`, a modern asynchronous embedded framework.
+embassy = ["esp-hal-common/embassy"]
+## Use the interrupt-mode embassy executor.
+embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
+## Use the thread-mode embassy executor.
+embassy-executor-thread = ["esp-hal-common/embassy-executor-thread"]
+## Uses hardware timers as alarms for the executors. Using this feature
+## limits the number of executors to the number of hardware alarms provided
+## by the time driver.
+embassy-integrated-timers = ["esp-hal-common/embassy-integrated-timers"]
+## Enable the embassy time driver using the `SYSTIMER` peripheral. The
+## `SYSTIMER` peripheral has three alarams available for use.
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
+## peripheral has two alarms available for use.
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [profile.release]
 debug = true

--- a/esp32s2-hal/Cargo.toml
+++ b/esp32s2-hal/Cargo.toml
@@ -21,7 +21,8 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.15.0", features = ["esp32s2"], path = "../esp-hal-common" }
+document-features = "0.2.7"
+esp-hal-common    = { version = "0.15.0", features = ["esp32s2"], path = "../esp-hal-common" }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32s2-hal/src/lib.rs
+++ b/esp32s2-hal/src/lib.rs
@@ -1,62 +1,9 @@
-//! `no_std` HAL for the ESP32-S2 from Espressif.
+//! A bare-metal (`no_std`) Hardware Abstraction Layer for the ESP32-S2 from
+//! Espressif.
 //!
-//! Implements a number of the traits defined by the various packages in the
-//! [embedded-hal] repository.
-//!
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-//!
-//! ### Cargo Features
-//!
-//! - `async` - Enable support for asynchronous operation, with interfaces
-//!   provided by [embedded-hal-async] and [embedded-io-async]
-//! - `debug` - Enable debug features in the HAL (used for development)
-//! - `defmt` - Enable [`defmt::Format`] on certain types
-//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
-//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
-//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
-//!   framework. One of `embassy-time-*` features must also be enabled when
-//!   using this feature.
-//! - `embassy-executor-interrupt` - Use the interrupt-mode embassy executor
-//! - `embassy-executor-thread` - Use the thread-mode embassy executor
-//! - `embassy-time-systick` - Enable the [embassy] time driver using the
-//!   `SYSTIMER` peripheral
-//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
-//!   peripheral
-//! - `embassy-time-systick` - Enable the [embassy] time driver using the
-//!   `SYSTIMER` peripheral. The `SYSTIMER` peripheral has three alarms
-//!   available for use
-//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
-//!   peripheral. The `TIMG0` peripheral has two alarms available for use
-//! - `embassy-integrated-timers` - Uses hardware timers as alarms for the
-//!   executors. Using this feature limits the number of executors to the number
-//!   of hardware alarms provided by the time driver
-//! - `embassy-generic-queue-N` (where `N` can be `8`, `16`, `32`, `64` or
-//!   `128`) - Use a generic timer queue of size `N` for the executors' timer
-//!   queues. Using this feature can expand the number of executors you can use
-//!   to `N`
-//! - `log` - enable log output using the `log` crate
-//! - `psram-2m` - Use externally connected PSRAM (2MB)
-//! - `psram-4m` - Use externally connected PSRAM (4MB)
-//! - `psram-8m` - Use externally connected PSRAM (8MB)
-//! - `rt` - Runtime support
-//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART driver
-//! - `vectored` - Enable interrupt vectoring
-//!
-//! #### Default Features
-//!
-//! The `rt`, `vectored` and `embassy-integrated-timers` features are enabled by
-//! default.
-//!
-//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
-//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
-//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
-//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
-//! [embassy]: https://github.com/embassy-rs/embassy
-//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
-//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
-
-#![no_std]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![no_std]
 
 pub use esp_hal_common::*;

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -54,39 +54,69 @@ usb-device         = "0.3.1"
 usbd-serial        = "0.2.0"
 
 [features]
-default     = ["rt", "vectored", "embassy-integrated-timers"]
-async       = ["esp-hal-common/async"]
-debug       = ["esp-hal-common/debug"]
-defmt       = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+default = ["embassy-integrated-timers", "rt", "vectored"]
+
+## Enable debug features in the HAL (used for development).
+debug = ["esp-hal-common/debug"]
+## Enable logging output using the `log` crate.
+log = ["esp-hal-common/log", "esp-println/log"]
+## Enable runtime support.
+rt = ["esp-hal-common/rt-xtensa"]
+## Enable interrupt vectoring.
+vectored = ["esp-hal-common/vectored"]
+
+#! ### Trait Implementation Feature Flags
+## Enable support for asynchronous operation, with interfaces provided by
+## `embedded-hal-async` and `embedded-io-async`.
+async = ["esp-hal-common/async"]
+## Implement `defmt::Format` on certain types.
+defmt = ["esp-hal-common/defmt", "esp-println/defmt-espflash"]
+## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
+## `embedded-hal-nb` for the relevant peripherals.
+eh1 = ["esp-hal-common/eh1"]
+## Implement the traits defined in `embedded-io` for certain peripherals.
 embedded-io = ["esp-hal-common/embedded-io"]
-eh1         = ["esp-hal-common/eh1"]
-log         = ["esp-hal-common/log", "esp-println/log"]
-rt          = ["esp-hal-common/rt-xtensa"]
-ufmt        = ["esp-hal-common/ufmt"]
-vectored    = ["esp-hal-common/vectored"]
+## Implement the `ufmt_write::uWrite` trait for certain peripherals.
+ufmt = ["esp-hal-common/ufmt"]
 
-# Embassy support
-embassy                    = ["esp-hal-common/embassy"]
-embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
-embassy-executor-thread    = ["esp-hal-common/embassy-executor-thread"]
-embassy-integrated-timers  = ["esp-hal-common/embassy-integrated-timers"]
-embassy-time-systick       = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
-embassy-time-timg0         = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
-
-# PSRAM support
-psram    = []
+#! ### PSRAM Feature Flags
+psram = []
+## Use externally connected PSRAM (2MB).
 psram-2m = ["esp-hal-common/psram-2m", "psram"]
+## Use externally connected PSRAM (4MB).
 psram-4m = ["esp-hal-common/psram-4m", "psram"]
+## Use externally connected PSRAM (8MB).
 psram-8m = ["esp-hal-common/psram-8m", "psram"]
+## Connected PSRAM has 80MHz frequency.
+psram-80mhz  = ["esp-hal-common/psram-80mhz"]
 
-# Octal RAM support
+#! ### Octal RAM Feature Flags
+## Use externally connected Octal RAM (2MB).
 opsram-2m  = ["esp-hal-common/opsram-2m", "psram"]
+## Use externally connected Octal RAM (4MB).
 opsram-4m  = ["esp-hal-common/opsram-4m", "psram"]
+## Use externally connected Octal RAM (8MB).
 opsram-8m  = ["esp-hal-common/opsram-8m", "psram"]
+## Use externally connected Octal RAM (16MB).
 opsram-16m = ["esp-hal-common/opsram-16m", "psram"]
 
-# PSRAM 80Mhz frequency support
-psram-80mhz  = ["esp-hal-common/psram-80mhz"]
+#! ### Embassy Feature Flags
+## Enable support for `embassy`, a modern asynchronous embedded framework.
+embassy = ["esp-hal-common/embassy"]
+## Use the interrupt-mode embassy executor.
+embassy-executor-interrupt = ["esp-hal-common/embassy-executor-interrupt"]
+## Use the thread-mode embassy executor.
+embassy-executor-thread = ["esp-hal-common/embassy-executor-thread"]
+## Uses hardware timers as alarms for the executors. Using this feature
+## limits the number of executors to the number of hardware alarms provided
+## by the time driver.
+embassy-integrated-timers = ["esp-hal-common/embassy-integrated-timers"]
+## Enable the embassy time driver using the `SYSTIMER` peripheral. The
+## `SYSTIMER` peripheral has three alarams available for use.
+embassy-time-systick = ["esp-hal-common/embassy-time-systick", "embassy-time/tick-hz-16_000_000"]
+## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
+## peripheral has two alarms available for use.
+embassy-time-timg0 = ["esp-hal-common/embassy-time-timg0", "embassy-time/tick-hz-1_000_000"]
 
 [profile.release]
 debug = true

--- a/esp32s3-hal/Cargo.toml
+++ b/esp32s3-hal/Cargo.toml
@@ -21,8 +21,9 @@ categories = [
 ]
 
 [dependencies]
-esp-hal-common = { version = "0.15.0", features = ["esp32s3"], path = "../esp-hal-common" }
-r0             = { version = "1.0.0",  optional = true }
+document-features = "0.2.7"
+esp-hal-common    = { version = "0.15.0", features = ["esp32s3"], path = "../esp-hal-common" }
+r0                = { version = "1.0.0",  optional = true }
 
 [dev-dependencies]
 aes                = "0.8.3"

--- a/esp32s3-hal/src/lib.rs
+++ b/esp32s3-hal/src/lib.rs
@@ -1,64 +1,9 @@
-//! `no_std` HAL for the ESP32-S3 from Espressif.
+//! A bare-metal (`no_std`) Hardware Abstraction Layer for the ESP32-S3 from
+//! Espressif.
 //!
-//! Implements a number of the traits defined by the various packages in the
-//! [embedded-hal] repository.
-//!
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
-//!
-//! ### Cargo Features
-//!
-//! - `async` - Enable support for asynchronous operation, with interfaces
-//!   provided by [embedded-hal-async] and [embedded-io-async]
-//! - `debug` - Enable debug features in the HAL (used for development)
-//! - `defmt` - Enable [`defmt::Format`] on certain types
-//! - `eh1` - Implement the traits defined in the `1.0.0-xxx` pre-releases of
-//!   [embedded-hal], [embedded-hal-nb], and [embedded-io]
-//! - `embassy` - Enable support for [embassy], a modern asynchronous embedded
-//!   framework. One of `embassy-time-*` features must also be enabled when
-//!   using this feature.
-//! - `embassy-executor-interrupt` - Use the multicore-aware interrupt-mode
-//!   embassy executor
-//! - `embassy-executor-thread` - Use the multicore-aware thread-mode embassy
-//!   executor
-//! - `embassy-time-systick` - Enable the [embassy] time driver using the
-//!   `SYSTIMER` peripheral. The `SYSTIMER` peripheral has three alarms
-//!   available for use
-//! - `embassy-time-timg0` - Enable the [embassy] time driver using the `TIMG0`
-//!   peripheral. The `TIMG0` peripheral has two alarms available for use
-//! - `embassy-integrated-timers` - Uses hardware timers as alarms for the
-//!   executors. Using this feature limits the number of executors to the number
-//!   of hardware alarms provided by the time driver
-//! - `embassy-generic-queue-N` (where `N` can be `8`, `16`, `32`, `64` or
-//!   `128`) - Use a generic timer queue of size `N` for the executors' timer
-//!   queues. Using this feature can expand the number of executors you can use
-//!   to `N`
-//! - `log` - enable log output using the `log` crate
-//! - `opsram-2m` - Use externally connected Octal PSRAM (2MB)
-//! - `opsram-4m` - Use externally connected Octal PSRAM (4MB)
-//! - `opsram-8m` - Use externally connected Octal PSRAM (8MB)
-//! - `opsram-16m`- Use externally connected Octal PSRAM (16MB)
-//! - `psram-2m` - Use externally connected PSRAM (2MB)
-//! - `psram-4m` - Use externally connected PSRAM (4MB)
-//! - `psram-8m` - Use externally connected PSRAM (8MB)
-//! - `psram-80mhz` - Use faster 80Mhz PSRAM frequencty instead of default 40Mhz
-//! - `rt` - Runtime support
-//! - `ufmt` - Implement the [`ufmt_write::uWrite`] trait for the UART driver
-//! - `vectored` - Enable interrupt vectoring
-//!
-//! #### Default Features
-//!
-//! The `rt`, `vectored` and `embassy-integrated-timers` features are enabled by
-//! default.
-//!
-//! [embedded-hal-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async
-//! [embedded-io-async]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io-async
-//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal
-//! [embedded-hal-nb]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-nb
-//! [embedded-io]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-io
-//! [embassy]: https://github.com/embassy-rs/embassy
-//! [`ufmt_write::uWrite`]: https://docs.rs/ufmt-write/latest/ufmt_write/trait.uWrite.html
-//! [`defmt::Format`]: https://docs.rs/defmt/0.3.5/defmt/trait.Format.html
-#![no_std]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+#![no_std]
 
 pub use esp_hal_common::*;


### PR DESCRIPTION
Much easier to keep the documentation inline with the features this way, IMO. Also has the added benefit of requiring a comment for each feature in `Cargo.toml`.

Obviously there's a fair bit of duplication here, which we will need to be careful about when updating these doc comments, but once we unify these packages that is a non-issue.

Happy to make any changes if people have feedback regarding the organization and/or the documentation itself.

Rendered documentation:

<img width="1001" alt="Screenshot 2024-01-23 at 07 10 52" src="https://github.com/esp-rs/esp-hal/assets/1945813/8a8e6b06-87e8-4436-ab85-7f4312aee063">

(Hopefully I have not messed up any of the packages' features from copy-pasting 😅)

Closes #1103