### PR TITLE
wait for timer value to be latched for esp32(c3/c6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix docs.rs documentation builds (#1129)
 - Fix circular DMA (#1144)
 - Fix `hello_rgb` example for ESP32 (#1173)
+- Fix timer `now` for esp32c3 and esp32c6
 
 ### Changed
 

--- a/esp-hal/src/timer.rs
+++ b/esp-hal/src/timer.rs
@@ -420,7 +420,14 @@ where
     fn now(&self) -> u64 {
         let reg_block = unsafe { &*TG::register_block() };
 
+        #[cfg(not(any(esp32c3, esp32c6)))]
         reg_block.t0update().write(|w| unsafe { w.bits(0) });
+
+        #[cfg(any(esp32c3, esp32c6))]
+        {
+            reg_block.t0update().write(|w| w.update().set_bit());
+            while reg_block.t0update().read().update().bit_is_set() {}
+        }
 
         let value_lo = reg_block.t0lo().read().bits() as u64;
         let value_hi = (reg_block.t0hi().read().bits() as u64) << 32;


### PR DESCRIPTION
While using the timer on the esp32c3 i noticed that reading timer values was not working as expected. Seems the c3 and also c6 need to wait for the value to be correctly latched before reading the current timer value. 

Here the relevant section in the [TRM Section 11.3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf#subsection.11.3)

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [x] The code compiles without `errors` or `warnings`.
- [x] All examples work.
- [x] `cargo fmt` was run.
- [x] Your changes were added to the `CHANGELOG.md` in the proper section.
- [x] You updated existing examples or added examples (if applicable).
- [x] Added examples are checked in CI
