### PR TITLE
Remove package-level type exports

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,12 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+
 - Fixing `esp-wifi` + `TRNG` issue on `ESP32-S2` (#1272)
 
 ### Changed
+
 - Prefer mutable references over moving for DMA transactions (#1238)
 
 ### Removed
+
+- Remove package-level type exports (#1275)
 
 ## [0.16.1] - 2024-03-12
 

--- a/esp-hal/src/analog/adc/calibration/basic.rs
+++ b/esp-hal/src/analog/adc/calibration/basic.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::adc::{
+use crate::analog::adc::{
     AdcCalEfuse,
     AdcCalScheme,
     AdcCalSource,

--- a/esp-hal/src/analog/adc/calibration/curve.rs
+++ b/esp-hal/src/analog/adc/calibration/curve.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::adc::{
+use crate::analog::adc::{
     AdcCalEfuse,
     AdcCalLine,
     AdcCalScheme,

--- a/esp-hal/src/analog/adc/calibration/line.rs
+++ b/esp-hal/src/analog/adc/calibration/line.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::adc::{
+use crate::analog::adc::{
     AdcCalBasic,
     AdcCalEfuse,
     AdcCalScheme,

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -28,20 +28,6 @@ pub use xtensa_lx;
 #[cfg(all(xtensa, feature = "rt"))]
 pub use xtensa_lx_rt::{self, entry};
 
-#[cfg(adc)]
-pub use self::analog::adc;
-#[cfg(dac)]
-pub use self::analog::dac;
-#[cfg(any(xtensa, all(riscv, systimer)))]
-pub use self::delay::Delay;
-#[cfg(gpio)]
-pub use self::gpio::IO;
-#[cfg(rmt)]
-pub use self::rmt::Rmt;
-#[cfg(rng)]
-pub use self::rng::Rng;
-#[cfg(any(lp_clkrst, rtc_cntl))]
-pub use self::rtc_cntl::{Rtc, Rwdt};
 #[cfg(any(esp32, esp32s3))]
 pub use self::soc::cpu_control;
 #[cfg(efuse)]
@@ -53,12 +39,6 @@ pub use self::soc::peripherals;
 pub use self::soc::psram;
 #[cfg(ulp_riscv_core)]
 pub use self::soc::ulp_core;
-#[cfg(any(timg0, timg1))]
-pub use self::timer::Timer;
-#[cfg(any(uart0, uart1, uart2))]
-pub use self::uart::{Uart, UartRx, UartTx};
-#[cfg(usb_device)]
-pub use self::usb_serial_jtag::UsbSerialJtag;
 
 #[cfg(aes)]
 pub mod aes;

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -270,7 +270,11 @@ impl<'d> Rtc<'d> {
 
     /// enter deep sleep and wake with the provided `wake_sources`
     #[cfg(any(esp32, esp32s3, esp32c3, esp32c6))]
-    pub fn sleep_deep(&mut self, wake_sources: &[&dyn WakeSource], delay: &mut crate::Delay) -> ! {
+    pub fn sleep_deep(
+        &mut self,
+        wake_sources: &[&dyn WakeSource],
+        delay: &mut crate::delay::Delay,
+    ) -> ! {
         let config = RtcSleepConfig::deep();
         self.sleep(&config, wake_sources, delay);
         unreachable!();
@@ -278,7 +282,11 @@ impl<'d> Rtc<'d> {
 
     /// enter light sleep and wake with the provided `wake_sources`
     #[cfg(any(esp32, esp32s3, esp32c3, esp32c6))]
-    pub fn sleep_light(&mut self, wake_sources: &[&dyn WakeSource], delay: &mut crate::Delay) {
+    pub fn sleep_light(
+        &mut self,
+        wake_sources: &[&dyn WakeSource],
+        delay: &mut crate::delay::Delay,
+    ) {
         let config = RtcSleepConfig::default();
         self.sleep(&config, wake_sources, delay);
     }
@@ -290,7 +298,7 @@ impl<'d> Rtc<'d> {
         &mut self,
         config: &RtcSleepConfig,
         wake_sources: &[&dyn WakeSource],
-        delay: &mut crate::Delay,
+        delay: &mut crate::delay::Delay,
     ) {
         let mut config = *config;
         let mut wakeup_triggers = WakeTriggers::default();

--- a/esp-hal/src/rtc_cntl/sleep/esp32.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32.rs
@@ -1,8 +1,7 @@
 use super::{Ext0WakeupSource, Ext1WakeupSource, TimerWakeupSource, WakeSource, WakeTriggers};
 use crate::{
     gpio::{RTCPin, RtcFunction},
-    rtc_cntl::{sleep::WakeupLevel, Clock, RtcClock},
-    Rtc,
+    rtc_cntl::{sleep::WakeupLevel, Clock, Rtc, RtcClock},
 };
 
 // Approximate mapping of voltages to RTC_CNTL_DBIAS_WAK, RTC_CNTL_DBIAS_SLP,

--- a/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
@@ -2,8 +2,7 @@ use super::{TimerWakeupSource, WakeSource, WakeTriggers, WakeupLevel};
 use crate::{
     gpio::{RTCPinWithResistors, RtcFunction},
     regi2c_write_mask,
-    rtc_cntl::{sleep::RtcioWakeupSource, Clock, RtcClock},
-    Rtc,
+    rtc_cntl::{sleep::RtcioWakeupSource, Clock, Rtc, RtcClock},
 };
 
 const I2C_DIG_REG: u32 = 0x6D;

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -17,9 +17,9 @@ use crate::{
             SavedClockConfig,
         },
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeSource, WakeTriggers, WakeupLevel},
+        Rtc,
         RtcClock,
     },
-    Rtc,
 };
 
 impl WakeSource for TimerWakeupSource {

--- a/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
@@ -9,8 +9,7 @@ use super::{
 use crate::{
     gpio::{RTCPin, RtcFunction},
     regi2c_write_mask,
-    rtc_cntl::{sleep::RtcioWakeupSource, Clock, RtcClock},
-    Rtc,
+    rtc_cntl::{sleep::RtcioWakeupSource, Clock, Rtc, RtcClock},
 };
 
 const I2C_DIG_REG: u32 = 0x6d;

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -28,7 +28,7 @@ use core::time::Duration;
 use crate::gpio::RTCPin as RtcIoWakeupPinType;
 #[cfg(any(esp32c3, esp32c6))]
 use crate::gpio::RTCPinWithResistors as RtcIoWakeupPinType;
-use crate::Rtc;
+use crate::rtc_cntl::Rtc;
 
 #[cfg_attr(esp32, path = "esp32.rs")]
 #[cfg_attr(esp32s3, path = "esp32s3.rs")]

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -6,7 +6,7 @@
 //! for interacting with various system-related peripherals on `ESP32` chip.
 
 use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{timer::Wdt, Rtc};
+use crate::{rtc_cntl::Rtc, timer::Wdt};
 
 pub mod cpu_control;
 pub mod efuse;

--- a/esp-hal/src/soc/esp32c2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c2/efuse/mod.rs
@@ -34,7 +34,7 @@
 //! ```
 
 pub use self::fields::*;
-use crate::{adc::Attenuation, peripherals::EFUSE};
+use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 
 mod fields;
 

--- a/esp-hal/src/soc/esp32c2/mod.rs
+++ b/esp-hal/src/soc/esp32c2/mod.rs
@@ -6,7 +6,7 @@
 //! for interacting with various system-related peripherals on `ESP32-C2` chip.
 
 use self::peripherals::{LPWR, TIMG0};
-use crate::{timer::Wdt, Rtc};
+use crate::{rtc_cntl::Rtc, timer::Wdt};
 
 pub mod efuse;
 pub mod gpio;

--- a/esp-hal/src/soc/esp32c3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c3/efuse/mod.rs
@@ -34,7 +34,7 @@
 //! ```
 
 pub use self::fields::*;
-use crate::{adc::Attenuation, peripherals::EFUSE};
+use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 
 mod fields;
 

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -10,7 +10,7 @@
 //!    * I2S_DEFAULT_CLK_SRC: 2 - I2S clock source
 
 use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{timer::Wdt, Rtc};
+use crate::{rtc_cntl::Rtc, timer::Wdt};
 
 pub mod efuse;
 pub mod gpio;

--- a/esp-hal/src/soc/esp32c6/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c6/efuse/mod.rs
@@ -34,7 +34,7 @@
 //! ```
 
 pub use self::fields::*;
-use crate::{adc::Attenuation, peripherals::EFUSE};
+use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 
 mod fields;
 

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -11,7 +11,7 @@
 //!    * I2S_SCLK: 160_000_000 - I2S clock frequency
 
 use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{timer::Wdt, Rtc};
+use crate::{rtc_cntl::Rtc, timer::Wdt};
 
 pub mod efuse;
 pub mod gpio;

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -11,7 +11,7 @@
 //!    * I2S_SCLK: 96_000_000 - I2S clock frequency
 
 use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{timer::Wdt, Rtc};
+use crate::{rtc_cntl::Rtc, timer::Wdt};
 
 pub mod efuse;
 pub mod gpio;

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -10,7 +10,7 @@
 //!    * I2S_DEFAULT_CLK_SRC: 2 - I2S clock source
 
 use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{timer::Wdt, Rtc};
+use crate::{rtc_cntl::Rtc, timer::Wdt};
 
 pub mod efuse;
 pub mod gpio;

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -10,7 +10,7 @@
 //!    * I2S_DEFAULT_CLK_SRC: 2 - I2S clock source
 
 use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{timer::Wdt, Rtc};
+use crate::{rtc_cntl::Rtc, timer::Wdt};
 
 pub mod cpu_control;
 pub mod efuse;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1434,12 +1434,7 @@ mod asynch {
     use procmacros::interrupt;
 
     use super::{Error, Instance};
-    use crate::{
-        uart::{RegisterBlock, UART_FIFO_SIZE},
-        Uart,
-        UartRx,
-        UartTx,
-    };
+    use crate::uart::{RegisterBlock, Uart, UartRx, UartTx, UART_FIFO_SIZE};
 
     cfg_if! {
         if #[cfg(all(uart0, uart1, uart2))] {

--- a/examples/src/bin/adc.rs
+++ b/examples/src/bin/adc.rs
@@ -11,12 +11,12 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    adc::{AdcConfig, Attenuation, ADC},
+    analog::adc::{AdcConfig, Attenuation, ADC},
     clock::ClockControl,
+    delay::Delay,
     gpio::IO,
     peripherals::{Peripherals, ADC1},
     prelude::*,
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/adc_cal.rs
+++ b/examples/src/bin/adc_cal.rs
@@ -9,12 +9,12 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    adc::{AdcConfig, Attenuation, ADC},
+    analog::adc::{AdcConfig, Attenuation, ADC},
     clock::ClockControl,
+    delay::Delay,
     gpio::IO,
     peripherals::{Peripherals, ADC1},
     prelude::*,
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/advanced_serial.rs
+++ b/examples/src/bin/advanced_serial.rs
@@ -15,15 +15,15 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
     uart::{
         config::{Config, DataBits, Parity, StopBits},
         TxRxPins,
+        Uart,
     },
-    Delay,
-    Uart,
 };
 use esp_println::println;
 use nb::block;

--- a/examples/src/bin/blinky.rs
+++ b/examples/src/bin/blinky.rs
@@ -8,7 +8,7 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*, Delay};
+use esp_hal::{clock::ClockControl, delay::Delay, gpio::IO, peripherals::Peripherals, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/src/bin/blinky_erased_pins.rs
+++ b/examples/src/bin/blinky_erased_pins.rs
@@ -13,10 +13,10 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::{AnyPin, Input, Output, PullDown, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    Delay,
 };
 
 #[entry]

--- a/examples/src/bin/clock_monitor.rs
+++ b/examples/src/bin/clock_monitor.rs
@@ -16,7 +16,7 @@ use esp_hal::{
     interrupt::{self, Priority},
     peripherals::{Interrupt, Peripherals},
     prelude::*,
-    Rtc,
+    rtc_cntl::Rtc,
 };
 use esp_println::println;
 

--- a/examples/src/bin/crc.rs
+++ b/examples/src/bin/crc.rs
@@ -14,7 +14,7 @@ use esp_hal::{
     prelude::*,
     rom::{crc, md5},
     timer::TimerGroup,
-    Uart,
+    uart::Uart,
 };
 use nb::block;
 

--- a/examples/src/bin/dac.rs
+++ b/examples/src/bin/dac.rs
@@ -13,12 +13,12 @@
 
 use esp_backtrace as _;
 use esp_hal::{
+    analog::dac::{DAC1, DAC2},
     clock::ClockControl,
-    dac::{DAC1, DAC2},
+    delay::Delay,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    Delay,
 };
 
 #[entry]

--- a/examples/src/bin/ecc.rs
+++ b/examples/src/bin/ecc.rs
@@ -20,8 +20,8 @@ use esp_hal::{
     ecc::{Ecc, EllipticCurve, Error, WorkMode},
     peripherals::Peripherals,
     prelude::*,
+    rng::Rng,
     systimer::SystemTimer,
-    Rng,
 };
 use esp_println::{print, println};
 use hex_literal::hex;

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -23,11 +23,11 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     embassy::{self},
+    gpio::IO,
     i2c::I2C,
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    IO,
 };
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
 

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -24,12 +24,12 @@ use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    embassy::{self},
+    embassy,
+    gpio::IO,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -40,11 +40,11 @@ use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
     embassy::{self},
+    gpio::IO,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -14,12 +14,10 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     embassy::{self},
-    gpio::{Gpio5, Output, PushPull},
+    gpio::{Gpio5, Output, PushPull, IO},
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
-    Rmt,
-    IO,
+    rmt::{asynch::RxChannelAsync, PulseCode, Rmt, RxChannelConfig, RxChannelCreator},
 };
 use esp_println::{print, println};
 

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -14,13 +14,12 @@ use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
-    embassy::{self},
+    embassy,
+    gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    rmt::{asynch::TxChannelAsync, PulseCode, TxChannelConfig, TxChannelCreator},
+    rmt::{asynch::TxChannelAsync, PulseCode, Rmt, TxChannelConfig, TxChannelCreator},
     timer::TimerGroup,
-    Rmt,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -19,8 +19,7 @@ use esp_hal::{
     peripherals::{Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
-    uart::{config::AtCmdConfig, UartRx, UartTx},
-    Uart,
+    uart::{config::AtCmdConfig, Uart, UartRx, UartTx},
 };
 use static_cell::make_static;
 

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -29,6 +29,7 @@ use esp_hal::{
     dma::*,
     dma_descriptors,
     embassy::{self},
+    gpio::IO,
     peripherals::Peripherals,
     prelude::*,
     spi::{
@@ -36,7 +37,6 @@ use esp_hal::{
         SpiMode,
     },
     timer::TimerGroup,
-    IO,
 };
 
 #[main]

--- a/examples/src/bin/embassy_usb_serial_jtag.rs
+++ b/examples/src/bin/embassy_usb_serial_jtag.rs
@@ -18,8 +18,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx},
-    UsbSerialJtag,
+    usb_serial_jtag::{UsbSerialJtag, UsbSerialJtagRx, UsbSerialJtagTx},
 };
 use static_cell::make_static;
 

--- a/examples/src/bin/embassy_wait.rs
+++ b/examples/src/bin/embassy_wait.rs
@@ -16,10 +16,10 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     embassy::{self},
+    gpio::IO,
     peripherals::Peripherals,
     prelude::*,
     timer::TimerGroup,
-    IO,
 };
 
 #[main]

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -14,12 +14,12 @@ use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::{self, Event, Input, PullDown, IO},
     interrupt::{self, Priority},
     macros::ram,
     peripherals::{Interrupt, Peripherals},
     prelude::*,
-    Delay,
 };
 
 #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]

--- a/examples/src/bin/hello_rgb.rs
+++ b/examples/src/bin/hello_rgb.rs
@@ -14,7 +14,14 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, rmt::Rmt, Delay, IO};
+use esp_hal::{
+    clock::ClockControl,
+    delay::Delay,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    rmt::Rmt,
+};
 use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness,

--- a/examples/src/bin/hello_world.rs
+++ b/examples/src/bin/hello_world.rs
@@ -11,7 +11,13 @@
 use core::fmt::Write;
 
 use esp_backtrace as _;
-use esp_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Uart};
+use esp_hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    timer::TimerGroup,
+    uart::Uart,
+};
 use nb::block;
 
 #[entry]

--- a/examples/src/bin/hmac.rs
+++ b/examples/src/bin/hmac.rs
@@ -63,8 +63,8 @@ use esp_hal::{
     hmac::{Hmac, HmacPurpose, KeyId},
     peripherals::Peripherals,
     prelude::*,
+    rng::Rng,
     systimer::SystemTimer,
-    Rng,
 };
 use esp_println::println;
 use hmac::{Hmac as HmacSw, Mac};

--- a/examples/src/bin/i2s_read.rs
+++ b/examples/src/bin/i2s_read.rs
@@ -21,10 +21,10 @@ use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaPriority},
     dma_buffers,
+    gpio::IO,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     peripherals::Peripherals,
     prelude::*,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/i2s_sound.rs
+++ b/examples/src/bin/i2s_sound.rs
@@ -36,10 +36,10 @@ use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaPriority},
     dma_buffers,
+    gpio::IO,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     peripherals::Peripherals,
     prelude::*,
-    IO,
 };
 
 const SINE: [i16; 64] = [

--- a/examples/src/bin/lcd_i8080.rs
+++ b/examples/src/bin/lcd_i8080.rs
@@ -25,6 +25,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
@@ -34,7 +35,6 @@ use esp_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/lp_core_basic.rs
+++ b/examples/src/bin/lp_core_basic.rs
@@ -12,11 +12,10 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::lp_gpio::IntoLowPowerPin,
+    gpio::{lp_gpio::IntoLowPowerPin, IO},
     lp_core::{LpCore, LpCoreWakeupSource},
     peripherals::Peripherals,
     prelude::*,
-    IO,
 };
 use esp_println::{print, println};
 

--- a/examples/src/bin/lp_core_i2c.rs
+++ b/examples/src/bin/lp_core_i2c.rs
@@ -12,12 +12,11 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::lp_gpio::IntoLowPowerPin,
+    gpio::{lp_gpio::IntoLowPowerPin, IO},
     i2c::lp_i2c::LpI2c,
     lp_core::{LpCore, LpCoreWakeupSource},
     peripherals::Peripherals,
     prelude::*,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -13,7 +13,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
-    gpio::lp_gpio::IntoLowPowerPin,
+    gpio::{lp_gpio::IntoLowPowerPin, IO},
     lp_core::{LpCore, LpCoreWakeupSource},
     peripherals::Peripherals,
     prelude::*,
@@ -21,9 +21,8 @@ use esp_hal::{
         config::{Config, DataBits, Parity, StopBits},
         lp_uart::LpUart,
         TxRxPins,
+        Uart,
     },
-    Uart,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -11,13 +11,13 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
     parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
     prelude::*,
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/parl_io_tx.rs
+++ b/examples/src/bin/parl_io_tx.rs
@@ -15,6 +15,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
@@ -28,7 +29,6 @@ use esp_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -20,11 +20,11 @@ use core::{
 use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
+    gpio::IO,
     interrupt::{self, Priority},
     pcnt::{channel, channel::PcntSource, unit, PCNT},
     peripherals::{Interrupt, Peripherals},
     prelude::*,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/qspi_flash.rs
+++ b/examples/src/bin/qspi_flash.rs
@@ -30,6 +30,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
@@ -40,7 +41,6 @@ use esp_hal::{
         SpiDataMode,
         SpiMode,
     },
-    Delay,
 };
 use esp_println::{print, println};
 

--- a/examples/src/bin/ram.rs
+++ b/examples/src/bin/ram.rs
@@ -22,8 +22,8 @@ use esp_hal::{
     macros::ram,
     peripherals::Peripherals,
     prelude::*,
+    rtc_cntl::Rtc,
     timer::TimerGroup,
-    Rtc,
 };
 use esp_println::println;
 use nb::block;

--- a/examples/src/bin/rmt_rx.rs
+++ b/examples/src/bin/rmt_rx.rs
@@ -9,12 +9,11 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    rmt::{PulseCode, RxChannel, RxChannelConfig, RxChannelCreator},
-    Delay,
-    Rmt,
+    rmt::{PulseCode, Rmt, RxChannel, RxChannelConfig, RxChannelCreator},
 };
 use esp_println::{print, println};
 

--- a/examples/src/bin/rmt_tx.rs
+++ b/examples/src/bin/rmt_tx.rs
@@ -10,12 +10,11 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
-    rmt::{PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
-    Delay,
-    Rmt,
+    rmt::{PulseCode, Rmt, TxChannel, TxChannelConfig, TxChannelCreator},
 };
 
 #[entry]

--- a/examples/src/bin/rng.rs
+++ b/examples/src/bin/rng.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{peripherals::Peripherals, prelude::*, Rng};
+use esp_hal::{peripherals::Peripherals, prelude::*, rng::Rng};
 use esp_println::println;
 
 #[entry]

--- a/examples/src/bin/rtc_time.rs
+++ b/examples/src/bin/rtc_time.rs
@@ -6,7 +6,13 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay, Rtc};
+use esp_hal::{
+    clock::ClockControl,
+    delay::Delay,
+    peripherals::Peripherals,
+    prelude::*,
+    rtc_cntl::Rtc,
+};
 
 #[entry]
 fn main() -> ! {

--- a/examples/src/bin/rtc_watchdog.rs
+++ b/examples/src/bin/rtc_watchdog.rs
@@ -17,8 +17,7 @@ use esp_hal::{
     interrupt::{self, Priority},
     peripherals::{Interrupt, Peripherals},
     prelude::*,
-    Rtc,
-    Rwdt,
+    rtc_cntl::{Rtc, Rwdt},
 };
 
 static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -17,8 +17,7 @@ use esp_hal::{
     peripherals::{Interrupt, Peripherals, UART0},
     prelude::*,
     timer::TimerGroup,
-    uart::config::AtCmdConfig,
-    Uart,
+    uart::{config::AtCmdConfig, Uart},
 };
 use nb::block;
 

--- a/examples/src/bin/sleep_timer.rs
+++ b/examples/src/bin/sleep_timer.rs
@@ -10,13 +10,12 @@ use core::time::Duration;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     entry,
     peripherals::Peripherals,
     prelude::*,
-    rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, SocResetReason},
+    rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, Rtc, SocResetReason},
     Cpu,
-    Delay,
-    Rtc,
 };
 use esp_println::println;
 

--- a/examples/src/bin/sleep_timer_ext0.rs
+++ b/examples/src/bin/sleep_timer_ext0.rs
@@ -10,19 +10,19 @@ use core::time::Duration;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     entry,
+    gpio::IO,
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{
         get_reset_reason,
         get_wakeup_cause,
         sleep::{Ext0WakeupSource, TimerWakeupSource, WakeupLevel},
+        Rtc,
         SocResetReason,
     },
     Cpu,
-    Delay,
-    Rtc,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/sleep_timer_ext1.rs
+++ b/examples/src/bin/sleep_timer_ext1.rs
@@ -10,6 +10,7 @@ use core::time::Duration;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     entry,
     gpio::{RTCPin, IO},
     peripherals::Peripherals,
@@ -18,11 +19,10 @@ use esp_hal::{
         get_reset_reason,
         get_wakeup_cause,
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
+        Rtc,
         SocResetReason,
     },
     Cpu,
-    Delay,
-    Rtc,
 };
 use esp_println::println;
 

--- a/examples/src/bin/sleep_timer_lpio.rs
+++ b/examples/src/bin/sleep_timer_lpio.rs
@@ -10,20 +10,19 @@ use core::time::Duration;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     entry,
-    gpio::RTCPinWithResistors,
+    gpio::{RTCPinWithResistors, IO},
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{
         get_reset_reason,
         get_wakeup_cause,
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
+        Rtc,
         SocResetReason,
     },
     Cpu,
-    Delay,
-    Rtc,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/sleep_timer_rtcio.rs
+++ b/examples/src/bin/sleep_timer_rtcio.rs
@@ -11,20 +11,20 @@ use core::time::Duration;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     entry,
     gpio,
+    gpio::IO,
     peripherals::Peripherals,
     prelude::*,
     rtc_cntl::{
         get_reset_reason,
         get_wakeup_cause,
         sleep::{RtcioWakeupSource, TimerWakeupSource, WakeupLevel},
+        Rtc,
         SocResetReason,
     },
     Cpu,
-    Delay,
-    Rtc,
-    IO,
 };
 use esp_println::println;
 

--- a/examples/src/bin/software_interrupts.rs
+++ b/examples/src/bin/software_interrupts.rs
@@ -15,11 +15,11 @@ use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     interrupt::{self, Priority},
     peripherals::{Interrupt, Peripherals},
     prelude::*,
     system::{SoftwareInterrupt, SoftwareInterruptControl},
-    Delay,
 };
 
 static SWINT: Mutex<RefCell<Option<SoftwareInterruptControl>>> = Mutex::new(RefCell::new(None));

--- a/examples/src/bin/spi_eh1_device_loopback.rs
+++ b/examples/src/bin/spi_eh1_device_loopback.rs
@@ -36,11 +36,11 @@ use embedded_hal_bus::spi::RefCellDevice;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::{self, IO},
     peripherals::Peripherals,
     prelude::*,
     spi::{master::Spi, SpiMode},
-    Delay,
 };
 use esp_println::{print, println};
 

--- a/examples/src/bin/spi_eh1_loopback.rs
+++ b/examples/src/bin/spi_eh1_loopback.rs
@@ -23,11 +23,11 @@ use embedded_hal::spi::SpiBus;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
     spi::{master::Spi, SpiMode},
-    Delay,
 };
 use esp_println::{print, println};
 

--- a/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -30,6 +30,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
@@ -38,7 +39,6 @@ use esp_hal::{
         SpiDataMode,
         SpiMode,
     },
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -21,11 +21,11 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     gpio::IO,
     peripherals::Peripherals,
     prelude::*,
     spi::{master::Spi, SpiMode},
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -21,6 +21,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
@@ -30,7 +31,6 @@ use esp_hal::{
         master::{prelude::*, Spi},
         SpiMode,
     },
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -31,6 +31,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
@@ -40,7 +41,6 @@ use esp_hal::{
         slave::{prelude::*, Spi},
         SpiMode,
     },
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/systimer.rs
+++ b/examples/src/bin/systimer.rs
@@ -13,11 +13,11 @@ use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    delay::Delay,
     interrupt::{self, Priority},
     peripherals::{Interrupt, Peripherals},
     prelude::*,
     systimer::{Alarm, Periodic, SystemTimer, Target},
-    Delay,
 };
 use esp_println::println;
 

--- a/examples/src/bin/ulp_riscv_core_basic.rs
+++ b/examples/src/bin/ulp_riscv_core_basic.rs
@@ -9,7 +9,12 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{gpio::rtc_io::*, peripherals::Peripherals, prelude::*, ulp_core, IO};
+use esp_hal::{
+    gpio::{rtc_io::*, IO},
+    peripherals::Peripherals,
+    prelude::*,
+    ulp_core,
+};
 use esp_println::{print, println};
 
 #[entry]

--- a/examples/src/bin/usb_serial.rs
+++ b/examples/src/bin/usb_serial.rs
@@ -9,10 +9,10 @@
 
 use esp_backtrace as _;
 use esp_hal::{
+    gpio::IO,
     otg_fs::{UsbBus, USB},
     peripherals::Peripherals,
     prelude::*,
-    IO,
 };
 use usb_device::prelude::{UsbDeviceBuilder, UsbVidPid};
 use usbd_serial::{SerialPort, USB_CLASS_CDC};

--- a/examples/src/bin/usb_serial_jtag.rs
+++ b/examples/src/bin/usb_serial_jtag.rs
@@ -18,7 +18,7 @@ use esp_hal::{
     peripherals::{Interrupt, Peripherals},
     prelude::*,
     timer::TimerGroup,
-    UsbSerialJtag,
+    usb_serial_jtag::UsbSerialJtag,
 };
 use nb::block;
 


### PR DESCRIPTION
This was briefly discussed offline with @bjoernQ, but tl;dr the types we're exporting here are fairly arbitrary (we can't even remember why we did this in the first place!), and IMO there's no need to do this at all; just exporting the modules is adequate.