### PR TITLE
Fix delay on `esp32h2`.

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed ESP32 specific code for resolutions > 16 bit in ledc embedded_hal::pwm max_duty_cycle function. (#1441)
 - Fixed division by zero in ledc embedded_hal::pwm set_duty_cycle function and converted to set_duty_hw instead of set_duty to eliminate loss of granularity. (#1441)
 - Embassy examples now build on stable (#1485)
+- Fix delay on esp32h2 (#1535)
 
 ### Changed
 

--- a/esp-hal/src/delay.rs
+++ b/esp-hal/src/delay.rs
@@ -84,7 +84,11 @@ mod implementation {
             // The average clock frequency is fXTAL_CLK/2.5, which is 16 MHz.
             // The timer counting is incremented by 1/16 μs on each `CNT_CLK` cycle.
             Self {
+                #[cfg(not(esp32h2))]
                 freq: HertzU64::MHz(clocks.xtal_clock.to_MHz() as u64 * 10 / 25),
+                #[cfg(esp32h2)]
+                // esp32h2 TRM, section 11.2 Clock Source Selection
+                freq: HertzU64::MHz(clocks.xtal_clock.to_MHz() as u64 * 10 / 20),
             }
         }
 

--- a/hil-test/tests/get_time.rs
+++ b/hil-test/tests/get_time.rs
@@ -1,6 +1,6 @@
 //! current_time Test
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
closes #1509 

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Сoefficient for getting `16MHz` in Delay from `xtal_clock` (`2.5`) wrong because it's related for `40MHz` `xtal`, when `esp32h2`'s is `32MHz`

<img width="909" alt="image" src="https://github.com/esp-rs/esp-hal/assets/62840029/0bf0fb7d-aeaa-4c77-91b2-9424cfa769cb">


#### Testing
Tested delay time with DSLab LA, it's 500-501ms now.
