### PR TITLE
New package releases

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,6 +19,6 @@ jobs:
 
       - uses: dangoslen/changelog-enforcer@v3
         with:
-          changeLogPath: CHANGELOG.md
+          changeLogPath: esp-hal/CHANGELOG.md
           skipLabels: "skip-changelog"
           missingUpdateErrorMessage: "Please add a changelog entry in the CHANGELOG.md file."

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-hal-procmacros"
-version      = "0.8.0"
+version      = "0.9.0"
 edition      = "2021"
 rust-version = "1.76.0"
 description  = "Procedural macros for esp-hal"
@@ -14,15 +14,15 @@ features = ["embassy", "has-ulp-core", "interrupt", "ram", "is-ulp-core"]
 proc-macro = true
 
 [dependencies]
-darling           = "0.20.5"
+darling           = "0.20.8"
 document-features = "0.2.8"
 litrs             = "0.4.1"
-object            = { version = "0.32.2", optional = true }
+object            = { version = "0.33.0", optional = true }
 proc-macro-crate  = "3.1.0"
 proc-macro-error  = "1.0.4"
 proc-macro2       = "1.0.78"
 quote             = "1.0.35"
-syn               = { version = "2.0.48", features = ["extra-traits", "full"] }
+syn               = { version = "2.0.52", features = ["extra-traits", "full"] }
 
 [features]
 ## Provide a `#[main]` procmacro to mark the entry point for Embassy applications.

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-hal-smartled"
-version      = "0.8.0"
+version      = "0.9.0"
 edition      = "2021"
 rust-version = "1.76.0"
 description  = "RMT adapter for smartleds"
@@ -12,9 +12,9 @@ features = ["esp32c3"]
 targets  = ["riscv32imc-unknown-none-elf"]
 
 [dependencies]
-defmt             = { version = "=0.3.5", optional = true }
-document-features = "0.2.7"
-esp-hal           = { version = "0.15.0", path = "../esp-hal" }
+defmt             = { version = "0.3.6", optional = true }
+document-features = "0.2.8"
+esp-hal           = { version = "0.16.0", path = "../esp-hal" }
 fugit             = "0.3.7"
 smart-leds-trait  = "0.3.0"
 

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -12,7 +12,7 @@ features = ["esp32c3"]
 targets  = ["riscv32imc-unknown-none-elf"]
 
 [dependencies]
-defmt             = { version = "0.3.6", optional = true }
+defmt             = { version = "=0.3.6", optional = true }
 document-features = "0.2.8"
 esp-hal           = { version = "0.16.0", path = "../esp-hal" }
 fugit             = "0.3.7"

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-Please note that only changes to the `esp-hal-common` package are tracked in this CHANGELOG.
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.0] - 2024-03-07
 
 ### Added
 
@@ -449,7 +447,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2022-08-05
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/v0.15.0...HEAD
+[0.16.0]: https://github.com/esp-rs/esp-hal/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/esp-rs/esp-hal/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/esp-rs/esp-hal/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/esp-rs/esp-hal/compare/v0.13.1...v0.14.0

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.0] - 2024-03-07
+## [0.16.0] - 2024-03-08
 
 ### Added
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -212,3 +212,6 @@ opsram-4m  = []
 opsram-8m  = []
 ## Use externally connected Octal RAM (16MB).
 opsram-16m = []
+
+[lints.clippy]
+mixed_attributes_style = "allow"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
-name         = "esp-hal"
-version      = "0.15.0"
-edition      = "2021"
-rust-version = "1.76.0"
-description  = "Bare-metal HAL for Espressif devices"
-repository   = "https://github.com/esp-rs/esp-hal"
-license      = "MIT OR Apache-2.0"
-links        = "esp-hal"
+name          = "esp-hal"
+version       = "0.16.0"
+edition       = "2021"
+rust-version  = "1.76.0"
+description   = "Bare-metal HAL for Espressif devices"
+documentation = "https://docs.esp-rs.org/esp-hal/"
+repository    = "https://github.com/esp-rs/esp-hal"
+license       = "MIT OR Apache-2.0"
+links         = "esp-hal"
 
 [dependencies]
 bitflags             = "2.4.2"
 bitfield             = "0.14.0"
 cfg-if               = "1.0.0"
 critical-section     = "1.1.2"
-defmt                = { version = "=0.3.5", optional = true }
+defmt                = { version = "0.3.6", optional = true }
 document-features    = "0.2.8"
 embassy-executor     = { version = "0.5.0", optional = true }
 embassy-futures      = { version = "0.1.1", optional = true }
@@ -30,15 +31,15 @@ embedded-io-async    = { version = "0.6.1", optional = true }
 enumset              = "1.1.3"
 esp-synopsys-usb-otg = { version = "0.4.0", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
-log                  = { version = "0.4.20", optional = true }
+log                  = { version = "0.4.21", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.14"
 portable-atomic      = { version = "1.6.0", default-features = false }
-procmacros           = { version = "0.8.0", features = ["enum-dispatch", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-riscv                = { version = "0.11.0", optional = true }
-strum                = { version = "0.25.0", default-features = false, features = ["derive"] }
+procmacros           = { version = "0.9.0", features = ["enum-dispatch", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+riscv                = { version = "0.11.1", optional = true }
+strum                = { version = "0.26.1", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
-usb-device           = { version = "0.3.1", optional = true }
+usb-device           = { version = "0.3.2", optional = true }
 rand_core            = "0.6.4"
 ufmt-write           = { version = "0.1.0", optional = true }
 xtensa-lx            = { version = "0.9.0", optional = true }
@@ -56,15 +57,15 @@ esp32s2 = { version = "0.20.0", features = ["critical-section"], optional = true
 esp32s3 = { version = "0.24.0", features = ["critical-section"], optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-esp-riscv-rt = { version = "0.6.1", optional = true }
+esp-riscv-rt = { version = "0.7.0", optional = true, path = "../esp-riscv-rt" }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
 xtensa-lx-rt = { version = "0.16.0", optional = true }
 
 [build-dependencies]
 basic-toml = "0.1.8"
-serde      = { version = "1.0.195", features = ["derive"] }
-cfg-if = "1"
+cfg-if     = "1.0.0"
+serde      = { version = "1.0.197", features = ["derive"] }
 
 [features]
 default = ["rt", "vectored"]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -14,7 +14,7 @@ bitflags             = "2.4.2"
 bitfield             = "0.14.0"
 cfg-if               = "1.0.0"
 critical-section     = "1.1.2"
-defmt                = { version = "0.3.6", optional = true }
+defmt                = { version = "=0.3.6", optional = true }
 document-features    = "0.2.8"
 embassy-executor     = { version = "0.5.0", optional = true }
 embassy-futures      = { version = "0.1.1", optional = true }

--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -1,7 +1,6 @@
 # esp-hal
 
 [![Crates.io](https://img.shields.io/crates/v/esp-hal?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal)
-[![docs.rs](https://img.shields.io/docsrs/esp-hal?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-hal)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
@@ -15,7 +14,7 @@ Most traits defined by the [embedded-hal] family of packages are implemented as 
 
 ## [Documentation]
 
-[documentation]: https://docs.rs/esp-hal/
+[documentation]: https://docs.esp-rs.org/
 
 ## Usage
 

--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -14,7 +14,7 @@ Most traits defined by the [embedded-hal] family of packages are implemented as 
 
 ## [Documentation]
 
-[documentation]: https://docs.esp-rs.org/
+[documentation]: https://docs.esp-rs.org/esp-hal/
 
 ## Usage
 

--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 - 2024-03-07
+## 0.7.0 - 2024-03-08
 
 ### Changed
 

--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -5,17 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Added
-
-### Fixed
+## 0.7.0 - 2024-03-07
 
 ### Changed
 
 - `start_rust` calls `hal_main` instead of calling user's `main` directly (#1135)
-
-### Removed
 
 ## 0.6.1 - 2024-01-19
 

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-riscv-rt"
-version      = "0.6.1"
+version      = "0.7.0"
 edition      = "2021"
 rust-version = "1.65"
 description  = "Minimal runtime / startup for RISC-V CPUs from Espressif"
@@ -10,8 +10,8 @@ keywords     = ["esp32", "riscv", "runtime", "startup"]
 categories   = ["embedded", "no-std"]
 
 [dependencies]
-document-features = "0.2.7"
-riscv             = "0.11.0"
+document-features = "0.2.8"
+riscv             = "0.11.1"
 riscv-rt-macros   = "0.2.1"
 
 [features]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-aes                 = "0.8.3"
+aes                 = "0.8.4"
 cfg-if              = "1.0.0"
 critical-section    = "1.1.2"
 crypto-bigint       = { version = "0.5.5", default-features = false }
@@ -23,13 +23,13 @@ embedded-hal-bus    = "0.1.0"
 embedded-io-async   = "0.6.1"
 esp-alloc           = "0.3.0"
 esp-backtrace       = { version = "0.11.0", features = ["exception-handler", "panic-handler", "println"] }
-esp-hal             = { version = "0.15.0", path = "../esp-hal" }
-esp-hal-smartled    = { version = "0.8.0",  path = "../esp-hal-smartled", optional = true }
+esp-hal             = { version = "0.16.0", path = "../esp-hal" }
+esp-hal-smartled    = { version = "0.9.0",  path = "../esp-hal-smartled", optional = true }
 esp-println         = "0.9.0"
 heapless            = "0.8.0"
 hex-literal         = "0.4.1"
 hmac                = { version = "0.12.1", default-features = false }
-lis3dh-async        = "0.9.1"
+lis3dh-async        = "0.9.2"
 nb                  = "1.1.0"
 p192                = { version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256                = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
@@ -37,8 +37,8 @@ sha2                = { version = "0.10.8", default-features = false}
 smart-leds          = "0.4.0"
 ssd1306             = "0.8.4"
 static_cell         = { version = "2.0.0", features = ["nightly"] }
-usb-device          = "0.3.1"
-usbd-serial         = "0.2.0"
+usb-device          = "0.3.2"
+usbd-serial         = "0.2.1"
 
 [features]
 esp32   = ["esp-hal/esp32",   "esp-backtrace/esp32",   "esp-println/esp32",   "esp-hal-smartled/esp32"]

--- a/resources/index.html
+++ b/resources/index.html
@@ -88,51 +88,51 @@
                  the package version in the URL and '.crate-version' span. -->
 
       <div class="crate">
-        <span class="crate-name"><a href="esp-hal/0.15.0/esp32/esp_hal/index.html">esp32</a></span>
+        <span class="crate-name"><a href="esp-hal/0.16.0/esp32/esp_hal/index.html">esp32</a></span>
         <span class="crate-description">esp-hal (targeting ESP32)</span>
-        <span class="crate-version">0.15.0</span>
+        <span class="crate-version">0.16.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="esp-hal/0.15.0/esp32c2/esp_hal/index.html">esp32c2</a></span>
+        <span class="crate-name"><a href="esp-hal/0.16.0/esp32c2/esp_hal/index.html">esp32c2</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-C2)</span>
-        <span class="crate-version">0.15.0</span>
+        <span class="crate-version">0.16.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="esp-hal/0.15.0/esp32c3/esp_hal/index.html">esp32c3</a></span>
+        <span class="crate-name"><a href="esp-hal/0.16.0/esp32c3/esp_hal/index.html">esp32c3</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-C3)</span>
-        <span class="crate-version">0.15.0</span>
+        <span class="crate-version">0.16.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="esp-hal/0.15.0/esp32c6/esp_hal/index.html">esp32c6</a></span>
+        <span class="crate-name"><a href="esp-hal/0.16.0/esp32c6/esp_hal/index.html">esp32c6</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-C6)</span>
-        <span class="crate-version">0.15.0</span>
+        <span class="crate-version">0.16.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="esp-hal/0.15.0/esp32h2/esp_hal/index.html">esp32h2</a></span>
+        <span class="crate-name"><a href="esp-hal/0.16.0/esp32h2/esp_hal/index.html">esp32h2</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-H2)</span>
-        <span class="crate-version">0.15.0</span>
+        <span class="crate-version">0.16.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="esp-hal/0.15.0/esp32p4/esp_hal/index.html">esp32p4</a></span>
+        <span class="crate-name"><a href="esp-hal/0.16.0/esp32p4/esp_hal/index.html">esp32p4</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-P4)</span>
-        <span class="crate-version">0.15.0</span>
+        <span class="crate-version">0.16.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="esp-hal/0.15.0/esp32s2/esp_hal/index.html">esp32s2</a></span>
+        <span class="crate-name"><a href="esp-hal/0.16.0/esp32s2/esp_hal/index.html">esp32s2</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-S2)</span>
-        <span class="crate-version">0.15.0</span>
+        <span class="crate-version">0.16.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="esp-hal/0.15.0/esp32s3/esp_hal/index.html">esp32s3</a></span>
+        <span class="crate-name"><a href="esp-hal/0.16.0/esp32s3/esp_hal/index.html">esp32s3</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-S3)</span>
-        <span class="crate-version">0.15.0</span>
+        <span class="crate-version">0.16.0</span>
       </div>
     </div>
   </body>


### PR DESCRIPTION
**Leaving this as a draft until I'm a bit more confident we're ready to pull the trigger here.**

Nothing too noteworthy in this PR, just the usual dependency updates and what not. I've also moved `esp-hal`'s `CHANGELOG.md` into the `esp-hal` directory, where it probably belongs. Can revert this change if anybody feels it's the wrong move.

For `esp-hal`, I've added the `documentation` key to the Cargo manifest, but we will need to confirm the URL before publishing.

As usual, if anything looks off or if I'm missing anything, please let me know!

Closes #446