### PR TITLE
Add new embassy features for esp32s2 and other systimers. Enable embassy tick rate features by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The DMA peripheral is now called `Dma` for devices with both PDMA and GDMA controllers (#1125)
 - The `ADC` driver's constructor is now `new` instead of `adc`, to be more consistent with other APIs (#1133)
 - `embassy-executor`'s `integrated-timers` is no longer enabled by default.
+- Renamed `embassy-time-systick` to `embassy-time-systick-16mhz` for use with all chips with a systimer, except `esp32s2`. Added `embassy-time-systick-80mhz` specifically for the `esp32s2`. (#1247)
 
 ## [0.15.0] - 2024-01-19
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -64,6 +64,7 @@ xtensa-lx-rt = { version = "0.16.0", optional = true }
 [build-dependencies]
 basic-toml = "0.1.8"
 serde      = { version = "1.0.195", features = ["derive"] }
+cfg-if = "1"
 
 [features]
 default = ["rt", "vectored"]
@@ -180,11 +181,16 @@ embassy-executor-thread = ["embassy", "embassy-executor"]
 ## by the time driver.
 embassy-integrated-timers = ["embassy-executor?/integrated-timers"]
 ## Enable the embassy time driver using the `SYSTIMER` peripheral. The
-## `SYSTIMER` peripheral has three alarams available for use.
-embassy-time-systick = []
+## `SYSTIMER` peripheral has three alarams available for use. Do **not** 
+## use when targeting an `esp32s2`.
+embassy-time-systick-16mhz = ["embassy-time-driver/tick-hz-16_000_000"]
+## Enable the embassy time driver using the `SYSTIMER` peripheral. The
+## `SYSTIMER` peripheral has three alarams available for use. Must only 
+## be used when targeting an `esp32s2`.
+embassy-time-systick-80mhz = ["embassy-time-driver/tick-hz-80_000_000"]
 ## Enable the embassy time driver using the `TIMG0` peripheral. The `TIMG0`
 ## peripheral has two alarms available for use.
-embassy-time-timg0 = []
+embassy-time-timg0 = ["embassy-time-driver/tick-hz-1_000_000"]
 
 #! ### PSRAM Feature Flags
 ## Use externally connected PSRAM (2MB).

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -111,11 +111,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     // is available:
     #[cfg(feature = "embassy")]
     {
-        #[cfg(feature = "esp32")]
-        assert_unique_used_features!("embassy-time-timg0");
-
-        #[cfg(not(feature = "esp32"))]
-        assert_unique_used_features!("embassy-time-systick", "embassy-time-timg0");
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "esp32")] {
+                assert_unique_used_features!("embassy-time-timg0");
+            } else if #[cfg(feature = "esp32s2")] {
+                assert_unique_used_features!("embassy-time-systick-80mhz", "embassy-time-timg0");
+            } else {
+                assert_unique_used_features!("embassy-time-systick-16mhz", "embassy-time-timg0");
+            }
+        }
     }
 
     #[cfg(feature = "flip-link")]

--- a/esp-hal/src/embassy/mod.rs
+++ b/esp-hal/src/embassy/mod.rs
@@ -86,7 +86,13 @@ use embassy_time_driver::{AlarmHandle, Driver};
 use crate::{interrupt::Priority, peripherals::Interrupt};
 
 #[cfg_attr(
-    all(systimer, feature = "embassy-time-systick"),
+    all(
+        systimer,
+        any(
+            feature = "embassy-time-systick-16mhz",
+            feature = "embassy-time-systick-80mhz"
+        )
+    ),
     path = "time_driver_systimer.rs"
 )]
 #[cfg_attr(

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -59,7 +59,7 @@ embassy = ["esp-hal/embassy"]
 embassy-executor-thread    = ["esp-hal/embassy-executor-thread"]
 embassy-executor-interrupt = ["esp-hal/embassy-executor-interrupt"]
 
-embassy-time-timg0 = ["esp-hal/embassy-time-timg0", "embassy-time-driver/tick-hz-1_000_000"]
+embassy-time-timg0 = ["esp-hal/embassy-time-timg0"]
 embassy-generic-timers = ["embassy-time/generic-queue-8"]
 
 direct-vectoring     = ["esp-hal/direct-vectoring"]


### PR DESCRIPTION
Closes https://github.com/esp-rs/esp-hal/issues/1239

Ended up not being completely horrible. I did take another look at the trms to see if there was any way to make both types output the same freq, but sadly it doesn't seem possible.