### PR TITLE
Create safe wrappers for some ROM functions in the `rom` module

### DIFF
--- a/esp-hal/ld/esp32c6/rom-functions.x
+++ b/esp-hal/ld/esp32c6/rom-functions.x
@@ -1,5 +1,4 @@
 ets_printf = 0x40000028;
-ets_update_cpu_frequency = ets_update_cpu_frequency_rom;
 PROVIDE(esp_rom_printf = ets_printf);
 PROVIDE(cache_invalidate_icache_all = 0x4000064c);
 PROVIDE(cache_suspend_icache = 0x40000698);

--- a/esp-hal/ld/esp32h2/rom-functions.x
+++ b/esp-hal/ld/esp32h2/rom-functions.x
@@ -1,5 +1,4 @@
 ets_printf = 0x40000028;
-ets_update_cpu_frequency = ets_update_cpu_frequency_rom;
 PROVIDE(esp_rom_printf = ets_printf);
 PROVIDE(cache_invalidate_icache_all = 0x40000620);
 PROVIDE(cache_suspend_icache = 0x4000066c);

--- a/esp-hal/ld/esp32s3/rom-functions.x
+++ b/esp-hal/ld/esp32s3/rom-functions.x
@@ -19,6 +19,7 @@ PROVIDE(Cache_Resume_DCache = 0x400018c0 );
 PROVIDE(rom_config_data_cache_mode = 0x40001a28 );
 PROVIDE(rom_config_instruction_cache_mode = 0x40001a1c );
 PROVIDE(ets_efuse_get_wp_pad = 0x40001fa4);
+PROVIDE(ets_set_appcpu_boot_addr = 0x40000720);
 
 PROVIDE(esp_rom_crc32_be = 0x40001ca4);
 PROVIDE(esp_rom_crc16_be = 0x40001cbc);

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -590,12 +590,7 @@ where
             // the delay might be a bit generous but longer delay seem to not cause problems
             #[cfg(esp32c6)]
             {
-                extern "C" {
-                    fn ets_delay_us(us: u32);
-                }
-                unsafe {
-                    ets_delay_us(40);
-                }
+                crate::rom::ets_delay_us(40);
                 ADCI::start_onetime_sample();
             }
         }

--- a/esp-hal/src/clock/clocks_ll/esp32c2.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32c2.rs
@@ -4,10 +4,6 @@ use crate::{
     regi2c_write_mask,
 };
 
-extern "C" {
-    fn ets_update_cpu_frequency_rom(ticks_per_us: u32);
-}
-
 const I2C_BBPLL: u32 = 0x66;
 const I2C_BBPLL_HOSTID: u32 = 0;
 
@@ -123,10 +119,10 @@ pub(crate) fn esp32c2_rtc_bbpll_enable() {
 }
 
 pub(crate) fn esp32c2_rtc_update_to_xtal(freq: XtalClock, _div: u32) {
-    let system_control = unsafe { &*crate::peripherals::SYSTEM::ptr() };
+    crate::rom::ets_update_cpu_frequency_rom(freq.mhz());
 
+    let system_control = unsafe { &*crate::peripherals::SYSTEM::ptr() };
     unsafe {
-        ets_update_cpu_frequency_rom(freq.mhz());
         // Set divider from XTAL to APB clock. Need to set divider to 1 (reg. value 0)
         // first.
         system_control.sysclk_conf().modify(|_, w| {
@@ -158,8 +154,9 @@ pub(crate) fn esp32c2_rtc_freq_to_pll_mhz(cpu_clock_speed: CpuClock) {
                 CpuClock::Clock120MHz => 1,
             })
         });
-        ets_update_cpu_frequency_rom(cpu_clock_speed.mhz());
     }
+
+    crate::rom::ets_update_cpu_frequency_rom(cpu_clock_speed.mhz());
 }
 
 pub(crate) fn esp32c2_rtc_apb_freq_update(apb_freq: ApbClock) {

--- a/esp-hal/src/clock/clocks_ll/esp32c6.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32c6.rs
@@ -7,10 +7,6 @@ use crate::{
     rtc_cntl::rtc::CpuClockSource,
 };
 
-extern "C" {
-    fn ets_update_cpu_frequency(ticks_per_us: u32);
-}
-
 const I2C_BBPLL: u8 = 0x66;
 const I2C_BBPLL_HOSTID: u8 = 0;
 
@@ -248,21 +244,21 @@ pub(crate) fn esp32c6_rtc_update_to_xtal(freq: XtalClock, div: u8) {
 }
 
 pub(crate) fn esp32c6_rtc_update_to_xtal_raw(freq_mhz: u32, div: u8) {
-    unsafe {
-        esp32c6_ahb_set_ls_divider(div);
-        esp32c6_cpu_set_ls_divider(div);
-        CpuClockSource::Xtal.select();
-        ets_update_cpu_frequency(freq_mhz);
-    }
+    esp32c6_ahb_set_ls_divider(div);
+    esp32c6_cpu_set_ls_divider(div);
+
+    CpuClockSource::Xtal.select();
+
+    crate::rom::ets_update_cpu_frequency_rom(freq_mhz);
 }
 
 pub(crate) fn esp32c6_rtc_update_to_8m() {
-    unsafe {
-        esp32c6_ahb_set_ls_divider(1);
-        esp32c6_cpu_set_ls_divider(1);
-        CpuClockSource::RcFast.select();
-        ets_update_cpu_frequency(20);
-    }
+    esp32c6_ahb_set_ls_divider(1);
+    esp32c6_cpu_set_ls_divider(1);
+
+    CpuClockSource::RcFast.select();
+
+    crate::rom::ets_update_cpu_frequency_rom(20);
 }
 
 pub(crate) fn esp32c6_rtc_freq_to_pll_mhz(cpu_clock_speed: CpuClock) {
@@ -289,9 +285,9 @@ pub(crate) fn esp32c6_rtc_freq_to_pll_mhz_raw(cpu_clock_speed_mhz: u32) {
             .modify(|_, w| w.cpu_hs_120m_force().clear_bit());
 
         CpuClockSource::Pll.select();
-
-        ets_update_cpu_frequency(cpu_clock_speed_mhz);
     }
+
+    crate::rom::ets_update_cpu_frequency_rom(cpu_clock_speed_mhz);
 }
 
 pub(crate) fn esp32c6_rtc_apb_freq_update(apb_freq: ApbClock) {

--- a/esp-hal/src/reset.rs
+++ b/esp-hal/src/reset.rs
@@ -104,17 +104,20 @@ bitflags::bitflags! {
 
 /// Performs a software reset on the chip.
 pub fn software_reset() {
-    unsafe { crate::rtc_cntl::software_reset() }
+    crate::rom::software_reset();
 }
+
 /// Performs a software reset on the CPU.
 pub fn software_reset_cpu() {
-    unsafe { crate::rtc_cntl::software_reset_cpu() }
+    crate::rom::software_reset_cpu();
 }
+
 /// Retrieves the reason for the last reset as a SocResetReason enum value.
 /// Returns `None` if the reset reason cannot be determined.
 pub fn get_reset_reason() -> Option<SocResetReason> {
     crate::rtc_cntl::get_reset_reason(crate::get_core())
 }
+
 /// Retrieves the cause of the last wakeup event as a SleepSource enum value.
 pub fn get_wakeup_cause() -> SleepSource {
     crate::rtc_cntl::get_wakeup_cause()

--- a/esp-hal/src/rom/mod.rs
+++ b/esp-hal/src/rom/mod.rs
@@ -82,6 +82,7 @@ macro_rules! regi2c_write_mask {
     };
 }
 
+#[inline(always)]
 pub(crate) fn ets_delay_us(us: u32) {
     extern "C" {
         fn ets_delay_us(us: u32);
@@ -91,6 +92,7 @@ pub(crate) fn ets_delay_us(us: u32) {
 }
 
 #[allow(unused)]
+#[inline(always)]
 pub(crate) fn ets_update_cpu_frequency_rom(ticks_per_us: u32) {
     extern "C" {
         fn ets_update_cpu_frequency_rom(ticks_per_us: u32);
@@ -99,6 +101,7 @@ pub(crate) fn ets_update_cpu_frequency_rom(ticks_per_us: u32) {
     unsafe { ets_update_cpu_frequency_rom(ticks_per_us) };
 }
 
+#[inline(always)]
 pub(crate) fn rtc_get_reset_reason(cpu_num: u32) -> u32 {
     extern "C" {
         fn rtc_get_reset_reason(cpu_num: u32) -> u32;
@@ -107,6 +110,7 @@ pub(crate) fn rtc_get_reset_reason(cpu_num: u32) -> u32 {
     unsafe { rtc_get_reset_reason(cpu_num) }
 }
 
+#[inline(always)]
 pub(crate) fn software_reset_cpu() {
     extern "C" {
         fn software_reset_cpu();
@@ -115,6 +119,7 @@ pub(crate) fn software_reset_cpu() {
     unsafe { software_reset_cpu() };
 }
 
+#[inline(always)]
 pub(crate) fn software_reset() {
     extern "C" {
         fn software_reset();
@@ -124,6 +129,7 @@ pub(crate) fn software_reset() {
 }
 
 #[cfg(esp32s3)]
+#[inline(always)]
 pub(crate) fn ets_set_appcpu_boot_addr(boot_addr: u32) {
     extern "C" {
         fn ets_set_appcpu_boot_addr(boot_addr: u32);

--- a/esp-hal/src/rom/mod.rs
+++ b/esp-hal/src/rom/mod.rs
@@ -122,3 +122,12 @@ pub(crate) fn software_reset() {
 
     unsafe { software_reset() };
 }
+
+#[cfg(esp32s3)]
+pub(crate) fn ets_set_appcpu_boot_addr(boot_addr: u32) {
+    extern "C" {
+        fn ets_set_appcpu_boot_addr(boot_addr: u32);
+    }
+
+    unsafe { ets_set_appcpu_boot_addr(boot_addr) };
+}

--- a/esp-hal/src/rom/mod.rs
+++ b/esp-hal/src/rom/mod.rs
@@ -23,6 +23,8 @@
 //! [CRC (Cyclic Redundancy Check)]: ./crc/index.html
 //! [MD5 (Message Digest 5)]: ./md5/index.html
 
+#![allow(unused_macros)]
+
 #[cfg(any(rom_crc_be, rom_crc_le))]
 pub mod crc;
 #[cfg(any(rom_md5_bsd, rom_md5_mbedtls))]
@@ -78,4 +80,45 @@ macro_rules! regi2c_write_mask {
             }
         }
     };
+}
+
+pub(crate) fn ets_delay_us(us: u32) {
+    extern "C" {
+        fn ets_delay_us(us: u32);
+    }
+
+    unsafe { ets_delay_us(us) };
+}
+
+#[allow(unused)]
+pub(crate) fn ets_update_cpu_frequency_rom(ticks_per_us: u32) {
+    extern "C" {
+        fn ets_update_cpu_frequency_rom(ticks_per_us: u32);
+    }
+
+    unsafe { ets_update_cpu_frequency_rom(ticks_per_us) };
+}
+
+pub(crate) fn rtc_get_reset_reason(cpu_num: u32) -> u32 {
+    extern "C" {
+        fn rtc_get_reset_reason(cpu_num: u32) -> u32;
+    }
+
+    unsafe { rtc_get_reset_reason(cpu_num) }
+}
+
+pub(crate) fn software_reset_cpu() {
+    extern "C" {
+        fn software_reset_cpu();
+    }
+
+    unsafe { software_reset_cpu() };
+}
+
+pub(crate) fn software_reset() {
+    extern "C" {
+        fn software_reset();
+    }
+
+    unsafe { software_reset() };
 }

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -107,14 +107,6 @@ pub(crate) mod rtc;
 #[cfg(any(esp32c6, esp32h2))]
 pub use rtc::RtcClock;
 
-extern "C" {
-    #[allow(dead_code)]
-    fn ets_delay_us(us: u32);
-    fn rtc_get_reset_reason(cpu_num: u32) -> u32;
-    pub fn software_reset_cpu();
-    pub fn software_reset();
-}
-
 #[cfg(not(any(esp32c6, esp32h2)))]
 #[allow(unused)]
 #[derive(Debug, Clone, Copy)]
@@ -228,10 +220,8 @@ impl<'d> Rtc<'d> {
         let (l, h) = {
             rtc_cntl.time_update().write(|w| w.time_update().set_bit());
             while rtc_cntl.time_update().read().time_valid().bit_is_clear() {
-                unsafe {
-                    // might take 1 RTC slowclk period, don't flood RTC bus
-                    ets_delay_us(1);
-                }
+                // might take 1 RTC slowclk period, don't flood RTC bus
+                crate::rom::ets_delay_us(1);
             }
             let h = rtc_cntl.time1().read().time_hi().bits();
             let l = rtc_cntl.time0().read().time_lo().bits();
@@ -345,8 +335,8 @@ impl RtcClock {
             rtc_cntl.clk_conf().modify(|_, w| w.enb_ck8m().clear_bit());
             unsafe {
                 rtc_cntl.timer1().modify(|_, w| w.ck8m_wait().bits(5));
-                ets_delay_us(50);
             }
+            crate::rom::ets_delay_us(50);
         } else {
             rtc_cntl.clk_conf().modify(|_, w| w.enb_ck8m().set_bit());
             rtc_cntl
@@ -424,9 +414,9 @@ impl RtcClock {
                     .ck8m_force_pu()
                     .bit(matches!(slow_freq, RtcSlowClock::RtcSlowClock8mD256))
             });
-
-            ets_delay_us(300u32);
         };
+
+        crate::rom::ets_delay_us(300u32);
     }
 
     /// Select source for RTC_FAST_CLK
@@ -440,9 +430,9 @@ impl RtcClock {
                     RtcFastClock::RtcFastClockXtalD4 => false,
                 })
             });
-
-            ets_delay_us(3u32);
         };
+
+        crate::rom::ets_delay_us(3u32);
     }
 
     /// Calibration of RTC_SLOW_CLK is performed using a special feature of
@@ -547,9 +537,7 @@ impl RtcClock {
             .modify(|_, w| w.rtc_cali_start().clear_bit().rtc_cali_start().set_bit());
 
         // Wait for calibration to finish up to another us_time_estimate
-        unsafe {
-            ets_delay_us(us_time_estimate);
-        }
+        crate::rom::ets_delay_us(us_time_estimate);
 
         #[cfg(esp32)]
         let mut timeout_us = us_time_estimate;
@@ -568,9 +556,7 @@ impl RtcClock {
             #[cfg(esp32)]
             if timeout_us > 0 {
                 timeout_us -= 1;
-                unsafe {
-                    ets_delay_us(1);
-                }
+                crate::rom::ets_delay_us(1);
             } else {
                 // Timed out waiting for calibration
                 break 0;
@@ -957,7 +943,7 @@ impl WatchdogDisable for Swd {
 }
 
 pub fn get_reset_reason(cpu: Cpu) -> Option<SocResetReason> {
-    let reason = unsafe { rtc_get_reset_reason(cpu as u32) };
+    let reason = crate::rom::rtc_get_reset_reason(cpu as u32);
 
     SocResetReason::from_repr(reason as usize)
 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -1350,10 +1350,6 @@ pub enum SocResetReason {
     Cpu0JtagCpu   = 0x18,
 }
 
-extern "C" {
-    fn ets_delay_us(us: u32);
-}
-
 #[allow(unused)]
 #[derive(Debug, Clone, Copy)]
 /// RTC SLOW_CLK frequency values
@@ -1498,8 +1494,9 @@ impl RtcClock {
                     RtcFastClock::RtcFastClockXtalD2 => true,
                 })
             });
-            ets_delay_us(3);
         }
+
+        crate::rom::ets_delay_us(3);
     }
 
     /// Calibration of RTC_SLOW_CLK is performed using a special feature of
@@ -1602,18 +1599,14 @@ impl RtcClock {
             if !rc_fast_enabled {
                 pmu.hp_sleep_lp_ck_power()
                     .modify(|_, w| w.hp_sleep_xpd_fosc_clk().set_bit());
-                unsafe {
-                    ets_delay_us(50);
-                }
+                crate::rom::ets_delay_us(50);
             }
 
             if !dig_rc_fast_enabled {
                 lp_clkrst
                     .clk_to_hp()
                     .modify(|_, w| w.icg_hp_fosc().set_bit());
-                unsafe {
-                    ets_delay_us(5);
-                }
+                crate::rom::ets_delay_us(5);
             }
         }
 
@@ -1628,9 +1621,7 @@ impl RtcClock {
             if !rc32k_enabled {
                 pmu.hp_sleep_lp_ck_power()
                     .modify(|_, w| w.hp_sleep_xpd_rc32k().set_bit());
-                unsafe {
-                    ets_delay_us(300);
-                }
+                crate::rom::ets_delay_us(300);
             }
 
             if !dig_rc32k_enabled {
@@ -1705,9 +1696,7 @@ impl RtcClock {
             .modify(|_, w| w.rtc_cali_start().set_bit());
 
         // Wait for calibration to finish up to another us_time_estimate
-        unsafe {
-            ets_delay_us(us_time_estimate);
-        }
+        crate::rom::ets_delay_us(us_time_estimate);
 
         let cal_val = loop {
             if timg0.rtccalicfg().read().rtc_cali_rdy().bit_is_set() {
@@ -1746,18 +1735,14 @@ impl RtcClock {
             if rc_fast_enabled {
                 pmu.hp_sleep_lp_ck_power()
                     .modify(|_, w| w.hp_sleep_xpd_fosc_clk().set_bit());
-                unsafe {
-                    ets_delay_us(50);
-                }
+                crate::rom::ets_delay_us(50);
             }
 
             if dig_rc_fast_enabled {
                 lp_clkrst
                     .clk_to_hp()
                     .modify(|_, w| w.icg_hp_fosc().set_bit());
-                unsafe {
-                    ets_delay_us(5);
-                }
+                crate::rom::ets_delay_us(5);
             }
         }
 
@@ -1765,9 +1750,7 @@ impl RtcClock {
             if rc32k_enabled {
                 pmu.hp_sleep_lp_ck_power()
                     .modify(|_, w| w.hp_sleep_xpd_rc32k().set_bit());
-                unsafe {
-                    ets_delay_us(300);
-                }
+                crate::rom::ets_delay_us(300);
             }
             if dig_rc32k_enabled {
                 lp_clkrst

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -221,10 +221,6 @@ impl Clock for RtcFastClock {
     }
 }
 
-extern "C" {
-    fn ets_delay_us(us: u32);
-}
-
 /// RTC SLOW_CLK frequency values
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -314,8 +310,9 @@ impl RtcClock {
                     RtcFastClock::RtcFastClockXtalD2 => 0b01,
                 })
             });
-            ets_delay_us(3);
         }
+
+        crate::rom::ets_delay_us(3);
     }
 
     fn set_slow_freq(slow_freq: RtcSlowClock) {
@@ -457,18 +454,14 @@ impl RtcClock {
             if !rc_fast_enabled {
                 pmu.hp_sleep_lp_ck_power()
                     .modify(|_, w| w.hp_sleep_xpd_fosc_clk().set_bit());
-                unsafe {
-                    ets_delay_us(50);
-                }
+                crate::rom::ets_delay_us(50);
             }
 
             if !dig_rc_fast_enabled {
                 lp_clkrst
                     .clk_to_hp()
                     .modify(|_, w| w.icg_hp_fosc().set_bit());
-                unsafe {
-                    ets_delay_us(5);
-                }
+                crate::rom::ets_delay_us(5);
             }
         }
 
@@ -483,9 +476,7 @@ impl RtcClock {
             if !rc32k_enabled {
                 pmu.hp_sleep_lp_ck_power()
                     .modify(|_, w| w.hp_sleep_xpd_rc32k().set_bit());
-                unsafe {
-                    ets_delay_us(300);
-                }
+                crate::rom::ets_delay_us(300);
             }
 
             if !dig_rc32k_enabled {
@@ -560,9 +551,7 @@ impl RtcClock {
             .modify(|_, w| w.rtc_cali_start().set_bit());
 
         // Wait for calibration to finish up to another us_time_estimate
-        unsafe {
-            ets_delay_us(us_time_estimate);
-        }
+        crate::rom::ets_delay_us(us_time_estimate);
 
         let cal_val = loop {
             if timg0.rtccalicfg().read().rtc_cali_rdy().bit_is_set() {
@@ -589,18 +578,14 @@ impl RtcClock {
             if rc_fast_enabled {
                 pmu.hp_sleep_lp_ck_power()
                     .modify(|_, w| w.hp_sleep_xpd_fosc_clk().set_bit());
-                unsafe {
-                    ets_delay_us(50);
-                }
+                crate::rom::ets_delay_us(50);
             }
 
             if dig_rc_fast_enabled {
                 lp_clkrst
                     .clk_to_hp()
                     .modify(|_, w| w.icg_hp_fosc().set_bit());
-                unsafe {
-                    ets_delay_us(5);
-                }
+                crate::rom::ets_delay_us(5);
             }
         }
 
@@ -608,9 +593,7 @@ impl RtcClock {
             if rc32k_enabled {
                 pmu.hp_sleep_lp_ck_power()
                     .modify(|_, w| w.hp_sleep_xpd_rc32k().set_bit());
-                unsafe {
-                    ets_delay_us(300);
-                }
+                crate::rom::ets_delay_us(300);
             }
             if dig_rc32k_enabled {
                 lp_clkrst

--- a/esp-hal/src/soc/esp32s2/ulp_core.rs
+++ b/esp-hal/src/soc/esp32s2/ulp_core.rs
@@ -40,10 +40,6 @@ use esp32s2 as pac;
 
 use crate::peripheral::{Peripheral, PeripheralRef};
 
-extern "C" {
-    fn ets_delay_us(delay: u32);
-}
-
 #[derive(Debug, Clone, Copy)]
 pub enum UlpCoreWakeupSource {
     HpCpu,
@@ -109,9 +105,7 @@ fn ulp_run(wakeup_src: UlpCoreWakeupSource) {
         .modify(|_, w| w.ulp_cp_slp_timer_en().clear_bit());
 
     // wait for at least 1 RTC_SLOW_CLK cycle
-    unsafe {
-        ets_delay_us(20);
-    }
+    crate::rom::ets_delay_us(20);
 
     // Select ULP-RISC-V to send the DONE signal
     rtc_cntl
@@ -126,9 +120,7 @@ fn ulp_run(wakeup_src: UlpCoreWakeupSource) {
         .modify(|_, w| w.cocpu_sel().clear_bit());
 
     // Clear any spurious wakeup trigger interrupts upon ULP startup
-    unsafe {
-        ets_delay_us(20);
-    }
+    crate::rom::ets_delay_us(20);
 
     rtc_cntl.int_clr_rtc().write(|w| {
         w.cocpu_int_clr()

--- a/esp-hal/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal/src/soc/esp32s3/cpu_control.rs
@@ -293,14 +293,7 @@ impl CpuControl {
             APP_CORE_STACK_TOP = Some(stack.top());
         }
 
-        // TODO there is no boot_addr register in SVD or TRM - ESP-IDF uses a ROM
-        // function so we also have to for now
-        const ETS_SET_APPCPU_BOOT_ADDR: usize = 0x40000720;
-        unsafe {
-            let ets_set_appcpu_boot_addr: unsafe extern "C" fn(u32) =
-                core::mem::transmute(ETS_SET_APPCPU_BOOT_ADDR);
-            ets_set_appcpu_boot_addr(Self::start_core1_init::<F> as *const u32 as u32);
-        };
+        crate::rom::ets_set_appcpu_boot_addr(Self::start_core1_init::<F> as *const u32 as u32);
 
         system_control
             .core_1_control_0()

--- a/esp-hal/src/soc/esp32s3/ulp_core.rs
+++ b/esp-hal/src/soc/esp32s3/ulp_core.rs
@@ -41,10 +41,6 @@ use esp32s3 as pac;
 
 use crate::peripheral::{Peripheral, PeripheralRef};
 
-extern "C" {
-    fn ets_delay_us(delay: u32);
-}
-
 #[derive(Debug, Clone, Copy)]
 pub enum UlpCoreWakeupSource {
     HpCpu,
@@ -94,9 +90,7 @@ fn ulp_stop() {
         .cocpu_ctrl()
         .modify(|_, w| w.cocpu_shut_reset_en().set_bit());
 
-    unsafe {
-        ets_delay_us(20);
-    }
+    crate::rom::ets_delay_us(20);
 
     // above doesn't seem to halt the ULP core - this will
     rtc_cntl
@@ -124,9 +118,7 @@ fn ulp_run(wakeup_src: UlpCoreWakeupSource) {
         .modify(|_, w| w.ulp_cp_slp_timer_en().clear_bit());
 
     // wait for at least 1 RTC_SLOW_CLK cycle
-    unsafe {
-        ets_delay_us(20);
-    }
+    crate::rom::ets_delay_us(20);
 
     // We do not select RISC-V as the Coprocessor here as this could lead to a hang
     // in the main CPU. Instead, we reset RTC_CNTL_COCPU_SEL after we have enabled
@@ -154,9 +146,7 @@ fn ulp_run(wakeup_src: UlpCoreWakeupSource) {
         .modify(|_, w| w.cocpu_sel().clear_bit());
 
     // Clear any spurious wakeup trigger interrupts upon ULP startup
-    unsafe {
-        ets_delay_us(20);
-    }
+    crate::rom::ets_delay_us(20);
 
     rtc_cntl.int_clr_rtc().write(|w| {
         w.cocpu_int_clr()


### PR DESCRIPTION
The idea here is basically to provide consistent APIs (as consistent as possible, as least) for our ROM functions, contained within the `rom` module. Rather than having a bunch of externs and unsafe blocks throughout our drivers, we can simply define safe wrappers within this module.

There are still some lingering `extern "C" {}` blocks in the code base, but they're generally pretty specific to a peripheral and chip, so I've left them for now.

(Some unrelated cleanup got mixed in here, sorry for the noise)