### PR TITLE
Add `Delay` HIL test

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -57,6 +57,10 @@ harness = false
 name    = "get_time"
 harness = false
 
+[[test]]
+name    = "delay"
+harness = false
+
 [dependencies]
 cfg-if             = "1.0.0"
 critical-section   = "1.1.2"

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -1,0 +1,85 @@
+//! Delay Test
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use embedded_hal::delay::DelayNs;
+use esp_backtrace as _;
+use esp_hal::{
+    clock::ClockControl,
+    delay::Delay,
+    peripherals::Peripherals,
+    system::SystemControl,
+};
+
+struct Context {
+    delay: Delay,
+}
+
+impl Context {
+    pub fn init() -> Self {
+        let peripherals = Peripherals::take();
+        let system = SystemControl::new(peripherals.SYSTEM);
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let delay = Delay::new(&clocks);
+
+        Context { delay }
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use super::*;
+
+    #[init]
+    fn init() -> Context {
+        Context::init()
+    }
+
+    #[test]
+    #[timeout(1)]
+    fn delay_ns(mut ctx: Context) {
+        let t1 = esp_hal::time::current_time();
+        ctx.delay.delay_ns(600_000_000);
+        let t2 = esp_hal::time::current_time();
+
+        assert!(t2 > t1);
+        assert!((t2 - t1).to_nanos() >= 600_000_000u64);
+    }
+
+    #[test]
+    #[timeout(1)]
+    fn delay_700millis(ctx: Context) {
+        let t1 = esp_hal::time::current_time();
+        ctx.delay.delay_millis(700);
+        let t2 = esp_hal::time::current_time();
+
+        assert!(t2 > t1);
+        assert!((t2 - t1).to_millis() >= 700u64);
+    }
+
+    #[test]
+    #[timeout(2)]
+    fn delay_1_500_000us(mut ctx: Context) {
+        let t1 = esp_hal::time::current_time();
+        ctx.delay.delay_us(1_500_000);
+        let t2 = esp_hal::time::current_time();
+
+        assert!(t2 > t1);
+        assert!((t2 - t1).to_micros() >= 1_500_000u64);
+    }
+
+    #[test]
+    #[timeout(5)]
+    fn delay_3_000ms(mut ctx: Context) {
+        let t1 = esp_hal::time::current_time();
+        ctx.delay.delay_ms(3000);
+        let t2 = esp_hal::time::current_time();
+
+        assert!(t2 > t1);
+        assert!((t2 - t1).to_millis() >= 3000u64);
+    }
+}

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -6,12 +6,7 @@
 use defmt_rtt as _;
 use embedded_hal::delay::DelayNs;
 use esp_backtrace as _;
-use esp_hal::{
-    clock::ClockControl,
-    delay::Delay,
-    peripherals::Peripherals,
-    system::SystemControl,
-};
+use esp_hal::{clock::ClockControl, delay::Delay, peripherals::Peripherals, system::SystemControl};
 
 struct Context {
     delay: Delay,

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -19,8 +19,8 @@ use esp_hal::{
     gpio::{GpioPin, Input, Io, Output, OutputPin, PullDown, PushPull, Unknown},
     macros::handler,
     peripherals::Peripherals,
-    timer::TimerGroup,
     system::SystemControl,
+    timer::TimerGroup,
 };
 
 static COUNTER: Mutex<RefCell<u32>> = Mutex::new(RefCell::new(0));

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -15,9 +15,9 @@ use esp_hal::{
     clock::ClockControl,
     gpio::Io,
     peripherals::{Peripherals, UART0},
+    system::SystemControl,
     uart::{config::Config, TxRxPins, Uart, UartRx, UartTx},
     Async,
-    system::SystemControl,
 };
 
 struct Context {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds an HIL test for Delay. 
Not really sure, how useful these tests are though. Using the same value of delay as timeouts ends up in timeouts which is expected (correct me if I'm wrong). I used "random" delay values, maybe I can tune them a little bit but not sure if that make sense. Any feedback/suggestion is appreciated. 

#### Testing
Run Delay test locally on multiple chip targets and manually triggered [HIL job](https://github.com/esp-rs/esp-hal/actions/runs/8615443424) for this branch. 
