### PR TITLE
Make software interrupts shareable

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created virtual peripherals for CPU control and radio clocks, rather than splitting them from `SYSTEM` (#1428)
 - `IO`, `ADC`, `DAC`, `RTC*`, `LEDC`, `PWM` and `PCNT` drivers have been converted to camel case format (#1473)
 - RNG is no longer TRNG, the `CryptoRng` implementation has been removed. To track this being re-added see #1499 (#1498)
+- Make software interrupts shareable (#1500)
 
 ### Removed
 

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -121,7 +121,7 @@ impl<const NUM: u8> SoftwareInterrupt<NUM> {
     }
 
     /// Trigger this software-interrupt
-    pub fn raise(&mut self) {
+    pub fn raise(&self) {
         #[cfg(not(any(esp32c6, esp32h2)))]
         let system = unsafe { &*SYSTEM::PTR };
         #[cfg(any(esp32c6, esp32h2))]
@@ -153,7 +153,7 @@ impl<const NUM: u8> SoftwareInterrupt<NUM> {
     }
 
     /// Resets this software-interrupt
-    pub fn reset(&mut self) {
+    pub fn reset(&self) {
         #[cfg(not(any(esp32c6, esp32h2)))]
         let system = unsafe { &*SYSTEM::PTR };
         #[cfg(any(esp32c6, esp32h2))]

--- a/examples/src/bin/direct_vectoring.rs
+++ b/examples/src/bin/direct_vectoring.rs
@@ -74,7 +74,7 @@ fn main() -> ! {
 fn interrupt20() {
     unsafe { asm!("csrrwi x0, 0x7e1, 0 #disable timer") }
     critical_section::with(|cs| {
-        SWINT0.borrow_ref_mut(cs).as_mut().unwrap().reset();
+        SWINT0.borrow_ref(cs).as_ref().unwrap().reset();
     });
 
     let mut perf_counter: u32 = 0;

--- a/examples/src/bin/interrupt_preemption.rs
+++ b/examples/src/bin/interrupt_preemption.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     // exiting the handler Once the handler is exited we expect to see same
     // priority and low priority interrupts served in that order.
     critical_section::with(|cs| {
-        SWINT1.borrow_ref_mut(cs).as_mut().unwrap().raise();
+        SWINT1.borrow_ref(cs).as_ref().unwrap().raise();
     });
 
     loop {}
@@ -73,7 +73,7 @@ fn main() -> ! {
 fn swint0_handler() {
     esp_println::println!("SW interrupt0");
     critical_section::with(|cs| {
-        SWINT0.borrow_ref_mut(cs).as_mut().unwrap().reset();
+        SWINT0.borrow_ref(cs).as_ref().unwrap().reset();
     });
 }
 
@@ -81,10 +81,10 @@ fn swint0_handler() {
 fn swint1_handler() {
     esp_println::println!("SW interrupt1 entry");
     critical_section::with(|cs| {
-        SWINT1.borrow_ref_mut(cs).as_mut().unwrap().reset();
-        SWINT2.borrow_ref_mut(cs).as_mut().unwrap().raise(); // raise interrupt at same priority
-        SWINT3.borrow_ref_mut(cs).as_mut().unwrap().raise(); // raise interrupt at higher priority
-        SWINT0.borrow_ref_mut(cs).as_mut().unwrap().raise(); // raise interrupt at lower priority
+        SWINT1.borrow_ref(cs).as_ref().unwrap().reset();
+        SWINT2.borrow_ref(cs).as_ref().unwrap().raise(); // raise interrupt at same priority
+        SWINT3.borrow_ref(cs).as_ref().unwrap().raise(); // raise interrupt at higher priority
+        SWINT0.borrow_ref(cs).as_ref().unwrap().raise(); // raise interrupt at lower priority
     });
     esp_println::println!("SW interrupt1 exit");
 }
@@ -93,7 +93,7 @@ fn swint1_handler() {
 fn swint2_handler() {
     esp_println::println!("SW interrupt2");
     critical_section::with(|cs| {
-        SWINT2.borrow_ref_mut(cs).as_mut().unwrap().reset();
+        SWINT2.borrow_ref(cs).as_ref().unwrap().reset();
     });
 }
 
@@ -101,6 +101,6 @@ fn swint2_handler() {
 fn swint3_handler() {
     esp_println::println!("SW interrupt3");
     critical_section::with(|cs| {
-        SWINT3.borrow_ref_mut(cs).as_mut().unwrap().reset();
+        SWINT3.borrow_ref(cs).as_ref().unwrap().reset();
     });
 }

--- a/examples/src/bin/software_interrupts.rs
+++ b/examples/src/bin/software_interrupts.rs
@@ -70,17 +70,17 @@ fn main() -> ! {
         delay.delay_millis(500);
         match counter {
             0 => critical_section::with(|cs| {
-                SWINT0.borrow_ref_mut(cs).as_mut().unwrap().raise();
+                SWINT0.borrow_ref(cs).as_ref().unwrap().raise();
             }),
             1 => critical_section::with(|cs| {
-                SWINT1.borrow_ref_mut(cs).as_mut().unwrap().raise();
+                SWINT1.borrow_ref(cs).as_ref().unwrap().raise();
             }),
             2 => critical_section::with(|cs| {
-                SWINT2.borrow_ref_mut(cs).as_mut().unwrap().raise();
+                SWINT2.borrow_ref(cs).as_ref().unwrap().raise();
             }),
             3 => {
                 critical_section::with(|cs| {
-                    SWINT3.borrow_ref_mut(cs).as_mut().unwrap().raise();
+                    SWINT3.borrow_ref(cs).as_ref().unwrap().raise();
                 });
                 counter = -1
             }
@@ -94,7 +94,7 @@ fn main() -> ! {
 fn swint0_handler() {
     esp_println::println!("SW interrupt0");
     critical_section::with(|cs| {
-        SWINT0.borrow_ref_mut(cs).as_mut().unwrap().reset();
+        SWINT0.borrow_ref(cs).as_ref().unwrap().reset();
     });
 }
 
@@ -102,7 +102,7 @@ fn swint0_handler() {
 fn swint1_handler() {
     esp_println::println!("SW interrupt1");
     critical_section::with(|cs| {
-        SWINT1.borrow_ref_mut(cs).as_mut().unwrap().reset();
+        SWINT1.borrow_ref(cs).as_ref().unwrap().reset();
     });
 }
 
@@ -110,7 +110,7 @@ fn swint1_handler() {
 fn swint2_handler() {
     esp_println::println!("SW interrupt2");
     critical_section::with(|cs| {
-        SWINT2.borrow_ref_mut(cs).as_mut().unwrap().reset();
+        SWINT2.borrow_ref(cs).as_ref().unwrap().reset();
     });
 }
 
@@ -118,6 +118,6 @@ fn swint2_handler() {
 fn swint3_handler() {
     esp_println::println!("SW interrupt3");
     critical_section::with(|cs| {
-        SWINT3.borrow_ref_mut(cs).as_mut().unwrap().reset();
+        SWINT3.borrow_ref(cs).as_ref().unwrap().reset();
     });
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
My immediate use case for this is #1476 where I want to be able to `raise()` the interrupt from any core.
It feels silly to have to pull out a `RefCell` or `Mutex` just to ultimately toggle a volatile register.
I think it makes sense for this to be shareable within Rust rules. Exclusive access can still be achieved with a mutable reference.

#### Testing
CI
