### PR TITLE
Update to latest (unpublished) PACs and fix all breaking changes

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -52,14 +52,14 @@ xtensa-lx            = { version = "0.9.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
-esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section", "rt"], optional = true }
+esp32   = { git = "https://github.com/esp-rs/esp-pacs", rev = "1d58d95", features = ["critical-section", "rt"], optional = true }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1d58d95", features = ["critical-section", "rt"], optional = true }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1d58d95", features = ["critical-section", "rt"], optional = true }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1d58d95", features = ["critical-section", "rt"], optional = true }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1d58d95", features = ["critical-section", "rt"], optional = true }
+esp32p4 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1d58d95", features = ["critical-section", "rt"], optional = true }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1d58d95", features = ["critical-section", "rt"], optional = true }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs", rev = "1d58d95", features = ["critical-section", "rt"], optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 esp-riscv-rt = { version = "0.7.0", path = "../esp-riscv-rt" }

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -520,7 +520,7 @@ pub mod dma {
             self.aes
                 .aes
                 .mode()
-                .modify(|_, w| w.mode().variant(mode as u8));
+                .modify(|_, w| unsafe { w.mode().bits(mode as u8) });
         }
 
         fn start_transform(&self) {

--- a/esp-hal/src/assist_debug.rs
+++ b/esp-hal/src/assist_debug.rs
@@ -68,11 +68,11 @@ impl<'d> DebugAssist<'d> {
     pub fn enable_sp_monitor(&mut self, lower_bound: u32, upper_bound: u32) {
         self.debug_assist
             .core_0_sp_min()
-            .write(|w| w.core_0_sp_min().variant(lower_bound));
+            .write(|w| unsafe { w.core_0_sp_min().bits(lower_bound) });
 
         self.debug_assist
             .core_0_sp_max()
-            .write(|w| w.core_0_sp_max().variant(upper_bound));
+            .write(|w| unsafe { w.core_0_sp_max().bits(upper_bound) });
 
         self.debug_assist.core_0_montr_ena().modify(|_, w| {
             w.core_0_sp_spill_min_ena()
@@ -151,11 +151,11 @@ impl<'d> DebugAssist<'d> {
     pub fn enable_core1_sp_monitor(&mut self, lower_bound: u32, upper_bound: u32) {
         self.debug_assist
             .core_1_sp_min
-            .write(|w| w.core_1_sp_min().variant(lower_bound));
+            .write(|w| w.core_1_sp_min().bits(lower_bound));
 
         self.debug_assist
             .core_1_sp_max
-            .write(|w| w.core_1_sp_max().variant(upper_bound));
+            .write(|w| w.core_1_sp_max().bits(upper_bound));
 
         self.debug_assist.core_1_montr_ena.modify(|_, w| {
             w.core_1_sp_spill_min_ena()
@@ -237,11 +237,11 @@ impl<'d> DebugAssist<'d> {
     ) {
         self.debug_assist
             .core_0_area_dram0_0_min()
-            .write(|w| w.core_0_area_dram0_0_min().variant(lower_bound));
+            .write(|w| unsafe { w.core_0_area_dram0_0_min().bits(lower_bound) });
 
         self.debug_assist
             .core_0_area_dram0_0_max()
-            .write(|w| w.core_0_area_dram0_0_max().variant(upper_bound));
+            .write(|w| unsafe { w.core_0_area_dram0_0_max().bits(upper_bound) });
 
         self.debug_assist.core_0_montr_ena().modify(|_, w| {
             w.core_0_area_dram0_0_rd_ena()
@@ -314,11 +314,11 @@ impl<'d> DebugAssist<'d> {
     ) {
         self.debug_assist
             .core_0_area_dram0_1_min()
-            .write(|w| w.core_0_area_dram0_1_min().variant(lower_bound));
+            .write(|w| unsafe { w.core_0_area_dram0_1_min().bits(lower_bound) });
 
         self.debug_assist
             .core_0_area_dram0_1_max()
-            .write(|w| w.core_0_area_dram0_1_max().variant(upper_bound));
+            .write(|w| unsafe { w.core_0_area_dram0_1_max().bits(upper_bound) });
 
         self.debug_assist.core_0_montr_ena().modify(|_, w| {
             w.core_0_area_dram0_1_rd_ena()
@@ -403,11 +403,11 @@ impl<'d> DebugAssist<'d> {
     ) {
         self.debug_assist
             .core_1_area_dram0_0_min()
-            .write(|w| w.core_1_area_dram0_0_min().variant(lower_bound));
+            .write(|w| unsafe { w.core_1_area_dram0_0_min().bits(lower_bound) });
 
         self.debug_assist
             .core_1_area_dram0_0_max()
-            .write(|w| w.core_1_area_dram0_0_max().variant(upper_bound));
+            .write(|w| unsafe { w.core_1_area_dram0_0_max().bits(upper_bound) });
 
         self.debug_assist.core_1_montr_ena().modify(|_, w| {
             w.core_1_area_dram0_0_rd_ena()
@@ -480,11 +480,11 @@ impl<'d> DebugAssist<'d> {
     ) {
         self.debug_assist
             .core_1_area_dram0_1_min()
-            .write(|w| w.core_1_area_dram0_1_min().variant(lower_bound));
+            .write(|w| unsafe { w.core_1_area_dram0_1_min().bits(lower_bound) });
 
         self.debug_assist
             .core_1_area_dram0_1_max()
-            .write(|w| w.core_1_area_dram0_1_max().variant(upper_bound));
+            .write(|w| unsafe { w.core_1_area_dram0_1_max().bits(upper_bound) });
 
         self.debug_assist.core_1_montr_ena().modify(|_, w| {
             w.core_1_area_dram0_1_rd_ena()

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -99,7 +99,7 @@ impl<const N: u8> RegisterAccess for Channel<N> {
     fn set_out_priority(priority: DmaPriority) {
         Self::ch()
             .out_pri()
-            .write(|w| w.tx_pri().variant(priority as u8));
+            .write(|w| unsafe { w.tx_pri().bits(priority as u8) });
     }
 
     fn clear_out_interrupts() {
@@ -145,7 +145,7 @@ impl<const N: u8> RegisterAccess for Channel<N> {
     fn set_out_peripheral(peripheral: u8) {
         Self::ch()
             .out_peri_sel()
-            .modify(|_, w| w.peri_out_sel().variant(peripheral));
+            .modify(|_, w| unsafe { w.peri_out_sel().bits(peripheral) });
     }
 
     fn start_out() {
@@ -212,7 +212,7 @@ impl<const N: u8> RegisterAccess for Channel<N> {
     fn set_in_priority(priority: DmaPriority) {
         Self::ch()
             .in_pri()
-            .write(|w| w.rx_pri().variant(priority as u8));
+            .write(|w| unsafe { w.rx_pri().bits(priority as u8) });
     }
 
     fn clear_in_interrupts() {
@@ -268,7 +268,7 @@ impl<const N: u8> RegisterAccess for Channel<N> {
     fn set_in_peripheral(peripheral: u8) {
         Self::ch()
             .in_peri_sel()
-            .modify(|_, w| w.peri_in_sel().variant(peripheral));
+            .modify(|_, w| unsafe { w.peri_in_sel().bits(peripheral) });
     }
 
     fn start_in() {

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -54,12 +54,12 @@ macro_rules! ImplSpiChannel {
                             2 => {
                                 dport
                                 .spi_dma_chan_sel()
-                                .modify(|_, w| w.spi2_dma_chan_sel().variant(1));
+                                .modify(|_, w| unsafe { w.spi2_dma_chan_sel().bits(1) });
                             },
                             3 => {
                                 dport
                                 .spi_dma_chan_sel()
-                                .modify(|_, w| w.spi3_dma_chan_sel().variant(2));
+                                .modify(|_, w| unsafe { w.spi3_dma_chan_sel().bits(2) });
                             },
                             _ => panic!("Only SPI2 and SPI3 supported"),
                         }

--- a/esp-hal/src/gpio/etm.rs
+++ b/esp-hal/src/gpio/etm.rs
@@ -315,7 +315,7 @@ fn enable_event_channel(channel: u8, pin: u8) {
         .modify(|_, w| w.etm_ch0_event_en().clear_bit());
     gpio_sd
         .etm_event_ch_cfg(channel as usize)
-        .modify(|_, w| w.etm_ch0_event_sel().variant(pin));
+        .modify(|_, w| unsafe { w.etm_ch0_event_sel().bits(pin) });
     gpio_sd
         .etm_event_ch_cfg(channel as usize)
         .modify(|_, w| w.etm_ch0_event_en().set_bit());

--- a/esp-hal/src/gpio/lp_io.rs
+++ b/esp-hal/src/gpio/lp_io.rs
@@ -38,11 +38,11 @@ impl<MODE, const PIN: u8> LowPowerPin<MODE, PIN> {
         if enable {
             lp_io
                 .out_enable_w1ts()
-                .write(|w| w.enable_w1ts().variant(1 << PIN));
+                .write(|w| unsafe { w.enable_w1ts().bits(1 << PIN) });
         } else {
             lp_io
                 .out_enable_w1tc()
-                .write(|w| w.enable_w1tc().variant(1 << PIN));
+                .write(|w| unsafe { w.enable_w1tc().bits(1 << PIN) });
         }
     }
 
@@ -64,11 +64,11 @@ impl<MODE, const PIN: u8> LowPowerPin<MODE, PIN> {
         if level {
             lp_io
                 .out_data_w1ts()
-                .write(|w| w.out_data_w1ts().variant(1 << PIN));
+                .write(|w| unsafe { w.out_data_w1ts().bits(1 << PIN) });
         } else {
             lp_io
                 .out_data_w1tc()
-                .write(|w| w.out_data_w1tc().variant(1 << PIN));
+                .write(|w| unsafe { w.out_data_w1tc().bits(1 << PIN) });
         }
     }
 
@@ -140,9 +140,9 @@ pub(crate) fn init_low_power_pin(pin: u8) {
 
     lp_aon
         .gpio_mux()
-        .modify(|r, w| w.sel().variant(r.sel().bits() | 1 << pin));
+        .modify(|r, w| unsafe { w.sel().bits(r.sel().bits() | 1 << pin) });
 
-    get_pin_reg(pin).modify(|_, w| w.mcu_sel().variant(0));
+    get_pin_reg(pin).modify(|_, w| unsafe { w.mcu_sel().bits(0) });
 }
 
 #[inline(always)]

--- a/esp-hal/src/gpio/rtc_io.rs
+++ b/esp-hal/src/gpio/rtc_io.rs
@@ -40,21 +40,15 @@ impl<MODE, const PIN: u8> LowPowerPin<MODE, PIN> {
     #[doc(hidden)]
     pub fn output_enable(&self, enable: bool) {
         let rtc_io = unsafe { crate::peripherals::RTC_IO::steal() };
-        if enable {
-            // TODO align PAC
-            #[cfg(esp32s2)]
-            rtc_io
-                .rtc_gpio_enable_w1ts()
-                .write(|w| w.reg_rtcio_reg_gpio_enable_w1ts().variant(1 << PIN));
 
-            #[cfg(esp32s3)]
+        if enable {
             rtc_io
                 .rtc_gpio_enable_w1ts()
-                .write(|w| w.rtc_gpio_enable_w1ts().variant(1 << PIN));
+                .write(|w| unsafe { w.rtc_gpio_enable_w1ts().bits(1 << PIN) });
         } else {
             rtc_io
                 .enable_w1tc()
-                .write(|w| w.enable_w1tc().variant(1 << PIN));
+                .write(|w| unsafe { w.enable_w1tc().bits(1 << PIN) });
         }
     }
 
@@ -74,27 +68,14 @@ impl<MODE, const PIN: u8> LowPowerPin<MODE, PIN> {
     pub fn set_level(&mut self, level: bool) {
         let rtc_io = unsafe { &*crate::peripherals::RTC_IO::PTR };
 
-        // TODO align PACs
-        #[cfg(esp32s2)]
         if level {
             rtc_io
                 .rtc_gpio_out_w1ts()
-                .write(|w| w.gpio_out_data_w1ts().variant(1 << PIN));
+                .write(|w| unsafe { w.rtc_gpio_out_data_w1ts().bits(1 << PIN) });
         } else {
             rtc_io
                 .rtc_gpio_out_w1tc()
-                .write(|w| w.gpio_out_data_w1tc().variant(1 << PIN));
-        }
-
-        #[cfg(esp32s3)]
-        if level {
-            rtc_io
-                .rtc_gpio_out_w1ts()
-                .write(|w| w.rtc_gpio_out_data_w1ts().variant(1 << PIN));
-        } else {
-            rtc_io
-                .rtc_gpio_out_w1tc()
-                .write(|w| w.rtc_gpio_out_data_w1tc().variant(1 << PIN));
+                .write(|w| unsafe { w.rtc_gpio_out_data_w1tc().bits(1 << PIN) });
         }
     }
 

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -1162,7 +1162,7 @@ pub trait Instance: crate::private::Sealed {
                         .to()
                         .write(|w| w.time_out_en().bit(time_out_en)
                         .time_out_value()
-                        .variant(time_out_value.try_into().unwrap())
+                        .bits(time_out_value.try_into().unwrap())
                     );
                 }
             }
@@ -1538,7 +1538,7 @@ pub trait Instance: crate::private::Sealed {
     #[cfg(not(esp32))]
     fn reset_fifo(&self) {
         // First, reset the fifo buffers
-        self.register_block().fifo_conf().modify(|_, w| {
+        self.register_block().fifo_conf().modify(|_, w| unsafe {
             w.tx_fifo_rst()
                 .set_bit()
                 .rx_fifo_rst()
@@ -1548,9 +1548,9 @@ pub trait Instance: crate::private::Sealed {
                 .fifo_prt_en()
                 .set_bit()
                 .rxfifo_wm_thrhd()
-                .variant(1)
+                .bits(1)
                 .txfifo_wm_thrhd()
-                .variant(8)
+                .bits(8)
         });
 
         self.register_block()
@@ -1571,7 +1571,7 @@ pub trait Instance: crate::private::Sealed {
     #[cfg(esp32)]
     fn reset_fifo(&self) {
         // First, reset the fifo buffers
-        self.register_block().fifo_conf().modify(|_, w| {
+        self.register_block().fifo_conf().modify(|_, w| unsafe {
             w.tx_fifo_rst()
                 .set_bit()
                 .rx_fifo_rst()
@@ -1579,9 +1579,9 @@ pub trait Instance: crate::private::Sealed {
                 .nonfifo_en()
                 .clear_bit()
                 .nonfifo_rx_thres()
-                .variant(1)
+                .bits(1)
                 .nonfifo_tx_thres()
-                .variant(32)
+                .bits(32)
         });
 
         self.register_block()
@@ -1983,9 +1983,9 @@ pub mod lp_i2c {
                 lp_aon
                     .gpio_mux()
                     .modify(|r, w| w.sel().bits(r.sel().bits() | (1 << 7)));
-                lp_io.gpio6().modify(|_, w| w.mcu_sel().variant(1)); // TODO
+                lp_io.gpio6().modify(|_, w| w.mcu_sel().bits(1)); // TODO
 
-                lp_io.gpio7().modify(|_, w| w.mcu_sel().variant(1));
+                lp_io.gpio7().modify(|_, w| w.mcu_sel().bits(1));
 
                 // Set output mode to Normal
                 lp_io.pin6().modify(|_, w| w.pad_driver().set_bit());
@@ -2169,7 +2169,7 @@ pub mod lp_i2c {
                     w.time_out_en()
                         .bit(time_out_en)
                         .time_out_value()
-                        .variant(time_out_value.try_into().unwrap())
+                        .bits(time_out_value.try_into().unwrap())
                 });
             }
 

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -1172,25 +1172,25 @@ mod private {
             #[cfg(esp32)]
             i2s.clkm_conf().modify(|_, w| w.clka_ena().clear_bit());
 
-            i2s.clkm_conf().modify(|_, w| {
+            i2s.clkm_conf().modify(|_, w| unsafe {
                 w.clk_en()
                     .set_bit()
                     .clkm_div_num()
-                    .variant(clock_settings.mclk_divider as u8)
+                    .bits(clock_settings.mclk_divider as u8)
             });
 
-            i2s.clkm_conf().modify(|_, w| {
+            i2s.clkm_conf().modify(|_, w| unsafe {
                 w.clkm_div_a()
-                    .variant(clock_settings.denominator as u8)
+                    .bits(clock_settings.denominator as u8)
                     .clkm_div_b()
-                    .variant(clock_settings.numerator as u8)
+                    .bits(clock_settings.numerator as u8)
             });
 
-            i2s.sample_rate_conf().modify(|_, w| {
+            i2s.sample_rate_conf().modify(|_, w| unsafe {
                 w.tx_bck_div_num()
-                    .variant(clock_settings.bclk_divider as u8)
+                    .bits(clock_settings.bclk_divider as u8)
                     .rx_bck_div_num()
-                    .variant(clock_settings.bclk_divider as u8)
+                    .bits(clock_settings.bclk_divider as u8)
             });
         }
 
@@ -1203,9 +1203,9 @@ mod private {
             };
 
             i2s.sample_rate_conf()
-                .modify(|_, w| w.tx_bits_mod().variant(data_format.channel_bits()));
+                .modify(|_, w| unsafe { w.tx_bits_mod().bits(data_format.channel_bits()) });
             i2s.sample_rate_conf()
-                .modify(|_, w| w.rx_bits_mod().variant(data_format.channel_bits()));
+                .modify(|_, w| unsafe { w.rx_bits_mod().bits(data_format.channel_bits()) });
 
             i2s.conf().modify(|_, w| {
                 w.tx_slave_mod()
@@ -1217,9 +1217,9 @@ mod private {
                     .rx_msb_shift()
                     .set_bit() // ?
                     .tx_short_sync()
-                    .variant(false) //??
+                    .bit(false) //??
                     .rx_short_sync()
-                    .variant(false) //??
+                    .bit(false) //??
                     .tx_msb_right()
                     .clear_bit()
                     .rx_msb_right()
@@ -1236,21 +1236,21 @@ mod private {
                     .clear_bit()
             });
 
-            i2s.fifo_conf().modify(|_, w| {
+            i2s.fifo_conf().modify(|_, w| unsafe {
                 w.tx_fifo_mod()
-                    .variant(fifo_mod)
+                    .bits(fifo_mod)
                     .tx_fifo_mod_force_en()
                     .set_bit()
                     .dscr_en()
                     .set_bit()
                     .rx_fifo_mod()
-                    .variant(fifo_mod)
+                    .bits(fifo_mod)
                     .rx_fifo_mod_force_en()
                     .set_bit()
             });
 
             i2s.conf_chan()
-                .modify(|_, w| w.tx_chan_mod().variant(0).rx_chan_mod().variant(0)); // for now only stereo
+                .modify(|_, w| unsafe { w.tx_chan_mod().bits(0).rx_chan_mod().bits(0) }); // for now only stereo
 
             i2s.conf1()
                 .modify(|_, w| w.tx_pcm_bypass().set_bit().rx_pcm_bypass().set_bit());
@@ -1338,12 +1338,12 @@ mod private {
 
             #[cfg(not(esp32))]
             i2s.rxeof_num()
-                .modify(|_, w| w.rx_eof_num().variant(len as u32));
+                .modify(|_, w| unsafe { w.rx_eof_num().bits(len as u32) });
 
             // On ESP32, the eof_num count in words.
             #[cfg(esp32)]
             i2s.rxeof_num()
-                .modify(|_, w| w.rx_eof_num().variant((len / 4) as u32));
+                .modify(|_, w| unsafe { w.rx_eof_num().bits((len / 4) as u32) });
 
             i2s.conf().modify(|_, w| w.rx_start().set_bit());
         }
@@ -1489,58 +1489,58 @@ mod private {
                 clkm_div_yn1 = 0;
             }
 
-            i2s.tx_clkm_div_conf().modify(|_, w| {
+            i2s.tx_clkm_div_conf().modify(|_, w| unsafe {
                 w.tx_clkm_div_x()
-                    .variant(clkm_div_x as u16)
+                    .bits(clkm_div_x as u16)
                     .tx_clkm_div_y()
-                    .variant(clkm_div_y as u16)
+                    .bits(clkm_div_y as u16)
                     .tx_clkm_div_yn1()
-                    .variant(clkm_div_yn1 != 0)
+                    .bit(clkm_div_yn1 != 0)
                     .tx_clkm_div_z()
-                    .variant(clkm_div_z as u16)
+                    .bits(clkm_div_z as u16)
             });
 
-            i2s.tx_clkm_conf().modify(|_, w| {
+            i2s.tx_clkm_conf().modify(|_, w| unsafe {
                 w.clk_en()
                     .set_bit()
                     .tx_clk_active()
                     .set_bit()
                     .tx_clk_sel()
-                    .variant(crate::soc::constants::I2S_DEFAULT_CLK_SRC) // for now fixed at 160MHz
+                    .bits(crate::soc::constants::I2S_DEFAULT_CLK_SRC) // for now fixed at 160MHz
                     .tx_clkm_div_num()
-                    .variant(clock_settings.mclk_divider as u8)
+                    .bits(clock_settings.mclk_divider as u8)
             });
 
-            i2s.tx_conf1().modify(|_, w| {
+            i2s.tx_conf1().modify(|_, w| unsafe {
                 w.tx_bck_div_num()
-                    .variant((clock_settings.bclk_divider - 1) as u8)
+                    .bits((clock_settings.bclk_divider - 1) as u8)
             });
 
-            i2s.rx_clkm_div_conf().modify(|_, w| {
+            i2s.rx_clkm_div_conf().modify(|_, w| unsafe {
                 w.rx_clkm_div_x()
-                    .variant(clkm_div_x as u16)
+                    .bits(clkm_div_x as u16)
                     .rx_clkm_div_y()
-                    .variant(clkm_div_y as u16)
+                    .bits(clkm_div_y as u16)
                     .rx_clkm_div_yn1()
-                    .variant(clkm_div_yn1 != 0)
+                    .bit(clkm_div_yn1 != 0)
                     .rx_clkm_div_z()
-                    .variant(clkm_div_z as u16)
+                    .bits(clkm_div_z as u16)
             });
 
-            i2s.rx_clkm_conf().modify(|_, w| {
+            i2s.rx_clkm_conf().modify(|_, w| unsafe {
                 w.rx_clk_active()
                     .set_bit()
                     .rx_clk_sel()
-                    .variant(crate::soc::constants::I2S_DEFAULT_CLK_SRC) // for now fixed at 160MHz
+                    .bits(crate::soc::constants::I2S_DEFAULT_CLK_SRC) // for now fixed at 160MHz
                     .rx_clkm_div_num()
-                    .variant(clock_settings.mclk_divider as u8)
+                    .bits(clock_settings.mclk_divider as u8)
                     .mclk_sel()
-                    .variant(true)
+                    .bit(true)
             });
 
-            i2s.rx_conf1().modify(|_, w| {
+            i2s.rx_conf1().modify(|_, w| unsafe {
                 w.rx_bck_div_num()
-                    .variant((clock_settings.bclk_divider - 1) as u8)
+                    .bits((clock_settings.bclk_divider - 1) as u8)
             });
         }
 
@@ -1588,67 +1588,67 @@ mod private {
                 clkm_div_yn1 = 0;
             }
 
-            pcr.i2s_tx_clkm_div_conf().modify(|_, w| {
+            pcr.i2s_tx_clkm_div_conf().modify(|_, w| unsafe {
                 w.i2s_tx_clkm_div_x()
-                    .variant(clkm_div_x as u16)
+                    .bits(clkm_div_x as u16)
                     .i2s_tx_clkm_div_y()
-                    .variant(clkm_div_y as u16)
+                    .bits(clkm_div_y as u16)
                     .i2s_tx_clkm_div_yn1()
-                    .variant(clkm_div_yn1 != 0)
+                    .bit(clkm_div_yn1 != 0)
                     .i2s_tx_clkm_div_z()
-                    .variant(clkm_div_z as u16)
+                    .bits(clkm_div_z as u16)
             });
 
-            pcr.i2s_tx_clkm_conf().modify(|_, w| {
+            pcr.i2s_tx_clkm_conf().modify(|_, w| unsafe {
                 w.i2s_tx_clkm_en()
                     .set_bit()
                     .i2s_tx_clkm_sel()
-                    .variant(crate::soc::constants::I2S_DEFAULT_CLK_SRC) // for now fixed at 160MHz for C6 and 96MHz for H2
+                    .bits(crate::soc::constants::I2S_DEFAULT_CLK_SRC) // for now fixed at 160MHz for C6 and 96MHz for H2
                     .i2s_tx_clkm_div_num()
-                    .variant(clock_settings.mclk_divider as u8)
+                    .bits(clock_settings.mclk_divider as u8)
             });
 
             #[cfg(not(esp32h2))]
-            i2s.tx_conf1().modify(|_, w| {
+            i2s.tx_conf1().modify(|_, w| unsafe {
                 w.tx_bck_div_num()
-                    .variant((clock_settings.bclk_divider - 1) as u8)
+                    .bits((clock_settings.bclk_divider - 1) as u8)
             });
             #[cfg(esp32h2)]
-            i2s.tx_conf().modify(|_, w| {
+            i2s.tx_conf().modify(|_, w| unsafe {
                 w.tx_bck_div_num()
-                    .variant((clock_settings.bclk_divider - 1) as u8)
+                    .bits((clock_settings.bclk_divider - 1) as u8)
             });
 
-            pcr.i2s_rx_clkm_div_conf().modify(|_, w| {
+            pcr.i2s_rx_clkm_div_conf().modify(|_, w| unsafe {
                 w.i2s_rx_clkm_div_x()
-                    .variant(clkm_div_x as u16)
+                    .bits(clkm_div_x as u16)
                     .i2s_rx_clkm_div_y()
-                    .variant(clkm_div_y as u16)
+                    .bits(clkm_div_y as u16)
                     .i2s_rx_clkm_div_yn1()
-                    .variant(clkm_div_yn1 != 0)
+                    .bit(clkm_div_yn1 != 0)
                     .i2s_rx_clkm_div_z()
-                    .variant(clkm_div_z as u16)
+                    .bits(clkm_div_z as u16)
             });
 
-            pcr.i2s_rx_clkm_conf().modify(|_, w| {
+            pcr.i2s_rx_clkm_conf().modify(|_, w| unsafe {
                 w.i2s_rx_clkm_en()
                     .set_bit()
                     .i2s_rx_clkm_sel()
-                    .variant(crate::soc::constants::I2S_DEFAULT_CLK_SRC) // for now fixed at 160MHz for C6 and 96MHz for H2
+                    .bits(crate::soc::constants::I2S_DEFAULT_CLK_SRC) // for now fixed at 160MHz for C6 and 96MHz for H2
                     .i2s_rx_clkm_div_num()
-                    .variant(clock_settings.mclk_divider as u8)
+                    .bits(clock_settings.mclk_divider as u8)
                     .i2s_mclk_sel()
-                    .variant(true)
+                    .bit(true)
             });
             #[cfg(not(esp32h2))]
-            i2s.rx_conf1().modify(|_, w| {
+            i2s.rx_conf1().modify(|_, w| unsafe {
                 w.rx_bck_div_num()
-                    .variant((clock_settings.bclk_divider - 1) as u8)
+                    .bits((clock_settings.bclk_divider - 1) as u8)
             });
             #[cfg(esp32h2)]
-            i2s.rx_conf().modify(|_, w| {
+            i2s.rx_conf().modify(|_, w| unsafe {
                 w.rx_bck_div_num()
-                    .variant((clock_settings.bclk_divider - 1) as u8)
+                    .bits((clock_settings.bclk_divider - 1) as u8)
             });
         }
 
@@ -1656,21 +1656,21 @@ mod private {
             let i2s = Self::register_block();
 
             #[allow(clippy::useless_conversion)]
-            i2s.tx_conf1().modify(|_, w| {
+            i2s.tx_conf1().modify(|_, w| unsafe {
                 w.tx_tdm_ws_width()
-                    .variant((data_format.channel_bits() - 1).into())
+                    .bits((data_format.channel_bits() - 1).into())
                     .tx_bits_mod()
-                    .variant(data_format.data_bits() - 1)
+                    .bits(data_format.data_bits() - 1)
                     .tx_tdm_chan_bits()
-                    .variant(data_format.channel_bits() - 1)
+                    .bits(data_format.channel_bits() - 1)
                     .tx_half_sample_bits()
-                    .variant(data_format.channel_bits() - 1)
+                    .bits(data_format.channel_bits() - 1)
             });
             #[cfg(not(esp32h2))]
             i2s.tx_conf1().modify(|_, w| w.tx_msb_shift().set_bit());
             #[cfg(esp32h2)]
             i2s.tx_conf().modify(|_, w| w.tx_msb_shift().set_bit());
-            i2s.tx_conf().modify(|_, w| {
+            i2s.tx_conf().modify(|_, w| unsafe {
                 w.tx_mono()
                     .clear_bit()
                     .tx_mono_fst_vld()
@@ -1690,12 +1690,12 @@ mod private {
                     .tx_bit_order()
                     .clear_bit()
                     .tx_chan_mod()
-                    .variant(0)
+                    .bits(0)
             });
 
-            i2s.tx_tdm_ctrl().modify(|_, w| {
+            i2s.tx_tdm_ctrl().modify(|_, w| unsafe {
                 w.tx_tdm_tot_chan_num()
-                    .variant(1)
+                    .bits(1)
                     .tx_tdm_chan0_en()
                     .set_bit()
                     .tx_tdm_chan1_en()
@@ -1731,28 +1731,28 @@ mod private {
             });
 
             #[allow(clippy::useless_conversion)]
-            i2s.rx_conf1().modify(|_, w| {
+            i2s.rx_conf1().modify(|_, w| unsafe {
                 w.rx_tdm_ws_width()
-                    .variant((data_format.channel_bits() - 1).into())
+                    .bits((data_format.channel_bits() - 1).into())
                     .rx_bits_mod()
-                    .variant(data_format.data_bits() - 1)
+                    .bits(data_format.data_bits() - 1)
                     .rx_tdm_chan_bits()
-                    .variant(data_format.channel_bits() - 1)
+                    .bits(data_format.channel_bits() - 1)
                     .rx_half_sample_bits()
-                    .variant(data_format.channel_bits() - 1)
+                    .bits(data_format.channel_bits() - 1)
             });
             #[cfg(not(esp32h2))]
             i2s.rx_conf1().modify(|_, w| w.rx_msb_shift().set_bit());
             #[cfg(esp32h2)]
             i2s.rx_conf().modify(|_, w| w.rx_msb_shift().set_bit());
 
-            i2s.rx_conf().modify(|_, w| {
+            i2s.rx_conf().modify(|_, w| unsafe {
                 w.rx_mono()
                     .clear_bit()
                     .rx_mono_fst_vld()
                     .set_bit()
                     .rx_stop_mode()
-                    .variant(2)
+                    .bits(2)
                     .rx_tdm_en()
                     .set_bit()
                     .rx_pdm_en()
@@ -1765,9 +1765,9 @@ mod private {
                     .clear_bit()
             });
 
-            i2s.rx_tdm_ctrl().modify(|_, w| {
+            i2s.rx_tdm_ctrl().modify(|_, w| unsafe {
                 w.rx_tdm_tot_chan_num()
-                    .variant(1)
+                    .bits(1)
                     .rx_tdm_pdm_chan0_en()
                     .set_bit()
                     .rx_tdm_pdm_chan1_en()
@@ -1862,7 +1862,7 @@ mod private {
         fn rx_start(len: usize) {
             let i2s = Self::register_block();
             i2s.rxeof_num()
-                .write(|w| w.rx_eof_num().variant(len as u16));
+                .write(|w| unsafe { w.rx_eof_num().bits(len as u16) });
             i2s.rx_conf().modify(|_, w| w.rx_start().set_bit());
         }
 

--- a/esp-hal/src/mcpwm/mod.rs
+++ b/esp-hal/src/mcpwm/mod.rs
@@ -108,7 +108,7 @@ impl<'d, PWM: PwmPeripheral> MCPWM<'d, PWM> {
             // set prescaler
             peripheral
                 .clk_cfg()
-                .write(|w| w.clk_prescale().variant(peripheral_clock.prescaler));
+                .write(|w| unsafe { w.clk_prescale().bits(peripheral_clock.prescaler) });
 
             // enable clock
             peripheral.clk().write(|w| w.en().set_bit());
@@ -120,7 +120,7 @@ impl<'d, PWM: PwmPeripheral> MCPWM<'d, PWM> {
                 .pwm_clk_conf()
                 .modify(|_, w| unsafe {
                     w.pwm_div_num()
-                        .variant(peripheral_clock.prescaler)
+                        .bits(peripheral_clock.prescaler)
                         .pwm_clkm_en()
                         .set_bit()
                         .pwm_clkm_sel()
@@ -136,7 +136,7 @@ impl<'d, PWM: PwmPeripheral> MCPWM<'d, PWM> {
                 .pwm_clk_conf()
                 .modify(|_, w| unsafe {
                     w.pwm_div_num()
-                        .variant(peripheral_clock.prescaler)
+                        .bits(peripheral_clock.prescaler)
                         .pwm_clkm_en()
                         .set_bit()
                         .pwm_clkm_sel()

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -179,9 +179,9 @@ impl<const OP: u8, PWM: PwmPeripheral> Operator<OP, PWM> {
         // We only write to our OPERATORx_TIMERSEL register
         let block = unsafe { &*PWM::block() };
         block.operator_timersel().modify(|_, w| match OP {
-            0 => w.operator0_timersel().variant(TIM),
-            1 => w.operator1_timersel().variant(TIM),
-            2 => w.operator2_timersel().variant(TIM),
+            0 => unsafe { w.operator0_timersel().bits(TIM) },
+            1 => unsafe { w.operator1_timersel().bits(TIM) },
+            2 => unsafe { w.operator2_timersel().bits(TIM) },
             _ => {
                 unreachable!()
             }

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -351,12 +351,8 @@ where
 {
     fn configure(&mut self) {
         let pcr = unsafe { &*crate::peripherals::PCR::PTR };
-        pcr.parl_clk_tx_conf().modify(|_, w| {
-            w.parl_clk_tx_sel()
-                .variant(3)
-                .parl_clk_tx_div_num()
-                .variant(0)
-        }); // PAD_CLK_TX, no divider
+        pcr.parl_clk_tx_conf()
+            .modify(|_, w| unsafe { w.parl_clk_tx_sel().bits(3).parl_clk_tx_div_num().bits(0) }); // PAD_CLK_TX, no divider
 
         self.pin
             .set_to_input()
@@ -387,12 +383,8 @@ where
 {
     fn configure(&mut self) {
         let pcr = unsafe { &*crate::peripherals::PCR::PTR };
-        pcr.parl_clk_rx_conf().modify(|_, w| {
-            w.parl_clk_rx_sel()
-                .variant(3)
-                .parl_clk_rx_div_num()
-                .variant(0)
-        }); // PAD_CLK_TX, no divider
+        pcr.parl_clk_rx_conf()
+            .modify(|_, w| unsafe { w.parl_clk_rx_sel().bits(3).parl_clk_rx_div_num().bits(0) }); // PAD_CLK_TX, no divider
 
         self.pin
             .set_to_input()
@@ -1351,22 +1343,22 @@ where
     }
     let divider = divider as u16;
 
-    pcr.parl_clk_tx_conf().modify(|_, w| {
+    pcr.parl_clk_tx_conf().modify(|_, w| unsafe {
         w.parl_clk_tx_en()
             .set_bit()
             .parl_clk_tx_sel()
-            .variant(1) // PLL
+            .bits(1) // PLL
             .parl_clk_tx_div_num()
-            .variant(divider)
+            .bits(divider)
     });
 
-    pcr.parl_clk_rx_conf().modify(|_, w| {
+    pcr.parl_clk_rx_conf().modify(|_, w| unsafe {
         w.parl_clk_rx_en()
             .set_bit()
             .parl_clk_rx_sel()
-            .variant(1) // PLL
+            .bits(1) // PLL
             .parl_clk_rx_div_num()
-            .variant(divider)
+            .bits(divider)
     });
     Instance::set_rx_sw_en(true);
     Instance::set_rx_sample_mode(SampleMode::InternalSoftwareEnable);
@@ -1806,7 +1798,7 @@ mod private {
 
             reg_block
                 .tx_cfg0()
-                .modify(|_, w| w.tx_bus_wid_sel().variant(width as u8));
+                .modify(|_, w| unsafe { w.tx_bus_wid_sel().bits(width as u8) });
         }
 
         pub fn set_tx_idle_value(value: u16) {
@@ -1814,7 +1806,7 @@ mod private {
                 unsafe { crate::peripherals::PARL_IO::steal() };
             reg_block
                 .tx_cfg1()
-                .modify(|_, w| w.tx_idle_value().variant(value));
+                .modify(|_, w| unsafe { w.tx_idle_value().bits(value) });
         }
 
         pub fn set_tx_sample_edge(value: SampleEdge) {
@@ -1822,7 +1814,7 @@ mod private {
                 unsafe { crate::peripherals::PARL_IO::steal() };
             reg_block
                 .tx_cfg0()
-                .modify(|_, w| w.tx_smp_edge_sel().variant(value as u8 == 1));
+                .modify(|_, w| w.tx_smp_edge_sel().bit(value as u8 == 1));
         }
 
         pub fn set_tx_bit_order(value: BitPackOrder) {
@@ -1830,7 +1822,7 @@ mod private {
                 unsafe { crate::peripherals::PARL_IO::steal() };
             reg_block
                 .tx_cfg0()
-                .modify(|_, w| w.tx_bit_unpack_order().variant(value as u8 == 1));
+                .modify(|_, w| w.tx_bit_unpack_order().bit(value as u8 == 1));
         }
 
         pub fn clear_tx_interrupts() {
@@ -1851,7 +1843,7 @@ mod private {
 
             reg_block
                 .tx_cfg0()
-                .modify(|_, w| w.tx_bytelen().variant(len));
+                .modify(|_, w| unsafe { w.tx_bytelen().bits(len) });
         }
 
         pub fn is_tx_ready() -> bool {
@@ -1894,7 +1886,7 @@ mod private {
 
             reg_block
                 .rx_cfg0()
-                .modify(|_, w| w.rx_bus_wid_sel().variant(width as u8));
+                .modify(|_, w| unsafe { w.rx_bus_wid_sel().bits(width as u8) });
         }
 
         pub fn rx_valid_pin_signal() -> crate::gpio::InputSignal {
@@ -1923,7 +1915,7 @@ mod private {
 
             reg_block
                 .rx_cfg0()
-                .modify(|_, w| w.rx_data_bytelen().variant(len));
+                .modify(|_, w| unsafe { w.rx_data_bytelen().bits(len) });
         }
 
         pub fn set_rx_sample_mode(sample_mode: SampleMode) {
@@ -1932,7 +1924,7 @@ mod private {
 
             reg_block
                 .rx_cfg0()
-                .modify(|_, w| w.rx_smp_mode_sel().variant(sample_mode as u8));
+                .modify(|_, w| unsafe { w.rx_smp_mode_sel().bits(sample_mode as u8) });
         }
 
         pub fn set_eof_gen_sel(mode: EofMode) {
@@ -1941,7 +1933,7 @@ mod private {
 
             reg_block
                 .rx_cfg0()
-                .modify(|_, w| w.rx_eof_gen_sel().variant(mode == EofMode::EnableSignal));
+                .modify(|_, w| w.rx_eof_gen_sel().bit(mode == EofMode::EnableSignal));
         }
 
         pub fn set_rx_pulse_submode_sel(sel: u8) {
@@ -1950,7 +1942,7 @@ mod private {
 
             reg_block
                 .rx_cfg0()
-                .modify(|_, w| w.rx_pulse_submode_sel().variant(sel));
+                .modify(|_, w| unsafe { w.rx_pulse_submode_sel().bits(sel) });
         }
 
         pub fn set_rx_level_submode_sel(sel: u8) {
@@ -1959,7 +1951,7 @@ mod private {
 
             reg_block
                 .rx_cfg0()
-                .modify(|_, w| w.rx_level_submode_sel().variant(sel == 1));
+                .modify(|_, w| w.rx_level_submode_sel().bit(sel == 1));
         }
 
         pub fn set_rx_clk_edge_sel(edge: SampleEdge) {
@@ -1968,7 +1960,7 @@ mod private {
 
             reg_block
                 .rx_cfg0()
-                .modify(|_, w| w.rx_clk_edge_sel().variant(edge as u8 == 1));
+                .modify(|_, w| w.rx_clk_edge_sel().bit(edge as u8 == 1));
         }
 
         pub fn set_rx_start(value: bool) {
@@ -1992,17 +1984,17 @@ mod private {
                 unsafe { crate::peripherals::PARL_IO::steal() };
             reg_block
                 .rx_cfg0()
-                .modify(|_, w| w.rx_bit_pack_order().variant(value as u8 == 1));
+                .modify(|_, w| w.rx_bit_pack_order().bit(value as u8 == 1));
         }
 
         pub fn set_rx_timeout_ticks(value: Option<u16>) {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
-            reg_block.rx_cfg1().modify(|_, w| {
+            reg_block.rx_cfg1().modify(|_, w| unsafe {
                 w.rx_timeout_en()
                     .bit(value.is_some())
                     .rx_timeout_threshold()
-                    .variant(value.unwrap_or(0xfff))
+                    .bits(value.unwrap_or(0xfff))
             });
         }
 
@@ -2062,7 +2054,7 @@ mod private {
 
             reg_block
                 .tx_data_cfg()
-                .modify(|_, w| w.tx_bus_wid_sel().variant(width as u8));
+                .modify(|_, w| unsafe { w.tx_bus_wid_sel().bits(width as u8) });
         }
 
         pub fn set_tx_idle_value(value: u16) {
@@ -2070,7 +2062,7 @@ mod private {
                 unsafe { crate::peripherals::PARL_IO::steal() };
             reg_block
                 .tx_genrl_cfg()
-                .modify(|_, w| w.tx_idle_value().variant(value));
+                .modify(|_, w| unsafe { w.tx_idle_value().bits(value) });
         }
 
         pub fn set_tx_sample_edge(value: SampleEdge) {
@@ -2089,7 +2081,7 @@ mod private {
                 unsafe { crate::peripherals::PARL_IO::steal() };
             reg_block
                 .tx_data_cfg()
-                .modify(|_, w| w.tx_data_order_inv().variant(value as u8 == 1));
+                .modify(|_, w| w.tx_data_order_inv().bit(value as u8 == 1));
         }
 
         pub fn clear_tx_interrupts() {
@@ -2110,7 +2102,7 @@ mod private {
 
             reg_block
                 .tx_data_cfg()
-                .modify(|_, w| w.tx_bitlen().variant((len as u32) * 8));
+                .modify(|_, w| unsafe { w.tx_bitlen().bits((len as u32) * 8) });
         }
 
         pub fn is_tx_ready() -> bool {
@@ -2155,7 +2147,7 @@ mod private {
 
             reg_block
                 .rx_data_cfg()
-                .modify(|_, w| w.rx_bus_wid_sel().variant(width as u8));
+                .modify(|_, w| unsafe { w.rx_bus_wid_sel().bits(width as u8) });
         }
 
         pub fn rx_valid_pin_signal() -> crate::gpio::InputSignal {
@@ -2186,7 +2178,7 @@ mod private {
 
             reg_block
                 .rx_data_cfg()
-                .modify(|_, w| w.rx_bitlen().variant((len as u32) * 8));
+                .modify(|_, w| unsafe { w.rx_bitlen().bits((len as u32) * 8) });
         }
 
         pub fn set_rx_sample_mode(sample_mode: SampleMode) {
@@ -2195,7 +2187,7 @@ mod private {
 
             reg_block
                 .rx_mode_cfg()
-                .modify(|_, w| w.rx_smp_mode_sel().variant(sample_mode as u8));
+                .modify(|_, w| unsafe { w.rx_smp_mode_sel().bits(sample_mode as u8) });
         }
 
         pub fn set_eof_gen_sel(mode: EofMode) {
@@ -2204,7 +2196,7 @@ mod private {
 
             reg_block
                 .rx_genrl_cfg()
-                .modify(|_, w| w.rx_eof_gen_sel().variant(mode == EofMode::EnableSignal));
+                .modify(|_, w| w.rx_eof_gen_sel().bit(mode == EofMode::EnableSignal));
         }
 
         pub fn set_rx_pulse_submode_sel(sel: u8) {
@@ -2213,7 +2205,7 @@ mod private {
 
             reg_block
                 .rx_mode_cfg()
-                .modify(|_, w| w.rx_pulse_submode_sel().variant(sel));
+                .modify(|_, w| unsafe { w.rx_pulse_submode_sel().bits(sel) });
         }
 
         pub fn set_rx_level_submode_sel(_sel: u8) {
@@ -2255,17 +2247,17 @@ mod private {
                 unsafe { crate::peripherals::PARL_IO::steal() };
             reg_block
                 .rx_data_cfg()
-                .modify(|_, w| w.rx_data_order_inv().variant(value as u8 == 1));
+                .modify(|_, w| w.rx_data_order_inv().bit(value as u8 == 1));
         }
 
         pub fn set_rx_timeout_ticks(value: Option<u16>) {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
-            reg_block.rx_genrl_cfg().modify(|_, w| {
+            reg_block.rx_genrl_cfg().modify(|_, w| unsafe {
                 w.rx_timeout_en()
                     .bit(value.is_some())
                     .rx_timeout_thres()
-                    .variant(value.unwrap_or(0xfff))
+                    .bits(value.unwrap_or(0xfff))
             });
         }
 

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -287,9 +287,9 @@ fn modem_clock_hal_select_wifi_lpclk_source(src: ModemClockLpclkSource) {
             | ModemClockLpclkSource::RcFast
             | ModemClockLpclkSource::MainXtal => w,
 
-            ModemClockLpclkSource::RC32K => w.clk_modem_32k_sel().variant(1),
-            ModemClockLpclkSource::XTAL32K => w.clk_modem_32k_sel().variant(0),
-            ModemClockLpclkSource::EXT32K => w.clk_modem_32k_sel().variant(2),
+            ModemClockLpclkSource::RC32K => w.clk_modem_32k_sel().bits(1),
+            ModemClockLpclkSource::XTAL32K => w.clk_modem_32k_sel().bits(0),
+            ModemClockLpclkSource::EXT32K => w.clk_modem_32k_sel().bits(2),
         });
     }
 }
@@ -1811,11 +1811,11 @@ impl RtcClock {
         let timg0 = unsafe { crate::peripherals::TIMG0::steal() };
         while timg0.rtccalicfg().read().rtc_cali_rdy().bit_is_clear() {}
 
-        timg0.rtccalicfg().modify(|_, w| {
+        timg0.rtccalicfg().modify(|_, w| unsafe {
             w.rtc_cali_clk_sel()
-                .variant(0) // RTC_SLOW_CLK
+                .bits(0) // RTC_SLOW_CLK
                 .rtc_cali_max()
-                .variant(100)
+                .bits(100)
                 .rtc_cali_start_cycling()
                 .clear_bit()
                 .rtc_cali_start()

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -618,11 +618,11 @@ impl RtcClock {
         let timg0 = unsafe { crate::peripherals::TIMG0::steal() };
         while timg0.rtccalicfg().read().rtc_cali_rdy().bit_is_clear() {}
 
-        timg0.rtccalicfg().modify(|_, w| {
+        timg0.rtccalicfg().modify(|_, w| unsafe {
             w.rtc_cali_clk_sel()
-                .variant(0) // RTC_SLOW_CLK
+                .bits(0) // RTC_SLOW_CLK
                 .rtc_cali_max()
-                .variant(100)
+                .bits(100)
                 .rtc_cali_start_cycling()
                 .clear_bit()
                 .rtc_cali_start()

--- a/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
@@ -172,7 +172,7 @@ fn isolate_digital_gpio() {
             // make pad work as gpio (otherwise, deep_sleep bottom current will rise)
             io_mux
                 .gpio(pin_num)
-                .modify(|_, w| w.mcu_sel().variant(RtcFunction::Digital as u8));
+                .modify(|_, w| unsafe { w.mcu_sel().bits(RtcFunction::Digital as u8) });
         }
     }
 }

--- a/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
@@ -197,8 +197,8 @@ impl<'a, 'b> RtcioWakeupSource<'a, 'b> {
 
         pin.rtc_set_config(true, true, RtcFunction::Rtc);
 
-        rtcio.pin(pin.number() as usize).modify(|_, w| {
-            w.wakeup_enable().set_bit().int_type().variant(match level {
+        rtcio.pin(pin.number() as usize).modify(|_, w| unsafe {
+            w.wakeup_enable().set_bit().int_type().bits(match level {
                 WakeupLevel::Low => 4,
                 WakeupLevel::High => 5,
             })

--- a/esp-hal/src/soc/esp32/psram.rs
+++ b/esp-hal/src/soc/esp32/psram.rs
@@ -655,7 +655,7 @@ pub(crate) mod utils {
             });
             dport
                 .pro_cache_ctrl1()
-                .modify(|_, w| w.pro_cmmu_sram_page_mode().variant(0));
+                .modify(|_, w| w.pro_cmmu_sram_page_mode().bits(0));
 
             // use Dram1 to visit ext sram. cache page mode : 1 -->16k  4 -->2k
             // 0-->32k,(accord with the settings in cache_sram_mmu_set)
@@ -667,7 +667,7 @@ pub(crate) mod utils {
             });
             dport
                 .app_cache_ctrl1()
-                .modify(|_, w| w.app_cmmu_sram_page_mode().variant(0));
+                .modify(|_, w| w.app_cmmu_sram_page_mode().bits(0));
         }
 
         // ENABLE SPI0 CS1 TO PSRAM(CS0--FLASH; CS1--SRAM)

--- a/esp-hal/src/soc/esp32c2/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32c2/radio_clocks.rs
@@ -118,7 +118,7 @@ fn ble_rtc_clk_init() {
     // assume 40MHz xtal
     modem_clkrst
         .modem_lp_timer_conf()
-        .modify(|_, w| w.lp_timer_clk_div_num().variant(249));
+        .modify(|_, w| unsafe { w.lp_timer_clk_div_num().bits(249) });
 
     modem_clkrst
         .etm_clk_conf()

--- a/esp-hal/src/soc/esp32c6/lp_core.rs
+++ b/esp-hal/src/soc/esp32c6/lp_core.rs
@@ -168,7 +168,7 @@ fn ulp_lp_core_run(wakeup_src: LpCoreWakeupSource) {
         LpCoreWakeupSource::HpCpu => 0x01,
     };
     pmu.lp_cpu_pwr1()
-        .modify(|_, w| w.lp_cpu_wakeup_en().variant(src));
+        .modify(|_, w| unsafe { w.lp_cpu_wakeup_en().bits(src) });
 
     // Enable JTAG debugging
     lp_peri

--- a/esp-hal/src/soc/esp32c6/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32c6/radio_clocks.rs
@@ -336,11 +336,11 @@ fn init_clocks() {
         let pmu = &*esp32c6::PMU::PTR;
 
         pmu.hp_sleep_icg_modem()
-            .modify(|_, w| w.hp_sleep_dig_icg_modem_code().variant(0));
+            .modify(|_, w| w.hp_sleep_dig_icg_modem_code().bits(0));
         pmu.hp_modem_icg_modem()
-            .modify(|_, w| w.hp_modem_dig_icg_modem_code().variant(1));
+            .modify(|_, w| w.hp_modem_dig_icg_modem_code().bits(1));
         pmu.hp_active_icg_modem()
-            .modify(|_, w| w.hp_active_dig_icg_modem_code().variant(2));
+            .modify(|_, w| w.hp_active_dig_icg_modem_code().bits(2));
         pmu.imm_modem_icg()
             .as_ptr()
             .write_volatile(pmu.imm_modem_icg().as_ptr().read_volatile() | 1 << 31);
@@ -351,29 +351,29 @@ fn init_clocks() {
         let modem_syscon = &*esp32c6::MODEM_SYSCON::PTR;
         modem_syscon.clk_conf_power_st().modify(|_, w| {
             w.clk_modem_apb_st_map()
-                .variant(6)
+                .bits(6)
                 .clk_modem_peri_st_map()
-                .variant(4)
+                .bits(4)
                 .clk_wifi_st_map()
-                .variant(6)
+                .bits(6)
                 .clk_bt_st_map()
-                .variant(6)
+                .bits(6)
                 .clk_fe_st_map()
-                .variant(6)
+                .bits(6)
                 .clk_zb_st_map()
-                .variant(6)
+                .bits(6)
         });
 
         let modem_lpcon = &*esp32c6::MODEM_LPCON::PTR;
         modem_lpcon.clk_conf_power_st().modify(|_, w| {
             w.clk_lp_apb_st_map()
-                .variant(6)
+                .bits(6)
                 .clk_i2c_mst_st_map()
-                .variant(6)
+                .bits(6)
                 .clk_coex_st_map()
-                .variant(6)
+                .bits(6)
                 .clk_wifipwr_st_map()
-                .variant(6)
+                .bits(6)
         });
 
         modem_lpcon.wifi_lp_clk_conf().modify(|_, w| {
@@ -389,7 +389,7 @@ fn init_clocks() {
 
         modem_lpcon
             .wifi_lp_clk_conf()
-            .modify(|_, w| w.clk_wifipwr_lp_div_num().variant(0));
+            .modify(|_, w| w.clk_wifipwr_lp_div_num().bits(0));
 
         modem_lpcon
             .clk_conf()

--- a/esp-hal/src/soc/esp32h2/radio_clocks.rs
+++ b/esp-hal/src/soc/esp32h2/radio_clocks.rs
@@ -125,11 +125,11 @@ fn init_clocks() {
         let pmu = &*esp32h2::PMU::PTR;
 
         pmu.hp_sleep_icg_modem()
-            .modify(|_, w| w.hp_sleep_dig_icg_modem_code().variant(0));
+            .modify(|_, w| w.hp_sleep_dig_icg_modem_code().bits(0));
         pmu.hp_modem_icg_modem()
-            .modify(|_, w| w.hp_modem_dig_icg_modem_code().variant(1));
+            .modify(|_, w| w.hp_modem_dig_icg_modem_code().bits(1));
         pmu.hp_active_icg_modem()
-            .modify(|_, w| w.hp_active_dig_icg_modem_code().variant(2));
+            .modify(|_, w| w.hp_active_dig_icg_modem_code().bits(2));
         pmu.imm_modem_icg()
             .as_ptr()
             .write_volatile(pmu.imm_modem_icg().as_ptr().read_volatile() | 1 << 31);

--- a/esp-hal/src/soc/esp32s3/psram.rs
+++ b/esp-hal/src/soc/esp32s3/psram.rs
@@ -731,7 +731,7 @@ pub(crate) mod utils {
                 let iomux = &*esp32s3::IO_MUX::PTR;
                 iomux
                     .gpio(cs1_io as usize)
-                    .modify(|_, w| w.mcu_sel().variant(FUNC_SPICS1_SPICS1))
+                    .modify(|_, w| w.mcu_sel().bits(FUNC_SPICS1_SPICS1))
             }
         } else {
             unsafe {
@@ -740,7 +740,7 @@ pub(crate) mod utils {
                 let iomux = &*esp32s3::IO_MUX::PTR;
                 iomux
                     .gpio(cs1_io as usize)
-                    .modify(|_, w| w.mcu_sel().variant(PIN_FUNC_GPIO))
+                    .modify(|_, w| w.mcu_sel().bits(PIN_FUNC_GPIO))
             }
         }
 
@@ -1375,7 +1375,7 @@ pub(crate) mod utils {
         for pin in pins {
             unsafe {
                 let iomux = &*esp32s3::IO_MUX::PTR;
-                iomux.gpio(*pin).modify(|_, w| w.fun_drv().variant(3))
+                iomux.gpio(*pin).modify(|_, w| w.fun_drv().bits(3))
             }
         }
     }
@@ -1474,7 +1474,7 @@ pub(crate) mod utils {
             let iomux = &*esp32s3::IO_MUX::PTR;
             iomux
                 .gpio(OCT_PSRAM_CS1_IO as usize)
-                .modify(|_, w| w.mcu_sel().variant(FUNC_SPICS1_SPICS1))
+                .modify(|_, w| w.mcu_sel().bits(FUNC_SPICS1_SPICS1))
         }
 
         // Set mspi cs1 drive strength
@@ -1482,7 +1482,7 @@ pub(crate) mod utils {
             let iomux = &*esp32s3::IO_MUX::PTR;
             iomux
                 .gpio(OCT_PSRAM_CS1_IO as usize)
-                .modify(|_, w| w.fun_drv().variant(3))
+                .modify(|_, w| w.fun_drv().bits(3))
         }
 
         // Set psram clock pin drive strength

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1217,22 +1217,24 @@ pub mod dma {
             // set cmd, address, dummy cycles
             let reg_block = self.spi.register_block();
             if !cmd.is_none() {
-                reg_block.user2().modify(|_, w| {
+                reg_block.user2().modify(|_, w| unsafe {
                     w.usr_command_bitlen()
-                        .variant((cmd.width() - 1) as u8)
+                        .bits((cmd.width() - 1) as u8)
                         .usr_command_value()
-                        .variant(cmd.value())
+                        .bits(cmd.value())
                 });
             }
 
             #[cfg(not(esp32))]
             if !address.is_none() {
-                reg_block
-                    .user1()
-                    .modify(|_, w| w.usr_addr_bitlen().variant((address.width() - 1) as u8));
+                reg_block.user1().modify(|_, w| unsafe {
+                    w.usr_addr_bitlen().bits((address.width() - 1) as u8)
+                });
 
                 let addr = address.value() << (32 - address.width());
-                reg_block.addr().write(|w| w.usr_addr_value().variant(addr));
+                reg_block
+                    .addr()
+                    .write(|w| unsafe { w.usr_addr_value().bits(addr) });
             }
 
             #[cfg(esp32)]
@@ -1248,7 +1250,7 @@ pub mod dma {
             if dummy > 0 {
                 reg_block
                     .user1()
-                    .modify(|_, w| w.usr_dummy_cyclelen().variant(dummy - 1));
+                    .modify(|_, w| unsafe { w.usr_dummy_cyclelen().bits(dummy - 1) });
             }
 
             self.spi
@@ -1288,22 +1290,24 @@ pub mod dma {
             // set cmd, address, dummy cycles
             let reg_block = self.spi.register_block();
             if !cmd.is_none() {
-                reg_block.user2().modify(|_, w| {
+                reg_block.user2().modify(|_, w| unsafe {
                     w.usr_command_bitlen()
-                        .variant((cmd.width() - 1) as u8)
+                        .bits((cmd.width() - 1) as u8)
                         .usr_command_value()
-                        .variant(cmd.value())
+                        .bits(cmd.value())
                 });
             }
 
             #[cfg(not(esp32))]
             if !address.is_none() {
-                reg_block
-                    .user1()
-                    .modify(|_, w| w.usr_addr_bitlen().variant((address.width() - 1) as u8));
+                reg_block.user1().modify(|_, w| unsafe {
+                    w.usr_addr_bitlen().bits((address.width() - 1) as u8)
+                });
 
                 let addr = address.value() << (32 - address.width());
-                reg_block.addr().write(|w| w.usr_addr_value().variant(addr));
+                reg_block
+                    .addr()
+                    .write(|w| unsafe { w.usr_addr_value().bits(addr) });
             }
 
             #[cfg(esp32)]
@@ -1319,7 +1323,7 @@ pub mod dma {
             if dummy > 0 {
                 reg_block
                     .user1()
-                    .modify(|_, w| w.usr_dummy_cyclelen().variant(dummy - 1));
+                    .modify(|_, w| unsafe { w.usr_dummy_cyclelen().bits(dummy - 1) });
             }
 
             self.spi
@@ -2871,11 +2875,11 @@ pub trait Instance: crate::private::Sealed {
         // set cmd, address, dummy cycles
         let reg_block = self.register_block();
         if !cmd.is_none() {
-            reg_block.user2().modify(|_, w| {
+            reg_block.user2().modify(|_, w| unsafe {
                 w.usr_command_bitlen()
-                    .variant((cmd.width() - 1) as u8)
+                    .bits((cmd.width() - 1) as u8)
                     .usr_command_value()
-                    .variant(cmd.value())
+                    .bits(cmd.value())
             });
         }
 
@@ -2883,10 +2887,12 @@ pub trait Instance: crate::private::Sealed {
         if !address.is_none() {
             reg_block
                 .user1()
-                .modify(|_, w| w.usr_addr_bitlen().variant((address.width() - 1) as u8));
+                .modify(|_, w| unsafe { w.usr_addr_bitlen().bits((address.width() - 1) as u8) });
 
             let addr = address.value() << (32 - address.width());
-            reg_block.addr().write(|w| w.usr_addr_value().variant(addr));
+            reg_block
+                .addr()
+                .write(|w| unsafe { w.usr_addr_value().bits(addr) });
         }
 
         #[cfg(esp32)]
@@ -2902,7 +2908,7 @@ pub trait Instance: crate::private::Sealed {
         if dummy > 0 {
             reg_block
                 .user1()
-                .modify(|_, w| w.usr_dummy_cyclelen().variant(dummy - 1));
+                .modify(|_, w| unsafe { w.usr_dummy_cyclelen().bits(dummy - 1) });
         }
 
         if !buffer.is_empty() {
@@ -2934,11 +2940,11 @@ pub trait Instance: crate::private::Sealed {
         // set cmd, address, dummy cycles
         let reg_block = self.register_block();
         if !cmd.is_none() {
-            reg_block.user2().modify(|_, w| {
+            reg_block.user2().modify(|_, w| unsafe {
                 w.usr_command_bitlen()
-                    .variant((cmd.width() - 1) as u8)
+                    .bits((cmd.width() - 1) as u8)
                     .usr_command_value()
-                    .variant(cmd.value())
+                    .bits(cmd.value())
             });
         }
 
@@ -2946,10 +2952,12 @@ pub trait Instance: crate::private::Sealed {
         if !address.is_none() {
             reg_block
                 .user1()
-                .modify(|_, w| w.usr_addr_bitlen().variant((address.width() - 1) as u8));
+                .modify(|_, w| unsafe { w.usr_addr_bitlen().bits((address.width() - 1) as u8) });
 
             let addr = address.value() << (32 - address.width());
-            reg_block.addr().write(|w| w.usr_addr_value().variant(addr));
+            reg_block
+                .addr()
+                .write(|w| unsafe { w.usr_addr_value().bits(addr) });
         }
 
         #[cfg(esp32)]
@@ -2965,7 +2973,7 @@ pub trait Instance: crate::private::Sealed {
         if dummy > 0 {
             reg_block
                 .user1()
-                .modify(|_, w| w.usr_dummy_cyclelen().variant(dummy - 1));
+                .modify(|_, w| unsafe { w.usr_dummy_cyclelen().bits(dummy - 1) });
         }
 
         self.configure_datalen(buffer.len() as u32 * 8);

--- a/esp-hal/src/trace.rs
+++ b/esp-hal/src/trace.rs
@@ -76,13 +76,12 @@ where
     pub fn start_trace(&mut self, buffer: &'d mut [u8]) {
         let reg_block = self.peripheral.register_block();
 
-        reg_block.mem_start_addr().modify(|_, w| {
-            w.mem_start_addr()
-                .variant(buffer.as_ptr() as *const _ as u32)
-        });
-        reg_block.mem_end_addr().modify(|_, w| {
+        reg_block
+            .mem_start_addr()
+            .modify(|_, w| unsafe { w.mem_start_addr().bits(buffer.as_ptr() as *const _ as u32) });
+        reg_block.mem_end_addr().modify(|_, w| unsafe {
             w.mem_end_addr()
-                .variant((buffer.as_ptr() as *const _ as u32) + (buffer.len() as u32))
+                .bits((buffer.as_ptr() as *const _ as u32) + (buffer.len() as u32))
         });
         reg_block
             .mem_addr_update()

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -697,19 +697,16 @@ where
         let prescale = prescale as u8;
 
         // Set up the prescaler and sync jump width.
-        T::register_block().bus_timing_0().modify(|_, w| {
-            w.baud_presc()
-                .variant(prescale)
-                .sync_jump_width()
-                .variant(sjw)
-        });
+        T::register_block()
+            .bus_timing_0()
+            .modify(|_, w| unsafe { w.baud_presc().bits(prescale).sync_jump_width().bits(sjw) });
 
         // Set up the time segment 1, time segment 2, and triple sample.
-        T::register_block().bus_timing_1().modify(|_, w| {
+        T::register_block().bus_timing_1().modify(|_, w| unsafe {
             w.time_seg1()
-                .variant(tseg_1)
+                .bits(tseg_1)
                 .time_seg2()
-                .variant(tseg_2)
+                .bits(tseg_2)
                 .time_samp()
                 .bit(triple_sample)
         });
@@ -749,7 +746,7 @@ where
     pub fn set_error_warning_limit(&mut self, limit: u8) {
         T::register_block()
             .err_warning_limit()
-            .write(|w| w.err_warning_limit().variant(limit));
+            .write(|w| unsafe { w.err_warning_limit().bits(limit) });
     }
 
     /// Put the peripheral into Operation Mode, allowing the transmission and
@@ -1140,7 +1137,7 @@ pub trait OperationInstance: Instance {
 
         register_block
             .data_0()
-            .write(|w| w.tx_byte_0().variant(data_0));
+            .write(|w| unsafe { w.tx_byte_0().bits(data_0) });
 
         // Assemble the identifier information of the packet.
         match frame.id {
@@ -1149,27 +1146,27 @@ pub trait OperationInstance: Instance {
 
                 register_block
                     .data_1()
-                    .write(|w| w.tx_byte_1().variant((id >> 3) as u8));
+                    .write(|w| unsafe { w.tx_byte_1().bits((id >> 3) as u8) });
 
                 register_block
                     .data_2()
-                    .write(|w| w.tx_byte_2().variant((id << 5) as u8));
+                    .write(|w| unsafe { w.tx_byte_2().bits((id << 5) as u8) });
             }
             Id::Extended(id) => {
                 let id = id.as_raw();
 
                 register_block
                     .data_1()
-                    .write(|w| w.tx_byte_1().variant((id >> 21) as u8));
+                    .write(|w| unsafe { w.tx_byte_1().bits((id >> 21) as u8) });
                 register_block
                     .data_2()
-                    .write(|w| w.tx_byte_2().variant((id >> 13) as u8));
+                    .write(|w| unsafe { w.tx_byte_2().bits((id >> 13) as u8) });
                 register_block
                     .data_3()
-                    .write(|w| w.tx_byte_3().variant((id >> 5) as u8));
+                    .write(|w| unsafe { w.tx_byte_3().bits((id >> 5) as u8) });
                 register_block
                     .data_4()
-                    .write(|w| w.tx_byte_4().variant((id << 3) as u8));
+                    .write(|w| unsafe { w.tx_byte_4().bits((id << 3) as u8) });
             }
         }
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2034,13 +2034,13 @@ pub mod lp_uart {
 
             lp_aon
                 .gpio_mux()
-                .modify(|r, w| w.sel().variant(r.sel().bits() | 1 << 4));
+                .modify(|r, w| unsafe { w.sel().bits(r.sel().bits() | 1 << 4) });
             lp_aon
                 .gpio_mux()
-                .modify(|r, w| w.sel().variant(r.sel().bits() | 1 << 5));
+                .modify(|r, w| unsafe { w.sel().bits(r.sel().bits() | 1 << 5) });
 
-            lp_io.gpio4().modify(|_, w| w.mcu_sel().variant(1));
-            lp_io.gpio5().modify(|_, w| w.mcu_sel().variant(1));
+            lp_io.gpio4().modify(|_, w| unsafe { w.mcu_sel().bits(1) });
+            lp_io.gpio5().modify(|_, w| unsafe { w.mcu_sel().bits(1) });
 
             Self::new_with_config(uart, Config::default())
         }


### PR DESCRIPTION
Lots of small changes here, but they're all pretty much the same thing. The `variant` function was supposed to require an enum value all this time and didn't, and it seems this has been resolved, so we now use `bits` instead.

I also aligned a few register/field names between the ESP32-S2/S3 in the `rtc_io` module.