### PR TITLE
Allow for splitting of the USB Serial JTAG peripheral into tx/rx components (continuation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add initial support for the ESP32-P4 (#1101)
 
+- Allow for splitting of the USB Serial JTAG peripheral into tx/rx components (#1024)
+
 ### Fixed
 
 ### Changed

--- a/esp-hal-common/src/usb_serial_jtag.rs
+++ b/esp-hal-common/src/usb_serial_jtag.rs
@@ -15,10 +15,10 @@
 //! // Initialize USB Serial/JTAG peripheral
 //! let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
 
-use core::convert::Infallible;
+use core::{convert::Infallible, marker::PhantomData};
 
 use crate::{
-    peripheral::{Peripheral, PeripheralRef},
+    peripheral::Peripheral,
     peripherals::{usb_device::RegisterBlock, USB_DEVICE},
     system::PeripheralClockControl,
 };
@@ -28,44 +28,36 @@ type Error = Infallible;
 
 /// USB Serial JTAG driver
 pub struct UsbSerialJtag<'d> {
-    usb_serial: PeripheralRef<'d, USB_DEVICE>,
+    tx: UsbSerialJtagTx<'d>,
+    rx: UsbSerialJtagRx<'d>,
 }
 
-impl<'d> UsbSerialJtag<'d> {
-    /// Create a new USB serial/JTAG instance with defaults
-    pub fn new(usb_serial: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
-        crate::into_ref!(usb_serial);
+/// USB Serial JTAG TX driver
+pub struct UsbSerialJtagTx<'d> {
+    phantom: PhantomData<&'d mut USB_DEVICE>,
+}
 
-        PeripheralClockControl::enable(crate::system::Peripheral::UsbDevice);
+/// USB Serial JTAG RX driver
+pub struct UsbSerialJtagRx<'d> {
+    phantom: PhantomData<&'d mut USB_DEVICE>,
+}
 
-        let mut dev = Self { usb_serial };
-        dev.usb_serial.disable_rx_interrupts();
-        dev.usb_serial.disable_tx_interrupts();
+impl<'d> UsbSerialJtagTx<'d> {
+    // If we want to implement a standalone UsbSerialJtagTx, uncomment below and
+    // take care of the configuration
+    // pub fn new(_usb_device: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
+    //     Self::new_inner()
+    // }
 
-        #[cfg(any(esp32c3, esp32s3))]
-        {
-            use crate::soc::efuse::*;
-
-            // On the esp32c3, and esp32s3 the USB_EXCHG_PINS efuse is bugged and
-            // doesn't swap the pullups too, this works around that.
-            if Efuse::read_field_le(USB_EXCHG_PINS) {
-                dev.usb_serial.conf0().modify(|_, w| {
-                    w.pad_pull_override()
-                        .set_bit()
-                        .dm_pullup()
-                        .clear_bit()
-                        .dp_pullup()
-                        .set_bit()
-                });
-            }
+    fn new_inner() -> Self {
+        Self {
+            phantom: PhantomData,
         }
-
-        dev
     }
 
     /// Write data to the serial output in chunks of up to 64 bytes
     pub fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
-        let reg_block = self.usb_serial.register_block();
+        let reg_block = unsafe { &*USB_DEVICE::PTR };
 
         for chunk in data.chunks(64) {
             for byte in chunk {
@@ -86,7 +78,7 @@ impl<'d> UsbSerialJtag<'d> {
     /// Write data to the serial output in a non-blocking manner
     /// Requires manual flushing (automatically flushed every 64 bytes)
     pub fn write_byte_nb(&mut self, word: u8) -> nb::Result<(), Error> {
-        let reg_block = self.usb_serial.register_block();
+        let reg_block = unsafe { &*USB_DEVICE::PTR };
 
         if reg_block
             .ep1_conf()
@@ -107,7 +99,7 @@ impl<'d> UsbSerialJtag<'d> {
 
     /// Flush the output FIFO and block until it has been sent
     pub fn flush_tx(&mut self) -> Result<(), Error> {
-        let reg_block = self.usb_serial.register_block();
+        let reg_block = unsafe { &*USB_DEVICE::PTR };
         reg_block.ep1_conf().write(|w| w.wr_done().set_bit());
 
         while reg_block.ep1_conf().read().bits() & 0b011 == 0b000 {
@@ -119,7 +111,7 @@ impl<'d> UsbSerialJtag<'d> {
 
     /// Flush the output FIFO but don't block if it isn't ready immediately
     pub fn flush_tx_nb(&mut self) -> nb::Result<(), Error> {
-        let reg_block = self.usb_serial.register_block();
+        let reg_block = unsafe { &*USB_DEVICE::PTR };
         reg_block.ep1_conf().write(|w| w.wr_done().set_bit());
 
         if reg_block.ep1_conf().read().bits() & 0b011 == 0b000 {
@@ -128,9 +120,23 @@ impl<'d> UsbSerialJtag<'d> {
             Ok(())
         }
     }
+}
+
+impl<'d> UsbSerialJtagRx<'d> {
+    // If we want to implement a standalone UsbSerialJtagRx, uncomment below and
+    // take care of the configuration
+    // pub fn new(_usb_device: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
+    //     Self::new_inner()
+    // }
+
+    fn new_inner() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
 
     pub fn read_byte(&mut self) -> nb::Result<u8, Error> {
-        let reg_block = self.usb_serial.register_block();
+        let reg_block = unsafe { &*USB_DEVICE::PTR };
 
         // Check if there are any bytes to read
         if reg_block
@@ -149,24 +155,21 @@ impl<'d> UsbSerialJtag<'d> {
 
     /// Listen for RX-PACKET-RECV interrupts
     pub fn listen_rx_packet_recv_interrupt(&mut self) {
-        let reg_block = self.usb_serial.register_block();
-        reg_block
+        unsafe { &*USB_DEVICE::PTR }
             .int_ena()
             .modify(|_, w| w.serial_out_recv_pkt_int_ena().set_bit());
     }
 
     /// Stop listening for RX-PACKET-RECV interrupts
     pub fn unlisten_rx_packet_recv_interrupt(&mut self) {
-        let reg_block = self.usb_serial.register_block();
-        reg_block
+        unsafe { &*USB_DEVICE::PTR }
             .int_ena()
             .modify(|_, w| w.serial_out_recv_pkt_int_ena().clear_bit());
     }
 
     /// Checks if RX-PACKET-RECV interrupt is set
     pub fn rx_packet_recv_interrupt_set(&mut self) -> bool {
-        let reg_block = unsafe { &*USB_DEVICE::PTR };
-        reg_block
+        unsafe { &*USB_DEVICE::PTR }
             .int_st()
             .read()
             .serial_out_recv_pkt_int_st()
@@ -175,16 +178,96 @@ impl<'d> UsbSerialJtag<'d> {
 
     /// Reset RX-PACKET-RECV interrupt
     pub fn reset_rx_packet_recv_interrupt(&mut self) {
-        let reg_block = unsafe { &*USB_DEVICE::PTR };
-
-        reg_block
+        unsafe { &*USB_DEVICE::PTR }
             .int_clr()
             .write(|w| w.serial_out_recv_pkt_int_clr().set_bit())
     }
+}
 
-    #[cfg(feature = "async")]
-    pub(crate) fn inner(&self) -> &USB_DEVICE {
-        &self.usb_serial
+impl<'d> UsbSerialJtag<'d> {
+    /// Create a new USB serial/JTAG instance with defaults
+    pub fn new(usb_device: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
+        crate::into_ref!(usb_device);
+
+        PeripheralClockControl::enable(crate::system::Peripheral::UsbDevice);
+
+        usb_device.disable_tx_interrupts();
+        usb_device.disable_rx_interrupts();
+
+        #[cfg(any(esp32c3, esp32s3))]
+        {
+            use crate::soc::efuse::*;
+
+            // On the esp32c3, and esp32s3 the USB_EXCHG_PINS efuse is bugged and
+            // doesn't swap the pullups too, this works around that.
+            if Efuse::read_field_le(USB_EXCHG_PINS) {
+                dev.usb_serial.conf0().modify(|_, w| {
+                    w.pad_pull_override()
+                        .set_bit()
+                        .dm_pullup()
+                        .clear_bit()
+                        .dp_pullup()
+                        .set_bit()
+                });
+            }
+        }
+
+        Self {
+            tx: UsbSerialJtagTx::new_inner(),
+            rx: UsbSerialJtagRx::new_inner(),
+        }
+    }
+
+    /// Split the USB Serial JTAG peripheral into a transmitter and receiver,
+    /// which is particuarly useful when having two tasks correlating to
+    /// transmitting and receiving.
+    pub fn split(self) -> (UsbSerialJtagTx<'d>, UsbSerialJtagRx<'d>) {
+        (self.tx, self.rx)
+    }
+
+    /// Write data to the serial output in chunks of up to 64 bytes
+    pub fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
+        self.tx.write_bytes(data)
+    }
+
+    /// Write data to the serial output in a non-blocking manner
+    /// Requires manual flushing (automatically flushed every 64 bytes)
+    pub fn write_byte_nb(&mut self, word: u8) -> nb::Result<(), Error> {
+        self.tx.write_byte_nb(word)
+    }
+
+    /// Flush the output FIFO and block until it has been sent
+    pub fn flush_tx(&mut self) -> Result<(), Error> {
+        self.tx.flush_tx()
+    }
+
+    /// Flush the output FIFO but don't block if it isn't ready immediately
+    pub fn flush_tx_nb(&mut self) -> nb::Result<(), Error> {
+        self.tx.flush_tx_nb()
+    }
+
+    pub fn read_byte(&mut self) -> nb::Result<u8, Error> {
+        self.rx.read_byte()
+    }
+
+    /// Listen for RX-PACKET-RECV interrupts
+    pub fn listen_rx_packet_recv_interrupt(&mut self) {
+        self.rx.listen_rx_packet_recv_interrupt()
+    }
+
+    /// Stop listening for RX-PACKET-RECV interrupts
+    pub fn unlisten_rx_packet_recv_interrupt(&mut self) {
+        self.rx.unlisten_rx_packet_recv_interrupt()
+    }
+
+    /// Checks if RX-PACKET-RECV interrupt is set
+    pub fn rx_packet_recv_interrupt_set(&mut self) -> bool {
+        self.rx.rx_packet_recv_interrupt_set()
+    }
+
+    /// Reset RX-PACKET-RECV interrupt
+    pub fn reset_rx_packet_recv_interrupt(&mut self) {
+        self.rx.reset_rx_packet_recv_interrupt()
     }
 }
 
@@ -211,30 +294,6 @@ pub trait Instance {
             .int_clr()
             .write(|w| w.serial_out_recv_pkt_int_clr().set_bit())
     }
-
-    fn get_rx_fifo_count(&self) -> u16 {
-        let ep0_state = self.register_block().in_ep0_st().read();
-        let wr_addr = ep0_state.in_ep0_wr_addr().bits();
-        let rd_addr = ep0_state.in_ep0_rd_addr().bits();
-
-        (wr_addr - rd_addr).into()
-    }
-
-    fn get_tx_fifo_count(&self) -> u16 {
-        let ep1_state = self.register_block().in_ep1_st().read();
-        let wr_addr = ep1_state.in_ep1_wr_addr().bits();
-        let rd_addr = ep1_state.in_ep1_rd_addr().bits();
-
-        (wr_addr - rd_addr).into()
-    }
-
-    fn txfifo_empty(&self) -> bool {
-        self.register_block()
-            .jfifo_st()
-            .read()
-            .out_fifo_empty()
-            .bit_is_clear()
-    }
 }
 
 impl Instance for USB_DEVICE {
@@ -246,6 +305,12 @@ impl Instance for USB_DEVICE {
 
 impl core::fmt::Write for UsbSerialJtag<'_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        core::fmt::Write::write_str(&mut self.tx, s)
+    }
+}
+
+impl core::fmt::Write for UsbSerialJtagTx<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
         self.write_bytes(s.as_bytes())
             .map_err(|_| core::fmt::Error)?;
         Ok(())
@@ -254,6 +319,21 @@ impl core::fmt::Write for UsbSerialJtag<'_> {
 
 #[cfg(feature = "ufmt")]
 impl ufmt_write::uWrite for UsbSerialJtag<'_> {
+    type Error = Error;
+
+    #[inline]
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        ufmt_write::uWrite::write_str(&mut self.tx, s)
+    }
+
+    #[inline]
+    fn write_char(&mut self, ch: char) -> Result<(), Self::Error> {
+        ufmt_write::uWrite::write_char(&mut self.tx, ch)
+    }
+}
+
+#[cfg(feature = "ufmt")]
+impl ufmt_write::uWrite for UsbSerialJtagTx<'_> {
     type Error = Error;
 
     #[inline]
@@ -275,11 +355,31 @@ impl embedded_hal::serial::Read<u8> for UsbSerialJtag<'_> {
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        embedded_hal::serial::Read::read(&mut self.rx)
+    }
+}
+
+impl embedded_hal::serial::Read<u8> for UsbSerialJtagRx<'_> {
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.read_byte()
     }
 }
 
 impl embedded_hal::serial::Write<u8> for UsbSerialJtag<'_> {
+    type Error = Error;
+
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        embedded_hal::serial::Write::write(&mut self.tx, word)
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        embedded_hal::serial::Write::flush(&mut self.tx)
+    }
+}
+
+impl embedded_hal::serial::Write<u8> for UsbSerialJtagTx<'_> {
     type Error = Error;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
@@ -297,7 +397,24 @@ impl embedded_hal_nb::serial::ErrorType for UsbSerialJtag<'_> {
 }
 
 #[cfg(feature = "eh1")]
+impl embedded_hal_nb::serial::ErrorType for UsbSerialJtagTx<'_> {
+    type Error = Error;
+}
+
+#[cfg(feature = "eh1")]
+impl embedded_hal_nb::serial::ErrorType for UsbSerialJtagRx<'_> {
+    type Error = Error;
+}
+
+#[cfg(feature = "eh1")]
 impl embedded_hal_nb::serial::Read for UsbSerialJtag<'_> {
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        embedded_hal_nb::serial::Read::read(&mut self.rx)
+    }
+}
+
+#[cfg(feature = "eh1")]
+impl embedded_hal_nb::serial::Read for UsbSerialJtagRx<'_> {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.read_byte()
     }
@@ -305,6 +422,17 @@ impl embedded_hal_nb::serial::Read for UsbSerialJtag<'_> {
 
 #[cfg(feature = "eh1")]
 impl embedded_hal_nb::serial::Write for UsbSerialJtag<'_> {
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        embedded_hal_nb::serial::Write::write(&mut self.tx, word)
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        embedded_hal_nb::serial::Write::flush(&mut self.tx)
+    }
+}
+
+#[cfg(feature = "eh1")]
+impl embedded_hal_nb::serial::Write for UsbSerialJtagTx<'_> {
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         self.write_byte_nb(word)
     }
@@ -320,7 +448,24 @@ impl embedded_io::ErrorType for UsbSerialJtag<'_> {
 }
 
 #[cfg(feature = "embedded-io")]
+impl embedded_io::ErrorType for UsbSerialJtagTx<'_> {
+    type Error = Error;
+}
+
+#[cfg(feature = "embedded-io")]
+impl embedded_io::ErrorType for UsbSerialJtagRx<'_> {
+    type Error = Error;
+}
+
+#[cfg(feature = "embedded-io")]
 impl embedded_io::Read for UsbSerialJtag<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        embedded_io::Read::read(&mut self.rx, buf)
+    }
+}
+
+#[cfg(feature = "embedded-io")]
+impl embedded_io::Read for UsbSerialJtagRx<'_> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         let mut count = 0;
         loop {
@@ -350,6 +495,17 @@ impl embedded_io::Read for UsbSerialJtag<'_> {
 #[cfg(feature = "embedded-io")]
 impl embedded_io::Write for UsbSerialJtag<'_> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        embedded_io::Write::write(&mut self.tx, buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        embedded_io::Write::flush(&mut self.tx)
+    }
+}
+
+#[cfg(feature = "embedded-io")]
+impl embedded_io::Write for UsbSerialJtagTx<'_> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.write_bytes(buf)?;
 
         Ok(buf.len())
@@ -362,36 +518,36 @@ impl embedded_io::Write for UsbSerialJtag<'_> {
 
 #[cfg(feature = "async")]
 mod asynch {
-    use core::task::Poll;
+    use core::{marker::PhantomData, task::Poll};
 
     use embassy_sync::waitqueue::AtomicWaker;
     use procmacros::interrupt;
 
-    use super::{Error, Instance};
-    use crate::UsbSerialJtag;
+    use super::{Error, UsbSerialJtag, UsbSerialJtagRx, UsbSerialJtagTx};
+    use crate::peripherals::USB_DEVICE;
 
     // Single static instance of the waker
     static WAKER: AtomicWaker = AtomicWaker::new();
 
     pub(crate) struct UsbSerialJtagWriteFuture<'d> {
-        instance: &'d crate::peripherals::USB_DEVICE,
+        phantom: PhantomData<&'d mut USB_DEVICE>,
     }
 
     impl<'d> UsbSerialJtagWriteFuture<'d> {
-        pub fn new(instance: &'d crate::peripherals::USB_DEVICE) -> Self {
+        pub fn new() -> Self {
             // Set the interrupt enable bit for the USB_SERIAL_JTAG_SERIAL_IN_EMPTY_INT
             // interrupt
-            instance
-                .register_block()
+            unsafe { &*USB_DEVICE::PTR }
                 .int_ena()
                 .modify(|_, w| w.serial_in_empty_int_ena().set_bit());
 
-            Self { instance }
+            Self {
+                phantom: PhantomData,
+            }
         }
 
         fn event_bit_is_clear(&self) -> bool {
-            self.instance
-                .register_block()
+            unsafe { &*USB_DEVICE::PTR }
                 .int_ena()
                 .read()
                 .serial_in_empty_int_ena()
@@ -416,24 +572,24 @@ mod asynch {
     }
 
     pub(crate) struct UsbSerialJtagReadFuture<'d> {
-        instance: &'d crate::peripherals::USB_DEVICE,
+        phantom: PhantomData<&'d mut USB_DEVICE>,
     }
 
     impl<'d> UsbSerialJtagReadFuture<'d> {
-        pub fn new(instance: &'d crate::peripherals::USB_DEVICE) -> Self {
+        pub fn new() -> Self {
             // Set the interrupt enable bit for the USB_SERIAL_JTAG_SERIAL_OUT_RECV_PKT
             // interrupt
-            instance
-                .register_block()
+            unsafe { &*USB_DEVICE::PTR }
                 .int_ena()
                 .modify(|_, w| w.serial_out_recv_pkt_int_ena().set_bit());
 
-            Self { instance }
+            Self {
+                phantom: PhantomData,
+            }
         }
 
         fn event_bit_is_clear(&self) -> bool {
-            self.instance
-                .register_block()
+            unsafe { &*USB_DEVICE::PTR }
                 .int_ena()
                 .read()
                 .serial_out_recv_pkt_int_ena()
@@ -457,9 +613,9 @@ mod asynch {
         }
     }
 
-    impl UsbSerialJtag<'_> {
+    impl UsbSerialJtagTx<'_> {
         async fn write_bytes_async(&mut self, words: &[u8]) -> Result<(), Error> {
-            let reg_block = self.usb_serial.register_block();
+            let reg_block = unsafe { &*USB_DEVICE::PTR };
 
             for chunk in words.chunks(64) {
                 for byte in chunk {
@@ -469,15 +625,30 @@ mod asynch {
                 }
                 reg_block.ep1_conf().write(|w| w.wr_done().set_bit());
 
-                UsbSerialJtagWriteFuture::new(self.inner()).await;
+                UsbSerialJtagWriteFuture::new().await;
             }
 
             Ok(())
         }
 
+        async fn flush_tx_async(&mut self) -> Result<(), Error> {
+            if unsafe { &*USB_DEVICE::PTR }
+                .jfifo_st()
+                .read()
+                .out_fifo_empty()
+                .bit_is_clear()
+            {
+                UsbSerialJtagWriteFuture::new().await;
+            }
+
+            Ok(())
+        }
+    }
+
+    impl UsbSerialJtagRx<'_> {
         async fn read_bytes_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
             fn read_nb<'d>(
-                usb: &'d mut UsbSerialJtag,
+                usb: &'d mut UsbSerialJtagRx,
                 buf: &mut [u8],
             ) -> Result<Result<usize, Error>, UsbSerialJtagReadFuture<'d>> {
                 let mut count = 0;
@@ -495,7 +666,7 @@ mod asynch {
                             if count > 0 {
                                 return Ok(Ok(count));
                             } else {
-                                return Err(UsbSerialJtagReadFuture::new(usb.inner()));
+                                return Err(UsbSerialJtagReadFuture::new());
                             }
                         }
                         Err(nb::Error::Other(e)) => return Ok(Err(e)),
@@ -514,17 +685,19 @@ mod asynch {
                 }
             }
         }
-
-        async fn flush_tx_async(&mut self) -> Result<(), Error> {
-            if self.inner().txfifo_empty() {
-                UsbSerialJtagWriteFuture::new(self.inner()).await;
-            }
-
-            Ok(())
-        }
     }
 
     impl embedded_io_async::Write for UsbSerialJtag<'_> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            embedded_io_async::Write::write(&mut self.tx, buf).await
+        }
+
+        async fn flush(&mut self) -> Result<(), Self::Error> {
+            embedded_io_async::Write::flush(&mut self.tx).await
+        }
+    }
+
+    impl embedded_io_async::Write for UsbSerialJtagTx<'_> {
         async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
             self.write_bytes_async(buf).await?;
 
@@ -538,13 +711,20 @@ mod asynch {
 
     impl embedded_io_async::Read for UsbSerialJtag<'_> {
         async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            embedded_io_async::Read::read(&mut self.rx, buf).await
+        }
+    }
+
+    impl embedded_io_async::Read for UsbSerialJtagRx<'_> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
             self.read_bytes_async(buf).await
         }
     }
 
     #[interrupt]
     fn USB_DEVICE() {
-        let usb = unsafe { &*crate::peripherals::USB_DEVICE::ptr() };
+        let usb = unsafe { &*USB_DEVICE::PTR };
+
         let in_empty = usb.int_st().read().serial_in_empty_int_st().bit_is_set();
         let out_recv = usb
             .int_st()
@@ -560,12 +740,14 @@ mod asynch {
             usb.int_ena()
                 .write(|w| w.serial_out_recv_pkt_int_ena().clear_bit());
         }
+
         usb.int_clr().write(|w| {
             w.serial_in_empty_int_clr()
                 .set_bit()
                 .serial_out_recv_pkt_int_clr()
                 .set_bit()
         });
+
         WAKER.wake();
     }
 }

--- a/esp32c3-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/embassy_usb_serial_jtag.rs
@@ -8,18 +8,57 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
-use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32c3_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    UsbSerialJtag,
+    clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, UsbSerialJtag,
 };
 use esp_backtrace as _;
+use esp_hal_common::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};
+use static_cell::make_static;
+
+const MAX_BUFFER_SIZE: usize = 512;
+
+#[embassy_executor::task]
+async fn writer(
+    mut tx: UsbSerialJtagTx<'static>,
+    signal: &'static Signal<NoopRawMutex, heapless::String<MAX_BUFFER_SIZE>>,
+) {
+    use core::fmt::Write;
+    embedded_io_async::Write::write_all(
+        &mut tx,
+        b"Hello async USB Serial JTAG. Type something.\r\n",
+    )
+    .await
+    .unwrap();
+    loop {
+        let message = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "-- received '{}' --\r\n", message).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
+}
+
+#[embassy_executor::task]
+async fn reader(
+    mut rx: UsbSerialJtagRx<'static>,
+    signal: &'static Signal<NoopRawMutex, heapless::String<MAX_BUFFER_SIZE>>,
+) {
+    let mut rbuf = [0u8; MAX_BUFFER_SIZE];
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf).await;
+        match r {
+            Ok(len) => {
+                let mut string_buffer: heapless::Vec<_, MAX_BUFFER_SIZE> = heapless::Vec::new();
+                string_buffer.extend_from_slice(&rbuf[..len]).unwrap();
+                signal.signal(heapless::String::from_utf8(string_buffer).unwrap());
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
+        }
+    }
+}
 
 #[main]
-async fn main(_spawner: Spawner) -> ! {
+async fn main(spawner: Spawner) -> () {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -37,22 +76,10 @@ async fn main(_spawner: Spawner) -> ! {
         esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks),
     );
 
-    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
+    let (tx, rx) = UsbSerialJtag::new(peripherals.USB_DEVICE).split();
 
-    loop {
-        let mut read_buf = [0; 64];
+    let signal = &*make_static!(Signal::new());
 
-        match AsyncRead::read(&mut usb_serial, &mut read_buf).await {
-            Ok(n) => {
-                AsyncWrite::write_all(&mut usb_serial, b"echo: ")
-                    .await
-                    .unwrap();
-                AsyncWrite::write_all(&mut usb_serial, &read_buf[..n])
-                    .await
-                    .unwrap();
-                AsyncWrite::write_all(&mut usb_serial, b"\n").await.unwrap();
-            }
-            Err(e) => esp_println::println!("error: {e}"),
-        }
-    }
+    spawner.spawn(reader(rx, &signal)).unwrap();
+    spawner.spawn(writer(tx, &signal)).unwrap();
 }

--- a/esp32c3-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32c3-hal/examples/embassy_usb_serial_jtag.rs
@@ -10,7 +10,11 @@
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32c3_hal::{
-    clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, UsbSerialJtag,
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    UsbSerialJtag,
 };
 use esp_backtrace as _;
 use esp_hal_common::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};

--- a/esp32c6-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32c6-hal/examples/embassy_usb_serial_jtag.rs
@@ -9,7 +9,11 @@
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32c6_hal::{
-    clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, UsbSerialJtag,
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    UsbSerialJtag,
 };
 use esp_backtrace as _;
 use esp_hal_common::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};

--- a/esp32c6-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32c6-hal/examples/embassy_usb_serial_jtag.rs
@@ -7,18 +7,57 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
-use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32c6_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    UsbSerialJtag,
+    clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, UsbSerialJtag,
 };
 use esp_backtrace as _;
+use esp_hal_common::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};
+use static_cell::make_static;
+
+const MAX_BUFFER_SIZE: usize = 512;
+
+#[embassy_executor::task]
+async fn writer(
+    mut tx: UsbSerialJtagTx<'static>,
+    signal: &'static Signal<NoopRawMutex, heapless::String<MAX_BUFFER_SIZE>>,
+) {
+    use core::fmt::Write;
+    embedded_io_async::Write::write_all(
+        &mut tx,
+        b"Hello async USB Serial JTAG. Type something.\r\n",
+    )
+    .await
+    .unwrap();
+    loop {
+        let message = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "-- received '{}' --\r\n", message).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
+}
+
+#[embassy_executor::task]
+async fn reader(
+    mut rx: UsbSerialJtagRx<'static>,
+    signal: &'static Signal<NoopRawMutex, heapless::String<MAX_BUFFER_SIZE>>,
+) {
+    let mut rbuf = [0u8; MAX_BUFFER_SIZE];
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf).await;
+        match r {
+            Ok(len) => {
+                let mut string_buffer: heapless::Vec<_, MAX_BUFFER_SIZE> = heapless::Vec::new();
+                string_buffer.extend_from_slice(&rbuf[..len]).unwrap();
+                signal.signal(heapless::String::from_utf8(string_buffer).unwrap());
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
+        }
+    }
+}
 
 #[main]
-async fn main(_spawner: Spawner) -> ! {
+async fn main(spawner: Spawner) -> () {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -36,22 +75,10 @@ async fn main(_spawner: Spawner) -> ! {
         esp32c6_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks),
     );
 
-    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
+    let (tx, rx) = UsbSerialJtag::new(peripherals.USB_DEVICE).split();
 
-    loop {
-        let mut read_buf = [0; 64];
+    let signal = &*make_static!(Signal::new());
 
-        match AsyncRead::read(&mut usb_serial, &mut read_buf).await {
-            Ok(n) => {
-                AsyncWrite::write_all(&mut usb_serial, b"echo: ")
-                    .await
-                    .unwrap();
-                AsyncWrite::write_all(&mut usb_serial, &read_buf[..n])
-                    .await
-                    .unwrap();
-                AsyncWrite::write_all(&mut usb_serial, b"\n").await.unwrap();
-            }
-            Err(e) => esp_println::println!("error: {e}"),
-        }
-    }
+    spawner.spawn(reader(rx, &signal)).unwrap();
+    spawner.spawn(writer(tx, &signal)).unwrap();
 }

--- a/esp32h2-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32h2-hal/examples/embassy_usb_serial_jtag.rs
@@ -9,7 +9,11 @@
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32h2_hal::{
-    clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, UsbSerialJtag,
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    UsbSerialJtag,
 };
 use esp_backtrace as _;
 use esp_hal_common::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};

--- a/esp32h2-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32h2-hal/examples/embassy_usb_serial_jtag.rs
@@ -7,18 +7,57 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
-use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32h2_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    UsbSerialJtag,
+    clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, UsbSerialJtag,
 };
 use esp_backtrace as _;
+use esp_hal_common::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};
+use static_cell::make_static;
+
+const MAX_BUFFER_SIZE: usize = 512;
+
+#[embassy_executor::task]
+async fn writer(
+    mut tx: UsbSerialJtagTx<'static>,
+    signal: &'static Signal<NoopRawMutex, heapless::String<MAX_BUFFER_SIZE>>,
+) {
+    use core::fmt::Write;
+    embedded_io_async::Write::write_all(
+        &mut tx,
+        b"Hello async USB Serial JTAG. Type something.\r\n",
+    )
+    .await
+    .unwrap();
+    loop {
+        let message = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "-- received '{}' --\r\n", message).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
+}
+
+#[embassy_executor::task]
+async fn reader(
+    mut rx: UsbSerialJtagRx<'static>,
+    signal: &'static Signal<NoopRawMutex, heapless::String<MAX_BUFFER_SIZE>>,
+) {
+    let mut rbuf = [0u8; MAX_BUFFER_SIZE];
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf).await;
+        match r {
+            Ok(len) => {
+                let mut string_buffer: heapless::Vec<_, MAX_BUFFER_SIZE> = heapless::Vec::new();
+                string_buffer.extend_from_slice(&rbuf[..len]).unwrap();
+                signal.signal(heapless::String::from_utf8(string_buffer).unwrap());
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
+        }
+    }
+}
 
 #[main]
-async fn main(_spawner: Spawner) -> ! {
+async fn main(spawner: Spawner) -> () {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -36,22 +75,10 @@ async fn main(_spawner: Spawner) -> ! {
         esp32h2_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks),
     );
 
-    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
+    let (tx, rx) = UsbSerialJtag::new(peripherals.USB_DEVICE).split();
 
-    loop {
-        let mut read_buf = [0; 64];
+    let signal = &*make_static!(Signal::new());
 
-        match AsyncRead::read(&mut usb_serial, &mut read_buf).await {
-            Ok(n) => {
-                AsyncWrite::write_all(&mut usb_serial, b"echo: ")
-                    .await
-                    .unwrap();
-                AsyncWrite::write_all(&mut usb_serial, &read_buf[..n])
-                    .await
-                    .unwrap();
-                AsyncWrite::write_all(&mut usb_serial, b"\n").await.unwrap();
-            }
-            Err(e) => esp_println::println!("error: {e}"),
-        }
-    }
+    spawner.spawn(reader(rx, &signal)).unwrap();
+    spawner.spawn(writer(tx, &signal)).unwrap();
 }

--- a/esp32s3-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/embassy_usb_serial_jtag.rs
@@ -7,18 +7,57 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
-use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32s3_hal::{
-    clock::ClockControl,
-    embassy,
-    peripherals::Peripherals,
-    prelude::*,
-    UsbSerialJtag,
+    clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, UsbSerialJtag,
 };
 use esp_backtrace as _;
+use esp_hal_common::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};
+use static_cell::make_static;
+
+const MAX_BUFFER_SIZE: usize = 512;
+
+#[embassy_executor::task]
+async fn writer(
+    mut tx: UsbSerialJtagTx<'static>,
+    signal: &'static Signal<NoopRawMutex, heapless::String<MAX_BUFFER_SIZE>>,
+) {
+    use core::fmt::Write;
+    embedded_io_async::Write::write_all(
+        &mut tx,
+        b"Hello async USB Serial JTAG. Type something.\r\n",
+    )
+    .await
+    .unwrap();
+    loop {
+        let message = signal.wait().await;
+        signal.reset();
+        write!(&mut tx, "-- received '{}' --\r\n", message).unwrap();
+        embedded_io_async::Write::flush(&mut tx).await.unwrap();
+    }
+}
+
+#[embassy_executor::task]
+async fn reader(
+    mut rx: UsbSerialJtagRx<'static>,
+    signal: &'static Signal<NoopRawMutex, heapless::String<MAX_BUFFER_SIZE>>,
+) {
+    let mut rbuf = [0u8; MAX_BUFFER_SIZE];
+    loop {
+        let r = embedded_io_async::Read::read(&mut rx, &mut rbuf).await;
+        match r {
+            Ok(len) => {
+                let mut string_buffer: heapless::Vec<_, MAX_BUFFER_SIZE> = heapless::Vec::new();
+                string_buffer.extend_from_slice(&rbuf[..len]).unwrap();
+                signal.signal(heapless::String::from_utf8(string_buffer).unwrap());
+            }
+            Err(e) => esp_println::println!("RX Error: {:?}", e),
+        }
+    }
+}
 
 #[main]
-async fn main(_spawner: Spawner) -> ! {
+async fn main(spawner: Spawner) -> () {
     esp_println::println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
@@ -36,22 +75,10 @@ async fn main(_spawner: Spawner) -> ! {
         esp32s3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks),
     );
 
-    let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
+    let (tx, rx) = UsbSerialJtag::new(peripherals.USB_DEVICE).split();
 
-    loop {
-        let mut read_buf = [0; 64];
+    let signal = &*make_static!(Signal::new());
 
-        match AsyncRead::read(&mut usb_serial, &mut read_buf).await {
-            Ok(n) => {
-                AsyncWrite::write_all(&mut usb_serial, b"echo: ")
-                    .await
-                    .unwrap();
-                AsyncWrite::write_all(&mut usb_serial, &read_buf[..n])
-                    .await
-                    .unwrap();
-                AsyncWrite::write_all(&mut usb_serial, b"\n").await.unwrap();
-            }
-            Err(e) => esp_println::println!("error: {e}"),
-        }
-    }
+    spawner.spawn(reader(rx, &signal)).unwrap();
+    spawner.spawn(writer(tx, &signal)).unwrap();
 }

--- a/esp32s3-hal/examples/embassy_usb_serial_jtag.rs
+++ b/esp32s3-hal/examples/embassy_usb_serial_jtag.rs
@@ -9,7 +9,11 @@
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp32s3_hal::{
-    clock::ClockControl, embassy, peripherals::Peripherals, prelude::*, UsbSerialJtag,
+    clock::ClockControl,
+    embassy,
+    peripherals::Peripherals,
+    prelude::*,
+    UsbSerialJtag,
 };
 use esp_backtrace as _;
 use esp_hal_common::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};


### PR DESCRIPTION
This is a continuation of PR https://github.com/esp-rs/esp-hal/pull/1024, which fixes https://github.com/esp-rs/esp-hal/issues/1006

My commit fixes a bug in the wakers. I assume that's why this was originally dropped. The wakers were swapped, so a tx interrupt would trigger the rx waker, and vice versa. I also updated the embassy example to use the new split function.