### PR TITLE
Add CRC and MD5 HIL tests

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -9,6 +9,10 @@ name    = "aes"
 harness = false
 
 [[test]]
+name    = "crc"
+harness = false
+
+[[test]]
 name    = "gpio"
 harness = false
 

--- a/hil-test/tests/crc.rs
+++ b/hil-test/tests/crc.rs
@@ -1,0 +1,68 @@
+//! CRC and MD5 Tests
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use core::ops::Deref;
+
+use defmt_rtt as _;
+use esp_backtrace as _;
+use esp_hal::rom::{crc, md5};
+
+#[embedded_test::tests]
+mod tests {
+    use defmt::assert_eq;
+
+    use super::*;
+
+    #[init]
+    fn init() {}
+
+    #[test]
+    fn test_crc() {
+        let data = "123456789";
+
+        let crc_hdlc = crc::crc32_le(!0xffffffff, data.as_ref());
+        let crc_bzip2 = crc::crc32_be(!0xffffffff, data.as_ref());
+        let crc_mpeg2 = !crc::crc32_be(!0xffffffff, data.as_ref());
+        let crc_cksum = crc::crc32_be(!0, data.as_ref());
+        let crc_kermit = !crc::crc16_le(!0, data.as_ref());
+        let crc_genibus = crc::crc16_be(!0xffff, data.as_ref());
+        let crc_rohc = !crc::crc8_le(!0xff, data.as_ref());
+        let crc_smbus = !crc::crc8_be(!0, data.as_ref());
+
+        assert_eq!(crc_hdlc, 0xcbf43926);
+        assert_eq!(crc_bzip2, 0xfc891918);
+        assert_eq!(crc_mpeg2, 0x0376e6e7);
+        assert_eq!(crc_cksum, 0x765e7680);
+        assert_eq!(crc_kermit, 0x2189);
+        assert_eq!(crc_genibus, 0xd64e);
+        assert_eq!(crc_rohc, 0xd0);
+        assert_eq!(crc_smbus, 0xf4);
+    }
+
+    #[test]
+    fn test_md5() {
+        let sentence = "The quick brown fox jumps over a lazy dog";
+
+        let mut md5_ctx = md5::Context::new();
+        let mut it = sentence.split_whitespace().peekable();
+        while let Some(word) = it.next() {
+            md5_ctx.consume(word);
+            if it.peek().is_some() {
+                md5_ctx.consume(" ");
+            }
+        }
+        let md5_digest = md5_ctx.compute();
+
+        let expected_md5_digest = md5::Digest([
+            0x30, 0xde, 0xd8, 0x07, 0xd6, 0x5e, 0xe0, 0x37, 0x0f, 0xc6, 0xd7, 0x3d, 0x6a, 0xb5,
+            0x5a, 0x95,
+        ])
+        .deref();
+
+        assert_eq!(expected_md5_digest, md5_digest.deref());
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds an HIL test for CRC and MD5. Not sure how useful are this tests since they are mostly calling ROM functions, but I thought it might be good to have them.

#### Testing
Tested locally on C3,C6 and H2. Also, I manually triggered the HIL CI to run in my fork/branch of this PR: https://github.com/esp-rs/esp-hal/actions/runs/8629177503
