### PR TITLE
Provide native APIs for I2C/SPI functionality currently handled by `embedded-hal@0.2.x` traits

### DIFF
--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -191,6 +191,33 @@ pub struct I2C<'d, T, DM: crate::Mode> {
     phantom: PhantomData<DM>,
 }
 
+impl<T, DM> I2C<'_, T, DM>
+where
+    T: Instance,
+    DM: crate::Mode,
+{
+    /// Reads enough bytes from slave with `address` to fill `buffer`
+    pub fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
+        self.peripheral.master_read(address, buffer)
+    }
+
+    /// Writes bytes to slave with address `address`
+    pub fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+        self.peripheral.master_write(addr, bytes)
+    }
+
+    /// Writes bytes to slave with address `address` and then reads enough bytes
+    /// to fill `buffer` *in a single transaction*
+    pub fn write_read(
+        &mut self,
+        address: u8,
+        bytes: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        self.peripheral.master_write_read(address, bytes, buffer)
+    }
+}
+
 #[cfg(feature = "embedded-hal-02")]
 impl<T, DM: crate::Mode> embedded_hal_02::blocking::i2c::Read for I2C<'_, T, DM>
 where
@@ -199,7 +226,7 @@ where
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.peripheral.master_read(address, buffer)
+        self.read(address, buffer)
     }
 }
 
@@ -211,7 +238,7 @@ where
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        self.peripheral.master_write(addr, bytes)
+        self.write(addr, bytes)
     }
 }
 
@@ -228,7 +255,7 @@ where
         bytes: &[u8],
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
-        self.peripheral.master_write_read(address, bytes, buffer)
+        self.write_read(address, bytes, buffer)
     }
 }
 

--- a/examples/src/bin/i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/i2c_bmp180_calibration_data.rs
@@ -7,12 +7,10 @@
 //! - SCL => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::blocking::i2c::WriteRead;
 use esp_backtrace as _;
 use esp_hal::{clock::ClockControl, gpio::IO, i2c::I2C, peripherals::Peripherals, prelude::*};
 use esp_println::println;

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -14,12 +14,10 @@
 //! data.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::blocking::spi::Transfer;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -66,8 +66,7 @@ mod tests {
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
-        ctx.spi
-            .transfer(&mut read[..], &write[..])
+        SpiBus::transfer(&mut ctx.spi, &mut read[..], &write[..])
             .expect("Symmetric transfer failed");
         assert_eq!(write, read);
     }
@@ -77,8 +76,7 @@ mod tests {
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00; 4];
 
-        ctx.spi
-            .transfer(&mut read[0..2], &write[..])
+        SpiBus::transfer(&mut ctx.spi, &mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
         assert_eq!(write[0], read[0]);
         assert_eq!(read[2], 0x00u8);
@@ -92,9 +90,7 @@ mod tests {
         }
         let mut read = [0x00u8; 4096];
 
-        ctx.spi
-            .transfer(&mut read[..], &write[..])
-            .expect("Huge transfer failed");
+        SpiBus::transfer(&mut ctx.spi, &mut read[..], &write[..]).expect("Huge transfer failed");
         assert_eq!(write, read);
     }
 


### PR DESCRIPTION
I was a little unsure of a few things with regard to our SPI driver, so @bjoernQ please let me know if anything doesn't look right here. I _think_ this should be correct, though 😅 