### PR TITLE
ESP32/S2: I2S wait for TX start

### DIFF
--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -1293,6 +1293,10 @@ mod private {
         fn tx_start() {
             let i2s = Self::register_block();
             i2s.conf().modify(|_, w| w.tx_start().set_bit());
+
+            while i2s.state().read().tx_idle().bit_is_set() {
+                // wait
+            }
         }
 
         fn tx_stop() {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
On ESP32/S2 it was possible that the I2S still was in TX_IDLE when immediately calling `wait` on the transaction causing no bytes to get transferred.

#### Testing
Change the `i2s_sound.rs` example to use one-shot transfers - e.g.
```rust
    let mut idx = 0;
    for x in &mut *tx_buffer {
        *x = idx;
        idx = idx.wrapping_add(1);
    }
    loop {
        let mut transfer = i2s_tx.write_dma(&tx_buffer).unwrap();
        transfer.wait().unwrap();
        delay.delay_millis(550);

        println!("done");
    }
```
