### PR TITLE
Remove clippy lint exceptions from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,25 +715,15 @@ jobs:
 
       # Run 'cargo clippy' on all packages targeting RISC-V:
       - name: clippy (esp32c2-hal)
-        run: |
-          cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --features=esp32c2,xtal-40mhz \
-            -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::enum_variant_names -A clippy::field_reassign_with_default
+        run: cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --features=esp32c2,xtal-40mhz -- -D warnings
       - name: clippy (esp32c3-hal)
-        run: |
-          cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --features=esp32c3 \
-            -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::enum_variant_names -A clippy::field_reassign_with_default
+        run: cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imc-unknown-none-elf --features=esp32c3 -- -D warnings
       - name: clippy (esp32c6-hal)
-        run: |
-          cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imac-unknown-none-elf --features=esp32c6 \
-            -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::enum_variant_names -A clippy::field_reassign_with_default
+        run: cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imac-unknown-none-elf --features=esp32c6 -- -D warnings
       - name: clippy (esp32h2-hal)
-        run: |
-          cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imac-unknown-none-elf --features=esp32h2 \
-            -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::enum_variant_names -A clippy::field_reassign_with_default
+        run: cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imac-unknown-none-elf --features=esp32h2 -- -D warnings
       # - name: clippy (esp32p4-hal)
-      #   run: |
-      #     cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imafc-unknown-none-elf --features=esp32p4 \
-      #       -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity -A clippy::enum_variant_names -A clippy::field_reassign_with_default
+      #   run: cargo clippy --manifest-path=esp-hal/Cargo.toml --target=riscv32imafc-unknown-none-elf --features=esp32p4 -- -D warnings
 
       - name: clippy (esp-lp-hal, esp32c6)
         run: cd esp-lp-hal && cargo clippy --features=esp32c6 -- -D warnings
@@ -757,17 +747,11 @@ jobs:
 
       # Run 'cargo clippy' on all packages targeting Xtensa:
       - name: clippy (esp32-hal)
-        run: |
-          cargo clippy -Zbuild-std=core --manifest-path=esp-hal/Cargo.toml --target=xtensa-esp32-none-elf --features=esp32,xtal-40mhz \
-            -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity
+        run: cargo clippy -Zbuild-std=core --manifest-path=esp-hal/Cargo.toml --target=xtensa-esp32-none-elf --features=esp32,xtal-40mhz -- -D warnings
       - name: clippy (esp32s2-hal)
-        run: |
-          cargo clippy -Zbuild-std=core --manifest-path=esp-hal/Cargo.toml --target=xtensa-esp32s2-none-elf --features=esp32s2 \
-            -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity
+        run: cargo clippy -Zbuild-std=core --manifest-path=esp-hal/Cargo.toml --target=xtensa-esp32s2-none-elf --features=esp32s2 -- -D warnings
       - name: clippy (esp32s3-hal)
-        run: |
-          cargo clippy -Zbuild-std=core --manifest-path=esp-hal/Cargo.toml --target=xtensa-esp32s3-none-elf --features=esp32s3 \
-            -- -D warnings -A clippy::too_many_arguments -A clippy::type_complexity
+        run: cargo clippy -Zbuild-std=core --manifest-path=esp-hal/Cargo.toml --target=xtensa-esp32s3-none-elf --features=esp32s3 -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -441,6 +441,7 @@ pub mod dma {
             })
         }
 
+        #[allow(clippy::too_many_arguments)]
         fn start_transfer_dma(
             &mut self,
             write_buffer_ptr: *const u8,

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -161,7 +161,7 @@ impl Clock for XtalClock {
     }
 }
 
-#[allow(unused)]
+#[allow(clippy::enum_variant_names, unused)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum PllClock {
     #[cfg(esp32h2)]

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1170,7 +1170,7 @@ pub trait DmaTransfer<B, T>: Drop {
 }
 
 /// Trait to be implemented for an in progress dma transfer.
-#[allow(drop_bounds)]
+#[allow(clippy::type_complexity, drop_bounds)]
 pub trait DmaTransferRxTx<BR, BT, T>: Drop {
     /// Wait for the transfer to finish.
     fn wait(self) -> Result<(BR, BT, T), (DmaError, BR, BT, T)>;

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -380,6 +380,7 @@ impl<'d> Ecc<'d> {
     ///
     /// This function will return an error if the point is not on the selected
     /// elliptic curve.
+    #[allow(clippy::too_many_arguments)]
     #[cfg(esp32h2)]
     pub fn affine_point_verification_multiplication(
         &mut self,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -970,7 +970,7 @@ pub trait Instance {
         );
     }
 
-    #[allow(unused)]
+    #[allow(clippy::too_many_arguments, unused)]
     fn configure_clock(
         &mut self,
         sclk_div: u32,

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -226,6 +226,7 @@ where
 
     /// Stop for the DMA transfer and return the buffer and the
     /// I2sTx instance.
+    #[allow(clippy::type_complexity)]
     pub fn stop(self) -> Result<(BUFFER, I2sTx<'d, T, CH>), (DmaError, BUFFER, I2sTx<'d, T, CH>)> {
         T::tx_stop();
 
@@ -356,6 +357,7 @@ where
     /// I2sTx instance after copying the read data to the given buffer.
     /// Length of the received data is returned at the third element of the
     /// tuple.
+    #[allow(clippy::type_complexity)]
     pub fn wait_receive(
         mut self,
         dst: &mut [u8],

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -438,6 +438,7 @@ pub struct Transfer<'d, TX: Tx, BUFFER, P> {
 }
 
 impl<'d, TX: Tx, BUFFER, P> Transfer<'d, TX, BUFFER, P> {
+    #[allow(clippy::type_complexity)]
     pub fn wait(
         mut self,
     ) -> Result<(BUFFER, I8080<'d, TX, P>), (DmaError, BUFFER, I8080<'d, TX, P>)> {
@@ -566,6 +567,7 @@ where
     P6: OutputPin,
     P7: OutputPin,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pin_0: impl Peripheral<P = P0> + 'd,
         pin_1: impl Peripheral<P = P1> + 'd,
@@ -678,6 +680,7 @@ where
     P14: OutputPin,
     P15: OutputPin,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pin_0: impl Peripheral<P = P0> + 'd,
         pin_1: impl Peripheral<P = P1> + 'd,

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -488,11 +488,12 @@ macro_rules! tx_pins {
             where
                 $($pin: OutputPin),+
             {
+                #[allow(clippy::too_many_arguments)]
                 pub fn new(
                     $(
                         [< pin_ $pin:lower >] : impl Peripheral<P = $pin> + 'd,
                     )+
-                    ) -> Self {
+                ) -> Self {
                     crate::into_ref!($( [< pin_ $pin:lower >] ),+);
                     Self { $( [< pin_ $pin:lower >] ),+ }
                 }
@@ -731,11 +732,12 @@ macro_rules! rx_pins {
             where
                 $($pin: InputPin),+
             {
+                #[allow(clippy::too_many_arguments)]
                 pub fn new(
                     $(
                         [< pin_ $pin:lower >] : impl Peripheral<P = $pin> + 'd,
                     )+
-                    ) -> Self {
+                ) -> Self {
                     crate::into_ref!($( [< pin_ $pin:lower >] ),+);
                     Self { $( [< pin_ $pin:lower >] ),+ }
                 }
@@ -1239,6 +1241,7 @@ where
 {
     /// Wait for the DMA transfer to complete and return the buffers and the
     /// SPI instance.
+    #[allow(clippy::type_complexity)]
     pub fn wait(
         self,
     ) -> Result<(BUFFER, ParlIoTx<'d, C, P, CP>), (DmaError, BUFFER, ParlIoTx<'d, C, P, CP>)> {
@@ -1355,6 +1358,7 @@ where
 {
     /// Wait for the DMA transfer to complete and return the buffers and the
     /// SPI instance.
+    #[allow(clippy::type_complexity)]
     pub fn wait(
         self,
     ) -> Result<(BUFFER, ParlIoRx<'d, C, P, CP>), (DmaError, BUFFER, ParlIoRx<'d, C, P, CP>)> {

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -662,9 +662,11 @@ impl HpSystemInit {
 
         power.xtal.set_xpd_xtal(true);
 
-        let mut clock = SystemClockParam::default();
-        clock.icg_func = 0xffffffff;
-        clock.icg_apb = 0xffffffff;
+        let mut clock = SystemClockParam {
+            icg_func: 0xffffffff,
+            icg_apb: 0xffffffff,
+            ..SystemClockParam::default()
+        };
         clock.icg_modem.set_code(ICG_MODEM_CODE_ACTIVE);
         clock.sysclk.set_dig_sysclk_nodiv(false);
         clock.sysclk.set_icg_sysclk_en(true);
@@ -754,9 +756,11 @@ impl HpSystemInit {
 
         power.xtal.set_xpd_xtal(true);
 
-        let mut clock = SystemClockParam::default();
-        clock.icg_func = 0;
-        clock.icg_apb = 0;
+        let mut clock = SystemClockParam {
+            icg_func: 0,
+            icg_apb: 0,
+            ..SystemClockParam::default()
+        };
         clock.icg_modem.set_code(ICG_MODEM_CODE_MODEM);
         clock.sysclk.set_dig_sysclk_nodiv(false);
         clock.sysclk.set_icg_sysclk_en(true);
@@ -834,9 +838,11 @@ impl HpSystemInit {
 
         power.xtal.set_xpd_xtal(false);
 
-        let mut clock = SystemClockParam::default();
-        clock.icg_func = 0;
-        clock.icg_apb = 0;
+        let mut clock = SystemClockParam {
+            icg_func: 0,
+            icg_apb: 0,
+            ..SystemClockParam::default()
+        };
         clock.icg_modem.set_code(ICG_MODEM_CODE_SLEEP);
         clock.sysclk.set_dig_sysclk_nodiv(false);
         clock.sysclk.set_icg_sysclk_en(false);
@@ -1367,6 +1373,7 @@ impl Clock for RtcFastClock {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// RTC SLOW_CLK frequency values
 pub(crate) enum RtcSlowClock {

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -226,6 +226,7 @@ extern "C" {
 }
 
 /// RTC SLOW_CLK frequency values
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum RtcSlowClock {
     /// Select RC_SLOW_CLK as RTC_SLOW_CLK source

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -784,11 +784,10 @@ impl RtcSleepConfig {
 
     pub fn deep() -> Self {
         // Set up for ultra-low power sleep. Wakeup sources may modify these settings.
-        let mut cfg = Self::default();
-
-        cfg.deep = true;
-
-        cfg
+        Self {
+            deep: true,
+            ..Self::default()
+        }
     }
 
     pub(crate) fn base_settings(_rtc: &Rtc) {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1781,6 +1781,7 @@ where
         Ok(read_buffer)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn start_transfer_dma(
         &mut self,
         write_buffer_ptr: *const u8,

--- a/esp-hal/src/twai/filter.rs
+++ b/esp-hal/src/twai/filter.rs
@@ -369,6 +369,7 @@ impl DualStandardFilter {
     /// The masks indicate which bits of the code the filter should match
     /// against. Set bits in the mask indicate that the corresponding bit in
     /// the code should match.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_from_code_mask(
         first_id_code: StandardId,
         first_id_mask: StandardId,


### PR DESCRIPTION
For the most part I've just allowed these lints on a per-instance basis via `#[allow()]` attributes, however I have created #1166 to address these in the future. The primary intent here is to ensure that we're not introducing more code which violates these rules.

There are still some improvements to be made, but this is a good step forward.

Closes #1161