### PR TITLE
Add unsafe dma api

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ESP32-PICO-V3-02: Initial support (#1155)
 - `time::current_time` API (#1503)
+- Add an unsafe API to SPI master enabling use-cases which are not possible using the safe API (#1523)
 
 ### Fixed
 

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -281,7 +281,7 @@ pub mod dma {
             ChannelTypes,
             DmaError,
             DmaPeripheral,
-            DmaTransferRxTx,
+            DmaTransfer,
             RxPrivate,
             TxPrivate,
         },
@@ -346,7 +346,7 @@ pub mod dma {
         aes_dma: &'t mut AesDma<'d, C>,
     }
 
-    impl<'t, 'd, C> DmaTransferRxTx for AesDmaTransferRxTx<'t, 'd, C>
+    impl<'t, 'd, C> DmaTransfer for AesDmaTransferRxTx<'t, 'd, C>
     where
         C: ChannelTypes,
         C::P: AesPeripheral,

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1504,16 +1504,6 @@ pub trait DmaTransfer: Drop {
     fn is_done(&self) -> bool;
 }
 
-/// Trait to be implemented for an in progress dma transfer.
-#[allow(clippy::type_complexity, drop_bounds)]
-#[doc(hidden)]
-pub trait DmaTransferRxTx: Drop {
-    /// Wait for the transfer to finish.
-    fn wait(self) -> Result<(), DmaError>;
-    /// Check if the transfer is finished.
-    fn is_done(&self) -> bool;
-}
-
 #[cfg(feature = "async")]
 pub(crate) mod asynch {
     use core::task::Poll;

--- a/esp-hal/src/prelude.rs
+++ b/esp-hal/src/prelude.rs
@@ -16,10 +16,7 @@ pub use nb;
 #[cfg(any(dport, pcr, system))]
 pub use crate::clock::Clock as _esp_hal_clock_Clock;
 #[cfg(any(gdma, pdma))]
-pub use crate::dma::{
-    DmaTransfer as _esp_hal_dma_DmaTransfer,
-    DmaTransferRxTx as _esp_hal_dma_DmaTransferRxTx,
-};
+pub use crate::dma::DmaTransfer as _esp_hal_dma_DmaTransfer;
 #[cfg(gpio)]
 pub use crate::gpio::{
     InputPin as _esp_hal_gpio_InputPin,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -823,7 +823,6 @@ pub mod dma {
             ChannelTypes,
             DmaError,
             DmaTransfer,
-            DmaTransferRxTx,
             RxPrivate,
             Spi2Peripheral,
             SpiPeripheral,
@@ -914,7 +913,7 @@ pub mod dma {
         spi_dma: &'t mut SpiDma<'d, T, C, M, DmaMode>,
     }
 
-    impl<'t, 'd, T, C, M, DmaMode> DmaTransferRxTx for SpiDmaTransferRxTx<'t, 'd, T, C, M, DmaMode>
+    impl<'t, 'd, T, C, M, DmaMode> DmaTransfer for SpiDmaTransferRxTx<'t, 'd, T, C, M, DmaMode>
     where
         T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
         C: ChannelTypes,

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -137,7 +137,6 @@ pub mod dma {
             ChannelTypes,
             DmaError,
             DmaTransfer,
-            DmaTransferRxTx,
             RxPrivate,
             Spi2Peripheral,
             SpiPeripheral,
@@ -239,7 +238,7 @@ pub mod dma {
         spi_dma: &'t mut SpiDma<'d, T, C, DmaMode>,
     }
 
-    impl<'t, 'd, T, C, DmaMode> DmaTransferRxTx for SpiDmaTransferRxTx<'t, 'd, T, C, DmaMode>
+    impl<'t, 'd, T, C, DmaMode> DmaTransfer for SpiDmaTransferRxTx<'t, 'd, T, C, DmaMode>
     where
         T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
         C: ChannelTypes,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1512

Bringing back the old clumsy API doesn't seem to be a good solution so this adds unsafe versions of write_dma, read_dma and transfer_dma for SPI master

#### Testing
Tested with https://github.com/bjoernQ/rust-esp32s3-ili9341 and the existing examples
