### PR TITLE
Adding clock support for `ESP32-P4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow for splitting of the USB Serial JTAG peripheral into tx/rx components (#1024)
 - `RngCore` trait is implemented (#1122)
 - Support Rust's `stack-protector` feature (#1135)
+- Adding clock support for `ESP32-P4` (#1145)
 
 ### Fixed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -65,9 +65,9 @@ ufmt-write = { version = "0.1.0", optional = true }
 esp32   = { version = "0.28.0", features = ["critical-section"], optional = true }
 esp32c2 = { version = "0.17.0", features = ["critical-section"], optional = true }
 esp32c3 = { version = "0.20.0", features = ["critical-section"], optional = true }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a066f0e", features = ["critical-section"], optional = true }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a066f0e", features = ["critical-section"], optional = true }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a066f0e", features = ["critical-section"], optional = true }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "9cd33c6", features = ["critical-section"], optional = true }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "9cd33c6", features = ["critical-section"], optional = true }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "9cd33c6", features = ["critical-section"], optional = true }
 esp32s2 = { version = "0.19.0", features = ["critical-section"], optional = true }
 esp32s3 = { version = "0.23.0", features = ["critical-section"], optional = true }
 

--- a/esp-hal/ld/esp32p4/rom-functions.x
+++ b/esp-hal/ld/esp32p4/rom-functions.x
@@ -1,0 +1,3 @@
+ets_update_cpu_frequency = 0x4fc00044;
+ets_printf = 0x4fc00024;
+PROVIDE(ets_delay_us = 0x4fc0003c);

--- a/esp-hal/src/clock/clocks_ll/esp32p4.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32p4.rs
@@ -1,1 +1,246 @@
+use crate::clock::{PllClock, XtalClock};
 
+const DR_REG_LPPERIPH_BASE: u32 = 0x50120000;
+const DR_REG_I2C_ANA_MST_BASE: u32 = DR_REG_LPPERIPH_BASE + 0x4000;
+
+const LPPERI_CLK_EN_REG: u32 = DR_REG_LPPERIPH_BASE + 0x0;
+const LPPERI_CK_EN_LP_I2CMST: u32 = 1 << 27;
+
+const I2C_CPLL_OC_DCHGP_LSB: u8 = 4;
+const I2C_CPLL_OC_ENB_FCAL_LSB: u8 = 7;
+const I2C_CPLL_OC_DLREF_SEL_LSB: u8 = 6;
+const I2C_CPLL_OC_DHREF_SEL_LSB: u8 = 4;
+const I2C_ANA_MST_CLK160M_REG: u32 = DR_REG_I2C_ANA_MST_BASE + 0x34;
+const I2C_ANA_MST_CLK_I2C_MST_SEL_160M: u32 = 1 << 0;
+
+const I2C_CPLL: u8 = 0x67;
+const I2C_CPLL_HOSTID: u8 = 0;
+const I2C_CPLL_OC_REF_DIV: u8 = 2;
+const I2C_CPLL_OC_DIV_7_0: u8 = 3;
+const I2C_CPLL_OC_DCUR: u8 = 6;
+
+const I2C_ANA_MST_ANA_CONF1_REG: u32 = DR_REG_I2C_ANA_MST_BASE + 0x1C;
+const I2C_ANA_MST_ANA_CONF1: u32 = 0x00FFFFFF;
+const I2C_ANA_MST_ANA_CONF1_V: u32 = 0xFFFFFF;
+const I2C_ANA_MST_ANA_CONF1_S: u32 = 0;
+
+const I2C_ANA_MST_ANA_CONF2_REG: u32 = DR_REG_I2C_ANA_MST_BASE + 0x20;
+const I2C_ANA_MST_ANA_CONF2: u32 = 0x00FFFFFF;
+const I2C_ANA_MST_ANA_CONF2_V: u32 = 0xFFFFFF;
+const I2C_ANA_MST_ANA_CONF2_S: u32 = 0;
+
+const REGI2C_RTC_SLAVE_ID_V: u8 = 0xFF;
+const REGI2C_RTC_SLAVE_ID_S: u8 = 0;
+const REGI2C_RTC_ADDR_V: u8 = 0xFF;
+const REGI2C_RTC_ADDR_S: u8 = 8;
+const REGI2C_RTC_WR_CNTL_V: u8 = 0x1;
+const REGI2C_RTC_WR_CNTL_S: u8 = 24;
+const REGI2C_RTC_DATA_V: u8 = 0xFF;
+const REGI2C_RTC_DATA_S: u8 = 16;
+const REGI2C_RTC_BUSY: u32 = 1 << 25;
+
+const I2C_ANA_MST_I2C0_CTRL_REG: u32 = DR_REG_I2C_ANA_MST_BASE + 0x0;
+
+const DR_REG_LPAON_BASE: u32 = 0x50110000;
+const DR_REG_PMU_BASE: u32 = DR_REG_LPAON_BASE = 0x5000;
+const PMU_IMM_HP_CK_POWER: u32 = DR_REG_PMU_BASE + 0xcc;
+const PMU_TIE_HIGH_XPD_CPLL: u32 = 1 << 27;
+const PMU_TIE_HIGH_XPD_CPLL_I2C: u32 = 1 << 23;
+const PMU_TIE_HIGH_GLOBAL_CPLL_ICG: u32 = 1 << 17;
+
+const DR_REG_HPPERIPH1_BASE: u32 = 0x500C0000;
+const DR_REG_HP_SYS_CLKRST_BASE: u32 = DR_REG_HPPERIPH1_BASE + 0x26000;
+const HP_SYS_CLKRST_ANA_PLL_CTRL0: u32 = DR_REG_HP_SYS_CLKRST_BASE + 0xbc;
+const HP_SYS_CLKRST_REG_CPU_PLL_CAL_STOP: u32 = 1 << 3;
+
+const REGI2C_DIG_REG: u8 = 0x6d;
+const REGI2C_CPU_PLL: u8 = 0x67;
+const REGI2C_SDIO_PLL: u8 = 0x62;
+const REGI2C_BIAS: u8 = 0x6a;
+const REGI2C_MSPI: u8 = 0x63;
+const REGI2C_SYS_PLL: u8 = 0x66;
+const REGI2C_PLLA: u8 = 0x6f;
+const REGI2C_SAR_I2C: u8 = 0x69;
+
+const REGI2C_DIG_REG_MST_SEL: u32 = 1 << 10;
+const REGI2C_PLL_CPU_MST_SEL: u32 = 1 << 11;
+const REGI2C_PLL_SDIO_MST_SEL: u32 = 1 << 6;
+const REGI2C_BIAS_MST_SEL: u32 = 1 << 12;
+const REGI2C_MSPI_XTAL_MST_SEL: u32 = 1 << 9;
+const REGI2C_PLL_SYS_MST_SEL: u32 = 1 << 5;
+const REGI2C_PLLA_MST_SEL: u32 = 1 << 8;
+const REGI2C_SAR_I2C_MST_SEL: u32 = 1 << 7;
+
+// rtc_clk.c (L125) -> clk_tree_ll.h
+pub(crate) fn esp32p4_rtc_cpll_enable() {
+    (PMU_IMM_HP_CK_POWER as *mut u32).write_volatile(
+        (PMU_IMM_HP_CK_POWER as *mut u32).read_volatile()
+            | (PMU_TIE_HIGH_XPD_CPLL | PMU_TIE_HIGH_XPD_CPLL_I2C),
+    );
+
+    (PMU_IMM_HP_CK_POWER as *mut u32).write_volatile(
+        (PMU_IMM_HP_CK_POWER as *mut u32).read_volatile() | PMU_TIE_HIGH_GLOBAL_CPLL_ICG,
+    )
+}
+
+// rtc_clk.c (L136)
+pub(crate) fn esp32p4_rtc_cpll_configure(_xtal_freq: XtalClock, _cpll_freq: PllClock) {
+    // CPLL CALIBRATION START
+    (HP_SYS_CLKRST_ANA_PLL_CTRL0_REG as *mut u32).write_volatile(
+        (HP_SYS_CLKRST_ANA_PLL_CTRL0_REG as *mut u32).read_volatile()
+            | !HP_SYS_CLKRST_REG_CPU_PLL_CAL_STOP,
+    );
+
+    // Set configuration
+    let oc_div_ref = 0u32;
+    let div = 1u32;
+    let dcur = 3u32;
+    let dchgp = 5u32;
+    let enb_fcal = 0u32;
+
+    // Currently only supporting 40MHz XTAL
+    assert!(xtal_freq == XtalClock::RtcXtalFreq40M);
+
+    match cpll_freq {
+        PllClock::Pll400MHz => {
+            div = 6u32;
+            dif_ref = 0u32;
+        }
+        PllClock::Pll360MHz => {
+            div = 5u32;
+            div_ref = 0u32;
+        }
+    }
+
+    let i2c_cpll_lref =
+        (oc_enb_fcal << I2C_CPLL_OC_ENB_FCAL_LSB) | (dchgp << I2C_CPLL_OC_DCHGP_LSB) | (dif_ref);
+
+    let i2c_cpll_dcur = (1 << I2C_CPLL_OC_DLREF_SEL_LSB) | (3 << I2C_CPLL_OC_DHREF_SEL_LSB) | dcur;
+
+    regi2c_write(
+        I2C_CPLL,
+        I2C_CPLL_HOSTID,
+        I2C_CPLL_OC_REF_DIV,
+        i2c_cpll_lref,
+    );
+
+    regi2c_write(I2C_CPLL, I2C_CPLL_HOSTID, I2C_CPLL_OC_DIV_7_0, div);
+
+    regi2c_write(I2C_CPLL, I2C_CPLL_HOSTID, I2C_CPLL_OC_DCUR, i2c_cpll_dcur);
+}
+
+// esp_rom_regi2c_esp32p4.c (L84)
+fn regi2c_enable_block(block: u8) {
+    reg_set_bit(LPPERI_CLK_EN_REG, LPPERI_CK_EN_LP_I2CMST);
+    set_peri_reg_mask(I2C_ANA_MST_CLK160M_REG, I2C_ANA_MST_CLK_I2C_MST_SEL_160M);
+
+    reg_set_field(
+        I2C_ANA_MST_ANA_CONF2_REG,
+        I2C_ANA_MST_ANA_CONF2_V,
+        I2C_ANA_MST_ANA_CONF2_S,
+        0,
+    );
+
+    reg_set_field(
+        I2C_ANA_MST_ANA_CONF1_REG,
+        I2C_ANA_MST_ANA_CONF1_V,
+        I2C_ANA_MST_ANA_CONF1_S,
+        0,
+    );
+
+    match block {
+        REGI2C_DIG_REG => {
+            reg_set_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_DIG_REG_MST_SEL);
+        }
+        REGI2C_CPU_PLL => {
+            reg_set_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_PLL_CPU_MST_SEL);
+        }
+        REGI2C_SDIO_PLL => {
+            reg_set_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_PLL_SDIO_MST_SEL);
+        }
+        REGI2C_BIAS => {
+            reg_set_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_BIAS_MST_SEL);
+        }
+        REGI2C_MSPI => {
+            reg_set_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_MSPI_XTAL_MST_SEL);
+        }
+        REGI2C_SYS_PLL => {
+            reg_set_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_PLL_SYS_MST_SEL);
+        }
+        REGI2C_PLLA => {
+            reg_set_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_PLLA_MST_SEL);
+        }
+        REGI2C_SAR_I2C => {
+            reg_set_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_SAR_I2C_MST_SEL);
+        }
+        _ => (),
+    }
+}
+
+fn regi2c_disable_block(block: u8) {
+    match block {
+        REGI2C_DIG_REG => {
+            reg_clr_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_DIG_REG_MST_SEL);
+        }
+        REGI2C_CPU_PLL => {
+            reg_clr_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_PLL_CPU_MST_SEL);
+        }
+        REGI2C_SDIO_PLL => {
+            reg_clr_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_PLL_SDIO_MST_SEL);
+        }
+        REGI2C_BIAS => {
+            reg_clr_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_BIAS_MST_SEL);
+        }
+        REGI2C_MSPI => {
+            reg_clr_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_MSPI_XTAL_MST_SEL);
+        }
+        REGI2C_SYS_PLL => {
+            reg_clr_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_PLL_SYS_MST_SEL);
+        }
+        REGI2C_PLLA => {
+            reg_clr_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_PLLA_MST_SEL);
+        }
+        REGI2C_SAR_I2C => {
+            reg_clr_bit(I2C_ANA_MST_ANA_CONF2_REG, REGI2C_SAR_I2C_MST_SEL);
+        }
+        _ => (),
+    }
+}
+
+pub(crate) fn regi2c_write(block: u8, _host_id: u8, reg_add: u8, data: u8) {
+    regi2c_enable_block(block);
+
+    let temp: u32 = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32) << REGI2C_RTC_SLAVE_ID_S as u32)
+    | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32)
+    | ((0x1 & REGI2C_RTC_WR_CNTL_V as u32) << REGI2C_RTC_WR_CNTL_S as u32) // 0: READ I2C register; 1: Write I2C register;
+    | (((data as u32) & REGI2C_RTC_DATA_V as u32) << REGI2C_RTC_DATA_S as u32);
+    reg_write(LP_I2C_ANA_MST_I2C0_CTRL_REG, temp);
+    while reg_get_bit(I2C_ANA_MST_I2C0_CTRL_REG, REGI2C_RTC_BUSY) != 0 {}
+
+    regi2c_disable_block(block);
+}
+
+fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
+    (reg as *mut u32).write_volatile(
+        ((reg as *mut u32).read_volatile() & !(field_v << field_s))
+            | ((value & field_v) << field_s),
+    )
+}
+
+fn reg_set_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
+    }
+}
+
+fn reg_clr_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
+    }
+}
+
+fn set_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
+    }
+}

--- a/esp-hal/src/clock/clocks_ll/esp32p4.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32p4.rs
@@ -175,14 +175,15 @@ pub(crate) fn esp32p4_rtc_update_to_xtal(freq: XtalClock, div: u8, default: bool
         sys_divider = 2u32;
     }
 
-    //clk_ll_cpu_set_src(SOC_CPU_CLK_SRC_XTAL -> 0)
+    // clk_ll_cpu_set_src(SOC_CPU_CLK_SRC_XTAL -> 0)
     unsafe {
         (&*crate::soc::peripherals::LP_AON_CLKRST::PTR)
             .lp_aonclkrst_hp_clk_ctrl()
             .modify(|_, w| w.lp_aonclkrst_hp_root_clk_src_sel().bits(0b00))
     }
 
-    // clk_ll_cpu_set_divider(div, 0, 0) -> clk_tree_ll.h(comp/hal/p4/include/hal/L407)
+    // clk_ll_cpu_set_divider(div, 0, 0) ->
+    // clk_tree_ll.h(comp/hal/p4/include/hal/L407)
     assert!(div >= 1 && (div as u32) < HP_SYS_CLKRST_REG_CPU_CLK_DIV_NUM_V);
 
     // Set CPU divider
@@ -282,14 +283,14 @@ pub(crate) fn esp32p4_rtc_freq_to_cpll_mhz(cpu_clock_speed: CpuClock) {
     // CPLL -> CPU_CLK -> MEM_CLK -> SYS_CLK -> APB_CLK
     // Constraint: MEM_CLK <= 200MHz, APB_CLK <= 100MHz
     // This implies that when clock source is CPLL,
-    //                   If cpu_divider < 2, mem_divider must be larger or equal to 2
-    //                   If cpu_divider < 2, mem_divider = 2, sys_divider < 2, apb_divider must be larger or equal to 2
-    // Current available configurations:
-    // 360  -   360   -    180    -    180   -    90
+    //                   If cpu_divider < 2, mem_divider must be larger or equal to
+    // 2                   If cpu_divider < 2, mem_divider = 2, sys_divider < 2,
+    // apb_divider must be larger or equal to 2 Current available
+    // configurations: 360  -   360   -    180    -    180   -    90
     // 360  -   180   -    180    -    180   -    90
     // 360  -   90    -    90     -    90    -    90
 
-    //freq_mhz_to_config part (rtc_clk.c L251)
+    // freq_mhz_to_config part (rtc_clk.c L251)
 
     // rtc_clk_xtal_freq_get() -> xtal_load_freq_mhz()
     let xtal_freq_reg = unsafe { (RTC_XTAL_FREQ_REG as *mut u32).read_volatile() as u32 };

--- a/esp-hal/src/clock/clocks_ll/esp32p4.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32p4.rs
@@ -2,6 +2,8 @@ use crate::clock::{Clock, CpuClock, PllClock, XtalClock};
 
 extern "C" {
     fn ets_update_cpu_frequency(ticks_per_us: u32);
+    fn ets_delay_us(delay: u32);
+
 }
 
 const DR_REG_LPAON_BASE: u32 = 0x50110000;
@@ -155,7 +157,9 @@ pub(crate) fn esp32p4_rtc_cpll_configure(xtal_freq: XtalClock, cpll_freq: PllClo
     ) == 1
     {}
 
-    // TODO requires sleep
+    unsafe {
+        ets_delay_us(10);
+    }
 
     // CPLL calibration stop
     set_peri_reg_mask(

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -684,15 +684,14 @@ impl<'d> ClockControl<'d> {
         if cpu_clock_speed.mhz() <= xtal_freq.mhz() {
             apb_freq = ApbClock::ApbFreqOther(cpu_clock_speed.mhz());
             clocks_ll::esp32p4_rtc_update_to_xtal(xtal_freq, 1, true);
-            // clocks_ll::esp32p4_rtc_apb_freq_update(apb_freq);
         } else {
             apb_freq = ApbClock::ApbFreq100MHz;
             clocks_ll::esp32p4_rtc_cpll_enable();
-            // Calibrate CPLL freq to a new value requires to switch CPU clock source to XTAL first
+            // Calibrate CPLL freq to a new value requires to switch CPU clock source to
+            // XTAL first
             clocks_ll::esp32p4_rtc_update_to_xtal(xtal_freq, 1, false);
             clocks_ll::esp32p4_rtc_cpll_configure(xtal_freq, pll_freq);
-            clocks_ll::esp32p4_rtc_freq_to_cpll_mhz(cpu_clock_speed); // rtc_clk_cpu_freq_mhz_to_config blocking
-                                                                      // clocks_ll::esp32p4_rtc_apb_freq_update(apb_freq);
+            clocks_ll::esp32p4_rtc_freq_to_cpll_mhz(cpu_clock_speed);
         }
 
         ClockControl {

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -171,6 +171,8 @@ pub(crate) enum PllClock {
     #[cfg(not(any(esp32c2, esp32c6, esp32h2, esp32p4)))]
     Pll320MHz,
     #[cfg(esp32p4)]
+    Pll360MHz,
+    #[cfg(esp32p4)]
     Pll400MHz,
     #[cfg(not(esp32h2))]
     Pll480MHz,

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -111,14 +111,20 @@ impl Clock for CpuClock {
         match self {
             #[cfg(not(any(esp32h2, esp32p4)))]
             CpuClock::Clock80MHz => HertzU32::MHz(80),
+            #[cfg(esp32p4)]
+            CpuClock::Clock90MHz => HertzU32::MHz(90),
             #[cfg(esp32h2)]
             CpuClock::Clock96MHz => HertzU32::MHz(96),
             #[cfg(esp32c2)]
             CpuClock::Clock120MHz => HertzU32::MHz(120),
             #[cfg(not(any(esp32c2, esp32h2, esp32p4)))]
             CpuClock::Clock160MHz => HertzU32::MHz(160),
+            #[cfg(esp32p4)]
+            CpuClock::Clock180MHz => HertzU32::MHz(180),
             #[cfg(xtensa)]
             CpuClock::Clock240MHz => HertzU32::MHz(240),
+            #[cfg(esp32p4)]
+            CpuClock::Clock360MHz => HertzU32::MHz(360),
             #[cfg(esp32p4)]
             CpuClock::Clock400MHz => HertzU32::MHz(400),
         }
@@ -207,6 +213,8 @@ impl Clock for PllClock {
             Self::Pll240MHz => HertzU32::MHz(240),
             #[cfg(not(any(esp32c2, esp32c6, esp32h2, esp32p4)))]
             Self::Pll320MHz => HertzU32::MHz(320),
+            #[cfg(esp32p4)]
+            Self::Pll360MHz => HertzU32::MHz(360),
             #[cfg(esp32p4)]
             Self::Pll400MHz => HertzU32::MHz(400),
             #[cfg(not(esp32h2))]
@@ -678,10 +686,10 @@ impl<'d> ClockControl<'d> {
             clocks_ll::esp32p4_rtc_update_to_xtal(xtal_freq, 1, true);
             // clocks_ll::esp32p4_rtc_apb_freq_update(apb_freq);
         } else {
-            // apb_freq = ApbClock::ApbFreq100MHz;
+            apb_freq = ApbClock::ApbFreq100MHz;
             clocks_ll::esp32p4_rtc_cpll_enable();
             // Calibrate CPLL freq to a new value requires to switch CPU clock source to XTAL first
-            clocks_ll::esp32h2_rtc_update_to_xtal(xtal_freq, 1, false);
+            clocks_ll::esp32p4_rtc_update_to_xtal(xtal_freq, 1, false);
             clocks_ll::esp32p4_rtc_cpll_configure(xtal_freq, pll_freq);
             clocks_ll::esp32p4_rtc_freq_to_cpll_mhz(cpu_clock_speed); // rtc_clk_cpu_freq_mhz_to_config blocking
                                                                       // clocks_ll::esp32p4_rtc_apb_freq_update(apb_freq);

--- a/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
@@ -1,0 +1,96 @@
+use fugit::HertzU32;
+use strum::FromRepr;
+
+use crate::clock::Clock;
+
+pub(crate) fn init() {
+    todo!()
+}
+
+pub(crate) fn configure_clock() {
+    todo!()
+}
+
+// Terminology:
+//
+// CPU Reset:    Reset CPU core only, once reset done, CPU will execute from
+//               reset vector
+// Core Reset:   Reset the whole digital system except RTC sub-system
+// System Reset: Reset the whole digital system, including RTC sub-system
+// Chip Reset:   Reset the whole chip, including the analog part
+
+// spc/p4/include/soc/reset_reasons.h
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromRepr)]
+pub enum SocResetReason {
+    /// Power on reset
+    ///
+    /// In ESP-IDF this value (0x01) can *also* be `ChipBrownOut` or
+    /// `ChipSuperWdt`, however that is not really compatible with Rust-style
+    /// enums.
+    ChipPowerOn = 0x01,
+    /// Software resets the digital core by RTC_CNTL_SW_SYS_RST
+    CoreSw = 0x03,
+    /// Deep sleep reset the digital core
+    CoreDeepSleep = 0x05,
+    // PMU HP power down system reset
+    SysPmuPwrDown = 0x05,
+    // PMU HP power down CPU reset
+    CpuPmuPwrDown = 0x06,
+    /// HP watch dog resets system
+    SysHpWdt = 0x07,
+    /// LP watch dog resets system
+    SysLpWdt = 0x09,
+    /// HP watch dog resets digital core
+    CoreHpWdt = 0x0B,
+    /// Software resets CPU 0
+    Cpu0Sw = 0x0C,
+    /// LP watch dog resets digital core
+    CpuLpWdt = 0x0D,
+    /// VDD voltage is not stable and resets the digital core
+    SysBrownOut = 0x0F,
+    /// LP watch dog resets chip
+    ChipLpWdt = 0x10,
+    /// Super watch dog resets the digital core and rtc module
+    SysSuperWdt = 0x12,
+    /// Glitch on clock resets the digital core and rtc module
+    SysClkGlitch = 0x13,
+    /// eFuse CRC error resets the digital core
+    CoreEfuseCrc = 0x14,
+    /// USB JTAG resets the digital core
+    CoreUsbJtag = 0x16,
+    // USB Serial/JTAG controller's UART resets the digital core
+    CoreUsbUart = 0x17,
+    // Glitch on power resets the digital core
+    CpuJtag = 0x18,
+}
+
+/// RTC SLOW_CLK frequency values
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RtcFastClock {}
+
+impl Clock for RtcFastClock {
+    fn frequency(&self) -> HertzU32 {
+        todo!()
+    }
+}
+
+/// RTC SLOW_CLK frequency values
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum RtcSlowClock {}
+
+impl Clock for RtcSlowClock {
+    fn frequency(&self) -> HertzU32 {
+        todo!()
+    }
+}
+
+/// RTC Watchdog Timer
+pub struct RtcClock;
+
+/// RTC Watchdog Timer driver
+impl RtcClock {
+    /// Calculate the necessary RTC_SLOW_CLK cycles to complete 1 millisecond.
+    pub(crate) fn cycles_to_1ms() -> u16 {
+        todo!()
+    }
+}

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -176,7 +176,7 @@ impl SoftwareInterruptControl {
 /// Controls the enablement of peripheral clocks.
 pub(crate) struct PeripheralClockControl;
 
-#[cfg(not(any(esp32c6, esp32h2)))]
+#[cfg(not(any(esp32c6, esp32h2, esp32p4)))]
 impl PeripheralClockControl {
     /// Enables and resets the given peripheral
     pub(crate) fn enable(peripheral: Peripheral) {
@@ -603,6 +603,12 @@ impl PeripheralClockControl {
             }
         }
     }
+}
+
+#[cfg(esp32p4)]
+impl PeripheralClockControl {
+    /// Enables and resets the given peripheral
+    pub(crate) fn enable(_peripheral: Peripheral) {}
 }
 
 /// Controls the configuration of the chip's clocks.

--- a/esp32p4-hal/examples/hello_world.rs
+++ b/esp32p4-hal/examples/hello_world.rs
@@ -10,12 +10,8 @@ use esp_backtrace as _;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock360MHz).freeze();
 
-    let mut delay = Delay::new(&clocks);
-
-    loop {
-        esp_println::println!("Hello, world!");
-        delay.delay_ms(1000 as u32);
-    }
+    esp_println::println!("Hello, world!");
+    loop {}
 }

--- a/esp32p4-hal/examples/hello_world.rs
+++ b/esp32p4-hal/examples/hello_world.rs
@@ -2,7 +2,10 @@
 #![no_main]
 
 use esp32p4_hal::{
-    clock::ClockControl, peripherals::Peripherals, prelude::*, system::SystemExt, Delay,
+    clock::{ClockControl, CpuClock},
+    peripherals::Peripherals,
+    prelude::*,
+    system::SystemExt,
 };
 use esp_backtrace as _;
 
@@ -10,7 +13,7 @@ use esp_backtrace as _;
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock360MHz).freeze();
+    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock90MHz).freeze();
 
     esp_println::println!("Hello, world!");
     loop {}

--- a/esp32p4-hal/examples/hello_world.rs
+++ b/esp32p4-hal/examples/hello_world.rs
@@ -1,11 +1,15 @@
 #![no_std]
 #![no_main]
 
-use esp32p4_hal::prelude::*;
+use esp32p4_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*};
 use esp_backtrace as _;
 
 #[entry]
 fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
     esp_println::println!("Hello, world!");
     loop {}
 }

--- a/esp32p4-hal/examples/hello_world.rs
+++ b/esp32p4-hal/examples/hello_world.rs
@@ -1,7 +1,9 @@
 #![no_std]
 #![no_main]
 
-use esp32p4_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*};
+use esp32p4_hal::{
+    clock::ClockControl, peripherals::Peripherals, prelude::*, system::SystemExt, Delay,
+};
 use esp_backtrace as _;
 
 #[entry]
@@ -10,6 +12,10 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    esp_println::println!("Hello, world!");
-    loop {}
+    let mut delay = Delay::new(&clocks);
+
+    loop {
+        esp_println::println!("Hello, world!");
+        delay.delay_ms(1000 as u32);
+    }
 }


### PR DESCRIPTION
At this point `esp32p4-hal` is not buildable because the patch from `esp-pacs` must be applied to the register description.

The main purpose of this update is to unlock further work on esp32p4 peripherals, so that at some point the implementation of this part can be improved/changed/fixed