### PR TITLE
Fixing `esp-wifi` + `TRNG` issue on `ESP32-S2`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fixing `esp-wifi` + `TRNG` issue on `ESP32-S2` (#1272)
 
 ### Changed
 

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -76,7 +76,7 @@ pub struct Rng {
 impl Rng {
     /// Create a new random number generator instance
     pub fn new(_rng: impl Peripheral<P = RNG>) -> Self {
-        #[cfg(not(any(esp32p4, esp32s2)))]
+        #[cfg(not(esp32p4))]
         crate::soc::trng::ensure_randomness();
 
         Self {
@@ -138,5 +138,5 @@ impl rand_core::RngCore for Rng {
     }
 }
 
-#[cfg(not(any(esp32p4, esp32s2)))]
+#[cfg(not(esp32p4))]
 impl rand_core::CryptoRng for Rng {}

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -18,7 +18,7 @@ pub mod peripherals;
 #[cfg(psram)]
 pub mod psram;
 pub mod radio_clocks;
-// pub mod trng;
+pub mod trng;
 pub mod ulp_core;
 
 pub(crate) mod constants {

--- a/esp-hal/src/soc/esp32s2/trng.rs
+++ b/esp-hal/src/soc/esp32s2/trng.rs
@@ -211,10 +211,6 @@ fn reg_get_bit(reg: u32, b: u32) -> u32 {
     unsafe { (reg as *mut u32).read_volatile() & b }
 }
 
-fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
-    unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
-}
-
 fn reg_clr_bit(reg: u32, bit: u32) {
     unsafe {
         (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
@@ -282,10 +278,8 @@ pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, l
         | (reg_add as u32 & I2C_RTC_ADDR_V as u32) << I2C_RTC_ADDR_S as u32;
     reg_write(I2C_RTC_CONFIG2, temp);
     while reg_get_bit(I2C_RTC_CONFIG2, I2C_RTC_BUSY) != 0 {}
-    temp = reg_get_field(I2C_RTC_CONFIG2, I2C_RTC_DATA_S, I2C_RTC_DATA_V);
     // Write the i2c bus register
-    temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
-    temp |= (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
+    temp = (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
     temp = ((block as u32 & I2C_RTC_SLAVE_ID_V as u32) << I2C_RTC_SLAVE_ID_S as u32)
         | ((reg_add as u32 & I2C_RTC_ADDR_V as u32) << I2C_RTC_ADDR_S as u32)
         | ((0x1 & I2C_RTC_WR_CNTL_V as u32) << I2C_RTC_WR_CNTL_S as u32)


### PR DESCRIPTION
From the beginning of that issue I was pretty much sure that the problem is, that when both `Wi-Fi` and `RNG` are initialized, there is some register interference, which causes wrong behaviour of `Wi-Fi` (#1257) 
After some debugging and experiments I was able to locate 3 "problematic" register-modifying functions (when they're commented out `Wi-Fi` works). What the corresponding function from `esp-idf` (random_disable) did was to roll back that change. 🥁 that didn't work, unfortunately...

Huge thanks to @bjoernQ for his help in spotting the problematic place in `esp-idf`'s [`regi2c_write_mask` ](https://github.com/espressif/esp-idf/blob/master/components/esp_rom/patches/esp_rom_regi2c_esp32s2.c#L157-L160), there's some dead code, which I, unfortunately, didn't notice before.

After that fix `esp-wifi` works on `esp32-s2`

closes #1257 

PS: I still have those "random_disable" functions stored in branch, so maybe one day we'll decide to have them in our driver as well