### PR TITLE
[WIP] Prototype for using buffered uart rx

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -46,6 +46,7 @@ embassy-executor     = { version = "0.5.0", optional = true }
 embassy-futures      = { version = "0.1.1", optional = true }
 embassy-sync         = { version = "0.5.0", optional = true }
 embassy-time-driver  = { version = "0.1.0", optional = true }
+heapless             = { version = "0.8.0", optional = true }
 
 # RISC-V
 riscv        = { version = "0.11.0", optional = true }
@@ -136,6 +137,7 @@ async = [
     "embassy-futures",
     "embedded-io",
     "embedded-io-async",
+    "heapless"
 ]
 
 # Embassy support

--- a/esp32c6-hal/examples/embassy_serial.rs
+++ b/esp32c6-hal/examples/embassy_serial.rs
@@ -87,7 +87,8 @@ async fn main(spawner: Spawner) {
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)
         .unwrap();
-    let (tx, rx) = uart0.split();
+    let (tx, mut rx) = uart0.split();
+    rx.set_buffer(make_static!(heapless::Deque::<u8, 1024>::new()));
 
     let signal = &*make_static!(Signal::new());
 


### PR DESCRIPTION
I would like to get the discussion going on how to best implement (async) uart rx buffering. 

In my usecase the hw fifio of 132 bytes quickly overflows when I receive a lot of data from an LTE modem, while doing other tasks. But in other usecases the hw fifo might be enough, thats why I would let it up to the user to decide whether he wants an additional buffer or not.

What do you think of my approach? 
(Would you like to see a `heapless::blocking_mutex::CriticalSectionMutex<RefCell<..>>` instead of a plain `static mut` to store the buffer? )

