### PR TITLE
Add InterruptHandler wrapper

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensuring that the random number generator is TRNG. (#1200)
 - ESP32-C6: Add timer wakeup source for deepsleep (#1201)
 - Introduce `InterruptExecutor::spawner()` (#1211)
+- Add `InterruptHandler` struct, which couples interrupt handlers and their priority together (#1299)
 
 ### Fixed
 

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -60,3 +60,31 @@ pub use self::xtensa::*;
 mod riscv;
 #[cfg(xtensa)]
 mod xtensa;
+
+/// An interrupt handler
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct InterruptHandler {
+    f: extern "C" fn(),
+    prio: Priority,
+}
+
+impl InterruptHandler {
+    pub const fn new(f: extern "C" fn(), prio: Priority) -> Self {
+        Self { f, prio }
+    }
+
+    #[inline]
+    pub fn handler(&self) -> extern "C" fn() {
+        self.f
+    }
+
+    #[inline]
+    pub fn priority(&self) -> Priority {
+        self.prio
+    }
+
+    #[inline]
+    pub(crate) extern "C" fn call(&self) {
+        (self.f)()
+    }
+}

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -88,6 +88,7 @@ pub enum CpuInterrupt {
 }
 
 /// Interrupt priority levels.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum Priority {
@@ -118,7 +119,7 @@ pub enum Priority {
 }
 
 impl Priority {
-    pub fn max() -> Priority {
+    pub const fn max() -> Priority {
         cfg_if::cfg_if! {
             if #[cfg(not(clic))] {
                 Priority::Priority15
@@ -128,7 +129,7 @@ impl Priority {
         }
     }
 
-    pub fn min() -> Priority {
+    pub const fn min() -> Priority {
         Priority::Priority1
     }
 }

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -241,11 +241,11 @@ mod vectored {
     }
 
     impl Priority {
-        pub fn max() -> Priority {
+        pub const fn max() -> Priority {
             Priority::Priority3
         }
 
-        pub fn min() -> Priority {
+        pub const fn min() -> Priority {
             Priority::Priority1
         }
     }

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -18,9 +18,8 @@ use esp_hal::{
     clock::ClockControl,
     delay::Delay,
     gpio::{self, Event, Input, PullDown, IO},
-    interrupt::{self, Priority},
     macros::ram,
-    peripherals::{Interrupt, Peripherals},
+    peripherals::Peripherals,
     prelude::*,
 };
 
@@ -46,12 +45,11 @@ fn main() -> ! {
     let mut button = io.pins.gpio0.into_pull_down_input();
     #[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
     let mut button = io.pins.gpio9.into_pull_down_input();
-    button.listen(Event::FallingEdge);
 
-    critical_section::with(|cs| BUTTON.borrow_ref_mut(cs).replace(button));
-
-    interrupt::enable(Interrupt::GPIO, Priority::Priority2).unwrap();
-
+    critical_section::with(|cs| {
+        button.listen(Event::FallingEdge);
+        BUTTON.borrow_ref_mut(cs).replace(button)
+    });
     led.set_high().unwrap();
 
     // Initialize the Delay peripheral, and use it to toggle the LED state in a


### PR DESCRIPTION
* Which takes the handler and a prio.
* Updates the `#[handler]` macro to create this for us.

The idea here to to couple the handler and priority together, so we can make the interrupt enabling part of the driver, instead of something a user has to remember to do (I've been burnt by this _so_ many times).
