### PR TITLE
Fix panic when setting LEDC duty cycle to 0 with `SetDutyCycle::set_duty_cycle`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed GPIO counts so that using async code with the higher GPIO number should no longer panic (#1361, #1362)
 - ESP32/ESP32-S2: Wait for I2S getting out of TX_IDLE when starting a transfer (#1375)
 - Fixed writes to SPI not flushing before attempting to write, causing corrupted writes (#1381)
+- Fixed a divide by zero panic when setting the LEDC duty cycle to 0 with `SetDutyCycle::set_duty_cycle` (#1403)
 
 ### Changed
 

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -323,8 +323,12 @@ mod ehal1 {
         }
 
         fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
-            let duty_pct = 100 / (self.max_duty_cycle() / duty);
-            self.set_duty(duty_pct as u8)?;
+            if duty == 0 {
+                self.set_duty(0)?;
+            } else {
+                let duty_pct = 100 / (self.max_duty_cycle() / duty);
+                self.set_duty(duty_pct as u8)?;
+            }
             Ok(())
         }
     }


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The equation in `SetDutyCycle::set_duty_cycle` does not work for `duty` = 0 and results in a divide by zero panic (#1390). Not the most elegant solution, as the driver still deals with percentages internally, but that would be for another PR.

#### Testing
Tested on ESP32C3 by setting the duty cycle to 0, doesn't crash.
