### PR TITLE
Improve AES HIL tests

### DIFF
--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -124,8 +124,12 @@ const ALIGN_SIZE: usize = core::mem::size_of::<u32>();
 
 pub enum Mode {
     Encryption128 = 0,
+    #[cfg(any(esp32, esp32s2))]
+    Encryption192 = 1,
     Encryption256 = 2,
     Decryption128 = 4,
+    #[cfg(any(esp32, esp32s2))]
+    Decryption192 = 5,
     Decryption256 = 6,
 }
 

--- a/hil-test/tests/aes.rs
+++ b/hil-test/tests/aes.rs
@@ -37,7 +37,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aes_encryption(mut ctx: Context<'static>) {
+    fn test_aes_128_encryption(mut ctx: Context<'static>) {
         let keytext = "SUp4SeCp@sSw0rd".as_bytes();
         let plaintext = "message".as_bytes();
         let encrypted_message = [
@@ -45,11 +45,9 @@ mod tests {
             0x31, 0x96,
         ];
 
-        // create an array with aes128 key size
         let mut keybuf = [0_u8; 16];
         keybuf[..keytext.len()].copy_from_slice(keytext);
 
-        // create an array with aes block size
         let mut block_buf = [0_u8; 16];
         block_buf[..plaintext.len()].copy_from_slice(plaintext);
 
@@ -59,7 +57,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aes_decryption(mut ctx: Context<'static>) {
+    fn test_aes_128_decryption(mut ctx: Context<'static>) {
         let keytext = "SUp4SeCp@sSw0rd".as_bytes();
         let plaintext = "message".as_bytes();
         let mut encrypted_message = [
@@ -67,12 +65,87 @@ mod tests {
             0x31, 0x96,
         ];
 
-        // create an array with aes128 key size
         let mut keybuf = [0_u8; 16];
         keybuf[..keytext.len()].copy_from_slice(keytext);
 
         ctx.aes
             .process(&mut encrypted_message, Mode::Decryption128, &keybuf);
+        assert_eq!(&encrypted_message[..plaintext.len()], plaintext);
+    }
+
+    #[test]
+    #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+    fn test_aes_192_encryption(mut ctx: Context<'static>) {
+        let keytext = "SUp4SeCp@sSw0rd".as_bytes();
+        let plaintext = "message".as_bytes();
+        let encrypted_message = [
+            0x79, 0x88, 0x3f, 0x9d, 0x67, 0x27, 0xf4, 0x18, 0x3, 0xe3, 0xc6, 0x6a, 0x2e, 0x76,
+            0xb6, 0xf7,
+        ];
+
+        let mut keybuf = [0_u8; 16];
+        keybuf[..keytext.len()].copy_from_slice(keytext);
+
+        let mut block_buf = [0_u8; 16];
+        block_buf[..plaintext.len()].copy_from_slice(plaintext);
+
+        let mut block = block_buf.clone();
+        ctx.aes.process(&mut block, Mode::Encryption192, &keybuf);
+        assert_eq!(block, encrypted_message);
+    }
+
+    #[test]
+    #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+    fn test_aes_192_decryption(mut ctx: Context<'static>) {
+        let keytext = "SUp4SeCp@sSw0rd".as_bytes();
+        let plaintext = "message".as_bytes();
+        let mut encrypted_message = [
+            0x79, 0x88, 0x3f, 0x9d, 0x67, 0x27, 0xf4, 0x18, 0x3, 0xe3, 0xc6, 0x6a, 0x2e, 0x76,
+            0xb6, 0xf7,
+        ];
+
+        let mut keybuf = [0_u8; 16];
+        keybuf[..keytext.len()].copy_from_slice(keytext);
+
+        ctx.aes
+            .process(&mut encrypted_message, Mode::Decryption192, &keybuf);
+        assert_eq!(&encrypted_message[..plaintext.len()], plaintext);
+    }
+
+    #[test]
+    fn test_aes_256_encryption(mut ctx: Context<'static>) {
+        let keytext = "SUp4SeCp@sSw0rd".as_bytes();
+        let plaintext = "message".as_bytes();
+        let encrypted_message = [
+            0x0, 0x63, 0x3f, 0x2, 0xa4, 0x53, 0x9, 0x72, 0x20, 0x6d, 0xc9, 0x8, 0x7c, 0xe5, 0xfd,
+            0xc,
+        ];
+
+        let mut keybuf = [0_u8; 16];
+        keybuf[..keytext.len()].copy_from_slice(keytext);
+
+        let mut block_buf = [0_u8; 16];
+        block_buf[..plaintext.len()].copy_from_slice(plaintext);
+
+        let mut block = block_buf.clone();
+        ctx.aes.process(&mut block, Mode::Encryption256, &keybuf);
+        assert_eq!(block, encrypted_message);
+    }
+
+    #[test]
+    fn test_aes_256_decryption(mut ctx: Context<'static>) {
+        let keytext = "SUp4SeCp@sSw0rd".as_bytes();
+        let plaintext = "message".as_bytes();
+        let mut encrypted_message = [
+            0x0, 0x63, 0x3f, 0x2, 0xa4, 0x53, 0x9, 0x72, 0x20, 0x6d, 0xc9, 0x8, 0x7c, 0xe5, 0xfd,
+            0xc,
+        ];
+
+        let mut keybuf = [0_u8; 16];
+        keybuf[..keytext.len()].copy_from_slice(keytext);
+
+        ctx.aes
+            .process(&mut encrypted_message, Mode::Decryption256, &keybuf);
         assert_eq!(&encrypted_message[..plaintext.len()], plaintext);
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Cover all the AES modes in the HIL test.

#### Testing
Tested locally on S2 (required to use some changes of https://github.com/esp-rs/esp-hal/pull/1412) and C6.

<details>
  <summary>ESP32-S2 Output</summary>

```
     Running tests/aes.rs (target/xtensa-esp32s2-none-elf/debug/deps/aes-42356b01d01b75bf)
      Erasing ✔ [00:00:00] [#######################################################################] 192.00 KiB/192.00 KiB @ 209.95 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [##########################################################################] 46.65 KiB/46.65 KiB @ 34.01 KiB/s (eta 0s )    Finished in 2.354s

running 6 tests
test tests::test_aes_128_encryption ... ok
test tests::test_aes_128_decryption ... ok
test tests::test_aes_192_encryption ... ok
test tests::test_aes_192_decryption ... ok
test tests::test_aes_256_encryption ... ok
test tests::test_aes_256_decryption ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.77s
```
</details>

<details>
  <summary>ESP32-C6 Output</summary>

```
     Running tests/aes.rs (target/riscv32imac-unknown-none-elf/debug/deps/aes-dc94f37583cbbc3f)
      Erasing ✔ [00:00:00] [###########################################################################] 192.00 KiB/192.00 KiB @ 1.77 MiB/s (eta 0s )
  Programming ✔ [00:00:00] [############################################################################] 49.16 KiB/49.16 KiB @ 51.73 KiB/s (eta 0s )    Finished in 1.075s

running 4 tests
test tests::test_aes_128_encryption ... ok
test tests::test_aes_128_decryption ... ok
test tests::test_aes_256_encryption ... ok
test tests::test_aes_256_decryption ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.47s
```
</details>



Manually triggered the HIL workflow: https://github.com/esp-rs/esp-hal/actions/runs/8646947366
