### PR TITLE
uart: allow driver to init as blocking or async

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support runtime interrupt binding, adapt GPIO driver (#1231)
 - Renamed `eh1` feature to `embedded-hal`, feature-gated `embedded-hal@0.2.x` trait implementations (#1273)
 - Enable `embedded-hal` feature by default, instead of the `embedded-hal-02` feature (#1313)
+- `Uart` structs now take a `Mode` parameter which defines how the driver is initialized (#1294)
 
 ### Removed
 

--- a/esp-hal/src/embassy/mod.rs
+++ b/esp-hal/src/embassy/mod.rs
@@ -163,11 +163,6 @@ pub fn init(clocks: &Clocks, td: time_driver::TimerType) {
         #[cfg(all(parl_io, esp32h2))]
         crate::interrupt::enable(Interrupt::PARL_IO_TX, Priority::min()).unwrap();
 
-        #[cfg(uart0)]
-        crate::interrupt::enable(Interrupt::UART0, Priority::min()).unwrap();
-        #[cfg(uart1)]
-        crate::interrupt::enable(Interrupt::UART1, Priority::min()).unwrap();
-
         crate::interrupt::enable(Interrupt::I2C_EXT0, Priority::min()).unwrap();
         crate::interrupt::enable(Interrupt::GPIO, Priority::min()).unwrap();
 

--- a/esp-hal/src/fmt.rs
+++ b/esp-hal/src/fmt.rs
@@ -201,6 +201,7 @@ pub struct NoneError;
 pub trait Try {
     type Ok;
     type Error;
+    #[allow(unused)]
     fn into_result(self) -> Result<Self::Ok, Self::Error>;
 }
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -154,6 +154,20 @@ extern "C" fn EspDefaultHandler(_interrupt: peripherals::Interrupt) {
     );
 }
 
+/// A marker trait for intializing drivers in a specific mode.
+pub trait Mode: crate::private::Sealed {}
+
+/// Driver initialized in blocking mode.
+pub struct Blocking;
+
+/// Driver initialized in async mode.
+pub struct Async;
+
+impl crate::Mode for Blocking {}
+impl crate::Mode for Async {}
+impl crate::private::Sealed for Blocking {}
+impl crate::private::Sealed for Async {}
+
 pub(crate) mod private {
     pub trait Sealed {}
 }

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -446,7 +446,8 @@ impl<'d, T> Uart<'d, T, Blocking>
 where
     T: Instance + 'd,
 {
-    /// Create a new UART instance with configuration options in [`Blocking`] mode.
+    /// Create a new UART instance with configuration options in [`Blocking`]
+    /// mode.
     pub fn new_with_config<P>(
         uart: impl Peripheral<P = T> + 'd,
         config: Config,
@@ -1689,7 +1690,8 @@ mod asynch {
     where
         T: Instance + 'd,
     {
-        /// Create a new UART instance with configuration options in [`Async`] mode.
+        /// Create a new UART instance with configuration options in [`Async`]
+        /// mode.
         pub fn new_async_with_config<P>(
             uart: impl Peripheral<P = T> + 'd,
             config: Config,

--- a/examples/src/bin/advanced_serial.rs
+++ b/examples/src/bin/advanced_serial.rs
@@ -49,7 +49,7 @@ fn main() -> ! {
         io.pins.gpio5.into_floating_input(),
     );
 
-    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks, None);
 
     let delay = Delay::new(&clocks);
 

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -20,6 +20,7 @@ use esp_hal::{
     prelude::*,
     timer::TimerGroup,
     uart::{config::AtCmdConfig, Uart, UartRx, UartTx},
+    Async,
 };
 use static_cell::make_static;
 
@@ -29,7 +30,10 @@ const READ_BUF_SIZE: usize = 64;
 const AT_CMD: u8 = 0x04;
 
 #[embassy_executor::task]
-async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+async fn writer(
+    mut tx: UartTx<'static, UART0, Async>,
+    signal: &'static Signal<NoopRawMutex, usize>,
+) {
     use core::fmt::Write;
     embedded_io_async::Write::write(
         &mut tx,
@@ -47,7 +51,10 @@ async fn writer(mut tx: UartTx<'static, UART0>, signal: &'static Signal<NoopRawM
 }
 
 #[embassy_executor::task]
-async fn reader(mut rx: UartRx<'static, UART0>, signal: &'static Signal<NoopRawMutex, usize>) {
+async fn reader(
+    mut rx: UartRx<'static, UART0, Async>,
+    signal: &'static Signal<NoopRawMutex, usize>,
+) {
     const MAX_BUFFER_SIZE: usize = 10 * READ_BUF_SIZE + 16;
 
     let mut rbuf: [u8; MAX_BUFFER_SIZE] = [0u8; MAX_BUFFER_SIZE];
@@ -76,7 +83,7 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timg0);
 
-    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let mut uart0 = Uart::new_async(peripherals.UART0, &clocks);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -50,7 +50,7 @@ fn main() -> ! {
         io.pins.gpio7.into_floating_input(),
     );
 
-    let mut uart1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
+    let mut uart1 = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks, None);
 
     // Set up (LP) UART:
     let lp_tx = io.pins.gpio5.into_low_power().into_push_pull_output();

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -20,10 +20,11 @@ use esp_hal::{
     prelude::*,
     timer::TimerGroup,
     uart::{config::AtCmdConfig, Uart},
+    Blocking,
 };
 use nb::block;
 
-static SERIAL: Mutex<RefCell<Option<Uart<UART0>>>> = Mutex::new(RefCell::new(None));
+static SERIAL: Mutex<RefCell<Option<Uart<UART0, Blocking>>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -21,11 +21,12 @@ use esp_hal::{
         TxRxPins,
         Uart,
     },
+    Blocking,
 };
 use nb::block;
 
 struct Context {
-    uart: Uart<'static, UART0>,
+    uart: Uart<'static, UART0, Blocking>,
 }
 
 impl Context {
@@ -45,7 +46,7 @@ impl Context {
             stop_bits: StopBits::STOP1,
         };
 
-        let uart = Uart::new_with_config(peripherals.UART0, config, Some(pins), &clocks);
+        let uart = Uart::new_with_config(peripherals.UART0, config, Some(pins), &clocks, None);
 
         Context { uart }
     }


### PR DESCRIPTION
* adds a mode type param to Uart types
* remove #[interrupt] usage
* add constructor for blocking and async modes
* blocking constructor takes optional interrupt
* async chooses the correct handler to bind at runtime
* moves interrupt enable for uart into the driver

I'm opening this _very_ early to bikeshed names and conventions, but it works and I'm quite pleased how easy it was to get working. I haven't updated all the examples yet, based on the the bikeshedding questions that need answering below.

**EDIT**: Forgot to mention this initially, but the blocking methods are available on _all_ modes, i.e you can still call the blocking versions of the functions on an async driver (but not the other way around), this is by design. Sometimes blocking to send a small amount of data is cheaper than an async context switch.

## Bikeshedding

- How do we want to name the constructors? Currently `new` is blocking, and `new_async` creates an async driver, but I only did this because of the current naming scheme i.e `read_async` exists. We should think about the best way to handle this.

- Do we only want to set the interrupt in the constructor? Should we add another method to set/update the interrupt handler after construction of the driver?

## TODO

- Document at the top level how the drivers can be initialized and why
