### PR TITLE
Do not ensure randomness or implement `CryptoRng` for ESP32-P4/S2

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Do not ensure randomness or implement the `CryptoRng` trait for ESP32-P4/S2 (#1267)
+
 ### Removed
 
 ## [0.16.0] - 2024-03-08

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -65,8 +65,6 @@
 
 use core::{convert::Infallible, marker::PhantomData};
 
-use rand_core::{CryptoRng, RngCore};
-
 use crate::{peripheral::Peripheral, peripherals::RNG};
 
 /// Random number generator driver
@@ -110,7 +108,7 @@ impl embedded_hal::blocking::rng::Read for Rng {
     }
 }
 
-impl RngCore for Rng {
+impl rand_core::RngCore for Rng {
     fn next_u32(&mut self) -> u32 {
         // Directly use the existing random method to get a u32 random number
         self.random()
@@ -141,4 +139,4 @@ impl RngCore for Rng {
 }
 
 #[cfg(not(any(esp32p4, esp32s2)))]
-impl CryptoRng for Rng {}
+impl rand_core::CryptoRng for Rng {}

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -78,7 +78,7 @@ pub struct Rng {
 impl Rng {
     /// Create a new random number generator instance
     pub fn new(_rng: impl Peripheral<P = RNG>) -> Self {
-        #[cfg(not(esp32p4))]
+        #[cfg(not(any(esp32p4, esp32s2)))]
         crate::soc::trng::ensure_randomness();
 
         Self {
@@ -140,4 +140,5 @@ impl RngCore for Rng {
     }
 }
 
+#[cfg(not(any(esp32p4, esp32s2)))]
 impl CryptoRng for Rng {}

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -18,7 +18,7 @@ pub mod peripherals;
 #[cfg(psram)]
 pub mod psram;
 pub mod radio_clocks;
-pub mod trng;
+// pub mod trng;
 pub mod ulp_core;
 
 pub(crate) mod constants {


### PR DESCRIPTION
This was causing issues with `esp-wifi`, so for the sake of getting this next release out and restoring order over there, we will disable this functionality for these chips until the root problem has been resolved. This will be tracked in #1257