### PR TITLE
Fix `get_raw_core` on Xtensa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix embassy-time tick rate not set when using systick as the embassy timebase (#1124)
+- Fix `get_raw_core` on Xtensa (#1126)
 
 ### Changed
 

--- a/esp-hal-common/src/lib.rs
+++ b/esp-hal-common/src/lib.rs
@@ -221,7 +221,7 @@ fn get_raw_core() -> usize {
 
 #[cfg(xtensa)]
 fn get_raw_core() -> usize {
-    xtensa_lx::get_processor_id() as usize & 0x2000
+    ((xtensa_lx::get_processor_id() as usize & 0x2000) != 0) as usize
 }
 
 mod critical_section_impl {


### PR DESCRIPTION
Fixes the crash on dual core Xtensa platforms