### PR TITLE
Properly disable USB pullups/pulldowns on esp32c3/esp32s3

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART's TX/RX FIFOs are now cleared during initialization (#1344)
 - Fixed `LCD_CAM I8080` driver potentially sending garbage to display (#1301)
 - The TWAI driver can now be used without requiring the `embedded-hal` traits (#1355)
-- USB pullup/pulldown now gets properly cleared and does not interfere anymore on esp32c3 and esp32c6 (#1244)
+- USB pullup/pulldown now gets properly cleared and does not interfere anymore on esp32c3 and esp32s3 (#1244)
 
 ### Changed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART's TX/RX FIFOs are now cleared during initialization (#1344)
 - Fixed `LCD_CAM I8080` driver potentially sending garbage to display (#1301)
 - The TWAI driver can now be used without requiring the `embedded-hal` traits (#1355)
+- USB pullup/pulldown now gets properly cleared and does not interfere anymore on esp32c3 and esp32c6 (#1244)
 
 ### Changed
 

--- a/esp-hal/src/gpio.rs
+++ b/esp-hal/src/gpio.rs
@@ -47,11 +47,11 @@ static USER_INTERRUPT_HANDLER: Mutex<Cell<Option<InterruptHandler>>> = Mutex::ne
 
 #[derive(Copy, Clone)]
 pub enum Event {
-    RisingEdge = 1,
+    RisingEdge  = 1,
     FallingEdge = 2,
-    AnyEdge = 3,
-    LowLevel = 4,
-    HighLevel = 5,
+    AnyEdge     = 3,
+    LowLevel    = 4,
+    HighLevel   = 5,
 }
 
 pub struct Unknown {}
@@ -142,7 +142,7 @@ pub struct AF1;
 pub struct AF2;
 
 pub enum DriveStrength {
-    I5mA = 0,
+    I5mA  = 0,
     I10mA = 1,
     I20mA = 2,
     I40mA = 3,
@@ -160,7 +160,7 @@ pub enum AlternateFunction {
 
 #[derive(PartialEq)]
 pub enum RtcFunction {
-    Rtc = 0,
+    Rtc     = 0,
     Digital = 1,
 }
 

--- a/esp-hal/src/gpio.rs
+++ b/esp-hal/src/gpio.rs
@@ -47,11 +47,11 @@ static USER_INTERRUPT_HANDLER: Mutex<Cell<Option<InterruptHandler>>> = Mutex::ne
 
 #[derive(Copy, Clone)]
 pub enum Event {
-    RisingEdge  = 1,
+    RisingEdge = 1,
     FallingEdge = 2,
-    AnyEdge     = 3,
-    LowLevel    = 4,
-    HighLevel   = 5,
+    AnyEdge = 3,
+    LowLevel = 4,
+    HighLevel = 5,
 }
 
 pub struct Unknown {}
@@ -142,7 +142,7 @@ pub struct AF1;
 pub struct AF2;
 
 pub enum DriveStrength {
-    I5mA  = 0,
+    I5mA = 0,
     I10mA = 1,
     I20mA = 2,
     I40mA = 3,
@@ -160,7 +160,7 @@ pub enum AlternateFunction {
 
 #[derive(PartialEq)]
 pub enum RtcFunction {
-    Rtc     = 0,
+    Rtc = 0,
     Digital = 1,
 }
 
@@ -631,7 +631,18 @@ where
         if GPIONUM == 18 || GPIONUM == 19 {
             unsafe { &*crate::peripherals::USB_DEVICE::PTR }
                 .conf0()
-                .modify(|_, w| w.usb_pad_enable().clear_bit());
+                .modify(|_, w| {
+                    w.usb_pad_enable()
+                        .clear_bit()
+                        .dm_pullup()
+                        .clear_bit()
+                        .dm_pulldown()
+                        .clear_bit()
+                        .dp_pullup()
+                        .clear_bit()
+                        .dp_pulldown()
+                        .clear_bit()
+                });
         }
 
         // Same workaround as above for ESP32-S3
@@ -639,7 +650,18 @@ where
         if GPIONUM == 19 || GPIONUM == 20 {
             unsafe { &*crate::peripherals::USB_DEVICE::PTR }
                 .conf0()
-                .modify(|_, w| w.usb_pad_enable().clear_bit());
+                .modify(|_, w| {
+                    w.usb_pad_enable()
+                        .clear_bit()
+                        .dm_pullup()
+                        .clear_bit()
+                        .dm_pulldown()
+                        .clear_bit()
+                        .dp_pullup()
+                        .clear_bit()
+                        .dp_pulldown()
+                        .clear_bit()
+                });
         }
 
         get_io_mux_reg(GPIONUM).modify(|_, w| unsafe {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Even though the USB device pads are disabled by clearing the corresponding bit, the corresponding pullups/pulldowns do not get deactivated. This fix cleares those bits too.

#### Testing
Works on my device (esp32c3)