### PR TITLE
ci: Update build-test name to match the required CI jobs

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-tests:
-    name: Build Tests | ${{ matrix.target.soc }}
+    name: HIL Test | ${{ matrix.target.soc }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR just updates the name of the `build-test` job so we avoid merging PRs where the building the tests failed like: https://github.com/esp-rs/esp-hal/actions/runs/8942444773. This happened because, as build failed the "HIL Test | ${{ matrix.target.soc }}" steps of the `hil` job were not executed, so they were not required test to merge the PR.

Its a bit ugly but, it will avoid these situations. I wish there was a better way to do this...

#### Testing
I havent, I cant think of an easy way to test this.
