### PR TITLE
Enable S3 HIL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        soc: [esp32c3, esp32c6, esp32h2]
+        soc: [esp32c3, esp32c6, esp32h2, esp32s3]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,20 +308,40 @@ jobs:
         run: cargo fmt --all --manifest-path=examples/Cargo.toml -- --check
 
   hil:
-    name: HIL Test | ${{ matrix.soc }}
+    name: HIL Test | ${{ matrix.target.soc }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        soc: [esp32c3, esp32c6, esp32h2, esp32s3]
+        target:
+          # RISC-V devices:
+          - soc: esp32c3
+            rust-target: riscv32imc-unknown-none-elf
+          - soc: esp32c6
+            rust-target: riscv32imac-unknown-none-elf
+          - soc: esp32h2
+            rust-target: riscv32imac-unknown-none-elf
+          # Xtensa devices:
+          - soc: esp32s3
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+        # Install the Rust toolchain for RISC-V devices:
+
+      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.target.soc) }}
+        uses: dtolnay/rust-toolchain@v1
         with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
+          target: ${{ matrix.target.rust-target }}
           toolchain: nightly
           components: rust-src
+      # Install the Rust toolchain for Xtensa devices:
+      - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.target.soc)
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          buildtargets: ${{ matrix.target.soc }}
+          default: true
+          ldproxy: false
+
       - uses: Swatinem/rust-cache@v2
-      - run: cargo xtask build-examples hil-test ${{ matrix.soc }}
+      - run: cargo xtask build-examples hil-test ${{ matrix.target.soc }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
       - name: rustfmt (examples)
         run: cargo fmt --all --manifest-path=examples/Cargo.toml -- --check
 
-  riscv-hil:
+  hil:
     name: HIL Test | ${{ matrix.soc }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -17,8 +17,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Test RISC-V targets:
-  riscv-hil:
+  hil:
     name: HIL Test | ${{ matrix.target.soc }}
     runs-on:
       labels: [self-hosted, "${{ matrix.target.runner }}"]
@@ -26,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          # RISC-V devices:
           - soc: esp32c3
             runner: rustboard
             rust-target: riscv32imc-unknown-none-elf
@@ -35,6 +35,9 @@ jobs:
           - soc: esp32h2
             runner: esp32h2-usb
             rust-target: riscv32imac-unknown-none-elf
+          # Xtensa devices:
+          - soc: esp32s3
+            runner: esp32s3-usb
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'workflow_dispatch'
@@ -45,14 +48,20 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.branch }}
 
-      - uses: dtolnay/rust-toolchain@v1
+      # Install the Rust toolchain for RISC-V devices:
+      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.target.soc) }}
+        uses: dtolnay/rust-toolchain@v1
         with:
           target: ${{ matrix.target.rust-target }}
           toolchain: nightly
           components: rust-src
+      # Install the Rust toolchain for Xtensa devices:
+      - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.target.soc)
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          buildtargets: ${{ matrix.target.soc }}
+          default: true
+          ldproxy: false
 
       - name: Run tests
         run: cargo xtask run-tests ${{ matrix.target.soc }}
-
-  # Test Xtensa targets:
-  # TODO: Add jobs for Xtensa once supported by `probe-rs`

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -70,6 +70,10 @@ Our Virtual Machines have the following setup:
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
   - VM: Ubuntu 20.04.5 configured with the following [setup](#vm-setup)
+- ESP32-S3 (`esp32s3-usb`):
+  - Devkit: `ESP32-S3-DevKitC-1` connected via USB-Serial-JTAG.
+    - `GPIO2` and `GPIO4` are connected.
+  - VM: Ubuntu 22.04.4 configured with the following [setup](#vm-setup)
 
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml
 
@@ -87,7 +91,7 @@ cargo install probe-rs --git=https://github.com/probe-rs/probe-rs --rev=ddd59fa 
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group
 sudo usermod -a -G plugdev $USER
-# Reboot the
+# Reboot the VM
 sudo reboot
 ```
 

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -151,6 +151,8 @@ mod tests {
     }
 
     #[test]
+    // TODO: See https://github.com/esp-rs/esp-hal/issues/1413
+    #[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
     fn test_gpio_interrupt(mut ctx: Context) {
         critical_section::with(|cs| {
             *COUNTER.borrow_ref_mut(cs) = 0;


### PR DESCRIPTION
#### Description
Enables HIL CI for ESP32-S3.

#### Considerations
- The VM needs to be Ubuntu 22.04 due to https://github.com/esp-rs/rust-build/issues/252
  - Other VMs are using Ubuntu 20.04. I've manually updated this one.

#### Testing
I've manually triggered the HIL workflow in this branch:  https://github.com/esp-rs/esp-hal/actions/runs/8704247425

And tested it locally: 
<details>
  <summary>ESP32-S3 output</summary>

```
esp-hal/xtask on  feat/s3-hil [$!⇕] is 📦 v0.0.0 via 🦀 v1.79.0-nightly took 34s 
❯ cargo xtask run-tests esp32s3
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `/home/sergio/Documents/Espressif/esp-rs/esp-hal/target/debug/xtask run-tests esp32s3`
[2024-04-16T10:02:03Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/aes_dma.rs' for 'esp32s3'
[2024-04-16T10:02:03Z INFO  xtask] Package: "tests/aes_dma.rs"
    Finished release [optimized + debuginfo] target(s) in 0.10s
     Running tests/aes_dma.rs (target/xtensa-esp32s3-none-elf/release/deps/aes_dma-678a29e2a6e15193)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 338.03 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 41.75 KiB/41.75 KiB @ 59.10 KiB/s (eta 0s )    Finished in 1.287s

running 4 tests
test tests::test_aes_128_dma_encryption ... ok
test tests::test_aes_128_dma_decryption ... ok
test tests::test_aes_256_dma_encryption ... ok
test tests::test_aes_256_dma_decryption ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.69s

[2024-04-16T10:02:07Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/gpio.rs' for 'esp32s3'
[2024-04-16T10:02:07Z INFO  xtask] Package: "tests/gpio.rs"
   Compiling hil-test v0.0.0 (/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test)
warning: unused imports: `Event`, `Pin`
  --> tests/gpio.rs:76:25
   |
76 |     use esp_hal::gpio::{Event, Pin};
   |                         ^^^^^  ^^^
   |
help: consider adding a `#[cfg(test)]` to the containing module
  --> tests/gpio.rs:72:1
   |
72 | #[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: `#[warn(unused_imports)]` on by default
   = note: this warning originates in the attribute macro `embedded_test::tests` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `hil-test` (test "gpio") generated 1 warning (run `cargo fix --test "gpio"` to apply 1 suggestion)
    Finished release [optimized + debuginfo] target(s) in 1.11s
     Running tests/gpio.rs (target/xtensa-esp32s3-none-elf/release/deps/gpio-6d34b93e4b92e780)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 334.76 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 44.62 KiB/44.62 KiB @ 61.33 KiB/s (eta 0s )    Finished in 1.315s

running 5 tests
test tests::test_async_edge     ... ok
test tests::test_a_pin_can_wait ... ok
test tests::test_gpio_input     ... ok
test tests::test_gpio_output    ... ok
test tests::test_gpio_od        ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.32s

[2024-04-16T10:02:12Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/rsa.rs' for 'esp32s3'
[2024-04-16T10:02:12Z INFO  xtask] Package: "tests/rsa.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/rsa.rs (target/xtensa-esp32s3-none-elf/release/deps/rsa-5030715296a40b73)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 332.36 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 42.40 KiB/42.40 KiB @ 59.57 KiB/s (eta 0s )    Finished in 1.302s

running 3 tests
test tests::test_modular_exponentiation ... ok
test tests::test_modular_multiplication ... ok
test tests::test_multiplication         ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.27s

[2024-04-16T10:02:15Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/sha.rs' for 'esp32s3'
[2024-04-16T10:02:15Z INFO  xtask] Package: "tests/sha.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/sha.rs (target/xtensa-esp32s3-none-elf/release/deps/sha-b85dd2d9e87de5fe)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 340.45 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 42.35 KiB/42.35 KiB @ 59.62 KiB/s (eta 0s )    Finished in 1.287s

running 7 tests
test tests::test_sha_1       ... ok
test tests::test_sha_224     ... ok
test tests::test_sha_256     ... ok
test tests::test_sha_384     ... ok
test tests::test_sha_512     ... ok
test tests::test_sha_512_224 ... ok
test tests::test_sha_512_256 ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.95s

[2024-04-16T10:02:20Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/aes.rs' for 'esp32s3'
[2024-04-16T10:02:20Z INFO  xtask] Package: "tests/aes.rs"
    Finished release [optimized + debuginfo] target(s) in 0.10s
     Running tests/aes.rs (target/xtensa-esp32s3-none-elf/release/deps/aes-e04548ecd65d68c7)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 339.87 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 39.81 KiB/39.81 KiB @ 58.10 KiB/s (eta 0s )    Finished in 1.263s

running 4 tests
test tests::test_aes_128_encryption ... ok
test tests::test_aes_128_decryption ... ok
test tests::test_aes_256_encryption ... ok
test tests::test_aes_256_decryption ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.69s

[2024-04-16T10:02:24Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/crc.rs' for 'esp32s3'
[2024-04-16T10:02:24Z INFO  xtask] Package: "tests/crc.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/crc.rs (target/xtensa-esp32s3-none-elf/release/deps/crc-45c50dfcecb0ea11)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 334.13 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 39.79 KiB/39.79 KiB @ 58.22 KiB/s (eta 0s )    Finished in 1.27s

running 2 tests
test tests::test_crc ... ok
test tests::test_md5 ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.84s

[2024-04-16T10:02:26Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/uart_async.rs' for 'esp32s3'
[2024-04-16T10:02:26Z INFO  xtask] Package: "tests/uart_async.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/uart_async.rs (target/xtensa-esp32s3-none-elf/release/deps/uart_async-caa80edae6460bf1)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 340.93 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 43.26 KiB/43.26 KiB @ 60.56 KiB/s (eta 0s )    Finished in 1.29s

running 1 test
test tests::test_send_receive ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.42s

[2024-04-16T10:02:29Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/clock_monitor.rs' for 'esp32s3'
[2024-04-16T10:02:29Z INFO  xtask] Package: "tests/clock_monitor.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/clock_monitor.rs (target/xtensa-esp32s3-none-elf/release/deps/clock_monitor-ab1c01c4c09c4246)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 337.04 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 38.73 KiB/38.73 KiB @ 57.41 KiB/s (eta 0s )    Finished in 1.257s

running 1 test
test tests::test_estimated_clock ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.42s

[2024-04-16T10:02:31Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/spi_full_duplex.rs' for 'esp32s3'
[2024-04-16T10:02:31Z INFO  xtask] Package: "tests/spi_full_duplex.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/spi_full_duplex.rs (target/xtensa-esp32s3-none-elf/release/deps/spi_full_duplex-3baa5b28e0709d30)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 337.34 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 41.47 KiB/41.47 KiB @ 59.35 KiB/s (eta 0s )    Finished in 1.281s

running 4 tests
test tests::test_symestric_transfer                      ... ok
test tests::test_asymestric_transfer                     ... ok
test tests::test_symestric_transfer_huge_buffer          ... ok
test tests::test_symestric_transfer_huge_buffer_no_alloc ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.69s

[2024-04-16T10:02:34Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/uart.rs' for 'esp32s3'
[2024-04-16T10:02:34Z INFO  xtask] Package: "tests/uart.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/uart.rs (target/xtensa-esp32s3-none-elf/release/deps/uart-381fbee4016cda4b)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 337.49 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [########################################################################################################################################################################################] 39.72 KiB/39.72 KiB @ 58.27 KiB/s (eta 0s )    Finished in 1.263s

running 1 test
test tests::test_send_receive ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.42s
```
</details>

