### PR TITLE
HIL SHA tests

### DIFF
--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -96,9 +96,9 @@ pub enum ShaMode {
     #[cfg(not(esp32))]
     SHA224,
     SHA256,
-    #[cfg(any(esp32s2, esp32s3, esp32))]
+    #[cfg(any(esp32, esp32s2, esp32s3))]
     SHA384,
-    #[cfg(any(esp32s2, esp32s3, esp32))]
+    #[cfg(any(esp32, esp32s2, esp32s3))]
     SHA512,
     #[cfg(any(esp32s2, esp32s3))]
     SHA512_224,

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -25,6 +25,10 @@ name    = "rsa"
 harness = false
 
 [[test]]
+name    = "sha"
+harness = false
+
+[[test]]
 name    = "uart"
 harness = false
 

--- a/hil-test/tests/aes.rs
+++ b/hil-test/tests/aes.rs
@@ -25,6 +25,7 @@ impl Context<'_> {
     }
 }
 
+#[cfg(test)]
 #[embedded_test::tests]
 mod tests {
     use defmt::assert_eq;

--- a/hil-test/tests/crc.rs
+++ b/hil-test/tests/crc.rs
@@ -11,6 +11,7 @@ use defmt_rtt as _;
 use esp_backtrace as _;
 use esp_hal::rom::{crc, md5};
 
+#[cfg(test)]
 #[embedded_test::tests]
 mod tests {
     use defmt::assert_eq;

--- a/hil-test/tests/rsa.rs
+++ b/hil-test/tests/rsa.rs
@@ -59,6 +59,7 @@ const fn compute_mprime(modulus: &U512) -> u32 {
     (-1 * m_inv as i64 % 4294967296) as u32
 }
 
+#[cfg(test)]
 #[embedded_test::tests]
 mod tests {
     use defmt::assert_eq;

--- a/hil-test/tests/sha.rs
+++ b/hil-test/tests/sha.rs
@@ -14,22 +14,6 @@ use esp_hal::{
 };
 use nb::block;
 
-struct Context<'a> {
-    sha: Sha<'a, esp_hal::Blocking>,
-}
-
-impl Context<'_> {
-    pub fn init() -> Self {
-        let peripherals = Peripherals::take();
-        #[cfg(not(feature = "esp32"))]
-        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA256, None);
-        #[cfg(feature = "esp32")]
-        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA256);
-
-        Context { sha }
-    }
-}
-
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
@@ -38,12 +22,64 @@ mod tests {
     use super::*;
 
     #[init]
-    fn init() -> Context<'static> {
-        Context::init()
+    fn init() {}
+
+    #[test]
+    fn test_sha_1() {
+        let peripherals = Peripherals::take();
+        #[cfg(not(feature = "esp32"))]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA1, None);
+        #[cfg(feature = "esp32")]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA1);
+
+        let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+        let mut remaining = source_data;
+        let expected_output = [
+            0x57, 0xf5, 0x3e, 0xd5, 0x59, 0x85, 0x24, 0x49, 0x3e, 0xc5, 0x76, 0x77, 0xa, 0xaf,
+            0x3b, 0xb1, 0x0, 0x63, 0xe3, 0xce, 0xef, 0x5, 0xf8, 0xe3, 0xfe, 0x3d, 0x96, 0xa4, 0x63,
+            0x29, 0xa5, 0x78,
+        ];
+        let mut output = [0u8; 32];
+
+        while remaining.len() > 0 {
+            remaining = block!(sha.update(remaining)).unwrap();
+        }
+        block!(sha.finish(output.as_mut_slice())).unwrap();
+
+        assert_eq!(expected_output, output);
     }
 
     #[test]
-    fn test_sha_hashing(mut ctx: Context<'static>) {
+    #[cfg(not(feature = "esp32"))]
+    fn test_sha_224() {
+        let peripherals = Peripherals::take();
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA224, None);
+
+        let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+        let mut remaining = source_data;
+        let expected_output = [
+            0x3b, 0x29, 0x33, 0xca, 0xfa, 0x6, 0xc0, 0x29, 0x68, 0x10, 0xa1, 0x3e, 0x54, 0x5f,
+            0x25, 0x40, 0xa4, 0x35, 0x17, 0x3, 0x6d, 0xa2, 0xb, 0xeb, 0x8c, 0xbe, 0x79, 0x3b, 0xb6,
+            0xa8, 0x8c, 0xff,
+        ];
+        let mut output = [0u8; 32];
+
+        while remaining.len() > 0 {
+            remaining = block!(sha.update(remaining)).unwrap();
+        }
+        block!(sha.finish(output.as_mut_slice())).unwrap();
+
+        assert_eq!(expected_output, output);
+    }
+
+    #[test]
+    fn test_sha_256() {
+        let peripherals = Peripherals::take();
+        #[cfg(not(feature = "esp32"))]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA256, None);
+        #[cfg(feature = "esp32")]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA256);
+
         let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
         let mut remaining = source_data;
         let expected_output = [
@@ -51,26 +87,111 @@ mod tests {
             0x06, 0x09, 0x72, 0x3d, 0x92, 0xc6, 0x40, 0xb6, 0x5b, 0xa9, 0x97, 0x4d, 0x66, 0x6c,
             0x36, 0x4a, 0x3a, 0x63,
         ];
-
-        // Short hashes can be created by decreasing the output buffer to the desired
-        // length
         let mut output = [0u8; 32];
 
         while remaining.len() > 0 {
-            // Can add println to view progress, however println takes a few orders of
-            // magnitude longer than the Sha function itself so not useful for
-            // comparing processing time println!("Remaining len: {}",
-            // remaining.len());
-
-            // All the HW Sha functions are infallible so unwrap is fine to use if you use
-            // block!
-            remaining = block!(ctx.sha.update(remaining)).unwrap();
+            remaining = block!(sha.update(remaining)).unwrap();
         }
+        block!(sha.finish(output.as_mut_slice())).unwrap();
 
-        // Finish can be called as many times as desired to get mutliple copies of the
-        // output.
-        block!(ctx.sha.finish(output.as_mut_slice())).unwrap();
+        assert_eq!(expected_output, output);
+    }
 
-        assert_eq!(output, expected_output);
+    #[test]
+    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
+    fn test_sha_384() {
+        let peripherals = Peripherals::take();
+        #[cfg(not(feature = "esp32"))]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA384, None);
+        #[cfg(feature = "esp32")]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA384);
+
+        let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+        let mut remaining = source_data;
+        let expected_output = [
+            0x8a, 0x1d, 0xe0, 0x7f, 0xa9, 0xc, 0x4c, 0xbb, 0xac, 0xe4, 0x62, 0xbd, 0xd9, 0x2f,
+            0x90, 0x88, 0x61, 0x69, 0x40, 0xc0, 0x55, 0x6b, 0x80, 0x6, 0xaa, 0xfc, 0xd4, 0xff,
+            0xc1, 0x8, 0xe9, 0xb2,
+        ];
+        let mut output = [0u8; 32];
+
+        while remaining.len() > 0 {
+            remaining = block!(sha.update(remaining)).unwrap();
+        }
+        block!(sha.finish(output.as_mut_slice())).unwrap();
+
+        assert_eq!(expected_output, output);
+    }
+
+    #[test]
+    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
+    fn test_sha_512() {
+        let peripherals = Peripherals::take();
+        #[cfg(not(feature = "esp32"))]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA512, None);
+        #[cfg(feature = "esp32")]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA512);
+
+        let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+        let mut remaining = source_data;
+        let expected_output = [
+            0xee, 0x8d, 0xe, 0x15, 0xde, 0xdc, 0xd8, 0xc8, 0x86, 0xa2, 0xef, 0xb1, 0xac, 0x6a,
+            0x49, 0xcf, 0xd8, 0x3f, 0x67, 0x65, 0x64, 0xb3, 0x0, 0xce, 0x48, 0x51, 0x5e, 0xce,
+            0x5f, 0x4b, 0xee, 0x10,
+        ];
+        let mut output = [0u8; 32];
+
+        while remaining.len() > 0 {
+            remaining = block!(sha.update(remaining)).unwrap();
+        }
+        block!(sha.finish(output.as_mut_slice())).unwrap();
+
+        assert_eq!(expected_output, output);
+    }
+
+    #[test]
+    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+    fn test_sha_512_224() {
+        let peripherals = Peripherals::take();
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA512_224, None);
+
+        let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+        let mut remaining = source_data;
+        let expected_output = [
+            0x19, 0xf2, 0xb3, 0x88, 0x22, 0x86, 0x94, 0x38, 0xee, 0x24, 0xc1, 0xc3, 0xb0, 0xb1,
+            0x21, 0x6a, 0xf4, 0x81, 0x14, 0x8f, 0x4, 0x34, 0xfd, 0xd7, 0x54, 0x3, 0x2b, 0x88, 0xa3,
+            0xc1, 0xb8, 0x60,
+        ];
+        let mut output = [0u8; 32];
+
+        while remaining.len() > 0 {
+            remaining = block!(sha.update(remaining)).unwrap();
+        }
+        block!(sha.finish(output.as_mut_slice())).unwrap();
+
+        assert_eq!(expected_output, output);
+    }
+
+    #[test]
+    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+    fn test_sha_512_256() {
+        let peripherals = Peripherals::take();
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA512_256, None);
+
+        let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+        let mut remaining = source_data;
+        let expected_output = [
+            0xb7, 0x49, 0x4e, 0xe1, 0xdb, 0xcd, 0xe5, 0x47, 0x5a, 0x61, 0x25, 0xac, 0x27, 0xc2,
+            0x1b, 0x53, 0xcd, 0x6b, 0x16, 0x33, 0xb4, 0x94, 0xac, 0xa4, 0x2a, 0xe6, 0x99, 0x2f,
+            0xe7, 0xd, 0x83, 0x19,
+        ];
+        let mut output = [0u8; 32];
+
+        while remaining.len() > 0 {
+            remaining = block!(sha.update(remaining)).unwrap();
+        }
+        block!(sha.finish(output.as_mut_slice())).unwrap();
+
+        assert_eq!(expected_output, output);
     }
 }

--- a/hil-test/tests/sha.rs
+++ b/hil-test/tests/sha.rs
@@ -1,0 +1,76 @@
+//! SHA Test
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use esp_backtrace as _;
+use esp_hal::{
+    peripherals::Peripherals,
+    prelude::*,
+    sha::{Sha, ShaMode},
+};
+use nb::block;
+
+struct Context<'a> {
+    sha: Sha<'a, esp_hal::Blocking>,
+}
+
+impl Context<'_> {
+    pub fn init() -> Self {
+        let peripherals = Peripherals::take();
+        #[cfg(not(feature = "esp32"))]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA256, None);
+        #[cfg(feature = "esp32")]
+        let mut sha = Sha::new(peripherals.SHA, ShaMode::SHA256);
+
+        Context { sha }
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use defmt::assert_eq;
+
+    use super::*;
+
+    #[init]
+    fn init() -> Context<'static> {
+        Context::init()
+    }
+
+    #[test]
+    fn test_sha_hashing(mut ctx: Context<'static>) {
+        let source_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+        let mut remaining = source_data;
+        let expected_output = [
+            0x1e, 0xbb, 0xda, 0xb3, 0x35, 0xe0, 0x54, 0x01, 0x5f, 0x0f, 0xc1, 0x7f, 0x62, 0x77,
+            0x06, 0x09, 0x72, 0x3d, 0x92, 0xc6, 0x40, 0xb6, 0x5b, 0xa9, 0x97, 0x4d, 0x66, 0x6c,
+            0x36, 0x4a, 0x3a, 0x63,
+        ];
+
+        // Short hashes can be created by decreasing the output buffer to the desired
+        // length
+        let mut output = [0u8; 32];
+
+        while remaining.len() > 0 {
+            // Can add println to view progress, however println takes a few orders of
+            // magnitude longer than the Sha function itself so not useful for
+            // comparing processing time println!("Remaining len: {}",
+            // remaining.len());
+
+            // All the HW Sha functions are infallible so unwrap is fine to use if you use
+            // block!
+            remaining = block!(ctx.sha.update(remaining)).unwrap();
+        }
+
+        // Finish can be called as many times as desired to get mutliple copies of the
+        // output.
+        block!(ctx.sha.finish(output.as_mut_slice())).unwrap();
+
+        assert_eq!(output, expected_output);
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds an HIL test for SHA

#### Testing
Tested locally on S3 (required to use some changes of https://github.com/esp-rs/esp-hal/pull/1412), C6 and H2.

<details>
  <summary>ESP32-S3 Output</summary>

```
     Running tests/sha.rs (target/xtensa-esp32s3-none-elf/debug/deps/sha-b2f1d22ba5d76ad5)
      Erasing ✔ [00:00:00] [##################################################################] 192.00 KiB/192.00 KiB @ 326.24 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [#####################################################################] 48.76 KiB/48.76 KiB @ 49.45 KiB/s (eta 0s )    Finished in 1.597s

running 7 tests
test tests::test_sha_1       ... ok
test tests::test_sha_224     ... ok
test tests::test_sha_256     ... ok
test tests::test_sha_384     ... ok
test tests::test_sha_512     ... ok
test tests::test_sha_512_224 ... ok
test tests::test_sha_512_256 ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.30s
```
</details>

<details>
  <summary>ESP32-C6 Output</summary>

```
     Running tests/sha.rs (target/riscv32imac-unknown-none-elf/debug/deps/sha-0ef72a0ebd885bd2)
      Erasing ✔ [00:00:00] [##################################################################] 192.00 KiB/192.00 KiB @ 629.50 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [#####################################################################] 49.67 KiB/49.67 KiB @ 73.82 KiB/s (eta 0s )    Finished in 0.994s

running 3 tests
test tests::test_sha_1   ... ok
test tests::test_sha_224 ... ok
test tests::test_sha_256 ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.48s
```
</details>

<details>
  <summary>ESP32-H2 Output</summary>

```
     Running tests/sha.rs (target/riscv32imac-unknown-none-elf/debug/deps/sha-c0acbc88e4804f4a)
      Erasing ✔ [00:00:00] [##################################################################################] 192.00 KiB/192.00 KiB @ 1002.40 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [######################################################################################] 45.16 KiB/45.16 KiB @ 65.61 KiB/s (eta 0s )    Finished in 0.896s

running 3 tests
test tests::test_sha_1   ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 560705263 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_sha_224 ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 1577470528 while buffer size is 1024 for "up" channel 0 (defmt)
ok
test tests::test_sha_256 ... ERROR probe_rs::util::rtt: 
Error reading from RTT: The control block has been corrupted. write pointer is 610487893 while buffer size is 1024 for "up" channel 0 (defmt)
ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.45s
```
</details>

Manually triggered the HIL workflow: https://github.com/esp-rs/esp-hal/actions/runs/8644022372