### PR TITLE
ESP32: Use generated register-access code to modify xtal_tick_num

### DIFF
--- a/esp-hal/src/clock/clocks_ll/esp32.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32.rs
@@ -183,9 +183,9 @@ pub(crate) fn esp32_rtc_update_to_xtal(freq: XtalClock, _div: u32) {
         });
 
         // adjust ref_tick
-        apb_cntl.xtal_tick_conf().as_ptr().write_volatile(
-            ((freq.hz()) / REF_CLK_FREQ - 1) | apb_cntl.xtal_tick_conf().as_ptr().read_volatile(),
-        ); // TODO make it RW in SVD
+        apb_cntl
+            .xtal_tick_conf()
+            .modify(|_, w| w.xtal_tick_num().bits((freq.hz() / REF_CLK_FREQ - 1) as u8));
 
         // switch clock source
         rtc_cntl.clk_conf().modify(|_, w| w.soc_clk_sel().xtal());

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -274,7 +274,6 @@ pub struct Clocks<'d> {
     pub pll_48m_clock: HertzU32,
     #[cfg(esp32h2)]
     pub pll_96m_clock: HertzU32,
-    // TODO chip specific additional ones as needed
 }
 
 #[doc(hidden)]
@@ -325,7 +324,6 @@ pub struct RawClocks {
     pub pll_48m_clock: HertzU32,
     #[cfg(esp32h2)]
     pub pll_96m_clock: HertzU32,
-    // TODO chip specific additional ones as needed
 }
 
 /// Used to configure the frequencies of the clocks present in the chip.


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
There was a TODO to prefer generated register access code over "write_voltatile" once the register is RW in the SVD - that happened some time ago

#### Testing
Run ESP32 examples with CPU speeds != default
