### PR TITLE
1376 - I2C runtime ISR binding example update

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Updated example on i2c to use the new `interrupt_handler` parameter (#1376)
 
 ### Added
 

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -23,6 +23,7 @@
 //!     io.pins.gpio2,
 //!     100.kHz(),
 //!     &clocks,
+//!     None,
 //! );
 //! loop {
 //!     let mut data = [0u8; 22];

--- a/esp-hal/src/soc/esp32/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32/efuse/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! ### Read chip's MAC address from the eFuse storage.
 //! ```no_run
-//! let mac_address = Efuse::get_mac_address();
+//! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,
 //!     "MAC: {:#X}:{:#X}:{:#X}:{:#X}:{:#X}:{:#X}",

--- a/esp-hal/src/soc/esp32c2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c2/efuse/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! ### Read chip's MAC address from the eFuse storage.
 //! ```no_run
-//! let mac_address = Efuse::get_mac_address();
+//! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,
 //!     "MAC: {:#X}:{:#X}:{:#X}:{:#X}:{:#X}:{:#X}",

--- a/esp-hal/src/soc/esp32c3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c3/efuse/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! ### Read chip's MAC address from the eFuse storage.
 //! ```no_run
-//! let mac_address = Efuse::get_mac_address();
+//! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,
 //!     "MAC: {:#X}:{:#X}:{:#X}:{:#X}:{:#X}:{:#X}",

--- a/esp-hal/src/soc/esp32c6/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c6/efuse/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! ### Read chip's MAC address from the eFuse storage.
 //! ```no_run
-//! let mac_address = Efuse::get_mac_address();
+//! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,
 //!     "MAC: {:#X}:{:#X}:{:#X}:{:#X}:{:#X}:{:#X}",

--- a/esp-hal/src/soc/esp32h2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32h2/efuse/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! ### Read chip's MAC address from the eFuse storage.
 //! ```no_run
-//! let mac_address = Efuse::get_mac_address();
+//! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,
 //!     "MAC: {:#X}:{:#X}:{:#X}:{:#X}:{:#X}:{:#X}",

--- a/esp-hal/src/soc/esp32s2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32s2/efuse/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! ### Read chip's MAC address from the eFuse storage.
 //! ```no_run
-//! let mac_address = Efuse::get_mac_address();
+//! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,
 //!     "MAC: {:#X}:{:#X}:{:#X}:{:#X}:{:#X}:{:#X}",

--- a/esp-hal/src/soc/esp32s3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32s3/efuse/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! ### Read chip's MAC address from the eFuse storage.
 //! ```no_run
-//! let mac_address = Efuse::get_mac_address();
+//! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,
 //!     "MAC: {:#X}:{:#X}:{:#X}:{:#X}:{:#X}:{:#X}",


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
After #1376 and upgrading esp-hal from 0.16 to 0.17, the reference example requires the extra parameter `<Option<InterruptHandler>`, adding it to the doc example/snippet.

#### Testing
These doc tests are in no_run, just adding them for future reference.
