### PR TITLE
Fix LCD_CAM i8080 potentially sending garbage data to display

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: Apply fix for Errata 3.6 in all the places necessary. (#1315)
 - ESP32 & ESP32-S2: Fix I²C frequency (#1306)
 - UART's TX/RX FIFOs are now cleared during initialization (#1344)
+- Fixed `LCD_CAM I8080` driver potentially sending garbage to display (#1301)
+
 
 ### Changed
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -374,6 +374,10 @@ impl<'d, TX: Tx, P> I8080<'d, TX, P> {
             .lc_dma_int_clr()
             .write(|w| w.lcd_trans_done_int_clr().set_bit());
 
+        // Before issuing lcd_start need to wait shortly for fifo to get data
+        // Otherwise, some garbage data will be sent out
+        crate::rom::ets_delay_us(1);
+
         self.lcd_cam
             .lcd_user()
             .modify(|_, w| w.lcd_update().set_bit().lcd_start().set_bit());


### PR DESCRIPTION
LCD_CAM i8080 sometime outputs garbage to the display.

This is due to a race condition when LCD_CAM starts sending data to display before the DMA had time to get data to the FIFO. The solution is quite simple, adding a short delay (delay based on what's used in esp-idf) between starting the DMA and activating LCD_CAM send.

For more info - https://github.com/esp-rs/esp-hal/pull/1086#issuecomment-1924669710

## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [X] The code compiles without `errors` or `warnings`.
- [X] All examples work.
- [X] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [N/A ] You updated existing examples or added examples (if applicable).
- [N/A] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.
