### PR TITLE
Update documentation/comments in `soc::peripherals` modules

### DIFF
--- a/esp-hal-common/src/soc/esp32/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32/peripherals.rs
@@ -1,25 +1,12 @@
-//! # Peripheral instance singletons (ESP32)
+//! # Peripheral Instances
 //!
-//! ## Overview
+//! This module creates singleton instances for each of the various peripherals,
+//! and re-exports them to allow users to access and use them in their
+//! applications.
 //!
-//! The `Peripherals` module provides singleton instances of various peripherals
-//! and allows users to access and use them in their applications.
-//!
-//! These peripherals provide various functionalities and interfaces for
-//! interacting with different hardware components on the `ESP32` chip, such as
-//! timers, `GPIO` pins, `I2C`, `SPI`, `UART`, and more. Users can access and
-//! utilize these peripherals by importing the respective singleton instances
-//! from this module.
-//!
-//! It's important to note that the module also exports the `Interrupt` enum
-//! from the `ESP32` `PAC (Peripheral Access Crate)` for users to handle
-//! interrupts associated with these peripherals.
-//!
-//! ⚠️ NOTE: notice that `psram` and `radio` are marked with `false` in the
-//! `peripherals!` macro. Basically, that means that there's no real peripheral
-//! (no `PSRAM` nor `RADIO` peripheral in the PACs) but we're creating "virtual
-//! peripherals" for them in order to ensure the uniqueness of the instances
-//! (Singletons).
+//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! from the PAC, allowing users to handle interrupts associated with these
+//! peripherals.
 
 use esp32 as pac;
 // We need to export this for users to use
@@ -28,6 +15,10 @@ pub use pac::Interrupt;
 // We need to export this in the hal for the drivers to use
 pub(crate) use self::peripherals::*;
 
+// Note that certain are marked with `virtual` in the invocation of the
+// `peripherals!` macro below. Basically, this indicates there's no physical
+// peripheral (no `PSRAM`, `RADIO`, etc. peripheral in the PACs), so we're
+// creating "virtual peripherals" for them.
 crate::peripherals! {
     AES <= AES,
     APB_CTRL <= APB_CTRL,

--- a/esp-hal-common/src/soc/esp32c2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32c2/peripherals.rs
@@ -1,24 +1,12 @@
-//! # Peripheral instance singletons (ESP32-C2)
+//! # Peripheral Instances
 //!
-//! ## Overview
+//! This module creates singleton instances for each of the various peripherals,
+//! and re-exports them to allow users to access and use them in their
+//! applications.
 //!
-//! The `Peripherals` module provides singleton instances of various peripherals
-//! and allows users to access and use them in their applications.
-//!
-//! These peripherals provide various functionalities and interfaces for
-//! interacting with different hardware components on the `ESP32-C2` chip, such
-//! as timers, `GPIO` pins, `I2C`, `SPI`, `UART`, and more. Users can access and
-//! utilize these peripherals by importing the respective singleton instances
-//! from this module.
-//!
-//! It's important to note that the module also exports the `Interrupt` enum
-//! from the `ESP32-C2` `PAC (Peripheral Access Crate)` for users to handle
-//! interrupts associated with these peripherals.
-//!
-//! ⚠️ NOTE: notice that `radio` is marked with `false` in the `peripherals!`
-//! macro. Basically, that means that there's no real peripheral (no `RADIO`
-//! peripheral in the PACs) but we're creating "virtual peripherals" for it in
-//! order to ensure the uniqueness of the instance (Singleton).
+//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! from the PAC, allowing users to handle interrupts associated with these
+//! peripherals.
 
 use esp32c2 as pac;
 // We need to export this for users to use
@@ -27,6 +15,10 @@ pub use pac::Interrupt;
 // We need to export this in the hal for the drivers to use
 pub(crate) use self::peripherals::*;
 
+// Note that certain are marked with `virtual` in the invocation of the
+// `peripherals!` macro below. Basically, this indicates there's no physical
+// peripheral (no `PSRAM`, `RADIO`, etc. peripheral in the PACs), so we're
+// creating "virtual peripherals" for them.
 crate::peripherals! {
     APB_CTRL <= APB_CTRL,
     APB_SARADC <= APB_SARADC,

--- a/esp-hal-common/src/soc/esp32c3/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32c3/peripherals.rs
@@ -1,24 +1,12 @@
-//! # Peripheral instance singletons (ESP32-C3)
+//! # Peripheral Instances
 //!
-//! ## Overview
+//! This module creates singleton instances for each of the various peripherals,
+//! and re-exports them to allow users to access and use them in their
+//! applications.
 //!
-//! The `Peripherals` module provides singleton instances of various peripherals
-//! and allows users to access and use them in their applications.
-//!
-//! These peripherals provide various functionalities and interfaces for
-//! interacting with different hardware components on the `ESP32-C3` chip, such
-//! as timers, `GPIO` pins, `I2C`, `SPI`, `UART`, and more. Users can access and
-//! utilize these peripherals by importing the respective singleton instances
-//! from this module.
-//!
-//! It's important to note that the module also exports the `Interrupt` enum
-//! from the `ESP32-C3` `PAC (Peripheral Access Crate)` for users to handle
-//! interrupts associated with these peripherals.
-//!
-//! ⚠️ NOTE: notice that `radio` is marked with `false` in the `peripherals!`
-//! macro. Basically, that means that there's no real peripheral (no `RADIO`
-//! peripheral in the PACs) but we're creating "virtual peripherals" for it in
-//! order to ensure the uniqueness of the instance (Singleton).
+//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! from the PAC, allowing users to handle interrupts associated with these
+//! peripherals.
 
 use esp32c3 as pac;
 // We need to export this for users to use
@@ -27,6 +15,10 @@ pub use pac::Interrupt;
 // We need to export this in the hal for the drivers to use
 pub(crate) use self::peripherals::*;
 
+// Note that certain are marked with `virtual` in the invocation of the
+// `peripherals!` macro below. Basically, this indicates there's no physical
+// peripheral (no `PSRAM`, `RADIO`, etc. peripheral in the PACs), so we're
+// creating "virtual peripherals" for them.
 crate::peripherals! {
     AES <= AES,
     APB_CTRL <= APB_CTRL,

--- a/esp-hal-common/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32c6/peripherals.rs
@@ -1,25 +1,12 @@
-//! # Peripheral instance singletons (ESP32-C6)
+//! # Peripheral Instances
 //!
-//! ## Overview
+//! This module creates singleton instances for each of the various peripherals,
+//! and re-exports them to allow users to access and use them in their
+//! applications.
 //!
-//! The `Peripherals` module provides singleton instances of various peripherals
-//! and allows users to access and use them in their applications.
-//!
-//! These peripherals provide various functionalities and interfaces for
-//! interacting with different hardware components on the `ESP32-C6` chip, such
-//! as timers, `GPIO` pins, `I2C`, `SPI`, `UART`, and more. Users can access and
-//! utilize these peripherals by importing the respective singleton instances
-//! from this module.
-//!
-//! It's important to note that the module also exports the `Interrupt` enum
-//! from the `ESP32-C6` `PAC (Peripheral Access Crate)` for users to handle
-//! interrupts associated with these peripherals.
-//!
-//! ⚠️ NOTE: notice that `radio` and `lp_core` are marked with `false` in the
-//! `peripherals!` macro. Basically, that means that there's no real peripheral
-//! (no `RADIO` nor `LP_CORE` peripheral in the PACs) but we're
-//! creating "virtual peripherals" for them in order to ensure the uniqueness of
-//! the instances (Singletons).
+//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! from the PAC, allowing users to handle interrupts associated with these
+//! peripherals.
 
 use esp32c6 as pac;
 // We need to export this for users to use
@@ -28,6 +15,10 @@ pub use pac::Interrupt;
 // We need to export this in the hal for the drivers to use
 pub(crate) use self::peripherals::*;
 
+// Note that certain are marked with `virtual` in the invocation of the
+// `peripherals!` macro below. Basically, this indicates there's no physical
+// peripheral (no `PSRAM`, `RADIO`, etc. peripheral in the PACs), so we're
+// creating "virtual peripherals" for them.
 crate::peripherals! {
     AES <= AES,
     APB_SARADC <= APB_SARADC,

--- a/esp-hal-common/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32h2/peripherals.rs
@@ -1,24 +1,12 @@
-//! # Peripheral instance singletons (ESP32-H2)
+//! # Peripheral Instances
 //!
-//! ## Overview
+//! This module creates singleton instances for each of the various peripherals,
+//! and re-exports them to allow users to access and use them in their
+//! applications.
 //!
-//! The `Peripherals` module provides singleton instances of various peripherals
-//! and allows users to access and use them in their applications.
-//!
-//! These peripherals provide various functionalities and interfaces for
-//! interacting with different hardware components on the `ESP32-H2` chip, such
-//! as timers, `GPIO` pins, `I2C`, `SPI`, `UART`, and more. Users can access and
-//! utilize these peripherals by importing the respective singleton instances
-//! from this module.
-//!
-//! It's important to note that the module also exports the `Interrupt` enum
-//! from the `ESP32-H2` `PAC (Peripheral Access Crate)` for users to handle
-//! interrupts associated with these peripherals.
-//!
-//! ⚠️ NOTE: notice that `radio` is marked with `false` in the `peripherals!`
-//! macro. Basically, that means that there's no real peripheral (no `RADIO`
-//! peripheral in the PACs) but we're creating "virtual peripherals" for it in
-//! order to ensure the uniqueness of the instance (Singleton).
+//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! from the PAC, allowing users to handle interrupts associated with these
+//! peripherals.
 
 use esp32h2 as pac;
 // We need to export this for users to use
@@ -27,6 +15,10 @@ pub use pac::Interrupt;
 // We need to export this in the hal for the drivers to use
 pub(crate) use self::peripherals::*;
 
+// Note that certain are marked with `virtual` in the invocation of the
+// `peripherals!` macro below. Basically, this indicates there's no physical
+// peripheral (no `PSRAM`, `RADIO`, etc. peripheral in the PACs), so we're
+// creating "virtual peripherals" for them.
 crate::peripherals! {
     AES <= AES,
     APB_SARADC <= APB_SARADC,

--- a/esp-hal-common/src/soc/esp32p4/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32p4/peripherals.rs
@@ -1,25 +1,12 @@
-//! # Peripheral instance singletons (ESP32-P4)
+//! # Peripheral Instances
 //!
-//! ## Overview
+//! This module creates singleton instances for each of the various peripherals,
+//! and re-exports them to allow users to access and use them in their
+//! applications.
 //!
-//! The `Peripherals` module provides singleton instances of various peripherals
-//! and allows users to access and use them in their applications.
-//!
-//! These peripherals provide various functionalities and interfaces for
-//! interacting with different hardware components on the `ESP32-P4` chip, such
-//! as timers, `GPIO` pins, `I2C`, `SPI`, `UART`, and more. Users can access and
-//! utilize these peripherals by importing the respective singleton instances
-//! from this module.
-//!
-//! It's important to note that the module also exports the `Interrupt` enum
-//! from the `ESP32-P4` `PAC (Peripheral Access Crate)` for users to handle
-//! interrupts associated with these peripherals.
-//!
-//! ⚠️ NOTE: notice that `radio` and `lp_core` are marked with `false` in the
-//! `peripherals!` macro. Basically, that means that there's no real peripheral
-//! (no `RADIO` nor `LP_CORE` peripheral in the PACs) but we're
-//! creating "virtual peripherals" for them in order to ensure the uniqueness of
-//! the instances (Singletons).
+//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! from the PAC, allowing users to handle interrupts associated with these
+//! peripherals.
 
 use esp32p4 as pac;
 // We need to export this for users to use
@@ -28,6 +15,10 @@ pub use pac::Interrupt;
 // We need to export this in the hal for the drivers to use
 pub(crate) use self::peripherals::*;
 
+// Note that certain are marked with `virtual` in the invocation of the
+// `peripherals!` macro below. Basically, this indicates there's no physical
+// peripheral (no `PSRAM`, `RADIO`, etc. peripheral in the PACs), so we're
+// creating "virtual peripherals" for them.
 crate::peripherals! {
     ADC <= ADC,
     AES <= AES,

--- a/esp-hal-common/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32s2/peripherals.rs
@@ -1,25 +1,12 @@
-//! # Peripheral instance singletons (ESP32-S2)
+//! # Peripheral Instances
 //!
-//! ## Overview
+//! This module creates singleton instances for each of the various peripherals,
+//! and re-exports them to allow users to access and use them in their
+//! applications.
 //!
-//! The `Peripherals` module singleton instances of various peripherals and
-//! allows users to access and use them in their applications.
-//!
-//! These peripherals provide various functionalities and interfaces for
-//! interacting with different hardware components on the `ESP32-S2` chip, such
-//! as timers, `GPIO` pins, `I2C`, `SPI`, `UART`, and more. Users can access and
-//! utilize these peripherals by importing the respective singleton instances
-//! from this module.
-//!
-//! It's important to note that the module also exports the `Interrupt` enum
-//! from the `ESP32-S2` `PAC (Peripheral Access Crate)` for users to handle
-//! interrupts associated with these peripherals.
-//!
-//! ⚠️ NOTE: notice that `psram`, `radio` and `ulp_riscv_core` are marked with
-//! `false` in the `peripherals!` macro. Basically, that means that there's no
-//! real peripheral (no `PSRAM`, `RADIO` nor `ULP_RISCV_CORE` peripheral in the
-//! `PAC`s) but we're creating "virtual peripherals" for them in order to ensure
-//! the uniqueness of the instances (Singletons).
+//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! from the PAC, allowing users to handle interrupts associated with these
+//! peripherals.
 
 use esp32s2 as pac;
 // We need to export this for users to use
@@ -28,6 +15,10 @@ pub use pac::Interrupt;
 // We need to export this in the hal for the drivers to use
 pub(crate) use self::peripherals::*;
 
+// Note that certain are marked with `virtual` in the invocation of the
+// `peripherals!` macro below. Basically, this indicates there's no physical
+// peripheral (no `PSRAM`, `RADIO`, etc. peripheral in the PACs), so we're
+// creating "virtual peripherals" for them.
 crate::peripherals! {
     AES <= AES,
     APB_SARADC <= APB_SARADC,

--- a/esp-hal-common/src/soc/esp32s3/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32s3/peripherals.rs
@@ -1,25 +1,12 @@
-//! # Peripheral instance singletons (ESP32-S3)
+//! # Peripheral Instances
 //!
-//! ## Overview
+//! This module creates singleton instances for each of the various peripherals,
+//! and re-exports them to allow users to access and use them in their
+//! applications.
 //!
-//! The `Peripherals` module provides singleton instances of various peripherals
-//! and allows users to access and use them in their applications.
-//!
-//! These peripherals provide various functionalities and interfaces for
-//! interacting with different hardware components on the `ESP32-S3` chip, such
-//! as timers, `GPIO` pins, `I2C`, `SPI`, `UART`, and more. Users can access and
-//! utilize these peripherals by importing the respective singleton instances
-//! from this module.
-//!
-//! It's important to note that the module also exports the `Interrupt` enum
-//! from the `ESP32-S3` `PAC (Peripheral Access Crate)` for users to handle
-//! interrupts associated with these peripherals.
-//!
-//! ⚠️ NOTE: notice that `psram`, `radio` and `ulp_riscv_core` are marked with
-//! `false` in the `peripherals!` macro. Basically, that means that there's no
-//! real peripheral (no `PSRAM` nor `RADIO` peripheral in the `PAC`s) but we're
-//! creating "virtual peripherals" for them in order to ensure the uniqueness of
-//! the instances (Singletons).
+//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! from the PAC, allowing users to handle interrupts associated with these
+//! peripherals.
 
 use esp32s3 as pac;
 // We need to export this for users to use
@@ -28,6 +15,10 @@ pub use pac::Interrupt;
 // We need to export this in the hal for the drivers to use
 pub(crate) use self::peripherals::*;
 
+// Note that certain are marked with `virtual` in the invocation of the
+// `peripherals!` macro below. Basically, this indicates there's no physical
+// peripheral (no `PSRAM`, `RADIO`, etc. peripheral in the PACs), so we're
+// creating "virtual peripherals" for them.
 crate::peripherals! {
     AES <= AES,
     APB_CTRL <= APB_CTRL,


### PR DESCRIPTION
As noted by @SergioGasquez in #1101, the module documentation in the `soc::peripherals` modules had fallen out of date a little. I've updated this (was a bit wordy previously), and moved some of the text to a regular comment (as it concerns developers of the HAL, not its users).