### PR TITLE
Don't use `#[interrupt}` in the serial_interrupts.rs example

### DIFF
--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -10,6 +10,8 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::ptr::addr_of_mut;
+
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Duration, Ticker};
@@ -67,7 +69,7 @@ async fn main(_spawner: Spawner) {
     let led = io.pins.gpio0.into_push_pull_output();
 
     let _guard = cpu_control
-        .start_app_core(unsafe { &mut APP_CORE_STACK }, move || {
+        .start_app_core(unsafe { &mut *addr_of_mut!(APP_CORE_STACK) }, move || {
             let executor = make_static!(Executor::new());
             executor.run(|spawner| {
                 spawner.spawn(control_led(led, led_ctrl_signal)).ok();

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -10,6 +10,8 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::ptr::addr_of_mut;
+
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Duration, Ticker};
 use embedded_hal_02::digital::v2::OutputPin;
@@ -109,7 +111,7 @@ fn main() -> ! {
         loop {}
     };
     let _guard = cpu_control
-        .start_app_core(unsafe { &mut APP_CORE_STACK }, cpu1_fnctn)
+        .start_app_core(unsafe { &mut *addr_of_mut!(APP_CORE_STACK) }, cpu1_fnctn)
         .unwrap();
 
     let spawner = INT_EXECUTOR_CORE_0.start(Priority::Priority1);

--- a/examples/src/bin/multicore.rs
+++ b/examples/src/bin/multicore.rs
@@ -8,7 +8,7 @@
 #![no_std]
 #![no_main]
 
-use core::cell::RefCell;
+use core::{cell::RefCell, ptr::addr_of_mut};
 
 use critical_section::Mutex;
 use esp_backtrace as _;
@@ -35,7 +35,7 @@ fn main() -> ! {
 
     let mut cpu_control = CpuControl::new(system.cpu_control);
     let _guard = cpu_control
-        .start_app_core(unsafe { &mut APP_CORE_STACK }, || {
+        .start_app_core(unsafe { &mut *addr_of_mut!(APP_CORE_STACK) }, || {
             println!("Hello World - Core 1!");
             loop {
                 delay.delay(500.millis());


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [ ] ~~My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.~~
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adapt the serial_interrupts example to use the new `#[handler]` mechanics. Avoid the code warnings for the multicore examples

I don't think this deserves a CHANGELOG.md entry

#### Testing
Run the modified examples
