### PR TITLE
Remove (unused) heapless dependency

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -29,7 +29,6 @@ embedded-io          = { version = "0.6.1", optional = true }
 enumset              = "1.1.3"
 esp-synopsys-usb-otg = { version = "0.4.0", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
-heapless             = "0.8.0"
 log                  = { version = "0.4.20", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.14"


### PR DESCRIPTION
For some reason we have a dependency on `heapless` we don't use it and we shouldn't use it
