### PR TITLE
Rename the ADC constructor to `new`, make it infallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ADC` and `DAC` drivers now take virtual peripherals in their constructors, instead of splitting `APB_SARADC`/`SENS` (#1100)
 - The `DAC` driver's constructor is now `new` instead of `dac`, to be more consistent with other APIs (#1100)
 - The DMA peripheral is now called `Dma` for devices with both PDMA and GDMA controllers (#1125)
+- The `ADC` driver's constructor is now `new` instead of `adc`, to be more consistent with other APIs (#1133)
 
 ## [0.15.0] - 2024-01-19
 

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -256,10 +256,10 @@ impl<'d, ADCI> ADC<'d, ADCI>
 where
     ADCI: RegisterAccess,
 {
-    pub fn adc(
+    pub fn new(
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
-    ) -> Result<Self, ()> {
+    ) -> Self {
         let sensors = unsafe { &*SENS::ptr() };
 
         // Set reading and sampling resolution
@@ -322,13 +322,11 @@ where
             .sar_read_ctrl2()
             .modify(|_, w| w.sar2_data_inv().set_bit());
 
-        let adc = ADC {
+        ADC {
             _adc: adc_instance.into_ref(),
             attenuations: config.attenuations,
             active_channel: None,
-        };
-
-        Ok(adc)
+        }
     }
 }
 

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! ```no_run
 //! let mut adc1_config = AdcConfig::new();
-//! let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+//! let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 //! let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
 //!
 //! let mut delay = Delay::new(&clocks);

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -490,14 +490,13 @@ impl<'d, ADCI> ADC<'d, ADCI>
 where
     ADCI: RegisterAccess + 'd,
 {
-    pub fn adc(
+    pub fn new(
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
-    ) -> Result<Self, ()> {
+    ) -> Self {
         PeripheralClockControl::enable(Peripheral::ApbSarAdc);
 
-        let sar_adc = unsafe { &*APB_SARADC::PTR };
-        sar_adc.ctrl().modify(|_, w| unsafe {
+        unsafe { &*APB_SARADC::PTR }.ctrl().modify(|_, w| unsafe {
             w.saradc_start_force()
                 .set_bit()
                 .saradc_start()
@@ -507,13 +506,12 @@ where
                 .saradc_xpd_sar_force()
                 .bits(0b11)
         });
-        let adc = ADC {
+
+        ADC {
             _adc: adc_instance.into_ref(),
             attenuations: config.attenuations,
             active_channel: None,
-        };
-
-        Ok(adc)
+        }
     }
 }
 

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -524,10 +524,10 @@ impl<'d, ADCI> ADC<'d, ADCI>
 where
     ADCI: RegisterAccess,
 {
-    pub fn adc(
+    pub fn new(
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
-    ) -> Result<Self, ()> {
+    ) -> Self {
         let sensors = unsafe { &*SENS::ptr() };
 
         // Set attenuation for pins
@@ -592,13 +592,11 @@ where
             .sar_amp_ctrl2()
             .modify(|_, w| unsafe { w.sar_amp_wait3().bits(1) });
 
-        let adc = ADC {
+        ADC {
             _adc: adc_instance.into_ref(),
             attenuations: config.attenuations,
             active_channel: None,
-        };
-
-        Ok(adc)
+        }
     }
 }
 

--- a/esp32-hal/examples/adc.rs
+++ b/esp32-hal/examples/adc.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let mut adc2_config = AdcConfig::new();
     let mut pin25 =
         adc2_config.enable_pin(io.pins.gpio25.into_analog(), Attenuation::Attenuation11dB);
-    let mut adc2 = ADC::<ADC2>::adc(peripherals.ADC2, adc2_config).unwrap();
+    let mut adc2 = ADC::<ADC2>::new(peripherals.ADC2, adc2_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c2-hal/examples/adc.rs
+++ b/esp32c2-hal/examples/adc.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
     // Create ADC instances
     let mut adc1_config = AdcConfig::new();
     let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c2-hal/examples/adc_cal.rs
+++ b/esp32c2-hal/examples/adc_cal.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
         io.pins.gpio2.into_analog(),
         Attenuation::Attenuation11dB,
     );
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c3-hal/examples/adc.rs
+++ b/esp32c3-hal/examples/adc.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
     // Create ADC instances
     let mut adc1_config = AdcConfig::new();
     let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c3-hal/examples/adc_cal.rs
+++ b/esp32c3-hal/examples/adc_cal.rs
@@ -40,7 +40,7 @@ fn main() -> ! {
         io.pins.gpio2.into_analog(),
         Attenuation::Attenuation11dB,
     );
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c6-hal/examples/adc.rs
+++ b/esp32c6-hal/examples/adc.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
     // Create ADC instances
     let mut adc1_config = AdcConfig::new();
     let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32c6-hal/examples/adc_cal.rs
+++ b/esp32c6-hal/examples/adc_cal.rs
@@ -40,7 +40,7 @@ fn main() -> ! {
         io.pins.gpio2.into_analog(),
         Attenuation::Attenuation11dB,
     );
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32h2-hal/examples/adc.rs
+++ b/esp32h2-hal/examples/adc.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
     // Create ADC instances
     let mut adc1_config = AdcConfig::new();
     let mut pin = adc1_config.enable_pin(io.pins.gpio2.into_analog(), Attenuation::Attenuation11dB);
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32s2-hal/examples/adc.rs
+++ b/esp32s2-hal/examples/adc.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let mut adc1_config = AdcConfig::new();
     let mut pin3 =
         adc1_config.enable_pin(io.pins.gpio3.into_analog(), Attenuation::Attenuation11dB);
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32s3-hal/examples/adc.rs
+++ b/esp32s3-hal/examples/adc.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let mut adc1_config = AdcConfig::new();
     let mut pin3 =
         adc1_config.enable_pin(io.pins.gpio3.into_analog(), Attenuation::Attenuation11dB);
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 

--- a/esp32s3-hal/examples/adc_cal.rs
+++ b/esp32s3-hal/examples/adc_cal.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
         io.pins.gpio3.into_analog(),
         Attenuation::Attenuation11dB,
     );
-    let mut adc1 = ADC::<ADC1>::adc(peripherals.ADC1, adc1_config).unwrap();
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 
     let mut delay = Delay::new(&clocks);
 


### PR DESCRIPTION
I somehow missed this in #1100, but just giving `ADC` the same treatment that `DAC` got with respect to its constructor.