### PR TITLE
Wait for update before reading timer count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix docs.rs documentation builds (#1129)
 - Fix circular DMA (#1144)
 - Fix `hello_rgb` example for ESP32 (#1173)
-- Fix timer `now` for esp32c3 and esp32c6
 - Fixed the multicore critical section on Xtensa (#1175)
 - Fix timer `now` for esp32c3 and esp32c6 (#1178)
 - Wait for registers to get synced before reading the timer count for all chips (#1183)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `hello_rgb` example for ESP32 (#1173)
 - Fix timer `now` for esp32c3 and esp32c6
 - Fixed the multicore critical section on Xtensa (#1175)
+- Fix timer `now` for esp32c3 and esp32c6 (#1178)
+- Wait for registers to get synced before reading the timer count for all chips except ESP32 (for now) (#1183)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix timer `now` for esp32c3 and esp32c6
 - Fixed the multicore critical section on Xtensa (#1175)
 - Fix timer `now` for esp32c3 and esp32c6 (#1178)
-- Wait for registers to get synced before reading the timer count for all chips except ESP32 (for now) (#1183)
+- Wait for registers to get synced before reading the timer count for all chips (#1183)
 
 ### Changed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -61,14 +61,14 @@ ufmt-write = { version = "0.1.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { git = "https://github.com/esp-rs/esp-pacs", rev = "55f9f6c", features = ["critical-section"], optional = true }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "55f9f6c", features = ["critical-section"], optional = true }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "55f9f6c", features = ["critical-section"], optional = true }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "55f9f6c", features = ["critical-section"], optional = true }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "55f9f6c", features = ["critical-section"], optional = true }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "55f9f6c", features = ["critical-section"], optional = true }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "55f9f6c", features = ["critical-section"], optional = true }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "55f9f6c", features = ["critical-section"], optional = true }
+esp32   = { git = "https://github.com/esp-rs/esp-pacs", rev = "8231fea", features = ["critical-section"], optional = true }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "8231fea", features = ["critical-section"], optional = true }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "8231fea", features = ["critical-section"], optional = true }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "8231fea", features = ["critical-section"], optional = true }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "8231fea", features = ["critical-section"], optional = true }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "8231fea", features = ["critical-section"], optional = true }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "8231fea", features = ["critical-section"], optional = true }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "8231fea", features = ["critical-section"], optional = true }
 
 [build-dependencies]
 basic-toml = "0.1.8"

--- a/esp-hal/src/timer.rs
+++ b/esp-hal/src/timer.rs
@@ -420,10 +420,10 @@ where
     fn now(&self) -> u64 {
         let reg_block = unsafe { &*TG::register_block() };
 
-        #[cfg(not(any(esp32c3, esp32c6)))]
+        #[cfg(esp32)]
         reg_block.t0update().write(|w| unsafe { w.bits(0) });
 
-        #[cfg(any(esp32c3, esp32c6))]
+        #[cfg(not(esp32))]
         {
             reg_block.t0update().write(|w| w.update().set_bit());
             while reg_block.t0update().read().update().bit_is_set() {}
@@ -597,7 +597,14 @@ where
     fn now(&self) -> u64 {
         let reg_block = unsafe { &*TG::register_block() };
 
+        #[cfg(esp32)]
         reg_block.t1update().write(|w| unsafe { w.bits(0) });
+
+        #[cfg(not(esp32))]
+        {
+            reg_block.t1update().write(|w| w.update().set_bit());
+            while reg_block.t1update().read().update().bit_is_set() {}
+        }
 
         let value_lo = reg_block.t1lo().read().bits() as u64;
         let value_hi = (reg_block.t1hi().read().bits() as u64) << 32;

--- a/esp-hal/src/timer.rs
+++ b/esp-hal/src/timer.rs
@@ -420,14 +420,8 @@ where
     fn now(&self) -> u64 {
         let reg_block = unsafe { &*TG::register_block() };
 
-        #[cfg(esp32)]
-        reg_block.t0update().write(|w| unsafe { w.bits(0) });
-
-        #[cfg(not(esp32))]
-        {
-            reg_block.t0update().write(|w| w.update().set_bit());
-            while reg_block.t0update().read().update().bit_is_set() {}
-        }
+        reg_block.t0update().write(|w| w.update().set_bit());
+        while reg_block.t0update().read().update().bit_is_set() {}
 
         let value_lo = reg_block.t0lo().read().bits() as u64;
         let value_hi = (reg_block.t0hi().read().bits() as u64) << 32;
@@ -597,14 +591,8 @@ where
     fn now(&self) -> u64 {
         let reg_block = unsafe { &*TG::register_block() };
 
-        #[cfg(esp32)]
-        reg_block.t1update().write(|w| unsafe { w.bits(0) });
-
-        #[cfg(not(esp32))]
-        {
-            reg_block.t1update().write(|w| w.update().set_bit());
-            while reg_block.t1update().read().update().bit_is_set() {}
-        }
+        reg_block.t1update().write(|w| w.update().set_bit());
+        while reg_block.t1update().read().update().bit_is_set() {}
 
         let value_lo = reg_block.t1lo().read().bits() as u64;
         let value_hi = (reg_block.t1hi().read().bits() as u64) << 32;


### PR DESCRIPTION
Closes #1180 

In #1178 there was a check introduced before reading the timer count. We should do it for all chips.

