### PR TITLE
esp-hal-smartled: Calculate RMT cycles from runtime clock config

### DIFF
--- a/esp32-hal/examples/hello_rgb.rs
+++ b/esp32-hal/examples/hello_rgb.rs
@@ -40,7 +40,7 @@ fn main() -> ! {
     // LEDs here to initialize the internal LED pulse buffer to the correct
     // size!
     let rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio33, rmt_buffer);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio33, rmt_buffer, &clocks);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
     let rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer, &clocks);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32c6-hal/examples/hello_rgb.rs
+++ b/esp32c6-hal/examples/hello_rgb.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
     let rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, rmt_buffer);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, rmt_buffer, &clocks);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32h2-hal/examples/hello_rgb.rs
+++ b/esp32h2-hal/examples/hello_rgb.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
     let rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, rmt_buffer);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, rmt_buffer, &clocks);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32s2-hal/examples/hello_rgb.rs
+++ b/esp32s2-hal/examples/hello_rgb.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
     let rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio18, rmt_buffer);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio18, rmt_buffer, &clocks);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.

--- a/esp32s3-hal/examples/hello_rgb.rs
+++ b/esp32s3-hal/examples/hello_rgb.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
     let rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio48, rmt_buffer);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio48, rmt_buffer, &clocks);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.


### PR DESCRIPTION
This replaces the hard-coded RMT cycle counts in the smartled driver with runtime calculations from the clock config. It resolves [this TODO](https://github.com/esp-rs/esp-hal/blob/285cfe4c5dbfb027e91e2e11ffbdea2c6a777d9c/esp-hal-smartled/src/lib.rs#L37-L38).

I've maintained the assumption that the RMT clock source is set to the APB, as it is by default (verified using the patch at the bottom of this PR). The only change to the calculation from the original is the final divisor (500 → 1000) as the original constants were half of the actual APB clock.

All my testing was done exclusively on an ESP32-S3 since that's what I've got on hand. The numbers do work out for the other chips, though.

I have not added anything to the changelog since it's not part of `esp-hal-common`/`esp-hal` and is a pretty small change anyway. Happy to add it if that's wanted.

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI

```patch
diff --git a/esp32s3-hal/examples/hello_rgb.rs b/esp32s3-hal/examples/hello_rgb.rs
index 1ef7bea..74c46d5 100644
--- a/esp32s3-hal/examples/hello_rgb.rs
+++ b/esp32s3-hal/examples/hello_rgb.rs
@@ -37,6 +37,18 @@ fn main() -> ! {
     let rmt_buffer = smartLedBuffer!(1);
     let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio48, rmt_buffer, &clocks);
 
+    let rmt_base_addr = 0x6001_6000;
+    let rmt_sys_conf_reg = unsafe { core::ptr::read_volatile((rmt_base_addr + 0x00C0) as *const u32) };
+    let rmt_sclk_sel = (rmt_sys_conf_reg >> 24) & 0b11;
+    let rmt_sclk_sel = match rmt_sclk_sel {
+        0 => "invalid",
+        1 => "APB_CLK",
+        2 => "RC_FAST_CLK",
+        3 => "XTAL_CLK",
+        _ => unreachable!(),
+    };
+    esp_println::println!("RMT_SCLK_SEL = {rmt_sclk_sel}");
+
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.
     let mut delay = Delay::new(&clocks);
```