### PR TITLE
Eliminate the `rt` and `vectored` features from the `esp-hal` package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,13 @@ jobs:
 
       # Make sure we're able to build the HAL without the default features
       # enabled:
-      # TODO: Remove `rt` and `vectored` features when able!
+      # TODO: Remove `rt` feature when able!
       #       See: https://github.com/esp-rs/esp-hal/issues/1371
       - name: Build (no features)
         run: |
           cargo xtask build-package \
             --no-default-features \
-            --features=${{ matrix.device.soc }},rt,vectored \
+            --features=${{ matrix.device.soc }},rt \
             --target=${{ matrix.device.target }} \
             esp-hal
       # Build all supported examples for the specified device:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,11 @@ jobs:
 
       # Make sure we're able to build the HAL without the default features
       # enabled:
-      # TODO: Remove `rt` feature when able!
-      #       See: https://github.com/esp-rs/esp-hal/issues/1371
       - name: Build (no features)
         run: |
           cargo xtask build-package \
             --no-default-features \
-            --features=${{ matrix.device.soc }},rt \
+            --features=${{ matrix.device.soc }} \
             --target=${{ matrix.device.target }} \
             esp-hal
       # Build all supported examples for the specified device:

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove package-level type exports (#1275)
 - Removed `direct-vectoring` & `interrupt-preemption` features, as they are now enabled by default (#1310)
+- Removed the `rt` and `vectored` features (#1380)
 
 ## [0.16.1] - 2024-03-12
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -40,7 +40,7 @@ log                  = { version = "0.4.21", optional = true }
 nb                   = "1.1.0"
 paste                = "1.0.14"
 portable-atomic      = { version = "1.6.0", default-features = false }
-procmacros           = { version = "0.9.0", features = ["enum-dispatch", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+procmacros           = { version = "0.9.0", features = ["enum-dispatch", "interrupt", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 riscv                = { version = "0.11.1", optional = true }
 strum                = { version = "0.26.1", default-features = false, features = ["derive"] }
 void                 = { version = "1.0.2", default-features = false }
@@ -75,7 +75,7 @@ esp-metadata = { version = "0.1.0", path = "../esp-metadata" }
 serde        = { version = "1.0.197", features = ["derive"] }
 
 [features]
-default = ["embedded-hal", "rt", "vectored"]
+default = ["embedded-hal", "rt"]
 
 riscv  = ["dep:riscv",     "critical-section/restore-state-u8",  "esp-riscv-rt?/zero-bss"]
 xtensa = ["dep:xtensa-lx", "critical-section/restore-state-u32"]
@@ -110,8 +110,6 @@ rt = [
     "esp32s2?/rt",
     "esp32s3?/rt",
 ]
-## Enable interrupt vectoring.
-vectored = ["procmacros/interrupt"]
 ## Configuration for placing device drivers in the IRAM for faster access.
 place-spi-driver-in-ram = []
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -52,20 +52,20 @@ xtensa-lx            = { version = "0.9.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
+esp32   = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-esp-riscv-rt = { version = "0.7.0", optional = true, path = "../esp-riscv-rt" }
+esp-riscv-rt = { version = "0.7.0", path = "../esp-riscv-rt" }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
-xtensa-lx-rt = { version = "0.16.0", optional = true }
+xtensa-lx-rt = "0.16.0"
 
 [build-dependencies]
 basic-toml   = "0.1.8"
@@ -75,9 +75,9 @@ esp-metadata = { version = "0.1.0", path = "../esp-metadata" }
 serde        = { version = "1.0.197", features = ["derive"] }
 
 [features]
-default = ["embedded-hal", "rt"]
+default = ["embedded-hal"]
 
-riscv  = ["dep:riscv",     "critical-section/restore-state-u8",  "esp-riscv-rt?/zero-bss"]
+riscv  = ["dep:riscv",     "critical-section/restore-state-u8",  "esp-riscv-rt/zero-bss"]
 xtensa = ["dep:xtensa-lx", "critical-section/restore-state-u32"]
 
 bluetooth = []
@@ -97,25 +97,12 @@ debug = [
 ]
 ## Enable logging output using the `log` crate.
 log = ["dep:log"]
-## Enable runtime support.
-rt = [
-    "dep:esp-riscv-rt",
-    "dep:xtensa-lx-rt",
-    "esp32?/rt",
-    "esp32c2?/rt",
-    "esp32c3?/rt",
-    "esp32c6?/rt",
-    "esp32h2?/rt",
-    "esp32p4?/rt",
-    "esp32s2?/rt",
-    "esp32s3?/rt",
-]
 ## Configuration for placing device drivers in the IRAM for faster access.
 place-spi-driver-in-ram = []
 
 # Chip Support Feature Flags
 # Target the ESP32.
-esp32   = ["dep:esp32",   "xtensa", "xtensa-lx/spin", "xtensa-lx-rt?/esp32"]
+esp32   = ["dep:esp32",   "xtensa", "xtensa-lx/spin", "xtensa-lx-rt/esp32"]
 # Target the ESP32-C2.
 esp32c2 = ["dep:esp32c2", "riscv",  "portable-atomic/unsafe-assume-single-core"]
 # Target the ESP32-C3.
@@ -127,20 +114,20 @@ esp32h2 = ["dep:esp32h2", "riscv", "rv-zero-rtc-bss"]
 # Target the ESP32-P4.
 esp32p4 = ["dep:esp32p4", "riscv",  "procmacros/has-lp-core", "rv-zero-rtc-bss"]
 # Target the ESP32-S2.
-esp32s2 = ["dep:esp32s2", "xtensa", "portable-atomic/critical-section", "procmacros/has-ulp-core", "xtensa-lx-rt?/esp32s2", "usb-otg"]
+esp32s2 = ["dep:esp32s2", "xtensa", "portable-atomic/critical-section", "procmacros/has-ulp-core", "xtensa-lx-rt/esp32s2", "usb-otg"]
 # Target the ESP32-S3.
-esp32s3 = ["dep:esp32s3", "xtensa", "procmacros/has-ulp-core", "xtensa-lx/spin", "xtensa-lx-rt?/esp32s3", "usb-otg"]
+esp32s3 = ["dep:esp32s3", "xtensa", "procmacros/has-ulp-core", "xtensa-lx/spin", "xtensa-lx-rt/esp32s3", "usb-otg"]
 
 #! ### RISC-V Exclusive Feature Flags
 ## Move the stack to start of RAM to get zero-cost stack overflow protection
 ## (ESP32-C6 and ESPS32-H2 only!).
 flip-link = ["esp-riscv-rt/fix-sp"]
 ## Initialize the `.data` section of memory.
-rv-init-data = ["esp-riscv-rt?/init-data", "esp-riscv-rt?/init-rw-text"]
+rv-init-data = ["esp-riscv-rt/init-data", "esp-riscv-rt/init-rw-text"]
 ## Zero the `.bss` section of low-power memory.
-rv-zero-rtc-bss = ["esp-riscv-rt?/zero-rtc-fast-bss"]
+rv-zero-rtc-bss = ["esp-riscv-rt/zero-rtc-fast-bss"]
 ## Initialize the `.data` section of low-power memory.
-rv-init-rtc-data = ["esp-riscv-rt?/init-rtc-fast-data", "esp-riscv-rt?/init-rtc-fast-text"]
+rv-init-rtc-data = ["esp-riscv-rt/init-rtc-fast-data", "esp-riscv-rt/init-rtc-fast-text"]
 
 #! ### Trait Implementation Feature Flags
 ## Enable support for asynchronous operation, with interfaces provided by

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -394,7 +394,6 @@ macro_rules! impl_channel {
             pub type [<Channel $num InterruptBinder>] = ChannelInterruptBinder<$num>;
 
             impl InterruptBinder for ChannelInterruptBinder<$num> {
-                #[cfg(feature = "vectored")]
                 fn set_isr(handler: $crate::interrupt::InterruptHandler) {
                     let mut dma = unsafe { crate::peripherals::DMA::steal() };
                     $(

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1298,7 +1298,6 @@ pub trait ChannelTypes {
 }
 
 pub trait InterruptBinder {
-    #[cfg(feature = "vectored")]
     fn set_isr(handler: InterruptHandler);
 }
 
@@ -1321,7 +1320,6 @@ where
     /// with [crate::interrupt::Priority::max()]
     ///
     /// Interrupts are not enabled at the peripheral level here.
-    #[cfg(feature = "vectored")]
     pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         C::Binder::set_isr(handler);
     }

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -26,7 +26,6 @@ macro_rules! ImplSpiChannel {
             pub struct [<Channel $num InterruptBinder>] {}
 
             impl InterruptBinder for [<Channel $num InterruptBinder>] {
-                #[cfg(feature = "vectored")]
                 fn set_isr(handler: $crate::interrupt::InterruptHandler) {
                     let mut spi = unsafe { $crate::peripherals::[< SPI $num >]::steal() };
                     spi.[< bind_spi $num _dma_interrupt>](handler.handler());
@@ -376,7 +375,6 @@ macro_rules! ImplI2sChannel {
             pub struct [<Channel $num InterruptBinder>] {}
 
             impl InterruptBinder for [<Channel $num InterruptBinder>] {
-                #[cfg(feature = "vectored")]
                 fn set_isr(handler:  $crate::interrupt::InterruptHandler) {
                     let mut i2s = unsafe { $crate::peripherals::[< I2S $num >]::steal() };
                     i2s.[< bind_i2s $num _interrupt>](handler.handler());

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -2,19 +2,18 @@
 //!
 //! Interrupt support functionality depends heavily on the features enabled.
 //!
-//! When the `vectored` feature is enabled, the
-//! [`enable`] method will map interrupt to a CPU
-//! interrupt, and handle the `vector`ing to the peripheral interrupt, for
-//! example `UART0`.
+//! The [`enable`] method will map interrupt to a CPU interrupt, and handle the
+//! vectoring to the peripheral interrupt, for example `UART0`.
 //!
 //! It is also possible, but not recommended, to bind an interrupt directly to a
 //! CPU interrupt. This can offer lower latency, at the cost of more complexity
 //! in the interrupt handler.
 //!
-//! The `vectored` reserves a number of CPU interrupts, which cannot be used see
+//! We reserve a number of CPU interrupts, which cannot be used; see
 //! [`RESERVED_INTERRUPTS`].
 //!
 //! ## Example
+//!
 //! ```no_run
 //! #[entry]
 //! fn main() -> ! {

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -873,7 +873,7 @@ mod clic {
 
     /// Set the priority level of an CPU interrupt
     ///
-    /// Great care must be taken when using this funciton; avoid changing the
+    /// Great care must be taken when using this function; avoid changing the
     /// priority of interrupts 1 - 15.
     pub unsafe fn set_priority(core: Cpu, which: CpuInterrupt, priority: Priority) {
         let cpu_interrupt_number = which as usize;

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -18,14 +18,12 @@
 // MUST be the first module
 mod fmt;
 
-#[cfg(all(riscv, feature = "rt"))]
-pub use esp_riscv_rt::{self, entry};
-pub use procmacros as macros;
 #[cfg(riscv)]
-pub use riscv;
+pub use esp_riscv_rt::{self, entry, riscv};
+pub use procmacros as macros;
 #[cfg(xtensa)]
 pub use xtensa_lx;
-#[cfg(all(xtensa, feature = "rt"))]
+#[cfg(xtensa)]
 pub use xtensa_lx_rt::{self, entry};
 
 #[cfg(any(esp32, esp32s3))]
@@ -66,7 +64,7 @@ pub mod hmac;
 pub mod i2c;
 #[cfg(any(i2s0, i2s1))]
 pub mod i2s;
-#[cfg(all(any(dport, interrupt_core0, interrupt_core1), feature = "rt"))]
+#[cfg(any(dport, interrupt_core0, interrupt_core1))]
 pub mod interrupt;
 #[cfg(lcd_cam)]
 pub mod lcd_cam;
@@ -115,7 +113,6 @@ pub mod uart;
 pub mod usb_serial_jtag;
 
 /// State of the CPU saved when entering exception or interrupt
-#[cfg(feature = "rt")]
 pub mod trapframe {
     #[cfg(riscv)]
     pub use esp_riscv_rt::TrapFrame;

--- a/esp-hal/src/prelude.rs
+++ b/esp-hal/src/prelude.rs
@@ -20,8 +20,6 @@ pub use crate::dma::{
     DmaTransfer as _esp_hal_dma_DmaTransfer,
     DmaTransferRxTx as _esp_hal_dma_DmaTransferRxTx,
 };
-#[cfg(feature = "rt")]
-pub use crate::entry;
 #[cfg(gpio)]
 pub use crate::gpio::{
     InputPin as _esp_hal_gpio_InputPin,
@@ -38,7 +36,6 @@ pub use crate::ledc::{
     },
     timer::{TimerHW as _esp_hal_ledc_timer_TimerHW, TimerIFace as _esp_hal_ledc_timer_TimerIFace},
 };
-pub use crate::macros::*;
 #[cfg(any(dport, pcr, system))]
 pub use crate::system::SystemExt as _esp_hal_system_SystemExt;
 #[cfg(any(timg0, timg1))]
@@ -48,3 +45,4 @@ pub use crate::timer::{
 };
 #[cfg(any(uart0, uart1, uart2))]
 pub use crate::uart::{Instance as _esp_hal_uart_Instance, UartPins as _esp_hal_uart_UartPins};
+pub use crate::{entry, macros::*};

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -36,7 +36,6 @@ pub(crate) mod constants {
 /// ENTRY point is defined in memory.x
 /// *Note: the pre_init function is called in the original reset handler
 /// after the initializations done in this function*
-#[cfg(feature = "rt")]
 #[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn ESP32Reset() -> ! {

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -40,7 +40,6 @@ pub(crate) mod constants {
 /// ENTRY point is defined in memory.x
 /// *Note: the pre_init function is called in the original reset handler
 /// after the initializations done in this function*
-#[cfg(feature = "rt")]
 #[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn ESP32Reset() -> ! {

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -37,7 +37,6 @@ pub(crate) mod constants {
     pub const SOC_DRAM_HIGH: u32 = 0x3FD0_0000;
 }
 
-#[cfg(feature = "rt")]
 #[doc(hidden)]
 #[link_section = ".rwtext"]
 pub unsafe fn configure_cpu_caches() {
@@ -72,7 +71,6 @@ pub unsafe fn configure_cpu_caches() {
 /// ENTRY point is defined in memory.x
 /// *Note: the pre_init function is called in the original reset handler
 /// after the initializations done in this function*
-#[cfg(feature = "rt")]
 #[doc(hidden)]
 #[no_mangle]
 #[link_section = ".rwtext"]


### PR DESCRIPTION
As discussed with the team earlier, since these two features cannot be disabled, and are generally useful, we will simply eliminate the features and this functionality will always be enabled.

We can revisit this in the future if there is a need for it.

Closes #1371.