### PR TITLE
Fix circular DMA (again) and small I2S improvements

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1002,6 +1002,20 @@ where
                         self.available += dw0.len();
                         ptr = ptr.offset(1);
                     }
+
+                    // add bytes pointed to by the last descriptor
+                    let dw0 = ptr.read_volatile();
+                    self.available += dw0.len();
+
+                    // in circular mode we need to honor the now available bytes at start
+                    if (*ptr).next == self.descriptors as *mut _ as *mut DmaDescriptor {
+                        ptr = self.descriptors as *mut _ as *mut DmaDescriptor;
+                        while ptr < descr_address {
+                            let dw0 = ptr.read_volatile();
+                            self.available += dw0.len();
+                            ptr = ptr.offset(1);
+                        }
+                    }
                 }
             }
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -404,10 +404,16 @@ where
 
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
 
+        let max_chunk_size = if !circular || len > CHUNK_SIZE * 2 {
+            CHUNK_SIZE
+        } else {
+            len / 3
+        };
+
         let mut processed = 0;
         let mut descr = 0;
         loop {
-            let chunk_size = usize::min(CHUNK_SIZE, len - processed);
+            let chunk_size = usize::min(max_chunk_size, len - processed);
             let last = processed + chunk_size >= len;
 
             let next = if last {
@@ -538,7 +544,7 @@ where
             return Err(DmaError::InvalidAlignment);
         }
 
-        if circular && len < CHUNK_SIZE * 2 {
+        if circular && len <= 3 {
             return Err(DmaError::BufferTooSmall);
         }
 
@@ -651,7 +657,7 @@ where
             let buffer_ptr = self.descriptors[idx].buffer;
             let next_dscr = self.descriptors[idx].next;
 
-            // Copy data to desination
+            // Copy data to destination
             let (dst_chunk, dst_remaining) = dst.split_at_mut(chunk_len);
             dst = dst_remaining;
 
@@ -765,10 +771,16 @@ where
 
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
 
+        let max_chunk_size = if !circular || len > CHUNK_SIZE * 2 {
+            CHUNK_SIZE
+        } else {
+            len / 3
+        };
+
         let mut processed = 0;
         let mut descr = 0;
         loop {
-            let chunk_size = usize::min(CHUNK_SIZE, len - processed);
+            let chunk_size = usize::min(max_chunk_size, len - processed);
             let last = processed + chunk_size >= len;
 
             let next = if last {
@@ -936,7 +948,7 @@ where
             return Err(DmaError::OutOfDescriptors);
         }
 
-        if circular && len < CHUNK_SIZE * 2 {
+        if circular && len <= 3 {
             return Err(DmaError::BufferTooSmall);
         }
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1109,7 +1109,7 @@ where
             } else {
                 unsafe {
                     while !((*ptr).next.is_null()
-                        || (*ptr).next == self.descriptors as *mut _ as *mut DmaDescriptor)
+                        || (*ptr).next == addr_of_mut!(self.descriptors[0]))
                     {
                         let dw0 = ptr.read_volatile();
                         self.available += dw0.len();
@@ -1121,8 +1121,8 @@ where
                     self.available += dw0.len();
 
                     // in circular mode we need to honor the now available bytes at start
-                    if (*ptr).next == self.descriptors as *mut _ as *mut DmaDescriptor {
-                        ptr = self.descriptors as *mut _ as *mut DmaDescriptor;
+                    if (*ptr).next == addr_of_mut!(self.descriptors[0]) {
+                        ptr = addr_of_mut!(self.descriptors[0]);
                         while ptr < descr_address {
                             let dw0 = ptr.read_volatile();
                             self.available += dw0.len();


### PR DESCRIPTION
Originally, I just wanted to finally fix circular DMA but also added some I2S improvements (which are related)

- fix available free buffer calculation for circular DMA
- lift the circular DMA buffer min-size requirement
- have a function to push into I2S DMA via a closure
