### PR TITLE
Warn users when attempting to build `esp-hal` using the `dev` profile

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add TWAI support for ESP32-C6 (#1323)
 - `GpioPin::steal` unsafe API (#1363)
 - Inherent implementions of GPIO pin `set_low`, `is_low`, etc.
+- Warn users when attempting to build using the `dev` profile (#1420)
 
 ### Fixed
 

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -10,6 +10,15 @@ use std::{
 use esp_build::assert_unique_used_features;
 use esp_metadata::{Chip, Config};
 
+#[cfg(debug_assertions)]
+esp_build::warning! {"
+WARNING: use --release
+  We *strongly* recommend using release profile when building esp-hal.
+  The dev profile can potentially be one or more orders of magnitude
+  slower than release, and may cause issues with timing-senstive
+  peripherals and/or devices.
+"}
+
 fn main() -> Result<(), Box<dyn Error>> {
     // NOTE: update when adding new device support!
     // Ensure that exactly one chip has been specified:


### PR DESCRIPTION
Happy to hear any input with regards to wording here, but I think this should be adequate.

Closes #1261, however we should open tracking issues for any other repos which still need updating.