### PR TITLE
Runtime interrupt binding

### DIFF
--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -374,6 +374,7 @@ pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
     use self::interrupt::{check_attr_whitelist, WhiteListCaller};
 
     let mut f: ItemFn = syn::parse(input).expect("`#[handler]` must be applied to a function");
+    let original_span = f.span();
 
     let attr_args = match NestedMeta::parse_meta_list(args.into()) {
         Ok(v) => v,
@@ -416,9 +417,9 @@ pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
         .into();
     }
 
-    f.sig.abi = syn::parse_quote!(extern "C");
+    f.sig.abi = syn::parse_quote_spanned!(original_span => extern "C");
 
-    quote::quote!(
+    quote::quote_spanned!( original_span =>
         #f
     )
     .into()

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -359,6 +359,71 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Mark a function as an interrupt handler.
+///
+/// This is really just a nicer looking way to make a function `unsafe extern
+/// "C"`
+#[cfg(feature = "interrupt")]
+#[proc_macro_attribute]
+pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
+    use darling::ast::NestedMeta;
+    use proc_macro::Span;
+    use proc_macro_error::abort;
+    use syn::{parse::Error as ParseError, spanned::Spanned, ItemFn, ReturnType, Type};
+
+    use self::interrupt::{check_attr_whitelist, WhiteListCaller};
+
+    let mut f: ItemFn = syn::parse(input).expect("`#[handler]` must be applied to a function");
+
+    let attr_args = match NestedMeta::parse_meta_list(args.into()) {
+        Ok(v) => v,
+        Err(e) => {
+            return TokenStream::from(darling::Error::from(e).write_errors());
+        }
+    };
+
+    if attr_args.len() > 0 {
+        abort!(Span::call_site(), "This attribute accepts no arguments")
+    }
+
+    // XXX should we blacklist other attributes?
+
+    if let Err(error) = check_attr_whitelist(&f.attrs, WhiteListCaller::Interrupt) {
+        return error;
+    }
+
+    let valid_signature = f.sig.constness.is_none()
+        && f.sig.abi.is_none()
+        && f.sig.generics.params.is_empty()
+        && f.sig.generics.where_clause.is_none()
+        && f.sig.variadic.is_none()
+        && match f.sig.output {
+            ReturnType::Default => true,
+            ReturnType::Type(_, ref ty) => match **ty {
+                Type::Tuple(ref tuple) => tuple.elems.is_empty(),
+                Type::Never(..) => true,
+                _ => false,
+            },
+        }
+        && f.sig.inputs.len() <= 1;
+
+    if !valid_signature {
+        return ParseError::new(
+            f.span(),
+            "`#[handler]` handlers must have signature `[unsafe] fn([&mut Context]) [-> !]`",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    f.sig.abi = syn::parse_quote!(extern "C");
+
+    quote::quote!(
+        #f
+    )
+    .into()
+}
+
 /// Create an enum for erased GPIO pins, using the enum-dispatch pattern
 ///
 /// Only used internally

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Prefer mutable references over moving for DMA transactions (#1238)
+- Support runtime interrupt binding, adapt GPIO driver (#1231)
 
 ### Removed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -220,3 +220,13 @@ opsram-16m = []
 
 [lints.clippy]
 mixed_attributes_style = "allow"
+
+[patch.crates-io]
+esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -222,11 +222,11 @@ opsram-16m = []
 mixed_attributes_style = "allow"
 
 [patch.crates-io]
-esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }

--- a/esp-hal/src/gpio.rs
+++ b/esp-hal/src/gpio.rs
@@ -1877,8 +1877,7 @@ impl IO {
 
 #[interrupt]
 unsafe fn GPIO() {
-    if let Some(user_handler) =
-        critical_section::with(|cs| USER_INTERRUPT_HANDLER.borrow(cs).get().clone())
+    if let Some(user_handler) = critical_section::with(|cs| USER_INTERRUPT_HANDLER.borrow(cs).get())
     {
         unsafe {
             user_handler();

--- a/esp-hal/src/gpio.rs
+++ b/esp-hal/src/gpio.rs
@@ -3186,9 +3186,9 @@ mod asynch {
     unsafe fn GPIO() {
         handle_gpio_interrupt();
 
-        if let Some(user_handler) = critical_section::with(|cs| {
-            USER_INTERRUPT_HANDLER.borrow_ref(cs).clone();
-        }) {
+        if let Some(user_handler) =
+            critical_section::with(|cs| USER_INTERRUPT_HANDLER.borrow_ref(cs).clone())
+        {
             unsafe {
                 user_handler();
             }

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -199,6 +199,13 @@ mod vectored {
         Ok(())
     }
 
+    /// Bind the given interrupt to the given handler
+    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn() -> ()) {
+        let ptr = &peripherals::__EXTERNAL_INTERRUPTS[interrupt as usize]._handler as *const _
+            as *mut unsafe extern "C" fn() -> ();
+        ptr.write_volatile(handler);
+    }
+
     /// Enables an interrupt at a given priority, maps it to the given CPU
     /// interrupt and assigns the given priority.
     ///

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -311,6 +311,13 @@ mod vectored {
         Ok(())
     }
 
+    /// Bind the given interrupt to the given handler
+    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn() -> ()) {
+        let ptr = &peripherals::__INTERRUPTS[interrupt as usize]._handler as *const _
+            as *mut unsafe extern "C" fn() -> ();
+        ptr.write_volatile(handler);
+    }
+
     fn interrupt_level_to_cpu_interrupt(
         level: Priority,
         is_edge: bool,

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -221,7 +221,7 @@ mod peripheral_macros {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! peripherals {
-        ($($(#[$cfg:meta])? $name:ident <= $from_pac:tt),*$(,)?) => {
+        ($($(#[$cfg:meta])? $name:ident <= $from_pac:tt $(($($interrupt:ident),*))? ),*$(,)?) => {
 
             /// Contains the generated peripherals which implement [`Peripheral`]
             mod peripherals {
@@ -278,6 +278,21 @@ mod peripheral_macros {
             $(
                 pub use peripherals::$name;
             )*
+
+            $(
+                $(
+                    impl peripherals::$name {
+                        $(
+                            paste::paste!{
+                                pub fn [<bind_ $interrupt:lower _interrupt >](&mut self, handler: unsafe extern "C" fn() -> ()) {
+                                    unsafe { $crate::interrupt::bind_interrupt($crate::peripherals::Interrupt::$interrupt, handler); }
+                                }
+                            }
+                        )*
+                    }
+                )*
+            )*
+
         }
     }
 

--- a/esp-hal/src/soc/esp32/peripherals.rs
+++ b/esp-hal/src/soc/esp32/peripherals.rs
@@ -32,7 +32,7 @@ crate::peripherals! {
     EFUSE <= EFUSE,
     FLASH_ENCRYPTION <= FLASH_ENCRYPTION,
     FRC_TIMER <= FRC_TIMER,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     GPIO_SD <= GPIO_SD,
     HINF <= HINF,
     I2C0 <= I2C0,

--- a/esp-hal/src/soc/esp32c2/peripherals.rs
+++ b/esp-hal/src/soc/esp32c2/peripherals.rs
@@ -28,7 +28,7 @@ crate::peripherals! {
     ECC <= ECC,
     EFUSE <= EFUSE,
     EXTMEM <= EXTMEM,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     I2C0 <= I2C0,
     INTERRUPT_CORE0 <= INTERRUPT_CORE0,
     IO_MUX <= IO_MUX,

--- a/esp-hal/src/soc/esp32c3/peripherals.rs
+++ b/esp-hal/src/soc/esp32c3/peripherals.rs
@@ -30,7 +30,7 @@ crate::peripherals! {
     DS <= DS,
     EFUSE <= EFUSE,
     EXTMEM <= EXTMEM,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     GPIO_SD <= GPIO_SD,
     HMAC <= HMAC,
     I2C0 <= I2C0,

--- a/esp-hal/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal/src/soc/esp32c6/peripherals.rs
@@ -30,7 +30,7 @@ crate::peripherals! {
     ECC <= ECC,
     EFUSE <= EFUSE,
     EXTMEM <= EXTMEM,
-    GPIO <= GPIO (GPIO,GPIO_NMI),,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     GPIO_SD <= GPIO_SD,
     HINF <= HINF,
     HMAC <= HMAC,

--- a/esp-hal/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal/src/soc/esp32c6/peripherals.rs
@@ -30,7 +30,7 @@ crate::peripherals! {
     ECC <= ECC,
     EFUSE <= EFUSE,
     EXTMEM <= EXTMEM,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),,
     GPIO_SD <= GPIO_SD,
     HINF <= HINF,
     HMAC <= HMAC,

--- a/esp-hal/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal/src/soc/esp32h2/peripherals.rs
@@ -28,7 +28,7 @@ crate::peripherals! {
     DS <= DS,
     ECC <= ECC,
     EFUSE <= EFUSE,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     GPIO_SD <= GPIO_SD,
     HMAC <= HMAC,
     HP_APM <= HP_APM,

--- a/esp-hal/src/soc/esp32p4/peripherals.rs
+++ b/esp-hal/src/soc/esp32p4/peripherals.rs
@@ -32,7 +32,7 @@ crate::peripherals! {
     ECC <= ECC,
     ECDSA <= ECDSA,
     EFUSE <= EFUSE,
-    GPIO <= GPIO (GPIO_INT0,GPIO_INT1,GPIO_INT2,GPIO_INT3),
+    GPIO <= GPIO (GPIO,GPIO_INT1,GPIO_INT2,GPIO_INT3),
     GPIO_SD <= GPIO_SD,
     H264 <= H264,
     H264_DMA <= H264_DMA,

--- a/esp-hal/src/soc/esp32p4/peripherals.rs
+++ b/esp-hal/src/soc/esp32p4/peripherals.rs
@@ -32,7 +32,7 @@ crate::peripherals! {
     ECC <= ECC,
     ECDSA <= ECDSA,
     EFUSE <= EFUSE,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO_INT0,GPIO_INT1,GPIO_INT2,GPIO_INT3),
     GPIO_SD <= GPIO_SD,
     H264 <= H264,
     H264_DMA <= H264_DMA,

--- a/esp-hal/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal/src/soc/esp32s2/peripherals.rs
@@ -30,7 +30,7 @@ crate::peripherals! {
     DS <= DS,
     EFUSE <= EFUSE,
     EXTMEM <= EXTMEM,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     GPIO_SD <= GPIO_SD,
     HMAC <= HMAC,
     I2C0 <= I2C0,

--- a/esp-hal/src/soc/esp32s3/peripherals.rs
+++ b/esp-hal/src/soc/esp32s3/peripherals.rs
@@ -30,7 +30,7 @@ crate::peripherals! {
     DS <= DS,
     EFUSE <= EFUSE,
     EXTMEM <= EXTMEM,
-    GPIO <= GPIO,
+    GPIO <= GPIO (GPIO,GPIO_NMI),
     GPIO_SD <= GPIO_SD,
     HMAC <= HMAC,
     I2C0 <= I2C0,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -72,11 +72,11 @@ psram-2m  = ["esp-hal/psram-2m"]
 debug = true
 
 [patch.crates-io]
-esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -70,3 +70,13 @@ psram-2m  = ["esp-hal/psram-2m"]
 
 [profile.release]
 debug = true
+
+[patch.crates-io]
+esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -72,11 +72,11 @@ psram-2m  = ["esp-hal/psram-2m"]
 debug = true
 
 [patch.crates-io]
-esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "35de99f1843abe2b7eaaa2c9246bd49f82f18d0f" }
+esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "e394c25fea52d7796955da4192e30e5ba5178e3c" }

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -36,7 +36,8 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Set GPIO2 as an output, and set its state high initially.
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let mut io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    io.set_interrupt_handler(handler);
     let mut led = io.pins.gpio2.into_push_pull_output();
 
     #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
@@ -61,9 +62,9 @@ fn main() -> ! {
     }
 }
 
+#[handler]
 #[ram]
-#[interrupt]
-fn GPIO() {
+fn handler() {
     #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
     esp_println::println!(
         "GPIO Interrupt with priority {}",


### PR DESCRIPTION
This implements the idea outlined in #1063 and explored in #1121

Only GPIO is changed for now to contain the user-facing API to set the interrupt. This is compatible with link-time binding of the interrupts.

I dropped the idea of having (additional) type-state on the drivers. Instead, it's now possible to have a user-handler in addition to the async interrupt handler. There is one possible pitfall: the user must not modify the interrupt status (i.e. clear the interrupt of a GPIO). If they do the async handler won't be able to identify the GPIO. We could avoid that by saving and restoring the interrupt state before/after calling user code. Wasn't sure if we really want that or not

As said, it's for now just implemented for GPIO since we probably first want to align on this before doing the same thing for the other drivers.

In theory we don't even need to apply the change to all drivers at once

