### PR TITLE
Initial support for CLIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial support for the ESP32-P4 (#1101)
 - Implement `embedded_hal::pwm::SetDutyCycle` trait for `ledc::channel::Channel` (#1097) 
 - ESP32-P4: Add initial GPIO support (#1109)
+- ESP32-P4: Add initial support for interrupts (#1112)
 
 ### Fixed
 

--- a/esp-hal-common/build.rs
+++ b/esp-hal-common/build.rs
@@ -45,7 +45,7 @@ macro_rules! assert_unique_used_features {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 enum Arch {
     #[serde(rename = "riscv")]
     RiscV,
@@ -175,6 +175,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         && (cfg!(feature = "psram-2m") || cfg!(feature = "psram-4m") || cfg!(feature = "psram-8m"))
     {
         panic!("The target does not support PSRAM");
+    }
+
+    // Don't support "interrupt-preemption" and "direct-vectoring" on Xtensa and
+    // RISCV-clic
+    if (*&device.symbols.contains(&String::from("clic")) || device.arch == Arch::Xtensa)
+        && (cfg!(feature = "direct-vectoring") || cfg!(feature = "interrupt-preemption"))
+    {
+        panic!("The target does not support interrupt-preemption and direct-vectoring");
     }
 
     // Define all necessary configuration symbols for the configured device:

--- a/esp-hal-common/devices/esp32p4/device.toml
+++ b/esp-hal-common/devices/esp32p4/device.toml
@@ -92,5 +92,6 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "plic",
+    "clic",
+    "very_large_intr_status",
 ]

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -199,7 +199,7 @@ extern "C" fn EspDefaultHandler(_interrupt: peripherals::Interrupt) {
 /// Available CPU cores
 ///
 /// The actual number of available cores depends on the target.
-#[derive(Debug, PartialEq, Eq, strum::FromRepr)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, strum::FromRepr)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Cpu {
     /// The first core

--- a/esp-hal-common/src/soc/esp32p4/mod.rs
+++ b/esp-hal-common/src/soc/esp32p4/mod.rs
@@ -4,6 +4,7 @@ pub mod peripherals;
 
 pub(crate) mod registers {
     pub const INTERRUPT_MAP_BASE: u32 = 0x500D_6000;
+    pub const INTERRUPT_MAP_BASE_APP_CPU: u32 = 0x500D_6800;
 }
 
 pub(crate) mod constants {


### PR DESCRIPTION
This adds support for interrupts on ESP32-P4

You can test it with this (you need to add the critical-section dependency)
```rust
#![no_std]
#![no_main]

use core::cell::RefCell;

use critical_section::Mutex;
use esp32p4_hal::{
    gpio::{Gpio35, Input, PullDown, IO},
    interrupt,
    peripherals,
    peripherals::Peripherals,
    prelude::*,
};
use esp_backtrace as _;
use esp_println::println;

static BUTTON: Mutex<RefCell<Option<Gpio35<Input<PullDown>>>>> = Mutex::new(RefCell::new(None));

#[entry]
fn main() -> ! {
    esp_println::logger::init_logger_from_env();
    let peripherals = Peripherals::take();

    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
    let mut led = io.pins.gpio36.into_push_pull_output();
    let mut button = io.pins.gpio35.into_pull_down_input();

    button.listen(esp32p4_hal::gpio::Event::FallingEdge);

    critical_section::with(|cs| BUTTON.borrow_ref_mut(cs).replace(button));
    interrupt::enable(
        peripherals::Interrupt::GPIO_INT0,
        interrupt::Priority::Priority3,
    )
    .unwrap();

    led.set_high().unwrap();
    loop {
        led.toggle().unwrap();

        #[cfg(debug_assertions)]
        let count = 150000;

        #[cfg(not(debug_assertions))]
        let count = 3500000;

        for _ in 0..count {
            unsafe {
                core::arch::asm!("nop");
            }
        }
        println!("blink!");
    }
}

#[interrupt]
fn GPIO_INT0() {
    critical_section::with(|cs| {
        println!("GPIO interrupt");
        BUTTON
            .borrow_ref_mut(cs)
            .as_mut()
            .unwrap()
            .clear_interrupt();
    });
}
```

This blinks an LED on GPIO36 and handles an interrupt when using the boot button.

Only external external peripheral interrupts are supported.

Doesn't support "interrupt-preemption" and "direct-vectoring" features - there is apparently support for pre-emption by CLIC and a different way to do direct vectored interrupts. We can explore that later.

Probably the naming of "very_large_intr_status" and "large_intr_status" could be improved. I don't expect to have "extremely_large_intr_status" in future but probably we can come up with better naming in future. (Out of scope of this PR)

Not tested with the second core and anything but the GPIO interrupt for obvious reasons.

