### PR TITLE
Refactor the ADC driver, allow use without `embedded-hal@0.2.x` traits

### DIFF
--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -335,14 +335,15 @@ impl<'d, ADC1> ADC<'d, ADC1> {
 }
 
 #[cfg(feature = "embedded-hal-02")]
-impl<'d, ADCI, PIN> embedded_hal_02::adc::OneShot<ADCI, u16, AdcPin<PIN, ADCI>> for ADC<'d, ADCI>
+impl<'d, ADCI, PIN> embedded_hal_02::adc::OneShot<ADCI, u16, super::AdcPin<PIN, ADCI>>
+    for ADC<'d, ADCI>
 where
-    PIN: embedded_hal_02::adc::Channel<ADCI, ID = u8>,
+    PIN: embedded_hal_02::adc::Channel<ADCI, ID = u8> + super::AdcChannel,
     ADCI: RegisterAccess,
 {
     type Error = ();
 
-    fn read(&mut self, pin: &mut AdcPin<PIN, ADCI>) -> nb::Result<u16, Self::Error> {
+    fn read(&mut self, pin: &mut super::AdcPin<PIN, ADCI>) -> nb::Result<u16, Self::Error> {
         self.read_oneshot(pin)
     }
 }

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -204,6 +204,8 @@ impl<'d, ADCI> ADC<'d, ADCI>
 where
     ADCI: RegisterAccess,
 {
+    /// Configure a given ADC instance using the provided configuration, and
+    /// initialize the ADC for use
     pub fn new(
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
@@ -277,6 +279,11 @@ where
         }
     }
 
+    /// Request that the ADC begin a conversion on the specified pin
+    ///
+    /// This method takes an [AdcPin](super::AdcPin) reference, as it is
+    /// expected that the ADC will be able to sample whatever channel
+    /// underlies the pin.
     pub fn read_oneshot<PIN>(&mut self, _pin: &mut super::AdcPin<PIN, ADCI>) -> nb::Result<u16, ()>
     where
         PIN: super::AdcChannel,

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -85,10 +85,12 @@ pub struct AdcConfig<ADCI> {
 }
 
 impl<ADCI> AdcConfig<ADCI> {
+    /// Create a new configuration struct with its default values
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Enable the specified pin with the given attenuation
     pub fn enable_pin<PIN>(&mut self, pin: PIN, attenuation: Attenuation) -> AdcPin<PIN, ADCI>
     where
         PIN: AdcChannel,
@@ -102,6 +104,8 @@ impl<ADCI> AdcConfig<ADCI> {
         }
     }
 
+    /// Enable the specified pin with the given attentuation and calibration
+    /// scheme
     #[cfg(not(esp32))]
     pub fn enable_pin_with_cal<PIN, CS>(
         &mut self,

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -21,6 +21,8 @@
 //! }
 //! ```
 
+use core::marker::PhantomData;
+
 pub use self::implementation::*;
 
 #[cfg_attr(esp32, path = "esp32.rs")]
@@ -53,6 +55,95 @@ pub enum Attenuation {
 pub enum AdcCalSource {
     Gnd,
     Ref,
+}
+
+/// An I/O pin which can be read using the ADC.
+pub struct AdcPin<PIN, ADCI, CS = ()> {
+    pub pin: PIN,
+    #[cfg_attr(esp32, allow(unused))]
+    pub cal_scheme: CS,
+    _phantom: PhantomData<ADCI>,
+}
+
+#[cfg(feature = "embedded-hal-02")]
+impl<PIN, ADCI, CS> embedded_hal_02::adc::Channel<ADCI> for AdcPin<PIN, ADCI, CS>
+where
+    PIN: embedded_hal_02::adc::Channel<ADCI, ID = u8>,
+{
+    type ID = u8;
+
+    fn channel() -> Self::ID {
+        PIN::channel()
+    }
+}
+
+/// Configuration for the ADC.
+pub struct AdcConfig<ADCI> {
+    pub resolution: Resolution,
+    pub attenuations: [Option<Attenuation>; NUM_ATTENS],
+    _phantom: PhantomData<ADCI>,
+}
+
+impl<ADCI> AdcConfig<ADCI> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn enable_pin<PIN>(&mut self, pin: PIN, attenuation: Attenuation) -> AdcPin<PIN, ADCI>
+    where
+        PIN: AdcChannel,
+    {
+        self.attenuations[PIN::CHANNEL as usize] = Some(attenuation);
+
+        AdcPin {
+            pin,
+            cal_scheme: AdcCalScheme::<()>::new_cal(attenuation),
+            _phantom: PhantomData,
+        }
+    }
+
+    #[cfg(not(esp32))]
+    pub fn enable_pin_with_cal<PIN, CS>(
+        &mut self,
+        pin: PIN,
+        attenuation: Attenuation,
+    ) -> AdcPin<PIN, ADCI, CS>
+    where
+        ADCI: CalibrationAccess,
+        PIN: AdcChannel,
+        CS: AdcCalScheme<ADCI>,
+    {
+        self.attenuations[PIN::CHANNEL as usize] = Some(attenuation);
+
+        AdcPin {
+            pin,
+            cal_scheme: CS::new_cal(attenuation),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<ADCI> Default for AdcConfig<ADCI> {
+    fn default() -> Self {
+        Self {
+            resolution: Resolution::default(),
+            attenuations: [None; NUM_ATTENS],
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[cfg(not(esp32))]
+#[doc(hidden)]
+pub trait CalibrationAccess: RegisterAccess {
+    const ADC_CAL_CNT_MAX: u16;
+    const ADC_CAL_CHANNEL: u16;
+    const ADC_VAL_MASK: u16;
+
+    fn enable_vdef(enable: bool);
+
+    /// Enable internal calibration voltage source
+    fn connect_cal(source: AdcCalSource, enable: bool);
 }
 
 /// A helper trait to get the ADC channel of a compatible GPIO pin.
@@ -105,3 +196,24 @@ trait AdcCalEfuse {
     /// Returns digital value for reference voltage for a given attenuation
     fn get_cal_code(atten: Attenuation) -> Option<u16>;
 }
+
+macro_rules! impl_adc_interface {
+    ($adc:ident [
+        $( ($pin:ident, $channel:expr) ,)+
+    ]) => {
+        $(
+            impl $crate::analog::adc::AdcChannel for crate::gpio::$pin<crate::gpio::Analog> {
+                const CHANNEL: u8 = $channel;
+            }
+
+            #[cfg(feature = "embedded-hal-02")]
+            impl embedded_hal_02::adc::Channel<crate::peripherals::$adc> for crate::gpio::$pin<crate::gpio::Analog> {
+                type ID = u8;
+
+                fn channel() -> u8 { $channel }
+            }
+        )+
+    }
+}
+
+pub(crate) use impl_adc_interface;

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -534,16 +534,16 @@ impl super::AdcCalEfuse for crate::peripherals::ADC2 {
 }
 
 #[cfg(feature = "embedded-hal-02")]
-impl<'d, ADCI, PIN, CS> embedded_hal_02::adc::OneShot<ADCI, u16, AdcPin<PIN, ADCI, CS>>
+impl<'d, ADCI, PIN, CS> embedded_hal_02::adc::OneShot<ADCI, u16, super::AdcPin<PIN, ADCI, CS>>
     for ADC<'d, ADCI>
 where
-    PIN: embedded_hal_02::adc::Channel<ADCI, ID = u8>,
+    PIN: embedded_hal_02::adc::Channel<ADCI, ID = u8> + super::AdcChannel,
     ADCI: RegisterAccess,
-    CS: AdcCalScheme<ADCI>,
+    CS: super::AdcCalScheme<ADCI>,
 {
     type Error = ();
 
-    fn read(&mut self, pin: &mut AdcPin<PIN, ADCI, CS>) -> nb::Result<u16, Self::Error> {
+    fn read(&mut self, pin: &mut super::AdcPin<PIN, ADCI, CS>) -> nb::Result<u16, Self::Error> {
         self.read_oneshot(pin)
     }
 }

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -1,10 +1,6 @@
-use core::marker::PhantomData;
-
 #[cfg(not(esp32h2))]
 pub use self::calibration::*;
-#[cfg(not(esp32h2))]
-use super::AdcCalEfuse;
-use super::{AdcCalScheme, AdcCalSource, AdcChannel, Attenuation};
+use super::{AdcCalSource, AdcConfig, Attenuation};
 #[cfg(any(esp32c6, esp32h2))]
 use crate::clock::clocks_ll::regi2c_write_mask;
 #[cfg(any(esp32c2, esp32c3, esp32c6))]
@@ -98,88 +94,27 @@ cfg_if::cfg_if! {
 // depends on which chip is being used
 cfg_if::cfg_if! {
     if #[cfg(esp32c6)] {
-        const NUM_ATTENS: usize = 7;
+        pub(super) const NUM_ATTENS: usize = 7;
     } else {
-        const NUM_ATTENS: usize = 5;
+        pub(super) const NUM_ATTENS: usize = 5;
     }
 }
 
 /// The sampling/readout resolution of the ADC.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Resolution {
+    #[default]
     Resolution12Bit,
-}
-
-/// An I/O pin which can be read using the ADC.
-pub struct AdcPin<PIN, ADCI, CS = ()> {
-    pub pin: PIN,
-    pub cal_scheme: CS,
-    _phantom: PhantomData<ADCI>,
-}
-
-#[cfg(feature = "embedded-hal-02")]
-impl<PIN, ADCI, CS> embedded_hal_02::adc::Channel<ADCI> for AdcPin<PIN, ADCI, CS>
-where
-    PIN: embedded_hal_02::adc::Channel<ADCI, ID = u8>,
-{
-    type ID = u8;
-
-    fn channel() -> Self::ID {
-        PIN::channel()
-    }
-}
-
-/// Configuration for the ADC.
-pub struct AdcConfig<ADCI> {
-    pub resolution: Resolution,
-    pub attenuations: [Option<Attenuation>; NUM_ATTENS],
-    _phantom: PhantomData<ADCI>,
 }
 
 impl<ADCI> AdcConfig<ADCI>
 where
     ADCI: RegisterAccess,
 {
-    pub fn new() -> AdcConfig<ADCI> {
-        Self::default()
-    }
-
-    pub fn enable_pin<PIN>(&mut self, pin: PIN, attenuation: Attenuation) -> AdcPin<PIN, ADCI>
-    where
-        PIN: AdcChannel,
-    {
-        self.attenuations[PIN::CHANNEL as usize] = Some(attenuation);
-
-        AdcPin {
-            pin,
-            cal_scheme: AdcCalScheme::<()>::new_cal(attenuation),
-            _phantom: PhantomData,
-        }
-    }
-
-    pub fn enable_pin_with_cal<PIN, CS>(
-        &mut self,
-        pin: PIN,
-        attenuation: Attenuation,
-    ) -> AdcPin<PIN, ADCI, CS>
-    where
-        ADCI: CalibrationAccess,
-        PIN: AdcChannel,
-        CS: AdcCalScheme<ADCI>,
-    {
-        self.attenuations[PIN::CHANNEL as usize] = Some(attenuation);
-
-        AdcPin {
-            pin,
-            cal_scheme: CS::new_cal(attenuation),
-            _phantom: PhantomData,
-        }
-    }
-
     /// Calibrate ADC with specified attenuation and voltage source
     pub fn adc_calibrate(atten: Attenuation, source: AdcCalSource) -> u16
     where
-        ADCI: CalibrationAccess,
+        ADCI: super::CalibrationAccess,
     {
         let mut adc_max: u16 = 0;
         let mut adc_min: u16 = u16::MAX;
@@ -220,16 +155,6 @@ where
     }
 }
 
-impl<ADCI> Default for AdcConfig<ADCI> {
-    fn default() -> Self {
-        AdcConfig {
-            resolution: Resolution::Resolution12Bit,
-            attenuations: [None; NUM_ATTENS],
-            _phantom: PhantomData,
-        }
-    }
-}
-
 #[doc(hidden)]
 pub trait RegisterAccess {
     /// Configure onetime sampling parameters
@@ -249,18 +174,6 @@ pub trait RegisterAccess {
 
     /// Set calibration parameter to ADC hardware
     fn set_init_code(data: u16);
-}
-
-#[doc(hidden)]
-pub trait CalibrationAccess: RegisterAccess {
-    const ADC_CAL_CNT_MAX: u16;
-    const ADC_CAL_CHANNEL: u16;
-    const ADC_VAL_MASK: u16;
-
-    fn enable_vdef(enable: bool);
-
-    /// Enable internal calibration voltage source
-    fn connect_cal(source: AdcCalSource, enable: bool);
 }
 
 impl RegisterAccess for crate::peripherals::ADC1 {
@@ -333,7 +246,7 @@ impl RegisterAccess for crate::peripherals::ADC1 {
     }
 }
 
-impl CalibrationAccess for crate::peripherals::ADC1 {
+impl super::CalibrationAccess for crate::peripherals::ADC1 {
     const ADC_CAL_CNT_MAX: u16 = ADC_CAL_CNT_MAX;
     const ADC_CAL_CHANNEL: u16 = ADC_CAL_CHANNEL;
     const ADC_VAL_MASK: u16 = ADC_VAL_MASK;
@@ -443,7 +356,7 @@ impl RegisterAccess for crate::peripherals::ADC2 {
 }
 
 #[cfg(esp32c3)]
-impl CalibrationAccess for crate::peripherals::ADC2 {
+impl super::CalibrationAccess for crate::peripherals::ADC2 {
     const ADC_CAL_CNT_MAX: u16 = ADC_CAL_CNT_MAX;
     const ADC_CAL_CHANNEL: u16 = ADC_CAL_CHANNEL;
     const ADC_VAL_MASK: u16 = ADC_VAL_MASK;
@@ -522,7 +435,7 @@ where
 }
 
 #[cfg(any(esp32c2, esp32c3, esp32c6))]
-impl AdcCalEfuse for crate::peripherals::ADC1 {
+impl super::AdcCalEfuse for crate::peripherals::ADC1 {
     fn get_init_code(atten: Attenuation) -> Option<u16> {
         Efuse::get_rtc_calib_init_code(1, atten)
     }
@@ -537,7 +450,7 @@ impl AdcCalEfuse for crate::peripherals::ADC1 {
 }
 
 #[cfg(esp32c3)]
-impl AdcCalEfuse for crate::peripherals::ADC2 {
+impl super::AdcCalEfuse for crate::peripherals::ADC2 {
     fn get_init_code(atten: Attenuation) -> Option<u16> {
         Efuse::get_rtc_calib_init_code(2, atten)
     }
@@ -567,7 +480,7 @@ where
         if self.attenuations[AdcPin::<PIN, ADCI>::channel() as usize].is_none() {
             panic!(
                 "Channel {} is not configured reading!",
-                AdcPin::<PIN, ADCI>::channel()
+                super::AdcPin::<PIN, ADCI>::channel()
             );
         }
 
@@ -629,31 +542,9 @@ where
     }
 }
 
-macro_rules! impl_adc_interface {
-    ($adc:ident [
-        $( ($pin:ident, $channel:expr) ,)+
-    ]) => {
-        $(
-            impl $crate::analog::adc::AdcChannel for crate::gpio::$pin<crate::gpio::Analog> {
-                const CHANNEL: u8 = $channel;
-            }
-
-            #[cfg(feature = "embedded-hal-02")]
-            impl embedded_hal_02::adc::Channel<$adc> for crate::gpio::$pin<crate::gpio::Analog> {
-                type ID = u8;
-
-                fn channel() -> u8 { $channel }
-            }
-        )+
-    }
-}
-
 #[cfg(esp32c2)]
 mod adc_implementation {
-    #[cfg(feature = "embedded-hal-02")]
-    use crate::peripherals::ADC1;
-
-    impl_adc_interface! {
+    crate::analog::adc::impl_adc_interface! {
         ADC1 [
             (Gpio0, 0),
             (Gpio1, 1),
@@ -666,10 +557,7 @@ mod adc_implementation {
 
 #[cfg(esp32c3)]
 mod adc_implementation {
-    #[cfg(feature = "embedded-hal-02")]
-    use crate::peripherals::{ADC1, ADC2};
-
-    impl_adc_interface! {
+    crate::analog::adc::impl_adc_interface! {
         ADC1 [
             (Gpio0, 0),
             (Gpio1, 1),
@@ -679,7 +567,7 @@ mod adc_implementation {
         ]
     }
 
-    impl_adc_interface! {
+    crate::analog::adc::impl_adc_interface! {
         ADC2 [
             (Gpio5, 0),
         ]
@@ -688,10 +576,7 @@ mod adc_implementation {
 
 #[cfg(esp32c6)]
 mod adc_implementation {
-    #[cfg(feature = "embedded-hal-02")]
-    use crate::peripherals::ADC1;
-
-    impl_adc_interface! {
+    crate::analog::adc::impl_adc_interface! {
         ADC1 [
             (Gpio0, 0),
             (Gpio1, 1),
@@ -706,10 +591,7 @@ mod adc_implementation {
 
 #[cfg(esp32h2)]
 mod adc_implementation {
-    #[cfg(feature = "embedded-hal-02")]
-    use crate::peripherals::ADC1;
-
-    impl_adc_interface! {
+    crate::analog::adc::impl_adc_interface! {
         ADC1 [
             (Gpio1, 0),
             (Gpio2, 1),

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -409,6 +409,8 @@ impl<'d, ADCI> ADC<'d, ADCI>
 where
     ADCI: RegisterAccess + 'd,
 {
+    /// Configure a given ADC instance using the provided configuration, and
+    /// initialize the ADC for use
     pub fn new(
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
@@ -433,6 +435,11 @@ where
         }
     }
 
+    /// Request that the ADC begin a conversion on the specified pin
+    ///
+    /// This method takes an [AdcPin](super::AdcPin) reference, as it is
+    /// expected that the ADC will be able to sample whatever channel
+    /// underlies the pin.
     pub fn read_oneshot<PIN, CS>(
         &mut self,
         pin: &mut super::AdcPin<PIN, ADCI, CS>,

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -439,7 +439,6 @@ impl super::CalibrationAccess for crate::peripherals::ADC2 {
 /// Analog-to-Digital Converter peripheral driver.
 pub struct ADC<'d, ADC> {
     _adc: PeripheralRef<'d, ADC>,
-    #[cfg(feature = "embedded-hal-02")]
     active_channel: Option<u8>,
     last_init_code: u16,
 }
@@ -518,7 +517,6 @@ where
 
         ADC {
             _adc: adc_instance.into_ref(),
-            #[cfg(feature = "embedded-hal-02")]
             active_channel: None,
             last_init_code: 0,
         }

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -447,6 +447,8 @@ impl<'d, ADCI> ADC<'d, ADCI>
 where
     ADCI: RegisterAccess,
 {
+    /// Configure a given ADC instance using the provided configuration, and
+    /// initialize the ADC for use
     pub fn new(
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
@@ -542,6 +544,11 @@ where
         pin.cal_scheme.adc_val(converted_value)
     }
 
+    /// Request that the ADC begin a conversion on the specified pin
+    ///
+    /// This method takes an [AdcPin](super::AdcPin) reference, as it is
+    /// expected that the ADC will be able to sample whatever channel
+    /// underlies the pin.
     pub fn read_oneshot<PIN, CS>(
         &mut self,
         pin: &mut super::AdcPin<PIN, ADCI, CS>,

--- a/examples/src/bin/adc.rs
+++ b/examples/src/bin/adc.rs
@@ -5,12 +5,10 @@
 //! maximum and minimum raw values read.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::adc::OneShot;
 use esp_backtrace as _;
 use esp_hal::{
     analog::adc::{AdcConfig, Attenuation, ADC},
@@ -47,7 +45,7 @@ fn main() -> ! {
     let delay = Delay::new(&clocks);
 
     loop {
-        let pin_value: u16 = nb::block!(adc1.read(&mut adc1_pin)).unwrap();
+        let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
         println!("ADC reading = {}", pin_value);
         delay.delay_millis(1500);
     }

--- a/examples/src/bin/adc_cal.rs
+++ b/examples/src/bin/adc_cal.rs
@@ -3,12 +3,10 @@
 //! 3V3 to see the maximum and minimum raw values read.
 
 //% CHIPS: esp32c2 esp32c3 esp32c6 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::adc::OneShot;
 use esp_backtrace as _;
 use esp_hal::{
     analog::adc::{AdcConfig, Attenuation, ADC},
@@ -53,7 +51,7 @@ fn main() -> ! {
     let delay = Delay::new(&clocks);
 
     loop {
-        let pin_mv = nb::block!(adc1.read(&mut adc1_pin)).unwrap();
+        let pin_mv = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
         println!("PIN2 ADC reading = {pin_mv} mV");
         delay.delay_millis(1500);
     }


### PR DESCRIPTION
I already had a local branch doing some refactoring to this drive which I had been rebasing for awhile now, so figured I'd just wrap it up while tackling the `embedded-hal` decoupling stuff.

Most of the refactoring should be pretty obvious, just reducing duplication of code where able.

I created a new `read_oneshot` function which encapsulates the code from the `embedded-hal` implementation, so the examples no longer require the trait.