### PR TITLE
Create virtual peripherals for CPU control and radio clocks

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Created virtual peripherals for CPU control and radio clocks, rather than splitting them from `SYSTEM` (#1428)
+
 ### Removed
 
 ## [0.17.0] - 2024-04-18

--- a/esp-hal/src/soc/esp32/cpu_control.rs
+++ b/esp-hal/src/soc/esp32/cpu_control.rs
@@ -53,7 +53,11 @@ use core::{
     mem::{ManuallyDrop, MaybeUninit},
 };
 
-use crate::Cpu;
+use crate::{
+    peripheral::{Peripheral, PeripheralRef},
+    peripherals::CPU_CTRL,
+    Cpu,
+};
 
 /// Data type for a properly aligned stack of N bytes
 // Xtensa ISA 10.5: [B]y default, the
@@ -125,8 +129,8 @@ pub enum Error {
 }
 
 /// Control CPU Cores
-pub struct CpuControl {
-    _cpu_control: crate::peripherals::CPU_CTRL,
+pub struct CpuControl<'d> {
+    _cpu_control: PeripheralRef<'d, CPU_CTRL>,
 }
 
 unsafe fn internal_park_core(core: Cpu) {
@@ -153,8 +157,10 @@ unsafe fn internal_park_core(core: Cpu) {
     }
 }
 
-impl CpuControl {
-    pub fn new(cpu_control: crate::peripherals::CPU_CTRL) -> CpuControl {
+impl<'d> CpuControl<'d> {
+    pub fn new(cpu_control: impl Peripheral<P = CPU_CTRL> + 'd) -> CpuControl<'d> {
+        crate::into_ref!(cpu_control);
+
         CpuControl {
             _cpu_control: cpu_control,
         }

--- a/esp-hal/src/soc/esp32/cpu_control.rs
+++ b/esp-hal/src/soc/esp32/cpu_control.rs
@@ -13,7 +13,7 @@
 //!
 //! let counter = Mutex::new(RefCell::new(0));
 //!
-//! let mut cpu_control = CpuControl::new(system.cpu_control);
+//! let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 //! let cpu1_fnctn = || {
 //!     cpu1_task(&mut timer1, &counter);
 //! };
@@ -126,7 +126,7 @@ pub enum Error {
 
 /// Control CPU Cores
 pub struct CpuControl {
-    _cpu_control: crate::system::CpuControl,
+    _cpu_control: crate::peripherals::CPU_CTRL,
 }
 
 unsafe fn internal_park_core(core: Cpu) {
@@ -154,7 +154,7 @@ unsafe fn internal_park_core(core: Cpu) {
 }
 
 impl CpuControl {
-    pub fn new(cpu_control: crate::system::CpuControl) -> CpuControl {
+    pub fn new(cpu_control: crate::peripherals::CPU_CTRL) -> CpuControl {
         CpuControl {
             _cpu_control: cpu_control,
         }

--- a/esp-hal/src/soc/esp32/peripherals.rs
+++ b/esp-hal/src/soc/esp32/peripherals.rs
@@ -26,6 +26,7 @@ crate::peripherals! {
     APB_CTRL <= APB_CTRL,
     BB <= BB,
     BT <= virtual,
+    CPU_CTRL <= virtual,
     DAC1 <= virtual,
     DAC2 <= virtual,
     DMA <= virtual,

--- a/esp-hal/src/soc/esp32/peripherals.rs
+++ b/esp-hal/src/soc/esp32/peripherals.rs
@@ -51,6 +51,7 @@ crate::peripherals! {
     RNG <= RNG,
     RSA <= RSA,
     LPWR <= RTC_CNTL,
+    RADIO_CLK <= virtual,
     RTC_IO <= RTC_IO,
     RTC_I2C <= RTC_I2C,
     SDHOST <= SDHOST,

--- a/esp-hal/src/soc/esp32/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32/radio_clocks.rs
@@ -11,13 +11,13 @@
 //! `RadioClockControl` struct. This trait provides methods to enable, disable,
 //! reset the MAC, initialize clocks and perform other related operations.
 
-use crate::system::{RadioClockControl, RadioClockController, RadioPeripherals};
+use crate::system::{RadioClockController, RadioPeripherals};
 
 const DPORT_WIFI_CLK_WIFI_BT_COMMON_M: u32 = 0x000003c9;
 const DPORT_WIFI_CLK_WIFI_EN_M: u32 = 0x00000406;
 const DPORT_WIFI_CLK_BT_EN_M: u32 = 0x00030800;
 
-impl RadioClockController for RadioClockControl {
+impl RadioClockController for crate::peripherals::RADIO_CLK {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),

--- a/esp-hal/src/soc/esp32c2/peripherals.rs
+++ b/esp-hal/src/soc/esp32c2/peripherals.rs
@@ -34,6 +34,7 @@ crate::peripherals! {
     IO_MUX <= IO_MUX,
     LEDC <= LEDC,
     LPWR <= RTC_CNTL,
+    RADIO_CLK <= virtual,
     RNG <= RNG,
     SENSITIVE <= SENSITIVE,
     SHA <= SHA,

--- a/esp-hal/src/soc/esp32c2/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32c2/radio_clocks.rs
@@ -11,7 +11,7 @@
 //! `RadioClockControl` struct. This trait provides methods to enable, disable,
 //! reset the MAC, initialize clocks and perform other related operations.
 
-use crate::system::{RadioClockControl, RadioClockController, RadioPeripherals};
+use crate::system::{RadioClockController, RadioPeripherals};
 
 // Mask for clock bits used by both WIFI and Bluetooth, 0, 1, 2, 3, 7, 8, 9, 10,
 // 19, 20, 21, 22, 23
@@ -19,7 +19,7 @@ const SYSTEM_WIFI_CLK_WIFI_BT_COMMON_M: u32 = 0x78078F;
 // SYSTEM_WIFI_CLK_EN : R/W ;bitpos:[31:0] ;default: 32'hfffce030
 const SYSTEM_WIFI_CLK_EN: u32 = 0x00FB9FCF;
 
-impl RadioClockController for RadioClockControl {
+impl RadioClockController for crate::peripherals::RADIO_CLK {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),

--- a/esp-hal/src/soc/esp32c3/peripherals.rs
+++ b/esp-hal/src/soc/esp32c3/peripherals.rs
@@ -39,6 +39,7 @@ crate::peripherals! {
     IO_MUX <= IO_MUX,
     LEDC <= LEDC,
     LPWR <= RTC_CNTL,
+    RADIO_CLK <= virtual,
     RMT <= RMT,
     RNG <= RNG,
     RSA <= RSA,

--- a/esp-hal/src/soc/esp32c3/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32c3/radio_clocks.rs
@@ -11,7 +11,7 @@
 //! `RadioClockControl` struct. This trait provides methods to enable, disable,
 //! reset the MAC, initialize clocks and perform other related operations.
 
-use crate::system::{RadioClockControl, RadioClockController, RadioPeripherals};
+use crate::system::{RadioClockController, RadioPeripherals};
 
 // Mask for clock bits used by both WIFI and Bluetooth, 0, 1, 2, 3, 7, 8, 9, 10,
 // 19, 20, 21, 22, 23
@@ -19,7 +19,7 @@ const SYSTEM_WIFI_CLK_WIFI_BT_COMMON_M: u32 = 0x78078F;
 // SYSTEM_WIFI_CLK_EN : R/W ;bitpos:[31:0] ;default: 32'hfffce030
 const SYSTEM_WIFI_CLK_EN: u32 = 0x00FB9FCF;
 
-impl RadioClockController for RadioClockControl {
+impl RadioClockController for crate::peripherals::RADIO_CLK {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),

--- a/esp-hal/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal/src/soc/esp32c6/peripherals.rs
@@ -64,6 +64,7 @@ crate::peripherals! {
     PAU <= PAU,
     PCNT <= PCNT,
     PMU <= PMU,
+    RADIO_CLK <= virtual,
     RMT <= RMT,
     RNG <= RNG,
     RSA <= RSA,

--- a/esp-hal/src/soc/esp32c6/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32c6/radio_clocks.rs
@@ -11,9 +11,9 @@
 //! `RadioClockControl` struct. This trait provides methods to enable, disable,
 //! reset the MAC, initialize clocks and perform other related operations.
 
-use crate::system::{RadioClockControl, RadioClockController, RadioPeripherals};
+use crate::system::{RadioClockController, RadioPeripherals};
 
-impl RadioClockController for RadioClockControl {
+impl RadioClockController for crate::peripherals::RADIO_CLK {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),

--- a/esp-hal/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal/src/soc/esp32h2/peripherals.rs
@@ -57,6 +57,7 @@ crate::peripherals! {
     PAU <= PAU,
     PCNT <= PCNT,
     PMU <= PMU,
+    RADIO_CLK <= virtual,
     RMT <= RMT,
     RNG <= RNG,
     RSA <= RSA,

--- a/esp-hal/src/soc/esp32h2/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32h2/radio_clocks.rs
@@ -11,9 +11,9 @@
 //! `RadioClockControl` struct. This trait provides methods to enable, disable,
 //! reset the MAC, initialize clocks and perform other related operations.
 
-use crate::system::{RadioClockControl, RadioClockController, RadioPeripherals};
+use crate::system::{RadioClockController, RadioPeripherals};
 
-impl RadioClockController for RadioClockControl {
+impl RadioClockController for crate::peripherals::RADIO_CLK {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),

--- a/esp-hal/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal/src/soc/esp32s2/peripherals.rs
@@ -43,6 +43,7 @@ crate::peripherals! {
     PCNT <= PCNT,
     PMS <= PMS,
     PSRAM <= virtual,
+    RADIO_CLK <= virtual,
     RMT <= RMT,
     RNG <= RNG,
     RSA <= RSA,

--- a/esp-hal/src/soc/esp32s2/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32s2/radio_clocks.rs
@@ -11,13 +11,13 @@
 //! `RadioClockControl` struct. This trait provides methods to enable, disable,
 //! reset the MAC, initialize clocks and perform other related operations.
 
-use crate::system::{RadioClockControl, RadioClockController, RadioPeripherals};
+use crate::system::{RadioClockController, RadioPeripherals};
 
 // Mask for clock bits used by both WIFI and Bluetooth, bit 0, 3, 6, 7, 8, 9
 const DPORT_WIFI_CLK_WIFI_BT_COMMON_M: u32 = 0x000003c9;
 const DPORT_WIFI_CLK_WIFI_EN_M: u32 = 0x000007cf;
 
-impl RadioClockController for RadioClockControl {
+impl RadioClockController for crate::peripherals::RADIO_CLK {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),

--- a/esp-hal/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal/src/soc/esp32s3/cpu_control.rs
@@ -13,7 +13,7 @@
 //!
 //! let counter = Mutex::new(RefCell::new(0));
 //!
-//! let mut cpu_control = CpuControl::new(system.cpu_control);
+//! let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 //! let cpu1_fnctn = || {
 //!     cpu1_task(&mut timer1, &counter);
 //! };
@@ -125,7 +125,7 @@ pub enum Error {
 
 /// Control CPU Cores
 pub struct CpuControl {
-    _cpu_control: crate::system::CpuControl,
+    _cpu_control: crate::peripherals::CPU_CTRL,
 }
 
 unsafe fn internal_park_core(core: Cpu) {
@@ -153,7 +153,7 @@ unsafe fn internal_park_core(core: Cpu) {
 }
 
 impl CpuControl {
-    pub fn new(cpu_control: crate::system::CpuControl) -> CpuControl {
+    pub fn new(cpu_control: crate::peripherals::CPU_CTRL) -> CpuControl {
         CpuControl {
             _cpu_control: cpu_control,
         }

--- a/esp-hal/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal/src/soc/esp32s3/cpu_control.rs
@@ -53,7 +53,11 @@ use core::{
     mem::{ManuallyDrop, MaybeUninit},
 };
 
-use crate::Cpu;
+use crate::{
+    peripheral::{Peripheral, PeripheralRef},
+    peripherals::CPU_CTRL,
+    Cpu,
+};
 
 /// Data type for a properly aligned stack of N bytes
 // Xtensa ISA 10.5: [B]y default, the
@@ -124,8 +128,8 @@ pub enum Error {
 }
 
 /// Control CPU Cores
-pub struct CpuControl {
-    _cpu_control: crate::peripherals::CPU_CTRL,
+pub struct CpuControl<'d> {
+    _cpu_control: PeripheralRef<'d, CPU_CTRL>,
 }
 
 unsafe fn internal_park_core(core: Cpu) {
@@ -152,8 +156,10 @@ unsafe fn internal_park_core(core: Cpu) {
     }
 }
 
-impl CpuControl {
-    pub fn new(cpu_control: crate::peripherals::CPU_CTRL) -> CpuControl {
+impl<'d> CpuControl<'d> {
+    pub fn new(cpu_control: impl Peripheral<P = CPU_CTRL> + 'd) -> CpuControl<'d> {
+        crate::into_ref!(cpu_control);
+
         CpuControl {
             _cpu_control: cpu_control,
         }

--- a/esp-hal/src/soc/esp32s3/peripherals.rs
+++ b/esp-hal/src/soc/esp32s3/peripherals.rs
@@ -26,6 +26,7 @@ crate::peripherals! {
     APB_CTRL <= APB_CTRL,
     ASSIST_DEBUG <= ASSIST_DEBUG,
     BT <= virtual,
+    CPU_CTRL <= virtual,
     DMA <= DMA (DMA_IN_CH0,DMA_IN_CH1,DMA_IN_CH2,DMA_IN_CH3,DMA_IN_CH4,DMA_OUT_CH0,DMA_OUT_CH1,DMA_OUT_CH2,DMA_OUT_CH3,DMA_OUT_CH4),
     DS <= DS,
     EFUSE <= EFUSE,

--- a/esp-hal/src/soc/esp32s3/peripherals.rs
+++ b/esp-hal/src/soc/esp32s3/peripherals.rs
@@ -49,6 +49,7 @@ crate::peripherals! {
     PSRAM <= virtual,
     MCPWM0 <= MCPWM0,
     MCPWM1 <= MCPWM1,
+    RADIO_CLK <= virtual,
     RMT <= RMT,
     RNG <= RNG,
     RSA <= RSA,

--- a/esp-hal/src/soc/esp32s3/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32s3/radio_clocks.rs
@@ -10,7 +10,8 @@
 //! The module defines a `RadioClockController` trait implemented by the
 //! `RadioClockControl` struct. This trait provides methods to enable, disable,
 //! reset the MAC, initialize clocks and perform other related operations.
-use crate::system::{RadioClockControl, RadioClockController, RadioPeripherals};
+
+use crate::system::{RadioClockController, RadioPeripherals};
 
 // Note: this comment has been copied from esp-idf, including the mistake.
 // Mask for clock bits used by both WIFI and Bluetooth, 0, 1, 2, 3, 7,
@@ -20,7 +21,7 @@ const SYSTEM_WIFI_CLK_WIFI_BT_COMMON_M: u32 = 0x78078F;
 // SYSTEM_WIFI_CLK_EN : R/W ;bitpos:[31:0] ;default: 32'hfffce030
 const SYSTEM_WIFI_CLK_EN: u32 = 0x00FB9FCF;
 
-impl RadioClockController for RadioClockControl {
+impl RadioClockController for crate::peripherals::RADIO_CLK {
     fn enable(&mut self, peripheral: RadioPeripherals) {
         match peripheral {
             RadioPeripherals::Phy => enable_phy(),

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -1078,6 +1078,7 @@ pub struct SystemClockControl {
 }
 
 /// Enumeration of the available radio peripherals for this chip.
+#[cfg(any(bt, ieee802154, wifi))]
 pub enum RadioPeripherals {
     #[cfg(phy)]
     Phy,
@@ -1089,12 +1090,8 @@ pub enum RadioPeripherals {
     Ieee802154,
 }
 
-/// Functionality of clocks controlling the radio peripherals.
-pub struct RadioClockControl {
-    _private: (),
-}
-
 /// Control the radio peripheral clocks
+#[cfg(any(bt, ieee802154, wifi))]
 pub trait RadioClockController {
     /// Enable the peripheral
     fn enable(&mut self, peripheral: RadioPeripherals);
@@ -1118,7 +1115,6 @@ pub trait RadioClockController {
 pub struct SystemParts<'d> {
     _private: PeripheralRef<'d, SYSTEM>,
     pub clock_control: SystemClockControl,
-    pub radio_clock_control: RadioClockControl,
     pub software_interrupt_control: SoftwareInterruptControl,
 }
 
@@ -1138,7 +1134,6 @@ impl<'d, T: crate::peripheral::Peripheral<P = SYSTEM> + 'd> SystemExt<'d> for T 
         Self::Parts {
             _private: self.into_ref(),
             clock_control: SystemClockControl { _private: () },
-            radio_clock_control: RadioClockControl { _private: () },
             software_interrupt_control: SoftwareInterruptControl::new_internal(),
         }
     }

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -1077,11 +1077,6 @@ pub struct SystemClockControl {
     _private: (),
 }
 
-/// Controls the configuration of the chip's clocks.
-pub struct CpuControl {
-    _private: (),
-}
-
 /// Enumeration of the available radio peripherals for this chip.
 pub enum RadioPeripherals {
     #[cfg(phy)]
@@ -1123,7 +1118,6 @@ pub trait RadioClockController {
 pub struct SystemParts<'d> {
     _private: PeripheralRef<'d, SYSTEM>,
     pub clock_control: SystemClockControl,
-    pub cpu_control: CpuControl,
     pub radio_clock_control: RadioClockControl,
     pub software_interrupt_control: SoftwareInterruptControl,
 }
@@ -1144,7 +1138,6 @@ impl<'d, T: crate::peripheral::Peripheral<P = SYSTEM> + 'd> SystemExt<'d> for T 
         Self::Parts {
             _private: self.into_ref(),
             clock_control: SystemClockControl { _private: () },
-            cpu_control: CpuControl { _private: () },
             radio_clock_control: RadioClockControl { _private: () },
             software_interrupt_control: SoftwareInterruptControl::new_internal(),
         }

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -61,7 +61,7 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new_async(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timg0);
 
-    let mut cpu_control = CpuControl::new(system.cpu_control);
+    let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 
     let led_ctrl_signal = &*make_static!(Signal::new());
 

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -80,7 +80,7 @@ fn main() -> ! {
     let timg0 = TimerGroup::new_async(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timg0);
 
-    let mut cpu_control = CpuControl::new(system.cpu_control);
+    let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 
     let led_ctrl_signal = &*make_static!(Signal::new());
 

--- a/examples/src/bin/multicore.rs
+++ b/examples/src/bin/multicore.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
 
     let counter = Mutex::new(RefCell::new(0u32));
 
-    let mut cpu_control = CpuControl::new(system.cpu_control);
+    let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
     let _guard = cpu_control
         .start_app_core(unsafe { &mut *addr_of_mut!(APP_CORE_STACK) }, || {
             println!("Hello World - Core 1!");


### PR DESCRIPTION
A first step towards #1401, the changes get a little more involved from here on out so I figured I'd just split things up to keep it easy to review.

In short, I've created virtual `CPU_CTRL` and `RADIO_CLK` peripherals, rather than manually defining the structs like we used to do when splitting.

Happy to hear any feedback regarding peripheral names, I think these are reasonable though.