### PR TITLE
ESP32-C3: Correct GPIO pin in `hello_rgb` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix docs.rs documentation builds (#1129)
 - Fix circular DMA (#1144)
 - Fix `hello_rgb` example for ESP32 (#1173)
+- ESP32-C3: Correct GPIO pin in `hello_rgb` example
 
 ### Changed
 

--- a/esp32c3-hal/examples/hello_rgb.rs
+++ b/esp32c3-hal/examples/hello_rgb.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations
     let rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer, &clocks);
+    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio8, rmt_buffer, &clocks);
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a
     // loop.


### PR DESCRIPTION
It seems that the LED pin was changed accidentally in an older commit, fix this.

The LED is connected to pin 8 and not pin 2, see:
https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html#j3

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI (not applicable)

### Nice to have

- [x] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code. (not applicable)
