### PR TITLE
C3: Fix the number of GPIO pins

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `LCD_CAM I8080` driver potentially sending garbage to display (#1301)
 - The TWAI driver can now be used without requiring the `embedded-hal` traits (#1355)
 - USB pullup/pulldown now gets properly cleared and does not interfere anymore on esp32c3 and esp32s3 (#1244)
+- Fixed number of GPIO pins in C3 (#1361)
 
 ### Changed
 

--- a/esp-hal/src/soc/esp32c3/gpio.rs
+++ b/esp-hal/src/soc/esp32c3/gpio.rs
@@ -51,7 +51,7 @@ use crate::{
     peripherals::GPIO,
 };
 
-pub const NUM_PINS: usize = 21;
+pub const NUM_PINS: usize = 22;
 
 pub(crate) const FUNC_IN_SEL_OFFSET: usize = 0;
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

ESP32-C3 does have 22 pins, trying to wait for an edge in embassy on gpio21 is leading to panic:

```
ERROR !! A panic occured in '/src/index.crates.io-6f17d22bba15001f/esp-hal-0.16.1/src/gpio.rs', at line 3123, column 13:
└─ esp_backtrace::panic_handler @ /.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-backtrace-0.11.1/src/lib.rs:26  
ERROR index out of bounds: the len is 21 but the index is 21
```

#### Description
A simple off by one identical too https://github.com/esp-rs/esp-hal/commit/111d00617f5b7ebdc938de6c74c1af3601b15d71

#### Testing
Changing the pin number to right 22 does remove the panic and the interrupt does work fine on it.
