### PR TITLE
Build `esp-hal` for the ESP32-P4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
             "esp32c3",
             "esp32c6",
             "esp32h2",
-            # "esp32p4",
+            "esp32p4",
             # Xtensa devices:
             "esp32",
             "esp32s2",

--- a/esp-hal/src/soc/esp32p4/peripherals.rs
+++ b/esp-hal/src/soc/esp32p4/peripherals.rs
@@ -54,7 +54,7 @@ crate::peripherals! {
     LCD_CAM <= LCD_CAM,
     LEDC <= LEDC,
     LP_ADC <= LP_ADC,
-    LP_ANA_PERI <= LP_ANA_PERI,
+    LP_ANA <= LP_ANA,
     LP_AON_CLKRST <= LP_AON_CLKRST,
     LP_GPIO <= LP_GPIO,
     LP_HUK <= LP_HUK,

--- a/examples/src/bin/interrupt_preemption.rs
+++ b/examples/src/bin/interrupt_preemption.rs
@@ -4,6 +4,8 @@
 //! priority. Should show higher-numbered software interrupts happening during
 //! the handling of lower-numbered ones.
 
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
There have been a couple changes introduced which broke the build for this chip, so even though we're not prioritizing it right now we should at least make sure it doesn't fall into disrepair, as there is essentially no maintenance burden involved in doing so.

I'm only building `esp-hal` with the `esp32p4` feature enabled, MSRV/Clippy/etc. checks are not being performed at this time, as this will likely cause annoyances.