### PR TITLE
optimize ADC::read and add ADC::read_blocking

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add `ADC::read_blocking` to xtensa chips (#1293)
 
 - ESP32-C6 / ESP32-H2: Implement `ETM` for general purpose timers (#1274)
 - `interrupt::enable` now has a direct CPU enable counter part, `interrupt::enable_direct` (#1310)


### PR DESCRIPTION
ESP32S2 and ESP32S3 only for now
* skip checking attenuations, if we have a pin the attenuation is set
* skip redundant calls to ADCI::set_init_code
* add read_blocking method