### PR TITLE
Runtime interrupt handler binding

### DIFF
--- a/esp-hal-common/Cargo.toml
+++ b/esp-hal-common/Cargo.toml
@@ -63,7 +63,7 @@ ufmt-write = { version = "0.1.0", optional = true }
 # corresponding feature.
 esp32   = { version = "0.28.0", features = ["critical-section"], optional = true }
 esp32c2 = { version = "0.17.0", features = ["critical-section"], optional = true }
-esp32c3 = { version = "0.20.0", features = ["critical-section"], optional = true }
+esp32c3 = { path = "/projects/esp/esp-pacs/esp32c3", version = "0.20.0", features = ["critical-section"], optional = true }
 esp32c6 = { version = "0.11.0", features = ["critical-section"], optional = true }
 esp32h2 = { version = "0.7.0",  features = ["critical-section"], optional = true }
 esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "c801d10", optional = true }

--- a/esp-hal-common/src/interrupt/riscv.rs
+++ b/esp-hal-common/src/interrupt/riscv.rs
@@ -196,6 +196,13 @@ mod vectored {
         Ok(())
     }
 
+    /// Bind the given interrupt to the given handler
+    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn() -> ()) {
+        let ptr = &peripherals::__EXTERNAL_INTERRUPTS[interrupt as usize]._handler as *const _
+            as *mut unsafe extern "C" fn() -> ();
+        ptr.write_volatile(handler);
+    }
+
     /// Enables an interrupt at a given priority, maps it to the given CPU
     /// interrupt and assigns the given priority.
     ///

--- a/esp-hal-common/src/interrupt/xtensa.rs
+++ b/esp-hal-common/src/interrupt/xtensa.rs
@@ -308,6 +308,13 @@ mod vectored {
         Ok(())
     }
 
+    /// Bind the given interrupt to the given handler
+    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn() -> ()) {
+        let ptr = &peripherals::__INTERRUPTS[interrupt as usize]._handler as *const _
+            as *mut unsafe extern "C" fn() -> ();
+        ptr.write_volatile(handler);
+    }
+
     fn interrupt_level_to_cpu_interrupt(
         level: Priority,
         is_edge: bool,

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -450,3 +450,11 @@ impl<T, const SIZE: usize> FlashSafeDma<T, SIZE> {
         self.inner
     }
 }
+
+/// Driver mode async
+#[non_exhaustive]
+pub struct AsyncMode;
+
+/// Driver mode non-async
+#[non_exhaustive]
+pub struct BlockingMode;

--- a/esp-hal-common/src/peripheral.rs
+++ b/esp-hal-common/src/peripheral.rs
@@ -225,7 +225,7 @@ mod peripheral_macros {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! peripherals {
-        ($($(#[$cfg:meta])? $name:ident <= $from_pac:tt),*$(,)?) => {
+        ($($(#[$cfg:meta])? $name:ident <= $from_pac:tt $(($($interrupt:ident),*))?  ),*$(,)?) => {
 
             /// Contains the generated peripherals which implement [`Peripheral`]
             mod peripherals {
@@ -281,6 +281,18 @@ mod peripheral_macros {
             // expose the new structs
             $(
                 pub use peripherals::$name;
+            )*
+
+            $(
+                $(
+                    $(
+                        paste::paste!{
+                            pub fn [<bind_ $interrupt:lower _interrupt >](_peripheral: &mut peripherals::$name, handler: unsafe extern "C" fn() -> ()) {
+                                unsafe { $crate::interrupt::bind_interrupt($crate::peripherals::Interrupt::$interrupt, handler); }
+                            }
+                        }
+                    )*
+                )*
             )*
         }
     }

--- a/esp-hal-common/src/soc/esp32c3/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32c3/peripherals.rs
@@ -30,7 +30,7 @@ crate::peripherals! {
     DS <= DS,
     EFUSE <= EFUSE,
     EXTMEM <= EXTMEM,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     GPIO_SD <= GPIO_SD,
     HMAC <= HMAC,
     I2C0 <= I2C0,

--- a/esp-hal-common/src/soc/esp32s3/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32s3/peripherals.rs
@@ -30,7 +30,7 @@ crate::peripherals! {
     DS <= DS,
     EFUSE <= EFUSE,
     EXTMEM <= EXTMEM,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     GPIO_SD <= GPIO_SD,
     HMAC <= HMAC,
     I2C0 <= I2C0,

--- a/esp32c3-hal/examples/embassy_wait.rs
+++ b/esp32c3-hal/examples/embassy_wait.rs
@@ -31,7 +31,7 @@ async fn main(_spawner: Spawner) {
         esp32c3_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks),
     );
 
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = IO::new_async(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 9 as input
     let mut input = io.pins.gpio9.into_pull_down_input();
 

--- a/esp32c3-hal/examples/gpio_interrupt.rs
+++ b/esp32c3-hal/examples/gpio_interrupt.rs
@@ -28,7 +28,9 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Set GPIO5 as an output
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let mut io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    io.set_interrupt_handler(handler);
+
     let mut led = io.pins.gpio5.into_push_pull_output();
 
     // Set GPIO9 as an input
@@ -46,8 +48,8 @@ fn main() -> ! {
     }
 }
 
-#[interrupt]
-fn GPIO() {
+#[handler]
+fn handler() {
     critical_section::with(|cs| {
         esp_println::println!("GPIO interrupt");
         BUTTON

--- a/esp32s3-hal/examples/embassy_wait.rs
+++ b/esp32s3-hal/examples/embassy_wait.rs
@@ -37,7 +37,7 @@ async fn main(_spawner: Spawner) {
         embassy::init(&clocks, timer_group0);
     }
 
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = IO::new_async(peripherals.GPIO, peripherals.IO_MUX);
     // GPIO 0 as input
     let mut input = io.pins.gpio0.into_pull_down_input();
 

--- a/esp32s3-hal/examples/gpio_interrupt.rs
+++ b/esp32s3-hal/examples/gpio_interrupt.rs
@@ -13,7 +13,6 @@ use esp32s3_hal::{
     clock::ClockControl,
     gpio::{Event, Gpio0, Input, PullDown, IO},
     interrupt,
-    macros::ram,
     peripherals::{self, Peripherals},
     prelude::*,
     xtensa_lx,
@@ -30,7 +29,9 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Set GPIO15 as an output, and set its state high initially.
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let mut io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    io.set_interrupt_handler(handler);
+
     let mut led = io.pins.gpio15.into_push_pull_output();
     let mut button = io.pins.gpio0.into_pull_down_input();
     button.listen(Event::FallingEdge);
@@ -51,9 +52,8 @@ fn main() -> ! {
     }
 }
 
-#[ram]
-#[interrupt]
-fn GPIO() {
+#[handler]
+fn handler() {
     esp_println::println!(
         "GPIO Interrupt with priority {}",
         xtensa_lx::interrupt::get_level()


### PR DESCRIPTION
This is not intended to get merged as is - it's exploring a possible solution to #1063

Idea is to have minimal changes and keep compatibility (to not break the direct-vectored feature and to reduce friction and effort)

Basically, to runtime bind an interrupt handler (without unsafe) the user needs to own or have a mutable reference of the corresponding peripheral. (Instead of making interrupts resources). This also means a user could re-bind / unbind the handler.

For RISC-V we would need to change the PACs to place the interrupt vector to `.rwtext` (tested with ESP32-C3 locally only - but is probably a good thing anyways).

Nothing changed regarding linking.

I only implemented it for C3 and S3 and only for GPIO here.

For the mentioned edge-case (and I think we have more like that) I have an idea which I will explore next
