### PR TITLE
Make sure to enable the GPIO interrupt

### DIFF
--- a/esp-hal/src/gpio.rs
+++ b/esp-hal/src/gpio.rs
@@ -1797,6 +1797,11 @@ impl IO {
     /// Initialize the I/O driver.
     pub fn new(mut gpio: GPIO, io_mux: IO_MUX) -> Self {
         gpio.bind_gpio_interrupt(gpio_interrupt_handler);
+        crate::interrupt::enable(
+            crate::peripherals::Interrupt::GPIO,
+            crate::interrupt::Priority::min(),
+        )
+        .unwrap();
 
         let pins = gpio.split();
 
@@ -1810,9 +1815,9 @@ impl IO {
     ///
     /// This decides the priority for the interrupt when only using async.
     pub fn new_with_priority(gpio: GPIO, io_mux: IO_MUX, prio: crate::interrupt::Priority) -> Self {
+        let io = Self::new(gpio, io_mux);
         crate::interrupt::enable(crate::peripherals::Interrupt::GPIO, prio).unwrap();
-
-        Self::new(gpio, io_mux)
+        io
     }
 
     /// Install the given interrupt handler replacing any previously set


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [ ] ~~My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.~~
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1393

In the case of `new` it just didn't enable the interrupt.

Given this is fixing something which was never released I guess it doesn't need a changelog entry. Not sure t.b.h.

#### Testing
Run the `embassy_wait` example
