### PR TITLE
Fix I²C frequency for esp32 and esp32s2.

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixing `esp-wifi` + `TRNG` issue on `ESP32-S2` (#1272)
 - Fixed core1 startup using the wrong stack on the esp32 and esp32s3 (#1286).
 - ESP32: Apply fix for Errata 3.6 in all the places necessary. (#1315)
+- ESP32 & ESP32-S2: Fix I²C frequency (#1306)
 
 ### Changed
 

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -398,7 +398,7 @@ impl<'d> ClockControl<'d> {
                 cpu_clock: cpu_clock_speed.frequency(),
                 apb_clock: HertzU32::MHz(80),
                 xtal_clock: HertzU32::MHz(40),
-                i2c_clock: HertzU32::MHz(40),
+                i2c_clock: HertzU32::MHz(80),
                 // The docs are unclear here. pwm_clock seems to be tied to clocks.apb_clock
                 // while simultaneously being fixed at 160 MHz.
                 // Testing showed 160 MHz to be correct for current clock configurations.

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -689,7 +689,9 @@ pub trait Instance {
         // Configure frequency
         #[cfg(esp32)]
         self.set_frequency(clocks.i2c_clock.convert(), frequency, timeout);
-        #[cfg(not(esp32))]
+        #[cfg(esp32s2)]
+        self.set_frequency(clocks.apb_clock.convert(), frequency, timeout);
+        #[cfg(not(any(esp32, esp32s2)))]
         self.set_frequency(clocks.xtal_clock.convert(), frequency, timeout);
 
         self.update_config();


### PR DESCRIPTION
On esp32 and esp32s2 the I²C clock needs to be based on the APB clock.

With these changes the SCL frequency is effectively the one being asked for when calling I2C::new() whatever the CpuClock configuration. This fixes [the issue I reported a few days ago](https://github.com/esp-rs/esp-hal/issues/1306).

This has been verified on esp32 and esp32s2 boards with a logic analyzer.
