### PR TITLE
Tweak the documentation URL slightly

### DIFF
--- a/.github/scripts/build_docs.sh
+++ b/.github/scripts/build_docs.sh
@@ -14,7 +14,7 @@ CHIPS=("esp32" "esp32c2" "esp32c3" "esp32c6" "esp32h2" "esp32p4" "esp32s2" "esp3
 
 for CHIP in "${CHIPS[@]}"; do
   cargo xtask build-documentation \
-    --output-path="docs/$PKG_VERSION"/"$CHIP"/ \
+    --output-path="docs/esp-hal/$PKG_VERSION"/"$CHIP"/ \
     esp-hal \
     "$CHIP"
 done

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ wokwi.toml
 
 # We'll ignore VS Code settings (at least for now...)
 **/.vscode/settings.json
+
+# Ignore generated documentation
+docs/

--- a/resources/.prettierrc.json
+++ b/resources/.prettierrc.json
@@ -1,4 +1,4 @@
 {
-  "printWidth": 100,
+  "printWidth": 120,
   "tabWidth": 2
 }

--- a/resources/index.html
+++ b/resources/index.html
@@ -7,10 +7,7 @@
     <title>esp-rs docs</title>
 
     <link rel="icon" href="esp-rs.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500&display=swap" rel="stylesheet" />
     <link
       href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,400;0,600;1,400;1,600&display=swap"
       rel="stylesheet"
@@ -91,49 +88,49 @@
                  the package version in the URL and '.crate-version' span. -->
 
       <div class="crate">
-        <span class="crate-name"><a href="0.15.0/esp32/esp_hal/index.html">esp32</a></span>
+        <span class="crate-name"><a href="esp-hal/0.15.0/esp32/esp_hal/index.html">esp32</a></span>
         <span class="crate-description">esp-hal (targeting ESP32)</span>
         <span class="crate-version">0.15.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="0.15.0/esp32c2/esp_hal/index.html">esp32c2</a></span>
+        <span class="crate-name"><a href="esp-hal/0.15.0/esp32c2/esp_hal/index.html">esp32c2</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-C2)</span>
         <span class="crate-version">0.15.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="0.15.0/esp32c3/esp_hal/index.html">esp32c3</a></span>
+        <span class="crate-name"><a href="esp-hal/0.15.0/esp32c3/esp_hal/index.html">esp32c3</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-C3)</span>
         <span class="crate-version">0.15.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="0.15.0/esp32c6/esp_hal/index.html">esp32c6</a></span>
+        <span class="crate-name"><a href="esp-hal/0.15.0/esp32c6/esp_hal/index.html">esp32c6</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-C6)</span>
         <span class="crate-version">0.15.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="0.15.0/esp32h2/esp_hal/index.html">esp32h2</a></span>
+        <span class="crate-name"><a href="esp-hal/0.15.0/esp32h2/esp_hal/index.html">esp32h2</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-H2)</span>
         <span class="crate-version">0.15.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="0.15.0/esp32p4/esp_hal/index.html">esp32p4</a></span>
+        <span class="crate-name"><a href="esp-hal/0.15.0/esp32p4/esp_hal/index.html">esp32p4</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-P4)</span>
         <span class="crate-version">0.15.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="0.15.0/esp32s2/esp_hal/index.html">esp32s2</a></span>
+        <span class="crate-name"><a href="esp-hal/0.15.0/esp32s2/esp_hal/index.html">esp32s2</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-S2)</span>
         <span class="crate-version">0.15.0</span>
       </div>
 
       <div class="crate">
-        <span class="crate-name"><a href="0.15.0/esp32s3/esp_hal/index.html">esp32s3</a></span>
+        <span class="crate-name"><a href="esp-hal/0.15.0/esp32s3/esp_hal/index.html">esp32s3</a></span>
         <span class="crate-description">esp-hal (targeting ESP32-S3)</span>
         <span class="crate-version">0.15.0</span>
       </div>


### PR DESCRIPTION
Forgot to namespace things by package as well, so that in the future we can also have docs for e.g. `esp-lp-hal`.