### PR TITLE
HIL updates

### DIFF
--- a/hil-test/.cargo/config.toml
+++ b/hil-test/.cargo/config.toml
@@ -1,13 +1,3 @@
-[alias]
-esp32   = "test --release --features=esp32   --target=xtensa-esp32-none-elf -- --chip esp32-3.3v"
-esp32c2 = "test --release --features=esp32c2 --target=riscv32imc-unknown-none-elf -- --chip esp32c2"
-esp32c3 = "test --release --features=esp32c3 --target=riscv32imc-unknown-none-elf -- --chip esp32c3"
-esp32c6 = "test --release --features=esp32c6 --target=riscv32imac-unknown-none-elf -- --chip esp32c6"
-esp32h2 = "test --release --features=esp32h2 --target=riscv32imac-unknown-none-elf -- --chip esp32h2"
-# esp32p4 = "test --release --features=esp32p4 --target=riscv32imafc-unknown-none-elf -- --chip esp32p4"
-esp32s2 = "test --release --features=esp32s2 --target=xtensa-esp32s2-none-elf -- --chip esp32s2"
-esp32s3 = "test --release --features=esp32s3 --target=xtensa-esp32s3-none-elf -- --chip esp32s3"
-
 [target.'cfg(target_arch = "riscv32")']
 runner    = "probe-rs run"
 rustflags = [

--- a/hil-test/.cargo/config.toml
+++ b/hil-test/.cargo/config.toml
@@ -1,11 +1,11 @@
 [alias]
-# esp32   = "test --release --features=esp32   --target=xtensa-esp32-none-elf -- --chip esp32-3.3v"
-# esp32c2 = "test --release --features=esp32c2 --target=riscv32imc-unknown-none-elf -- --chip esp32c2"
+esp32   = "test --release --features=esp32   --target=xtensa-esp32-none-elf -- --chip esp32-3.3v"
+esp32c2 = "test --release --features=esp32c2 --target=riscv32imc-unknown-none-elf -- --chip esp32c2"
 esp32c3 = "test --release --features=esp32c3 --target=riscv32imc-unknown-none-elf -- --chip esp32c3"
 esp32c6 = "test --release --features=esp32c6 --target=riscv32imac-unknown-none-elf -- --chip esp32c6"
 esp32h2 = "test --release --features=esp32h2 --target=riscv32imac-unknown-none-elf -- --chip esp32h2"
 # esp32p4 = "test --release --features=esp32p4 --target=riscv32imafc-unknown-none-elf -- --chip esp32p4"
-# esp32s2 = "test --release --features=esp32s2 --target=xtensa-esp32s2-none-elf -- --chip esp32s2"
+esp32s2 = "test --release --features=esp32s2 --target=xtensa-esp32s2-none-elf -- --chip esp32s2"
 esp32s3 = "test --release --features=esp32s3 --target=xtensa-esp32s3-none-elf -- --chip esp32s3"
 
 [target.'cfg(target_arch = "riscv32")']

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -29,8 +29,8 @@ name    = "uart"
 harness = false
 
 [[test]]
-name    = "uart_async"
-harness = false
+name              = "uart_async"
+harness           = false
 required-features = ["async", "embassy"]
 
 [[test]]
@@ -64,24 +64,28 @@ p192                = { version = "0.13.0", default-features = false, features =
 p256                = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
 
 [features]
-default = ["async", "embassy", "embassy-time-timg0", "embassy-executor-thread"]
+default = ["async", "embassy", "embassy-executor-thread", "embassy-time-timg0"]
 
 # Device support (required!):
-esp32   = ["esp-hal/esp32", "esp-backtrace/esp32"]
-esp32c2 = ["esp-hal/esp32c2", "esp-backtrace/esp32c2"]
-esp32c3 = ["esp-hal/esp32c3", "esp-backtrace/esp32c3"]
-esp32c6 = ["esp-hal/esp32c6", "esp-backtrace/esp32c6"]
-esp32h2 = ["esp-hal/esp32h2", "esp-backtrace/esp32h2"]
-esp32s2 = ["esp-hal/esp32s2", "esp-backtrace/esp32s2"]
-esp32s3 = ["esp-hal/esp32s3", "esp-backtrace/esp32s3"]
+esp32   = ["esp-backtrace/esp32", "esp-hal/esp32"]
+esp32c2 = ["esp-backtrace/esp32c2", "esp-hal/esp32c2"]
+esp32c3 = ["esp-backtrace/esp32c3", "esp-hal/esp32c3"]
+esp32c6 = ["esp-backtrace/esp32c6", "esp-hal/esp32c6"]
+esp32h2 = ["esp-backtrace/esp32h2", "esp-hal/esp32h2"]
+esp32s2 = ["esp-backtrace/esp32s2", "esp-hal/esp32s2"]
+esp32s3 = ["esp-backtrace/esp32s3", "esp-hal/esp32s3"]
 # Async & Embassy:
-async                      = ["dep:embedded-hal-async", "esp-hal?/async"]
-embassy                    = ["esp-hal?/embassy", "embedded-test/embassy", "embedded-test/external-executor"]
+async = ["dep:embedded-hal-async", "esp-hal?/async"]
+embassy = [
+    "embedded-test/embassy",
+    "embedded-test/external-executor",
+    "esp-hal?/embassy",
+]
 embassy-executor-interrupt = ["esp-hal?/embassy-executor-interrupt"]
-embassy-executor-thread    = ["esp-hal?/embassy-executor-thread"]
+embassy-executor-thread = ["esp-hal?/embassy-executor-thread"]
 embassy-time-systick-16mhz = ["esp-hal?/embassy-time-systick-16mhz"]
 embassy-time-systick-80mhz = ["esp-hal?/embassy-time-systick-80mhz"]
-embassy-time-timg0         = ["esp-hal?/embassy-time-timg0"]
+embassy-time-timg0 = ["esp-hal?/embassy-time-timg0"]
 
 # https://doc.rust-lang.org/cargo/reference/profiles.html#test
 # Test and bench profiles inherit from dev and release respectively.

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -67,13 +67,25 @@ p256                = { version = "0.13.2", default-features = false, features =
 default = ["async", "embassy", "embassy-executor-thread", "embassy-time-timg0"]
 
 # Device support (required!):
-esp32   = ["esp-backtrace/esp32", "esp-hal/esp32"]
+esp32 = [
+    "embedded-test/xtensa-semihosting",
+    "esp-backtrace/esp32",
+    "esp-hal/esp32",
+]
 esp32c2 = ["esp-backtrace/esp32c2", "esp-hal/esp32c2"]
 esp32c3 = ["esp-backtrace/esp32c3", "esp-hal/esp32c3"]
 esp32c6 = ["esp-backtrace/esp32c6", "esp-hal/esp32c6"]
 esp32h2 = ["esp-backtrace/esp32h2", "esp-hal/esp32h2"]
-esp32s2 = ["esp-backtrace/esp32s2", "esp-hal/esp32s2"]
-esp32s3 = ["esp-backtrace/esp32s3", "esp-hal/esp32s3"]
+esp32s2 = [
+    "embedded-test/xtensa-semihosting",
+    "esp-backtrace/esp32s2",
+    "esp-hal/esp32s2",
+]
+esp32s3 = [
+    "embedded-test/xtensa-semihosting",
+    "esp-backtrace/esp32s3",
+    "esp-hal/esp32s3",
+]
 # Async & Embassy:
 async = ["dep:embedded-hal-async", "esp-hal?/async"]
 embassy = [

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -38,7 +38,7 @@ name    = "ecc"
 harness = false
 
 [dependencies]
-cfg-if = "1.0.0"
+cfg-if             = "1.0.0"
 critical-section   = "1.1.2"
 defmt              = "0.3.6"
 defmt-rtt          = "0.4.0"
@@ -48,23 +48,23 @@ embedded-hal       = "1.0.0"
 embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = ["unproven"] }
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-hal-nb    = { version = "1.0.0", optional = true }
-esp-backtrace       = { version = "0.11.1", git = "https://github.com/esp-rs/esp-backtrace", rev = "edff83c3945e8aa11081d8467af65803a82434ba", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
+esp-backtrace      = { version = "0.11.1", git = "https://github.com/esp-rs/esp-backtrace", rev = "edff83c3945e8aa11081d8467af65803a82434ba", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
 esp-hal            = { path = "../esp-hal", features = ["defmt", "embedded-hal", "embedded-hal-02"], optional = true }
 portable-atomic = "1.6.0"
 
 [dev-dependencies]
-embassy-executor   = { version = "0.5.0", default-features = false, features = ["executor-thread", "arch-riscv32"] }
+crypto-bigint       = { version = "0.5.5", default-features = false }
+elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
+embassy-executor    = { version = "0.5.0", default-features = false }
 # Add the `embedded-test/defmt` feature for more verbose testing
-embedded-test  = { git = "https://github.com/probe-rs/embedded-test", rev = "b67dec33992f5bd79d414a0e70220dc4142278cf", default-features = false }
-crypto-bigint  = { version = "0.5.5", default-features = false }
-nb             = "1.1.0"
-hex-literal    = "0.4.1"
-p192           = { version = "0.13.0", default-features = false, features = ["arithmetic"] }
-p256           = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
-elliptic-curve = { version = "0.13.8", default-features = false, features = ["sec1"] }
+embedded-test       = { git = "https://github.com/probe-rs/embedded-test", rev = "1aa5a426d6b29ae2b509c5876dd33523b03e107c", default-features = false }
+hex-literal         = "0.4.1"
+nb                  = "1.1.0"
+p192                = { version = "0.13.0", default-features = false, features = ["arithmetic"] }
+p256                = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
 
 [features]
-default = ["async", "embassy", "embassy-time-timg0"]
+default = ["async", "embassy", "embassy-time-timg0", "embassy-executor-thread"]
 
 # Device support (required!):
 esp32   = ["esp-hal/esp32", "esp-backtrace/esp32"]
@@ -76,7 +76,7 @@ esp32s2 = ["esp-hal/esp32s2", "esp-backtrace/esp32s2"]
 esp32s3 = ["esp-hal/esp32s3", "esp-backtrace/esp32s3"]
 # Async & Embassy:
 async                      = ["dep:embedded-hal-async", "esp-hal?/async"]
-embassy                    = ["esp-hal?/embassy", "embedded-test/embassy"]
+embassy                    = ["esp-hal?/embassy", "embedded-test/embassy", "embedded-test/external-executor"]
 embassy-executor-interrupt = ["esp-hal?/embassy-executor-interrupt"]
 embassy-executor-thread    = ["esp-hal?/embassy-executor-thread"]
 embassy-time-systick-16mhz = ["esp-hal?/embassy-time-systick-16mhz"]

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -38,19 +38,19 @@ name    = "ecc"
 harness = false
 
 [dependencies]
-defmt              = { version = "0.3.6" }
-defmt-rtt          = { version = "0.4.0" }
+cfg-if = "1.0.0"
+critical-section   = "1.1.2"
+defmt              = "0.3.6"
+defmt-rtt          = "0.4.0"
+embassy-futures    = "0.1.1"
 embassy-time       = { version = "0.3.0", features = ["generic-queue-64"] }
-embassy-futures    = { version = "0.1" }
-embedded-hal       = { version = "1.0.0" }
+embedded-hal       = "1.0.0"
 embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = ["unproven"] }
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-hal-nb    = { version = "1.0.0", optional = true }
-esp-hal            = { path = "../esp-hal", features = ["defmt", "embedded-hal", "embedded-hal-02"], optional = true }
 esp-backtrace       = { version = "0.11.1", git = "https://github.com/esp-rs/esp-backtrace", rev = "edff83c3945e8aa11081d8467af65803a82434ba", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
-critical-section   = { version = "1.1.2" }
-portable-atomic = "1"
-cfg-if = "1"
+esp-hal            = { path = "../esp-hal", features = ["defmt", "embedded-hal", "embedded-hal-02"], optional = true }
+portable-atomic = "1.6.0"
 
 [dev-dependencies]
 embassy-executor   = { version = "0.5.0", default-features = false, features = ["executor-thread", "arch-riscv32"] }
@@ -85,7 +85,6 @@ embassy-time-timg0         = ["esp-hal?/embassy-time-timg0"]
 
 # https://doc.rust-lang.org/cargo/reference/profiles.html#test
 # Test and bench profiles inherit from dev and release respectively.
-
 [profile.dev]
 codegen-units    = 1
 debug            = 2

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -28,7 +28,7 @@ cargo install probe-rs \
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
 
-You can run all test for a given device running the following command from the `xtask` folder:
+You can run all tests for a given device by running the following command from the `xtask` folder:
 
 ```shell
 cargo xtask run-tests $CHIP
@@ -38,7 +38,7 @@ For running a single test on a target, from the `xtask` folder run:
 
 ```shell
 # Run GPIO tests for ESP32-C6
-cargo xtask run-tests esp32h2 --test gpio
+cargo xtask run-tests esp32c6 --test gpio
 ```
 
 Another alternative way of running a single test is, from the `hil-tests` folder:
@@ -103,4 +103,5 @@ sudo reboot
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 ```
+If the test is supported by all the targets, you can omit the header.
 6. Write some documentation at the top of the `tests/$PERIPHERAL.rs` file with the pins being used and the required connections, if applicable.

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -28,15 +28,13 @@ cargo install probe-rs \
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
 
-You can run all test for a given device using:
+You can run all test for a given device running the following command from the `xtask` folder:
 
 ```shell
-cargo +nightly esp32c6
-# or
-cargo +esp esp32s3
+cargo xtask run-tests $CHIP
 ```
 
-For running a single test on a target:
+For running a single test on a target, from the `hil-test` folder run:
 
 ```shell
 # Run GPIO tests for ESP32-C6
@@ -44,7 +42,7 @@ CARGO_BUILD_TARGET=riscv32imac-unknown-none-elf \
 PROBE_RS_CHIP=esp32c6 \
   cargo +nightly test --features=esp32c6 --test=gpio
 ```
-- If the `--test` argument is omitted, then all tests will be run.
+- If the `--test` argument is omitted, then all tests will be run, independently if the tests are supported for that target, for this reason we encourage using the `xtask` approach.
 - The build target **MUST** be specified via the `CARGO_BUILD_TARGET` environment variable or as an argument (`--target`).
 - The chip **MUST** be specified via the `PROBE_RS_CHIP` environment variable or as an argument of `probe-rs` (`--chip`).
 
@@ -57,15 +55,15 @@ Our Virtual Machines have the following setup:
 - ESP32-C3 (`rustboard`):
   - Devkit: `ESP32-C3-DevKit-RUST-1` connected via USB-Serial-JTAG.
     - `GPIO2` and `GPIO4` are connected.
-  - VM: Configured with the following [setup](#vm-setup)
+  - VM: Ubuntu 20.04.5 configured with the following [setup](#vm-setup)
 - ESP32-C6 (`esp32c6-usb`):
   - Devkit: `ESP32-C6-DevKitC-1 V1.2` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
-  - VM: Configured with the following [setup](#vm-setup)
+  - VM: Ubuntu 20.04.5 configured with the following [setup](#vm-setup)
 - ESP32-H2 (`esp32h2-usb`):
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
-  - VM: Configured with the following [setup](#vm-setup)
+  - VM: Ubuntu 20.04.5 configured with the following [setup](#vm-setup)
 
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml
 
@@ -83,7 +81,8 @@ cargo install probe-rs --git=https://github.com/probe-rs/probe-rs --rev=ddd59fa 
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group
 sudo usermod -a -G plugdev $USER
-# Reboot the VM
+# Reboot the
+sudo reboot
 ```
 
 ## Adding New Tests
@@ -92,4 +91,10 @@ sudo usermod -a -G plugdev $USER
 2. Add a corresponding `[[test]]` entry to `Cargol.toml` (**MUST** set `harness = false`)
 3. Write the tests
 4. Document any necessary physical connections on boards connected to self-hosted runners
-5. Write some documentation at the top of the `tests/$PERIPHERAL.rs` file with the pins being used and the required connections, if applicable.
+5. Add a header in the test stating which targets support the given tests. Eg:
+```rust
+//! AES Test
+
+//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+```
+6. Write some documentation at the top of the `tests/$PERIPHERAL.rs` file with the pins being used and the required connections, if applicable.

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -34,15 +34,21 @@ You can run all test for a given device running the following command from the `
 cargo xtask run-tests $CHIP
 ```
 
-For running a single test on a target, from the `hil-test` folder run:
+For running a single test on a target, from the `xtask` folder run:
 
+```shell
+# Run GPIO tests for ESP32-C6
+cargo xtask run-tests esp32h2 --test gpio
+```
+
+Another alternative way of running a single test is, from the `hil-tests` folder:
 ```shell
 # Run GPIO tests for ESP32-C6
 CARGO_BUILD_TARGET=riscv32imac-unknown-none-elf \
 PROBE_RS_CHIP=esp32c6 \
   cargo +nightly test --features=esp32c6 --test=gpio
 ```
-- If the `--test` argument is omitted, then all tests will be run, independently if the tests are supported for that target, for this reason we encourage using the `xtask` approach.
+- If the `--test` argument is omitted, then all tests will be run, independently if the tests are supported for that target, for this reason, we encourage using the `xtask` approach.
 - The build target **MUST** be specified via the `CARGO_BUILD_TARGET` environment variable or as an argument (`--target`).
 - The chip **MUST** be specified via the `PROBE_RS_CHIP` environment variable or as an argument of `probe-rs` (`--chip`).
 

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -69,7 +69,7 @@ pub fn interrupt_handler() {
 }
 
 #[cfg(test)]
-#[embedded_test::tests]
+#[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]
 mod tests {
     use defmt::assert_eq;
     use embassy_time::{Duration, Timer};

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -148,8 +148,6 @@ mod tests {
         ctx.io4.toggle();
         assert_eq!(ctx.io4.is_set_low(), false);
         assert_eq!(ctx.io4.is_set_high(), true);
-        // Leave in initial state for next test
-        ctx.io4.toggle();
     }
 
     #[test]

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -56,7 +56,7 @@ impl Context {
 }
 
 #[cfg(test)]
-#[embedded_test::tests]
+#[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]
 mod tests {
     use defmt::assert_eq;
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -14,6 +14,7 @@ Commands:
   bump-version           Bump the version of the specified package(s)
   generate-efuse-fields  Generate the eFuse fields source file from a CSV
   run-example            Run the given example for the specified chip
+  run-tests              Run all applicable tests or the specified test for a specified chip
   help                   Print this message or the help of the given subcommand(s)
 
 Options:

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -35,7 +35,7 @@ pub fn run_with_input(args: &[String], cwd: &Path) -> Result<()> {
         bail!("The `cwd` argument MUST be a directory");
     }
 
-    let _status = Command::new(get_cargo())
+    let status = Command::new(get_cargo())
         .args(args)
         .current_dir(cwd)
         .stdout(std::process::Stdio::inherit())
@@ -43,7 +43,11 @@ pub fn run_with_input(args: &[String], cwd: &Path) -> Result<()> {
         .stdin(std::process::Stdio::inherit())
         .status()?;
 
-    Ok(())
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("Failed to execute cargo subcommand"))
+    }
 }
 
 fn get_cargo() -> String {

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -35,7 +35,7 @@ pub fn run_with_input(args: &[String], cwd: &Path) -> Result<()> {
         bail!("The `cwd` argument MUST be a directory");
     }
 
-    let _status = Command::new(get_cargo())
+    let status = Command::new(get_cargo())
         .args(args)
         .current_dir(cwd)
         .stdout(std::process::Stdio::inherit())
@@ -43,7 +43,11 @@ pub fn run_with_input(args: &[String], cwd: &Path) -> Result<()> {
         .stdin(std::process::Stdio::inherit())
         .status()?;
 
-    Ok(())
+    if status.success() {
+        Ok(())
+    } else {
+        bail!("Failed to execute cargo subcommand")
+    }
 }
 
 fn get_cargo() -> String {

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -35,7 +35,7 @@ pub fn run_with_input(args: &[String], cwd: &Path) -> Result<()> {
         bail!("The `cwd` argument MUST be a directory");
     }
 
-    let status = Command::new(get_cargo())
+    let _status = Command::new(get_cargo())
         .args(args)
         .current_dir(cwd)
         .stdout(std::process::Stdio::inherit())
@@ -43,11 +43,7 @@ pub fn run_with_input(args: &[String], cwd: &Path) -> Result<()> {
         .stdin(std::process::Stdio::inherit())
         .status()?;
 
-    if status.success() {
-        Ok(())
-    } else {
-        bail!("Failed to execute cargo subcommand")
-    }
+    Ok(())
 }
 
 fn get_cargo() -> String {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -462,8 +462,8 @@ pub fn generate_efuse_table(
     // Determine the commit (short) hash of the HEAD commit in the
     // provided ESP-IDF repository:
     let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
-        .current_dir(&idf_path)
+        .args(["rev-parse", "HEAD"])
+        .current_dir(idf_path)
         .output()?;
     let idf_hash = String::from_utf8_lossy(&output.stdout[0..=7]).to_string();
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -331,8 +331,7 @@ pub fn run_example(
     let args = builder.build();
     log::debug!("{args:#?}");
 
-    cargo::run_with_input(&args, package_path)?;
-    Ok(())
+    cargo::run_with_input(&args, package_path)
 }
 
 /// Build the specified package, using the given toolchain/target/features if
@@ -427,7 +426,7 @@ const EFUSE_FIELDS_RS_HEADER: &str = r#"
 //!
 //! For information on how to regenerate these files, please refer to the
 //! `xtask` package's `README.md` file.
-//! 
+//!
 //! Generated on:   $DATE
 //! ESP-IDF Commit: $HASH
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -335,9 +335,7 @@ pub fn run_example(
     let args = builder.build();
     log::debug!("{args:#?}");
 
-    cargo::run_with_input(&args, package_path)?;
-
-    Ok(())
+    cargo::run_with_input(&args, package_path)
 }
 
 /// Build the specified package, using the given toolchain/target/features if

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -320,7 +320,11 @@ pub fn run_example(
     // probe-rs cannot currently do auto detection, so we need to tell probe-rs run
     // which chip we are testing
     if subcommand == "test" {
-        builder = builder.arg("--").arg("--chip").arg(format!("{}", chip));
+        if chip == Chip::Esp32 {
+            builder = builder.arg("--").arg("--chip").arg("esp32-3.3v");
+        } else {
+            builder = builder.arg("--").arg("--chip").arg(format!("{}", chip));
+        }
     }
 
     // If targeting an Xtensa device, we must use the '+esp' toolchain modifier:

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -335,7 +335,9 @@ pub fn run_example(
     let args = builder.build();
     log::debug!("{args:#?}");
 
-    cargo::run_with_input(&args, package_path)
+    cargo::run_with_input(&args, package_path)?;
+
+    Ok(())
 }
 
 /// Build the specified package, using the given toolchain/target/features if

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -361,8 +361,14 @@ fn run_tests(workspace: &Path, args: RunTestsArgs) -> Result<(), anyhow::Error> 
             log::error!("Test not found or unsupported for the given chip");
         }
     } else {
+        let mut failed_tests: Vec<String> = Vec::new();
         for test in supported_tests {
-            xtask::run_example(&package_path, args.chip, target, test)?;
+            if xtask::run_example(&package_path, args.chip, target, test).is_err() {
+                failed_tests.push(test.name());
+            }
+        }
+        if !failed_tests.is_empty() {
+            bail!("Failed tests: {:?}", failed_tests);
         }
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -142,7 +142,7 @@ fn build_documentation(workspace: &Path, args: BuildDocumentationArgs) -> Result
     let resources = workspace.join("resources");
 
     let package = args.package.to_string();
-    let version = xtask::package_version(&workspace, args.package)?;
+    let version = xtask::package_version(workspace, args.package)?;
 
     let mut crates = Vec::new();
 
@@ -188,10 +188,7 @@ fn build_documentation(workspace: &Path, args: BuildDocumentationArgs) -> Result
     }
 
     // Copy any additional assets to the documentation's output path:
-    fs::copy(
-        &resources.join("esp-rs.svg"),
-        &output_path.join("esp-rs.svg"),
-    )?;
+    fs::copy(resources.join("esp-rs.svg"), output_path.join("esp-rs.svg"))?;
 
     // Render the index and write it out to the documentaiton's output path:
     let source = fs::read_to_string(resources.join("index.html.jinja"))?;
@@ -280,7 +277,7 @@ fn generate_efuse_src(workspace: &Path, args: GenerateEfuseFieldsArgs) -> Result
 
     // Generate the Rust source file from the CSV file, and write it out to
     // the appropriate path:
-    xtask::generate_efuse_table(&args.chip, &idf_path, out_path)?;
+    xtask::generate_efuse_table(&args.chip, idf_path, out_path)?;
 
     // Format the generated code:
     xtask::cargo::run(&["fmt".into()], &esp_hal)?;
@@ -337,7 +334,7 @@ fn run_example(workspace: &Path, mut args: RunExampleArgs) -> Result<()> {
     Ok(())
 }
 
-fn run_tests(workspace: &PathBuf, args: RunTestsArgs) -> Result<(), anyhow::Error> {
+fn run_tests(workspace: &Path, args: RunTestsArgs) -> Result<(), anyhow::Error> {
     // Absolute path of the package's root:
     let package_path = xtask::windows_safe_path(&workspace.join("hil-test"));
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR addresses a few different things:
- Adds a `-t/--test` to only run a test with the `xtask run-tests` command
- Document the new HIL `xtask` subcommands in the readme
- Formated the `hil-tests` deps
- Updated `embedded-tests` to allow custom executors, see https://github.com/probe-rs/embedded-test/pull/30. Thanks @bjoernQ!
- When executing all the test,  it prints the list of failed tests and exits with a failure if there is any failed test. 
- Fix `xtask` package Clippy lints

I wonder if its still worth to keep the `hil-tests` aliases that run all the tests for a target.
#### Testing
Execution of a single test:
```
esp-hal/xtask on  feat/hil-update is  v0.0.0 via  v1.79.0-nightly 
❯ cargo xtask run-tests esp32h2 -t uart
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `/Users/sergio/Documents/Espressif/forks/esp-hal/target/debug/xtask run-tests esp32h2 -t uart`
[2024-04-08T08:58:17Z INFO  xtask] Building example '/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test/tests/uart.rs' for 'esp32h2'
[2024-04-08T08:58:17Z INFO  xtask] Package: "tests/uart.rs"
    Finished `release` profile [optimized + debuginfo] target(s) in 0.15s
     Running tests/uart.rs (target/riscv32imac-unknown-none-elf/release/deps/uart-5f44d4b03a865568)
      Erasing ✔ [00:00:00] [####################################################################################] 192.00 KiB/192.00 KiB @ 1.29 MiB/s (eta 0s )
  Programming ✔ [00:00:00] [#####################################################################################] 35.75 KiB/35.75 KiB @ 39.81 KiB/s (eta 0s )    Finished in 1.059s

running 1 test
test tests::test_send_receive ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 289207279 while buffer size is 1024 for "up" channel 0 (defmt)
ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s
```
Execution of all tests:
```
esp-hal/xtask on  feat/hil-update is  v0.0.0 via  v1.79.0-nightly took 2s 
❯ cargo xtask run-tests esp32h2 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `/Users/sergio/Documents/Espressif/forks/esp-hal/target/debug/xtask run-tests esp32h2`
[2024-04-08T08:59:06Z INFO  xtask] Building example '/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test/tests/aes.rs' for 'esp32h2'
[2024-04-08T08:59:06Z INFO  xtask] Package: "tests/aes.rs"
   Compiling hil-test v0.0.0 (/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test)
    Finished `release` profile [optimized + debuginfo] target(s) in 1.13s
     Running tests/aes.rs (target/riscv32imac-unknown-none-elf/release/deps/aes-0bacdfb841a99582)
      Erasing ✔ [00:00:00] [##################################################################################] 192.00 KiB/192.00 KiB @ 984.93 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [#####################################################################################] 35.96 KiB/35.96 KiB @ 60.16 KiB/s (eta 0s )    Finished in 0.809s
ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 598283353 while buffer size is 1024 for "up" channel 0 (defmt)

running 2 tests
test tests::test_aes_encryption ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 1973464005 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_aes_decryption ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 773238864 while buffer size is 1024 for "up" channel 0 (defmt)
ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.97s

[2024-04-08T08:59:09Z INFO  xtask] Building example '/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test/tests/spi_full_duplex.rs' for 'esp32h2'
[2024-04-08T08:59:09Z INFO  xtask] Package: "tests/spi_full_duplex.rs"
   Compiling hil-test v0.0.0 (/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.95s
     Running tests/spi_full_duplex.rs (target/riscv32imac-unknown-none-elf/release/deps/spi_full_duplex-a183c7e207700c0f)
      Erasing ✔ [00:00:00] [##################################################################################] 192.00 KiB/192.00 KiB @ 853.19 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [#####################################################################################] 37.64 KiB/37.64 KiB @ 53.62 KiB/s (eta 0s )    Finished in 0.943s
ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 303502708 while buffer size is 1024 for "up" channel 0 (defmt)

running 4 tests
test tests::test_symestric_transfer                      ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 290607941 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_asymestric_transfer                     ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 1341298459 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_symestric_transfer_huge_buffer          ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 135274955 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_symestric_transfer_huge_buffer_no_alloc ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 2247497692 while buffer size is 1024 for "up" channel 0 (defmt)
ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.93s

[2024-04-08T08:59:14Z INFO  xtask] Building example '/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test/tests/uart_async.rs' for 'esp32h2'
[2024-04-08T08:59:14Z INFO  xtask] Package: "tests/uart_async.rs"
   Compiling hil-test v0.0.0 (/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test)
    Finished `release` profile [optimized + debuginfo] target(s) in 1.00s
     Running tests/uart_async.rs (target/riscv32imac-unknown-none-elf/release/deps/uart_async-6403fcaac0a504a3)
      Erasing ✔ [00:00:00] [##################################################################################] 192.00 KiB/192.00 KiB @ 887.71 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [#####################################################################################] 38.79 KiB/38.79 KiB @ 56.94 KiB/s (eta 0s )    Finished in 0.916s
ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 3734281554 while buffer size is 1024 for "up" channel 0 (defmt)

running 1 test
test tests::test_send_receive ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 982331164 while buffer size is 1024 for "up" channel 0 (defmt)
ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s

[2024-04-08T08:59:17Z INFO  xtask] Building example '/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test/tests/gpio.rs' for 'esp32h2'
[2024-04-08T08:59:17Z INFO  xtask] Package: "tests/gpio.rs"
   Compiling hil-test v0.0.0 (/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test)
    Finished `release` profile [optimized + debuginfo] target(s) in 1.03s
     Running tests/gpio.rs (target/riscv32imac-unknown-none-elf/release/deps/gpio-8a798c29a24e8e6a)
      Erasing ✔ [00:00:00] [##################################################################################] 192.00 KiB/192.00 KiB @ 866.50 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [#####################################################################################] 39.68 KiB/39.68 KiB @ 55.87 KiB/s (eta 0s )    Finished in 0.95s
ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 4094361401 while buffer size is 1024 for "up" channel 0 (defmt)

running 6 tests
test tests::test_async_edge     ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 194126822 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_a_pin_can_wait ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 2729777517 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_gpio_input     ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 3204006546 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_gpio_output    ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 1691747781 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_gpio_interrupt ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 3566446721 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_gpio_od        ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 1232102943 while buffer size is 1024 for "up" channel 0 (defmt)
ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.99s

[2024-04-08T08:59:22Z INFO  xtask] Building example '/Users/sergio/Documents/Espressif/forks/esp-hal/hil-test/tests/uart.rs' for 'esp32h2'
[2024-04-08T08:59:22Z INFO  xtask] Package: "tests/uart.rs"
    Finished `release` profile [optimized + debuginfo] target(s) in 0.14s
     Running tests/uart.rs (target/riscv32imac-unknown-none-elf/release/deps/uart-5f44d4b03a865568)
      Erasing ✔ [00:00:00] [##################################################################################] 192.00 KiB/192.00 KiB @ 862.97 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [#####################################################################################] 35.75 KiB/35.75 KiB @ 51.28 KiB/s (eta 0s )    Finished in 0.937s
ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 4062726515 while buffer size is 1024 for "up" channel 0 (defmt)

running 1 test
test tests::test_send_receive ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 1267861596 while buffer size is 1024 for "up" channel 0 (defmt)
ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s
```

`probe-rs` is still throwing some werid RTT errors, but those can be still ignored. `probe-rs` used for tests is the one in the VMs (`ddd59fa`), I've also tried the latest `probe-rs` but same output
