### PR TITLE
Refactor DMA to make API more consistent across devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ADC` and `DAC` drivers now take virtual peripherals in their constructors, instead of splitting `APB_SARADC`/`SENS` (#1100)
 - The `DAC` driver's constructor is now `new` instead of `dac`, to be more consistent with other APIs (#1100)
+- The DMA peripheral is now called `Dma` for devices with both PDMA and GDMA controllers (#1125)
 
 ## [0.15.0] - 2024-01-19
 

--- a/esp-hal-common/src/dma/gdma.rs
+++ b/esp-hal-common/src/dma/gdma.rs
@@ -609,7 +609,7 @@ impl_channel!(4);
 /// GDMA Peripheral
 ///
 /// This offers the available DMA channels.
-pub struct Gdma<'d> {
+pub struct Dma<'d> {
     _inner: PeripheralRef<'d, crate::peripherals::DMA>,
     pub channel0: ChannelCreator0,
     #[cfg(not(esp32c2))]
@@ -622,11 +622,11 @@ pub struct Gdma<'d> {
     pub channel4: ChannelCreator4,
 }
 
-impl<'d> Gdma<'d> {
+impl<'d> Dma<'d> {
     /// Create a DMA instance.
     pub fn new(
         dma: impl crate::peripheral::Peripheral<P = crate::peripherals::DMA> + 'd,
-    ) -> Gdma<'d> {
+    ) -> Dma<'d> {
         crate::into_ref!(dma);
 
         PeripheralClockControl::enable(Peripheral::Gdma);
@@ -635,7 +635,7 @@ impl<'d> Gdma<'d> {
             .modify(|_, w| w.ahbm_rst_inter().clear_bit());
         dma.misc_conf().modify(|_, w| w.clk_en().set_bit());
 
-        Gdma {
+        Dma {
             _inner: dma,
             channel0: ChannelCreator0 {},
             #[cfg(not(esp32c2))]

--- a/esp-hal-common/src/dma/mod.rs
+++ b/esp-hal-common/src/dma/mod.rs
@@ -39,12 +39,8 @@
 //! ### Initialize and utilize DMA controller in `SPI`
 //!
 //! ```no_run
-//! let dma = Gdma::new(peripherals.DMA);
+//! let dma = Dma::new(peripherals.DMA);
 //! let dma_channel = dma.channel0;
-//!
-//! // For `ESP32` and `ESP32-S2` chips use `pdma::Dma` instead:
-//! // let dma = Dma::new(system.dma);
-//! // let dma_channel = dma.spi2channel;
 //!
 //! let mut descriptors = [DmaDescriptor::EMPTY; 8];
 //! let mut rx_descriptors = [DmaDescriptor::EMPTY; 8];
@@ -136,9 +132,14 @@ impl DmaDescriptor {
 }
 
 #[cfg(gdma)]
-pub mod gdma;
+pub use self::gdma::*;
 #[cfg(pdma)]
-pub mod pdma;
+pub use self::pdma::*;
+
+#[cfg(gdma)]
+mod gdma;
+#[cfg(pdma)]
+mod pdma;
 
 const CHUNK_SIZE: usize = 4092;
 

--- a/esp-hal-common/src/dma/pdma.rs
+++ b/esp-hal-common/src/dma/pdma.rs
@@ -650,7 +650,7 @@ ImplI2sChannel!(1, "I2S1");
 ///
 /// This offers the available DMA channels.
 pub struct Dma<'d> {
-    _inner: PeripheralRef<'d, crate::system::Dma>,
+    _inner: PeripheralRef<'d, crate::peripherals::DMA>,
     pub spi2channel: Spi2DmaChannelCreator,
     pub spi3channel: Spi3DmaChannelCreator,
     pub i2s0channel: I2s0DmaChannelCreator,
@@ -660,7 +660,9 @@ pub struct Dma<'d> {
 
 impl<'d> Dma<'d> {
     /// Create a DMA instance.
-    pub fn new(dma: impl crate::peripheral::Peripheral<P = crate::system::Dma> + 'd) -> Dma<'d> {
+    pub fn new(
+        dma: impl crate::peripheral::Peripheral<P = crate::peripherals::DMA> + 'd,
+    ) -> Dma<'d> {
         PeripheralClockControl::enable(Peripheral::Dma);
 
         Dma {

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -51,10 +51,6 @@ pub use self::analog::adc;
 pub use self::analog::dac;
 #[cfg(any(xtensa, all(riscv, systimer)))]
 pub use self::delay::Delay;
-#[cfg(gdma)]
-pub use self::dma::gdma;
-#[cfg(pdma)]
-pub use self::dma::pdma;
 #[cfg(gpio)]
 pub use self::gpio::IO;
 #[cfg(rmt)]

--- a/esp-hal-common/src/soc/esp32/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32/peripherals.rs
@@ -28,6 +28,7 @@ crate::peripherals! {
     BT <= virtual,
     DAC1 <= virtual,
     DAC2 <= virtual,
+    DMA <= virtual,
     EFUSE <= EFUSE,
     FLASH_ENCRYPTION <= FLASH_ENCRYPTION,
     FRC_TIMER <= FRC_TIMER,

--- a/esp-hal-common/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal-common/src/soc/esp32s2/peripherals.rs
@@ -25,6 +25,7 @@ crate::peripherals! {
     AES <= AES,
     DAC1 <= virtual,
     DAC2 <= virtual,
+    DMA <= virtual,
     DEDICATED_GPIO <= DEDICATED_GPIO,
     DS <= DS,
     EFUSE <= EFUSE,

--- a/esp-hal-common/src/system.rs
+++ b/esp-hal-common/src/system.rs
@@ -615,12 +615,6 @@ pub struct CpuControl {
     _private: (),
 }
 
-/// Dummy DMA peripheral.
-#[cfg(pdma)]
-pub struct Dma {
-    _private: (),
-}
-
 pub enum RadioPeripherals {
     #[cfg(phy)]
     Phy,
@@ -661,8 +655,6 @@ pub struct SystemParts<'d> {
     _private: PeripheralRef<'d, SYSTEM>,
     pub clock_control: SystemClockControl,
     pub cpu_control: CpuControl,
-    #[cfg(pdma)]
-    pub dma: Dma,
     pub radio_clock_control: RadioClockControl,
     pub software_interrupt_control: SoftwareInterruptControl,
 }
@@ -684,8 +676,6 @@ impl<'d, T: crate::peripheral::Peripheral<P = SYSTEM> + 'd> SystemExt<'d> for T 
             _private: self.into_ref(),
             clock_control: SystemClockControl { _private: () },
             cpu_control: CpuControl { _private: () },
-            #[cfg(pdma)]
-            dma: Dma { _private: () },
             radio_clock_control: RadioClockControl { _private: () },
             software_interrupt_control: SoftwareInterruptControl { _private: () },
         }
@@ -702,18 +692,3 @@ impl crate::peripheral::Peripheral for SystemClockControl {
 }
 
 impl crate::peripheral::sealed::Sealed for SystemClockControl {}
-
-#[cfg(pdma)]
-mod dma_peripheral {
-    use super::Dma;
-
-    impl crate::peripheral::Peripheral for Dma {
-        type P = Dma;
-        #[inline]
-        unsafe fn clone_unchecked(&mut self) -> Self::P {
-            Dma { _private: () }
-        }
-    }
-
-    impl crate::peripheral::sealed::Sealed for Dma {}
-}

--- a/esp32-hal/examples/embassy_i2s_read.rs
+++ b/esp32-hal/examples/embassy_i2s_read.rs
@@ -17,11 +17,10 @@
 use embassy_executor::Spawner;
 use esp32_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy::{self},
     i2s::{asynch::*, DataFormat, I2s, Standard},
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
@@ -44,7 +43,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.i2s0channel;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32-hal/examples/embassy_i2s_sound.rs
+++ b/esp32-hal/examples/embassy_i2s_sound.rs
@@ -33,11 +33,10 @@
 use embassy_executor::Spawner;
 use esp32_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy::{self},
     i2s::{asynch::*, DataFormat, I2s, Standard},
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
@@ -68,7 +67,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.i2s0channel;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32-hal/examples/embassy_spi.rs
+++ b/esp32-hal/examples/embassy_spi.rs
@@ -22,10 +22,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{DmaPriority, *},
     dma_descriptors,
     embassy::{self},
-    pdma::*,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -53,7 +52,7 @@ async fn main(_spawner: Spawner) {
     let mosi = io.pins.gpio23;
     let cs = io.pins.gpio22;
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.spi2channel;
 
     let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);

--- a/esp32-hal/examples/i2s_read.rs
+++ b/esp32-hal/examples/i2s_read.rs
@@ -15,10 +15,9 @@
 
 use esp32_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -34,7 +33,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.i2s0channel;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32-hal/examples/i2s_sound.rs
+++ b/esp32-hal/examples/i2s_sound.rs
@@ -31,10 +31,9 @@
 
 use esp32_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -57,7 +56,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.i2s0channel;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32-hal/examples/qspi_flash.rs
+++ b/esp32-hal/examples/qspi_flash.rs
@@ -19,10 +19,9 @@
 
 use esp32_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -49,7 +48,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio16;
     let cs = io.pins.gpio4;
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.spi2channel;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);

--- a/esp32-hal/examples/spi_loopback_dma.rs
+++ b/esp32-hal/examples/spi_loopback_dma.rs
@@ -18,10 +18,9 @@
 
 use esp32_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -45,7 +44,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio23;
     let cs = io.pins.gpio22;
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.spi2channel;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32c2-hal/examples/embassy_spi.rs
+++ b/esp32c2-hal/examples/embassy_spi.rs
@@ -22,10 +22,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{DmaPriority, *},
     dma_descriptors,
     embassy,
-    gdma::*,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -61,7 +60,7 @@ async fn main(_spawner: Spawner) {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);

--- a/esp32c2-hal/examples/qspi_flash.rs
+++ b/esp32c2-hal/examples/qspi_flash.rs
@@ -19,9 +19,8 @@
 
 use esp32c2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -49,7 +48,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio8;
     let cs = io.pins.gpio9;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);

--- a/esp32c2-hal/examples/spi_loopback_dma.rs
+++ b/esp32c2-hal/examples/spi_loopback_dma.rs
@@ -18,9 +18,8 @@
 
 use esp32c2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -45,7 +44,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32c2-hal/examples/spi_slave_dma.rs
+++ b/esp32c2-hal/examples/spi_slave_dma.rs
@@ -27,9 +27,8 @@
 
 use esp32c2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -61,7 +60,7 @@ fn main() -> ! {
     master_sclk.set_low().unwrap();
     master_mosi.set_low().unwrap();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(3200);

--- a/esp32c3-hal/examples/aes_dma.rs
+++ b/esp32c3-hal/examples/aes_dma.rs
@@ -2,6 +2,7 @@
 
 #![no_std]
 #![no_main]
+
 use aes::{
     cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit},
     Aes128 as Aes128SW,
@@ -13,8 +14,7 @@ use esp32c3_hal::{
         Mode,
     },
     clock::ClockControl,
-    dma::{DmaDescriptor, DmaPriority},
-    gdma::Gdma,
+    dma::{Dma, DmaDescriptor, DmaPriority},
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
@@ -28,7 +28,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [DmaDescriptor::EMPTY; 1];

--- a/esp32c3-hal/examples/embassy_i2s_read.rs
+++ b/esp32c3-hal/examples/embassy_i2s_read.rs
@@ -18,10 +18,9 @@
 use embassy_executor::Spawner;
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -53,7 +52,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32c3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c3-hal/examples/embassy_i2s_sound.rs
@@ -34,10 +34,9 @@
 use embassy_executor::Spawner;
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -77,7 +76,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32c3-hal/examples/embassy_spi.rs
+++ b/esp32c3-hal/examples/embassy_spi.rs
@@ -22,10 +22,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{DmaPriority, *},
     dma_descriptors,
     embassy,
-    gdma::*,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -61,7 +60,7 @@ async fn main(_spawner: Spawner) {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);

--- a/esp32c3-hal/examples/i2s_read.rs
+++ b/esp32c3-hal/examples/i2s_read.rs
@@ -16,9 +16,8 @@
 
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -35,7 +34,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32c3-hal/examples/i2s_sound.rs
+++ b/esp32c3-hal/examples/i2s_sound.rs
@@ -32,9 +32,8 @@
 
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -58,7 +57,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32c3-hal/examples/qspi_flash.rs
+++ b/esp32c3-hal/examples/qspi_flash.rs
@@ -19,9 +19,8 @@
 
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -49,7 +48,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio5;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);

--- a/esp32c3-hal/examples/spi_loopback_dma.rs
+++ b/esp32c3-hal/examples/spi_loopback_dma.rs
@@ -18,9 +18,8 @@
 
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -45,7 +44,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32c3-hal/examples/spi_slave_dma.rs
+++ b/esp32c3-hal/examples/spi_slave_dma.rs
@@ -27,9 +27,8 @@
 
 use esp32c3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -61,7 +60,7 @@ fn main() -> ! {
     master_sclk.set_low().unwrap();
     master_mosi.set_low().unwrap();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32c6-hal/examples/aes_dma.rs
+++ b/esp32c6-hal/examples/aes_dma.rs
@@ -13,8 +13,7 @@ use esp32c6_hal::{
         Mode,
     },
     clock::ClockControl,
-    dma::{DmaDescriptor, DmaPriority},
-    gdma::Gdma,
+    dma::{Dma, DmaDescriptor, DmaPriority},
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
@@ -28,7 +27,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [DmaDescriptor::EMPTY; 1];

--- a/esp32c6-hal/examples/embassy_i2s_read.rs
+++ b/esp32c6-hal/examples/embassy_i2s_read.rs
@@ -18,10 +18,9 @@
 use embassy_executor::Spawner;
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -53,7 +52,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32c6-hal/examples/embassy_i2s_sound.rs
+++ b/esp32c6-hal/examples/embassy_i2s_sound.rs
@@ -34,10 +34,9 @@
 use embassy_executor::Spawner;
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -77,7 +76,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32c6-hal/examples/embassy_parl_io_rx.rs
+++ b/esp32c6-hal/examples/embassy_parl_io_rx.rs
@@ -11,10 +11,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     gpio::IO,
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
@@ -46,7 +45,7 @@ async fn main(_spawner: Spawner) {
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);

--- a/esp32c6-hal/examples/embassy_parl_io_tx.rs
+++ b/esp32c6-hal/examples/embassy_parl_io_tx.rs
@@ -15,10 +15,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     gpio::IO,
     parl_io::{
         BitPackOrder,
@@ -57,7 +56,7 @@ async fn main(_spawner: Spawner) {
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);

--- a/esp32c6-hal/examples/embassy_spi.rs
+++ b/esp32c6-hal/examples/embassy_spi.rs
@@ -22,10 +22,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{DmaPriority, *},
     dma_descriptors,
     embassy,
-    gdma::*,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -61,7 +60,7 @@ async fn main(_spawner: Spawner) {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);

--- a/esp32c6-hal/examples/i2s_read.rs
+++ b/esp32c6-hal/examples/i2s_read.rs
@@ -16,9 +16,8 @@
 
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -35,7 +34,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4 * 4092);

--- a/esp32c6-hal/examples/i2s_sound.rs
+++ b/esp32c6-hal/examples/i2s_sound.rs
@@ -32,9 +32,8 @@
 
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -58,7 +57,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32c6-hal/examples/parl_io_rx.rs
+++ b/esp32c6-hal/examples/parl_io_rx.rs
@@ -8,9 +8,8 @@
 
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
@@ -30,7 +29,7 @@ fn main() -> ! {
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);

--- a/esp32c6-hal/examples/parl_io_tx.rs
+++ b/esp32c6-hal/examples/parl_io_tx.rs
@@ -12,9 +12,8 @@
 
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     parl_io::{
         BitPackOrder,
@@ -41,7 +40,7 @@ fn main() -> ! {
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);

--- a/esp32c6-hal/examples/qspi_flash.rs
+++ b/esp32c6-hal/examples/qspi_flash.rs
@@ -19,9 +19,8 @@
 
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -49,7 +48,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio0;
     let cs = io.pins.gpio1;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);

--- a/esp32c6-hal/examples/spi_loopback_dma.rs
+++ b/esp32c6-hal/examples/spi_loopback_dma.rs
@@ -18,9 +18,8 @@
 
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -45,7 +44,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32c6-hal/examples/spi_slave_dma.rs
+++ b/esp32c6-hal/examples/spi_slave_dma.rs
@@ -27,9 +27,8 @@
 
 use esp32c6_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -61,7 +60,7 @@ fn main() -> ! {
     master_sclk.set_low().unwrap();
     master_mosi.set_low().unwrap();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32h2-hal/examples/aes_dma.rs
+++ b/esp32h2-hal/examples/aes_dma.rs
@@ -13,8 +13,7 @@ use esp32h2_hal::{
         Mode,
     },
     clock::ClockControl,
-    dma::{DmaDescriptor, DmaPriority},
-    gdma::Gdma,
+    dma::{Dma, DmaDescriptor, DmaPriority},
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
@@ -28,7 +27,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [DmaDescriptor::EMPTY; 1];

--- a/esp32h2-hal/examples/embassy_i2s_read.rs
+++ b/esp32h2-hal/examples/embassy_i2s_read.rs
@@ -18,10 +18,9 @@
 use embassy_executor::Spawner;
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -53,7 +52,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32h2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32h2-hal/examples/embassy_i2s_sound.rs
@@ -34,10 +34,9 @@
 use embassy_executor::Spawner;
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -77,7 +76,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32h2-hal/examples/embassy_parl_io_rx.rs
+++ b/esp32h2-hal/examples/embassy_parl_io_rx.rs
@@ -11,10 +11,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     gpio::IO,
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
@@ -46,7 +45,7 @@ async fn main(_spawner: Spawner) {
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);

--- a/esp32h2-hal/examples/embassy_parl_io_tx.rs
+++ b/esp32h2-hal/examples/embassy_parl_io_tx.rs
@@ -15,10 +15,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy,
-    gdma::Gdma,
     gpio::IO,
     parl_io::{
         BitPackOrder,
@@ -57,7 +56,7 @@ async fn main(_spawner: Spawner) {
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);

--- a/esp32h2-hal/examples/embassy_spi.rs
+++ b/esp32h2-hal/examples/embassy_spi.rs
@@ -22,10 +22,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{DmaPriority, *},
     dma_descriptors,
     embassy,
-    gdma::*,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -61,7 +60,7 @@ async fn main(_spawner: Spawner) {
     let mosi = io.pins.gpio3;
     let cs = io.pins.gpio11;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);

--- a/esp32h2-hal/examples/i2s_read.rs
+++ b/esp32h2-hal/examples/i2s_read.rs
@@ -16,9 +16,8 @@
 
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -35,7 +34,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4 * 4092);

--- a/esp32h2-hal/examples/i2s_sound.rs
+++ b/esp32h2-hal/examples/i2s_sound.rs
@@ -32,9 +32,8 @@
 
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -58,7 +57,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32h2-hal/examples/parl_io_rx.rs
+++ b/esp32h2-hal/examples/parl_io_rx.rs
@@ -8,9 +8,8 @@
 
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
@@ -30,7 +29,7 @@ fn main() -> ! {
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);

--- a/esp32h2-hal/examples/parl_io_tx.rs
+++ b/esp32h2-hal/examples/parl_io_tx.rs
@@ -12,9 +12,8 @@
 
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     parl_io::{
         BitPackOrder,
@@ -41,7 +40,7 @@ fn main() -> ! {
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);

--- a/esp32h2-hal/examples/qspi_flash.rs
+++ b/esp32h2-hal/examples/qspi_flash.rs
@@ -19,9 +19,8 @@
 
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -49,7 +48,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio5;
     let cs = io.pins.gpio11;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);

--- a/esp32h2-hal/examples/spi_loopback_dma.rs
+++ b/esp32h2-hal/examples/spi_loopback_dma.rs
@@ -18,9 +18,8 @@
 
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -45,7 +44,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio3;
     let cs = io.pins.gpio11;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32h2-hal/examples/spi_slave_dma.rs
+++ b/esp32h2-hal/examples/spi_slave_dma.rs
@@ -27,9 +27,8 @@
 
 use esp32h2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -61,7 +60,7 @@ fn main() -> ! {
     master_sclk.set_low().unwrap();
     master_mosi.set_low().unwrap();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32s2-hal/examples/embassy_i2s_read.rs
+++ b/esp32s2-hal/examples/embassy_i2s_read.rs
@@ -17,11 +17,10 @@
 use embassy_executor::Spawner;
 use esp32s2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy::{self},
     i2s::{asynch::*, DataFormat, I2s, Standard},
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -52,7 +51,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.i2s0channel;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32s2-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s2-hal/examples/embassy_i2s_sound.rs
@@ -34,11 +34,10 @@
 use embassy_executor::Spawner;
 use esp32s2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy::{self},
     i2s::{asynch::*, DataFormat, I2s, Standard},
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -77,7 +76,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.i2s0channel;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32s2-hal/examples/embassy_spi.rs
+++ b/esp32s2-hal/examples/embassy_spi.rs
@@ -22,10 +22,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{DmaPriority, *},
     dma_descriptors,
     embassy::{self},
-    pdma::*,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -61,7 +60,7 @@ async fn main(_spawner: Spawner) {
     let mosi = io.pins.gpio35;
     let cs = io.pins.gpio34;
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.spi2channel;
 
     let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);

--- a/esp32s2-hal/examples/i2s_read.rs
+++ b/esp32s2-hal/examples/i2s_read.rs
@@ -15,10 +15,9 @@
 
 use esp32s2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -34,7 +33,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.i2s0channel;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32s2-hal/examples/i2s_sound.rs
+++ b/esp32s2-hal/examples/i2s_sound.rs
@@ -32,10 +32,9 @@
 
 use esp32s2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     IO,
@@ -58,7 +57,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.i2s0channel;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32s2-hal/examples/qspi_flash.rs
+++ b/esp32s2-hal/examples/qspi_flash.rs
@@ -19,10 +19,9 @@
 
 use esp32s2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -49,7 +48,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio15;
     let cs = io.pins.gpio16;
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.spi2channel;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);

--- a/esp32s2-hal/examples/spi_loopback_dma.rs
+++ b/esp32s2-hal/examples/spi_loopback_dma.rs
@@ -18,10 +18,9 @@
 
 use esp32s2_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
-    pdma::Dma,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -45,7 +44,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio35;
     let cs = io.pins.gpio34;
 
-    let dma = Dma::new(system.dma);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.spi2channel;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32s3-hal/examples/aes_dma.rs
+++ b/esp32s3-hal/examples/aes_dma.rs
@@ -13,8 +13,7 @@ use esp32s3_hal::{
         Mode,
     },
     clock::ClockControl,
-    dma::{DmaDescriptor, DmaPriority},
-    gdma::Gdma,
+    dma::{Dma, DmaDescriptor, DmaPriority},
     peripherals::Peripherals,
     prelude::*,
     systimer::SystemTimer,
@@ -28,7 +27,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut descriptors = [DmaDescriptor::EMPTY; 1];

--- a/esp32s3-hal/examples/embassy_i2s_read.rs
+++ b/esp32s3-hal/examples/embassy_i2s_read.rs
@@ -18,10 +18,9 @@
 use embassy_executor::Spawner;
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy::{self},
-    gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -53,7 +52,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);

--- a/esp32s3-hal/examples/embassy_i2s_sound.rs
+++ b/esp32s3-hal/examples/embassy_i2s_sound.rs
@@ -34,10 +34,9 @@
 use embassy_executor::Spawner;
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
     embassy::{self},
-    gdma::Gdma,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -77,7 +76,7 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);

--- a/esp32s3-hal/examples/embassy_spi.rs
+++ b/esp32s3-hal/examples/embassy_spi.rs
@@ -22,10 +22,9 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{DmaPriority, *},
     dma_descriptors,
     embassy::{self},
-    gdma::*,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -61,7 +60,7 @@ async fn main(_spawner: Spawner) {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);

--- a/esp32s3-hal/examples/i2s_read.rs
+++ b/esp32s3-hal/examples/i2s_read.rs
@@ -16,9 +16,8 @@
 
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -35,7 +34,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4 * 4092);

--- a/esp32s3-hal/examples/i2s_sound.rs
+++ b/esp32s3-hal/examples/i2s_sound.rs
@@ -32,8 +32,7 @@
 
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::{DmaDescriptor, DmaPriority},
-    gdma::Gdma,
+    dma::{Dma, DmaDescriptor, DmaPriority},
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
@@ -57,7 +56,7 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let mut tx_descriptors = [DmaDescriptor::EMPTY; 20];

--- a/esp32s3-hal/examples/lcd_i8080.rs
+++ b/esp32s3-hal/examples/lcd_i8080.rs
@@ -21,9 +21,8 @@
 
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     lcd_cam::{
         lcd::i8080::{Config, TxEightBits, I8080},
@@ -50,7 +49,7 @@ fn main() -> ! {
     let lcd_wr = io.pins.gpio47; // Write clock
     let _lcd_te = io.pins.gpio48; // Frame sync
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32678, 0);

--- a/esp32s3-hal/examples/qspi_flash.rs
+++ b/esp32s3-hal/examples/qspi_flash.rs
@@ -19,9 +19,8 @@
 
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -49,7 +48,7 @@ fn main() -> ! {
     let sio3 = io.pins.gpio15;
     let cs = io.pins.gpio16;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);

--- a/esp32s3-hal/examples/spi_loopback_dma.rs
+++ b/esp32s3-hal/examples/spi_loopback_dma.rs
@@ -18,9 +18,8 @@
 
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -45,7 +44,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio7;
     let cs = io.pins.gpio10;
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);

--- a/esp32s3-hal/examples/spi_slave_dma.rs
+++ b/esp32s3-hal/examples/spi_slave_dma.rs
@@ -27,9 +27,8 @@
 
 use esp32s3_hal::{
     clock::ClockControl,
-    dma::DmaPriority,
+    dma::{Dma, DmaPriority},
     dma_buffers,
-    gdma::Gdma,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -61,7 +60,7 @@ fn main() -> ! {
     master_sclk.set_low().unwrap();
     master_mosi.set_low().unwrap();
 
-    let dma = Gdma::new(peripherals.DMA);
+    let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);


### PR DESCRIPTION
tl;dr of this is that the peripheral driver is now called `Dma`, regardless of whether the underlying peripheral is PDMA or GDMA, and the constructor also now takes a (sometimes virtual) peripheral singleton in its constructor for all devices. The `Dma` struct is not longer split from `peripherals.SYSTEM` on devices with PDMA.