### PR TITLE
Enable C3, H2, S2 and S3 HIL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,8 +315,8 @@ jobs:
             rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c6
             rust-target: riscv32imac-unknown-none-elf
-          # - soc: esp32h2
-          #   rust-target: riscv32imac-unknown-none-elf
+          - soc: esp32h2
+            rust-target: riscv32imac-unknown-none-elf
           # Xtensa devices:
           - soc: esp32s2
           - soc: esp32s3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,9 +315,10 @@ jobs:
             rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c6
             rust-target: riscv32imac-unknown-none-elf
-          - soc: esp32h2
-            rust-target: riscv32imac-unknown-none-elf
+          # - soc: esp32h2
+          #   rust-target: riscv32imac-unknown-none-elf
           # Xtensa devices:
+          - soc: esp32s2
           - soc: esp32s3
 
     steps:
@@ -339,4 +340,4 @@ jobs:
           ldproxy: false
 
       - uses: Swatinem/rust-cache@v2
-      - run: cargo xtask build-examples hil-test ${{ matrix.target.soc }}
+      - run: cargo xtask build-tests ${{ matrix.target.soc }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -26,18 +26,21 @@ jobs:
       matrix:
         target:
           # RISC-V devices:
-          # - soc: esp32c3
-          #   rust-target: riscv32imc-unknown-none-elf
+          - soc: esp32c3
+            rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c6
             rust-target: riscv32imac-unknown-none-elf
-          # - soc: esp32h2
-          #   rust-target: riscv32imac-unknown-none-elf
+          - soc: esp32h2
+            rust-target: riscv32imac-unknown-none-elf
           # # Xtensa devices:
-          # - soc: esp32s3
+          - soc: esp32s2
+            rust-target: xtensa-esp32s2-none-elf
+          - soc: esp32s3
+            rust-target: xtensa-esp32s3-none-elf
+
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'workflow_dispatch'
-
       - uses: actions/checkout@v4
         if: github.event_name == 'workflow_dispatch'
         with:
@@ -59,7 +62,7 @@ jobs:
           default: true
           ldproxy: false
 
-      - name: Run tests
+      - name: Build tests
         run: cargo xtask build-tests ${{ matrix.target.soc }}
 
       - name: Prepare artifact
@@ -78,7 +81,6 @@ jobs:
             base_name="$(basename "$file" | cut -d'-' -f1)"
             mv "$file" "tests/$base_name"
           done
-
       - uses: actions/upload-artifact@v4
         with:
           name: tests-${{ matrix.target.soc }}
@@ -95,24 +97,44 @@ jobs:
       matrix:
         target:
           # RISC-V devices:
-          # - soc: esp32c3
-          #   runner: rustboard
+          - soc: esp32c3
+            runner: esp32c3-usb
           - soc: esp32c6
             runner: esp32c6-usb
-          # - soc: esp32h2
-          #   runner: esp32h2-usb
-          # # Xtensa devices:
-          # - soc: esp32s3
-          #   runner: esp32s3-usb
+          - soc: esp32h2
+            runner: esp32h2-usb
+          # Xtensa devices:
+          - soc: esp32s2
+            runner: esp32s2-jtag
+          - soc: esp32s3
+            runner: esp32s3-usb
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: tests-${{ matrix.target.soc }}
-          path: tests
-      - name: Run tests
+          path: test-suite
+
+      - name: Run Tests
         run: |
           export PATH=$PATH:/home/espressif/.cargo/bin
-          for file in "tests"/*; do
-            probe-rs run --chip ${{ matrix.target.soc }} "$file"
+          # Print the content in the 'tests' directory
+          ls -l test-suite
+
+          failed_tests=() # Initialize an empty array to hold failed tests
+          for test_file in "test-suite"/*; do
+            echo "Running test: $test_file"
+            if ! probe-rs run --chip ${{ matrix.target.soc }} "$test_file"; then
+              failed_tests+=("$test_file") # Add failed test to the array
+            fi
           done
 
+          # Report all failed tests at the end
+          if [ ${#failed_tests[@]} -gt 0 ]; then
+            echo "The following tests failed:"
+            for failed_test in "${failed_tests[@]}"; do
+              echo "- $failed_test"
+            done
+            exit 1 # Return a non-zero exit code to indicate failure
+          else
+            echo "All tests passed!"
+          fi

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -110,6 +110,7 @@ jobs:
           - soc: esp32s3
             runner: esp32s3-usb
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: tests-${{ matrix.target.soc }}
@@ -118,25 +119,4 @@ jobs:
       - name: Run Tests
         run: |
           export PATH=$PATH:/home/espressif/.cargo/bin
-
-          failed_tests=() # Initialize an empty array to hold failed tests
-          for test_file in "tests-${{ matrix.target.soc }}"/*; do
-            echo "Running test: $test_file"
-            if ! probe-rs run --chip ${{ matrix.target.soc }} "$test_file"; then
-              failed_tests+=("$test_file") # Add failed test to the array
-            fi
-          done
-
-          # Cleanup
-          rm -rf tests-${{ matrix.target.soc }}
-
-          # Report all failed tests at the end
-          if [ ${#failed_tests[@]} -gt 0 ]; then
-            echo "The following tests failed:"
-            for failed_test in "${failed_tests[@]}"; do
-              echo "- $failed_test"
-            done
-            exit 1 # Return a non-zero exit code to indicate failure
-          else
-            echo "All tests passed!"
-          fi
+          cargo xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -127,6 +127,9 @@ jobs:
             fi
           done
 
+          # Cleanup
+          rm -rf tests-${{ matrix.target.soc }}
+
           # Report all failed tests at the end
           if [ ${#failed_tests[@]} -gt 0 ]; then
             echo "The following tests failed:"
@@ -137,6 +140,3 @@ jobs:
           else
             echo "All tests passed!"
           fi
-
-      - name: Cleanup
-        run: rm -rf tests-${{ matrix.target.soc }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -137,3 +137,6 @@ jobs:
           else
             echo "All tests passed!"
           fi
+
+      - name: Cleanup
+        run: rm -rf tests-${{ matrix.target.soc }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -113,14 +113,14 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: tests-${{ matrix.target.soc }}
-          path: test-suite
+          path: tests-${{ matrix.target.soc }}
 
       - name: Run Tests
         run: |
           export PATH=$PATH:/home/espressif/.cargo/bin
 
           failed_tests=() # Initialize an empty array to hold failed tests
-          for test_file in "test-suite"/*; do
+          for test_file in "tests-${{ matrix.target.soc }}"/*; do
             echo "Running test: $test_file"
             if ! probe-rs run --chip ${{ matrix.target.soc }} "$test_file"; then
               failed_tests+=("$test_file") # Add failed test to the array

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -30,8 +30,8 @@ jobs:
             rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c6
             rust-target: riscv32imac-unknown-none-elf
-          - soc: esp32h2
-            rust-target: riscv32imac-unknown-none-elf
+          # - soc: esp32h2
+          #   rust-target: riscv32imac-unknown-none-elf
           # # Xtensa devices:
           - soc: esp32s2
             rust-target: xtensa-esp32s2-none-elf
@@ -101,8 +101,8 @@ jobs:
             runner: esp32c3-usb
           - soc: esp32c6
             runner: esp32c6-usb
-          - soc: esp32h2
-            runner: esp32h2-usb
+          # - soc: esp32h2
+          #   runner: esp32h2-usb
           # Xtensa devices:
           - soc: esp32s2
             runner: esp32s2-jtag
@@ -117,8 +117,6 @@ jobs:
       - name: Run Tests
         run: |
           export PATH=$PATH:/home/espressif/.cargo/bin
-          # Print the content in the 'tests' directory
-          ls -l test-suite
 
           failed_tests=() # Initialize an empty array to hold failed tests
           for test_file in "test-suite"/*; do

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -86,6 +86,7 @@ jobs:
           name: tests-${{ matrix.target.soc }}
           path: /home/runner/work/esp-hal/esp-hal/tests
           if-no-files-found: error
+          overwrite: true
 
   hil:
     name: HIL Test | ${{ matrix.target.soc }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -30,8 +30,8 @@ jobs:
             rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c6
             rust-target: riscv32imac-unknown-none-elf
-          # - soc: esp32h2
-          #   rust-target: riscv32imac-unknown-none-elf
+          - soc: esp32h2
+            rust-target: riscv32imac-unknown-none-elf
           # # Xtensa devices:
           - soc: esp32s2
             rust-target: xtensa-esp32s2-none-elf
@@ -102,8 +102,8 @@ jobs:
             runner: esp32c3-usb
           - soc: esp32c6
             runner: esp32c6-usb
-          # - soc: esp32h2
-          #   runner: esp32h2-usb
+          - soc: esp32h2
+            runner: esp32h2-usb
           # Xtensa devices:
           - soc: esp32s2
             runner: esp32s2-jtag

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -64,7 +64,7 @@ Our Virtual Machines have the following setup:
   - Devkit: `ESP32-C6-DevKitC-1 V1.2` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
-- ESP32-H2 (`esp32h2-usb`): Currently disabled
+- ESP32-H2 (`esp32h2-usb`):
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -19,11 +19,9 @@ We use [embedded-test] as our testing framework, which relies on [defmt] interna
 We use [probe-rs] for flashing and running the tests on a target device, however, this **MUST** be installed from the correct revision, and with the correct features enabled:
 
 ```text
-cargo install probe-rs \
-  --git=https://github.com/probe-rs/probe-rs \
-  --rev=ddd59fa \
-  --features=cli \
-  --bin=probe-rs
+cargo install probe-rs-tools \
+  --git https://github.com/probe-rs/probe-rs \
+  --rev 4dc1701 --force --locked
 ```
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
@@ -61,19 +59,24 @@ Our Virtual Machines have the following setup:
 - ESP32-C3 (`rustboard`):
   - Devkit: `ESP32-C3-DevKit-RUST-1` connected via USB-Serial-JTAG.
     - `GPIO2` and `GPIO4` are connected.
-  - VM: Ubuntu 20.04.5 configured with the following [setup](#vm-setup)
+  - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-C6 (`esp32c6-usb`):
   - Devkit: `ESP32-C6-DevKitC-1 V1.2` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
-- ESP32-H2 (`esp32h2-usb`):
+- ESP32-H2 (`esp32h2-usb`): Currently disabled
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
-  - VM: Ubuntu 20.04.5 configured with the following [setup](#vm-setup)
+  - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
+- ESP32-S2 (`esp32s2-jtag`):
+  - Devkit: `ESP32-S2-Saola-1` connected via UART.
+    - `GPIO2` and `GPIO4` are connected.
+  - Probe: `ESP-Prog` connected with the [following connections](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware)
+  - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-S3 (`esp32s3-usb`):
   - Devkit: `ESP32-S3-DevKitC-1` connected via USB-Serial-JTAG.
     - `GPIO2` and `GPIO4` are connected.
-  - VM: Ubuntu 22.04.4 configured with the following [setup](#vm-setup)
+  - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml
 
@@ -86,7 +89,7 @@ source "$HOME/.cargo/env"
 # Install dependencies
 sudo apt install -y pkg-config libudev-dev
 # Install probe-rs
-cargo install probe-rs --git=https://github.com/probe-rs/probe-rs --rev=ddd59fa --features=cli --bin=probe-rs --locked --force
+cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev 4dc1701 --force
 # Add the udev rules
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -1,7 +1,8 @@
 //! Delay Test
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s3
 // TODO: esp32h2 is disabled due to https://github.com/esp-rs/esp-hal/issues/1509
+// TODO: esp32s2 is disabled due to https://github.com/esp-rs/esp-hal/issues/1524
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -1,8 +1,6 @@
 //! Delay Test
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s3
-// TODO: esp32h2 is disabled due to https://github.com/esp-rs/esp-hal/issues/1509
-// TODO: esp32s2 is disabled due to https://github.com/esp-rs/esp-hal/issues/1524
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -1,5 +1,8 @@
 //! Delay Test
 
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s2 esp32s3
+// TODO: esp32h2 is disabled due to https://github.com/esp-rs/esp-hal/issues/1509
+
 #![no_std]
 #![no_main]
 

--- a/hil-test/tests/get_time.rs
+++ b/hil-test/tests/get_time.rs
@@ -1,6 +1,6 @@
 //! current_time Test
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -153,7 +153,6 @@ mod tests {
     }
 
     #[test]
-    // TODO: See https://github.com/esp-rs/esp-hal/issues/1413
     #[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
     fn test_gpio_interrupt(mut ctx: Context) {
         critical_section::with(|cs| {

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -4,6 +4,8 @@
 //! GPIO2
 //! GPIO4
 
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
 #![no_std]
 #![no_main]
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -8,6 +8,8 @@
 //!
 //! Connect MISO (GPIO2) and MOSI (GPIO4) pins.
 
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
 #![no_std]
 #![no_main]
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -9,7 +9,6 @@
 //! Connect MISO (GPIO2) and MOSI (GPIO4) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
-// TODO: esp32s2 is disabled due to https://github.com/esp-rs/esp-hal/issues/1524
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -8,7 +8,7 @@
 //!
 //! Connect MISO (GPIO2) and MOSI (GPIO4) pins.
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -9,6 +9,7 @@
 //! Connect MISO (GPIO2) and MOSI (GPIO4) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
+// TODO: esp32s2 is disabled due to https://github.com/esp-rs/esp-hal/issues/1524
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -120,11 +120,7 @@ mod tests {
 
         let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
         transfer.wait().unwrap();
-        assert_eq!(send[0], receive[0]);
-        assert_eq!(send[1], receive[1]);
-        // Read the 2 remaining bytes so it does not cause issues in the next test.
-        let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
-        transfer.wait().unwrap();
+        assert_eq!(send[0..1], receive[0..1]);
     }
 
     #[test]

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -121,6 +121,10 @@ mod tests {
         let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
         transfer.wait().unwrap();
         assert_eq!(send[0], receive[0]);
+        assert_eq!(send[1], receive[1]);
+        // Read the 2 remaining bytes so it does not cause issues in the next test.
+        let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
+        transfer.wait().unwrap();
     }
 
     #[test]

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -6,6 +6,8 @@
 //!
 //! Connect TX (GPIO2) and RX (GPIO4) pins.
 
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
 #![no_std]
 #![no_main]
 
@@ -108,11 +110,15 @@ mod tests {
 
         #[cfg(not(feature = "esp32s2"))]
         {
-            // 9600 baud, RC FAST clock source:
-            ctx.uart.change_baud(9600, ClockSource::RcFast, &ctx.clocks);
-            ctx.uart.write(7).ok();
-            let read = block!(ctx.uart.read());
-            assert_eq!(read, Ok(7));
+            // TODO: Remove cfg once https://github.com/esp-rs/esp-hal/issues/1524 is solved
+            #[cfg(not(feature = "esp32c3"))]
+            {
+                // 9600 baud, RC FAST clock source:
+                ctx.uart.change_baud(9600, ClockSource::RcFast, &ctx.clocks);
+                ctx.uart.write(7).ok();
+                let read = block!(ctx.uart.read());
+                assert_eq!(read, Ok(7));
+            }
 
             // 19,200 baud, XTAL clock source:
             ctx.uart.change_baud(19_200, ClockSource::Xtal, &ctx.clocks);

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -110,7 +110,6 @@ mod tests {
 
         #[cfg(not(feature = "esp32s2"))]
         {
-            // TODO: Remove cfg once https://github.com/esp-rs/esp-hal/issues/1524 is solved
             #[cfg(not(feature = "esp32c3"))]
             {
                 // 9600 baud, RC FAST clock source:

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -106,22 +106,40 @@ mod tests {
         // working as expected. We will also using different clock sources
         // while we're at it.
 
-        // 9600 baud, RC FAST clock source:
-        ctx.uart.change_baud(9600, ClockSource::RcFast, &ctx.clocks);
-        ctx.uart.write(7).ok();
-        let read = block!(ctx.uart.read());
-        assert_eq!(read, Ok(7));
+        #[cfg(not(feature = "esp32s2"))]
+        {
+            // 9600 baud, RC FAST clock source:
+            ctx.uart.change_baud(9600, ClockSource::RcFast, &ctx.clocks);
+            ctx.uart.write(7).ok();
+            let read = block!(ctx.uart.read());
+            assert_eq!(read, Ok(7));
 
-        // 19,200 baud, XTAL clock source:
-        ctx.uart.change_baud(19_200, ClockSource::Xtal, &ctx.clocks);
-        ctx.uart.write(55).ok();
-        let read = block!(ctx.uart.read());
-        assert_eq!(read, Ok(55));
+            // 19,200 baud, XTAL clock source:
+            ctx.uart.change_baud(19_200, ClockSource::Xtal, &ctx.clocks);
+            ctx.uart.write(55).ok();
+            let read = block!(ctx.uart.read());
+            assert_eq!(read, Ok(55));
 
-        // 921,600 baud, APB clock source:
-        ctx.uart.change_baud(921_600, ClockSource::Apb, &ctx.clocks);
-        ctx.uart.write(253).ok();
-        let read = block!(ctx.uart.read());
-        assert_eq!(read, Ok(253));
+            // 921,600 baud, APB clock source:
+            ctx.uart.change_baud(921_600, ClockSource::Apb, &ctx.clocks);
+            ctx.uart.write(253).ok();
+            let read = block!(ctx.uart.read());
+            assert_eq!(read, Ok(253));
+        }
+        #[cfg(feature = "esp32s2")]
+        {
+            // 9600 baud, REF TICK clock source:
+            ctx.uart
+                .change_baud(9600, ClockSource::RefTick, &ctx.clocks);
+            ctx.uart.write(7).ok();
+            let read = block!(ctx.uart.read());
+            assert_eq!(read, Ok(7));
+
+            // 921,600 baud, APB clock source:
+            ctx.uart.change_baud(921_600, ClockSource::Apb, &ctx.clocks);
+            ctx.uart.write(253).ok();
+            let read = block!(ctx.uart.read());
+            assert_eq!(read, Ok(253));
+        }
     }
 }

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -17,9 +17,9 @@ use esp_hal::{
     clock::ClockControl,
     gpio::Io,
     peripherals::{Peripherals, UART0},
+    system::SystemControl,
     uart::{config::Config, TxRxPins, Uart, UartRx, UartTx},
     Async,
-    system::SystemControl,
 };
 
 struct Context {

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -6,6 +6,8 @@
 //!
 //! Connect TX (GPIO2) and RX (GPIO4) pins.
 
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
 #![no_std]
 #![no_main]
 
@@ -15,9 +17,9 @@ use esp_hal::{
     clock::ClockControl,
     gpio::Io,
     peripherals::{Peripherals, UART0},
-    system::SystemControl,
     uart::{config::Config, TxRxPins, Uart, UartRx, UartTx},
     Async,
+    system::SystemControl,
 };
 
 struct Context {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -257,14 +257,12 @@ pub fn execute_app(
             format!("--example={}", app.name())
         };
         (bin, "build")
+    } else if package.starts_with("src/bin") {
+        (format!("--bin={}", app.name()), "run")
+    } else if package.starts_with("tests") {
+        (format!("--test={}", app.name()), "test")
     } else {
-        if package.starts_with("src/bin") {
-            (format!("--bin={}", app.name()), "run")
-        } else if package.starts_with("tests") {
-            (format!("--test={}", app.name()), "test")
-        } else {
-            (format!("--example={}", app.name()), "run")
-        }
+        (format!("--example={}", app.name()), "run")
     };
 
     let mut features = app.features().to_vec();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- Enables C3, H2, S2 and S3 HIL.
- Updates the version of `probe-rs` being used.
##### Limitations
 Some test are disabled for some targets, see: https://github.com/esp-rs/esp-hal/issues/1524 and https://github.com/esp-rs/esp-hal/issues/1509

> [!IMPORTANT]  
> Once merged we need to add the `HIL Test | esp32c3`, `HIL Test | esp32h2`,  `HIL Test | esp32s2` and `HIL Test | esp32s3` test to the required checks

#### Testing
Manually triggered the HIL tests workflow: https://github.com/esp-rs/esp-hal/actions/runs/8891148274



