### PR TITLE
Fix ESP32 hello_rgb example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `get_raw_core` on Xtensa (#1126)
 - Fix docs.rs documentation builds (#1129)
 - Fix circular DMA (#1144)
+- Fix `hello_rgb` example for ESP32 (#1173)
 
 ### Changed
 

--- a/esp32-hal/examples/hello_rgb.rs
+++ b/esp32-hal/examples/hello_rgb.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
     // -> We need to use the macro `smartLedBuffer!` with the number of addressed
     // LEDs here to initialize the internal LED pulse buffer to the correct
     // size!
-    let rmt_buffer = smartLedBuffer!(1);
+    let rmt_buffer = smartLedBuffer!(12);
     let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio33, rmt_buffer, &clocks);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a


### PR DESCRIPTION
The example tries to use 12 LEDs but the buffer was only sized for one

Fixes #1159