### PR TITLE
Enable S2 HIL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,7 @@ jobs:
           - soc: esp32h2
             rust-target: riscv32imac-unknown-none-elf
           # Xtensa devices:
+          - soc: esp32s2
           - soc: esp32s3
 
     steps:

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -36,6 +36,8 @@ jobs:
             runner: esp32h2-usb
             rust-target: riscv32imac-unknown-none-elf
           # Xtensa devices:
+          - soc: esp32s2
+            runner: esp32s2-jtag
           - soc: esp32s3
             runner: esp32s3-usb
     steps:

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -74,6 +74,11 @@ Our Virtual Machines have the following setup:
   - Devkit: `ESP32-S3-DevKitC-1` connected via USB-Serial-JTAG.
     - `GPIO2` and `GPIO4` are connected.
   - VM: Ubuntu 22.04.4 configured with the following [setup](#vm-setup)
+- ESP32-S2 (`esp32s2-jtag`):
+  - Devkit: `ESP32-S2-Saola-1` connected via UART.
+    - `GPIO2` and `GPIO4` are connected.
+  - Probe: `ESP-Prog` connected with the [following connections](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware)
+  - VM: Ubuntu 22.04.4 configured with the following [setup](#vm-setup)
 
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -120,6 +120,10 @@ mod tests {
         let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
         transfer.wait().unwrap();
         assert_eq!(send[0], receive[0]);
+        assert_eq!(send[1], receive[1]);
+        // Read the 2 remaining bytes so it does not cause issues in the next test.
+        let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
+        transfer.wait().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Enables HIL CI for ESP32-S2. Thanks @JurajSadel for creating the VM!

#### Testing
I've manually triggered the HIL workflow in this branch:  https://github.com/esp-rs/esp-hal/actions/runs/8739230899

And tested it locally: 
<details>
  <summary>ESP32-S2 output</summary>

```
esp-hal on  feat/enable-s2 [$!] via 🦀 v1.79.0-nightly took 5s 
❯ cargo xtask run-tests esp32s2 -t spi_full_duplex_dma
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/xtask run-tests esp32s2 -t spi_full_duplex_dma`
[2024-04-18T13:52:08Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/spi_full_duplex_dma.rs' for 'esp32s2'
[2024-04-18T13:52:08Z INFO  xtask] Package: "tests/spi_full_duplex_dma.rs"
   Compiling hil-test v0.0.0 (/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test)
    Finished release [optimized + debuginfo] target(s) in 1.04s
     Running tests/spi_full_duplex_dma.rs (target/xtensa-esp32s2-none-elf/release/deps/spi_full_duplex_dma-cc42003f0945733c)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 206.93 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 42.20 KiB/42.20 KiB @ 35.23 KiB/s (eta 0s )    Finished in 2.189s

running 3 tests
test tests::test_symmetric_dma_transfer             ... ok
test tests::test_asymmetric_dma_transfer            ... ok
test tests::test_symmetric_dma_transfer_huge_buffer ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.83s


esp-hal on  feat/enable-s2 [$] via 🦀 v1.79.0-nightly took 5s 
❯ cargo xtask run-tests esp32s2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/xtask run-tests esp32s2`
[2024-04-18T13:52:54Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/gpio.rs' for 'esp32s2'
[2024-04-18T13:52:54Z INFO  xtask] Package: "tests/gpio.rs"
warning: unused imports: `Event`, `Pin`
  --> tests/gpio.rs:76:25
   |
76 |     use esp_hal::gpio::{Event, Pin};
   |                         ^^^^^  ^^^
   |
help: consider adding a `#[cfg(test)]` to the containing module
  --> tests/gpio.rs:72:1
   |
72 | #[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: `#[warn(unused_imports)]` on by default
   = note: this warning originates in the attribute macro `embedded_test::tests` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `hil-test` (test "gpio") generated 1 warning (run `cargo fix --test "gpio"` to apply 1 suggestion)
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/gpio.rs (target/xtensa-esp32s2-none-elf/release/deps/gpio-e372ebdb8be3cd5b)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 206.25 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 43.53 KiB/43.53 KiB @ 35.71 KiB/s (eta 0s )    Finished in 2.213s

running 5 tests
test tests::test_async_edge     ... ok
test tests::test_a_pin_can_wait ... ok
test tests::test_gpio_input     ... ok
test tests::test_gpio_output    ... ok
test tests::test_gpio_od        ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.89s

[2024-04-18T13:53:00Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/rsa.rs' for 'esp32s2'
[2024-04-18T13:53:00Z INFO  xtask] Package: "tests/rsa.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/rsa.rs (target/xtensa-esp32s2-none-elf/release/deps/rsa-3cdcbfc34362fb05)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 204.89 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 42.13 KiB/42.13 KiB @ 35.29 KiB/s (eta 0s )    Finished in 2.194s

running 3 tests
test tests::test_modular_exponentiation ... ok
test tests::test_modular_multiplication ... ok
test tests::test_multiplication         ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.61s

[2024-04-18T13:53:04Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/spi_full_duplex_dma.rs' for 'esp32s2'
[2024-04-18T13:53:04Z INFO  xtask] Package: "tests/spi_full_duplex_dma.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/spi_full_duplex_dma.rs (target/xtensa-esp32s2-none-elf/release/deps/spi_full_duplex_dma-cc42003f0945733c)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 205.57 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 42.20 KiB/42.20 KiB @ 35.23 KiB/s (eta 0s )    Finished in 2.195s

running 3 tests
test tests::test_symmetric_dma_transfer             ... ok
test tests::test_asymmetric_dma_transfer            ... ok
test tests::test_symmetric_dma_transfer_huge_buffer ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.84s

[2024-04-18T13:53:09Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/sha.rs' for 'esp32s2'
[2024-04-18T13:53:09Z INFO  xtask] Package: "tests/sha.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/sha.rs (target/xtensa-esp32s2-none-elf/release/deps/sha-dff417c0385895a6)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 206.23 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 43.30 KiB/43.30 KiB @ 35.58 KiB/s (eta 0s )    Finished in 2.211s

running 7 tests
test tests::test_sha_1       ... ok
test tests::test_sha_224     ... ok
test tests::test_sha_256     ... ok
test tests::test_sha_384     ... ok
test tests::test_sha_512     ... ok
test tests::test_sha_512_224 ... ok
test tests::test_sha_512_256 ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.66s

[2024-04-18T13:53:16Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/aes.rs' for 'esp32s2'
[2024-04-18T13:53:16Z INFO  xtask] Package: "tests/aes.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/aes.rs (target/xtensa-esp32s2-none-elf/release/deps/aes-82b128cdab0e67d9)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 206.64 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 39.88 KiB/39.88 KiB @ 34.38 KiB/s (eta 0s )    Finished in 2.152s

running 6 tests
test tests::test_aes_128_encryption ... ok
test tests::test_aes_128_decryption ... ok
test tests::test_aes_192_encryption ... ok
test tests::test_aes_192_decryption ... ok
test tests::test_aes_256_encryption ... ok
test tests::test_aes_256_decryption ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.15s

[2024-04-18T13:53:22Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/crc.rs' for 'esp32s2'
[2024-04-18T13:53:22Z INFO  xtask] Package: "tests/crc.rs"
    Finished release [optimized + debuginfo] target(s) in 0.10s
     Running tests/crc.rs (target/xtensa-esp32s2-none-elf/release/deps/crc-55cdc771eaa72695)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 206.19 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 39.39 KiB/39.39 KiB @ 34.20 KiB/s (eta 0s )    Finished in 2.146s

running 2 tests
test tests::test_crc ... ok
test tests::test_md5 ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.05s

[2024-04-18T13:53:26Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/uart_async.rs' for 'esp32s2'
[2024-04-18T13:53:26Z INFO  xtask] Package: "tests/uart_async.rs"
    Finished release [optimized + debuginfo] target(s) in 0.10s
     Running tests/uart_async.rs (target/xtensa-esp32s2-none-elf/release/deps/uart_async-b6f481a76c5bb374)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 209.83 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 42.57 KiB/42.57 KiB @ 35.42 KiB/s (eta 0s )    Finished in 2.181s

running 1 test
test tests::test_send_receive ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.53s

[2024-04-18T13:53:30Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/clock_monitor.rs' for 'esp32s2'
[2024-04-18T13:53:30Z INFO  xtask] Package: "tests/clock_monitor.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/clock_monitor.rs (target/xtensa-esp32s2-none-elf/release/deps/clock_monitor-40d93a4f0168f3a8)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 206.40 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 38.46 KiB/38.46 KiB @ 33.86 KiB/s (eta 0s )    Finished in 2.129s

running 1 test
test tests::test_estimated_clock ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.54s

[2024-04-18T13:53:33Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/spi_full_duplex.rs' for 'esp32s2'
[2024-04-18T13:53:33Z INFO  xtask] Package: "tests/spi_full_duplex.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/spi_full_duplex.rs (target/xtensa-esp32s2-none-elf/release/deps/spi_full_duplex-6490b0e67f2b854b)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 204.27 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 41.05 KiB/41.05 KiB @ 34.88 KiB/s (eta 0s )    Finished in 2.18s

running 4 tests
test tests::test_symmetric_transfer                      ... ok
test tests::test_asymmetric_transfer                     ... ok
test tests::test_symmetric_transfer_huge_buffer          ... ok
test tests::test_symmetric_transfer_huge_buffer_no_alloc ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.13s

[2024-04-18T13:53:39Z INFO  xtask] Building example '/home/sergio/Documents/Espressif/esp-rs/esp-hal/hil-test/tests/uart.rs' for 'esp32s2'
[2024-04-18T13:53:39Z INFO  xtask] Package: "tests/uart.rs"
    Finished release [optimized + debuginfo] target(s) in 0.09s
     Running tests/uart.rs (target/xtensa-esp32s2-none-elf/release/deps/uart-0605c3c45228ccf7)
      Erasing ✔ [00:00:00] [#####################################################################################################################################################################################] 192.00 KiB/192.00 KiB @ 205.53 KiB/s (eta 0s )
  Programming ✔ [00:00:01] [########################################################################################################################################################################################] 39.26 KiB/39.26 KiB @ 34.20 KiB/s (eta 0s )    Finished in 2.145s

running 1 test
test tests::test_send_receive ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.53s
```
</details>

> [!IMPORTANT]  
> Once merged we need to add the `HIL Test | esp32s2` test to the required checks

