### PR TITLE
Update `README`s, housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # esp-hal
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/esp-rs/esp-hal/ci.yml?label=CI&logo=github&style=flat-square)
-![MIT/Apache-2.0 licensed](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue?style=flat-square)
-[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/esp-rs/esp-hal/ci.yml?labelColor=1C2C2E&label=CI&logo=github&style=flat-square)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/esp-rs/esp-hal/hil.yml?labelColor=1C2C2E&label=HIL&logo=github&style=flat-square&event=merge_group)
+![MIT/Apache-2.0 licensed](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?labelColor=1C2C2E&label=join%20matrix&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-**H**ardware **A**bstraction **L**ayer crates for the **ESP32**, **ESP32-C2/C3/C6**, **ESP32-H2**, **ESP32-P4**, and **ESP32-S2/S3** from Espressif. Additionally provides support for programming the low-power RISC-V cores found on the **ESP32-C6** and **ESP32-S2/S3**.
+Bare-metal (`no_std`) hardware abstraction layer for Espressif devices. Currently supports, to varying degrees, the following devices:
 
-These HALs are `no_std`; if you are looking for `std` support, please use [esp-idf-hal] instead.
+- ESP32 Series: _ESP32_
+- ESP32-C Series: _ESP32-C2 (aka ESP8684), ESP32-C3 (aka ESP8685), ESP32-C6_
+- ESP32-H Series: _ESP32-H2_
+- ESP32-P Series: _ESP32-P4_
+- ESP32-S Series: _ESP32-S2, ESP32-S3_
+
+Additionally provides limited support for programming the low-power RISC-V cores found on the _ESP32-C6_, _ESP32-S2_, and _ESP32-S3_ via the [esp-lp-hal] package.
+
+These packages are all `no_std`; if you are looking for `std` support, please use [esp-idf-svc] instead.
 
 If you have any questions, comments, or concerns, please [open an issue], [start a new discussion], or join us on [Matrix]. For additional information regarding any of the crates in this repository, please refer to the relevant crate's README.
 
@@ -14,7 +23,8 @@ If you have any questions, comments, or concerns, please [open an issue], [start
 >
 > This project is still in the relatively early stages of development, and as such there should be no expectation of API stability. A significant number of peripherals currently have drivers implemented but have varying levels of functionality. For most basic tasks, this should be usable already, however some more advanced or uncommon features may not yet be implemented.
 
-[esp-idf-hal]: https://github.com/esp-rs/esp-idf-hal
+[esp-lp-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp-lp-hal
+[esp-idf-svc]: https://github.com/esp-rs/esp-idf-svc
 [open an issue]: https://github.com/esp-rs/esp-hal/issues/new
 [start a new discussion]: https://github.com/esp-rs/esp-hal/discussions/new
 [matrix]: https://matrix.to/#/#esp-rs:matrix.org
@@ -23,10 +33,10 @@ If you have any questions, comments, or concerns, please [open an issue], [start
 
 For information relating to the development of Rust applications on ESP devices, please first read [The Rust on ESP Book].
 
-For information about the HAL and how to use it in your own projects, please refer to the documentation on [docs.rs] for the relevant chip.
+For information about the HAL and how to use it in your own projects, please refer to the [documentation].
 
 [The Rust on ESP Book]: https://esp-rs.github.io/book/
-[docs.rs]: https://docs.rs
+[documentation]: https://docs.esp-rs.org/esp-hal/
 
 ## Resources
 
@@ -38,56 +48,7 @@ For information about the HAL and how to use it in your own projects, please ref
 
 ## Crates
 
-### [esp-hal]
-
-Implements number of the traits defined in [embedded-hal](https://github.com/rust-embedded/embedded-hal) for various ESP devices. Full list of currently supported devices with basic information is in the table below.
-
-|   Feature     | Technical Reference Manual |             Target              |    MSRV    |
-| :-----------: | :------------------------: | :-----------------------------: | :--------: |
-| `esp32`       |           [ESP32]          |     `xtensa-esp32-none-elf`     |   ![esp]   |
-| `esp32c2`     |         [ESP32-C2]         |  `riscv32imc-unknown-none-elf`  | ![stable] |
-| `esp32c3`     |         [ESP32-C3]         |  `riscv32imc-unknown-none-elf`  | ![stable] |
-| `esp32c6`     |         [ESP32-C6]         | `riscv32imac-unknown-none-elf`  | ![stable] |
-| `esp32h2`     |         [ESP32-H2]         | `riscv32imac-unknown-none-elf`  | ![stable] |
-| `esp32p4`     |         [ESP32-P4]         | `riscv32imafc-unknown-none-elf` | ![stable] |
-| `esp32s2`     |         [ESP32-S2]         |    `xtensa-esp32s2-none-elf`    |   ![esp]   |
-| `esp32s3`     |         [ESP32-S3]         |    `xtensa-esp32s3-none-elf`    |   ![esp]   |
-
-[esp-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp-hal
-[esp]: https://img.shields.io/badge/rustc-esp%201.74+-red.svg
-[stable]: https://img.shields.io/badge/rustc-stable%201.76+-red.svg
-[esp32]: https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
-[esp32-c2]: https://www.espressif.com/sites/default/files/documentation/esp8684_technical_reference_manual_en.pdf
-[esp32-c3]: https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
-[esp32-c6]: https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf
-[esp32-h2]: https://www.espressif.com/sites/default/files/documentation/esp32-h2_technical_reference_manual_en.pdf
-[esp32-p4]: https://www.espressif.com/sites/default/files/documentation/esp32-p4_technical_reference_manual_en.pdf
-[esp32-s2]: https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
-[esp32-s3]: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
-
-### [esp-lp-hal]
-
-Implements a number of the traits defined in [embedded-hal](https://github.com/rust-embedded/embedded-hal) for the low-power (lp) RISC-V coprocessors found on the ESP32-C6, ESP32-S2, and ESP32-S3 from Espressif. The main idea is to have code running on lp core and putting the main core into sleep, making it more power-efficient.
-
-
-|    Crate     |       Documentation       |                            Targets                            |
-| :----------: | :-----------------------: | :-----------------------------------------------------------: |
-| [esp-lp-hal] | N/A (_Not yet published_) | `riscv32imc-unknown-none-elf`, `riscv32imac-unknown-none-elf` |
-
-
-[esp-lp-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp-lp-hal
-
-### [esp-hal-procmacros]
-
-Procedural macros for use with the esp-hal family of HAL packages.
-
-[esp-hal-procmacros]: https://github.com/esp-rs/esp-hal/tree/main/esp-hal-procmacros
-
-### [esp-riscv-rt]
-
-Minimal runtime / startup for RISC-V CPUs from Espressif.
-
-[esp-riscv-rt]: https://github.com/esp-rs/esp-hal/tree/main/esp-riscv-rt
+This repository is home to a number of different packages; for more information regarding a particular package, please refer to its `README.md` and/or documentation.
 
 ## Ancillary Crates
 
@@ -112,18 +73,6 @@ There are a number of other crates within the [esp-rs organization] which can be
 [esp-storage]: https://github.com/esp-rs/esp-storage
 [embedded-storage]: https://github.com/rust-embedded-community/embedded-storage
 [esp-wifi]: https://github.com/esp-rs/esp-wifi
-
-## Git Hooks
-
-We provide a simple `pre-commit` hook to verify the formatting of each package prior to committing changes. We _strongly_ encourage use of this git hook.
-
-The hook can be enabled by copying it in to the `.git/hooks/` directory:
-
-```bash
-cp pre-commit .git/hooks/pre-commit
-```
-
-When using this hook, you can choose to ignore its failure on a per-commit basis by committing with the `--no-verify` flag; however, you will need to be sure that all packages are formatted when submitting a pull request.
 
 ## License
 

--- a/esp-build/README.md
+++ b/esp-build/README.md
@@ -1,11 +1,14 @@
 # esp-build
 
-[![Crates.io](https://img.shields.io/crates/v/esp-build?color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-build)
-[![docs.rs](https://img.shields.io/docsrs/esp-build?color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-build)
-![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?style=flat-square)
-![Crates.io](https://img.shields.io/crates/l/esp-build?style=flat-square)
+[![Crates.io](https://img.shields.io/crates/v/esp-build?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-build)
+[![docs.rs](https://img.shields.io/docsrs/esp-build?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-build)
+![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?labelColor=1C2C2E&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-build?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-Build utilities for `esp-hal`.
+Build utilities for use with `esp-hal` and other related packages, intended for use in [build scripts]. This package is still quite minimal, but provides:
+
+[build scripts]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
 
 ## [Documentation](https://docs.rs/crate/esp-build)
 

--- a/esp-hal-procmacros/README.md
+++ b/esp-hal-procmacros/README.md
@@ -2,20 +2,20 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-hal-procmacros?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal-procmacros)
 [![docs.rs](https://img.shields.io/docsrs/esp-hal-procmacros?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-hal-procmacros)
+![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal-procmacros?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-Procedural macros for use with the `esp-hal` family of HAL packages.
-
-Provides macros for:
-
-- Placing statics and functions into RAM
-- Marking interrupt handlers
-- Automatically creating an `embassy` executor instance and spawning the defined entry point
+Procedural macros for use with `esp-hal` and other related packages.
 
 ## [Documentation]
 
 [documentation]: https://docs.rs/esp-hal-procmacros/
+
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_
+compile with older versions but that may change in any new patch release.
 
 ## License
 

--- a/esp-hal-smartled/README.md
+++ b/esp-hal-smartled/README.md
@@ -2,21 +2,22 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-hal-smartled?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal-smartled)
 [![docs.rs](https://img.shields.io/docsrs/esp-hal-smartled?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-hal-smartled)
+![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal-smartled?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-This adapter allows for the use of an RMT output channel to easily interact with RGB LEDs and use the convenience functions of the [`smart-leds`](https://crates.io/crates/smart-leds) crate.
+Allows for the use of an RMT output channel to easily interact with RGB LEDs and use the convenience functions of the [smart-leds] crate.
+
+[smart-leds]: https://crates.io/crates/smart-leds
 
 ## [Documentation]
 
 [documentation]: https://docs.rs/esp-hal-smartled/
 
-## Usage
+## Minimum Supported Rust Version (MSRV)
 
-### `defmt` Feature
-
-Please note that `defmt` does _not_ provide MSRV guarantees with releases, and as such we are not able to make any MSRV guarantees when this feature is enabled. For more information refer to the MSRV section of `defmt`'s README:
-https://github.com/knurling-rs/defmt?tab=readme-ov-file#msrv
+This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_
+compile with older versions but that may change in any new patch release.
 
 ## License
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -52,14 +52,14 @@ xtensa-lx            = { version = "0.9.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.29.0", features = ["critical-section"], optional = true }
-esp32c2 = { version = "0.18.0", features = ["critical-section"], optional = true }
-esp32c3 = { version = "0.21.0", features = ["critical-section"], optional = true }
-esp32c6 = { version = "0.12.0", features = ["critical-section"], optional = true }
-esp32h2 = { version = "0.8.0",  features = ["critical-section"], optional = true }
-esp32p4 = { version = "0.1.0",  features = ["critical-section"], optional = true }
-esp32s2 = { version = "0.20.0", features = ["critical-section"], optional = true }
-esp32s3 = { version = "0.24.0", features = ["critical-section"], optional = true }
+esp32   = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280", features = ["critical-section"], optional = true }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280", features = ["critical-section"], optional = true }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280", features = ["critical-section"], optional = true }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280", features = ["critical-section"], optional = true }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280", features = ["critical-section"], optional = true }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280", features = ["critical-section"], optional = true }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280", features = ["critical-section"], optional = true }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280", features = ["critical-section"], optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 esp-riscv-rt = { version = "0.7.0", optional = true, path = "../esp-riscv-rt" }
@@ -228,13 +228,3 @@ ci = [
 
 [lints.clippy]
 mixed_attributes_style = "allow"
-
-[patch.crates-io]
-esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }

--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -1,59 +1,55 @@
 # esp-hal
 
 [![Crates.io](https://img.shields.io/crates/v/esp-hal?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal)
+[![docs.rs](https://img.shields.io/docsrs/esp-hal?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.esp-rs.org/esp-hal)
+![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-The `esp-hal` package aims to provide a safe, idiomatic Hardware Abstraction Layer (HAL) for the entire family of ESP32 devices from Espressif.
+Bare-metal (`no_std`) hardware abstraction layer for Espressif devices.
 
-This package implements both blocking and, when able, asynchronous drivers for the various peripherals. At this time the blocking APIs are used by default, with all asynchronous functionality gated behind the `async` feature. See the package documentation for more information on its features.
+Implements a number of blocking and, where applicable, async traits from the various packages in the [embedded-hal] repository.
 
-Most traits defined by the [embedded-hal] family of packages are implemented as applicable.
+For help getting started with this HAL, please refer to [The Rust on ESP Book] and the [documentation].
 
 [embedded-hal]: https://github.com/rust-embedded/embedded-hal
+[the rust on esp book]: https://docs.esp-rs.org/book/
 
 ## [Documentation]
 
 [documentation]: https://docs.esp-rs.org/esp-hal/
 
-## Usage
+## Supported Devices
 
-Before using `esp-hal`, ensure that you have configured your [development environment] correctly, and the [required tooling] has been installed.
+|   Chip   |        Datasheet         | Technical Reference Manual |             Target             |
+| :------: | :----------------------: | :------------------------: | :----------------------------: |
+|  ESP32   |  [ESP32][32-datasheet]   |      [ESP32][32-trm]       |    `xtensa-esp32-none-elf`     |
+| ESP32-C2 | [ESP32-C2][c2-datasheet] |     [ESP32-C2][c2-trm]     | `riscv32imc-unknown-none-elf`  |
+| ESP32-C3 | [ESP32-C3][c3-datasheet] |     [ESP32-C3][c3-trm]     | `riscv32imc-unknown-none-elf`  |
+| ESP32-C6 | [ESP32-C6][c6-datasheet] |     [ESP32-C6][c6-trm]     | `riscv32imac-unknown-none-elf` |
+| ESP32-H2 | [ESP32-H2][h2-datasheet] |     [ESP32-H2][h2-trm]     | `riscv32imac-unknown-none-elf` |
+| ESP32-S2 | [ESP32-S2][s2-datasheet] |     [ESP32-S2][s2-trm]     |   `xtensa-esp32s2-none-elf`    |
+| ESP32-S3 | [ESP32-S3][s3-datasheet] |     [ESP32-S3][s3-trm]     |   `xtensa-esp32s3-none-elf`    |
 
-When starting a new project using `esp-hal`, we strongly recommend you generate a project skeleton using [cargo-generate] and [esp-template]. This will take much of the guesswork out of the process and give you a starting point to build an application from.
+[32-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
+[c2-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp8684_datasheet_en.pdf
+[c3-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+[c6-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
+[h2-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf
+[s2-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
+[s3-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf
+[32-trm]: https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
+[c2-trm]: https://www.espressif.com/sites/default/files/documentation/esp8684_technical_reference_manual_en.pdf
+[c3-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
+[c6-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf
+[h2-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-h2_technical_reference_manual_en.pdf
+[s2-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
+[s3-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
 
-Much of the functionality available is feature-gated, so be sure to refer to the documentation to read about all available Cargo features.
+## Minimum Supported Rust Version (MSRV)
 
-[development environment]: https://esp-rs.github.io/book/installation/index.html
-[required tooling]: https://esp-rs.github.io/book/tooling/espflash.html
-[cargo-generate]: https://github.com/cargo-generate/cargo-generate/
-[esp-template]: https://github.com/esp-rs/esp-template/
-
-### `defmt` Feature
-
-Please note that `defmt` does _not_ provide MSRV guarantees with releases, and as such we are not able to make any MSRV guarantees when this feature is enabled. For more information refer to the MSRV section of `defmt`'s README:
-https://github.com/knurling-rs/defmt?tab=readme-ov-file#msrv
-
-### Supporting Packages
-
-A number of additional packages are available which add additional functionality beyond the HAL.
-
-Within this repository, the [esp-lp-hal] package provides support for the (ultra-)low-power RISC-V coprocessors found aboard the ESP32-C6, ESP32-S2, and ESP32-S3.
-
-There is also the [esp-wifi] package, which provides support for Bluetooth and Wi-Fi.
-
-For additional libraries, you can check the [list of repositories] in the [esp-rs organization].
-
-[esp-lp-hal]: ../esp-lp-hal/
-[esp-wifi]: https://github.com/esp-rs/esp-wifi
-[list of repositories]: https://github.com/orgs/esp-rs/repositories
-[esp-rs organization]: https://github.com/esp-rs
-
-## Examples
-
-Examples demonstrating the use of various peripherals and features of the HAL are available in the [examples] package.
-
-[examples]: ../examples/
+This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_
+compile with older versions but that may change in any new patch release.
 
 ## License
 

--- a/esp-lp-hal/README.md
+++ b/esp-lp-hal/README.md
@@ -2,23 +2,18 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-lp-hal?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-lp-hal)
 [![docs.rs](https://img.shields.io/docsrs/esp-lp-hal?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-lp-hal)
+![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-lp-hal?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-`no_std` HAL for the low-power RISC-V coprocessors found on the ESP32-C6, ESP32-S2, and ESP32-S3 from Espressif.
+Bare-metal (`no_std`) hardware abstraction layer for the low-power RISC-V coprocessors found in the ESP32-C6, ESP32-S2, and ESP32-S3 from Espressif.
 
-Implements a number of the traits defined in [embedded-hal](https://github.com/rust-embedded/embedded-hal).
+Implements a number of blocking and, where applicable, async traits from the various packages in the [embedded-hal] repository.
 
-These devices uses the RISC-V ISA, which is officially supported by the Rust compiler via the `riscv32imc-unknown-none-elf` and `riscv32imac-unknown-none-elf` targets.
+For help getting started with this HAL, please refer to [The Rust on ESP Book] and the [documentation].
 
-Please refer to the documentation for more information.
-
-[c6-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
-[s2-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
-[s3-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf
-[c6-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf
-[s2-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
-[s3-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+[embedded-hal]: https://github.com/rust-embedded/embedded-hal
+[the rust on esp book]: https://docs.esp-rs.org/book/
 
 ## [Documentation]
 
@@ -32,30 +27,17 @@ Please refer to the documentation for more information.
 | ESP32-S2 | [ESP32-S2][s2-datasheet] |     [ESP32-S2][s2-trm]     | `riscv32imc-unknown-none-elf`  |
 | ESP32-S3 | [ESP32-S3][s3-datasheet] |     [ESP32-S3][s3-trm]     | `riscv32imc-unknown-none-elf`  |
 
-## Resources
+[c6-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
+[s2-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
+[s3-datasheet]: https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf
+[c6-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf
+[s2-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
+[s3-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
 
-- [The Rust Programming Language](https://doc.rust-lang.org/book/)
-- [The Embedded Rust Book](https://docs.rust-embedded.org/book/index.html)
-- [The Rust on ESP Book](https://esp-rs.github.io/book/)
-- Datasheets:
-  - [ESP32-C6](https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf)
-  - [ESP32-S2](https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf)
-  - [ESP32-S3](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf)
-- Technical Reference Manuals:
-  - [ESP32-C6](https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf)
-  - [ESP32-S2](https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf)
-  - [ESP32-S3](https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf)
+## Minimum Supported Rust Version (MSRV)
 
-## Getting Started
-
-### Installing the Rust Compiler Targets
-
-The compilation targets for these devices are officially supported by the mainline Rust compiler and can be installed using [rustup](https://rustup.rs/):
-
-```shell
-rustup target add riscv32imc-unknown-none-elf
-rustup target add riscv32imac-unknown-none-elf
-```
+This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_
+compile with older versions but that may change in any new patch release.
 
 ## License
 

--- a/esp-metadata/README.md
+++ b/esp-metadata/README.md
@@ -2,10 +2,13 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-metadata?color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-metadata)
 [![docs.rs](https://img.shields.io/docsrs/esp-metadata?color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-metadata)
-![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-metadata?style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-Metadata for Espressif devices, primarily intended for use in build scripts.
+Metadata for Espressif devices, intended for use in [build scripts].
+
+[build scripts]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
 
 ## [Documentation](https://docs.rs/crate/esp-metadata)
 

--- a/esp-riscv-rt/README.md
+++ b/esp-riscv-rt/README.md
@@ -1,27 +1,30 @@
 # esp-riscv-rt
 
-[![Crates.io](https://img.shields.io/crates/v/esp-riscv-rt?color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-riscv-rt)
-[![docs.rs](https://img.shields.io/docsrs/esp-riscv-rt?color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-riscv-rt)
-![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?style=flat-square)
-![Crates.io](https://img.shields.io/crates/l/esp-riscv-rt?style=flat-square)
+[![Crates.io](https://img.shields.io/crates/v/esp-riscv-rt?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-riscv-rt)
+[![docs.rs](https://img.shields.io/docsrs/esp-riscv-rt?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-riscv-rt)
+![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?labelColor=1C2C2E&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-riscv-rt?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-> Minimal runtime / startup for RISC-V CPUs from Espressif.
+Minimal runtime / startup for RISC-V devices from Espressif.
 
-Much of the code in this repository originated in the [rust-embedded/riscv-rt](https://github.com/rust-embedded/riscv-rt) repository.
+Much of the code in this package originated in the [rust-embedded/riscv] repository.
+
+[rust-embedded/riscv]: https://github.com/rust-embedded/riscv
 
 ## [Documentation](https://docs.rs/crate/esp-riscv-rt)
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.60 and up. It _might_
+This crate is guaranteed to compile on stable Rust 1.65 and up. It _might_
 compile with older versions but that may change in any new patch release.
 
 ## License
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -77,13 +77,3 @@ incremental      = false
 opt-level        = 3
 lto = 'fat'
 overflow-checks  = false
-
-[patch.crates-io]
-esp32 =   { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "963c280621f0b7ec26546a5eff24a5032305437f" }


### PR DESCRIPTION
A few mostly unrelated things going on here:

- There were some crates.io patches which had snuck in (I think we should try to avoid these moving forward, but that's probably another conversation), so I have removed these and just replaced them with git dependencies
- I have updated the various `README.md` files:
    - Updated/normalized the badges
    - Simplified the READMEs as much as possible, defer to the book and documentation (which will need improving now 😉 ) wherever possible
- ~~Possibly controversial (can revert this one if needed): added a minimal `.vscode/settings.json` just to deal with the annoying TOML formatting issues~~
    - ~~`git update-index --skip-worktree .vscode/settings.json` will ignore any subsequent changes to this file, so people can modify it as needed without the changes being tracked~~
    - ~~Still kind of annoying to deal with, don't think we can do anything at the git repo level~~
    - Never mind, this is super annoying to deal with already.

I would like to try and keep the READMEs minimal I think, just because things tend to fall out of sync. If there's anything else anybody thinks is worth mentioning please let me know, I have no problem updating this further. However, as I stated, I think we should try to defer to the book and documentation whenever possible.