### PR TITLE
AES DMA HIL Tests

### DIFF
--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -100,7 +100,7 @@
 //!         keybuf,
 //!     )
 //!     .unwrap();
-//! let (hw_encrypted, plaintext, aes) = transfer.wait().unwrap();
+//! transfer.wait().unwrap();
 //! ```
 
 #[cfg(esp32)]

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -530,6 +530,7 @@ pub mod dma {
         pub fn finish_transform(&self) {
             self.aes.aes.dma_exit().write(|w| w.dma_exit().set_bit());
             self.enable_dma(false);
+            self.reset_aes();
         }
 
         fn set_num_block(&self, block: u32) {

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -9,6 +9,10 @@ name    = "aes"
 harness = false
 
 [[test]]
+name    = "aes_dma"
+harness = false
+
+[[test]]
 name    = "crc"
 harness = false
 

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -75,6 +75,7 @@ mod tests {
         (&mut encrypted_output[..]).copy_from_slice(output);
 
         assert_eq!(encrypted_output, encrypted_message);
+        aes.reset_aes();
     }
 
     #[test]
@@ -120,6 +121,7 @@ mod tests {
         (&mut decrypted_output[..]).copy_from_slice(output);
 
         assert_eq!(&decrypted_output[..plaintext.len()], plaintext);
+        aes.reset_aes();
     }
 
     #[test]
@@ -166,6 +168,7 @@ mod tests {
         (&mut encrypted_output[..]).copy_from_slice(output);
 
         assert_eq!(encrypted_output, encrypted_message);
+        aes.reset_aes();
     }
 
     #[test]
@@ -211,5 +214,6 @@ mod tests {
         (&mut decrypted_output[..]).copy_from_slice(output);
 
         assert_eq!(&decrypted_output[..plaintext.len()], plaintext);
+        aes.reset_aes();
     }
 }

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -75,7 +75,6 @@ mod tests {
         (&mut encrypted_output[..]).copy_from_slice(output);
 
         assert_eq!(encrypted_output, encrypted_message);
-        aes.reset_aes();
     }
 
     #[test]
@@ -121,7 +120,6 @@ mod tests {
         (&mut decrypted_output[..]).copy_from_slice(output);
 
         assert_eq!(&decrypted_output[..plaintext.len()], plaintext);
-        aes.reset_aes();
     }
 
     #[test]
@@ -168,7 +166,6 @@ mod tests {
         (&mut encrypted_output[..]).copy_from_slice(output);
 
         assert_eq!(encrypted_output, encrypted_message);
-        aes.reset_aes();
     }
 
     #[test]
@@ -214,6 +211,5 @@ mod tests {
         (&mut decrypted_output[..]).copy_from_slice(output);
 
         assert_eq!(&decrypted_output[..plaintext.len()], plaintext);
-        aes.reset_aes();
     }
 }

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -1,0 +1,150 @@
+//! AES DMA Test
+
+//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use esp_backtrace as _;
+use esp_hal::{
+    aes::{
+        dma::{AesDma, CipherMode, WithDmaAes},
+        Aes,
+        Mode,
+    },
+    dma::{Dma, DmaDescriptor, DmaPriority},
+    dma_buffers,
+    peripherals::Peripherals,
+    prelude::*,
+};
+
+const DMA_BUFFER_SIZE: usize = 16;
+
+// struct Context<'a> {
+//     aes_dma: AesDma<'a, esp_hal::dma::Channel0>,
+// }
+
+// impl Context<'_> {
+//     pub fn init() -> Self {
+//         let peripherals = Peripherals::take();
+
+//         let dma = Dma::new(peripherals.DMA);
+//         let dma_channel = dma.channel0;
+
+//         let (input, mut tx_descriptors, mut output, mut rx_descriptors) =
+//             dma_buffers!(DMA_BUFFER_SIZE);
+
+//         let aes_dma =
+// Aes::new(peripherals.AES).with_dma(dma_channel.configure(             false,
+//             &mut tx_descriptors,
+//             &mut rx_descriptors,
+//             DmaPriority::Priority0,
+//         ));
+
+//         Context { aes_dma }
+//     }
+// }
+
+#[embedded_test::tests]
+mod tests {
+    use defmt::assert_eq;
+
+    use super::*;
+
+    // #[init]
+    // fn init() -> Context<'static> {
+    //     Context::init()
+    // }
+
+    #[test]
+    fn test_aes_128_dma_encryption() {
+        let peripherals = Peripherals::take();
+
+        let dma = Dma::new(peripherals.DMA);
+        let dma_channel = dma.channel0;
+
+        let (input, mut tx_descriptors, mut output, mut rx_descriptors) =
+            dma_buffers!(DMA_BUFFER_SIZE);
+
+        let mut aes = Aes::new(peripherals.AES).with_dma(dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ));
+
+        let keytext = "SUp4SeCp@sSw0rd".as_bytes();
+        let mut keybuf = [0_u8; 16];
+        keybuf[..keytext.len()].copy_from_slice(keytext);
+
+        let plaintext = "message".as_bytes();
+        input[..plaintext.len()].copy_from_slice(plaintext);
+
+        let encrypted_message = [
+            0xb3, 0xc8, 0xd2, 0x3b, 0xa7, 0x36, 0x5f, 0x18, 0x61, 0x70, 0x0, 0x3e, 0xd9, 0x3a,
+            0x31, 0x96,
+        ];
+
+        let transfer = aes
+            .process(
+                &input,
+                &mut output,
+                Mode::Encryption128,
+                CipherMode::Ecb,
+                keybuf,
+            )
+            .unwrap();
+        transfer.wait().unwrap();
+
+        let mut encrypted_output = [0u8; 16];
+        (&mut encrypted_output[..]).copy_from_slice(output);
+
+        assert_eq!(encrypted_output, encrypted_message);
+    }
+
+    #[test]
+    fn test_aes_128_dma_decryption() {
+        let peripherals = Peripherals::take();
+
+        let dma = Dma::new(peripherals.DMA);
+        let dma_channel = dma.channel0;
+
+        let (input, mut tx_descriptors, mut output, mut rx_descriptors) =
+            dma_buffers!(DMA_BUFFER_SIZE);
+
+        let mut aes = Aes::new(peripherals.AES).with_dma(dma_channel.configure(
+            false,
+            &mut tx_descriptors,
+            &mut rx_descriptors,
+            DmaPriority::Priority0,
+        ));
+
+        let keytext = "SUp4SeCp@sSw0rd".as_bytes();
+        let mut keybuf = [0_u8; 16];
+        keybuf[..keytext.len()].copy_from_slice(keytext);
+
+        let plaintext = "message".as_bytes();
+        let encrypted_message = [
+            0xb3, 0xc8, 0xd2, 0x3b, 0xa7, 0x36, 0x5f, 0x18, 0x61, 0x70, 0x0, 0x3e, 0xd9, 0x3a,
+            0x31, 0x96,
+        ];
+        input.copy_from_slice(&encrypted_message);
+
+        let transfer = aes
+            .process(
+                &input,
+                &mut output,
+                Mode::Decryption128,
+                CipherMode::Ecb,
+                keybuf,
+            )
+            .unwrap();
+        transfer.wait().unwrap();
+
+        let mut decrypted_output = [0u8; 16];
+        (&mut decrypted_output[..]).copy_from_slice(output);
+
+        assert_eq!(&decrypted_output[..plaintext.len()], plaintext);
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds AES DMA HIL tests for every AES mode.

I really tried to use `Context` as with other tests, but Rust compiler just wasn't happy with the types and all the movements of them, so I ended up copy/pasting it all over, which makes it really ugly.

Had to add a `reset_aes` call at the end of `finish_transform` to clear the interrupt as otherwise, the `aes` test failed, see https://github.com/esp-rs/esp-hal/actions/runs/8659868769

#### Testing
Tested locally on S3, C6 and H2.

Manually triggered the HIL workflow:  https://github.com/esp-rs/esp-hal/actions/runs/8685641126