### PR TITLE
Flush in spi::master::Instance::write before attemting any writes

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - USB pullup/pulldown now gets properly cleared and does not interfere anymore on esp32c3 and esp32s3 (#1244)
 - Fixed GPIO counts so that using async code with the higher GPIO number should no longer panic (#1361, #1362)
 - ESP32/ESP32-S2: Wait for I2S getting out of TX_IDLE when starting a transfer (#1375)
+- Fixed writes to SPI not flushing before attemting to write, causing corrupted writes (#1381)
 
 ### Changed
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2618,6 +2618,10 @@ pub trait Instance: crate::private::Sealed {
     fn write_bytes(&mut self, words: &[u8]) -> Result<(), Error> {
         let num_chunks = words.len() / FIFO_SIZE;
 
+        // Flush in case previous writes have not completed yet, required as per
+        // embedded-hal documentation (#1369).
+        self.flush();
+
         // The fifo has a limited fixed size, so the data must be chunked and then
         // transmitted
         for (i, chunk) in words.chunks(FIFO_SIZE).enumerate() {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2620,7 +2620,7 @@ pub trait Instance: crate::private::Sealed {
 
         // Flush in case previous writes have not completed yet, required as per
         // embedded-hal documentation (#1369).
-        self.flush();
+        self.flush()?;
 
         // The fifo has a limited fixed size, so the data must be chunked and then
         // transmitted


### PR DESCRIPTION
### Submission Checklist 📝
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This change calls `flush()` in `spi::master::Instancee::write` before attemting any writes and provides the fix for #1369. 

Without this change, transactions in `embedded-hal-bus` may get corrupted. This is also required as per the `embedded-hal` documentation.

#### Testing
Testing with existing code on an ESP32C3 that didn't work before this change (see #1369).