### PR TITLE
Use `esp-synopsys-usb-otg` 0.4.1

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -34,7 +34,7 @@ embedded-hal-nb      = { version = "1.0.0", optional = true }
 embedded-io          = { version = "0.6.1", optional = true }
 embedded-io-async    = { version = "0.6.1", optional = true }
 enumset              = "1.1.3"
-esp-synopsys-usb-otg = { version = "0.4.0", optional = true, features = ["fs", "esp32sx"] }
+esp-synopsys-usb-otg = { version = "0.4.1", optional = true, features = ["fs", "esp32sx"] }
 fugit                = "0.3.7"
 log                  = { version = "0.4.21", optional = true }
 nb                   = "1.1.0"

--- a/examples/src/bin/usb_serial.rs
+++ b/examples/src/bin/usb_serial.rs
@@ -7,6 +7,8 @@
 #![no_std]
 #![no_main]
 
+use core::ptr::addr_of_mut;
+
 use esp_backtrace as _;
 use esp_hal::{
     gpio::IO,
@@ -26,7 +28,7 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let usb = USB::new(peripherals.USB0, io.pins.gpio19, io.pins.gpio20);
-    let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
+    let usb_bus = UsbBus::new(usb, unsafe { &mut *addr_of_mut!(EP_MEMORY) });
 
     let mut serial = SerialPort::new(&usb_bus);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Use the most current patch-level release of `esp-synopsys-usb-otg` - not really needed since anyone doing `cargo update` will get it.

Also fixed a Clippy warning in the example

#### Testing
Run `usb_serial` example
