### PR TITLE
Add TimerWakeupSource for the esp32-c6 deepsleep.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A way to push into I2S DMA buffer via a closure (#1189)
 - Added basic `LP-I2C` driver for C6 (#1185)
 - Ensuring that the random number generator is TRNG. (#1200)
+- ESP32-C6: Add timer wakeup source for deepsleep (#1201)
 
 ### Fixed
 

--- a/esp-hal/src/reset.rs
+++ b/esp-hal/src/reset.rs
@@ -73,8 +73,12 @@ bitflags::bitflags! {
         const ExtEvent1Trig   = 1 << 1;
         /// GPIO wakeup (light sleep only)
         const GpioTrigEn      = 1 << 2;
+        #[cfg(not(any(esp32c6, esp32h2)))]
         /// Timer wakeup
         const TimerTrigEn     = 1 << 3;
+        #[cfg(any(esp32c6, esp32h2))]
+        /// Timer wakeup
+        const TimerTrigEn     = 1 << 4;
         #[cfg(pm_support_wifi_wakeup)]
         /// MAC wakeup (light sleep only)
         const WifiTrigEn      = 1 << 5;

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -21,7 +21,7 @@
 //!    * `BT (Bluetooth) wake` - light sleep only
 
 use core::cell::RefCell;
-#[cfg(any(esp32, esp32c3, esp32s3))]
+#[cfg(any(esp32, esp32c3, esp32s3, esp32c6))]
 use core::time::Duration;
 
 #[cfg(any(esp32, esp32s3))]
@@ -46,12 +46,12 @@ pub enum WakeupLevel {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg(any(esp32, esp32c3, esp32s3))]
+#[cfg(any(esp32, esp32c3, esp32s3, esp32c6))]
 pub struct TimerWakeupSource {
     duration: Duration,
 }
 
-#[cfg(any(esp32, esp32c3, esp32s3))]
+#[cfg(any(esp32, esp32c3, esp32s3, esp32c6))]
 impl TimerWakeupSource {
     pub fn new(duration: Duration) -> Self {
         Self { duration }

--- a/examples/src/bin/sleep_timer.rs
+++ b/examples/src/bin/sleep_timer.rs
@@ -1,6 +1,6 @@
 //! Demonstrates deep sleep with timer wakeup
 
-//% CHIPS: esp32 esp32c3 esp32s3
+//% CHIPS: esp32 esp32c3 esp32c6 esp32s3
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
This PR adds support for deepsleep-wakeup by timer on the esp32c6