### PR TITLE
i2c: i2c1_handler used I2C0 register block by mistake

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- i2c: i2c1_handler used I2C0 register block by mistake (#1487)
+
 ### Changed
 
 ### Removed

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -705,14 +705,12 @@ mod asynch {
 
     #[handler]
     pub(super) fn i2c0_handler() {
-        unsafe { &*crate::peripherals::I2C0::PTR }
-            .int_ena()
+        let regs = unsafe { &*crate::peripherals::I2C0::PTR };
+        regs.int_ena()
             .modify(|_, w| w.end_detect().clear_bit().trans_complete().clear_bit());
 
         #[cfg(not(any(esp32, esp32s2)))]
-        unsafe { &*crate::peripherals::I2C0::PTR }
-            .int_ena()
-            .modify(|_, w| w.txfifo_wm().clear_bit());
+        regs.int_ena().modify(|_, w| w.txfifo_wm().clear_bit());
 
         WAKERS[0].wake();
     }
@@ -720,14 +718,12 @@ mod asynch {
     #[cfg(i2c1)]
     #[handler]
     pub(super) fn i2c1_handler() {
-        unsafe { &*crate::peripherals::I2C1::PTR }
-            .int_ena()
+        let regs = unsafe { &*crate::peripherals::I2C1::PTR };
+        regs.int_ena()
             .modify(|_, w| w.end_detect().clear_bit().trans_complete().clear_bit());
 
         #[cfg(not(any(esp32, esp32s2)))]
-        unsafe { &*crate::peripherals::I2C0::PTR }
-            .int_ena()
-            .modify(|_, w| w.txfifo_wm().clear_bit());
+        regs.int_ena().modify(|_, w| w.txfifo_wm().clear_bit());
 
         WAKERS[1].wake();
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
The `i2cX_handler` functions contained two `unsafe` blocks grabbing the register block. For `i2c1_handler` the second referenced `I2C0`. 

#### Description
 I've refactored both `i2c0_handler` and `i2c1_handler` to have one unsafe block so the register blocks are guaranteed to be consistent in each function.

#### Testing
Tested  on a custom `esp32s3` clock board that has a ds3231 on `I2C0` and a `veml7700` and a `FT6236` on `I2C1`.
