### PR TITLE
Add SPI Full Duplex DMA test

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -29,6 +29,10 @@ name    = "spi_full_duplex"
 harness = false
 
 [[test]]
+name    = "spi_full_duplex_dma"
+harness = false
+
+[[test]]
 name    = "rsa"
 harness = false
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -62,6 +62,7 @@ mod tests {
     }
 
     #[test]
+    #[timeout(3)]
     fn test_symestric_transfer(mut ctx: Context) {
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
@@ -72,6 +73,7 @@ mod tests {
     }
 
     #[test]
+    #[timeout(3)]
     fn test_asymestric_transfer(mut ctx: Context) {
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00; 4];
@@ -83,6 +85,7 @@ mod tests {
     }
 
     #[test]
+    #[timeout(3)]
     fn test_symestric_transfer_huge_buffer(mut ctx: Context) {
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    fn test_symestric_transfer(mut ctx: Context) {
+    fn test_symmetric_transfer(mut ctx: Context) {
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00u8; 4];
 
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    fn test_asymestric_transfer(mut ctx: Context) {
+    fn test_asymmetric_transfer(mut ctx: Context) {
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00; 4];
 
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    fn test_symestric_transfer_huge_buffer(mut ctx: Context) {
+    fn test_symmetric_transfer_huge_buffer(mut ctx: Context) {
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;
@@ -99,7 +99,7 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    fn test_symestric_transfer_huge_buffer_no_alloc(mut ctx: Context) {
+    fn test_symmetric_transfer_huge_buffer_no_alloc(mut ctx: Context) {
         let mut write = [0x55u8; 4096];
         for byte in 0..write.len() {
             write[byte] = byte as u8;

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -1,0 +1,83 @@
+//! SPI Full Duplex DMA Test
+//!
+//! Folowing pins are used:
+//! SCLK    GPIO0
+//! MISO    GPIO2
+//! MOSI    GPIO4
+//! CS      GPIO5
+//!
+//! Connect MISO (GPIO2) and MOSI (GPIO4) pins.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use embedded_hal::spi::SpiBus;
+use esp_backtrace as _;
+use esp_hal::{
+    clock::ClockControl,
+    delay::Delay,
+    dma::{Dma, DmaPriority},
+    dma_buffers,
+    gpio::IO,
+    peripherals::Peripherals,
+    prelude::*,
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
+};
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use defmt::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_symestric_transfer() {
+        const DMA_BUFFER_SIZE: usize = 4;
+
+        let peripherals = Peripherals::take();
+        let system = peripherals.SYSTEM.split();
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+        let sclk = io.pins.gpio0;
+        let miso = io.pins.gpio2;
+        let mosi = io.pins.gpio4;
+        let cs = io.pins.gpio5;
+
+        let dma = Dma::new(peripherals.DMA);
+
+        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        let dma_channel = dma.spi2channel;
+        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        let dma_channel = dma.channel0;
+
+        let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) =
+            dma_buffers!(DMA_BUFFER_SIZE);
+
+        let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
+            .with_dma(dma_channel.configure(
+                false,
+                &mut tx_descriptors,
+                &mut rx_descriptors,
+                DmaPriority::Priority0,
+            ));
+
+        // DMA buffer require a static life-time
+        let mut send = tx_buffer;
+        let mut receive = rx_buffer;
+
+        send.copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+        let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
+        transfer.wait().unwrap();
+        assert_eq!(send, receive);
+    }
+}

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -14,11 +14,9 @@
 #![no_main]
 
 use defmt_rtt as _;
-use embedded_hal::spi::SpiBus;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
-    delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::IO,
@@ -38,7 +36,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_symestric_transfer() {
+    #[timeout(3)]
+    fn test_symestric_dma_transfer() {
         const DMA_BUFFER_SIZE: usize = 4;
 
         let peripherals = Peripherals::take();
@@ -75,6 +74,96 @@ mod tests {
         let mut receive = rx_buffer;
 
         send.copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+        let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
+        transfer.wait().unwrap();
+        assert_eq!(send, receive);
+    }
+
+    #[test]
+    #[timeout(3)]
+    fn test_asymestric_dma_transfer() {
+        let peripherals = Peripherals::take();
+        let system = peripherals.SYSTEM.split();
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+        let sclk = io.pins.gpio0;
+        let miso = io.pins.gpio2;
+        let mosi = io.pins.gpio4;
+        let cs = io.pins.gpio5;
+
+        let dma = Dma::new(peripherals.DMA);
+
+        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        let dma_channel = dma.spi2channel;
+        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        let dma_channel = dma.channel0;
+
+        let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(4, 2);
+
+        let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
+            .with_dma(dma_channel.configure(
+                false,
+                &mut tx_descriptors,
+                &mut rx_descriptors,
+                DmaPriority::Priority0,
+            ));
+
+        // DMA buffer require a static life-time
+        let mut send = tx_buffer;
+        let mut receive = rx_buffer;
+
+        send.copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+        let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
+        transfer.wait().unwrap();
+        assert_eq!(send[0], receive[0]);
+    }
+
+    #[test]
+    #[timeout(3)]
+    fn test_symestric_dma_transfer_huge_buffer() {
+        const DMA_BUFFER_SIZE: usize = 4096;
+
+        let peripherals = Peripherals::take();
+        let system = peripherals.SYSTEM.split();
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+        let sclk = io.pins.gpio0;
+        let miso = io.pins.gpio2;
+        let mosi = io.pins.gpio4;
+        let cs = io.pins.gpio5;
+
+        let dma = Dma::new(peripherals.DMA);
+
+        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        let dma_channel = dma.spi2channel;
+        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        let dma_channel = dma.channel0;
+
+        let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) =
+            dma_buffers!(DMA_BUFFER_SIZE);
+
+        let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
+            .with_dma(dma_channel.configure(
+                false,
+                &mut tx_descriptors,
+                &mut rx_descriptors,
+                DmaPriority::Priority0,
+            ));
+
+        // DMA buffer require a static life-time
+        let mut send = tx_buffer;
+        let mut receive = rx_buffer;
+
+        send.copy_from_slice(&[0x55u8; 4096]);
+        for byte in 0..send.len() {
+            send[byte] = byte as u8;
+        }
 
         let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
         transfer.wait().unwrap();

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -37,7 +37,7 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    fn test_symestric_dma_transfer() {
+    fn test_symmetric_dma_transfer() {
         const DMA_BUFFER_SIZE: usize = 4;
 
         let peripherals = Peripherals::take();
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    fn test_asymestric_dma_transfer() {
+    fn test_asymmetric_dma_transfer() {
         let peripherals = Peripherals::take();
         let system = peripherals.SYSTEM.split();
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    fn test_symestric_dma_transfer_huge_buffer() {
+    fn test_symmetric_dma_transfer_huge_buffer() {
         const DMA_BUFFER_SIZE: usize = 4096;
 
         let peripherals = Peripherals::take();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Add SPI Full Duplex DMA tests

As with AES DMA, I tried to use Context as with other tests, but Rust compiler just wasn't happy with the types and all the movements of them, so I ended up copy/pasting it all over, which makes it really ugly.

#### Testing
Tested locally on C3, C6, H2 and S3.

Manually triggered the HIL workflow: https://github.com/esp-rs/esp-hal/actions/runs/8701948778

