### PR TITLE
UART: Allow the change of baudrate after instantiation

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Rmt` can be created in async or blocking mode. The blocking constructor takes an optional interrupt handler argument. (#1341)
 - All `Instance` traits are now sealed, and can no longer be implemented for arbitrary types (#1346)
 - DMA channels can/have to be explicitly created for async or blocking drivers, added `set_interrupt_handler` to DMA channels, SPI, I2S, PARL_IO, don't enable interrupts on startup for DMA, I2S, PARL_IO, GPIO (#1300)
+- UART: Rework `change_baud` so it is possible to set baud rate even after instantiation (#1350)
+
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -41,7 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DMA channels can/have to be explicitly created for async or blocking drivers, added `set_interrupt_handler` to DMA channels, SPI, I2S, PARL_IO, don't enable interrupts on startup for DMA, I2S, PARL_IO, GPIO (#1300)
 - UART: Rework `change_baud` so it is possible to set baud rate even after instantiation (#1350)
 
-
 ### Removed
 
 - Remove package-level type exports (#1275)

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2095,7 +2095,7 @@ pub mod lp_uart {
 
             // Override protocol parameters from the configuration
             // uart_hal_set_baudrate(&hal, cfg->uart_proto_cfg.baud_rate, sclk_freq);
-            me.change_baud(config.baudrate);
+            me.change_baud_internal(config.baudrate);
             // uart_hal_set_parity(&hal, cfg->uart_proto_cfg.parity);
             me.change_parity(config.parity);
             // uart_hal_set_data_bit_num(&hal, cfg->uart_proto_cfg.data_bits);

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -985,6 +985,7 @@ where
         T::disable_tx_interrupts();
     }
 
+    /// Modify UART baud rate and reset TX/RX fifo.
     pub fn change_baud(&mut self, baudrate: u32, clocks: &Clocks) {
         self.change_baud_internal(baudrate, clocks);
         self.txfifo_reset();
@@ -2169,6 +2170,7 @@ pub mod lp_uart {
             self.update();
         }
 
+        /// Modify UART baud rate and reset TX/RX fifo.
         pub fn change_baud(&mut self, baudrate: u32) {
             self.change_baud_internal(baudrate);
             self.txfifo_reset();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This change allows us to set the UART baud rate once it has been instantiated.

#### Testing
I used a modified `hello_world` example:

```rust
...
    let mut uart0 = Uart::new(peripherals.UART0, &clocks);

    uart0.change_baud(56000, &clocks); // HERE IS MY CHANGE

    loop {
        writeln!(uart0, "Hello world!").unwrap();
        delay.delay(1.secs());
    }
```

and I used `HTerm` terminal where I could change the baud rate accordingly. 

closes #944