### PR TITLE
Use task arena instead of `embassy-executor`'s `nightly` feature

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,7 @@ cfg-if              = "1.0.0"
 critical-section    = "1.1.2"
 crypto-bigint       = { version = "0.5.5", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
-embassy-executor    = { version = "0.5.0", features = ["nightly"] }
+embassy-executor    = { version = "0.5.0", features = ["task-arena-size-8192"] }
 embassy-sync        = "0.5.0"
 embassy-time        = "0.3.0"
 embassy-time-driver = { version = "0.1.0", optional = true }


### PR DESCRIPTION
Gets our CI green again, closes #1308.