### PR TITLE
Use ROM memcpy and friends over compiler-builtins function

### DIFF
--- a/esp-hal/ld/esp32/rom-functions.x
+++ b/esp-hal/ld/esp32/rom-functions.x
@@ -27,3 +27,8 @@ PROVIDE (esp_rom_crc8_le = 0x4005d0e0);
 PROVIDE (esp_rom_md5_init   = 0x4005da7c);
 PROVIDE (esp_rom_md5_update = 0x4005da9c);
 PROVIDE (esp_rom_md5_final  = 0x4005db1c);
+
+memcmp = 0x4000c260;
+memcpy = 0x4000c2c8;
+memmove = 0x4000c3c0;
+memset = 0x4000c44c;

--- a/esp-hal/ld/esp32c2/rom-functions.x
+++ b/esp-hal/ld/esp32c2/rom-functions.x
@@ -16,3 +16,8 @@ PROVIDE(esp_rom_crc8_le = 0x40000804);
 PROVIDE(esp_rom_mbedtls_md5_starts_ret = 0x40002be4);
 PROVIDE(esp_rom_mbedtls_md5_update_ret = 0x40002be8);
 PROVIDE(esp_rom_mbedtls_md5_finish_ret = 0x40002bec);
+
+memset = 0x40000488;
+memcpy = 0x4000048c;
+memmove = 0x40000490;
+memcmp = 0x40000494;

--- a/esp-hal/ld/esp32c3/rom-functions.x
+++ b/esp-hal/ld/esp32c3/rom-functions.x
@@ -23,3 +23,8 @@ PROVIDE(esp_rom_crc8_le = 0x40000638);
 PROVIDE(esp_rom_md5_init = 0x40000614);
 PROVIDE(esp_rom_md5_update = 0x40000618);
 PROVIDE(esp_rom_md5_final = 0x4000061c);
+
+memset = 0x40000354;
+memcpy = 0x40000358;
+memmove = 0x4000035c;
+memcmp = 0x40000360;

--- a/esp-hal/ld/esp32c6/rom-functions.x
+++ b/esp-hal/ld/esp32c6/rom-functions.x
@@ -23,3 +23,8 @@ PROVIDE(esp_rom_crc8_le = 0x40000760);
 PROVIDE(esp_rom_md5_init = 0x4000074c);
 PROVIDE(esp_rom_md5_update = 0x40000750);
 PROVIDE(esp_rom_md5_final = 0x40000754);
+
+memset = 0x400004a8;
+memcpy = 0x400004ac;
+memmove = 0x400004b0;
+memcmp = 0x400004b4;

--- a/esp-hal/ld/esp32h2/rom-functions.x
+++ b/esp-hal/ld/esp32h2/rom-functions.x
@@ -23,3 +23,8 @@ PROVIDE(esp_rom_crc8_le = 0x4000072c);
 PROVIDE(esp_rom_md5_init = 0x40000718);
 PROVIDE(esp_rom_md5_update = 0x4000071c);
 PROVIDE(esp_rom_md5_final = 0x40000720);
+
+memset = 0x400004a0;
+memcpy = 0x400004a4;
+memmove = 0x400004a8;
+memcmp = 0x400004ac;

--- a/esp-hal/ld/esp32p4/rom-functions.x
+++ b/esp-hal/ld/esp32p4/rom-functions.x
@@ -1,3 +1,8 @@
 ets_update_cpu_frequency = 0x4fc00044;
 ets_printf = 0x4fc00024;
 PROVIDE(ets_delay_us = 0x4fc0003c);
+
+memset = 0x4fc00268;
+memcpy = 0x4fc0026c;
+memmove = 0x4fc00270;
+memcmp = 0x4fc00274;

--- a/esp-hal/ld/esp32s2/rom-functions.x
+++ b/esp-hal/ld/esp32s2/rom-functions.x
@@ -27,3 +27,8 @@ PROVIDE(esp_rom_crc8_le = 0x40011a4c);
 PROVIDE(esp_rom_md5_final = 0x4000530c);
 PROVIDE(esp_rom_md5_init = 0x4000526c);
 PROVIDE(esp_rom_md5_update = 0x4000528c);
+
+memcmp = 0x4001ab40;
+memcpy = 0x4001aba8;
+memmove = 0x4001acb0;
+memset = 0x4001ad3c;

--- a/esp-hal/ld/esp32s3/rom-functions.x
+++ b/esp-hal/ld/esp32s3/rom-functions.x
@@ -34,3 +34,8 @@ PROVIDE(esp_rom_md5_final = 0x40001c74);
 PROVIDE (esp_rom_opiflash_exec_cmd = 0x400008b8);
 PROVIDE( esp_rom_spi_set_dtr_swap_mode = 0x4000093c );
 PROVIDE( esp_rom_opiflash_pin_config = 0x40000894 );
+
+memset = 0x400011e8;
+memcpy = 0x400011f4;
+memmove = 0x40001200;
+memcmp = 0x4000120c;


### PR DESCRIPTION
`nm examples/target/xtensa-esp32s3-none-elf/release/gpio_interrupt | grep memcpy` shows `0x400011f4` on esp32s3, so it looks like this is correctly overriding the linkage.

@bjoernQ maybe you were using `PROVIDE` which I think only "fills" in the symbol if its missing.

I think the last time memcpy from ROM was enabled, bad things with esp-wifi happened, @bjoernQ do you recall this, and would you mind testing?