### PR TITLE
Un-pin the `defmt` package's version, bump `esp-println` and `esp-backtrace` dependency versions

### DIFF
--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -12,7 +12,7 @@ features = ["esp32c3"]
 targets  = ["riscv32imc-unknown-none-elf"]
 
 [dependencies]
-defmt             = { version = "=0.3.6", optional = true }
+defmt             = { version = "0.3.6", optional = true }
 document-features = "0.2.8"
 esp-hal           = { version = "0.16.0", path = "../esp-hal" }
 fugit             = "0.3.7"

--- a/esp-hal-smartled/README.md
+++ b/esp-hal-smartled/README.md
@@ -11,6 +11,13 @@ This adapter allows for the use of an RMT output channel to easily interact with
 
 [documentation]: https://docs.rs/esp-hal-smartled/
 
+## Usage
+
+### `defmt` Feature
+
+Please note that `defmt` does _not_ provide MSRV guarantees with releases, and as such we are not able to make any MSRV guarantees when this feature is enabled. For more information refer to the MSRV section of `defmt`'s README:
+https://github.com/knurling-rs/defmt?tab=readme-ov-file#msrv
+
 ## License
 
 Licensed under either of:

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -14,7 +14,7 @@ bitflags             = "2.4.2"
 bitfield             = "0.14.0"
 cfg-if               = "1.0.0"
 critical-section     = "1.1.2"
-defmt                = { version = "=0.3.6", optional = true }
+defmt                = { version = "0.3.6", optional = true }
 document-features    = "0.2.8"
 embassy-executor     = { version = "0.5.0", optional = true }
 embassy-futures      = { version = "0.1.1", optional = true }

--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -29,6 +29,11 @@ Much of the functionality available is feature-gated, so be sure to refer to the
 [cargo-generate]: https://github.com/cargo-generate/cargo-generate/
 [esp-template]: https://github.com/esp-rs/esp-template/
 
+### `defmt` Feature
+
+Please note that `defmt` does _not_ provide MSRV guarantees with releases, and as such we are not able to make any MSRV guarantees when this feature is enabled. For more information refer to the MSRV section of `defmt`'s README:
+https://github.com/knurling-rs/defmt?tab=readme-ov-file#msrv
+
 ### Supporting Packages
 
 A number of additional packages are available which add additional functionality beyond the HAL.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,10 +22,10 @@ embedded-hal-async  = "1.0.0"
 embedded-hal-bus    = "0.1.0"
 embedded-io-async   = "0.6.1"
 esp-alloc           = "0.3.0"
-esp-backtrace       = { version = "0.11.0", features = ["exception-handler", "panic-handler", "println"] }
+esp-backtrace       = { version = "0.11.1", features = ["exception-handler", "panic-handler", "println"] }
 esp-hal             = { version = "0.16.0", path = "../esp-hal" }
 esp-hal-smartled    = { version = "0.9.0",  path = "../esp-hal-smartled", optional = true }
-esp-println         = "0.9.0"
+esp-println         = "0.9.1"
 heapless            = "0.8.0"
 hex-literal         = "0.4.1"
 hmac                = { version = "0.12.1", default-features = false }


### PR DESCRIPTION
Closes #1263