### PR TITLE
fix esp32c3 uart initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wait for registers to get synced before reading the timer count for all chips (#1183)
 - Fix I2C error handling (#1184)
 - Fix circular DMA (#1189)
+- Fix esp32c3 uart initialization (#1156)
 
 ### Changed
 


### PR DESCRIPTION
Implement uart initialization according to the [esp32c3 technical reference manual section 26.5.2.1](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf#subsubsection.26.5.2)

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI
