### PR TITLE
Use fewer `embedded-hal@0.2.x` traits in examples, build HAL without default features in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,55 +45,67 @@ jobs:
   # Build Packages
 
   esp-hal:
+    name: esp-hal (${{ matrix.device.soc }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        soc: [
+        device: [
             # RISC-V devices:
-            "esp32c2",
-            "esp32c3",
-            "esp32c6",
-            "esp32h2",
-            "esp32p4",
+            { soc: "esp32c2", target: "riscv32imc-unknown-none-elf" },
+            { soc: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+            { soc: "esp32c6", target: "riscv32imac-unknown-none-elf" },
+            { soc: "esp32h2", target: "riscv32imac-unknown-none-elf" },
+            { soc: "esp32p4", target: "riscv32imafc-unknown-none-elf" },
             # Xtensa devices:
-            "esp32",
-            "esp32s2",
-            "esp32s3",
+            { soc: "esp32", target: "xtensa-esp32-none-elf" },
+            { soc: "esp32s2", target: "xtensa-esp32s2-none-elf" },
+            { soc: "esp32s3", target: "xtensa-esp32s3-none-elf" },
           ]
 
     steps:
       - uses: actions/checkout@v4
 
       # Install the Rust toolchain for RISC-V devices:
-      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.soc) }}
+      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
         uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
           toolchain: nightly
           components: rust-src
       # Install the Rust toolchain for Xtensa devices:
-      - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.soc)
+      - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc)
         uses: esp-rs/xtensa-toolchain@v1.5
         with:
-          buildtargets: ${{ matrix.soc }}
+          buildtargets: ${{ matrix.device.soc }}
           default: true
           ldproxy: false
 
       - uses: Swatinem/rust-cache@v2
 
       # Build all supported examples for the low-power core first (if present):
-      - if: contains(fromJson('["esp32c6", "esp32s2", "esp32s3"]'), matrix.soc)
+      - if: contains(fromJson('["esp32c6", "esp32s2", "esp32s3"]'), matrix.device.soc)
         name: Build prerequisites (esp-lp-hal)
-        run: cargo xtask build-examples esp-lp-hal ${{ matrix.soc }}
+        run: cargo xtask build-examples esp-lp-hal ${{ matrix.device.soc }}
 
+      # Make sure we're able to build the HAL without the default features
+      # enabled:
+      # TODO: Remove `rt` and `vectored` features when able!
+      #       See: https://github.com/esp-rs/esp-hal/issues/1371
+      - name: Build (no features)
+        run: |
+          cargo xtask build-package \
+            --no-default-features \
+            --features=${{ matrix.device.soc }},rt,vectored \
+            --target=${{ matrix.device.target }} \
+            esp-hal
       # Build all supported examples for the specified device:
-      - name: Build examples
-        run: cargo xtask build-examples esp-hal ${{ matrix.soc }}
+      - name: Build (examples)
+        run: cargo xtask build-examples esp-hal ${{ matrix.device.soc }}
       # Ensure we can build the documentation for the specified device:
-      - name: Build documentation
-        run: cargo xtask build-documentation esp-hal ${{ matrix.soc }}
+      - name: Build (documentation)
+        run: cargo xtask build-documentation esp-hal ${{ matrix.device.soc }}
 
   esp-lp-hal:
     runs-on: ubuntu-latest

--- a/esp-hal/src/gpio.rs
+++ b/esp-hal/src/gpio.rs
@@ -22,7 +22,7 @@
 //!
 //! [embedded-hal]: https://docs.rs/embedded-hal/latest/embedded_hal/
 
-use core::{cell::Cell, convert::Infallible, marker::PhantomData};
+use core::{cell::Cell, marker::PhantomData};
 
 use critical_section::Mutex;
 
@@ -548,7 +548,7 @@ impl<MODE, const GPIONUM: u8> embedded_hal_02::digital::v2::InputPin
 where
     Self: GpioProperties,
 {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(<Self as GpioProperties>::Bank::read_input() & (1 << (GPIONUM % 32)) != 0)
     }
@@ -563,7 +563,7 @@ impl<const GPIONUM: u8> embedded_hal_02::digital::v2::InputPin
 where
     Self: GpioProperties,
 {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(<Self as GpioProperties>::Bank::read_input() & (1 << (GPIONUM % 32)) != 0)
     }
@@ -577,7 +577,7 @@ impl<MODE, const GPIONUM: u8> embedded_hal::digital::ErrorType for GpioPin<Input
 where
     Self: GpioProperties,
 {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
 }
 
 #[cfg(feature = "embedded-hal")]
@@ -899,7 +899,7 @@ where
     Self: GpioProperties,
     <Self as GpioProperties>::PinType: IsOutputPin,
 {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
     fn set_high(&mut self) -> Result<(), Self::Error> {
         <Self as GpioProperties>::Bank::write_output_set(1 << (GPIONUM % 32));
         Ok(())
@@ -932,7 +932,7 @@ where
     Self: GpioProperties,
     <Self as GpioProperties>::PinType: IsOutputPin,
 {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
     fn toggle(&mut self) -> Result<(), Self::Error> {
         use embedded_hal_02::digital::v2::{OutputPin as _, StatefulOutputPin as _};
         if self.is_set_high()? {
@@ -949,7 +949,7 @@ where
     Self: GpioProperties,
     <Self as GpioProperties>::PinType: IsOutputPin,
 {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
 }
 
 #[cfg(feature = "embedded-hal")]
@@ -1775,7 +1775,7 @@ impl<MODE, TYPE> embedded_hal_02::digital::v2::InputPin for AnyPin<Input<MODE>, 
 
 #[cfg(feature = "embedded-hal")]
 impl<MODE, TYPE> embedded_hal::digital::ErrorType for AnyPin<Input<MODE>, TYPE> {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
 }
 
 #[cfg(feature = "embedded-hal")]
@@ -1793,7 +1793,7 @@ impl<MODE, TYPE> embedded_hal::digital::InputPin for AnyPin<Input<MODE>, TYPE> {
 
 #[cfg(feature = "embedded-hal-02")]
 impl<MODE, TYPE> embedded_hal_02::digital::v2::OutputPin for AnyPin<Output<MODE>, TYPE> {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
         let inner = &mut self.inner;
@@ -1821,7 +1821,7 @@ impl<MODE, TYPE> embedded_hal_02::digital::v2::StatefulOutputPin for AnyPin<Outp
 
 #[cfg(feature = "embedded-hal-02")]
 impl<MODE, TYPE> embedded_hal_02::digital::v2::ToggleableOutputPin for AnyPin<Output<MODE>, TYPE> {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
 
     fn toggle(&mut self) -> Result<(), Self::Error> {
         let inner = &mut self.inner;
@@ -1831,7 +1831,7 @@ impl<MODE, TYPE> embedded_hal_02::digital::v2::ToggleableOutputPin for AnyPin<Ou
 
 #[cfg(feature = "embedded-hal")]
 impl<MODE, TYPE> embedded_hal::digital::ErrorType for AnyPin<Output<MODE>, TYPE> {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
 }
 
 #[cfg(feature = "embedded-hal")]

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -399,7 +399,7 @@ impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
     }
 
     /// Get the period of the timer.
-    fn get_period(&self) -> u16 {
+    pub fn get_period(&self) -> u16 {
         // SAFETY:
         // We only grant access to our CFG0 register with the lifetime of &mut self
         let block = unsafe { &*PWM::block() };

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -68,6 +68,7 @@ impl self::efuse::Efuse {
     }
 }
 
-pub fn is_valid_ram_address(address: u32) -> bool {
+#[allow(unused)]
+pub(crate) fn is_valid_ram_address(address: u32) -> bool {
     (self::constants::SOC_DRAM_LOW..=self::constants::SOC_DRAM_HIGH).contains(&address)
 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -790,7 +790,6 @@ pub mod dma {
             SpiPeripheral,
             TxPrivate,
         },
-        FlashSafeDma,
         Mode,
     };
 
@@ -1330,7 +1329,7 @@ pub mod dma {
 
     #[cfg(feature = "embedded-hal-02")]
     impl<T: embedded_hal_02::blocking::spi::Transfer<u8>, const SIZE: usize>
-        embedded_hal_02::blocking::spi::Transfer<u8> for FlashSafeDma<T, SIZE>
+        embedded_hal_02::blocking::spi::Transfer<u8> for crate::FlashSafeDma<T, SIZE>
     {
         type Error = T::Error;
 
@@ -1341,7 +1340,7 @@ pub mod dma {
 
     #[cfg(feature = "embedded-hal-02")]
     impl<T: embedded_hal_02::blocking::spi::Write<u8>, const SIZE: usize>
-        embedded_hal_02::blocking::spi::Write<u8> for FlashSafeDma<T, SIZE>
+        embedded_hal_02::blocking::spi::Write<u8> for crate::FlashSafeDma<T, SIZE>
     {
         type Error = T::Error;
 
@@ -1361,7 +1360,7 @@ pub mod dma {
 
     #[cfg(feature = "embedded-hal-02")]
     impl<T: embedded_hal_02::spi::FullDuplex<u8>, const SIZE: usize>
-        embedded_hal_02::spi::FullDuplex<u8> for FlashSafeDma<T, SIZE>
+        embedded_hal_02::spi::FullDuplex<u8> for crate::FlashSafeDma<T, SIZE>
     where
         Self: embedded_hal_02::blocking::spi::Transfer<u8, Error = T::Error>,
         Self: embedded_hal_02::blocking::spi::Write<u8, Error = T::Error>,
@@ -1496,7 +1495,7 @@ pub mod dma {
         }
 
         impl<T: embedded_hal_async::spi::SpiBus, const SIZE: usize> embedded_hal_async::spi::SpiBus
-            for FlashSafeDma<T, SIZE>
+            for crate::FlashSafeDma<T, SIZE>
         {
             async fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
                 self.inner.read(words).await
@@ -1600,11 +1599,11 @@ pub mod dma {
             }
         }
 
-        impl<T: ErrorType, const SIZE: usize> ErrorType for FlashSafeDma<T, SIZE> {
+        impl<T: ErrorType, const SIZE: usize> ErrorType for crate::FlashSafeDma<T, SIZE> {
             type Error = T::Error;
         }
 
-        impl<T: SpiBus, const SIZE: usize> SpiBus for FlashSafeDma<T, SIZE> {
+        impl<T: SpiBus, const SIZE: usize> SpiBus for crate::FlashSafeDma<T, SIZE> {
             fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
                 self.inner.read(words)
             }

--- a/esp-hal/src/timer.rs
+++ b/esp-hal/src/timer.rs
@@ -40,8 +40,6 @@ use core::{
 };
 
 use fugit::{HertzU32, MicrosDurationU64};
-#[cfg(feature = "embedded-hal-02")]
-use void::Void;
 
 #[cfg(timg1)]
 use crate::peripherals::TIMG1;
@@ -546,7 +544,7 @@ where
         (*self).start(timeout.into())
     }
 
-    fn wait(&mut self) -> nb::Result<(), Void> {
+    fn wait(&mut self) -> nb::Result<(), void::Void> {
         if self.has_elapsed() {
             Ok(())
         } else {

--- a/examples/src/bin/advanced_serial.rs
+++ b/examples/src/bin/advanced_serial.rs
@@ -8,12 +8,10 @@
 //! - RX => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::serial::{Read, Write};
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
@@ -55,8 +53,8 @@ fn main() -> ! {
 
     println!("Start");
     loop {
-        serial1.write(0x42).ok();
-        let read = block!(serial1.read());
+        serial1.write_byte(0x42).ok();
+        let read = block!(serial1.read_byte());
 
         match read {
             Ok(read) => println!("Read 0x{:02x}", read),

--- a/examples/src/bin/clock_monitor.rs
+++ b/examples/src/bin/clock_monitor.rs
@@ -3,7 +3,6 @@
 //! clock cycles within a given number of RTC_SLOW_CLK cycles.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
@@ -11,7 +10,6 @@
 use core::cell::RefCell;
 
 use critical_section::Mutex;
-use embedded_hal_02::watchdog::WatchdogEnable;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
@@ -31,7 +29,7 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let mut rtc = Rtc::new(peripherals.LPWR);
-    rtc.rwdt.start(2000.millis());
+    rtc.rwdt.set_timeout(2000.millis());
     rtc.rwdt.listen();
 
     println!(

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -6,12 +6,10 @@
 //! Make sure to first compile the `esp-lp-hal/examples/uart.rs` example
 
 //% CHIPS: esp32c6
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::serial::Read;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
@@ -70,7 +68,7 @@ fn main() -> ! {
     println!("lpcore run");
 
     loop {
-        let read = nb::block!(uart1.read());
+        let read = nb::block!(uart1.read_byte());
 
         match read {
             Ok(read) => println!("Read 0x{:02x}", read),

--- a/examples/src/bin/rtc_watchdog.rs
+++ b/examples/src/bin/rtc_watchdog.rs
@@ -5,7 +5,6 @@
 //! to reset both the main system and the RTC.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
@@ -13,7 +12,6 @@
 use core::cell::RefCell;
 
 use critical_section::Mutex;
-use embedded_hal_02::watchdog::WatchdogEnable;
 use esp_backtrace as _;
 use esp_hal::{
     interrupt::{self, Priority},
@@ -29,7 +27,7 @@ fn main() -> ! {
     let peripherals = Peripherals::take();
 
     let mut rtc = Rtc::new(peripherals.LPWR);
-    rtc.rwdt.start(2000.millis());
+    rtc.rwdt.set_timeout(2000.millis());
     rtc.rwdt.listen();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
@@ -52,7 +50,7 @@ fn interrupt_handler() {
 
         esp_println::println!("Restarting in 5 seconds...");
 
-        rwdt.start(5000.millis());
+        rwdt.set_timeout(5000.millis());
         rwdt.unlisten();
     });
 }

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -3,7 +3,6 @@
 //! espflash won't work)
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
@@ -11,7 +10,6 @@
 use core::{cell::RefCell, fmt::Write};
 
 use critical_section::Mutex;
-use embedded_hal_02::serial::Read;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
@@ -61,7 +59,7 @@ fn UART0() {
         let serial = serial.as_mut().unwrap();
 
         let mut cnt = 0;
-        while let nb::Result::Ok(_c) = serial.read() {
+        while let nb::Result::Ok(_c) = serial.read_byte() {
             cnt += 1;
         }
         writeln!(serial, "Read {} bytes", cnt,).ok();

--- a/examples/src/bin/watchdog.rs
+++ b/examples/src/bin/watchdog.rs
@@ -4,12 +4,10 @@
 //! `wdt.feed()` the watchdog will reset the system.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::watchdog::{Watchdog, WatchdogEnable};
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
@@ -30,7 +28,8 @@ fn main() -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let mut wdt0 = timg0.wdt;
-    wdt0.start(2u64.secs());
+    wdt0.enable();
+    wdt0.set_timeout(2u64.secs());
 
     loop {
         wdt0.feed();


### PR DESCRIPTION
This branch turned into a bit of a grab bag of changes, and nothing too exciting here, but the gist is:

- Build `esp-hal` package in CI without the default features enabled
    - Big asterisk here, the `rt` and `vectored` features are currently still required, see #1371
- Cleaned up some warnings which appeared without either `embedded-hal` or `embedded-hal-02` traits
- Small miscellaneous changes/cleanup