### PR TITLE
ESP32: Apply Errata 3.6 fix in more places

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reserve `esp32` ROM stacks to prevent the trashing of dram2 section (#1289)
 - Fixing `esp-wifi` + `TRNG` issue on `ESP32-S2` (#1272)
 - Fixed core1 startup using the wrong stack on the esp32 and esp32s3 (#1286).
+- ESP32: Apply fix for Errata 3.6 in all the places necessary. (#1315)
 
 ### Changed
 

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -619,85 +619,141 @@ pub enum OutputSignal {
     MTDO,
 }
 
-pub(crate) fn errata36(pin_num: u8, pull_up: bool, pull_down: bool) {
+pub(crate) fn errata36(pin_num: u8, pull_up: Option<bool>, pull_down: Option<bool>) {
     use crate::peripherals::RTC_IO;
     let rtcio = unsafe { &*RTC_IO::PTR };
 
     match pin_num {
         0 => {
-            rtcio
-                .touch_pad1()
-                .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit(pull_up).rde().bit(pull_down) });
+            rtcio.touch_pad1().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.rde().bit(pull_down);
+                }
+                w
+            });
         }
         2 => {
-            rtcio
-                .touch_pad2()
-                .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit(pull_up).rde().bit(pull_down) });
+            rtcio.touch_pad2().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.rde().bit(pull_down);
+                }
+                w
+            });
         }
         4 => {
-            rtcio
-                .touch_pad0()
-                .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit(pull_up).rde().bit(pull_down) });
+            rtcio.touch_pad0().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.rde().bit(pull_down);
+                }
+                w
+            });
         }
         12 => {
-            rtcio
-                .touch_pad5()
-                .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit(pull_up).rde().bit(pull_down) });
+            rtcio.touch_pad5().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.rde().bit(pull_down);
+                }
+                w
+            });
         }
         13 => {
-            rtcio
-                .touch_pad4()
-                .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit(pull_up).rde().bit(pull_down) });
+            rtcio.touch_pad4().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.rde().bit(pull_down);
+                }
+                w
+            });
         }
         14 => {
-            rtcio
-                .touch_pad6()
-                .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit(pull_up).rde().bit(pull_down) });
+            rtcio.touch_pad6().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.rde().bit(pull_down);
+                }
+                w
+            });
         }
         15 => {
-            rtcio
-                .touch_pad3()
-                .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit(pull_up).rde().bit(pull_down) });
+            rtcio.touch_pad3().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.rde().bit(pull_down);
+                }
+                w
+            });
         }
         25 => {
-            rtcio.pad_dac1().modify(|r, w| unsafe {
-                w.bits(r.bits())
-                    .pdac1_rue()
-                    .bit(pull_up)
-                    .pdac1_rde()
-                    .bit(pull_down)
+            rtcio.pad_dac1().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.pdac1_rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.pdac1_rde().bit(pull_down);
+                }
+                w
             });
         }
         26 => {
-            rtcio.pad_dac2().modify(|r, w| unsafe {
-                w.bits(r.bits())
-                    .pdac2_rue()
-                    .bit(pull_up)
-                    .pdac2_rde()
-                    .bit(pull_down)
+            rtcio.pad_dac2().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.pdac2_rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.pdac2_rde().bit(pull_down);
+                }
+                w
             });
         }
         27 => {
-            rtcio
-                .touch_pad7()
-                .modify(|r, w| unsafe { w.bits(r.bits()).rue().bit(pull_up).rde().bit(pull_down) });
+            rtcio.touch_pad7().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.rde().bit(pull_down);
+                }
+                w
+            });
         }
         32 => {
-            rtcio.xtal_32k_pad().modify(|r, w| unsafe {
-                w.bits(r.bits())
-                    .x32p_rue()
-                    .bit(pull_up)
-                    .x32p_rde()
-                    .bit(pull_down)
+            rtcio.xtal_32k_pad().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.x32p_rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.x32p_rde().bit(pull_down);
+                }
+                w
             });
         }
         33 => {
-            rtcio.xtal_32k_pad().modify(|r, w| unsafe {
-                w.bits(r.bits())
-                    .x32n_rue()
-                    .bit(pull_up)
-                    .x32n_rde()
-                    .bit(pull_down)
+            rtcio.xtal_32k_pad().modify(|_, w| {
+                if let Some(pull_up) = pull_up {
+                    w.x32n_rue().bit(pull_up);
+                }
+                if let Some(pull_down) = pull_down {
+                    w.x32n_rde().bit(pull_down);
+                }
+                w
             });
         }
         _ => (),


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
In #1285 there was a problem discovered in configuring GPIO4 as open-drain. This made me find out we are not applying the errata36 fix in all places we should. Also #594 is probably pointing into that direction.

#### Testing

Easiest way to test this: Copy this into e.g. `examples/hello_world.rs`, connect GPIO 4 and 5
```rust
#![no_std]
#![no_main]

//% FEATURES: embedded-hal-02

use embedded_hal_02::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
use esp_backtrace as _;
use esp_hal::{clock::ClockControl, gpio::IO, peripherals::Peripherals, prelude::*};
use esp_println::println;

#[entry]
fn main() -> ! {
    let peripherals = Peripherals::take();
    let system = peripherals.SYSTEM.split();
    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
    let mut pin1 = io.pins.gpio4.into_open_drain_output();
    pin1.internal_pull_up(true);
    let mut pin2 = io.pins.gpio5.into_open_drain_output();
    pin2.internal_pull_up(true);

    pin1.set_high().unwrap();
    pin2.set_high().unwrap();

    println!("pin1 is set high {}", pin1.is_set_high().unwrap());
    println!("pin2 is set high {}", pin2.is_set_high().unwrap());
    println!("pin1 = {}", pin1.is_high().unwrap());
    println!("pin2 = {}", pin2.is_high().unwrap());

    loop {}
}
```

With the fix it prints as expected
```
pin1 is set high true
pin2 is set high true
pin1 = true
pin2 = true
```

Without the fix it looks like this
```
pin1 is set high true
pin2 is set high true
pin1 = false
pin2 = false
```
