### PR TITLE
CI: Use esp toolchain instead of nightly on in esp-hal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
 
   esp-hal:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_BOOTSTRAP: 1
 
     strategy:
       fail-fast: false
@@ -68,14 +70,10 @@ jobs:
 
       # Install the Rust toolchain for RISC-V devices:
       - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.soc) }}
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
-          toolchain: nightly
-          components: rust-src
-      # Install the Rust toolchain for Xtensa devices:
-      - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.soc)
-        uses: esp-rs/xtensa-toolchain@v1.5
+        name: Install rust-src
+        run: rustup component add rust-src --toolchain stable-x86_64-unknown-linux-gnu
+      # Install the Rust esp-toolchain:
+      - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           buildtargets: ${{ matrix.soc }}
           default: true


### PR DESCRIPTION
## Thank you!

Thank you for your contribution.
Please make sure that your submission includes the following:

### Must

- [ ] The code compiles without `errors` or `warnings`.
- [ ] All examples work.
- [ ] `cargo fmt` was run.
- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
- [ ] You updated existing examples or added examples (if applicable).
- [ ] Added examples are checked in CI

### Nice to have

- [ ] You add a description of your work to this PR.
- [ ] You added proper docs for your newly added features and code.


The idea of this PR is to _not_ use `nightly` toolchain for `esp-hal` job because of recent issues with `nightly`. Instead, our `esp` toolchain is used. Maybe we could do that for other jobs as well but IMHO `esp-hal` job is the crucial one for us.

closes #1308