### PR TITLE
spi: implement setting bit order

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - i2c: implement `I2C:transaction` for `embedded-hal` and `embedded-hal-async`
+- spi: implement `with_bit_order` - #1537
 - ESP32-PICO-V3-02: Initial support (#1155)
 - `time::current_time` API (#1503)
 - ESP32-S3: Add LCD_CAM Camera driver (#1483)

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2647,7 +2647,7 @@ pub trait Instance: crate::private::Sealed {
         });
     }
 
-    #[cfg(not(any(esp32, esp32s2)))]
+    #[cfg(not(any(esp32, esp32c3, esp32s2)))]
     fn set_bit_order(&mut self, read_order: SpiBitOrder, write_order: SpiBitOrder) {
         let reg_block = self.register_block();
 
@@ -2665,7 +2665,7 @@ pub trait Instance: crate::private::Sealed {
             w
         });
     }
-    #[cfg(any(esp32, esp32s2))]
+    #[cfg(any(esp32, esp32c3, esp32s2))]
     fn set_bit_order(&mut self, read_order: SpiBitOrder, write_order: SpiBitOrder) {
         let reg_block = self.register_block();
 
@@ -2677,7 +2677,7 @@ pub trait Instance: crate::private::Sealed {
             SpiBitOrder::MSBFirst => false,
             SpiBitOrder::LSBFirst => true,
         };
-        reg_block.ctrl().modify(|_, w| unsafe {
+        reg_block.ctrl().modify(|_, w| {
             w.rd_bit_order().bit(read_value);
             w.wr_bit_order().bit(write_value);
             w

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -44,6 +44,14 @@ pub enum SpiMode {
     Mode3,
 }
 
+/// SPI Bit Order
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SpiBitOrder {
+    MSBFirst,
+    LSBFirst,
+}
+
 pub trait DuplexMode {}
 pub trait IsFullDuplex: DuplexMode {}
 pub trait IsHalfDuplex: DuplexMode {}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Added `with_bit_order` to full and half duplex.

#### Description
Some chips like PM532 use LSB First and the default is MSBFirst. implementations.

NOTE that is a 2 bit field in the `SPI_CTRL_REG` register except on `esp32`, `esp32c3`, and `esp32s2` where its a one bit field.

#### Testing
I've only tested with PM532 on esp32s3.

