### PR TITLE
HIL xtask support

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -52,8 +52,7 @@ jobs:
           components: rust-src
 
       - name: Run tests
-        working-directory: hil-test
-        run: cargo ${{ matrix.target.soc }}
+        run: cargo xtask run-tests ${{ matrix.target.soc }}
 
   # Test Xtensa targets:
   # TODO: Add jobs for Xtensa once supported by `probe-rs`

--- a/hil-test/tests/aes.rs
+++ b/hil-test/tests/aes.rs
@@ -1,5 +1,7 @@
 //! AES Test
 
+//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
 #![no_std]
 #![no_main]
 
@@ -23,30 +25,6 @@ impl Context<'_> {
     }
 }
 
-#[cfg(not(any(
-    feature = "esp32c3",
-    feature = "esp32c6",
-    feature = "esp32h2",
-    feature = "esp32s3"
-)))]
-mod not_test {
-    #[esp_hal::entry]
-    fn main() -> ! {
-        semihosting::process::exit(0)
-    }
-    #[panic_handler]
-    fn panic(_info: &core::panic::PanicInfo) -> ! {
-        loop {}
-    }
-}
-
-#[cfg(test)]
-#[cfg(any(
-    feature = "esp32c3",
-    feature = "esp32c6",
-    feature = "esp32h2",
-    feature = "esp32s3"
-))]
 #[embedded_test::tests]
 mod tests {
     use defmt::assert_eq;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -297,6 +297,7 @@ pub fn run_example(
     }
 
     let package = example.example_path().strip_prefix(package_path)?;
+    log::info!("Package: {:?}", package);
     let (bin, subcommand) = if package.starts_with("src/bin") {
         (format!("--bin={}", example.name()), "run")
     } else if package.starts_with("tests") {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -293,11 +293,10 @@ fn run_example(workspace: &Path, mut args: RunExampleArgs) -> Result<()> {
     // Absolute path of the package's root:
     let package_path = xtask::windows_safe_path(&workspace.join(args.package.to_string()));
 
-    // Absolute path to the directory containing the examples:
-    let example_path = if args.package == Package::Examples {
-        package_path.join("src").join("bin")
-    } else {
-        package_path.join("examples")
+    let example_path = match args.package {
+        Package::Examples => package_path.join("src").join("bin"),
+        Package::HilTest => package_path.join("tests"),
+        _ => package_path.join("examples"),
     };
 
     // Determine the appropriate build target for the given package and chip:


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The idea here is to move the testing into the xtask module.

I wanted to just use cargo's `test` framework, but it seems there is no way to truly "skip" an integration test, even with proper `skip` support, the test is still built and ran, its just that no test cases run :laughing:.

#### Testing

`cargo xtask run-tests $CHIP` locally, it should filter unsupported tests.


I will admit this a little bit hacky, and we should probably refactor the xtask to better support the different types of binaries, but I think this is okay for now.
