### PR TITLE
Seal all `Instance` traits

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable `embedded-hal` feature by default, instead of the `embedded-hal-02` feature (#1313)
 - `Uart` structs now take a `Mode` parameter which defines how the driver is initialized (#1294)
 - `Rmt` can be created in async or blocking mode. The blocking constructor takes an optional interrupt handler argument. (#1341)
+- All `Instance` traits are now sealed, and can no longer be implemented for arbitrary types (#1346)
 
 ### Removed
 

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -645,7 +645,7 @@ mod asynch {
 }
 
 /// I2C Peripheral Instance
-pub trait Instance {
+pub trait Instance: crate::private::Sealed {
     fn scl_output_signal(&self) -> OutputSignal;
     fn scl_input_signal(&self) -> InputSignal;
     fn sda_output_signal(&self) -> OutputSignal;

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1988,7 +1988,7 @@ pub trait ExtendedInstance: Instance {
     fn sio3_input_signal(&self) -> InputSignal;
 }
 
-pub trait Instance {
+pub trait Instance: crate::private::Sealed {
     fn register_block(&self) -> &RegisterBlock;
 
     fn sclk_signal(&self) -> OutputSignal;

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -701,7 +701,7 @@ where
 {
 }
 
-pub trait Instance {
+pub trait Instance: crate::private::Sealed {
     fn register_block(&self) -> &RegisterBlock;
 
     fn sclk_signal(&self) -> InputSignal;

--- a/esp-hal/src/timer.rs
+++ b/esp-hal/src/timer.rs
@@ -267,7 +267,7 @@ where
 }
 
 /// Timer peripheral instance
-pub trait Instance {
+pub trait Instance: crate::private::Sealed {
     fn reset_counter(&mut self);
 
     fn set_counter_active(&mut self, state: bool);
@@ -304,6 +304,8 @@ pub trait Instance {
 pub struct Timer0<TG> {
     phantom: PhantomData<TG>,
 }
+
+impl<TG> crate::private::Sealed for Timer0<TG> {}
 
 impl<TG> Timer0<TG>
 where
@@ -473,6 +475,9 @@ where
 pub struct Timer1<TG> {
     phantom: PhantomData<TG>,
 }
+
+#[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2)))]
+impl<TG> crate::private::Sealed for Timer1<TG> {}
 
 #[cfg(not(any(esp32c2, esp32c3, esp32c6, esp32h2)))]
 impl<TG> Timer1<TG>

--- a/esp-hal/src/trace.rs
+++ b/esp-hal/src/trace.rs
@@ -198,7 +198,7 @@ where
     }
 }
 
-pub trait Instance {
+pub trait Instance: crate::private::Sealed {
     fn register_block(&self) -> &RegisterBlock;
 }
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -641,7 +641,7 @@ where
     }
 }
 
-pub trait Instance {
+pub trait Instance: crate::private::Sealed {
     const SYSTEM_PERIPHERAL: system::Peripheral;
     const NUMBER: usize;
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1053,7 +1053,7 @@ where
 }
 
 /// UART peripheral instance
-pub trait Instance {
+pub trait Instance: crate::private::Sealed {
     fn register_block() -> &'static RegisterBlock;
     fn uart_number() -> usize;
     fn interrupt() -> Interrupt;

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -285,7 +285,7 @@ impl<'d> UsbSerialJtag<'d> {
 }
 
 /// USB Serial JTAG peripheral instance
-pub trait Instance {
+pub trait Instance: crate::private::Sealed {
     fn register_block() -> &'static RegisterBlock;
 
     fn disable_tx_interrupts() {


### PR DESCRIPTION
While the various `Instance` traits must be public for the sake of visibility, we should not allow users to implement these traits on arbitrary types. As such, I have sealed as `Instance` traits.

(Does this require a `CHANGELOG.md` entry? I don't think so?)