### PR TITLE
Clear the UART's TX/RX FIFOs at initialization

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed core1 startup using the wrong stack on the esp32 and esp32s3 (#1286).
 - ESP32: Apply fix for Errata 3.6 in all the places necessary. (#1315)
 - ESP32 & ESP32-S2: Fix I²C frequency (#1306)
+- UART's TX/RX FIFOs are now cleared during initialization (#1344)
 
 ### Changed
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -512,6 +512,11 @@ where
             }
         }
 
+        // Reset Tx/Rx FIFOs
+        serial.txfifo_reset();
+        serial.rxfifo_reset();
+        crate::rom::ets_delay_us(15);
+
         serial
     }
 
@@ -1021,6 +1026,30 @@ where
     #[cfg(not(any(esp32c3, esp32c6, esp32h2, esp32s3)))]
     #[inline(always)]
     fn sync_regs(&mut self) {}
+
+    fn rxfifo_reset(&mut self) {
+        T::register_block()
+            .conf0()
+            .modify(|_, w| w.rxfifo_rst().set_bit());
+        self.sync_regs();
+
+        T::register_block()
+            .conf0()
+            .modify(|_, w| w.rxfifo_rst().clear_bit());
+        self.sync_regs();
+    }
+
+    fn txfifo_reset(&mut self) {
+        T::register_block()
+            .conf0()
+            .modify(|_, w| w.txfifo_rst().set_bit());
+        self.sync_regs();
+
+        T::register_block()
+            .conf0()
+            .modify(|_, w| w.txfifo_rst().clear_bit());
+        self.sync_regs();
+    }
 }
 
 /// UART peripheral instance


### PR DESCRIPTION
This was required in order to get the async HIL test passing for UART (which I will submit in a subsequent PR, once I have cleaned it up a bit).

I don't love the delay, but based on my testing this was the minimum amount of time required for the FIFO to actually clear. I would like to understand this better, but for the time being it works at least.