### PR TITLE
Add docs.rs metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix embassy-time tick rate not set when using systick as the embassy timebase (#1124)
 - Fix `get_raw_core` on Xtensa (#1126)
+- Fix docs.rs documentation builds (#1129)
 
 ### Changed
 

--- a/esp32c2-hal/Cargo.toml
+++ b/esp32c2-hal/Cargo.toml
@@ -20,6 +20,9 @@ categories = [
     "no-std",
 ]
 
+[package.metadata.docs.rs]
+targets = ["riscv32imc-unknown-none-elf"]
+
 [dependencies]
 document-features   = "0.2.7"
 esp-hal-common      = { version = "0.15.0", features = ["esp32c2"], path = "../esp-hal-common" }

--- a/esp32c3-hal/Cargo.toml
+++ b/esp32c3-hal/Cargo.toml
@@ -20,6 +20,9 @@ categories = [
     "no-std",
 ]
 
+[package.metadata.docs.rs]
+targets = ["riscv32imc-unknown-none-elf"]
+
 [dependencies]
 document-features   = "0.2.7"
 esp-hal-common      = { version = "0.15.0", features = ["esp32c3"], path = "../esp-hal-common" }

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 
 [package.metadata.docs.rs]
-targets = ["riscv32imc-unknown-none-elf"]
+targets = ["riscv32imac-unknown-none-elf"]
 
 [dependencies]
 document-features   = "0.2.7"

--- a/esp32c6-hal/Cargo.toml
+++ b/esp32c6-hal/Cargo.toml
@@ -20,6 +20,9 @@ categories = [
     "no-std",
 ]
 
+[package.metadata.docs.rs]
+targets = ["riscv32imc-unknown-none-elf"]
+
 [dependencies]
 document-features   = "0.2.7"
 esp-hal-common      = { version = "0.15.0", features = ["esp32c6"], path = "../esp-hal-common" }

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 
 [package.metadata.docs.rs]
-targets = ["riscv32imc-unknown-none-elf"]
+targets = ["riscv32imac-unknown-none-elf"]
 
 [dependencies]
 document-features   = "0.2.7"

--- a/esp32h2-hal/Cargo.toml
+++ b/esp32h2-hal/Cargo.toml
@@ -20,6 +20,9 @@ categories = [
     "no-std",
 ]
 
+[package.metadata.docs.rs]
+targets = ["riscv32imc-unknown-none-elf"]
+
 [dependencies]
 document-features   = "0.2.7"
 esp-hal-common      = { version = "0.15.0", features = ["esp32h2"], path = "../esp-hal-common" }

--- a/esp32p4-hal/Cargo.toml
+++ b/esp32p4-hal/Cargo.toml
@@ -20,6 +20,9 @@ categories = [
     "no-std",
 ]
 
+[package.metadata.docs.rs]
+targets = ["riscv32imc-unknown-none-elf"]
+
 [dependencies]
 document-features   = "0.2.7"
 esp-hal-common      = { version = "0.15.0", features = ["esp32p4"], path = "../esp-hal-common" }

--- a/esp32p4-hal/Cargo.toml
+++ b/esp32p4-hal/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 
 [package.metadata.docs.rs]
-targets = ["riscv32imc-unknown-none-elf"]
+targets = ["riscv32imafc-unknown-none-elf"]
 
 [dependencies]
 document-features   = "0.2.7"


### PR DESCRIPTION
The riscv docs are broken on docs.rs. I think it's because of the atomics changes, since docs.rs defaults to x86_64, which portable-atomics doesn't support.

This pr sets the target specifically for all the riscv hals. It's hard to check for sure whether this fixes the docs without doing a release, but at least I tried the docs.rs build locally and it worked.

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
