### PR TITLE
Display a warning banner linking to docs.esp-rs.org when documentation is hosted on docs.rs

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -9,6 +9,11 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 links         = "esp-hal"
 
+[package.metadata.docs.rs]
+default-target = "riscv32imac-unknown-none-elf"
+features       = ["esp32c6"]
+rustdoc-args   = ["--cfg", "docsrs"]
+
 [dependencies]
 bitflags             = "2.4.2"
 bitfield             = "0.14.0"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -11,7 +11,7 @@ links         = "esp-hal"
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
-features       = ["esp32c6"]
+features       = ["eh1", "esp32c6"]
 rustdoc-args   = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/esp-hal/src/etm.rs
+++ b/esp-hal/src/etm.rs
@@ -18,7 +18,7 @@
 //! a particular Event to a particular Task. When an event is activated, the ETM
 //! channel will trigger the corresponding task automatically.
 //!
-//! More information: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-reference/peripherals/etm.html
+//! More information: <https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-reference/peripherals/etm.html>
 //!
 //! ## Example
 //! ```no_run

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -1,6 +1,11 @@
-//! `no_std` HAL implementations for the peripherals which are common among
-//! Espressif devices. Implements a number of the traits defined by
-//! [embedded-hal].
+#![cfg_attr(
+    docsrs,
+    doc = "<div style='padding:30px;background:#810;color:#fff;text-align:center;'><p>You might want to <a href='https://docs.esp-rs.org/esp-hal/'>browse the <code>esp-hal</code> documentation on the esp-rs website</a> instead.</p><p>The documentation here on <a href='https://docs.rs'>docs.rs</a> is built for a single chip only (ESP32-C6, in particular), while on the esp-rs website you can select your exact chip from the list of supported devices. Available peripherals and their APIs change depending on the chip.</p></div>\n\n<br/>\n\n"
+)]
+//! Bare-metal (`no_std`) HAL for Espressif devices. Implements most of the
+//! traits defined by various packages in the [embedded-hal] repository.
+//!
+//! [embedded-hal]: https://github.com/rust-embedded/embedded-hal
 //!
 //! ## Feature Flags
 #![doc = document_features::document_features!()]

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -36,7 +36,7 @@ impl self::efuse::Efuse {
     /// The new value will be returned by `read_mac_address` instead of the one
     /// hard-coded in eFuse. This does not persist across device resets.
     ///
-    /// Can only be called once. Returns `Err(`[`SetMacError::AlreadySet`]`)`
+    /// Can only be called once. Returns `Err(SetMacError::AlreadySet)`
     /// otherwise.
     pub fn set_mac_address(mac: [u8; 6]) -> Result<(), SetMacError> {
         if MAC_OVERRIDE_STATE


### PR DESCRIPTION
Since there is no great solution for handling our documentation, we were forced to self-host it. However, this is a problem from a discoverability standpoint, as users who are not aware of this may check docs.rs instead.

This PR does a few things:

- Adds the required package metadata to get the HAL building on docs.rs (targeting the ESP32-C6)
- Adds a warning banner, only when hosted on docs.rs, which links the user to the proper documentation
- Fixes some unrelated warnings which popped up while building the docs