### PR TITLE
`estimate_xtal_frequency` for C6/H2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support Rust's `stack-protector` feature (#1135)
 - Adding clock support for `ESP32-P4` (#1145)
 - Implementation OutputPin and InputPin for AnyPin (#1067)
+- Implement `estimate_xtal_frequency` for ESP32-C6 / ESP32-H2 (#1174)
 
 ### Fixed
 

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -213,8 +213,6 @@ impl<'d> Rtc<'d> {
         this
     }
 
-    // TODO: implement for ESP32-C6
-    #[cfg(not(any(esp32c6, esp32h2)))]
     pub fn estimate_xtal_frequency(&mut self) -> u32 {
         RtcClock::estimate_xtal_frequency()
     }

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -1823,6 +1823,27 @@ impl RtcClock {
 
         (100_000_000 * 1000 / period) as u16
     }
+
+    pub(crate) fn estimate_xtal_frequency() -> u32 {
+        let timg0 = unsafe { crate::peripherals::TIMG0::steal() };
+        while timg0.rtccalicfg().read().rtc_cali_rdy().bit_is_clear() {}
+
+        timg0.rtccalicfg().modify(|_, w| {
+            w.rtc_cali_clk_sel()
+                .variant(0) // RTC_SLOW_CLK
+                .rtc_cali_max()
+                .variant(100)
+                .rtc_cali_start_cycling()
+                .clear_bit()
+                .rtc_cali_start()
+                .set_bit()
+        });
+        while timg0.rtccalicfg().read().rtc_cali_rdy().bit_is_clear() {}
+
+        (timg0.rtccalicfg1().read().rtc_cali_value().bits()
+            * (RtcSlowClock::RtcSlowClockRcSlow.frequency().to_Hz() / 100))
+            / 1_000_000
+    }
 }
 
 pub(crate) fn rtc_clk_cpu_freq_set_xtal() {

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -639,4 +639,25 @@ impl RtcClock {
 
         (100_000_000 * 1000 / period) as u16
     }
+
+    pub(crate) fn estimate_xtal_frequency() -> u32 {
+        let timg0 = unsafe { crate::peripherals::TIMG0::steal() };
+        while timg0.rtccalicfg().read().rtc_cali_rdy().bit_is_clear() {}
+
+        timg0.rtccalicfg().modify(|_, w| {
+            w.rtc_cali_clk_sel()
+                .variant(0) // RTC_SLOW_CLK
+                .rtc_cali_max()
+                .variant(100)
+                .rtc_cali_start_cycling()
+                .clear_bit()
+                .rtc_cali_start()
+                .set_bit()
+        });
+        while timg0.rtccalicfg().read().rtc_cali_rdy().bit_is_clear() {}
+
+        (timg0.rtccalicfg1().read().rtc_cali_value().bits()
+            * (RtcSlowClock::RtcSlowClockRcSlow.frequency().to_Hz() / 100))
+            / 1_000_000
+    }
 }

--- a/esp32c6-hal/examples/clock_monitor.rs
+++ b/esp32c6-hal/examples/clock_monitor.rs
@@ -1,0 +1,65 @@
+//! This demos a simple monitor for the XTAL frequency, by relying on a special
+//! feature of the TIMG0 (Timer Group 0). This feature counts the number of XTAL
+//! clock cycles within a given number of RTC_SLOW_CLK cycles.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use critical_section::Mutex;
+use esp32c6_hal::{
+    clock::ClockControl,
+    interrupt,
+    peripherals::{self, Peripherals},
+    prelude::*,
+    Rtc,
+};
+use esp_backtrace as _;
+
+static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.LPWR);
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    esp_println::println!(
+        "{: <10} XTAL frequency: {} MHz",
+        "[Expected]",
+        clocks.xtal_clock.to_MHz()
+    );
+
+    interrupt::enable(
+        peripherals::Interrupt::LP_WDT,
+        interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    critical_section::with(|cs| {
+        RTC.borrow_ref_mut(cs).replace(rtc);
+    });
+
+    loop {}
+}
+
+#[interrupt]
+fn LP_WDT() {
+    critical_section::with(|cs| {
+        let mut rtc = RTC.borrow(cs).borrow_mut();
+        let rtc = rtc.as_mut().unwrap();
+
+        esp_println::println!(
+            "{: <10} XTAL frequency: {} MHz",
+            "[Monitor]",
+            rtc.estimate_xtal_frequency()
+        );
+
+        rtc.rwdt.clear_interrupt();
+    });
+}

--- a/esp32h2-hal/examples/clock_monitor.rs
+++ b/esp32h2-hal/examples/clock_monitor.rs
@@ -1,0 +1,65 @@
+//! This demos a simple monitor for the XTAL frequency, by relying on a special
+//! feature of the TIMG0 (Timer Group 0). This feature counts the number of XTAL
+//! clock cycles within a given number of RTC_SLOW_CLK cycles.
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use critical_section::Mutex;
+use esp32h2_hal::{
+    clock::ClockControl,
+    interrupt,
+    peripherals::{self, Peripherals},
+    prelude::*,
+    Rtc,
+};
+use esp_backtrace as _;
+
+static RTC: Mutex<RefCell<Option<Rtc>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let mut rtc = Rtc::new(peripherals.LPWR);
+    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.listen();
+
+    esp_println::println!(
+        "{: <10} XTAL frequency: {} MHz",
+        "[Expected]",
+        clocks.xtal_clock.to_MHz()
+    );
+
+    interrupt::enable(
+        peripherals::Interrupt::LP_WDT,
+        interrupt::Priority::Priority1,
+    )
+    .unwrap();
+
+    critical_section::with(|cs| {
+        RTC.borrow_ref_mut(cs).replace(rtc);
+    });
+
+    loop {}
+}
+
+#[interrupt]
+fn LP_WDT() {
+    critical_section::with(|cs| {
+        let mut rtc = RTC.borrow(cs).borrow_mut();
+        let rtc = rtc.as_mut().unwrap();
+
+        esp_println::println!(
+            "{: <10} XTAL frequency: {} MHz",
+            "[Monitor]",
+            rtc.estimate_xtal_frequency()
+        );
+
+        rtc.rwdt.clear_interrupt();
+    });
+}


### PR DESCRIPTION
Fixes #1170 
Fixes #408 

The implementation differs a lot from what we have for other chips since I don't really understand that implementation.
It seems to return reasonable values however (for my two C6 it's 40 and 38, for my one and only H2 it's 32). t.b.h. on C6/H2 the function is not too useful since those chips are not available with different xtals. So, it's just for completeness

This also adds the `clock_monitor` example for the two chips.
