### PR TITLE
SmartLedsAdapter example requires clocks argument

### DIFF
--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -12,10 +12,10 @@
 //!
 //! ```rust,ignore
 //! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let rmt = Rmt::new(peripherals.RMT, 80.MHz(), &clocks).unwrap();
+//! let rmt = Rmt::new(peripherals.RMT, 80.MHz(), &clocks, None).unwrap();
 //!
 //! let rmt_buffer = smartLedBuffer!(1);
-//! let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer);
+//! let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer, &clocks);
 //! ```
 //!
 //! ## Feature Flags

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - i2c: i2c1_handler used I2C0 register block by mistake (#1487)
+- Smart LEDs docs example (#1504)
 
 ### Changed
 


### PR DESCRIPTION
### Submission Checklist 📝
- [X] I have updated existing examples or added new ones (if applicable).
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [X] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

[SmartLedsAdapter](https://docs.rs/esp-hal-smartled/0.10.0/esp_hal_smartled/struct.SmartLedsAdapter.html) requires 4 arguments, the last one is the clock.

And [Rmt::new](https://docs.esp-rs.org/esp-hal/esp-hal/0.17.0/esp32s3/esp_hal/rmt/struct.Rmt.html#method.new) requires an optional interrupt handler as the last argument.

#### Testing

Tested it with. my esp32s3 :)
