### PR TITLE
Enable TWAI for ESP32-C6

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `interrupt::enable` now has a direct CPU enable counter part, `interrupt::enable_direct` (#1310)
 - `Delay::delay(time: fugit::MicrosDurationU64)`
 - Added async support for TWAI (#1320)
+- Add TWAI support for ESP32-C6 (#1323)
 
 ### Fixed
 

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -684,6 +684,14 @@ impl PeripheralClockControl {
                 system
                     .twai0_conf()
                     .modify(|_, w| w.twai0_rst_en().clear_bit());
+
+                // use Xtal clk-src
+                system.twai0_func_clk_conf().modify(|_, w| {
+                    w.twai0_func_clk_en()
+                        .set_bit()
+                        .twai0_func_clk_sel()
+                        .variant(false)
+                });
             }
             #[cfg(twai1)]
             Peripheral::Twai1 => {

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -81,6 +81,7 @@ use core::marker::PhantomData;
 use embedded_can::{nb::Can, Error, ErrorKind, ExtendedId, Frame, Id, StandardId};
 #[cfg(not(feature = "embedded-hal"))] // FIXME
 use embedded_hal_02::can::{Can, Error, ErrorKind, ExtendedId, Frame, Id, StandardId};
+#[cfg(not(esp32c6))]
 use fugit::HertzU32;
 
 use self::filter::{Filter, FilterType};

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -310,11 +310,11 @@ where
     /// Set the bitrate of the bus.
     ///
     /// Note: The timings currently assume a APB_CLK of 80MHz.
-    fn set_baud_rate(&mut self, baud_rate: BaudRate, clocks: &Clocks) {
+    fn set_baud_rate(&mut self, baud_rate: BaudRate, _clocks: &Clocks) {
         // TWAI is clocked from the APB_CLK according to Table 6-4 [ESP32C3 Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf)
         // Included timings are all for 80MHz so assert that we are running at 80MHz.
         #[cfg(not(esp32c6))]
-        assert!(clocks.apb_clock == HertzU32::MHz(80));
+        assert!(_clocks.apb_clock == HertzU32::MHz(80));
 
         // Unpack the baud rate timings and convert them to the values needed for the
         // register. Many of the registers have a minimum value of 1 which is

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -10,7 +10,7 @@
 //! This example should work with another ESP board running the `twai` example
 //! with `IS_SENDER` set to `true`.
 
-//% CHIPS: esp32c3 esp32s2 esp32s3
+//% CHIPS: esp32c3 esp32c6 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -85,18 +85,6 @@ fn main() -> ! {
         let frame = Frame::new(StandardId::ZERO, &[1, 2, 3]).unwrap();
         block!(can.transmit(&frame)).unwrap();
         println!("Sent a frame");
-
-        // unsafe {
-        //     let mut old = 0;
-        //     loop {
-        //         let new = esp_hal::peripherals::TWAI0::steal().interrupt().read().bits();
-        //         if new != old {
-        //             old = new;
-        //             println!("{:032b}", new);
-        //         }
-
-        //     }
-        // }
     }
 
     // Wait for a frame to be received.

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -11,7 +11,7 @@
 //!
 //! `IS_FIRST_SENDER` below must be set to false on one of the ESP's
 
-//% CHIPS: esp32c3 esp32s2 esp32s3
+//% CHIPS: esp32c3 esp32c6 esp32s2 esp32s3
 //% FEATURES: embedded-hal
 
 #![no_std]
@@ -85,6 +85,18 @@ fn main() -> ! {
         let frame = Frame::new(StandardId::ZERO, &[1, 2, 3]).unwrap();
         block!(can.transmit(&frame)).unwrap();
         println!("Sent a frame");
+
+        // unsafe {
+        //     let mut old = 0;
+        //     loop {
+        //         let new = esp_hal::peripherals::TWAI0::steal().interrupt().read().bits();
+        //         if new != old {
+        //             old = new;
+        //             println!("{:032b}", new);
+        //         }
+
+        //     }
+        // }
     }
 
     // Wait for a frame to be received.


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This contains the necessary changes to get TWAI support for ESP32-C6.

#### Testing
I used two TWAI/CAN transceivers to connect one ESP32-C3 running the blocking twai example and one ESP32-C6 running the async example. Make sure to remove the ".into_open_drain_output()` when using transceivers.
