### PR TITLE
Delay::delay

### DIFF
--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```rust,ignore
 //! let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
+//! let rmt = Rmt::new(peripherals.RMT, 80.MHz(), &clocks).unwrap();
 //!
 //! let rmt_buffer = smartLedBuffer!(1);
 //! let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer);

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Delay::delay(time: fugit::MicrosDurationU64)`
+
 ### Fixed
 
 - Reserve `esp32` ROM stacks to prevent the trashing of dram2 section (#1289)
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove `Ext32` and `RateExtU64` from prelude
 - Prefer mutable references over moving for DMA transactions (#1238)
 - Support runtime interrupt binding, adapt GPIO driver (#1231)
 - Renamed `eh1` feature to `embedded-hal`, feature-gated `embedded-hal@0.2.x` trait implementations (#1273)

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -51,7 +51,7 @@
 //!     mosi,
 //!     miso,
 //!     cs,
-//!     100u32.kHz(),
+//!     100.kHz(),
 //!     SpiMode::Mode0,
 //!     &clocks,
 //! )

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -21,7 +21,7 @@
 //!     peripherals.I2C0,
 //!     io.pins.gpio1,
 //!     io.pins.gpio2,
-//!     100u32.kHz(),
+//!     100.kHz(),
 //!     &clocks,
 //! );
 //! loop {

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -27,7 +27,7 @@
 //!     peripherals.I2S0,
 //!     Standard::Philips,
 //!     DataFormat::Data16Channel16,
-//!     44100u32.Hz(),
+//!     44100.Hz(),
 //!     dma_channel.configure(
 //!         false,
 //!         &mut tx_descriptors,

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -26,7 +26,7 @@
 //!     lcd_cam.lcd,
 //!     channel.tx,
 //!     tx_pins,
-//!     20u32.MHz(),
+//!     20.MHz(),
 //!     Config::default(),
 //!     &clocks,
 //! )

--- a/esp-hal/src/ledc/mod.rs
+++ b/esp-hal/src/ledc/mod.rs
@@ -18,7 +18,7 @@
 //!     .configure(timer::config::Config {
 //!         duty: timer::config::Duty::Duty5Bit,
 //!         clock_source: timer::LSClockSource::APBClk,
-//!         frequency: 24u32.kHz(),
+//!         frequency: 24.kHz(),
 //!     })
 //!     .unwrap();
 //!
@@ -44,7 +44,7 @@
 //!     .configure(timer::config::Config {
 //!         duty: timer::config::Duty::Duty5Bit,
 //!         clock_source: timer::HSClockSource::APBClk,
-//!         frequency: 24u32.kHz(),
+//!         frequency: 24.kHz(),
 //!     })
 //!     .unwrap();
 //!

--- a/esp-hal/src/mcpwm/mod.rs
+++ b/esp-hal/src/mcpwm/mod.rs
@@ -32,7 +32,7 @@
 //! use mcpwm::{operator::PwmPinConfig, timer::PwmWorkingMode, PeripheralClockConfig, MCPWM};
 //!
 //! // initialize peripheral
-//! let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40u32.MHz()).unwrap();
+//! let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40.MHz()).unwrap();
 //! let mut mcpwm = MCPWM::new(peripherals.PWM0, clock_cfg);
 //!
 //! // connect operator0 to timer0
@@ -44,7 +44,7 @@
 //!
 //! // start timer with timestamp values in the range of 0..=99 and a frequency of 20 kHz
 //! let timer_clock_cfg = clock_cfg
-//!     .timer_clock_with_frequency(99, PwmWorkingMode::Increase, 20u32.kHz())
+//!     .timer_clock_with_frequency(99, PwmWorkingMode::Increase, 20.kHz())
 //!     .unwrap();
 //! mcpwm.timer0.start(timer_clock_cfg);
 //!

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -27,7 +27,7 @@
 //!         &mut rx_descriptors,
 //!         DmaPriority::Priority0,
 //!     ),
-//!     1u32.MHz(),
+//!     1.MHz(),
 //!     &clocks,
 //! )
 //! .unwrap();
@@ -60,7 +60,7 @@
 //!         &mut rx_descriptors,
 //!         DmaPriority::Priority0,
 //!     ),
-//!     1u32.MHz(),
+//!     1.MHz(),
 //!     &clocks,
 //! )
 //! .unwrap();

--- a/esp-hal/src/prelude.rs
+++ b/esp-hal/src/prelude.rs
@@ -10,12 +10,7 @@ pub use embedded_dma::{
     WriteBuffer as _embedded_dma_WriteBuffer,
     WriteTarget as _embedded_dma_WriteTarget,
 };
-pub use fugit::{
-    ExtU32 as _fugit_ExtU32,
-    ExtU64 as _fugit_ExtU64,
-    RateExtU32 as _fugit_RateExtU32,
-    RateExtU64 as _fugit_RateExtU64,
-};
+pub use fugit::{ExtU64 as _fugit_ExtU64, RateExtU32 as _fugit_RateExtU32};
 pub use nb;
 
 #[cfg(any(dport, pcr, system))]

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -41,7 +41,7 @@
 //! ### Initialization
 //!
 //! ```no_run
-//! let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &mut clock_control, &clocks).unwrap();
+//! let rmt = Rmt::new(peripherals.RMT, 80.MHz(), &mut clock_control, &clocks).unwrap();
 //! let mut channel = rmt
 //!     .channel0
 //!     .configure(

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -296,7 +296,7 @@ impl<'d> Rtc<'d> {
         }
 
         config.apply();
-        delay.delay_millis(100u32);
+        delay.delay_millis(100);
 
         config.start_sleep(wakeup_triggers);
         config.finish_sleep();

--- a/esp-hal/src/soc/esp32/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32/efuse/mod.rs
@@ -79,9 +79,9 @@ impl Efuse {
         let has_low_rating = Self::read_field_le::<bool>(CHIP_CPU_FREQ_LOW);
 
         if has_rating && has_low_rating {
-            160u32.MHz()
+            160.MHz()
         } else {
-            240u32.MHz()
+            240.MHz()
         }
     }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -16,7 +16,7 @@
 //!
 //! let mut spi = hal::spi::Spi::new(
 //!     peripherals.SPI2,
-//!     100u32.kHz(),
+//!     100.kHz(),
 //!     SpiMode::Mode0,
 //!     &mut peripheral_clock_control,
 //!     &mut clocks,

--- a/esp-hal/src/systimer.rs
+++ b/esp-hal/src/systimer.rs
@@ -418,7 +418,7 @@ pub mod etm {
     //! ```no_run
     //! let syst = SystemTimer::new(peripherals.SYSTIMER);
     //! let mut alarm0 = syst.alarm0.into_periodic();
-    //! alarm0.set_period(1u32.secs());
+    //! alarm0.set_period(1.secs());
     //!
     //! let timer_event = SysTimerEtmEvent::new(&mut alarm0);
     //! ```

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,6 +26,7 @@ esp-backtrace       = { version = "0.11.1", features = ["exception-handler", "pa
 esp-hal             = { version = "0.16.0", path = "../esp-hal" }
 esp-hal-smartled    = { version = "0.9.0",  path = "../esp-hal-smartled", optional = true }
 esp-println         = "0.9.1"
+fugit               = "0.3.7"
 heapless            = "0.8.0"
 hex-literal         = "0.4.1"
 hmac                = { version = "0.12.1", default-features = false }

--- a/examples/src/bin/adc.rs
+++ b/examples/src/bin/adc.rs
@@ -49,6 +49,6 @@ fn main() -> ! {
     loop {
         let pin_value: u16 = nb::block!(adc1.read(&mut adc1_pin)).unwrap();
         println!("ADC reading = {}", pin_value);
-        delay.delay_millis(1500u32);
+        delay.delay_millis(1500);
     }
 }

--- a/examples/src/bin/adc_cal.rs
+++ b/examples/src/bin/adc_cal.rs
@@ -55,6 +55,6 @@ fn main() -> ! {
     loop {
         let pin_mv = nb::block!(adc1.read(&mut adc1_pin)).unwrap();
         println!("PIN2 ADC reading = {pin_mv} mV");
-        delay.delay_millis(1500u32);
+        delay.delay_millis(1500);
     }
 }

--- a/examples/src/bin/advanced_serial.rs
+++ b/examples/src/bin/advanced_serial.rs
@@ -63,6 +63,6 @@ fn main() -> ! {
             Err(err) => println!("Error {:?}", err),
         }
 
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
     }
 }

--- a/examples/src/bin/blinky.rs
+++ b/examples/src/bin/blinky.rs
@@ -30,6 +30,9 @@ fn main() -> ! {
 
     loop {
         led.toggle().unwrap();
-        delay.delay_millis(500u32);
+        delay.delay_millis(500);
+        led.toggle().unwrap();
+        // or using `fugit` duration
+        delay.delay(2.secs());
     }
 }

--- a/examples/src/bin/blinky_erased_pins.rs
+++ b/examples/src/bin/blinky_erased_pins.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
 
     loop {
         toggle_pins(&mut pins, &button);
-        delay.delay_millis(500u32);
+        delay.delay_millis(500);
     }
 }
 

--- a/examples/src/bin/clock_monitor.rs
+++ b/examples/src/bin/clock_monitor.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.LPWR);
-    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.start(2000.millis());
     rtc.rwdt.listen();
 
     println!(

--- a/examples/src/bin/dac.rs
+++ b/examples/src/bin/dac.rs
@@ -54,6 +54,6 @@ fn main() -> ! {
 
         voltage_dac2 = voltage_dac2.wrapping_sub(1);
         dac2.write(voltage_dac2);
-        delay.delay_millis(50u32);
+        delay.delay_millis(50);
     }
 }

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -46,7 +46,7 @@ async fn main(_spawner: Spawner) {
         peripherals.I2C0,
         io.pins.gpio4,
         io.pins.gpio5,
-        400u32.kHz(),
+        400.kHz(),
         &clocks,
     );
 

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -57,7 +57,7 @@ async fn main(_spawner: Spawner) {
         peripherals.I2S0,
         Standard::Philips,
         DataFormat::Data16Channel16,
-        44100u32.Hz(),
+        44100.Hz(),
         dma_channel.configure(
             false,
             &mut tx_descriptors,

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -80,7 +80,7 @@ async fn main(_spawner: Spawner) {
         peripherals.I2S0,
         Standard::Philips,
         DataFormat::Data16Channel16,
-        44100u32.Hz(),
+        44100.Hz(),
         dma_channel.configure(
             false,
             &mut tx_descriptors,

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -53,7 +53,7 @@ async fn main(_spawner: Spawner) {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        1u32.MHz(),
+        1.MHz(),
         &clocks,
     )
     .unwrap();

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -66,7 +66,7 @@ async fn main(_spawner: Spawner) {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        1u32.MHz(),
+        1.MHz(),
         &clocks,
     )
     .unwrap();

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -52,9 +52,9 @@ async fn main(spawner: Spawner) {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
-            let freq = 32u32.MHz();
+            let freq = 32.MHz();
         } else {
-            let freq = 80u32.MHz();
+            let freq = 80.MHz();
         }
     };
 

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -37,9 +37,9 @@ async fn main(_spawner: Spawner) {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
-            let freq = 32u32.MHz();
+            let freq = 32.MHz();
         } else {
-            let freq = 80u32.MHz();
+            let freq = 80.MHz();
         }
     };
 

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -64,7 +64,7 @@ async fn main(_spawner: Spawner) {
 
     let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
 
-    let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
+    let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
         .with_dma(dma_channel.configure(
             false,

--- a/examples/src/bin/etm_blinky_systimer.rs
+++ b/examples/src/bin/etm_blinky_systimer.rs
@@ -13,6 +13,7 @@ use esp_hal::{
     prelude::*,
     systimer::{etm::SysTimerEtmEvent, SystemTimer},
 };
+use fugit::ExtU32;
 
 #[entry]
 fn main() -> ! {

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     loop {
         led.toggle().unwrap();
-        delay.delay_millis(500u32);
+        delay.delay_millis(500);
     }
 }
 

--- a/examples/src/bin/hello_rgb.rs
+++ b/examples/src/bin/hello_rgb.rs
@@ -56,9 +56,9 @@ fn main() -> ! {
 
     // Configure RMT peripheral globally
     #[cfg(not(feature = "esp32h2"))]
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 80.MHz(), &clocks).unwrap();
     #[cfg(feature = "esp32h2")]
-    let rmt = Rmt::new(peripherals.RMT, 32u32.MHz(), &clocks).unwrap();
+    let rmt = Rmt::new(peripherals.RMT, 32.MHz(), &clocks).unwrap();
 
     // We use one of the RMT channels to instantiate a `SmartLedsAdapter` which can
     // be used directly with all `smart_led` implementations

--- a/examples/src/bin/i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/i2c_bmp180_calibration_data.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
         peripherals.I2C0,
         io.pins.gpio4,
         io.pins.gpio5,
-        100u32.kHz(),
+        100.kHz(),
         &clocks,
     );
 

--- a/examples/src/bin/i2c_display.rs
+++ b/examples/src/bin/i2c_display.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
         peripherals.I2C0,
         io.pins.gpio4,
         io.pins.gpio5,
-        100u32.kHz(),
+        100.kHz(),
         &clocks,
     );
 

--- a/examples/src/bin/i2s_read.rs
+++ b/examples/src/bin/i2s_read.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
         peripherals.I2S0,
         Standard::Philips,
         DataFormat::Data16Channel16,
-        44100u32.Hz(),
+        44100.Hz(),
         dma_channel.configure(
             false,
             &mut tx_descriptors,

--- a/examples/src/bin/i2s_sound.rs
+++ b/examples/src/bin/i2s_sound.rs
@@ -70,7 +70,7 @@ fn main() -> ! {
         peripherals.I2S0,
         Standard::Philips,
         DataFormat::Data16Channel16,
-        44100u32.Hz(),
+        44100.Hz(),
         dma_channel.configure(
             false,
             &mut tx_descriptors,

--- a/examples/src/bin/lcd_i8080.rs
+++ b/examples/src/bin/lcd_i8080.rs
@@ -87,7 +87,7 @@ fn main() -> ! {
         lcd_cam.lcd,
         channel.tx,
         tx_pins,
-        20u32.MHz(),
+        20.MHz(),
         Config::default(),
         &clocks,
     )
@@ -98,9 +98,9 @@ fn main() -> ! {
         // https://github.com/lovyan03/LovyanGFX/blob/302169a6f23e9a2a6451f03311c366d182193831/src/lgfx/v1/panel/Panel_ST7796.hpp#L28
 
         reset.set_low().unwrap();
-        delay.delay_micros(8_000u32);
+        delay.delay_micros(8_000);
         reset.set_high().unwrap();
-        delay.delay_micros(64_000u32);
+        delay.delay_micros(64_000);
 
         // const CMD_FRMCTR1: u8 = 0xB1;
         // const CMD_FRMCTR2: u8 = 0xB2;
@@ -151,7 +151,7 @@ fn main() -> ! {
         i8080.send(CMD_PWCTR3, 0, &[0xA7]).unwrap(); // Power control 3  //Source driving current level=low, Gamma driving current
                                                      // level=High
         i8080.send(CMD_VMCTR, 0, &[0x18]).unwrap(); // VCOM Control    //VCOM=0.9
-        delay.delay_micros(120_000u32);
+        delay.delay_micros(120_000);
         i8080
             .send(
                 CMD_GMCTRP1,
@@ -172,13 +172,13 @@ fn main() -> ! {
                 ],
             )
             .unwrap();
-        delay.delay_micros(120_000u32);
+        delay.delay_micros(120_000);
         i8080.send(CMD_CSCON, 0, &[0x3C]).unwrap(); // Command Set control // Disable extension command 2 partI
         i8080.send(CMD_CSCON, 0, &[0x69]).unwrap(); // Command Set control // Disable
                                                     // extension command 2 partII
 
         i8080.send(0x11, 0, &[]).unwrap(); // ExitSleepMode
-        delay.delay_micros(130_000u32);
+        delay.delay_micros(130_000);
         i8080.send(0x38, 0, &[]).unwrap(); // ExitIdleMode
         i8080.send(0x29, 0, &[]).unwrap(); // SetDisplayOn
 
@@ -241,10 +241,10 @@ fn main() -> ! {
             transfer.wait().unwrap();
         }
 
-        delay.delay_millis(1_000u32);
+        delay.delay_millis(1_000);
     }
 
     loop {
-        delay.delay_millis(1_000u32);
+        delay.delay_millis(1_000);
     }
 }

--- a/examples/src/bin/ledc.rs
+++ b/examples/src/bin/ledc.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
         .configure(timer::config::Config {
             duty: timer::config::Duty::Duty5Bit,
             clock_source: timer::LSClockSource::APBClk,
-            frequency: 24u32.kHz(),
+            frequency: 24.kHz(),
         })
         .unwrap();
 

--- a/examples/src/bin/lp_core_i2c.rs
+++ b/examples/src/bin/lp_core_i2c.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     let lp_sda = io.pins.gpio6.into_low_power().into_open_drain_output();
     let lp_scl = io.pins.gpio7.into_low_power().into_open_drain_output();
 
-    let lp_i2c = LpI2c::new(peripherals.LP_I2C0, lp_sda, lp_scl, 100u32.kHz());
+    let lp_i2c = LpI2c::new(peripherals.LP_I2C0, lp_sda, lp_scl, 100.kHz());
 
     let mut lp_core = LpCore::new(peripherals.LP_CORE);
     lp_core.stop();

--- a/examples/src/bin/mcpwm.rs
+++ b/examples/src/bin/mcpwm.rs
@@ -28,9 +28,9 @@ fn main() -> ! {
 
     // initialize peripheral
     #[cfg(feature = "esp32h2")]
-    let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40u32.MHz()).unwrap();
+    let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 40.MHz()).unwrap();
     #[cfg(not(feature = "esp32h2"))]
-    let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 32u32.MHz()).unwrap();
+    let clock_cfg = PeripheralClockConfig::with_frequency(&clocks, 32.MHz()).unwrap();
 
     let mut mcpwm = MCPWM::new(peripherals.MCPWM0, clock_cfg);
 
@@ -44,7 +44,7 @@ fn main() -> ! {
     // start timer with timestamp values in the range of 0..=99 and a frequency of
     // 20 kHz
     let timer_clock_cfg = clock_cfg
-        .timer_clock_with_frequency(99, PwmWorkingMode::Increase, 20u32.kHz())
+        .timer_clock_with_frequency(99, PwmWorkingMode::Increase, 20.kHz())
         .unwrap();
     mcpwm.timer0.start(timer_clock_cfg);
 

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        1u32.MHz(),
+        1.MHz(),
         &clocks,
     )
     .unwrap();
@@ -64,6 +64,6 @@ fn main() -> ! {
         transfer.wait().unwrap();
         println!("Received: {:02x?} ...", &buffer[..30]);
 
-        delay.delay_millis(500u32);
+        delay.delay_millis(500);
     }
 }

--- a/examples/src/bin/parl_io_tx.rs
+++ b/examples/src/bin/parl_io_tx.rs
@@ -57,7 +57,7 @@ fn main() -> ! {
             &mut rx_descriptors,
             DmaPriority::Priority0,
         ),
-        1u32.MHz(),
+        1.MHz(),
         &clocks,
     )
     .unwrap();
@@ -87,6 +87,6 @@ fn main() -> ! {
         transfer.wait().unwrap();
         println!("Transferred {} bytes", buffer.len());
 
-        delay.delay_millis(500u32);
+        delay.delay_millis(500);
     }
 }

--- a/examples/src/bin/qspi_flash.rs
+++ b/examples/src/bin/qspi_flash.rs
@@ -77,7 +77,7 @@ fn main() -> ! {
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);
 
-    let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
+    let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
             Some(sclk),
             Some(mosi),
@@ -111,7 +111,7 @@ fn main() -> ! {
         )
         .unwrap();
     transfer.wait().unwrap();
-    delay.delay_millis(250u32);
+    delay.delay_millis(250);
 
     // erase sector
     let transfer = spi
@@ -124,7 +124,7 @@ fn main() -> ! {
         )
         .unwrap();
     transfer.wait().unwrap();
-    delay.delay_millis(250u32);
+    delay.delay_millis(250);
 
     // write enable
     let transfer = spi
@@ -137,7 +137,7 @@ fn main() -> ! {
         )
         .unwrap();
     transfer.wait().unwrap();
-    delay.delay_millis(250u32);
+    delay.delay_millis(250);
 
     // write data / program page
     send.fill(b'!');
@@ -152,7 +152,7 @@ fn main() -> ! {
         )
         .unwrap();
     transfer.wait().unwrap();
-    delay.delay_millis(250u32);
+    delay.delay_millis(250);
 
     loop {
         // quad fast read
@@ -181,6 +181,6 @@ fn main() -> ! {
         }
         println!();
 
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
     }
 }

--- a/examples/src/bin/rmt_rx.rs
+++ b/examples/src/bin/rmt_rx.rs
@@ -32,9 +32,9 @@ fn main() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
-            let freq = 32u32.MHz();
+            let freq = 32.MHz();
         } else {
-            let freq = 80u32.MHz();
+            let freq = 80.MHz();
         }
     };
 
@@ -127,6 +127,6 @@ fn main() -> ! {
             }
         }
 
-        delay.delay_millis(1500u32);
+        delay.delay_millis(1500);
     }
 }

--- a/examples/src/bin/rmt_tx.rs
+++ b/examples/src/bin/rmt_tx.rs
@@ -27,9 +27,9 @@ fn main() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
-            let freq = 32u32.MHz();
+            let freq = 32.MHz();
         } else {
-            let freq = 80u32.MHz();
+            let freq = 80.MHz();
         }
     };
 
@@ -62,6 +62,6 @@ fn main() -> ! {
     loop {
         let transaction = channel.transmit(&data);
         channel = transaction.wait().unwrap();
-        delay.delay_millis(500u32);
+        delay.delay_millis(500);
     }
 }

--- a/examples/src/bin/rtc_time.rs
+++ b/examples/src/bin/rtc_time.rs
@@ -25,6 +25,6 @@ fn main() -> ! {
 
     loop {
         esp_println::println!("rtc time in milliseconds is {}", rtc.get_time_ms());
-        delay.delay_millis(1000u32);
+        delay.delay_millis(1000);
     }
 }

--- a/examples/src/bin/rtc_watchdog.rs
+++ b/examples/src/bin/rtc_watchdog.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
 
     let mut rtc = Rtc::new(peripherals.LPWR);
-    rtc.rwdt.start(2000u64.millis());
+    rtc.rwdt.start(2000.millis());
     rtc.rwdt.listen();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
@@ -52,7 +52,7 @@ fn interrupt_handler() {
 
         esp_println::println!("Restarting in 5 seconds...");
 
-        rwdt.start(5000u64.millis());
+        rwdt.start(5000.millis());
         rwdt.unlisten();
     });
 }

--- a/examples/src/bin/sleep_timer.rs
+++ b/examples/src/bin/sleep_timer.rs
@@ -36,6 +36,6 @@ fn main() -> ! {
 
     let timer = TimerWakeupSource::new(Duration::from_secs(5));
     println!("sleeping!");
-    delay.delay_millis(100u32);
+    delay.delay_millis(100);
     rtc.sleep_deep(&[&timer], &mut delay);
 }

--- a/examples/src/bin/sleep_timer_ext0.rs
+++ b/examples/src/bin/sleep_timer_ext0.rs
@@ -48,6 +48,6 @@ fn main() -> ! {
     let timer = TimerWakeupSource::new(Duration::from_secs(30));
     let ext0 = Ext0WakeupSource::new(&mut ext0_pin, WakeupLevel::High);
     println!("sleeping!");
-    delay.delay_millis(100u32);
+    delay.delay_millis(100);
     rtc.sleep_deep(&[&timer, &ext0], &mut delay);
 }

--- a/examples/src/bin/sleep_timer_ext1.rs
+++ b/examples/src/bin/sleep_timer_ext1.rs
@@ -50,6 +50,6 @@ fn main() -> ! {
     let mut wakeup_pins: [&mut dyn RTCPin; 2] = [&mut pin_0, &mut pin_2];
     let ext1 = Ext1WakeupSource::new(&mut wakeup_pins, WakeupLevel::High);
     println!("sleeping!");
-    delay.delay_millis(100u32);
+    delay.delay_millis(100);
     rtc.sleep_deep(&[&timer, &ext1], &mut delay);
 }

--- a/examples/src/bin/sleep_timer_lpio.rs
+++ b/examples/src/bin/sleep_timer_lpio.rs
@@ -54,6 +54,6 @@ fn main() -> ! {
 
     let rtcio = Ext1WakeupSource::new(wakeup_pins);
     println!("sleeping!");
-    delay.delay_millis(100u32);
+    delay.delay_millis(100);
     rtc.sleep_deep(&[&timer, &rtcio], &mut delay);
 }

--- a/examples/src/bin/sleep_timer_rtcio.rs
+++ b/examples/src/bin/sleep_timer_rtcio.rs
@@ -58,6 +58,6 @@ fn main() -> ! {
 
     let rtcio = RtcioWakeupSource::new(wakeup_pins);
     println!("sleeping!");
-    delay.delay_millis(100u32);
+    delay.delay_millis(100);
     rtc.sleep_deep(&[&timer, &rtcio], &mut delay);
 }

--- a/examples/src/bin/software_interrupts.rs
+++ b/examples/src/bin/software_interrupts.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     let mut counter = 0;
 
     loop {
-        delay.delay_millis(500u32);
+        delay.delay_millis(500);
         match counter {
             0 => critical_section::with(|cs| {
                 SWINT

--- a/examples/src/bin/spi_eh1_device_loopback.rs
+++ b/examples/src/bin/spi_eh1_device_loopback.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
     let miso = io.pins.gpio2;
     let mosi = io.pins.gpio4;
 
-    let spi_bus = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0, &clocks).with_pins(
+    let spi_bus = Spi::new(peripherals.SPI2, 1000.kHz(), SpiMode::Mode0, &clocks).with_pins(
         Some(sclk),
         Some(mosi),
         Some(miso),
@@ -93,7 +93,7 @@ fn main() -> ! {
         spi_device_2.transfer(&mut read[..], &write[..]).unwrap();
         spi_device_3.transfer(&mut read[..], &write[..]).unwrap();
         println!(" SUCCESS");
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         // --- Asymmetric transfer (Read more than we write) ---
         print!("Starting asymetric transfer (read > write)...");
@@ -111,7 +111,7 @@ fn main() -> ! {
             .transfer(&mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
         println!(" SUCCESS");
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
@@ -133,7 +133,7 @@ fn main() -> ! {
             .transfer(&mut read[..], &write[..])
             .expect("Huge transfer failed");
         println!(" SUCCESS");
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
@@ -156,6 +156,6 @@ fn main() -> ! {
             .transfer_in_place(&mut write[..])
             .expect("Huge transfer failed");
         println!(" SUCCESS");
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
     }
 }

--- a/examples/src/bin/spi_eh1_loopback.rs
+++ b/examples/src/bin/spi_eh1_loopback.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio4;
     let cs = io.pins.gpio5;
 
-    let mut spi = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0, &clocks).with_pins(
+    let mut spi = Spi::new(peripherals.SPI2, 1000.kHz(), SpiMode::Mode0, &clocks).with_pins(
         Some(sclk),
         Some(mosi),
         Some(miso),
@@ -62,7 +62,7 @@ fn main() -> ! {
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Symmetric transfer failed");
         assert_eq!(write, read);
         println!(" SUCCESS");
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         // --- Asymmetric transfer (Read more than we write) ---
         print!("Starting asymetric transfer (read > write)...");
@@ -73,7 +73,7 @@ fn main() -> ! {
         assert_eq!(write[0], read[0]);
         assert_eq!(read[2], 0x00u8);
         println!(" SUCCESS");
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         // --- Symmetric transfer with huge buffer ---
         // Only your RAM is the limit!
@@ -87,7 +87,7 @@ fn main() -> ! {
         SpiBus::transfer(&mut spi, &mut read[..], &write[..]).expect("Huge transfer failed");
         assert_eq!(write, read);
         println!(" SUCCESS");
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         // --- Symmetric transfer with huge buffer in-place (No additional allocation
         // needed) ---
@@ -102,6 +102,6 @@ fn main() -> ! {
             assert_eq!(write[byte], byte as u8);
         }
         println!(" SUCCESS");
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
     }
 }

--- a/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -67,7 +67,7 @@ fn main() -> ! {
         }
     }
 
-    let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
+    let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
             Some(sclk),
             Some(mosi),
@@ -91,7 +91,7 @@ fn main() -> ! {
         )
         .unwrap();
         println!("Single {:x?}", data);
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
@@ -104,7 +104,7 @@ fn main() -> ! {
         )
         .unwrap();
         println!("Dual {:x?}", data);
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
@@ -117,6 +117,6 @@ fn main() -> ! {
         )
         .unwrap();
         println!("Quad {:x?}", data);
-        delay.delay_millis(1500u32);
+        delay.delay_millis(1500);
     }
 }

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     let mosi = io.pins.gpio4;
     let cs = io.pins.gpio5;
 
-    let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks).with_pins(
+    let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks).with_pins(
         Some(sclk),
         Some(mosi),
         Some(miso),
@@ -57,6 +57,6 @@ fn main() -> ! {
         spi.transfer(&mut data).unwrap();
         println!("{:x?}", data);
 
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
     }
 }

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
-    let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
+    let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
         .with_dma(dma_channel.configure(
             false,
@@ -86,7 +86,7 @@ fn main() -> ! {
         // Check is_done until the transfer is almost done (32000 bytes at 100kHz is
         // 2.56 seconds), then move to wait().
         while !transfer.is_done() && n < 10 {
-            delay.delay_millis(250u32);
+            delay.delay_millis(250);
             n += 1;
         }
 
@@ -97,6 +97,6 @@ fn main() -> ! {
             &receive[receive.len() - 10..]
         );
 
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
     }
 }

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -151,7 +151,7 @@ fn main() -> ! {
             &master_receive[master_receive.len() - 10..]
         );
 
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
 
         slave_receive.fill(0xff);
         let transfer = spi.dma_read(&mut slave_receive).unwrap();
@@ -179,7 +179,7 @@ fn main() -> ! {
             &slave_receive[slave_receive.len() - 10..],
         );
 
-        delay.delay_millis(250u32);
+        delay.delay_millis(250);
         let transfer = spi.dma_write(&mut slave_send).unwrap();
 
         master_receive.fill(0);

--- a/examples/src/bin/systimer.rs
+++ b/examples/src/bin/systimer.rs
@@ -20,6 +20,7 @@ use esp_hal::{
     systimer::{Alarm, Periodic, SystemTimer, Target},
 };
 use esp_println::println;
+use fugit::ExtU32;
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 static ALARM1: Mutex<RefCell<Option<Alarm<Target, 1>>>> = Mutex::new(RefCell::new(None));
@@ -62,7 +63,7 @@ fn main() -> ! {
     let delay = Delay::new(&clocks);
 
     loop {
-        delay.delay_millis(500u32);
+        delay.delay_millis(500);
     }
 }
 

--- a/examples/src/bin/usb_serial_jtag.rs
+++ b/examples/src/bin/usb_serial_jtag.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut timer0 = timg0.timer0;
 
-    timer0.start(1u64.secs());
+    timer0.start(1.secs());
 
     let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
     usb_serial.listen_rx_packet_recv_interrupt();


### PR DESCRIPTION
Adds `delay(MicrosDurationU64)` for `Delay`.
Removes `RateExtU64` as never used and `ExtU32` as used only for `Rtc`.

Removes `u32` suffixes on rate and `delay_millis` as now always takes `u32`.