### PR TITLE
Feature: correct TRNG mechanism

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `embassy-usb` support (#1517)
 - SPI Slave support for ESP32-S2 (#1562)
 - Add new generic `OneShotTimer` and `PeriodicTimer` drivers, plus new `Timer` trait which is implemented for `TIMGx` and `SYSTIMER` (#1570)
+- Feature: correct `TRNG` mechanism #1804
 
 ### Fixed
 

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -131,27 +131,37 @@ impl rand_core::RngCore for Rng {
 /// Due to pulling the entropy source from the ADC, it uses the associated
 /// regiters, so to use TRNG we need to "occupy" the ADC peripheral.
 ///
-/// ```rust, ignore
+/// ```rust, no_run
+#[doc = crate::before_snippet!()]
+/// # use esp_hal::rng::Trng;
+/// # use esp_hal::peripherals::Peripherals;
+/// # use esp_hal::peripherals::ADC1;
+/// # use esp_hal::analog::adc::{AdcConfig, Attenuation, Adc};
+/// # use esp_hal::gpio::Io;
+///
+/// let mut peripherals = Peripherals::take();
+/// let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 /// let mut buf = [0u8; 16];
+///
+/// // ADC is not available from now
 /// let mut trng = Trng::new(peripherals.RNG, &mut peripherals.ADC1);
 /// trng.read(&mut buf);
-///
-/// println!("TRNG: Random bytes: {:?}", buf);
-/// println!("TRNG: Random u32:  {}", rng.random());
+/// let mut true_rand = trng.random();
 ///
 /// let mut rng = trng.downgrade();
 ///
+/// // ADC is available now
 /// let analog_pin = io.pins.gpio3;
 /// let mut adc1_config = AdcConfig::new();
-/// let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
-/// let mut adc1 = Adc::<ADC1>::new(peripherals.ADC1, adc1_config);
-/// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
+/// let mut adc1_pin = adc1_config.enable_pin(analog_pin,
+/// Attenuation::Attenuation11dB); let mut adc1 =
+/// Adc::<ADC1>::new(peripherals.ADC1, adc1_config); let pin_value: u16 =
+/// nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
 ///
 /// rng.read(&mut buf);
-/// println!("Random bytes: {:?}", buf);
-/// println!("Random u32:  {}", rng.random());
+/// true_rand = rng.random();
 /// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
-/// println!("ADC reading = {}", pin_value);
+/// # }
 /// ```
 
 pub struct Trng<'d> {

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -123,30 +123,29 @@ impl rand_core::RngCore for Rng {
 /// True Random Number Generator (TRNG) driver
 ///
 /// The `Trng` struct represents a true random number generator that combines
-/// the randomness from the hardware RNG and an ADC. This struct provides methods
-/// to generate random numbers and fill buffers with random bytes. 
-/// Due to pulling the entropy source from the ADC, it uses the associated regiters,
-/// so to use TRNG we need to "occupy" the ADC peripheral.
-/// 
+/// the randomness from the hardware RNG and an ADC. This struct provides
+/// methods to generate random numbers and fill buffers with random bytes.
+/// Due to pulling the entropy source from the ADC, it uses the associated
+/// regiters, so to use TRNG we need to "occupy" the ADC peripheral.
+///
 /// ```no_run
 /// let analog_pin = io.pins.gpio3.into_analog();
 /// let mut adc1_config = AdcConfig::new();
 /// let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
 /// let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
 /// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
-/// 
+///
 /// let mut trng = Trng::new(peripherals.RNG, &mut adc1);
-/// 
+///
 /// let (mut rng, adc1) = trng.downgrade();
-/// 
-///  // Fill a buffer with random bytes:
+///
+/// // Fill a buffer with random bytes:
 /// let mut buf = [0u8; 16];
 /// println!("Random bytes: {:?}", buf);
-/// 
+///
 /// println!("Random u32:   {}", rng.random());
 /// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
 /// println!("ADC reading = {}", pin_value);
-/// 
 /// ```
 #[cfg(not(esp32p4))]
 pub struct Trng<'d> {
@@ -187,8 +186,9 @@ impl<'d> Trng<'d> {
         self.rng.read(buffer)
     }
 
-    /// Downgrades the `Trng` instance to a `Rng` instance and releases the ADC1.
-    /// Returns a tuple containing the `Rng` instance and a mutable reference to the `Adc`.
+    /// Downgrades the `Trng` instance to a `Rng` instance and releases the
+    /// ADC1. Returns a tuple containing the `Rng` instance and a mutable
+    /// reference to the `Adc`.
     pub fn downgrade(&mut self) -> (Rng, &'d mut Adc<'_, crate::peripherals::ADC1>) {
         crate::soc::trng::revert_trng();
         (self.rng, self.adc)
@@ -224,6 +224,7 @@ impl rand_core::RngCore for Trng<'_> {
     }
 }
 
-/// Implementing a CryptoRng marker trait that indicates that the generator is cryptographically secure.
+/// Implementing a CryptoRng marker trait that indicates that the generator is
+/// cryptographically secure.
 #[cfg(not(esp32p4))]
 impl rand_core::CryptoRng for Trng<'_> {}

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -131,29 +131,29 @@ impl rand_core::RngCore for Rng {
 /// Due to pulling the entropy source from the ADC, it uses the associated
 /// regiters, so to use TRNG we need to "occupy" the ADC peripheral.
 ///
-/// ```no_run
-/// let analog_pin = io.pins.gpio3.into_analog();
-/// let mut adc1_config = AdcConfig::new();
-/// let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
-/// let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
-/// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
-///
+/// ```rust, ignore
 /// let mut buf = [0u8; 16];
-/// let mut trng = Trng::new(peripherals.RNG, &mut adc1);
+/// let mut trng = Trng::new(peripherals.RNG, &mut peripherals.ADC1);
 /// trng.read(&mut buf);
 ///
 /// println!("TRNG: Random bytes: {:?}", buf);
-/// println!("TRNG: Random u32:   {}", rng.random());
+/// println!("TRNG: Random u32:  {}", rng.random());
 ///
 /// let mut rng = trng.downgrade();
 ///
+/// let analog_pin = io.pins.gpio3;
+/// let mut adc1_config = AdcConfig::new();
+/// let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
+/// let mut adc1 = Adc::<ADC1>::new(peripherals.ADC1, adc1_config);
+/// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
+///
 /// rng.read(&mut buf);
 /// println!("Random bytes: {:?}", buf);
-///
-/// println!("Random u32:   {}", rng.random());
+/// println!("Random u32:  {}", rng.random());
 /// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
 /// println!("ADC reading = {}", pin_value);
 /// ```
+
 pub struct Trng<'d> {
     /// The hardware random number generator instance.
     pub rng: Rng,

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -147,9 +147,7 @@ impl rand_core::RngCore for Rng {
 /// let mut trng = Trng::new(peripherals.RNG, &mut peripherals.ADC1);
 /// trng.read(&mut buf);
 /// let mut true_rand = trng.random();
-///
-/// let mut rng = trng.downgrade();
-///
+#[cfg_attr(not(esp32c6), doc = "let mut rng = trng.downgrade();")]
 /// // ADC is available now
 #[cfg_attr(esp32, doc = "let analog_pin = io.pins.gpio32;")]
 #[cfg_attr(not(esp32), doc = "let analog_pin = io.pins.gpio3;")]
@@ -158,9 +156,8 @@ impl rand_core::RngCore for Rng {
 /// Attenuation::Attenuation11dB); let mut adc1 =
 /// Adc::<ADC1>::new(peripherals.ADC1, adc1_config); let pin_value: u16 =
 /// nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
-///
-/// rng.read(&mut buf);
-/// true_rand = rng.random();
+#[cfg_attr(not(esp32c6), doc = "rng.read(&mut buf);")]
+#[cfg_attr(not(esp32c6), doc = "true_rand = rng.random();")]
 /// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
 /// # }
 /// ```
@@ -206,10 +203,15 @@ impl<'d> Trng<'d> {
 
     /// Downgrades the `Trng` instance to a `Rng` instance and releases the
     /// ADC1.
+    /// For esp32c6 - blocked on https://github.com/espressif/esp-idf/issues/14124
+    #[cfg(not(esp32c6))]
     pub fn downgrade(self) -> Rng {
         self.rng
     }
 }
+
+/// For esp32c6 - blocked on https://github.com/espressif/esp-idf/issues/14124
+#[cfg(not(esp32c6))]
 impl<'d> Drop for Trng<'d> {
     fn drop(&mut self) {
         crate::soc::trng::revert_trng();

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -131,6 +131,9 @@ impl rand_core::RngCore for Rng {
 /// Due to pulling the entropy source from the ADC, it uses the associated
 /// regiters, so to use TRNG we need to "occupy" the ADC peripheral.
 ///
+/// For now, even after calling `core::mem::drop()` on `TRNG` ADC1 will not be
+/// usable (details in esp-hal/#1750)
+///
 /// ```rust, no_run
 #[doc = crate::before_snippet!()]
 /// # use esp_hal::rng::Trng;

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -151,7 +151,8 @@ impl rand_core::RngCore for Rng {
 /// let mut rng = trng.downgrade();
 ///
 /// // ADC is available now
-/// let analog_pin = io.pins.gpio3;
+#[cfg_attr(esp32, doc = "let analog_pin = io.pins.gpio32;")]
+#[cfg_attr(not(esp32), doc = "let analog_pin = io.pins.gpio3;")]
 /// let mut adc1_config = AdcConfig::new();
 /// let mut adc1_pin = adc1_config.enable_pin(analog_pin,
 /// Attenuation::Attenuation11dB); let mut adc1 =

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -43,10 +43,8 @@
 #![doc = concat!("[ESP-IDF documentation](https://docs.espressif.com/projects/esp-idf/en/latest/", crate::soc::chip!(), "/api-reference/system/random.html)")]
 
 use core::marker::PhantomData;
-use core::ops::Deref;
-use crate::analog::adc::ADC;
 
-use crate::{peripheral::Peripheral , peripherals::RNG};
+use crate::{analog::adc::Adc, peripheral::Peripheral, peripherals::RNG};
 
 /// Random number generator driver
 #[derive(Clone, Copy)]
@@ -123,21 +121,21 @@ impl rand_core::RngCore for Rng {
 }
 
 #[cfg(not(esp32p4))]
-pub struct Trng<'d>{
+pub struct Trng<'d> {
     pub rng: Rng,
-    adc: &'d mut ADC<'d, crate::peripherals::ADC1>
+    adc: &'d mut Adc<'d, crate::peripherals::ADC1>,
 }
 
 #[cfg(not(esp32p4))]
 impl<'d> Trng<'d> {
     /// Create a new True Random Number Generator instance
-    pub fn new(rng: impl Peripheral<P = RNG>, adc: &'d mut ADC<'d, crate::peripherals::ADC1>) -> Self {
-        let gen = Rng::new(rng);  
+    pub fn new(
+        rng: impl Peripheral<P = RNG>,
+        adc: &'d mut Adc<'d, crate::peripherals::ADC1>,
+    ) -> Self {
+        let gen = Rng::new(rng);
         crate::soc::trng::ensure_randomness();
-        Self{
-            rng: gen,
-            adc: adc,
-        }
+        Self { rng: gen, adc: adc }
     }
 
     pub fn random(&mut self) -> u32 {
@@ -149,7 +147,7 @@ impl<'d> Trng<'d> {
     }
 
     /// Downgrade Trng to Rng and release ADC1
-    pub fn downgrade(&mut self) -> (Rng, &'d mut ADC<'_, crate::peripherals::ADC1>) {
+    pub fn downgrade(&mut self) -> (Rng, &'d mut Adc<'_, crate::peripherals::ADC1>) {
         crate::soc::trng::revert_trng();
         (self.rng, self.adc)
     }

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -119,3 +119,23 @@ impl rand_core::RngCore for Rng {
         Ok(())
     }
 }
+
+#[derive(Clone, Copy)]
+pub struct Trng<'d, ADC> {
+    pub rng: Rng,
+    _adc1: PeripheralRef<'d, ADCI>,
+    #[cfg(esp32c3, )]>,
+}
+
+impl Trng<ADC> {
+    /// Create a new True Random Number Generator instance
+    pub fn new(rng: impl Peripheral<P = RNG>) -> Self {
+        let gen = Rng::new(rng);  
+        #[cfg(not(esp32p4))]
+        crate::soc::trng::ensure_randomness();
+        Self{rng: gen}
+    }
+}
+
+#[cfg(not(esp32p4))]
+impl rand_core::CryptoRng for Rng {}

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -154,7 +154,7 @@ impl<'d> Trng<'d> {
 }
 
 #[cfg(feature = "embedded-hal-02")]
-impl embedded_hal_02::blocking::rng::Read for Trng {
+impl embedded_hal_02::blocking::rng::Read for Trng<'_> {
     type Error = core::convert::Infallible;
 
     fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -135,7 +135,7 @@ impl<'d> Trng<'d> {
     ) -> Self {
         let gen = Rng::new(rng);
         crate::soc::trng::ensure_randomness();
-        Self { rng: gen, adc: adc }
+        Self { rng: gen, adc }
     }
 
     pub fn random(&mut self) -> u32 {

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -17,6 +17,7 @@ pub mod peripherals;
 #[cfg(psram)]
 pub mod psram;
 pub mod radio_clocks;
+pub mod trng;
 
 /// The name of the chip ("esp32") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32/trng.rs
+++ b/esp-hal/src/soc/esp32/trng.rs
@@ -138,8 +138,7 @@ pub fn ensure_randomness() {
     set_peri_reg_mask(DR_REG_I2S_BASE + 0x00a8, I2S_RX_START);
 }
 
-pub fn revert_trng()
-{
+pub fn revert_trng() {
     clear_peri_reg_mask(I2S_CONF_REG0, I2S_RX_START);
     set_peri_reg_mask(I2S_CONF_REG0, I2S_RX_RESET);
     clear_peri_reg_mask(I2S_CONF_REG0, I2S_RX_RESET);
@@ -152,11 +151,24 @@ pub fn revert_trng()
     clear_peri_reg_mask(SENS_SAR_READ_CTRL2_REG, SENS_SAR2_DIG_FORCE);
 
     clear_peri_reg_mask(SENS_SAR_START_FORCE_REG, SENS_SAR2_EN_TEST);
-    clear_peri_reg_mask(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR2_MUX | SYSCON_SARADC_SAR_SEL | SYSCON_SARADC_DATA_TO_I2S);
+    clear_peri_reg_mask(
+        SYSCON_SARADC_CTRL_REG,
+        SYSCON_SARADC_SAR2_MUX | SYSCON_SARADC_SAR_SEL | SYSCON_SARADC_DATA_TO_I2S,
+    );
 
-    set_peri_reg_bits(SENS_SAR_MEAS_WAIT2_REG, SENS_FORCE_XPD_SAR, 0, SENS_FORCE_XPD_SAR_S);
+    set_peri_reg_bits(
+        SENS_SAR_MEAS_WAIT2_REG,
+        SENS_FORCE_XPD_SAR,
+        0,
+        SENS_FORCE_XPD_SAR_S,
+    );
 
-    set_peri_reg_bits(SYSCON_SARADC_FSM_REG, SYSCON_SARADC_START_WAIT, 8, SYSCON_SARADC_START_WAIT_S);
+    set_peri_reg_bits(
+        SYSCON_SARADC_FSM_REG,
+        SYSCON_SARADC_START_WAIT,
+        8,
+        SYSCON_SARADC_START_WAIT_S,
+    );
 }
 
 fn set_peri_reg_bits(reg: u32, bitmap: u32, value: u32, shift: u32) {

--- a/esp-hal/src/soc/esp32/trng.rs
+++ b/esp-hal/src/soc/esp32/trng.rs
@@ -1,0 +1,186 @@
+const DR_REG_RTCCNTL_BASE: u32 = 0x3ff48000;
+const RTC_CNTL_TEST_MUX_REG: u32 = DR_REG_RTCCNTL_BASE + 0xa8;
+const RTC_CNTL_DTEST_RTC: u32 = 0x00000003;
+const RTC_CNTL_DTEST_RTC_S: u32 = 30;
+const RTC_CNTL_ENT_RTC: u32 = 1 << 29;
+const SENS_SAR_START_FORCE_REG: u32 = 0x3ff48800 + 0x002c;
+const SENS_SAR2_EN_TEST: u32 = 1 << 4;
+const DPORT_PERIP_CLK_EN_REG: u32 = 0x3ff00000 + 0x0c0;
+const DPORT_I2C_EXT0_CLK_EN: u32 = 1 << 7;
+
+const DPORT_PERIP_RST_EN_REG: u32 = 0x3ff00000 + 0x0c4;
+const DPORT_I2C_EXT0_RST: u32 = 1 << 7;
+
+const SENS_ULP_CP_FORCE_START_TOP: u32 = 1 << 8;
+const SENS_ULP_CP_START_TOP: u32 = 1 << 9;
+
+const DR_REG_I2S_BASE: u32 = 0x3ff4f000;
+
+const DR_REG_SYSCON_BASE: u32 = 0x3ff66000;
+const SYSCON_SARADC_CTRL_REG: u32 = DR_REG_SYSCON_BASE + 0x10;
+const SYSCON_SARADC_FSM_REG: u32 = DR_REG_SYSCON_BASE + 0x18;
+const SYSCON_SARADC_SAR2_PATT_TAB1_REG: u32 = DR_REG_SYSCON_BASE + 0x2c;
+const SYSCON_SARADC_SAR2_PATT_TAB2_REG: u32 = DR_REG_SYSCON_BASE + 0x30;
+const SYSCON_SARADC_SAR2_PATT_TAB3_REG: u32 = DR_REG_SYSCON_BASE + 0x34;
+const SYSCON_SARADC_SAR2_PATT_TAB4_REG: u32 = DR_REG_SYSCON_BASE + 0x38;
+const SYSCON_SARADC_SAR2_MUX: u32 = 1 << 2;
+const SYSCON_SARADC_SAR_CLK_DIV: u32 = 0x000000FF;
+const SYSCON_SARADC_SAR_CLK_DIV_S: u32 = 7;
+const SYSCON_SARADC_RSTB_WAIT: u32 = 0x000000FF;
+const SYSCON_SARADC_RSTB_WAIT_S: u32 = 0;
+const SYSCON_SARADC_START_WAIT: u32 = 1 << 2;
+const SYSCON_SARADC_START_WAIT_S: u32 = 1 << 2;
+const SYSCON_SARADC_WORK_MODE: u32 = 0x00000003;
+const SYSCON_SARADC_WORK_MODE_S: u32 = 3;
+const SYSCON_SARADC_SAR_SEL: u32 = 1 << 5;
+const I2S_RX_BCK_DIV_NUM: u32 = 0x0000003F;
+const I2S_RX_BCK_DIV_NUM_S: u32 = 6;
+const SYSCON_SARADC_DATA_TO_I2S: u32 = 1 << 16;
+const SYSCON_SARADC_DATA_SAR_SEL: u32 = 1 << 25;
+
+const I2S_CAMERA_EN: u32 = 1 << 0;
+const I2S_LCD_EN: u32 = 1 << 5;
+const I2S_DATA_ENABLE: u32 = 1 << 4;
+const I2S_DATA_ENABLE_TEST_EN: u32 = 1 << 3;
+const I2S_RX_START: u32 = 1 << 5;
+const I2S_RX_RESET: u32 = 1 << 1;
+
+const DR_REG_SENS_BASE: u32 = 0x3ff48800;
+const SENS_SAR_MEAS_WAIT2_REG: u32 = DR_REG_SENS_BASE + 0x000c;
+const SENS_SAR_READ_CTRL_REG: u32 = DR_REG_SENS_BASE;
+const SENS_SAR_READ_CTRL2_REG: u32 = DR_REG_SENS_BASE + 0x0090;
+const SENS_FORCE_XPD_SAR: u32 = 0x00000003;
+const SENS_FORCE_XPD_SAR_S: u32 = 18;
+const SENS_SAR1_DIG_FORCE: u32 = 1 << 27;
+const SENS_SAR2_DIG_FORCE: u32 = 1 << 28;
+
+const I2S_CONF_REG0: u32 = DR_REG_I2S_BASE + 0x00a8;
+
+pub fn ensure_randomness() {
+    set_peri_reg_bits(
+        RTC_CNTL_TEST_MUX_REG,
+        RTC_CNTL_DTEST_RTC,
+        2,
+        RTC_CNTL_DTEST_RTC_S,
+    );
+
+    set_peri_reg_mask(RTC_CNTL_TEST_MUX_REG, RTC_CNTL_ENT_RTC);
+    set_peri_reg_mask(SENS_SAR_START_FORCE_REG, SENS_SAR2_EN_TEST);
+
+    // periph_module_enable(PERIPH_I2S0_MODULE);
+    set_peri_reg_mask(DPORT_PERIP_CLK_EN_REG, DPORT_I2C_EXT0_CLK_EN);
+    clear_peri_reg_mask(DPORT_PERIP_RST_EN_REG, DPORT_I2C_EXT0_RST);
+
+    clear_peri_reg_mask(SENS_SAR_START_FORCE_REG, SENS_ULP_CP_FORCE_START_TOP);
+    clear_peri_reg_mask(SENS_SAR_START_FORCE_REG, SENS_ULP_CP_START_TOP);
+
+    // Test pattern configuration byte 0xAD:
+    //--[7:4] channel_sel: 10-->en_test
+    //--[3:2] bit_width  : 3-->12bit
+    //--[1:0] atten      : 1-->3dB attenuation
+    write_peri_reg(SYSCON_SARADC_SAR2_PATT_TAB1_REG, 0xADADADAD);
+    write_peri_reg(SYSCON_SARADC_SAR2_PATT_TAB2_REG, 0xADADADAD);
+    write_peri_reg(SYSCON_SARADC_SAR2_PATT_TAB3_REG, 0xADADADAD);
+    write_peri_reg(SYSCON_SARADC_SAR2_PATT_TAB4_REG, 0xADADADAD);
+
+    set_peri_reg_bits(
+        SENS_SAR_MEAS_WAIT2_REG,
+        SENS_FORCE_XPD_SAR,
+        3,
+        SENS_FORCE_XPD_SAR_S,
+    );
+
+    set_peri_reg_mask(SENS_SAR_READ_CTRL_REG, SENS_SAR1_DIG_FORCE);
+    set_peri_reg_mask(SENS_SAR_READ_CTRL2_REG, SENS_SAR2_DIG_FORCE);
+
+    set_peri_reg_mask(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR2_MUX);
+    set_peri_reg_bits(
+        SYSCON_SARADC_CTRL_REG,
+        SYSCON_SARADC_SAR_CLK_DIV,
+        4,
+        SYSCON_SARADC_SAR_CLK_DIV_S,
+    );
+    set_peri_reg_bits(
+        SYSCON_SARADC_FSM_REG,
+        SYSCON_SARADC_RSTB_WAIT,
+        8,
+        SYSCON_SARADC_RSTB_WAIT_S,
+    );
+    set_peri_reg_bits(
+        SYSCON_SARADC_FSM_REG,
+        SYSCON_SARADC_START_WAIT,
+        10,
+        SYSCON_SARADC_START_WAIT_S,
+    );
+    set_peri_reg_bits(
+        SYSCON_SARADC_CTRL_REG,
+        SYSCON_SARADC_WORK_MODE,
+        0,
+        SYSCON_SARADC_WORK_MODE_S,
+    );
+
+    set_peri_reg_mask(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR_SEL);
+    clear_peri_reg_mask(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_DATA_SAR_SEL);
+
+    set_peri_reg_bits(
+        DR_REG_I2S_BASE + 0x00b0,
+        I2S_RX_BCK_DIV_NUM,
+        20,
+        I2S_RX_BCK_DIV_NUM_S,
+    );
+
+    set_peri_reg_mask(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_DATA_TO_I2S);
+
+    clear_peri_reg_mask(DR_REG_I2S_BASE + 0x00a8, I2S_CAMERA_EN);
+    set_peri_reg_mask(DR_REG_I2S_BASE + 0x00a8, I2S_LCD_EN);
+    set_peri_reg_mask(DR_REG_I2S_BASE + 0x00a8, I2S_DATA_ENABLE);
+    set_peri_reg_mask(DR_REG_I2S_BASE + 0x00a8, I2S_DATA_ENABLE_TEST_EN);
+    set_peri_reg_mask(DR_REG_I2S_BASE + 0x00a8, I2S_RX_START);
+}
+
+pub fn revert_trng()
+{
+    clear_peri_reg_mask(I2S_CONF_REG0, I2S_RX_START);
+    set_peri_reg_mask(I2S_CONF_REG0, I2S_RX_RESET);
+    clear_peri_reg_mask(I2S_CONF_REG0, I2S_RX_RESET);
+    clear_peri_reg_mask(I2S_CONF_REG0, I2S_CAMERA_EN);
+    clear_peri_reg_mask(I2S_CONF_REG0, I2S_LCD_EN);
+    clear_peri_reg_mask(I2S_CONF_REG0, I2S_DATA_ENABLE_TEST_EN);
+    clear_peri_reg_mask(I2S_CONF_REG0, I2S_DATA_ENABLE);
+
+    clear_peri_reg_mask(SENS_SAR_READ_CTRL_REG, SENS_SAR1_DIG_FORCE);
+    clear_peri_reg_mask(SENS_SAR_READ_CTRL2_REG, SENS_SAR2_DIG_FORCE);
+
+    clear_peri_reg_mask(SENS_SAR_START_FORCE_REG, SENS_SAR2_EN_TEST);
+    clear_peri_reg_mask(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR2_MUX | SYSCON_SARADC_SAR_SEL | SYSCON_SARADC_DATA_TO_I2S);
+
+    set_peri_reg_bits(SENS_SAR_MEAS_WAIT2_REG, SENS_FORCE_XPD_SAR, 0, SENS_FORCE_XPD_SAR_S);
+
+    set_peri_reg_bits(SYSCON_SARADC_FSM_REG, SYSCON_SARADC_START_WAIT, 8, SYSCON_SARADC_START_WAIT_S);
+}
+
+fn set_peri_reg_bits(reg: u32, bitmap: u32, value: u32, shift: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(
+            ((reg as *mut u32).read_volatile() & !(bitmap << shift)) | ((value & bitmap) << shift),
+        );
+    }
+}
+
+fn set_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
+    }
+}
+
+fn clear_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+    }
+}
+
+fn write_peri_reg(reg: u32, val: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(val);
+    }
+}

--- a/esp-hal/src/soc/esp32c2/mod.rs
+++ b/esp-hal/src/soc/esp32c2/mod.rs
@@ -12,6 +12,7 @@ pub mod efuse;
 pub mod gpio;
 pub mod peripherals;
 pub mod radio_clocks;
+pub mod trng;
 
 /// The name of the chip ("esp32c2") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32c2/trng.rs
+++ b/esp-hal/src/soc/esp32c2/trng.rs
@@ -1,10 +1,3 @@
-const DR_REG_RTCCNTL_BASE: u32 = 0x60008000;
-const RTC_CNTL_SENSOR_CTRL_REG: u32 = DR_REG_RTCCNTL_BASE + 0x108;
-const RTC_CNTL_FORCE_XPD_SAR_V: u32 = 0x3;
-const RTC_CNTL_FORCE_XPD_SAR_S: u32 = 30;
-const RTC_CNTL_ANA_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x2c;
-const RTC_CNTL_SAR_I2C_PU_M: u32 = 1 << 22;
-
 const I2C_SAR_ADC: u8 = 0x69;
 const I2C_SAR_ADC_HOSTID: u8 = 0;
 const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
@@ -20,203 +13,120 @@ const ADC_SARADC_ENT_TSENS_ADDR: u8 = 0x07;
 const ADC_SARADC_ENT_TSENS_ADDR_MSB: u8 = 2;
 const ADC_SARADC_ENT_TSENS_ADDR_LSB: u8 = 2;
 
-const DR_REG_SYSTEM_BASE: u32 = 0x600c0000;
-const SYSTEM_PERIP_CLK_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x10;
-const SYSTEM_PERIP_RST_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x18;
-const APB_SARADC_CLK_EN_M: u32 = 0x00000001 << 28;
-const DR_REG_APB_SARADC_BASE: u32 = 0x60040000;
-const APB_SARADC_APB_ADC_CLKM_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x54;
-const APB_SARADC_REG_CLK_SEL_V: u32 = 0x00000003;
-const APB_SARADC_REG_CLK_SEL_S: u32 = 21;
-const APB_SARADC_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE;
-const APB_SARADC_SAR_PATT_P_CLEAR_M: u32 = 0x00000001 << 23;
-const APB_SARADC_SAR_PATT_LEN_V: u32 = 0x00000007;
-const APB_SARADC_SAR_PATT_LEN_S: u32 = 15;
-const APB_SARADC_SAR_CLK_GATED_M: u32 = 0x00000001 << 6;
-const APB_SARADC_XPD_SAR_FORCE_V: u32 = 0x00000003;
-const APB_SARADC_XPD_SAR_FORCE_S: u32 = 27;
-const APB_SARADC_SAR_CLK_DIV_V: u32 = 0x000000FF;
-const APB_SARADC_SAR_CLK_DIV_S: u32 = 7;
-const APB_SARADC_SAR_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x18;
-const APB_SARADC_SAR_PATT_TAB2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x1c;
-const APB_SARADC_SAR_PATT_TAB1_V: u32 = 0x00FFFFFF;
-const APB_SARADC_SAR_PATT_TAB1_S: u32 = 0;
-const APB_SARADC_SAR_PATT_TAB2_V: u32 = 0x00FFFFFF;
-const APB_SARADC_SAR_PATT_TAB2_S: u32 = 0;
-const APB_SARADC_CTRL2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x4;
-const APB_SARADC_TIMER_TARGET_V: u32 = 0x00000FFF;
-const APB_SARADC_TIMER_TARGET_S: u32 = 12;
-const APB_SARADC_REG_CLKM_DIV_NUM_V: u32 = 0x000000FF;
-const APB_SARADC_REG_CLKM_DIV_NUM_S: u32 = 0;
-const APB_SARADC_MEAS_NUM_LIMIT: u32 = 1 << 0;
-const APB_SARADC_DMA_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x50;
-const APB_SARADC_APB_ADC_TRANS_M: u32 = 0x00000001 << 31;
-const APB_SARADC_TIMER_EN: u32 = 1 << 24;
-const APB_SARADC_FSM_WAIT_REG: u32 = DR_REG_APB_SARADC_BASE + 0xc;
-const APB_SARADC_RSTB_WAIT_V: u32 = 0x000000FF;
-const APB_SARADC_RSTB_WAIT_S: u32 = 8;
-const APB_SARADC_XPD_WAIT_V: u32 = 0x000000FF;
-const APB_SARADC_XPD_WAIT_S: u32 = 0;
-const APB_SARADC_STANDBY_WAIT_V: u32 = 0x000000FF;
-const APB_SARADC_STANDBY_WAIT_S: u32 = 16;
-const SYSTEM_APB_SARADC_RST_M: u32 = 0x00000001 << 28;
-const SYSTEM_APB_SARADC_CLK_EN_M: u32 = 0x00000001 << 28;
-
 use crate::regi2c_write_mask;
 
 pub(crate) fn ensure_randomness() {
-    // RNG module is always clock enabled
-    reg_set_field(
-        RTC_CNTL_SENSOR_CTRL_REG,
-        RTC_CNTL_FORCE_XPD_SAR_V,
-        RTC_CNTL_FORCE_XPD_SAR_S,
-        0x3,
-    );
+    let rtc_cntl = unsafe { &*crate::peripherals::RTC_CNTL::ptr() };
+    let system = unsafe { &*crate::peripherals::SYSTEM::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
 
-    set_peri_reg_mask(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_PU_M);
+    unsafe {
+        // RNG module is always clock enabled
+        rtc_cntl
+            .cntl_sensor_ctrl()
+            .modify(|_, w| w.force_xpd_sar().bits(3));
 
-    // Bridging sar2 internal reference voltage
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 1);
+        rtc_cntl.ana_conf().modify(|_, w| w.sar_i2c_pu().set_bit());
 
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
+        // Bridging sar2 internal reference voltage
+        // Cannot replace with PAC-based functions
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 1);
 
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
 
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
 
-    // Enable SAR ADC2 internal channel to read adc2 ref voltage for additional
-    // entropy
-    set_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, SYSTEM_APB_SARADC_CLK_EN_M);
-    clear_peri_reg_mask(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_APB_SARADC_RST_M);
-    reg_set_field(
-        APB_SARADC_APB_ADC_CLKM_CONF_REG,
-        APB_SARADC_REG_CLK_SEL_V,
-        APB_SARADC_REG_CLK_SEL_S,
-        0x2,
-    );
-    set_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
-    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_CLK_GATED_M);
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_XPD_SAR_FORCE_V,
-        APB_SARADC_XPD_SAR_FORCE_S,
-        0x3,
-    );
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR_CLK_DIV_V,
-        APB_SARADC_SAR_CLK_DIV_S,
-        1,
-    );
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
 
-    reg_set_field(
-        APB_SARADC_FSM_WAIT_REG,
-        APB_SARADC_RSTB_WAIT_V,
-        APB_SARADC_RSTB_WAIT_S,
-        8,
-    );
+        // Enable SAR ADC2 internal channel to read adc2 ref voltage for additional
+        // entropy
+        system
+            .perip_clk_en0()
+            .modify(|_, w| w.apb_saradc_clk_en().set_bit());
 
-    reg_set_field(
-        APB_SARADC_FSM_WAIT_REG,
-        APB_SARADC_XPD_WAIT_V,
-        APB_SARADC_XPD_WAIT_S,
-        5,
-    );
+        system
+            .perip_rst_en0()
+            .modify(|_, w| w.apb_saradc_rst().clear_bit());
 
-    reg_set_field(
-        APB_SARADC_FSM_WAIT_REG,
-        APB_SARADC_STANDBY_WAIT_V,
-        APB_SARADC_STANDBY_WAIT_S,
-        100,
-    );
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_sel().bits(2));
 
-    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_PATT_P_CLEAR_M);
-    clear_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_PATT_P_CLEAR_M);
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR_PATT_LEN_V,
-        APB_SARADC_SAR_PATT_LEN_S,
-        0,
-    );
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_en().set_bit());
 
-    reg_set_field(
-        APB_SARADC_SAR_PATT_TAB1_REG,
-        APB_SARADC_SAR_PATT_TAB1_V,
-        APB_SARADC_SAR_PATT_TAB1_S,
-        0x9cffff,
-    );
-    reg_set_field(
-        APB_SARADC_SAR_PATT_TAB2_REG,
-        APB_SARADC_SAR_PATT_TAB2_V,
-        APB_SARADC_SAR_PATT_TAB2_S,
-        0x9cffff,
-    );
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_gated().set_bit());
 
-    reg_set_field(
-        APB_SARADC_CTRL2_REG,
-        APB_SARADC_TIMER_TARGET_V,
-        APB_SARADC_TIMER_TARGET_S,
-        100,
-    );
-    reg_set_field(
-        APB_SARADC_APB_ADC_CLKM_CONF_REG,
-        APB_SARADC_REG_CLKM_DIV_NUM_V,
-        APB_SARADC_REG_CLKM_DIV_NUM_S,
-        15,
-    );
-    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_MEAS_NUM_LIMIT);
-    set_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
-    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+        apb_saradc.ctrl().modify(|_, w| w.xpd_sar_force().bits(3));
+
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_div().bits(1));
+
+        apb_saradc.fsm_wait().modify(|_, w| w.rstb_wait().bits(8));
+
+        apb_saradc.fsm_wait().modify(|_, w| w.xpd_wait().bits(5));
+
+        apb_saradc
+            .fsm_wait()
+            .modify(|_, w| w.standby_wait().bits(100));
+
+        apb_saradc
+            .ctrl()
+            .modify(|_, w| w.sar_patt_p_clear().set_bit());
+
+        apb_saradc
+            .ctrl()
+            .modify(|_, w| w.sar_patt_p_clear().clear_bit());
+
+        apb_saradc.ctrl().modify(|_, w| w.sar_patt_len().bits(0));
+
+        apb_saradc
+            .sar_patt_tab1()
+            .modify(|_, w| w.sar_patt_tab1().bits(0x9cffff));
+
+        apb_saradc
+            .sar_patt_tab2()
+            .modify(|_, w| w.sar_patt_tab2().bits(0x9cffff));
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_target().bits(100));
+
+        apb_saradc
+            .clkm_conf()
+            .modify(|_, w| w.clkm_div_num().bits(15));
+
+        apb_saradc
+            .ctrl2()
+            .modify(|_, w| w.meas_num_limit().clear_bit());
+
+        apb_saradc.dma_conf().modify(|_, w| w.adc_trans().set_bit());
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().set_bit());
+    }
 }
 
 pub(crate) fn revert_trng() {
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
-    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
-    clear_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
-    reg_set_field(
-        APB_SARADC_SAR_PATT_TAB1_REG,
-        APB_SARADC_SAR_PATT_TAB1_V,
-        APB_SARADC_SAR_PATT_TAB1_S,
-        0xffffff,
-    );
-    reg_set_field(
-        APB_SARADC_SAR_PATT_TAB2_REG,
-        APB_SARADC_SAR_PATT_TAB2_V,
-        APB_SARADC_SAR_PATT_TAB2_S,
-        0xffffff,
-    );
-    clear_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_XPD_SAR_FORCE_V,
-        APB_SARADC_XPD_SAR_FORCE_S,
-        0,
-    );
-    reg_set_field(
-        RTC_CNTL_SENSOR_CTRL_REG,
-        RTC_CNTL_FORCE_XPD_SAR_V,
-        RTC_CNTL_FORCE_XPD_SAR_S,
-        0,
-    );
-}
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
+    let rtc_cntl = unsafe { &*crate::peripherals::RTC_CNTL::ptr() };
 
-fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
     unsafe {
-        (reg as *mut u32).write_volatile(
-            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
-                | ((value & field_v) << field_s),
-        )
-    }
-}
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
 
-fn set_peri_reg_mask(reg: u32, mask: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
-    }
-}
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().clear_bit());
 
-fn clear_peri_reg_mask(reg: u32, mask: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+        apb_saradc
+            .dma_conf()
+            .modify(|_, w| w.adc_trans().clear_bit());
+
+        apb_saradc
+            .sar_patt_tab1()
+            .modify(|_, w| w.sar_patt_tab1().bits(0xffffff));
+
+        apb_saradc
+            .sar_patt_tab2()
+            .modify(|_, w| w.sar_patt_tab2().bits(0xffffff));
+
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_en().clear_bit());
+
+        apb_saradc.ctrl().modify(|_, w| w.xpd_sar_force().bits(0));
+
+        rtc_cntl
+            .cntl_sensor_ctrl()
+            .modify(|_, w| w.force_xpd_sar().bits(0));
     }
 }

--- a/esp-hal/src/soc/esp32c2/trng.rs
+++ b/esp-hal/src/soc/esp32c2/trng.rs
@@ -173,11 +173,31 @@ pub(crate) fn revert_trng() {
     regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
     clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
     clear_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
-    reg_set_field(APB_SARADC_SAR_PATT_TAB1_REG, APB_SARADC_SAR_PATT_TAB1_V, APB_SARADC_SAR_PATT_TAB1_S, 0xffffff);
-    reg_set_field(APB_SARADC_SAR_PATT_TAB2_REG, APB_SARADC_SAR_PATT_TAB2_V, APB_SARADC_SAR_PATT_TAB2_S, 0xffffff);
+    reg_set_field(
+        APB_SARADC_SAR_PATT_TAB1_REG,
+        APB_SARADC_SAR_PATT_TAB1_V,
+        APB_SARADC_SAR_PATT_TAB1_S,
+        0xffffff,
+    );
+    reg_set_field(
+        APB_SARADC_SAR_PATT_TAB2_REG,
+        APB_SARADC_SAR_PATT_TAB2_V,
+        APB_SARADC_SAR_PATT_TAB2_S,
+        0xffffff,
+    );
     clear_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
-    reg_set_field(APB_SARADC_CTRL_REG, APB_SARADC_XPD_SAR_FORCE_V, APB_SARADC_XPD_SAR_FORCE_S, 0);
-    reg_set_field(RTC_CNTL_SENSOR_CTRL_REG, RTC_CNTL_FORCE_XPD_SAR_V, RTC_CNTL_FORCE_XPD_SAR_S, 0);
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_XPD_SAR_FORCE_V,
+        APB_SARADC_XPD_SAR_FORCE_S,
+        0,
+    );
+    reg_set_field(
+        RTC_CNTL_SENSOR_CTRL_REG,
+        RTC_CNTL_FORCE_XPD_SAR_V,
+        RTC_CNTL_FORCE_XPD_SAR_S,
+        0,
+    );
 }
 
 fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {

--- a/esp-hal/src/soc/esp32c2/trng.rs
+++ b/esp-hal/src/soc/esp32c2/trng.rs
@@ -1,0 +1,202 @@
+const DR_REG_RTCCNTL_BASE: u32 = 0x60008000;
+const RTC_CNTL_SENSOR_CTRL_REG: u32 = DR_REG_RTCCNTL_BASE + 0x108;
+const RTC_CNTL_FORCE_XPD_SAR_V: u32 = 0x3;
+const RTC_CNTL_FORCE_XPD_SAR_S: u32 = 30;
+const RTC_CNTL_ANA_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x2c;
+const RTC_CNTL_SAR_I2C_PU_M: u32 = 1 << 22;
+
+const I2C_SAR_ADC: u8 = 0x69;
+const I2C_SAR_ADC_HOSTID: u8 = 0;
+const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
+const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 6;
+const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 6;
+const ADC_SARADC_DTEST_RTC_ADDR: u8 = 0x7;
+const ADC_SARADC_DTEST_RTC_ADDR_MSB: u8 = 1;
+const ADC_SARADC_DTEST_RTC_ADDR_LSB: u8 = 0;
+const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7;
+const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
+const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
+const ADC_SARADC_ENT_TSENS_ADDR: u8 = 0x07;
+const ADC_SARADC_ENT_TSENS_ADDR_MSB: u8 = 2;
+const ADC_SARADC_ENT_TSENS_ADDR_LSB: u8 = 2;
+
+const DR_REG_SYSTEM_BASE: u32 = 0x600c0000;
+const SYSTEM_PERIP_CLK_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x10;
+const SYSTEM_PERIP_RST_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x18;
+const APB_SARADC_CLK_EN_M: u32 = 0x00000001 << 28;
+const DR_REG_APB_SARADC_BASE: u32 = 0x60040000;
+const APB_SARADC_APB_ADC_CLKM_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x54;
+const APB_SARADC_REG_CLK_SEL_V: u32 = 0x00000003;
+const APB_SARADC_REG_CLK_SEL_S: u32 = 21;
+const APB_SARADC_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE;
+const APB_SARADC_SAR_PATT_P_CLEAR_M: u32 = 0x00000001 << 23;
+const APB_SARADC_SAR_PATT_LEN_V: u32 = 0x00000007;
+const APB_SARADC_SAR_PATT_LEN_S: u32 = 15;
+const APB_SARADC_SAR_CLK_GATED_M: u32 = 0x00000001 << 6;
+const APB_SARADC_XPD_SAR_FORCE_V: u32 = 0x00000003;
+const APB_SARADC_XPD_SAR_FORCE_S: u32 = 27;
+const APB_SARADC_SAR_CLK_DIV_V: u32 = 0x000000FF;
+const APB_SARADC_SAR_CLK_DIV_S: u32 = 7;
+const APB_SARADC_SAR_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x18;
+const APB_SARADC_SAR_PATT_TAB2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x1c;
+const APB_SARADC_SAR_PATT_TAB1_V: u32 = 0x00FFFFFF;
+const APB_SARADC_SAR_PATT_TAB1_S: u32 = 0;
+const APB_SARADC_SAR_PATT_TAB2_V: u32 = 0x00FFFFFF;
+const APB_SARADC_SAR_PATT_TAB2_S: u32 = 0;
+const APB_SARADC_CTRL2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x4;
+const APB_SARADC_TIMER_TARGET_V: u32 = 0x00000FFF;
+const APB_SARADC_TIMER_TARGET_S: u32 = 12;
+const APB_SARADC_REG_CLKM_DIV_NUM_V: u32 = 0x000000FF;
+const APB_SARADC_REG_CLKM_DIV_NUM_S: u32 = 0;
+const APB_SARADC_MEAS_NUM_LIMIT: u32 = 1 << 0;
+const APB_SARADC_DMA_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x50;
+const APB_SARADC_APB_ADC_TRANS_M: u32 = 0x00000001 << 31;
+const APB_SARADC_TIMER_EN: u32 = 1 << 24;
+const APB_SARADC_FSM_WAIT_REG: u32 = DR_REG_APB_SARADC_BASE + 0xc;
+const APB_SARADC_RSTB_WAIT_V: u32 = 0x000000FF;
+const APB_SARADC_RSTB_WAIT_S: u32 = 8;
+const APB_SARADC_XPD_WAIT_V: u32 = 0x000000FF;
+const APB_SARADC_XPD_WAIT_S: u32 = 0;
+const APB_SARADC_STANDBY_WAIT_V: u32 = 0x000000FF;
+const APB_SARADC_STANDBY_WAIT_S: u32 = 16;
+const SYSTEM_APB_SARADC_RST_M: u32 = 0x00000001 << 28;
+const SYSTEM_APB_SARADC_CLK_EN_M: u32 = 0x00000001 << 28;
+
+use crate::regi2c_write_mask;
+
+pub(crate) fn ensure_randomness() {
+    // RNG module is always clock enabled
+    reg_set_field(
+        RTC_CNTL_SENSOR_CTRL_REG,
+        RTC_CNTL_FORCE_XPD_SAR_V,
+        RTC_CNTL_FORCE_XPD_SAR_S,
+        0x3,
+    );
+
+    set_peri_reg_mask(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_PU_M);
+
+    // Bridging sar2 internal reference voltage
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 1);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
+
+    // Enable SAR ADC2 internal channel to read adc2 ref voltage for additional
+    // entropy
+    set_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, SYSTEM_APB_SARADC_CLK_EN_M);
+    clear_peri_reg_mask(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_APB_SARADC_RST_M);
+    reg_set_field(
+        APB_SARADC_APB_ADC_CLKM_CONF_REG,
+        APB_SARADC_REG_CLK_SEL_V,
+        APB_SARADC_REG_CLK_SEL_S,
+        0x2,
+    );
+    set_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
+    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_CLK_GATED_M);
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_XPD_SAR_FORCE_V,
+        APB_SARADC_XPD_SAR_FORCE_S,
+        0x3,
+    );
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR_CLK_DIV_V,
+        APB_SARADC_SAR_CLK_DIV_S,
+        1,
+    );
+
+    reg_set_field(
+        APB_SARADC_FSM_WAIT_REG,
+        APB_SARADC_RSTB_WAIT_V,
+        APB_SARADC_RSTB_WAIT_S,
+        8,
+    );
+
+    reg_set_field(
+        APB_SARADC_FSM_WAIT_REG,
+        APB_SARADC_XPD_WAIT_V,
+        APB_SARADC_XPD_WAIT_S,
+        5,
+    );
+
+    reg_set_field(
+        APB_SARADC_FSM_WAIT_REG,
+        APB_SARADC_STANDBY_WAIT_V,
+        APB_SARADC_STANDBY_WAIT_S,
+        100,
+    );
+
+    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_PATT_P_CLEAR_M);
+    clear_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_PATT_P_CLEAR_M);
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR_PATT_LEN_V,
+        APB_SARADC_SAR_PATT_LEN_S,
+        0,
+    );
+
+    reg_set_field(
+        APB_SARADC_SAR_PATT_TAB1_REG,
+        APB_SARADC_SAR_PATT_TAB1_V,
+        APB_SARADC_SAR_PATT_TAB1_S,
+        0x9cffff,
+    );
+    reg_set_field(
+        APB_SARADC_SAR_PATT_TAB2_REG,
+        APB_SARADC_SAR_PATT_TAB2_V,
+        APB_SARADC_SAR_PATT_TAB2_S,
+        0x9cffff,
+    );
+
+    reg_set_field(
+        APB_SARADC_CTRL2_REG,
+        APB_SARADC_TIMER_TARGET_V,
+        APB_SARADC_TIMER_TARGET_S,
+        100,
+    );
+    reg_set_field(
+        APB_SARADC_APB_ADC_CLKM_CONF_REG,
+        APB_SARADC_REG_CLKM_DIV_NUM_V,
+        APB_SARADC_REG_CLKM_DIV_NUM_S,
+        15,
+    );
+    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_MEAS_NUM_LIMIT);
+    set_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
+    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+}
+
+pub(crate) fn revert_trng() {
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
+    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+    clear_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
+    reg_set_field(APB_SARADC_SAR_PATT_TAB1_REG, APB_SARADC_SAR_PATT_TAB1_V, APB_SARADC_SAR_PATT_TAB1_S, 0xffffff);
+    reg_set_field(APB_SARADC_SAR_PATT_TAB2_REG, APB_SARADC_SAR_PATT_TAB2_V, APB_SARADC_SAR_PATT_TAB2_S, 0xffffff);
+    clear_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
+    reg_set_field(APB_SARADC_CTRL_REG, APB_SARADC_XPD_SAR_FORCE_V, APB_SARADC_XPD_SAR_FORCE_S, 0);
+    reg_set_field(RTC_CNTL_SENSOR_CTRL_REG, RTC_CNTL_FORCE_XPD_SAR_V, RTC_CNTL_FORCE_XPD_SAR_S, 0);
+}
+
+fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(
+            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
+                | ((value & field_v) << field_s),
+        )
+    }
+}
+
+fn set_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
+    }
+}
+
+fn clear_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+    }
+}

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -16,6 +16,7 @@ pub mod efuse;
 pub mod gpio;
 pub mod peripherals;
 pub mod radio_clocks;
+pub mod trng;
 
 /// The name of the chip ("esp32c3") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32c3/trng.rs
+++ b/esp-hal/src/soc/esp32c3/trng.rs
@@ -1,0 +1,205 @@
+const DR_REG_RTCCNTL_BASE: u32 = 0x60008000;
+const RTC_CNTL_SENSOR_CTRL_REG: u32 = DR_REG_RTCCNTL_BASE + 0x011C;
+const RTC_CNTL_FORCE_XPD_SAR_V: u32 = 0x3;
+const RTC_CNTL_FORCE_XPD_SAR_S: u32 = 30;
+const RTC_CNTL_ANA_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x0034;
+const RTC_CNTL_SAR_I2C_PU_M: u32 = 1 << 22;
+
+const I2C_SAR_ADC: u8 = 0x69;
+const I2C_SAR_ADC_HOSTID: u8 = 0;
+const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
+const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 6;
+const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 6;
+const ADC_SARADC_DTEST_RTC_ADDR: u8 = 0x7;
+const ADC_SARADC_DTEST_RTC_ADDR_MSB: u8 = 1;
+const ADC_SARADC_DTEST_RTC_ADDR_LSB: u8 = 0;
+const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7;
+const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
+const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
+const ADC_SARADC_ENT_TSENS_ADDR: u8 = 0x07;
+const ADC_SARADC_ENT_TSENS_ADDR_MSB: u8 = 2;
+const ADC_SARADC_ENT_TSENS_ADDR_LSB: u8 = 2;
+
+const DR_REG_SYSTEM_BASE: u32 = 0x600c0000;
+const SYSTEM_PERIP_CLK_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x010;
+const SYSTEM_PERIP_RST_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x018;
+const APB_SARADC_CLK_EN_M: u32 = 0x00000001 << 20;
+const DR_REG_APB_SARADC_BASE: u32 = 0x60040000;
+const APB_SARADC_APB_ADC_CLKM_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x054;
+const APB_SARADC_CLK_SEL_V: u32 = 0x00000003;
+const APB_SARADC_CLK_SEL_S: u32 = 21;
+const APB_SARADC_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE;
+const APB_SARADC_SAR_PATT_P_CLEAR_M: u32 = 1 << 23;
+const APB_SARADC_SAR_PATT_LEN_V: u32 = 7;
+const APB_SARADC_SAR_PATT_LEN_S: u32 = 15;
+const APB_SARADC_SAR_CLK_GATED_M: u32 = 1 << 6;
+const APB_SARADC_XPD_SAR_FORCE_V: u32 = 0x3;
+const APB_SARADC_XPD_SAR_FORCE_S: u32 = 27;
+const APB_SARADC_SAR_CLK_DIV_V: u32 = 0xFF;
+const APB_SARADC_SAR_CLK_DIV_S: u32 = 7;
+const APB_SARADC_SAR_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x018;
+const APB_SARADC_SAR_PATT_TAB2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x01c;
+const APB_SARADC_SAR_PATT_TAB1_V: u32 = 0xFFFFFF;
+const APB_SARADC_SAR_PATT_TAB1_S: u32 = 0;
+const APB_SARADC_SAR_PATT_TAB2_V: u32 = 0xFFFFFF;
+const APB_SARADC_SAR_PATT_TAB2_S: u32 = 0;
+const APB_SARADC_CTRL2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x004;
+const APB_SARADC_TIMER_TARGET_V: u32 = 0xFFF;
+const APB_SARADC_TIMER_TARGET_S: u32 = 12;
+const APB_SARADC_CLKM_DIV_NUM_V: u32 = 0xFF;
+const APB_SARADC_CLKM_DIV_NUM_S: u32 = 0;
+const APB_SARADC_MEAS_NUM_LIMIT: u32 = 1 << 0;
+const APB_SARADC_DMA_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x050;
+const APB_SARADC_APB_ADC_TRANS_M: u32 = 1 << 31;
+const APB_SARADC_TIMER_EN: u32 = 1 << 24;
+const APB_SARADC_FSM_WAIT_REG: u32 = DR_REG_APB_SARADC_BASE + 0x00c;
+const APB_SARADC_RSTB_WAIT_V: u32 = 0xFF;
+const APB_SARADC_RSTB_WAIT_S: u32 = 8;
+const APB_SARADC_XPD_WAIT_V: u32 = 0xFF;
+const APB_SARADC_XPD_WAIT_S: u32 = 0;
+const APB_SARADC_STANDBY_WAIT_V: u32 = 0xFF;
+const APB_SARADC_STANDBY_WAIT_S: u32 = 16;
+const SYSTEM_APB_SARADC_RST_M: u32 = 1 << 28;
+const SYSTEM_APB_SARADC_CLK_EN_M: u32 = 1 << 28;
+
+use crate::regi2c_write_mask;
+
+pub(crate) fn ensure_randomness() {
+    // RNG module is always clock enabled
+    reg_set_field(
+        RTC_CNTL_SENSOR_CTRL_REG,
+        RTC_CNTL_FORCE_XPD_SAR_V,
+        RTC_CNTL_FORCE_XPD_SAR_S,
+        0x3,
+    );
+
+    set_peri_reg_mask(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_PU_M);
+
+    // Bridging sar2 internal reference voltage
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 1);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
+
+    // Enable SAR ADC2 internal channel to read adc2 ref voltage for additional
+    // entropy
+    set_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, SYSTEM_APB_SARADC_CLK_EN_M);
+    clear_peri_reg_mask(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_APB_SARADC_RST_M);
+    reg_set_field(
+        APB_SARADC_APB_ADC_CLKM_CONF_REG,
+        APB_SARADC_CLK_SEL_V,
+        APB_SARADC_CLK_SEL_S,
+        0x2,
+    );
+    set_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
+    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_CLK_GATED_M);
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_XPD_SAR_FORCE_V,
+        APB_SARADC_XPD_SAR_FORCE_S,
+        0x3,
+    );
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR_CLK_DIV_V,
+        APB_SARADC_SAR_CLK_DIV_S,
+        1,
+    );
+
+    reg_set_field(
+        APB_SARADC_FSM_WAIT_REG,
+        APB_SARADC_RSTB_WAIT_V,
+        APB_SARADC_RSTB_WAIT_S,
+        8,
+    );
+
+    reg_set_field(
+        APB_SARADC_FSM_WAIT_REG,
+        APB_SARADC_XPD_WAIT_V,
+        APB_SARADC_XPD_WAIT_S,
+        5,
+    );
+
+    reg_set_field(
+        APB_SARADC_FSM_WAIT_REG,
+        APB_SARADC_STANDBY_WAIT_V,
+        APB_SARADC_STANDBY_WAIT_S,
+        100,
+    );
+
+    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_PATT_P_CLEAR_M);
+    clear_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_PATT_P_CLEAR_M);
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR_PATT_LEN_V,
+        APB_SARADC_SAR_PATT_LEN_S,
+        0,
+    );
+
+    reg_set_field(
+        APB_SARADC_SAR_PATT_TAB1_REG,
+        APB_SARADC_SAR_PATT_TAB1_V,
+        APB_SARADC_SAR_PATT_TAB1_S,
+        0x9cffff,
+    );
+    reg_set_field(
+        APB_SARADC_SAR_PATT_TAB2_REG,
+        APB_SARADC_SAR_PATT_TAB2_V,
+        APB_SARADC_SAR_PATT_TAB2_S,
+        0x9cffff,
+    );
+
+    reg_set_field(
+        APB_SARADC_CTRL2_REG,
+        APB_SARADC_TIMER_TARGET_V,
+        APB_SARADC_TIMER_TARGET_S,
+        100,
+    );
+    reg_set_field(
+        APB_SARADC_APB_ADC_CLKM_CONF_REG,
+        APB_SARADC_CLKM_DIV_NUM_V,
+        APB_SARADC_CLKM_DIV_NUM_S,
+        15,
+    );
+    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_MEAS_NUM_LIMIT);
+    set_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
+    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+}
+
+pub(crate) fn ensure_randomness() {
+    /* Restore internal I2C bus state */
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
+
+    /* Restore SARADC to default mode */
+    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+    clear_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
+    reg_set_field(APB_SARADC_SAR_PATT_TAB1_REG, APB_SARADC_SAR_PATT_TAB1_V, APB_SARADC_SAR_PATT_TAB1_S, 0xffffff);
+    reg_set_field(APB_SARADC_SAR_PATT_TAB2_REG, APB_SARADC_SAR_PATT_TAB2_V, APB_SARADC_SAR_PATT_TAB2_S, 0xffffff);
+    clear_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
+    reg_set_field(APB_SARADC_CTRL_REG, APB_SARADC_XPD_SAR_FORCE_V, APB_SARADC_XPD_SAR_FORCE_S, 0);
+    reg_set_field(RTC_CNTL_SENSOR_CTRL_REG, RTC_CNTL_FORCE_XPD_SAR_V, RTC_CNTL_FORCE_XPD_SAR_S, 0);
+}
+
+fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(
+            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
+                | ((value & field_v) << field_s),
+        )
+    }
+}
+
+fn set_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
+    }
+}
+
+fn clear_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+    }
+}

--- a/esp-hal/src/soc/esp32c3/trng.rs
+++ b/esp-hal/src/soc/esp32c3/trng.rs
@@ -1,10 +1,3 @@
-const DR_REG_RTCCNTL_BASE: u32 = 0x60008000;
-const RTC_CNTL_SENSOR_CTRL_REG: u32 = DR_REG_RTCCNTL_BASE + 0x011C;
-const RTC_CNTL_FORCE_XPD_SAR_V: u32 = 0x3;
-const RTC_CNTL_FORCE_XPD_SAR_S: u32 = 30;
-const RTC_CNTL_ANA_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x0034;
-const RTC_CNTL_SAR_I2C_PU_M: u32 = 1 << 22;
-
 const I2C_SAR_ADC: u8 = 0x69;
 const I2C_SAR_ADC_HOSTID: u8 = 0;
 const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
@@ -20,206 +13,120 @@ const ADC_SARADC_ENT_TSENS_ADDR: u8 = 0x07;
 const ADC_SARADC_ENT_TSENS_ADDR_MSB: u8 = 2;
 const ADC_SARADC_ENT_TSENS_ADDR_LSB: u8 = 2;
 
-const DR_REG_SYSTEM_BASE: u32 = 0x600c0000;
-const SYSTEM_PERIP_CLK_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x010;
-const SYSTEM_PERIP_RST_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x018;
-const APB_SARADC_CLK_EN_M: u32 = 0x00000001 << 20;
-const DR_REG_APB_SARADC_BASE: u32 = 0x60040000;
-const APB_SARADC_APB_ADC_CLKM_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x054;
-const APB_SARADC_CLK_SEL_V: u32 = 0x00000003;
-const APB_SARADC_CLK_SEL_S: u32 = 21;
-const APB_SARADC_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE;
-const APB_SARADC_SAR_PATT_P_CLEAR_M: u32 = 1 << 23;
-const APB_SARADC_SAR_PATT_LEN_V: u32 = 7;
-const APB_SARADC_SAR_PATT_LEN_S: u32 = 15;
-const APB_SARADC_SAR_CLK_GATED_M: u32 = 1 << 6;
-const APB_SARADC_XPD_SAR_FORCE_V: u32 = 0x3;
-const APB_SARADC_XPD_SAR_FORCE_S: u32 = 27;
-const APB_SARADC_SAR_CLK_DIV_V: u32 = 0xFF;
-const APB_SARADC_SAR_CLK_DIV_S: u32 = 7;
-const APB_SARADC_SAR_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x018;
-const APB_SARADC_SAR_PATT_TAB2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x01c;
-const APB_SARADC_SAR_PATT_TAB1_V: u32 = 0xFFFFFF;
-const APB_SARADC_SAR_PATT_TAB1_S: u32 = 0;
-const APB_SARADC_SAR_PATT_TAB2_V: u32 = 0xFFFFFF;
-const APB_SARADC_SAR_PATT_TAB2_S: u32 = 0;
-const APB_SARADC_CTRL2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x004;
-const APB_SARADC_TIMER_TARGET_V: u32 = 0xFFF;
-const APB_SARADC_TIMER_TARGET_S: u32 = 12;
-const APB_SARADC_CLKM_DIV_NUM_V: u32 = 0xFF;
-const APB_SARADC_CLKM_DIV_NUM_S: u32 = 0;
-const APB_SARADC_MEAS_NUM_LIMIT: u32 = 1 << 0;
-const APB_SARADC_DMA_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x050;
-const APB_SARADC_APB_ADC_TRANS_M: u32 = 1 << 31;
-const APB_SARADC_TIMER_EN: u32 = 1 << 24;
-const APB_SARADC_FSM_WAIT_REG: u32 = DR_REG_APB_SARADC_BASE + 0x00c;
-const APB_SARADC_RSTB_WAIT_V: u32 = 0xFF;
-const APB_SARADC_RSTB_WAIT_S: u32 = 8;
-const APB_SARADC_XPD_WAIT_V: u32 = 0xFF;
-const APB_SARADC_XPD_WAIT_S: u32 = 0;
-const APB_SARADC_STANDBY_WAIT_V: u32 = 0xFF;
-const APB_SARADC_STANDBY_WAIT_S: u32 = 16;
-const SYSTEM_APB_SARADC_RST_M: u32 = 1 << 28;
-const SYSTEM_APB_SARADC_CLK_EN_M: u32 = 1 << 28;
-
 use crate::regi2c_write_mask;
 
 pub(crate) fn ensure_randomness() {
-    // RNG module is always clock enabled
-    reg_set_field(
-        RTC_CNTL_SENSOR_CTRL_REG,
-        RTC_CNTL_FORCE_XPD_SAR_V,
-        RTC_CNTL_FORCE_XPD_SAR_S,
-        0x3,
-    );
+    let rtc_cntl = unsafe { &*crate::peripherals::RTC_CNTL::ptr() };
+    let system = unsafe { &*crate::peripherals::SYSTEM::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
 
-    set_peri_reg_mask(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_PU_M);
+    unsafe {
+        // RNG module is always clock enabled
+        rtc_cntl
+            .sensor_ctrl()
+            .modify(|_, w| w.force_xpd_sar().bits(3));
 
-    // Bridging sar2 internal reference voltage
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 1);
+        rtc_cntl.ana_conf().modify(|_, w| w.sar_i2c_pu().set_bit());
 
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
+        // Bridging sar2 internal reference voltage
+        // Cannot replace with PAC-based functions
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 1);
 
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
 
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
 
-    // Enable SAR ADC2 internal channel to read adc2 ref voltage for additional
-    // entropy
-    set_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, SYSTEM_APB_SARADC_CLK_EN_M);
-    clear_peri_reg_mask(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_APB_SARADC_RST_M);
-    reg_set_field(
-        APB_SARADC_APB_ADC_CLKM_CONF_REG,
-        APB_SARADC_CLK_SEL_V,
-        APB_SARADC_CLK_SEL_S,
-        0x2,
-    );
-    set_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
-    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_CLK_GATED_M);
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_XPD_SAR_FORCE_V,
-        APB_SARADC_XPD_SAR_FORCE_S,
-        0x3,
-    );
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR_CLK_DIV_V,
-        APB_SARADC_SAR_CLK_DIV_S,
-        1,
-    );
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
 
-    reg_set_field(
-        APB_SARADC_FSM_WAIT_REG,
-        APB_SARADC_RSTB_WAIT_V,
-        APB_SARADC_RSTB_WAIT_S,
-        8,
-    );
+        // Enable SAR ADC2 internal channel to read adc2 ref voltage for additional
+        // entropy
+        system
+            .perip_clk_en0()
+            .modify(|_, w| w.apb_saradc_clk_en().set_bit());
 
-    reg_set_field(
-        APB_SARADC_FSM_WAIT_REG,
-        APB_SARADC_XPD_WAIT_V,
-        APB_SARADC_XPD_WAIT_S,
-        5,
-    );
+        system
+            .perip_rst_en0()
+            .modify(|_, w| w.apb_saradc_rst().clear_bit());
 
-    reg_set_field(
-        APB_SARADC_FSM_WAIT_REG,
-        APB_SARADC_STANDBY_WAIT_V,
-        APB_SARADC_STANDBY_WAIT_S,
-        100,
-    );
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_sel().bits(2));
 
-    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_PATT_P_CLEAR_M);
-    clear_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_PATT_P_CLEAR_M);
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR_PATT_LEN_V,
-        APB_SARADC_SAR_PATT_LEN_S,
-        0,
-    );
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_en().set_bit());
 
-    reg_set_field(
-        APB_SARADC_SAR_PATT_TAB1_REG,
-        APB_SARADC_SAR_PATT_TAB1_V,
-        APB_SARADC_SAR_PATT_TAB1_S,
-        0x9cffff,
-    );
-    reg_set_field(
-        APB_SARADC_SAR_PATT_TAB2_REG,
-        APB_SARADC_SAR_PATT_TAB2_V,
-        APB_SARADC_SAR_PATT_TAB2_S,
-        0x9cffff,
-    );
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_gated().set_bit());
 
-    reg_set_field(
-        APB_SARADC_CTRL2_REG,
-        APB_SARADC_TIMER_TARGET_V,
-        APB_SARADC_TIMER_TARGET_S,
-        100,
-    );
-    reg_set_field(
-        APB_SARADC_APB_ADC_CLKM_CONF_REG,
-        APB_SARADC_CLKM_DIV_NUM_V,
-        APB_SARADC_CLKM_DIV_NUM_S,
-        15,
-    );
-    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_MEAS_NUM_LIMIT);
-    set_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
-    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+        apb_saradc.ctrl().modify(|_, w| w.xpd_sar_force().bits(3));
+
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_div().bits(1));
+
+        apb_saradc.fsm_wait().modify(|_, w| w.rstb_wait().bits(8));
+
+        apb_saradc.fsm_wait().modify(|_, w| w.xpd_wait().bits(5));
+
+        apb_saradc
+            .fsm_wait()
+            .modify(|_, w| w.standby_wait().bits(100));
+
+        apb_saradc
+            .ctrl()
+            .modify(|_, w| w.sar_patt_p_clear().set_bit());
+
+        apb_saradc
+            .ctrl()
+            .modify(|_, w| w.sar_patt_p_clear().clear_bit());
+
+        apb_saradc.ctrl().modify(|_, w| w.sar_patt_len().bits(0));
+
+        apb_saradc
+            .sar_patt_tab1()
+            .modify(|_, w| w.sar_patt_tab1().bits(0x9cffff));
+
+        apb_saradc
+            .sar_patt_tab2()
+            .modify(|_, w| w.sar_patt_tab2().bits(0x9cffff));
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_target().bits(100));
+
+        apb_saradc
+            .clkm_conf()
+            .modify(|_, w| w.clkm_div_num().bits(15));
+
+        apb_saradc
+            .ctrl2()
+            .modify(|_, w| w.meas_num_limit().clear_bit());
+
+        apb_saradc.dma_conf().modify(|_, w| w.adc_trans().set_bit());
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().set_bit());
+    }
 }
 
 pub(crate) fn revert_trng() {
-    // Restore internal I2C bus state
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
+    let rtc_cntl = unsafe { &*crate::peripherals::RTC_CNTL::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
 
-    // Restore SARADC to default mode
-    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
-    clear_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
-    reg_set_field(
-        APB_SARADC_SAR_PATT_TAB1_REG,
-        APB_SARADC_SAR_PATT_TAB1_V,
-        APB_SARADC_SAR_PATT_TAB1_S,
-        0xffffff,
-    );
-    reg_set_field(
-        APB_SARADC_SAR_PATT_TAB2_REG,
-        APB_SARADC_SAR_PATT_TAB2_V,
-        APB_SARADC_SAR_PATT_TAB2_S,
-        0xffffff,
-    );
-    clear_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_XPD_SAR_FORCE_V,
-        APB_SARADC_XPD_SAR_FORCE_S,
-        0,
-    );
-    reg_set_field(
-        RTC_CNTL_SENSOR_CTRL_REG,
-        RTC_CNTL_FORCE_XPD_SAR_V,
-        RTC_CNTL_FORCE_XPD_SAR_S,
-        0,
-    );
-}
-
-fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
     unsafe {
-        (reg as *mut u32).write_volatile(
-            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
-                | ((value & field_v) << field_s),
-        )
-    }
-}
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
 
-fn set_peri_reg_mask(reg: u32, mask: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
-    }
-}
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().clear_bit());
 
-fn clear_peri_reg_mask(reg: u32, mask: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+        apb_saradc
+            .dma_conf()
+            .modify(|_, w| w.adc_trans().clear_bit());
+
+        apb_saradc
+            .sar_patt_tab1()
+            .modify(|_, w| w.sar_patt_tab1().bits(0xffffff));
+
+        apb_saradc
+            .sar_patt_tab2()
+            .modify(|_, w| w.sar_patt_tab2().bits(0xffffff));
+
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_en().clear_bit());
+
+        apb_saradc.ctrl().modify(|_, w| w.xpd_sar_force().bits(0));
+
+        rtc_cntl
+            .sensor_ctrl()
+            .modify(|_, w| w.force_xpd_sar().bits(0));
     }
 }

--- a/esp-hal/src/soc/esp32c3/trng.rs
+++ b/esp-hal/src/soc/esp32c3/trng.rs
@@ -170,17 +170,37 @@ pub(crate) fn ensure_randomness() {
 }
 
 pub(crate) fn revert_trng() {
-    /* Restore internal I2C bus state */
+    // Restore internal I2C bus state
     regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
 
-    /* Restore SARADC to default mode */
+    // Restore SARADC to default mode
     clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
     clear_peri_reg_mask(APB_SARADC_DMA_CONF_REG, APB_SARADC_APB_ADC_TRANS_M);
-    reg_set_field(APB_SARADC_SAR_PATT_TAB1_REG, APB_SARADC_SAR_PATT_TAB1_V, APB_SARADC_SAR_PATT_TAB1_S, 0xffffff);
-    reg_set_field(APB_SARADC_SAR_PATT_TAB2_REG, APB_SARADC_SAR_PATT_TAB2_V, APB_SARADC_SAR_PATT_TAB2_S, 0xffffff);
+    reg_set_field(
+        APB_SARADC_SAR_PATT_TAB1_REG,
+        APB_SARADC_SAR_PATT_TAB1_V,
+        APB_SARADC_SAR_PATT_TAB1_S,
+        0xffffff,
+    );
+    reg_set_field(
+        APB_SARADC_SAR_PATT_TAB2_REG,
+        APB_SARADC_SAR_PATT_TAB2_V,
+        APB_SARADC_SAR_PATT_TAB2_S,
+        0xffffff,
+    );
     clear_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN_M);
-    reg_set_field(APB_SARADC_CTRL_REG, APB_SARADC_XPD_SAR_FORCE_V, APB_SARADC_XPD_SAR_FORCE_S, 0);
-    reg_set_field(RTC_CNTL_SENSOR_CTRL_REG, RTC_CNTL_FORCE_XPD_SAR_V, RTC_CNTL_FORCE_XPD_SAR_S, 0);
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_XPD_SAR_FORCE_V,
+        APB_SARADC_XPD_SAR_FORCE_S,
+        0,
+    );
+    reg_set_field(
+        RTC_CNTL_SENSOR_CTRL_REG,
+        RTC_CNTL_FORCE_XPD_SAR_V,
+        RTC_CNTL_FORCE_XPD_SAR_S,
+        0,
+    );
 }
 
 fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {

--- a/esp-hal/src/soc/esp32c3/trng.rs
+++ b/esp-hal/src/soc/esp32c3/trng.rs
@@ -169,7 +169,7 @@ pub(crate) fn ensure_randomness() {
     set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
 }
 
-pub(crate) fn ensure_randomness() {
+pub(crate) fn revert_trng() {
     /* Restore internal I2C bus state */
     regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
 

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -18,6 +18,7 @@ pub mod gpio;
 pub mod lp_core;
 pub mod peripherals;
 pub mod radio_clocks;
+pub mod trng;
 
 /// The name of the chip ("esp32c6") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32c6/trng.rs
+++ b/esp-hal/src/soc/esp32c6/trng.rs
@@ -1,25 +1,10 @@
-const PCR_SARADC_CONF_REG: u32 = 0x60096000 + 0x80;
-const PCR_SARADC_RST_EN: u32 = 1 << 1;
-const PCR_SARADC_REG_CLK_EN: u32 = 1 << 2;
-const PCR_SARADC_CLKM_CONF_REG: u32 = 0x60096000 + 0x84;
-const PCR_SARADC_CLKM_EN: u32 = 1 << 22;
-const PMU_RF_PWC_REG: u32 = 0x600B0000 + 0x154;
 const I2C_SAR_ADC: u8 = 0x69;
 const I2C_SAR_ADC_HOSTID: u8 = 0;
+
 const SAR2_CHANNEL: u32 = 9;
 const SAR2_ATTEN: u32 = 1;
 const SAR1_ATTEN: u32 = 1;
 const PATTERN_BIT_WIDTH: u32 = 6;
-const APB_SARADC_SAR_PATT_TAB1_REG: u32 = 0x60040000 + 0x18;
-const APB_SARADC_CTRL_REG: u32 = 0x60040000;
-const APB_SARADC_CTRL2_REG: u32 = 0x60040000 + 0x4;
-
-const DR_REG_MODEM_LPCON_BASE: u32 = 0x600AF000;
-const MODEM_LPCON_CLK_CONF_REG: u32 = DR_REG_MODEM_LPCON_BASE + 0x18;
-const MODEM_LPCON_CLK_I2C_MST_EN: u32 = 1 << 2;
-const DR_REG_LP_I2C_ANA_MST_BASE: u32 = 0x600B2400;
-const LP_I2C_ANA_MST_DATE_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x3fc;
-const LP_I2C_ANA_MST_I2C_MAT_CLK_EN: u32 = 1 << 28;
 
 const REGI2C_BBPLL: u8 = 0x66;
 const REGI2C_BIAS: u8 = 0x6a;
@@ -27,7 +12,6 @@ const REGI2C_DIG_REG: u8 = 0x6d;
 const REGI2C_ULP_CAL: u8 = 0x61;
 const REGI2C_SAR_I2C: u8 = 0x69;
 
-const LP_I2C_ANA_MST_DEVICE_EN_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x14;
 const REGI2C_BBPLL_DEVICE_EN: u32 = 1 << 5;
 const REGI2C_BIAS_DEVICE_EN: u32 = 1 << 4;
 const REGI2C_DIG_REG_DEVICE_EN: u32 = 1 << 8;
@@ -41,22 +25,6 @@ const REGI2C_RTC_WR_CNTL_V: u8 = 0x1;
 const REGI2C_RTC_WR_CNTL_S: u8 = 24;
 const REGI2C_RTC_DATA_V: u8 = 0xFF;
 const REGI2C_RTC_DATA_S: u8 = 16;
-
-const LP_I2C_ANA_MST_I2C0_CTRL_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE;
-const LP_I2C_ANA_MST_I2C0_BUSY: u32 = 1 << 25;
-
-const LP_I2C_ANA_MST_I2C0_DATA_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x8;
-const LP_I2C_ANA_MST_I2C0_RDATA_V: u32 = 0x000000FF;
-const LP_I2C_ANA_MST_I2C0_RDATA_S: u32 = 0;
-
-const PCR_SARADC_CLKM_SEL_V: u32 = 0x00000003;
-const PCR_SARADC_CLKM_SEL_S: u32 = 20;
-
-const PCR_SARADC_CLKM_DIV_NUM_V: u32 = 0x000000FF;
-const PCR_SARADC_CLKM_DIV_NUM_S: u32 = 12;
-
-const PMU_PERIF_I2C_RSTB: u32 = 1 << 26;
-const PMU_XPD_PERIF_I2C: u32 = 1 << 27;
 
 const ADC_SAR2_INITIAL_CODE_HIGH_ADDR: u8 = 0x4;
 const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
@@ -90,351 +58,385 @@ const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
 const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 6;
 const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 6;
 
-const APB_SARADC_SARADC_SAR_PATT_LEN_V: u32 = 0x00000007;
-const APB_SARADC_SARADC_SAR_PATT_LEN_S: u32 = 15;
-const APB_SARADC_SARADC_SAR_CLK_DIV_V: u32 = 0x000000FF;
-const APB_SARADC_SARADC_SAR_CLK_DIV_S: u32 = 7;
-const APB_SARADC_SARADC_TIMER_TARGET_V: u32 = 0x00000FFF;
-const APB_SARADC_SARADC_TIMER_TARGET_S: u32 = 12;
-const APB_SARADC_SARADC_TIMER_EN: u32 = 1 << 24;
-
 pub(crate) fn ensure_randomness() {
-    // Pull SAR ADC out of reset
-    reg_set_bit(PCR_SARADC_CONF_REG, PCR_SARADC_RST_EN);
-    reg_clr_bit(PCR_SARADC_CONF_REG, PCR_SARADC_RST_EN);
+    let pcr = unsafe { &*crate::peripherals::PCR::ptr() };
+    let pmu = unsafe { &*crate::peripherals::PMU::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
 
-    // Enable SAR ADC APB clock
-    reg_set_bit(PCR_SARADC_CONF_REG, PCR_SARADC_REG_CLK_EN);
+    unsafe {
+        // Pull SAR ADC out of reset
+        pcr.saradc_conf().modify(|_, w| w.saradc_rst_en().set_bit());
 
-    // Enable ADC_CTRL_CLK (SAR ADC function clock)
-    reg_set_bit(PCR_SARADC_CLKM_CONF_REG, PCR_SARADC_CLKM_EN);
+        pcr.saradc_conf()
+            .modify(|_, w| w.saradc_rst_en().clear_bit());
 
-    // Select XTAL clock (40 MHz) source for ADC_CTRL_CLK
-    reg_set_field(
-        PCR_SARADC_CLKM_CONF_REG,
-        PCR_SARADC_CLKM_SEL_V,
-        PCR_SARADC_CLKM_SEL_S,
-        0,
-    );
+        // Enable SAR ADC APB clock
+        pcr.saradc_conf()
+            .modify(|_, w| w.saradc_reg_clk_en().set_bit());
 
-    // Set the clock divider for ADC_CTRL_CLK to default value (in case it has been
-    // changed)
-    reg_set_field(
-        PCR_SARADC_CLKM_CONF_REG,
-        PCR_SARADC_CLKM_DIV_NUM_V,
-        PCR_SARADC_CLKM_DIV_NUM_S,
-        0,
-    );
+        // Enable ADC_CTRL_CLK (SAR ADC function clock)
+        pcr.saradc_clkm_conf()
+            .modify(|_, w| w.saradc_clkm_en().set_bit());
 
-    // some ADC sensor registers are in power group PERIF_I2C and need to be enabled
-    // via PMU
-    set_peri_reg_mask(PMU_RF_PWC_REG, PMU_PERIF_I2C_RSTB);
-    set_peri_reg_mask(PMU_RF_PWC_REG, PMU_XPD_PERIF_I2C);
+        // Select XTAL clock (40 MHz) source for ADC_CTRL_CLK
+        pcr.saradc_clkm_conf()
+            .modify(|_, w| w.saradc_clkm_sel().bits(0));
 
-    // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
-    // voltage as sampling source
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_DTEST_RTC_ADDR,
-        ADC_SARADC_DTEST_RTC_ADDR_MSB,
-        ADC_SARADC_DTEST_RTC_ADDR_LSB,
-        2,
-    );
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENT_RTC_ADDR,
-        ADC_SARADC_ENT_RTC_ADDR_MSB,
-        ADC_SARADC_ENT_RTC_ADDR_LSB,
-        1,
-    );
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC1_ENCAL_REF_ADDR,
-        ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC1_ENCAL_REF_ADDR_LSB,
-        1,
-    );
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC1_ENCAL_REF_ADDR,
-        ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC1_ENCAL_REF_ADDR_LSB,
-        1,
-    );
+        // Set the clock divider for ADC_CTRL_CLK to default value (in case it has been
+        // changed)
+        pcr.saradc_clkm_conf()
+            .modify(|_, w| w.saradc_clkm_div_num().bits(0));
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
-        0x60,
-    );
+        // some ADC sensor registers are in power group PERIF_I2C and need to be enabled
+        // via PMU
+        pmu.rf_pwc().modify(|_, w| w.perif_i2c_rstb().set_bit());
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
-        0x66,
-    );
+        pmu.rf_pwc().modify(|_, w| w.xpd_perif_i2c().set_bit());
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
-        0x08,
-    );
+        // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
+        // voltage as sampling source
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_DTEST_RTC_ADDR,
+            ADC_SARADC_DTEST_RTC_ADDR_MSB,
+            ADC_SARADC_DTEST_RTC_ADDR_LSB,
+            2,
+        );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_ENT_RTC_ADDR,
+            ADC_SARADC_ENT_RTC_ADDR_MSB,
+            ADC_SARADC_ENT_RTC_ADDR_LSB,
+            1,
+        );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC1_ENCAL_REF_ADDR,
+            ADC_SARADC1_ENCAL_REF_ADDR_MSB,
+            ADC_SARADC1_ENCAL_REF_ADDR_LSB,
+            1,
+        );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC1_ENCAL_REF_ADDR,
+            ADC_SARADC1_ENCAL_REF_ADDR_MSB,
+            ADC_SARADC1_ENCAL_REF_ADDR_LSB,
+            1,
+        );
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
-        0x66,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
+            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
+            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
+            0x60,
+        );
 
-    // create patterns and set them in pattern table
-    let pattern_one: u32 = (SAR2_CHANNEL << 2) | SAR2_ATTEN; // we want channel 9 with max attenuation
-    let pattern_two: u32 = SAR1_ATTEN; // we want channel 0 with max attenuation, channel doesn't really matter here
-    let pattern_table: u32 =
-        (pattern_two << (3 * PATTERN_BIT_WIDTH)) | (pattern_one << (2 * PATTERN_BIT_WIDTH));
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR2_INITIAL_CODE_LOW_ADDR,
+            ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
+            ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
+            0x66,
+        );
 
-    reg_write(APB_SARADC_SAR_PATT_TAB1_REG, pattern_table);
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
+            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
+            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
+            0x08,
+        );
 
-    // set pattern length to 2 (APB_SARADC_SAR_PATT_LEN counts from 0)
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SARADC_SAR_PATT_LEN_V,
-        APB_SARADC_SARADC_SAR_PATT_LEN_S,
-        1,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR1_INITIAL_CODE_LOW_ADDR,
+            ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
+            ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
+            0x66,
+        );
 
-    // Same as in C3
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SARADC_SAR_CLK_DIV_V,
-        APB_SARADC_SARADC_SAR_CLK_DIV_S,
-        15,
-    );
+        // create patterns and set them in pattern table
+        let pattern_one: u32 = (SAR2_CHANNEL << 2) | SAR2_ATTEN; // we want channel 9 with max attenuation
+        let pattern_two: u32 = SAR1_ATTEN; // we want channel 0 with max attenuation, channel doesn't really matter here
+        let pattern_table: u32 =
+            (pattern_two << (3 * PATTERN_BIT_WIDTH)) | (pattern_one << (2 * PATTERN_BIT_WIDTH));
 
-    // set timer expiry (timer is ADC_CTRL_CLK)
-    reg_set_field(
-        APB_SARADC_CTRL2_REG,
-        APB_SARADC_SARADC_TIMER_TARGET_V,
-        APB_SARADC_SARADC_TIMER_TARGET_S,
-        200,
-    );
+        apb_saradc
+            .sar_patt_tab1()
+            .modify(|_, w| w.bits(pattern_table));
 
-    // enable timer
-    reg_set_bit(APB_SARADC_CTRL2_REG, APB_SARADC_SARADC_TIMER_EN);
+        // set pattern length to 2 (APB_SARADC_SAR_PATT_LEN counts from 0)
+        apb_saradc.ctrl().modify(|_, w| w.sar_patt_len().bits(1));
+
+        // Same as in C3
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_div().bits(15));
+
+        // set timer expiry (timer is ADC_CTRL_CLK)
+        apb_saradc.ctrl2().modify(|_, w| w.timer_target().bits(200));
+
+        // enable timer
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().set_bit());
+    }
 }
 
 pub(crate) fn revert_trng() {
-    reg_clr_bit(APB_SARADC_CTRL2_REG, APB_SARADC_SARADC_TIMER_EN);
-    reg_write(APB_SARADC_SAR_PATT_TAB1_REG, 0xFFFFFF);
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
+    let pmu = unsafe { &*crate::peripherals::PMU::ptr() };
+    let pcr = unsafe { &*crate::peripherals::PCR::ptr() };
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
-        0x60,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
-        0,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
-        0x60,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
-        0,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_DTEST_RTC_ADDR,
-        ADC_SARADC_DTEST_RTC_ADDR_MSB,
-        ADC_SARADC_DTEST_RTC_ADDR_LSB,
-        0,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENT_RTC_ADDR,
-        ADC_SARADC_ENT_RTC_ADDR_MSB,
-        ADC_SARADC_ENT_RTC_ADDR_LSB,
-        0,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC1_ENCAL_REF_ADDR,
-        ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC1_ENCAL_REF_ADDR_LSB,
-        0,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC2_ENCAL_REF_ADDR,
-        ADC_SARADC2_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC2_ENCAL_REF_ADDR_LSB,
-        0,
-    );
-
-    clear_peri_reg_mask(PMU_RF_PWC_REG, PMU_PERIF_I2C_RSTB);
-    reg_write(PCR_SARADC_CLKM_CONF_REG, 0x00404000);
-    reg_write(PCR_SARADC_CONF_REG, 0x5);
-}
-
-fn reg_set_bit(reg: u32, bit: u32) {
     unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
-    }
-}
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().clear_bit());
 
-fn reg_clr_bit(reg: u32, bit: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
-    }
-}
+        apb_saradc.sar_patt_tab1().modify(|_, w| w.bits(0xFFFFFF));
 
-fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(
-            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
-                | ((value & field_v) << field_s),
-        )
-    }
-}
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
+            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
+            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
+            0x60,
+        );
 
-fn set_peri_reg_mask(reg: u32, mask: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
-    }
-}
-fn reg_write(reg: u32, v: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(v);
-    }
-}
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR2_INITIAL_CODE_LOW_ADDR,
+            ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
+            ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
+            0,
+        );
 
-fn reg_get_bit(reg: u32, b: u32) -> u32 {
-    unsafe { (reg as *mut u32).read_volatile() & b }
-}
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
+            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
+            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
+            0x60,
+        );
 
-fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
-    unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR1_INITIAL_CODE_LOW_ADDR,
+            ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
+            ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
+            0,
+        );
+
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_DTEST_RTC_ADDR,
+            ADC_SARADC_DTEST_RTC_ADDR_MSB,
+            ADC_SARADC_DTEST_RTC_ADDR_LSB,
+            0,
+        );
+
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_ENT_RTC_ADDR,
+            ADC_SARADC_ENT_RTC_ADDR_MSB,
+            ADC_SARADC_ENT_RTC_ADDR_LSB,
+            0,
+        );
+
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC1_ENCAL_REF_ADDR,
+            ADC_SARADC1_ENCAL_REF_ADDR_MSB,
+            ADC_SARADC1_ENCAL_REF_ADDR_LSB,
+            0,
+        );
+
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC2_ENCAL_REF_ADDR,
+            ADC_SARADC2_ENCAL_REF_ADDR_MSB,
+            ADC_SARADC2_ENCAL_REF_ADDR_LSB,
+            0,
+        );
+
+        pmu.rf_pwc().modify(|_, w| w.perif_i2c_rstb().clear_bit());
+
+        pcr.saradc_clkm_conf().modify(|_, w| w.bits(0x00404000));
+
+        pcr.saradc_conf().modify(|_, w| w.bits(0x5));
+    }
 }
 
 fn regi2c_enable_block(block: u8) {
-    reg_set_bit(MODEM_LPCON_CLK_CONF_REG, MODEM_LPCON_CLK_I2C_MST_EN);
-    reg_set_bit(LP_I2C_ANA_MST_DATE_REG, LP_I2C_ANA_MST_I2C_MAT_CLK_EN);
+    let modem_lpcon = unsafe { &*crate::peripherals::MODEM_LPCON::ptr() };
+    let lp_i2c_ana = unsafe { &*crate::peripherals::LP_I2C_ANA_MST::ptr() };
 
-    // Before config I2C register, enable corresponding slave.
-    match block {
-        v if v == REGI2C_BBPLL => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BBPLL_DEVICE_EN);
+    unsafe {
+        modem_lpcon
+            .clk_conf()
+            .modify(|_, w| w.clk_i2c_mst_en().set_bit());
+
+        lp_i2c_ana
+            .date()
+            .modify(|_, w| w.lp_i2c_ana_mast_i2c_mat_clk_en().set_bit());
+
+        match block {
+            REGI2C_BBPLL => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32 | REGI2C_BBPLL_DEVICE_EN)
+                            as u16,
+                    )
+                });
+            }
+            REGI2C_BIAS => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32 | REGI2C_BIAS_DEVICE_EN)
+                            as u16,
+                    )
+                });
+            }
+            REGI2C_DIG_REG => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32 | REGI2C_DIG_REG_DEVICE_EN)
+                            as u16,
+                    )
+                });
+            }
+            REGI2C_ULP_CAL => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32 | REGI2C_ULP_CAL_DEVICE_EN)
+                            as u16,
+                    )
+                });
+            }
+            REGI2C_SAR_I2C => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32 | REGI2C_SAR_I2C_DEVICE_EN)
+                            as u16,
+                    )
+                });
+            }
+            _ => (),
         }
-        v if v == REGI2C_BIAS => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BIAS_DEVICE_EN);
-        }
-        v if v == REGI2C_DIG_REG => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_DIG_REG_DEVICE_EN);
-        }
-        v if v == REGI2C_ULP_CAL => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_ULP_CAL_DEVICE_EN);
-        }
-        v if v == REGI2C_SAR_I2C => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_SAR_I2C_DEVICE_EN);
-        }
-        _ => (),
     }
 }
 
 fn regi2c_disable_block(block: u8) {
-    match block {
-        v if v == REGI2C_BBPLL => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BBPLL_DEVICE_EN);
+    let lp_i2c_ana = unsafe { &*crate::peripherals::LP_I2C_ANA_MST::ptr() };
+
+    unsafe {
+        match block {
+            REGI2C_BBPLL => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32 & !REGI2C_BBPLL_DEVICE_EN)
+                            as u16,
+                    )
+                });
+            }
+            REGI2C_BIAS => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32 & !REGI2C_BIAS_DEVICE_EN)
+                            as u16,
+                    )
+                });
+            }
+            REGI2C_DIG_REG => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32
+                            & !REGI2C_DIG_REG_DEVICE_EN) as u16,
+                    )
+                });
+            }
+            REGI2C_ULP_CAL => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32
+                            & !REGI2C_ULP_CAL_DEVICE_EN) as u16,
+                    )
+                });
+            }
+            REGI2C_SAR_I2C => {
+                lp_i2c_ana.device_en().modify(|r, w| {
+                    w.lp_i2c_ana_mast_i2c_device_en().bits(
+                        (r.lp_i2c_ana_mast_i2c_device_en().bits() as u32
+                            & !REGI2C_SAR_I2C_DEVICE_EN) as u16,
+                    )
+                });
+            }
+            _ => (),
         }
-        v if v == REGI2C_BIAS => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BIAS_DEVICE_EN);
-        }
-        v if v == REGI2C_DIG_REG => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_DIG_REG_DEVICE_EN);
-        }
-        v if v == REGI2C_ULP_CAL => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_ULP_CAL_DEVICE_EN);
-        }
-        v if v == REGI2C_SAR_I2C => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_SAR_I2C_DEVICE_EN);
-        }
-        _ => (),
     }
 }
 
 pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
     assert!(msb - lsb < 8);
-    regi2c_enable_block(block);
+    let lp_i2c_ana = unsafe { &*crate::peripherals::LP_I2C_ANA_MST::ptr() };
 
-    // Read the i2c bus register
-    let mut temp: u32 = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32)
-        << REGI2C_RTC_SLAVE_ID_S as u32)
-        | (reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32;
-    reg_write(LP_I2C_ANA_MST_I2C0_CTRL_REG, temp);
-    while reg_get_bit(LP_I2C_ANA_MST_I2C0_CTRL_REG, LP_I2C_ANA_MST_I2C0_BUSY) != 0 {}
-    temp = reg_get_field(
-        LP_I2C_ANA_MST_I2C0_DATA_REG,
-        LP_I2C_ANA_MST_I2C0_RDATA_S,
-        LP_I2C_ANA_MST_I2C0_RDATA_V,
-    );
-    // Write the i2c bus register
-    temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
-    temp |= (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
-    temp = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32) << REGI2C_RTC_SLAVE_ID_S as u32)
-        | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32)
-        | ((0x1 & REGI2C_RTC_WR_CNTL_V as u32) << REGI2C_RTC_WR_CNTL_S as u32)
-        | ((temp & REGI2C_RTC_DATA_V as u32) << REGI2C_RTC_DATA_S as u32);
-    reg_write(LP_I2C_ANA_MST_I2C0_CTRL_REG, temp);
-    while reg_get_bit(LP_I2C_ANA_MST_I2C0_CTRL_REG, LP_I2C_ANA_MST_I2C0_BUSY) != 0 {}
-
-    regi2c_disable_block(block);
-}
-
-fn clear_peri_reg_mask(reg: u32, mask: u32) {
     unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+        regi2c_enable_block(block);
+
+        // Read the i2c bus register
+        let mut temp: u32 = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32)
+            << REGI2C_RTC_SLAVE_ID_S as u32)
+            | (reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32;
+
+        lp_i2c_ana
+            .i2c0_ctrl()
+            .modify(|_, w| w.lp_i2c_ana_mast_i2c0_ctrl().bits(temp));
+
+        while lp_i2c_ana
+            .i2c0_ctrl()
+            .read()
+            .lp_i2c_ana_mast_i2c0_busy()
+            .bit()
+            != false
+        {}
+
+        temp = lp_i2c_ana
+            .i2c0_data()
+            .read()
+            .lp_i2c_ana_mast_i2c0_rdata()
+            .bits() as u32;
+
+        // Write the i2c bus register
+        temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
+        temp |= (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
+        temp = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32) << REGI2C_RTC_SLAVE_ID_S as u32)
+            | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32)
+            | ((0x1 & REGI2C_RTC_WR_CNTL_V as u32) << REGI2C_RTC_WR_CNTL_S as u32)
+            | ((temp & REGI2C_RTC_DATA_V as u32) << REGI2C_RTC_DATA_S as u32);
+
+        lp_i2c_ana
+            .i2c0_ctrl()
+            .modify(|_, w| w.lp_i2c_ana_mast_i2c0_ctrl().bits(temp));
+
+        while lp_i2c_ana
+            .i2c0_ctrl()
+            .read()
+            .lp_i2c_ana_mast_i2c0_busy()
+            .bit()
+            != false
+        {}
+
+        regi2c_disable_block(block);
     }
 }

--- a/esp-hal/src/soc/esp32c6/trng.rs
+++ b/esp-hal/src/soc/esp32c6/trng.rs
@@ -1,0 +1,363 @@
+const PCR_SARADC_CONF_REG: u32 = 0x60096000 + 0x80;
+const PCR_SARADC_RST_EN: u32 = 1 << 1;
+const PCR_SARADC_REG_CLK_EN: u32 = 1 << 2;
+const PCR_SARADC_CLKM_CONF_REG: u32 = 0x60096000 + 0x84;
+const PCR_SARADC_CLKM_EN: u32 = 1 << 22;
+const PMU_RF_PWC_REG: u32 = 0x600B0000 + 0x154;
+const I2C_SAR_ADC: u8 = 0x69;
+const I2C_SAR_ADC_HOSTID: u8 = 0;
+const ADC_SARADC_HOST_ADDR: u8 = 0x7;
+const DTEST_RTC_MSB: u8 = 1;
+const DTEST_RTC_LSB: u8 = 0;
+const ENT_RTC_MSB: u8 = 3;
+const ENT_RTC_LSB: u8 = 3;
+const SARADC1_ENCAL_REF_MSB: u8 = 4;
+const SARADC1_ENCAL_REF_LSB: u8 = 4;
+const SARADC2_ENCAL_REF_MSB: u8 = 6;
+const SARADC2_ENCAL_REF_LSB: u8 = 6;
+const SAR2_CHANNEL: u32 = 9;
+const SAR2_ATTEN: u32 = 1;
+const SAR1_ATTEN: u32 = 1;
+const PATTERN_BIT_WIDTH: u32 = 6;
+const APB_SARADC_SAR_PATT_TAB1_REG: u32 = 0x60040000 + 0x18;
+const APB_SARADC_CTRL_REG: u32 = 0x60040000;
+const APB_SARADC_CTRL2_REG: u32 = 0x60040000 + 0x4;
+
+const DR_REG_MODEM_LPCON_BASE: u32 = 0x600AF000;
+const MODEM_LPCON_CLK_CONF_REG: u32 = DR_REG_MODEM_LPCON_BASE + 0x18;
+const MODEM_LPCON_CLK_I2C_MST_EN: u32 = 1 << 2;
+const DR_REG_LP_I2C_ANA_MST_BASE: u32 = 0x600B2400;
+const LP_I2C_ANA_MST_DATE_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x3fc;
+const LP_I2C_ANA_MST_I2C_MAT_CLK_EN: u32 = 1 << 28;
+
+const REGI2C_BBPLL: u8 = 0x66;
+const REGI2C_BIAS: u8 = 0x6a;
+const REGI2C_DIG_REG: u8 = 0x6d;
+const REGI2C_ULP_CAL: u8 = 0x61;
+const REGI2C_SAR_I2C: u8 = 0x69;
+
+const LP_I2C_ANA_MST_DEVICE_EN_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x14;
+const REGI2C_BBPLL_DEVICE_EN: u32 = 1 << 5;
+const REGI2C_BIAS_DEVICE_EN: u32 = 1 << 4;
+const REGI2C_DIG_REG_DEVICE_EN: u32 = 1 << 8;
+const REGI2C_ULP_CAL_DEVICE_EN: u32 = 1 << 6;
+const REGI2C_SAR_I2C_DEVICE_EN: u32 = 1 << 7;
+const REGI2C_RTC_SLAVE_ID_V: u8 = 0xFF;
+const REGI2C_RTC_SLAVE_ID_S: u8 = 0;
+const REGI2C_RTC_ADDR_V: u8 = 0xFF;
+const REGI2C_RTC_ADDR_S: u8 = 8;
+const REGI2C_RTC_WR_CNTL_V: u8 = 0x1;
+const REGI2C_RTC_WR_CNTL_S: u8 = 24;
+const REGI2C_RTC_DATA_V: u8 = 0xFF;
+const REGI2C_RTC_DATA_S: u8 = 16;
+
+const LP_I2C_ANA_MST_I2C0_CTRL_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE;
+const LP_I2C_ANA_MST_I2C0_BUSY: u32 = 1 << 25;
+
+const LP_I2C_ANA_MST_I2C0_DATA_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x8;
+const LP_I2C_ANA_MST_I2C0_RDATA_V: u32 = 0x000000FF;
+const LP_I2C_ANA_MST_I2C0_RDATA_S: u32 = 0;
+
+const PCR_SARADC_CLKM_SEL_V: u32 = 0x00000003;
+const PCR_SARADC_CLKM_SEL_S: u32 = 20;
+
+const PCR_SARADC_CLKM_DIV_NUM_V: u32 = 0x000000FF;
+const PCR_SARADC_CLKM_DIV_NUM_S: u32 = 12;
+
+const PMU_PERIF_I2C_RSTB: u32 = 1 << 26;
+const PMU_XPD_PERIF_I2C: u32 = 1 << 27;
+
+const ADC_SARADC_DTEST_RTC_ADDR: u8 = 0x4;
+const ADC_SARADC_DTEST_RTC_ADDR_MSB: u8 = 0x3;
+const ADC_SARADC_DTEST_RTC_ADDR_LSB: u8 = 0x0;
+
+const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x3;
+const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 0x7;
+const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 0x0;
+
+const ADC_SARADC1_ENCAL_REF_ADDR: u8 = 0x1;
+const ADC_SARADC1_ENCAL_REF_ADDR_MSB: u8 = 0x3;
+const ADC_SARADC1_ENCAL_REF_ADDR_LSB: u8 = 0x0;
+
+const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x0;
+const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 0x7;
+const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 0x0;
+
+const APB_SARADC_SARADC_SAR_PATT_LEN_V: u32 = 0x00000007;
+const APB_SARADC_SARADC_SAR_PATT_LEN_S: u32 = 15;
+const APB_SARADC_SARADC_SAR_CLK_DIV_V: u32 = 0x000000FF;
+const APB_SARADC_SARADC_SAR_CLK_DIV_S: u32 = 7;
+const APB_SARADC_SARADC_TIMER_TARGET_V: u32 = 0x00000FFF;
+const APB_SARADC_SARADC_TIMER_TARGET_S: u32 = 12;
+const APB_SARADC_SARADC_TIMER_EN: u32 = 1 << 24;
+
+pub(crate) fn ensure_randomness() {
+    // Pull SAR ADC out of reset
+    reg_set_bit(PCR_SARADC_CONF_REG, PCR_SARADC_RST_EN);
+    reg_clr_bit(PCR_SARADC_CONF_REG, PCR_SARADC_RST_EN);
+
+    // Enable SAR ADC APB clock
+    reg_set_bit(PCR_SARADC_CONF_REG, PCR_SARADC_REG_CLK_EN);
+
+    // Enable ADC_CTRL_CLK (SAR ADC function clock)
+    reg_set_bit(PCR_SARADC_CLKM_CONF_REG, PCR_SARADC_CLKM_EN);
+
+    // Select XTAL clock (40 MHz) source for ADC_CTRL_CLK
+    reg_set_field(
+        PCR_SARADC_CLKM_CONF_REG,
+        PCR_SARADC_CLKM_SEL_V,
+        PCR_SARADC_CLKM_SEL_S,
+        0,
+    );
+
+    // Set the clock divider for ADC_CTRL_CLK to default value (in case it has been
+    // changed)
+    reg_set_field(
+        PCR_SARADC_CLKM_CONF_REG,
+        PCR_SARADC_CLKM_DIV_NUM_V,
+        PCR_SARADC_CLKM_DIV_NUM_S,
+        0,
+    );
+
+    // some ADC sensor registers are in power group PERIF_I2C and need to be enabled
+    // via PMU
+    set_peri_reg_mask(PMU_RF_PWC_REG, PMU_PERIF_I2C_RSTB);
+    set_peri_reg_mask(PMU_RF_PWC_REG, PMU_XPD_PERIF_I2C);
+
+    // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
+    // voltage as sampling source
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_HOST_ADDR,
+        DTEST_RTC_MSB,
+        DTEST_RTC_LSB,
+        2,
+    );
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_HOST_ADDR,
+        ENT_RTC_MSB,
+        ENT_RTC_LSB,
+        1,
+    );
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_HOST_ADDR,
+        SARADC1_ENCAL_REF_MSB,
+        SARADC1_ENCAL_REF_LSB,
+        1,
+    );
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_HOST_ADDR,
+        SARADC2_ENCAL_REF_MSB,
+        SARADC2_ENCAL_REF_LSB,
+        1,
+    );
+
+    // SAR2 High ADDR
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_DTEST_RTC_ADDR,
+        ADC_SARADC_DTEST_RTC_ADDR_MSB,
+        ADC_SARADC_DTEST_RTC_ADDR_LSB,
+        0x08,
+    );
+    // SAR2 Low ADDR
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_ENT_RTC_ADDR,
+        ADC_SARADC_ENT_RTC_ADDR_MSB,
+        ADC_SARADC_ENT_RTC_ADDR_LSB,
+        0x66,
+    );
+    // SAR1 High ADDR
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC1_ENCAL_REF_ADDR,
+        ADC_SARADC1_ENCAL_REF_ADDR_MSB,
+        ADC_SARADC1_ENCAL_REF_ADDR_LSB,
+        0x08,
+    );
+    // SAR1 Low ADDR
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC2_ENCAL_REF_ADDR,
+        ADC_SARADC2_ENCAL_REF_ADDR_MSB,
+        ADC_SARADC2_ENCAL_REF_ADDR_LSB,
+        0x66,
+    );
+
+    // create patterns and set them in pattern table
+    let pattern_one: u32 = (SAR2_CHANNEL << 2) | SAR2_ATTEN; // we want channel 9 with max attenuation
+    let pattern_two: u32 = SAR1_ATTEN; // we want channel 0 with max attenuation, channel doesn't really matter here
+    let pattern_table: u32 =
+        (pattern_two << (3 * PATTERN_BIT_WIDTH)) | (pattern_one << (2 * PATTERN_BIT_WIDTH));
+
+    reg_write(APB_SARADC_SAR_PATT_TAB1_REG, pattern_table);
+
+    // set pattern length to 2 (APB_SARADC_SAR_PATT_LEN counts from 0)
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SARADC_SAR_PATT_LEN_V,
+        APB_SARADC_SARADC_SAR_PATT_LEN_S,
+        1,
+    );
+
+    // Same as in C3
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SARADC_SAR_CLK_DIV_V,
+        APB_SARADC_SARADC_SAR_CLK_DIV_S,
+        15,
+    );
+
+    // set timer expiry (timer is ADC_CTRL_CLK)
+    reg_set_field(
+        APB_SARADC_CTRL2_REG,
+        APB_SARADC_SARADC_TIMER_TARGET_V,
+        APB_SARADC_SARADC_TIMER_TARGET_S,
+        200,
+    );
+
+    // enable timer
+    reg_set_bit(APB_SARADC_CTRL2_REG, APB_SARADC_SARADC_TIMER_EN);
+}
+
+pub(crate) fn ensure_randomness() {
+    reg_clr_bit(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+    reg_write(APB_SARADC_SAR_PATT_TAB1_REG, 0xFFFFFF);
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC2_ENCAL_REF_ADDR,
+        ADC_SARADC2_ENCAL_REF_ADDR_MSB,
+        ADC_SARADC2_ENCAL_REF_ADDR_LSB,
+        0x66,
+    );
+
+    regi2c_write_mask(I2C_SAR_ADC, I2C_SAR_ADC_HOSTID, HIGH)
+}
+
+fn reg_set_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
+    }
+}
+
+fn reg_clr_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
+    }
+}
+
+fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(
+            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
+                | ((value & field_v) << field_s),
+        )
+    }
+}
+
+fn set_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
+    }
+}
+fn reg_write(reg: u32, v: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(v);
+    }
+}
+
+fn reg_get_bit(reg: u32, b: u32) -> u32 {
+    unsafe { (reg as *mut u32).read_volatile() & b }
+}
+
+fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
+    unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
+}
+
+fn regi2c_enable_block(block: u8) {
+    reg_set_bit(MODEM_LPCON_CLK_CONF_REG, MODEM_LPCON_CLK_I2C_MST_EN);
+    reg_set_bit(LP_I2C_ANA_MST_DATE_REG, LP_I2C_ANA_MST_I2C_MAT_CLK_EN);
+
+    // Before config I2C register, enable corresponding slave.
+    match block {
+        v if v == REGI2C_BBPLL => {
+            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BBPLL_DEVICE_EN);
+        }
+        v if v == REGI2C_BIAS => {
+            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BIAS_DEVICE_EN);
+        }
+        v if v == REGI2C_DIG_REG => {
+            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_DIG_REG_DEVICE_EN);
+        }
+        v if v == REGI2C_ULP_CAL => {
+            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_ULP_CAL_DEVICE_EN);
+        }
+        v if v == REGI2C_SAR_I2C => {
+            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_SAR_I2C_DEVICE_EN);
+        }
+        _ => (),
+    }
+}
+
+fn regi2c_disable_block(block: u8) {
+    match block {
+        v if v == REGI2C_BBPLL => {
+            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BBPLL_DEVICE_EN);
+        }
+        v if v == REGI2C_BIAS => {
+            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BIAS_DEVICE_EN);
+        }
+        v if v == REGI2C_DIG_REG => {
+            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_DIG_REG_DEVICE_EN);
+        }
+        v if v == REGI2C_ULP_CAL => {
+            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_ULP_CAL_DEVICE_EN);
+        }
+        v if v == REGI2C_SAR_I2C => {
+            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_SAR_I2C_DEVICE_EN);
+        }
+        _ => (),
+    }
+}
+
+pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
+    assert!(msb - lsb < 8);
+    regi2c_enable_block(block);
+
+    // Read the i2c bus register
+    let mut temp: u32 = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32)
+        << REGI2C_RTC_SLAVE_ID_S as u32)
+        | (reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32;
+    reg_write(LP_I2C_ANA_MST_I2C0_CTRL_REG, temp);
+    while reg_get_bit(LP_I2C_ANA_MST_I2C0_CTRL_REG, LP_I2C_ANA_MST_I2C0_BUSY) != 0 {}
+    temp = reg_get_field(
+        LP_I2C_ANA_MST_I2C0_DATA_REG,
+        LP_I2C_ANA_MST_I2C0_RDATA_S,
+        LP_I2C_ANA_MST_I2C0_RDATA_V,
+    );
+    // Write the i2c bus register
+    temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
+    temp |= (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
+    temp = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32) << REGI2C_RTC_SLAVE_ID_S as u32)
+        | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32)
+        | ((0x1 & REGI2C_RTC_WR_CNTL_V as u32) << REGI2C_RTC_WR_CNTL_S as u32)
+        | ((temp & REGI2C_RTC_DATA_V as u32) << REGI2C_RTC_DATA_S as u32);
+    reg_write(LP_I2C_ANA_MST_I2C0_CTRL_REG, temp);
+    while reg_get_bit(LP_I2C_ANA_MST_I2C0_CTRL_REG, LP_I2C_ANA_MST_I2C0_BUSY) != 0 {}
+
+    regi2c_disable_block(block);
+}

--- a/esp-hal/src/soc/esp32c6/trng.rs
+++ b/esp-hal/src/soc/esp32c6/trng.rs
@@ -66,21 +66,21 @@ const ADC_SAR2_INITIAL_CODE_LOW_ADDR: u8 = 0x3;
 const ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
 const ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
 
-const  ADC_SAR1_INITIAL_CODE_HIGH_ADDR: u8 = 0x1;
-const  ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-const  ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
+const ADC_SAR1_INITIAL_CODE_HIGH_ADDR: u8 = 0x1;
+const ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
+const ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
 
 const ADC_SAR1_INITIAL_CODE_LOW_ADDR: u8 = 0x0;
 const ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
 const ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
 
-const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
-const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 1;
-const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 0;
+const ADC_SARADC_DTEST_RTC_ADDR: u8 = 0x7;
+const ADC_SARADC_DTEST_RTC_ADDR_MSB: u8 = 1;
+const ADC_SARADC_DTEST_RTC_ADDR_LSB: u8 = 0;
 
-const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7
+const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7;
 const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
-const  ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
+const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
 
 const ADC_SARADC1_ENCAL_REF_ADDR: u8 = 0x7;
 const ADC_SARADC1_ENCAL_REF_ADDR_MSB: u8 = 4;
@@ -169,7 +169,7 @@ pub(crate) fn ensure_randomness() {
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR
+        ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
         ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
         ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
         0x60,
@@ -178,16 +178,16 @@ pub(crate) fn ensure_randomness() {
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR
+        ADC_SAR2_INITIAL_CODE_LOW_ADDR,
         ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
         ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
         0x66,
     );
-    
+
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR
+        ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
         ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
         ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
         0x08,
@@ -196,7 +196,7 @@ pub(crate) fn ensure_randomness() {
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR
+        ADC_SAR1_INITIAL_CODE_LOW_ADDR,
         ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
         ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
         0x66,
@@ -239,7 +239,7 @@ pub(crate) fn ensure_randomness() {
 }
 
 pub(crate) fn revert_trng() {
-    reg_clr_bit(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+    reg_clr_bit(APB_SARADC_CTRL2_REG, APB_SARADC_SARADC_TIMER_EN);
     reg_write(APB_SARADC_SAR_PATT_TAB1_REG, 0xFFFFFF);
 
     regi2c_write_mask(
@@ -259,7 +259,7 @@ pub(crate) fn revert_trng() {
         ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
         0,
     );
-    
+
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
@@ -431,4 +431,10 @@ pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, l
     while reg_get_bit(LP_I2C_ANA_MST_I2C0_CTRL_REG, LP_I2C_ANA_MST_I2C0_BUSY) != 0 {}
 
     regi2c_disable_block(block);
+}
+
+fn clear_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+    }
 }

--- a/esp-hal/src/soc/esp32c6/trng.rs
+++ b/esp-hal/src/soc/esp32c6/trng.rs
@@ -408,7 +408,6 @@ pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, l
             .read()
             .lp_i2c_ana_mast_i2c0_busy()
             .bit()
-            != false
         {}
 
         temp = lp_i2c_ana
@@ -434,7 +433,6 @@ pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, l
             .read()
             .lp_i2c_ana_mast_i2c0_busy()
             .bit()
-            != false
         {}
 
         regi2c_disable_block(block);

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -17,6 +17,7 @@ pub mod efuse;
 pub mod gpio;
 pub mod peripherals;
 pub mod radio_clocks;
+pub mod trng;
 
 /// The name of the chip ("esp32h2") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32h2/trng.rs
+++ b/esp-hal/src/soc/esp32h2/trng.rs
@@ -243,7 +243,7 @@ pub(crate) fn revert_trng() {
         I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
         0,
     );
-    
+
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
@@ -291,7 +291,7 @@ pub(crate) fn revert_trng() {
 
     // disable ADC_CTRL_CLK (SAR ADC function clock)
     reg_write(PCR_SARADC_CLKM_CONF_REG, 0x00404000);
-    
+
     // Set PCR_SARADC_CONF_REG to initial state
     reg_write(PCR_SARADC_CONF_REG, 0x5);
 }

--- a/esp-hal/src/soc/esp32h2/trng.rs
+++ b/esp-hal/src/soc/esp32h2/trng.rs
@@ -3,9 +3,39 @@ const PCR_SARADC_RST_EN: u32 = 1 << 1;
 const PCR_SARADC_REG_CLK_EN: u32 = 1 << 2;
 const PCR_SARADC_CLKM_CONF_REG: u32 = 0x60096000 + 0x84;
 const PCR_SARADC_CLKM_EN: u32 = 1 << 22;
+const PCR_SARADC_CLKM_SEL_V: u32 = 0x00000003;
+const PCR_SARADC_CLKM_SEL_S: u32 = 20;
+const PCR_SARADC_CLKM_DIV_NUM_V: u32 = 0x000000FF;
+const PCR_SARADC_CLKM_DIV_NUM_S: u32 = 12;
 const PMU_RF_PWC_REG: u32 = 0x600B0000 + 0x154;
+const PMU_XPD_PERIF_I2C: u32 = 1 << 27;
 const I2C_SAR_ADC: u8 = 0x69;
 const I2C_SAR_ADC_HOSTID: u8 = 0;
+
+const I2C_SARADC_DTEST: u8 = 7;
+const I2C_SARADC_DTEST_MSB: u8 = 1;
+const I2C_SARADC_DTEST_LSB: u8 = 0;
+const I2C_SARADC_ENT_SAR: u8 = 7;
+const I2C_SARADC_ENT_SAR_MSB: u8 = 3;
+const I2C_SARADC_ENT_SAR_LSB: u8 = 1;
+const I2C_SARADC_EN_TOUT_SAR1_BUS: u8 = 7;
+const I2C_SARADC_EN_TOUT_SAR1_BUS_MSB: u8 = 5;
+const I2C_SARADC_EN_TOUT_SAR1_BUS_LSB: u8 = 5;
+
+const I2C_SARADC_SAR2_INIT_CODE_MSB: u8 = 4;
+const I2C_SARADC_SAR2_INIT_CODE_MSB_MSB: u8 = 3;
+const I2C_SARADC_SAR2_INIT_CODE_MSB_LSB: u8 = 0;
+const I2C_SARADC_SAR2_INIT_CODE_LSB: u8 = 3;
+const I2C_SARADC_SAR2_INIT_CODE_LSB_MSB: u8 = 7;
+const I2C_SARADC_SAR2_INIT_CODE_LSB_LSB: u8 = 0;
+
+const I2C_SARADC_SAR1_INIT_CODE_MSB: u8 = 1;
+const I2C_SARADC_SAR1_INIT_CODE_MSB_MSB: u8 = 3;
+const I2C_SARADC_SAR1_INIT_CODE_MSB_LSB: u8 = 0;
+const I2C_SARADC_SAR1_INIT_CODE_LSB: u8 = 3;
+const I2C_SARADC_SAR1_INIT_CODE_LSB_MSB: u8 = 7;
+const I2C_SARADC_SAR1_INIT_CODE_LSB_LSB: u8 = 0;
+
 const SAR2_CHANNEL: u32 = 9;
 const SAR2_ATTEN: u32 = 1;
 const SAR1_ATTEN: u32 = 1;
@@ -13,6 +43,14 @@ const PATTERN_BIT_WIDTH: u32 = 6;
 const APB_SARADC_SAR_PATT_TAB1_REG: u32 = 0x60040000 + 0x18;
 const APB_SARADC_CTRL_REG: u32 = 0x60040000;
 const APB_SARADC_CTRL2_REG: u32 = 0x60040000 + 0x4;
+
+const APB_SARADC_SARADC_SAR_PATT_LEN_V: u32 = 0x00000007;
+const APB_SARADC_SARADC_SAR_PATT_LEN_S: u32 = 15;
+const APB_SARADC_SARADC_SAR_CLK_DIV_V: u32 = 0x000000FF;
+const APB_SARADC_SARADC_SAR_CLK_DIV_S: u32 = 7;
+const APB_SARADC_SARADC_TIMER_TARGET_V: u32 = 0x00000FFF;
+const APB_SARADC_SARADC_TIMER_TARGET_S: u32 = 12;
+const APB_SARADC_SARADC_TIMER_EN: u32 = 1 << 24;
 
 const DR_REG_MODEM_LPCON_BASE: u32 = 0x600AF000;
 const MODEM_LPCON_CLK_CONF_REG: u32 = DR_REG_MODEM_LPCON_BASE + 0x18;
@@ -49,55 +87,6 @@ const LP_I2C_ANA_MST_I2C0_DATA_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x8;
 const LP_I2C_ANA_MST_I2C0_RDATA_V: u32 = 0x000000FF;
 const LP_I2C_ANA_MST_I2C0_RDATA_S: u32 = 0;
 
-const PCR_SARADC_CLKM_SEL_V: u32 = 0x00000003;
-const PCR_SARADC_CLKM_SEL_S: u32 = 20;
-
-const PCR_SARADC_CLKM_DIV_NUM_V: u32 = 0x000000FF;
-const PCR_SARADC_CLKM_DIV_NUM_S: u32 = 12;
-
-const PMU_PERIF_I2C_RSTB: u32 = 1 << 26;
-const PMU_XPD_PERIF_I2C: u32 = 1 << 27;
-
-const ADC_SAR2_INITIAL_CODE_HIGH_ADDR: u8 = 0x4;
-const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
-
-const ADC_SAR2_INITIAL_CODE_LOW_ADDR: u8 = 0x3;
-const ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
-const ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
-
-const  ADC_SAR1_INITIAL_CODE_HIGH_ADDR: u8 = 0x1;
-const  ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-const  ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
-
-const ADC_SAR1_INITIAL_CODE_LOW_ADDR: u8 = 0x0;
-const ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
-const ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
-
-const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
-const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 1;
-const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 0;
-
-const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7
-const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
-const  ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
-
-const ADC_SARADC1_ENCAL_REF_ADDR: u8 = 0x7;
-const ADC_SARADC1_ENCAL_REF_ADDR_MSB: u8 = 4;
-const ADC_SARADC1_ENCAL_REF_ADDR_LSB: u8 = 4;
-
-const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
-const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 6;
-const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 6;
-
-const APB_SARADC_SARADC_SAR_PATT_LEN_V: u32 = 0x00000007;
-const APB_SARADC_SARADC_SAR_PATT_LEN_S: u32 = 15;
-const APB_SARADC_SARADC_SAR_CLK_DIV_V: u32 = 0x000000FF;
-const APB_SARADC_SARADC_SAR_CLK_DIV_S: u32 = 7;
-const APB_SARADC_SARADC_TIMER_TARGET_V: u32 = 0x00000FFF;
-const APB_SARADC_SARADC_TIMER_TARGET_S: u32 = 12;
-const APB_SARADC_SARADC_TIMER_EN: u32 = 1 << 24;
-
 pub(crate) fn ensure_randomness() {
     // Pull SAR ADC out of reset
     reg_set_bit(PCR_SARADC_CONF_REG, PCR_SARADC_RST_EN);
@@ -128,7 +117,6 @@ pub(crate) fn ensure_randomness() {
 
     // some ADC sensor registers are in power group PERIF_I2C and need to be enabled
     // via PMU
-    set_peri_reg_mask(PMU_RF_PWC_REG, PMU_PERIF_I2C_RSTB);
     set_peri_reg_mask(PMU_RF_PWC_REG, PMU_XPD_PERIF_I2C);
 
     // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
@@ -136,69 +124,62 @@ pub(crate) fn ensure_randomness() {
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_DTEST_RTC_ADDR,
-        ADC_SARADC_DTEST_RTC_ADDR_MSB,
-        ADC_SARADC_DTEST_RTC_ADDR_LSB,
+        I2C_SARADC_DTEST,
+        I2C_SARADC_DTEST_MSB,
+        I2C_SARADC_DTEST_LSB,
         2,
     );
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENT_RTC_ADDR,
-        ADC_SARADC_ENT_RTC_ADDR_MSB,
-        ADC_SARADC_ENT_RTC_ADDR_LSB,
+        I2C_SARADC_ENT_SAR,
+        I2C_SARADC_ENT_SAR_MSB,
+        I2C_SARADC_ENT_SAR_LSB,
         1,
     );
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SARADC1_ENCAL_REF_ADDR,
-        ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC1_ENCAL_REF_ADDR_LSB,
-        1,
-    );
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC1_ENCAL_REF_ADDR,
-        ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC1_ENCAL_REF_ADDR_LSB,
+        I2C_SARADC_EN_TOUT_SAR1_BUS,
+        I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
+        I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
         1,
     );
 
+    // SAR2 High ADDR
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
-        0x60,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
-        0x66,
-    );
-    
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
+        I2C_SARADC_SAR2_INIT_CODE_MSB,
+        I2C_SARADC_SAR2_INIT_CODE_MSB_MSB,
+        I2C_SARADC_SAR2_INIT_CODE_MSB_LSB,
         0x08,
     );
-
+    // SAR2 Low ADDR
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
+        I2C_SARADC_SAR2_INIT_CODE_LSB,
+        I2C_SARADC_SAR2_INIT_CODE_LSB_MSB,
+        I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
+        0x66,
+    );
+    // SAR1 High ADDR
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        I2C_SARADC_SAR1_INIT_CODE_MSB,
+        I2C_SARADC_SAR1_INIT_CODE_MSB_MSB,
+        I2C_SARADC_SAR1_INIT_CODE_MSB_LSB,
+        0x08,
+    );
+    // SAR1 Low ADDR
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        I2C_SARADC_SAR1_INIT_CODE_LSB,
+        I2C_SARADC_SAR1_INIT_CODE_LSB_MSB,
+        I2C_SARADC_SAR1_INIT_CODE_LSB_LSB,
         0x66,
     );
 
@@ -207,7 +188,6 @@ pub(crate) fn ensure_randomness() {
     let pattern_two: u32 = SAR1_ATTEN; // we want channel 0 with max attenuation, channel doesn't really matter here
     let pattern_table: u32 =
         (pattern_two << (3 * PATTERN_BIT_WIDTH)) | (pattern_one << (2 * PATTERN_BIT_WIDTH));
-
     reg_write(APB_SARADC_SAR_PATT_TAB1_REG, pattern_table);
 
     // set pattern length to 2 (APB_SARADC_SAR_PATT_LEN counts from 0)
@@ -215,7 +195,7 @@ pub(crate) fn ensure_randomness() {
         APB_SARADC_CTRL_REG,
         APB_SARADC_SARADC_SAR_PATT_LEN_V,
         APB_SARADC_SARADC_SAR_PATT_LEN_S,
-        1,
+        0,
     );
 
     // Same as in C3
@@ -239,83 +219,80 @@ pub(crate) fn ensure_randomness() {
 }
 
 pub(crate) fn revert_trng() {
-    reg_clr_bit(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+    // Disable timer
+    reg_clr_bit(APB_SARADC_CTRL2_REG, APB_SARADC_SARADC_TIMER_EN);
+
+    // Write reset value
     reg_write(APB_SARADC_SAR_PATT_TAB1_REG, 0xFFFFFF);
 
+    // Revert ADC I2C configuration and initial voltage source setting
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
-        ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
+        I2C_SARADC_SAR2_INIT_CODE_MSB,
+        I2C_SARADC_SAR2_INIT_CODE_MSB_MSB,
+        I2C_SARADC_SAR2_INIT_CODE_MSB_LSB,
         0x60,
     );
 
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
-        ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
+        I2C_SARADC_SAR2_INIT_CODE_LSB,
+        I2C_SARADC_SAR2_INIT_CODE_LSB_MSB,
+        I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
         0,
     );
     
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
-        ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
+        I2C_SARADC_SAR1_INIT_CODE_MSB,
+        I2C_SARADC_SAR1_INIT_CODE_MSB_MSB,
+        I2C_SARADC_SAR1_INIT_CODE_MSB_LSB,
         0x60,
     );
 
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
-        ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
+        I2C_SARADC_SAR1_INIT_CODE_LSB,
+        I2C_SARADC_SAR1_INIT_CODE_LSB_MSB,
+        I2C_SARADC_SAR1_INIT_CODE_LSB_LSB,
         0,
     );
 
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_DTEST_RTC_ADDR,
-        ADC_SARADC_DTEST_RTC_ADDR_MSB,
-        ADC_SARADC_DTEST_RTC_ADDR_LSB,
+        I2C_SARADC_DTEST,
+        I2C_SARADC_DTEST_MSB,
+        I2C_SARADC_DTEST_LSB,
         0,
     );
 
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENT_RTC_ADDR,
-        ADC_SARADC_ENT_RTC_ADDR_MSB,
-        ADC_SARADC_ENT_RTC_ADDR_LSB,
+        I2C_SARADC_ENT_SAR,
+        I2C_SARADC_ENT_SAR_MSB,
+        I2C_SARADC_ENT_SAR_LSB,
         0,
     );
 
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        ADC_SARADC1_ENCAL_REF_ADDR,
-        ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC1_ENCAL_REF_ADDR_LSB,
+        I2C_SARADC_EN_TOUT_SAR1_BUS
+        I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
+        I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
         0,
     );
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC2_ENCAL_REF_ADDR,
-        ADC_SARADC2_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC2_ENCAL_REF_ADDR_LSB,
-        0,
-    );
-
-    clear_peri_reg_mask(PMU_RF_PWC_REG, PMU_PERIF_I2C_RSTB);
+    // disable ADC_CTRL_CLK (SAR ADC function clock)
     reg_write(PCR_SARADC_CLKM_CONF_REG, 0x00404000);
+    
+    // Set PCR_SARADC_CONF_REG to initial state
     reg_write(PCR_SARADC_CONF_REG, 0x5);
 }
 

--- a/esp-hal/src/soc/esp32h2/trng.rs
+++ b/esp-hal/src/soc/esp32h2/trng.rs
@@ -1,14 +1,3 @@
-const PCR_SARADC_CONF_REG: u32 = 0x60096000 + 0x80;
-const PCR_SARADC_RST_EN: u32 = 1 << 1;
-const PCR_SARADC_REG_CLK_EN: u32 = 1 << 2;
-const PCR_SARADC_CLKM_CONF_REG: u32 = 0x60096000 + 0x84;
-const PCR_SARADC_CLKM_EN: u32 = 1 << 22;
-const PCR_SARADC_CLKM_SEL_V: u32 = 0x00000003;
-const PCR_SARADC_CLKM_SEL_S: u32 = 20;
-const PCR_SARADC_CLKM_DIV_NUM_V: u32 = 0x000000FF;
-const PCR_SARADC_CLKM_DIV_NUM_S: u32 = 12;
-const PMU_RF_PWC_REG: u32 = 0x600B0000 + 0x154;
-const PMU_XPD_PERIF_I2C: u32 = 1 << 27;
 const I2C_SAR_ADC: u8 = 0x69;
 const I2C_SAR_ADC_HOSTID: u8 = 0;
 
@@ -40,37 +29,24 @@ const SAR2_CHANNEL: u32 = 9;
 const SAR2_ATTEN: u32 = 1;
 const SAR1_ATTEN: u32 = 1;
 const PATTERN_BIT_WIDTH: u32 = 6;
-const APB_SARADC_SAR_PATT_TAB1_REG: u32 = 0x60040000 + 0x18;
-const APB_SARADC_CTRL_REG: u32 = 0x60040000;
-const APB_SARADC_CTRL2_REG: u32 = 0x60040000 + 0x4;
-
-const APB_SARADC_SARADC_SAR_PATT_LEN_V: u32 = 0x00000007;
-const APB_SARADC_SARADC_SAR_PATT_LEN_S: u32 = 15;
-const APB_SARADC_SARADC_SAR_CLK_DIV_V: u32 = 0x000000FF;
-const APB_SARADC_SARADC_SAR_CLK_DIV_S: u32 = 7;
-const APB_SARADC_SARADC_TIMER_TARGET_V: u32 = 0x00000FFF;
-const APB_SARADC_SARADC_TIMER_TARGET_S: u32 = 12;
-const APB_SARADC_SARADC_TIMER_EN: u32 = 1 << 24;
-
-const DR_REG_MODEM_LPCON_BASE: u32 = 0x600AF000;
-const MODEM_LPCON_CLK_CONF_REG: u32 = DR_REG_MODEM_LPCON_BASE + 0x18;
-const MODEM_LPCON_CLK_I2C_MST_EN: u32 = 1 << 2;
-const DR_REG_LP_I2C_ANA_MST_BASE: u32 = 0x600B2400;
-const LP_I2C_ANA_MST_DATE_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x3fc;
-const LP_I2C_ANA_MST_I2C_MAT_CLK_EN: u32 = 1 << 28;
 
 const REGI2C_BBPLL: u8 = 0x66;
 const REGI2C_BIAS: u8 = 0x6a;
-const REGI2C_DIG_REG: u8 = 0x6d;
+const REGI2C_PMU: u8 = 0x6d;
 const REGI2C_ULP_CAL: u8 = 0x61;
 const REGI2C_SAR_I2C: u8 = 0x69;
 
-const LP_I2C_ANA_MST_DEVICE_EN_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x14;
-const REGI2C_BBPLL_DEVICE_EN: u32 = 1 << 5;
-const REGI2C_BIAS_DEVICE_EN: u32 = 1 << 4;
-const REGI2C_DIG_REG_DEVICE_EN: u32 = 1 << 8;
-const REGI2C_ULP_CAL_DEVICE_EN: u32 = 1 << 6;
-const REGI2C_SAR_I2C_DEVICE_EN: u32 = 1 << 7;
+const I2C_MST_ANA_CONF1_M: u32 = 0x00FFFFFF;
+const I2C_MST_I2C0_CTRL_REG: u32 = 0x600AD800;
+const I2C_MST_ANA_CONF1_REG: u32 = I2C_MST_I2C0_CTRL_REG + 0x1c;
+
+const REGI2C_BBPLL_RD_MASK: u32 = !(1 << 7) & I2C_MST_ANA_CONF1_M;
+const REGI2C_BIAS_RD_MASK: u32 = !(1 << 6) & I2C_MST_ANA_CONF1_M;
+const REGI2C_DIG_REG_RD_MASK: u32 = !(1 << 10) & I2C_MST_ANA_CONF1_M;
+const REGI2C_ULP_CAL_RD_MASK: u32 = !(1 << 8) & I2C_MST_ANA_CONF1_M;
+const REGI2C_SAR_I2C_RD_MASK: u32 = !(1 << 9) & I2C_MST_ANA_CONF1_M;
+const REGI2C_RTC_BUSY: u32 = 1 << 25;
+
 const REGI2C_RTC_SLAVE_ID_V: u8 = 0xFF;
 const REGI2C_RTC_SLAVE_ID_S: u8 = 0;
 const REGI2C_RTC_ADDR_V: u8 = 0xFF;
@@ -80,220 +56,265 @@ const REGI2C_RTC_WR_CNTL_S: u8 = 24;
 const REGI2C_RTC_DATA_V: u8 = 0xFF;
 const REGI2C_RTC_DATA_S: u8 = 16;
 
-const LP_I2C_ANA_MST_I2C0_CTRL_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE;
-const LP_I2C_ANA_MST_I2C0_BUSY: u32 = 1 << 25;
-
-const LP_I2C_ANA_MST_I2C0_DATA_REG: u32 = DR_REG_LP_I2C_ANA_MST_BASE + 0x8;
-const LP_I2C_ANA_MST_I2C0_RDATA_V: u32 = 0x000000FF;
-const LP_I2C_ANA_MST_I2C0_RDATA_S: u32 = 0;
-
 pub(crate) fn ensure_randomness() {
-    // Pull SAR ADC out of reset
-    reg_set_bit(PCR_SARADC_CONF_REG, PCR_SARADC_RST_EN);
-    reg_clr_bit(PCR_SARADC_CONF_REG, PCR_SARADC_RST_EN);
+    let pcr = unsafe { &*crate::peripherals::PCR::ptr() };
+    let pmu = unsafe { &*crate::peripherals::PMU::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
 
-    // Enable SAR ADC APB clock
-    reg_set_bit(PCR_SARADC_CONF_REG, PCR_SARADC_REG_CLK_EN);
+    unsafe {
+        // Pull SAR ADC out of reset
+        pcr.saradc_conf().modify(|_, w| w.saradc_rst_en().set_bit());
 
-    // Enable ADC_CTRL_CLK (SAR ADC function clock)
-    reg_set_bit(PCR_SARADC_CLKM_CONF_REG, PCR_SARADC_CLKM_EN);
+        pcr.saradc_conf()
+            .modify(|_, w| w.saradc_rst_en().clear_bit());
 
-    // Select XTAL clock (40 MHz) source for ADC_CTRL_CLK
-    reg_set_field(
-        PCR_SARADC_CLKM_CONF_REG,
-        PCR_SARADC_CLKM_SEL_V,
-        PCR_SARADC_CLKM_SEL_S,
-        0,
-    );
+        // Enable SAR ADC APB clock
+        pcr.saradc_conf()
+            .modify(|_, w| w.saradc_reg_clk_en().set_bit());
 
-    // Set the clock divider for ADC_CTRL_CLK to default value (in case it has been
-    // changed)
-    reg_set_field(
-        PCR_SARADC_CLKM_CONF_REG,
-        PCR_SARADC_CLKM_DIV_NUM_V,
-        PCR_SARADC_CLKM_DIV_NUM_S,
-        0,
-    );
+        // Enable ADC_CTRL_CLK (SAR ADC function clock)
+        pcr.saradc_clkm_conf()
+            .modify(|_, w| w.saradc_clkm_en().set_bit());
 
-    // some ADC sensor registers are in power group PERIF_I2C and need to be enabled
-    // via PMU
-    set_peri_reg_mask(PMU_RF_PWC_REG, PMU_XPD_PERIF_I2C);
+        // Select XTAL clock (40 MHz) source for ADC_CTRL_CLK
+        pcr.saradc_clkm_conf()
+            .modify(|_, w| w.saradc_clkm_sel().bits(0));
 
-    // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
-    // voltage as sampling source
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_DTEST,
-        I2C_SARADC_DTEST_MSB,
-        I2C_SARADC_DTEST_LSB,
-        2,
-    );
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_ENT_SAR,
-        I2C_SARADC_ENT_SAR_MSB,
-        I2C_SARADC_ENT_SAR_LSB,
-        1,
-    );
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_EN_TOUT_SAR1_BUS,
-        I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
-        I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
-        1,
-    );
+        // Set the clock divider for ADC_CTRL_CLK to default value (in case it has been
+        // changed)
+        pcr.saradc_clkm_conf()
+            .modify(|_, w| w.saradc_clkm_div_num().bits(0));
 
-    // SAR2 High ADDR
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_SAR2_INIT_CODE_MSB,
-        I2C_SARADC_SAR2_INIT_CODE_MSB_MSB,
-        I2C_SARADC_SAR2_INIT_CODE_MSB_LSB,
-        0x08,
-    );
-    // SAR2 Low ADDR
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_SAR2_INIT_CODE_LSB,
-        I2C_SARADC_SAR2_INIT_CODE_LSB_MSB,
-        I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
-        0x66,
-    );
-    // SAR1 High ADDR
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_SAR1_INIT_CODE_MSB,
-        I2C_SARADC_SAR1_INIT_CODE_MSB_MSB,
-        I2C_SARADC_SAR1_INIT_CODE_MSB_LSB,
-        0x08,
-    );
-    // SAR1 Low ADDR
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_SAR1_INIT_CODE_LSB,
-        I2C_SARADC_SAR1_INIT_CODE_LSB_MSB,
-        I2C_SARADC_SAR1_INIT_CODE_LSB_LSB,
-        0x66,
-    );
+        // some ADC sensor registers are in power group PERIF_I2C and need to be enabled
+        // via PMU
+        pmu.rf_pwc().modify(|_, w| w.xpd_perif_i2c().set_bit());
 
-    // create patterns and set them in pattern table
-    let pattern_one: u32 = (SAR2_CHANNEL << 2) | SAR2_ATTEN; // we want channel 9 with max attenuation
-    let pattern_two: u32 = SAR1_ATTEN; // we want channel 0 with max attenuation, channel doesn't really matter here
-    let pattern_table: u32 =
-        (pattern_two << (3 * PATTERN_BIT_WIDTH)) | (pattern_one << (2 * PATTERN_BIT_WIDTH));
-    reg_write(APB_SARADC_SAR_PATT_TAB1_REG, pattern_table);
+        // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
+        // voltage as sampling source
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_DTEST,
+            I2C_SARADC_DTEST_MSB,
+            I2C_SARADC_DTEST_LSB,
+            2,
+        );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_ENT_SAR,
+            I2C_SARADC_ENT_SAR_MSB,
+            I2C_SARADC_ENT_SAR_LSB,
+            1,
+        );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_EN_TOUT_SAR1_BUS,
+            I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
+            I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
+            1,
+        );
 
-    // set pattern length to 2 (APB_SARADC_SAR_PATT_LEN counts from 0)
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SARADC_SAR_PATT_LEN_V,
-        APB_SARADC_SARADC_SAR_PATT_LEN_S,
-        0,
-    );
+        // SAR2 High ADDR
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_SAR2_INIT_CODE_MSB,
+            I2C_SARADC_SAR2_INIT_CODE_MSB_MSB,
+            I2C_SARADC_SAR2_INIT_CODE_MSB_LSB,
+            0x08,
+        );
+        // SAR2 Low ADDR
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_SAR2_INIT_CODE_LSB,
+            I2C_SARADC_SAR2_INIT_CODE_LSB_MSB,
+            I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
+            0x66,
+        );
+        // SAR1 High ADDR
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_SAR1_INIT_CODE_MSB,
+            I2C_SARADC_SAR1_INIT_CODE_MSB_MSB,
+            I2C_SARADC_SAR1_INIT_CODE_MSB_LSB,
+            0x08,
+        );
+        // SAR1 Low ADDR
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_SAR1_INIT_CODE_LSB,
+            I2C_SARADC_SAR1_INIT_CODE_LSB_MSB,
+            I2C_SARADC_SAR1_INIT_CODE_LSB_LSB,
+            0x66,
+        );
 
-    // Same as in C3
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SARADC_SAR_CLK_DIV_V,
-        APB_SARADC_SARADC_SAR_CLK_DIV_S,
-        15,
-    );
+        // create patterns and set them in pattern table
+        let pattern_one: u32 = (SAR2_CHANNEL << 2) | SAR2_ATTEN; // we want channel 9 with max attenuation
+        let pattern_two: u32 = SAR1_ATTEN; // we want channel 0 with max attenuation, channel doesn't really matter here
+        let pattern_table: u32 =
+            (pattern_two << (3 * PATTERN_BIT_WIDTH)) | (pattern_one << (2 * PATTERN_BIT_WIDTH));
 
-    // set timer expiry (timer is ADC_CTRL_CLK)
-    reg_set_field(
-        APB_SARADC_CTRL2_REG,
-        APB_SARADC_SARADC_TIMER_TARGET_V,
-        APB_SARADC_SARADC_TIMER_TARGET_S,
-        200,
-    );
+        apb_saradc
+            .sar_patt_tab1()
+            .modify(|_, w| w.bits(pattern_table));
 
-    // enable timer
-    reg_set_bit(APB_SARADC_CTRL2_REG, APB_SARADC_SARADC_TIMER_EN);
+        // set pattern length to 2 (APB_SARADC_SAR_PATT_LEN counts from 0)
+        apb_saradc.ctrl().modify(|_, w| w.sar_patt_len().bits(0));
+
+        // Same as in C3
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_div().bits(15));
+
+        // set timer expiry (timer is ADC_CTRL_CLK)
+        apb_saradc.ctrl2().modify(|_, w| w.timer_target().bits(200));
+
+        // enable timer
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().set_bit());
+    }
 }
 
 pub(crate) fn revert_trng() {
-    // Disable timer
-    reg_clr_bit(APB_SARADC_CTRL2_REG, APB_SARADC_SARADC_TIMER_EN);
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
+    let pcr = unsafe { &*crate::peripherals::PCR::ptr() };
 
-    // Write reset value
-    reg_write(APB_SARADC_SAR_PATT_TAB1_REG, 0xFFFFFF);
+    unsafe {
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().clear_bit());
 
-    // Revert ADC I2C configuration and initial voltage source setting
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_SAR2_INIT_CODE_MSB,
-        I2C_SARADC_SAR2_INIT_CODE_MSB_MSB,
-        I2C_SARADC_SAR2_INIT_CODE_MSB_LSB,
-        0x60,
-    );
+        apb_saradc.sar_patt_tab1().modify(|_, w| w.bits(0xFFFFFF));
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_SAR2_INIT_CODE_LSB,
-        I2C_SARADC_SAR2_INIT_CODE_LSB_MSB,
-        I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
-        0,
-    );
+        // Revert ADC I2C configuration and initial voltage source setting
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_SAR2_INIT_CODE_MSB,
+            I2C_SARADC_SAR2_INIT_CODE_MSB_MSB,
+            I2C_SARADC_SAR2_INIT_CODE_MSB_LSB,
+            0x60,
+        );
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_SAR1_INIT_CODE_MSB,
-        I2C_SARADC_SAR1_INIT_CODE_MSB_MSB,
-        I2C_SARADC_SAR1_INIT_CODE_MSB_LSB,
-        0x60,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_SAR2_INIT_CODE_LSB,
+            I2C_SARADC_SAR2_INIT_CODE_LSB_MSB,
+            I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
+            0,
+        );
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_SAR1_INIT_CODE_LSB,
-        I2C_SARADC_SAR1_INIT_CODE_LSB_MSB,
-        I2C_SARADC_SAR1_INIT_CODE_LSB_LSB,
-        0,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_SAR1_INIT_CODE_MSB,
+            I2C_SARADC_SAR1_INIT_CODE_MSB_MSB,
+            I2C_SARADC_SAR1_INIT_CODE_MSB_LSB,
+            0x60,
+        );
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_DTEST,
-        I2C_SARADC_DTEST_MSB,
-        I2C_SARADC_DTEST_LSB,
-        0,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_SAR1_INIT_CODE_LSB,
+            I2C_SARADC_SAR1_INIT_CODE_LSB_MSB,
+            I2C_SARADC_SAR1_INIT_CODE_LSB_LSB,
+            0,
+        );
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_ENT_SAR,
-        I2C_SARADC_ENT_SAR_MSB,
-        I2C_SARADC_ENT_SAR_LSB,
-        0,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_DTEST,
+            I2C_SARADC_DTEST_MSB,
+            I2C_SARADC_DTEST_LSB,
+            0,
+        );
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_EN_TOUT_SAR1_BUS,
-        I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
-        I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
-        0,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_ENT_SAR,
+            I2C_SARADC_ENT_SAR_MSB,
+            I2C_SARADC_ENT_SAR_LSB,
+            0,
+        );
 
-    // disable ADC_CTRL_CLK (SAR ADC function clock)
-    reg_write(PCR_SARADC_CLKM_CONF_REG, 0x00404000);
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            I2C_SARADC_EN_TOUT_SAR1_BUS,
+            I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
+            I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
+            0,
+        );
 
-    // Set PCR_SARADC_CONF_REG to initial state
-    reg_write(PCR_SARADC_CONF_REG, 0x5);
+        // disable ADC_CTRL_CLK (SAR ADC function clock)
+        pcr.saradc_clkm_conf().modify(|_, w| w.bits(0x00404000));
+
+        // Set PCR_SARADC_CONF_REG to initial state
+        pcr.saradc_conf().modify(|_, w| w.bits(0x5));
+    }
+}
+
+fn regi2c_enable_block(block: u8) {
+    let modem_lpcon = unsafe { &*crate::peripherals::MODEM_LPCON::ptr() };
+
+    modem_lpcon
+        .clk_conf()
+        .modify(|_, w| w.clk_i2c_mst_en().set_bit());
+
+    // Before config I2C register, enable corresponding slave.
+    match block {
+        v if v == REGI2C_BBPLL => {
+            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_BBPLL_RD_MASK);
+        }
+        v if v == REGI2C_BIAS => {
+            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_BIAS_RD_MASK);
+        }
+        v if v == REGI2C_PMU => {
+            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_DIG_REG_RD_MASK);
+        }
+        v if v == REGI2C_ULP_CAL => {
+            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_ULP_CAL_RD_MASK);
+        }
+        v if v == REGI2C_SAR_I2C => {
+            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_SAR_I2C_RD_MASK);
+        }
+        _ => (),
+    }
+}
+
+fn regi2c_disable_block(block: u8) {
+    match block {
+        v if v == REGI2C_BBPLL => {
+            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_BBPLL_RD_MASK);
+        }
+        v if v == REGI2C_BIAS => {
+            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_BIAS_RD_MASK);
+        }
+        v if v == REGI2C_PMU => {
+            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_DIG_REG_RD_MASK);
+        }
+        v if v == REGI2C_ULP_CAL => {
+            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_ULP_CAL_RD_MASK);
+        }
+        v if v == REGI2C_SAR_I2C => {
+            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_SAR_I2C_RD_MASK);
+        }
+        _ => (),
+    }
+}
+
+fn reg_write(reg: u32, v: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(v);
+    }
+}
+
+fn reg_get_bit(reg: u32, b: u32) -> u32 {
+    unsafe { (reg as *mut u32).read_volatile() & b }
 }
 
 fn reg_set_bit(reg: u32, bit: u32) {
@@ -308,78 +329,8 @@ fn reg_clr_bit(reg: u32, bit: u32) {
     }
 }
 
-fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(
-            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
-                | ((value & field_v) << field_s),
-        )
-    }
-}
-
-fn set_peri_reg_mask(reg: u32, mask: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
-    }
-}
-fn reg_write(reg: u32, v: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(v);
-    }
-}
-
-fn reg_get_bit(reg: u32, b: u32) -> u32 {
-    unsafe { (reg as *mut u32).read_volatile() & b }
-}
-
 fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
     unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
-}
-
-fn regi2c_enable_block(block: u8) {
-    reg_set_bit(MODEM_LPCON_CLK_CONF_REG, MODEM_LPCON_CLK_I2C_MST_EN);
-    reg_set_bit(LP_I2C_ANA_MST_DATE_REG, LP_I2C_ANA_MST_I2C_MAT_CLK_EN);
-
-    // Before config I2C register, enable corresponding slave.
-    match block {
-        v if v == REGI2C_BBPLL => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BBPLL_DEVICE_EN);
-        }
-        v if v == REGI2C_BIAS => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BIAS_DEVICE_EN);
-        }
-        v if v == REGI2C_DIG_REG => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_DIG_REG_DEVICE_EN);
-        }
-        v if v == REGI2C_ULP_CAL => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_ULP_CAL_DEVICE_EN);
-        }
-        v if v == REGI2C_SAR_I2C => {
-            reg_set_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_SAR_I2C_DEVICE_EN);
-        }
-        _ => (),
-    }
-}
-
-fn regi2c_disable_block(block: u8) {
-    match block {
-        v if v == REGI2C_BBPLL => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BBPLL_DEVICE_EN);
-        }
-        v if v == REGI2C_BIAS => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_BIAS_DEVICE_EN);
-        }
-        v if v == REGI2C_DIG_REG => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_DIG_REG_DEVICE_EN);
-        }
-        v if v == REGI2C_ULP_CAL => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_ULP_CAL_DEVICE_EN);
-        }
-        v if v == REGI2C_SAR_I2C => {
-            reg_clr_bit(LP_I2C_ANA_MST_DEVICE_EN_REG, REGI2C_SAR_I2C_DEVICE_EN);
-        }
-        _ => (),
-    }
 }
 
 pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
@@ -387,15 +338,17 @@ pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, l
     regi2c_enable_block(block);
 
     // Read the i2c bus register
+    while reg_get_bit(I2C_MST_I2C0_CTRL_REG, REGI2C_RTC_BUSY) != 0 {}
+
     let mut temp: u32 = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32)
         << REGI2C_RTC_SLAVE_ID_S as u32)
         | (reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32;
-    reg_write(LP_I2C_ANA_MST_I2C0_CTRL_REG, temp);
-    while reg_get_bit(LP_I2C_ANA_MST_I2C0_CTRL_REG, LP_I2C_ANA_MST_I2C0_BUSY) != 0 {}
+    reg_write(I2C_MST_I2C0_CTRL_REG, temp);
+    while reg_get_bit(I2C_MST_I2C0_CTRL_REG, REGI2C_RTC_BUSY) != 0 {}
     temp = reg_get_field(
-        LP_I2C_ANA_MST_I2C0_DATA_REG,
-        LP_I2C_ANA_MST_I2C0_RDATA_S,
-        LP_I2C_ANA_MST_I2C0_RDATA_V,
+        I2C_MST_I2C0_CTRL_REG,
+        REGI2C_RTC_DATA_S as u32,
+        REGI2C_RTC_DATA_V as u32,
     );
     // Write the i2c bus register
     temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
@@ -404,8 +357,8 @@ pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, l
         | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32)
         | ((0x1 & REGI2C_RTC_WR_CNTL_V as u32) << REGI2C_RTC_WR_CNTL_S as u32)
         | ((temp & REGI2C_RTC_DATA_V as u32) << REGI2C_RTC_DATA_S as u32);
-    reg_write(LP_I2C_ANA_MST_I2C0_CTRL_REG, temp);
-    while reg_get_bit(LP_I2C_ANA_MST_I2C0_CTRL_REG, LP_I2C_ANA_MST_I2C0_BUSY) != 0 {}
+    reg_write(I2C_MST_I2C0_CTRL_REG, temp);
+    while reg_get_bit(I2C_MST_I2C0_CTRL_REG, REGI2C_RTC_BUSY) != 0 {}
 
     regi2c_disable_block(block);
 }

--- a/esp-hal/src/soc/esp32h2/trng.rs
+++ b/esp-hal/src/soc/esp32h2/trng.rs
@@ -283,7 +283,7 @@ pub(crate) fn revert_trng() {
     regi2c_write_mask(
         I2C_SAR_ADC,
         I2C_SAR_ADC_HOSTID,
-        I2C_SARADC_EN_TOUT_SAR1_BUS
+        I2C_SARADC_EN_TOUT_SAR1_BUS,
         I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
         I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
         0,

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -20,6 +20,7 @@ pub mod peripherals;
 #[cfg(psram)]
 pub mod psram;
 pub mod radio_clocks;
+pub mod trng;
 
 pub mod ulp_core;
 

--- a/esp-hal/src/soc/esp32s2/trng.rs
+++ b/esp-hal/src/soc/esp32s2/trng.rs
@@ -196,8 +196,7 @@ pub(crate) fn ensure_randomness() {
     set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
 }
 
-pub fn revert_trng()
-{
+pub fn revert_trng() {
     // Restore internal I2C bus state
     regi2c_write_mask(
         I2C_SAR_ADC,
@@ -205,7 +204,7 @@ pub fn revert_trng()
         ADC_SAR1_DREF_ADDR,
         ADC_SAR1_DREF_ADDR_MSB,
         ADC_SAR1_DREF_ADDR_LSB,
-        0x1
+        0x1,
     );
 
     regi2c_write_mask(
@@ -214,7 +213,7 @@ pub fn revert_trng()
         ADC_SAR2_DREF_ADDR,
         ADC_SAR2_DREF_ADDR_MSB,
         ADC_SAR2_DREF_ADDR_LSB,
-        0x1
+        0x1,
     );
 
     regi2c_write_mask(
@@ -247,7 +246,12 @@ pub fn revert_trng()
     // Restore SARADC to default mode
     clear_peri_reg_mask(SENS_SAR_MEAS1_MUX_REG, SENS_SAR1_DIG_FORCE);
     set_peri_reg_mask(DPORT_PERIP_CLK_EN0_REG, DPORT_APB_SARADC_CLK_EN);
-    set_peri_reg_bits(SENS_SAR_POWER_XPD_SAR_REG, SENS_FORCE_XPD_SAR, 0, SENS_FORCE_XPD_SAR_S);
+    set_peri_reg_bits(
+        SENS_SAR_POWER_XPD_SAR_REG,
+        SENS_FORCE_XPD_SAR,
+        0,
+        SENS_FORCE_XPD_SAR_S,
+    );
     clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
 }
 
@@ -370,8 +374,7 @@ fn set_peri_reg_mask(reg: u32, mask: u32) {
 fn set_peri_reg_bits(reg: u32, bitmap: u32, value: u32, shift: u32) {
     unsafe {
         (reg as *mut u32).write_volatile(
-            ((reg as *mut u32).read_volatile() & !(bitmap << shift))
-                | ((value & bitmap) << shift),
+            ((reg as *mut u32).read_volatile() & !(bitmap << shift)) | ((value & bitmap) << shift),
         );
     }
 }

--- a/esp-hal/src/soc/esp32s2/trng.rs
+++ b/esp-hal/src/soc/esp32s2/trng.rs
@@ -1,17 +1,3 @@
-const DR_REG_RTCCNTL_BASE: u32 = 0x3f408000;
-const DR_REG_SYSTEM_BASE: u32 = 0x3f4c0000;
-const DR_REG_SENS_BASE: u32 = 0x3f408800;
-const DR_REG_APB_SARADC_BASE: u32 = 0x3f440000;
-const DPORT_APB_SARADC_CLK_EN: u32 = 1 << 28;
-const RTC_CNTL_CLK_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x0074;
-const RTC_CNTL_DIG_CLK8M_EN: u32 = 1 << 10;
-const DPORT_PERIP_CLK_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x040;
-const APB_SARADC_APB_ADC_CLKM_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x05c;
-const APB_SARADC_CLK_SEL_V: u32 = 0x3;
-const APB_SARADC_CLK_SEL_S: u32 = 21;
-const RTC_CNTL_ANA_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x0034;
-const RTC_CNTL_SAR_I2C_FORCE_PD_M: u32 = 1 << 21;
-const RTC_CNTL_SAR_I2C_FORCE_PU_M: u32 = 1 << 22;
 const ANA_CONFIG_REG: u32 = 0x6000E044;
 const ANA_CONFIG2_REG: u32 = 0x6000E048;
 const I2C_SAR_ADC: u8 = 0x69;
@@ -31,29 +17,6 @@ const ADC_SARADC_ENT_TSENS_ADDR_LSB: u8 = 2;
 const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7;
 const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
 const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
-const APB_SARADC_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE;
-const APB_SARADC_SAR1_PATT_LEN_V: u32 = 0xF;
-const APB_SARADC_SAR1_PATT_LEN_S: u32 = 15;
-const APB_SARADC_SAR1_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x018;
-const APB_SARADC_SAR2_PATT_LEN_V: u32 = 0xF;
-const APB_SARADC_SAR2_PATT_LEN_S: u32 = 19;
-const APB_SARADC_SAR2_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x028;
-const SENS_SAR_MEAS1_MUX_REG: u32 = DR_REG_SENS_BASE + 0x0010;
-const SENS_SAR1_DIG_FORCE: u32 = 1 << 31;
-const APB_SARADC_WORK_MODE_V: u32 = 0x3;
-const APB_SARADC_WORK_MODE_S: u32 = 3;
-
-const APB_SARADC_CTRL2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x004;
-const APB_SARADC_MEAS_NUM_LIMIT: u32 = 1 << 0;
-const SENS_SAR_POWER_XPD_SAR_REG: u32 = DR_REG_SENS_BASE + 0x003c;
-const SENS_FORCE_XPD_SAR: u32 = 0x00000003;
-const SENS_FORCE_XPD_SAR_V: u32 = 0x3;
-const SENS_FORCE_XPD_SAR_S: u32 = 29;
-const APB_SARADC_TIMER_SEL: u32 = 1 << 11;
-const APB_SARADC_TIMER_TARGET_V: u32 = 0xFFF;
-const APB_SARADC_TIMER_TARGET_S: u32 = 12;
-const APB_SARADC_START_FORCE: u32 = 1 << 0;
-const APB_SARADC_TIMER_EN: u32 = 1 << 24;
 
 const I2C_RTC_SLAVE_ID_V: u8 = 0xFF;
 const I2C_RTC_SLAVE_ID_S: u8 = 0;
@@ -83,204 +46,184 @@ const I2C_RTC_SAR_MASK: u32 = 1 << 18;
 const I2C_RTC_BOD_MASK: u32 = 1 << 22;
 
 pub(crate) fn ensure_randomness() {
-    // Enable 8M clock source for RNG (this is actually enough to produce strong
-    // random results, but enabling the SAR ADC as well adds some insurance.)
-    reg_set_bit(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_DIG_CLK8M_EN);
+    let rtc_cntl = unsafe { &*crate::peripherals::RTC_CNTL::ptr() };
+    let dport = unsafe { &*crate::peripherals::SYSTEM::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
+    let sens = unsafe { &*crate::peripherals::SENS::ptr() };
 
-    // Enable SAR ADC to read a disconnected input for additional entropy
-    set_peri_reg_mask(DPORT_PERIP_CLK_EN0_REG, DPORT_APB_SARADC_CLK_EN);
+    unsafe {
+        // Enable 8M clock source for RNG (this is actually enough to produce strong
+        // random results, but enabling the SAR ADC as well adds some insurance.)
+        rtc_cntl
+            .clk_conf()
+            .modify(|_, w| w.dig_clk8m_en().set_bit());
 
-    reg_set_field(
-        APB_SARADC_APB_ADC_CLKM_CONF_REG,
-        APB_SARADC_CLK_SEL_V,
-        APB_SARADC_CLK_SEL_S,
-        2,
-    );
+        // Enable SAR ADC to read a disconnected input for additional entropy
+        dport
+            .perip_clk_en0()
+            .modify(|_, w| w.apb_saradc_clk_en().set_bit());
 
-    clear_peri_reg_mask(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_FORCE_PD_M);
-    set_peri_reg_mask(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_FORCE_PU_M);
-    clear_peri_reg_mask(ANA_CONFIG_REG, 1 << 18);
-    set_peri_reg_mask(ANA_CONFIG2_REG, 1 << 16);
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_sel().bits(2));
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_DREF_ADDR,
-        ADC_SAR1_DREF_ADDR_MSB,
-        ADC_SAR1_DREF_ADDR_LSB,
-        0x4,
-    );
+        rtc_cntl
+            .ana_conf()
+            .modify(|_, w| w.sar_i2c_force_pd().clear_bit());
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_DREF_ADDR,
-        ADC_SAR2_DREF_ADDR_MSB,
-        ADC_SAR2_DREF_ADDR_LSB,
-        0x4,
-    );
+        rtc_cntl
+            .ana_conf()
+            .modify(|_, w| w.sar_i2c_force_pu().set_bit());
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENCAL_REF_ADDR,
-        ADC_SARADC_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC_ENCAL_REF_ADDR_LSB,
-        1,
-    );
+        // Temporarily not in PACs
+        // esp-idf/components/soc/esp32s2/include/soc/regi2c_defs.h
+        clear_peri_reg_mask(ANA_CONFIG_REG, 1 << 18);
+        set_peri_reg_mask(ANA_CONFIG2_REG, 1 << 16);
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENT_TSENS_ADDR,
-        ADC_SARADC_ENT_TSENS_ADDR_MSB,
-        ADC_SARADC_ENT_TSENS_ADDR_LSB,
-        1,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR1_DREF_ADDR,
+            ADC_SAR1_DREF_ADDR_MSB,
+            ADC_SAR1_DREF_ADDR_LSB,
+            0x4,
+        );
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENT_RTC_ADDR,
-        ADC_SARADC_ENT_RTC_ADDR_MSB,
-        ADC_SARADC_ENT_RTC_ADDR_LSB,
-        0,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR2_DREF_ADDR,
+            ADC_SAR2_DREF_ADDR_MSB,
+            ADC_SAR2_DREF_ADDR_LSB,
+            0x4,
+        );
 
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR1_PATT_LEN_V,
-        APB_SARADC_SAR1_PATT_LEN_S,
-        0,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_ENCAL_REF_ADDR,
+            ADC_SARADC_ENCAL_REF_ADDR_MSB,
+            ADC_SARADC_ENCAL_REF_ADDR_LSB,
+            1,
+        );
 
-    write_peri_reg(APB_SARADC_SAR1_PATT_TAB1_REG, 0xafffffff);
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_ENT_TSENS_ADDR,
+            ADC_SARADC_ENT_TSENS_ADDR_MSB,
+            ADC_SARADC_ENT_TSENS_ADDR_LSB,
+            1,
+        );
 
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR2_PATT_LEN_V,
-        APB_SARADC_SAR2_PATT_LEN_S,
-        0,
-    );
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_ENT_RTC_ADDR,
+            ADC_SARADC_ENT_RTC_ADDR_MSB,
+            ADC_SARADC_ENT_RTC_ADDR_LSB,
+            0,
+        );
 
-    write_peri_reg(APB_SARADC_SAR2_PATT_TAB1_REG, 0xafffffff);
+        apb_saradc.ctrl().modify(|_, w| w.sar1_patt_len().bits(0));
 
-    set_peri_reg_mask(SENS_SAR_MEAS1_MUX_REG, SENS_SAR1_DIG_FORCE);
+        apb_saradc
+            .sar1_patt_tab1()
+            .modify(|_, w| w.bits(0xafffffff));
 
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_WORK_MODE_V,
-        APB_SARADC_WORK_MODE_S,
-        1,
-    );
+        apb_saradc.ctrl().modify(|_, w| w.sar2_patt_len().bits(0));
 
-    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_MEAS_NUM_LIMIT);
+        apb_saradc
+            .sar2_patt_tab1()
+            .modify(|_, w| w.bits(0xafffffff));
 
-    reg_set_field(
-        SENS_SAR_POWER_XPD_SAR_REG,
-        SENS_FORCE_XPD_SAR_V,
-        SENS_FORCE_XPD_SAR_S,
-        3,
-    );
+        sens.sar_meas1_mux()
+            .modify(|_, w| w.sar1_dig_force().set_bit());
 
-    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_SEL);
+        apb_saradc.ctrl().modify(|_, w| w.work_mode().bits(1));
 
-    reg_set_field(
-        APB_SARADC_CTRL2_REG,
-        APB_SARADC_TIMER_TARGET_V,
-        APB_SARADC_TIMER_TARGET_S,
-        100,
-    );
+        apb_saradc
+            .ctrl2()
+            .modify(|_, w| w.meas_num_limit().clear_bit());
 
-    clear_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_START_FORCE);
-    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+        sens.sar_power_xpd_sar()
+            .modify(|_, w| w.force_xpd_sar().bits(3));
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_sel().set_bit());
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_target().bits(100));
+
+        apb_saradc.ctrl().modify(|_, w| w.start_force().clear_bit());
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().set_bit());
+    }
 }
 
 pub fn revert_trng() {
-    // Restore internal I2C bus state
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR1_DREF_ADDR,
-        ADC_SAR1_DREF_ADDR_MSB,
-        ADC_SAR1_DREF_ADDR_LSB,
-        0x1,
-    );
+    let dport = unsafe { &*crate::peripherals::SYSTEM::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
+    let sens = unsafe { &*crate::peripherals::SENS::ptr() };
 
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SAR2_DREF_ADDR,
-        ADC_SAR2_DREF_ADDR_MSB,
-        ADC_SAR2_DREF_ADDR_LSB,
-        0x1,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENCAL_REF_ADDR,
-        ADC_SARADC_ENCAL_REF_ADDR_MSB,
-        ADC_SARADC_ENCAL_REF_ADDR_LSB,
-        0,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENT_TSENS_ADDR,
-        ADC_SARADC_ENT_TSENS_ADDR_MSB,
-        ADC_SARADC_ENT_TSENS_ADDR_LSB,
-        0,
-    );
-
-    regi2c_write_mask(
-        I2C_SAR_ADC,
-        I2C_SAR_ADC_HOSTID,
-        ADC_SARADC_ENT_RTC_ADDR,
-        ADC_SARADC_ENT_RTC_ADDR_MSB,
-        ADC_SARADC_ENT_RTC_ADDR_LSB,
-        0,
-    );
-
-    // Restore SARADC to default mode
-    clear_peri_reg_mask(SENS_SAR_MEAS1_MUX_REG, SENS_SAR1_DIG_FORCE);
-    set_peri_reg_mask(DPORT_PERIP_CLK_EN0_REG, DPORT_APB_SARADC_CLK_EN);
-    set_peri_reg_bits(
-        SENS_SAR_POWER_XPD_SAR_REG,
-        SENS_FORCE_XPD_SAR,
-        0,
-        SENS_FORCE_XPD_SAR_S,
-    );
-    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
-}
-
-fn reg_set_bit(reg: u32, bit: u32) {
     unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
+        // Restore internal I2C bus state
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR1_DREF_ADDR,
+            ADC_SAR1_DREF_ADDR_MSB,
+            ADC_SAR1_DREF_ADDR_LSB,
+            0x1,
+        );
+
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SAR2_DREF_ADDR,
+            ADC_SAR2_DREF_ADDR_MSB,
+            ADC_SAR2_DREF_ADDR_LSB,
+            0x1,
+        );
+
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_ENCAL_REF_ADDR,
+            ADC_SARADC_ENCAL_REF_ADDR_MSB,
+            ADC_SARADC_ENCAL_REF_ADDR_LSB,
+            0,
+        );
+
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_ENT_TSENS_ADDR,
+            ADC_SARADC_ENT_TSENS_ADDR_MSB,
+            ADC_SARADC_ENT_TSENS_ADDR_LSB,
+            0,
+        );
+
+        regi2c_write_mask(
+            I2C_SAR_ADC,
+            I2C_SAR_ADC_HOSTID,
+            ADC_SARADC_ENT_RTC_ADDR,
+            ADC_SARADC_ENT_RTC_ADDR_MSB,
+            ADC_SARADC_ENT_RTC_ADDR_LSB,
+            0,
+        );
+
+        // Restore SARADC to default mode
+        sens.sar_meas1_mux()
+            .modify(|_, w| w.sar1_dig_force().clear_bit());
+
+        dport
+            .perip_clk_en0()
+            .modify(|_, w| w.apb_saradc_clk_en().set_bit());
+
+        sens.sar_power_xpd_sar()
+            .modify(|_, w| w.force_xpd_sar().bits(0));
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().clear_bit());
     }
 }
-
-fn reg_write(reg: u32, v: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(v);
-    }
-}
-
-fn reg_get_bit(reg: u32, b: u32) -> u32 {
-    unsafe { (reg as *mut u32).read_volatile() & b }
-}
-
-fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
-    unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
-}
-
-fn reg_clr_bit(reg: u32, bit: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
-    }
-}
-
+// Temporarily not in PACs
 fn regi2c_enable_block(block: u8) {
     reg_set_field(
         I2C_RTC_CONFIG0,
@@ -356,6 +299,26 @@ pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, l
     regi2c_disable_block(block);
 }
 
+fn reg_write(reg: u32, v: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(v);
+    }
+}
+
+fn reg_get_bit(reg: u32, b: u32) -> u32 {
+    unsafe { (reg as *mut u32).read_volatile() & b }
+}
+
+fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
+    unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
+}
+
+fn reg_clr_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
+    }
+}
+
 fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
     unsafe {
         (reg as *mut u32).write_volatile(
@@ -365,28 +328,20 @@ fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
     }
 }
 
+fn reg_set_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
+    }
+}
+
 fn set_peri_reg_mask(reg: u32, mask: u32) {
     unsafe {
         (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
     }
 }
 
-fn set_peri_reg_bits(reg: u32, bitmap: u32, value: u32, shift: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(
-            ((reg as *mut u32).read_volatile() & !(bitmap << shift)) | ((value & bitmap) << shift),
-        );
-    }
-}
-
 fn clear_peri_reg_mask(reg: u32, mask: u32) {
     unsafe {
         (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
-    }
-}
-
-fn write_peri_reg(reg: u32, val: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(val);
     }
 }

--- a/esp-hal/src/soc/esp32s2/trng.rs
+++ b/esp-hal/src/soc/esp32s2/trng.rs
@@ -1,0 +1,389 @@
+const DR_REG_RTCCNTL_BASE: u32 = 0x3f408000;
+const DR_REG_SYSTEM_BASE: u32 = 0x3f4c0000;
+const DR_REG_SENS_BASE: u32 = 0x3f408800;
+const DR_REG_APB_SARADC_BASE: u32 = 0x3f440000;
+const DPORT_APB_SARADC_CLK_EN: u32 = 1 << 28;
+const RTC_CNTL_CLK_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x0074;
+const RTC_CNTL_DIG_CLK8M_EN: u32 = 1 << 10;
+const DPORT_PERIP_CLK_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x040;
+const APB_SARADC_APB_ADC_CLKM_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x05c;
+const APB_SARADC_CLK_SEL_V: u32 = 0x3;
+const APB_SARADC_CLK_SEL_S: u32 = 21;
+const RTC_CNTL_ANA_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x0034;
+const RTC_CNTL_SAR_I2C_FORCE_PD_M: u32 = 1 << 21;
+const RTC_CNTL_SAR_I2C_FORCE_PU_M: u32 = 1 << 22;
+const ANA_CONFIG_REG: u32 = 0x6000E044;
+const ANA_CONFIG2_REG: u32 = 0x6000E048;
+const I2C_SAR_ADC: u8 = 0x69;
+const I2C_SAR_ADC_HOSTID: u8 = 1;
+const ADC_SAR1_DREF_ADDR: u8 = 0x2;
+const ADC_SAR1_DREF_ADDR_MSB: u8 = 0x6;
+const ADC_SAR1_DREF_ADDR_LSB: u8 = 0x4;
+const ADC_SAR2_DREF_ADDR: u8 = 0x5;
+const ADC_SAR2_DREF_ADDR_MSB: u8 = 0x6;
+const ADC_SAR2_DREF_ADDR_LSB: u8 = 0x4;
+const ADC_SARADC_ENCAL_REF_ADDR: u8 = 0x7;
+const ADC_SARADC_ENCAL_REF_ADDR_MSB: u8 = 4;
+const ADC_SARADC_ENCAL_REF_ADDR_LSB: u8 = 4;
+const ADC_SARADC_ENT_TSENS_ADDR: u8 = 0x7;
+const ADC_SARADC_ENT_TSENS_ADDR_MSB: u8 = 2;
+const ADC_SARADC_ENT_TSENS_ADDR_LSB: u8 = 2;
+const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7;
+const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
+const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
+const APB_SARADC_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE;
+const APB_SARADC_SAR1_PATT_LEN_V: u32 = 0xF;
+const APB_SARADC_SAR1_PATT_LEN_S: u32 = 15;
+const APB_SARADC_SAR1_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x018;
+const APB_SARADC_SAR2_PATT_LEN_V: u32 = 0xF;
+const APB_SARADC_SAR2_PATT_LEN_S: u32 = 19;
+const APB_SARADC_SAR2_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x028;
+const SENS_SAR_MEAS1_MUX_REG: u32 = DR_REG_SENS_BASE + 0x0010;
+const SENS_SAR1_DIG_FORCE: u32 = 1 << 31;
+const APB_SARADC_WORK_MODE_V: u32 = 0x3;
+const APB_SARADC_WORK_MODE_S: u32 = 3;
+
+const APB_SARADC_CTRL2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x004;
+const APB_SARADC_MEAS_NUM_LIMIT: u32 = 1 << 0;
+const SENS_SAR_POWER_XPD_SAR_REG: u32 = DR_REG_SENS_BASE + 0x003c;
+const SENS_FORCE_XPD_SAR: u32 = 0x00000003;
+const SENS_FORCE_XPD_SAR_V: u32 = 0x3;
+const SENS_FORCE_XPD_SAR_S: u32 = 29;
+const APB_SARADC_TIMER_SEL: u32 = 1 << 11;
+const APB_SARADC_TIMER_TARGET_V: u32 = 0xFFF;
+const APB_SARADC_TIMER_TARGET_S: u32 = 12;
+const APB_SARADC_START_FORCE: u32 = 1 << 0;
+const APB_SARADC_TIMER_EN: u32 = 1 << 24;
+
+const I2C_RTC_SLAVE_ID_V: u8 = 0xFF;
+const I2C_RTC_SLAVE_ID_S: u8 = 0;
+const I2C_RTC_ADDR_V: u8 = 0xFF;
+const I2C_RTC_ADDR_S: u8 = 0x8;
+const I2C_RTC_CONFIG2: u32 = 0x6000e000;
+const I2C_RTC_BUSY: u32 = 1 << 25;
+const I2C_RTC_DATA_V: u32 = 0xFF;
+const I2C_RTC_DATA_S: u32 = 16;
+const I2C_RTC_WR_CNTL_V: u8 = 0x1;
+const I2C_RTC_WR_CNTL_S: u8 = 24;
+const I2C_RTC_CONFIG0: u32 = 0x6000e048;
+const I2C_RTC_CONFIG1: u32 = 0x6000e044;
+const I2C_RTC_MAGIC_CTRL_V: u32 = 0x1FFF;
+const I2C_RTC_MAGIC_CTRL_S: u32 = 4;
+const I2C_RTC_MAGIC_DEFAULT: u32 = 0x1c40;
+const I2C_RTC_ALL_MASK_V: u32 = 0x7FFF;
+const I2C_RTC_ALL_MASK_S: u32 = 8;
+const I2C_RTC_WIFI_CLK_EN: u32 = 0x3f426000 + 0x090;
+const I2C_RTC_CLK_GATE_EN: u32 = 1 << 18;
+const I2C_BOD: u8 = 0x61;
+const I2C_BBPLL: u8 = 0x66;
+const I2C_APLL: u8 = 0x6D;
+const I2C_RTC_APLL_MASK: u32 = 1 << 14;
+const I2C_RTC_BBPLL_MASK: u32 = 1 << 17;
+const I2C_RTC_SAR_MASK: u32 = 1 << 18;
+const I2C_RTC_BOD_MASK: u32 = 1 << 22;
+
+pub(crate) fn ensure_randomness() {
+    // Enable 8M clock source for RNG (this is actually enough to produce strong
+    // random results, but enabling the SAR ADC as well adds some insurance.)
+    reg_set_bit(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_DIG_CLK8M_EN);
+
+    // Enable SAR ADC to read a disconnected input for additional entropy
+    set_peri_reg_mask(DPORT_PERIP_CLK_EN0_REG, DPORT_APB_SARADC_CLK_EN);
+
+    reg_set_field(
+        APB_SARADC_APB_ADC_CLKM_CONF_REG,
+        APB_SARADC_CLK_SEL_V,
+        APB_SARADC_CLK_SEL_S,
+        2,
+    );
+
+    clear_peri_reg_mask(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_FORCE_PD_M);
+    set_peri_reg_mask(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_FORCE_PU_M);
+    clear_peri_reg_mask(ANA_CONFIG_REG, 1 << 18);
+    set_peri_reg_mask(ANA_CONFIG2_REG, 1 << 16);
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SAR1_DREF_ADDR,
+        ADC_SAR1_DREF_ADDR_MSB,
+        ADC_SAR1_DREF_ADDR_LSB,
+        0x4,
+    );
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SAR2_DREF_ADDR,
+        ADC_SAR2_DREF_ADDR_MSB,
+        ADC_SAR2_DREF_ADDR_LSB,
+        0x4,
+    );
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_ENCAL_REF_ADDR,
+        ADC_SARADC_ENCAL_REF_ADDR_MSB,
+        ADC_SARADC_ENCAL_REF_ADDR_LSB,
+        1,
+    );
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_ENT_TSENS_ADDR,
+        ADC_SARADC_ENT_TSENS_ADDR_MSB,
+        ADC_SARADC_ENT_TSENS_ADDR_LSB,
+        1,
+    );
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_ENT_RTC_ADDR,
+        ADC_SARADC_ENT_RTC_ADDR_MSB,
+        ADC_SARADC_ENT_RTC_ADDR_LSB,
+        0,
+    );
+
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR1_PATT_LEN_V,
+        APB_SARADC_SAR1_PATT_LEN_S,
+        0,
+    );
+
+    write_peri_reg(APB_SARADC_SAR1_PATT_TAB1_REG, 0xafffffff);
+
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR2_PATT_LEN_V,
+        APB_SARADC_SAR2_PATT_LEN_S,
+        0,
+    );
+
+    write_peri_reg(APB_SARADC_SAR2_PATT_TAB1_REG, 0xafffffff);
+
+    set_peri_reg_mask(SENS_SAR_MEAS1_MUX_REG, SENS_SAR1_DIG_FORCE);
+
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_WORK_MODE_V,
+        APB_SARADC_WORK_MODE_S,
+        1,
+    );
+
+    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_MEAS_NUM_LIMIT);
+
+    reg_set_field(
+        SENS_SAR_POWER_XPD_SAR_REG,
+        SENS_FORCE_XPD_SAR_V,
+        SENS_FORCE_XPD_SAR_S,
+        3,
+    );
+
+    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_SEL);
+
+    reg_set_field(
+        APB_SARADC_CTRL2_REG,
+        APB_SARADC_TIMER_TARGET_V,
+        APB_SARADC_TIMER_TARGET_S,
+        100,
+    );
+
+    clear_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_START_FORCE);
+    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+}
+
+pub fn revert_trng()
+{
+    // Restore internal I2C bus state
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SAR1_DREF_ADDR,
+        ADC_SAR1_DREF_ADDR_MSB,
+        ADC_SAR1_DREF_ADDR_LSB,
+        0x1
+    );
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SAR2_DREF_ADDR,
+        ADC_SAR2_DREF_ADDR_MSB,
+        ADC_SAR2_DREF_ADDR_LSB,
+        0x1
+    );
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_ENCAL_REF_ADDR,
+        ADC_SARADC_ENCAL_REF_ADDR_MSB,
+        ADC_SARADC_ENCAL_REF_ADDR_LSB,
+        0,
+    );
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_ENT_TSENS_ADDR,
+        ADC_SARADC_ENT_TSENS_ADDR_MSB,
+        ADC_SARADC_ENT_TSENS_ADDR_LSB,
+        0,
+    );
+
+    regi2c_write_mask(
+        I2C_SAR_ADC,
+        I2C_SAR_ADC_HOSTID,
+        ADC_SARADC_ENT_RTC_ADDR,
+        ADC_SARADC_ENT_RTC_ADDR_MSB,
+        ADC_SARADC_ENT_RTC_ADDR_LSB,
+        0,
+    );
+
+    // Restore SARADC to default mode
+    clear_peri_reg_mask(SENS_SAR_MEAS1_MUX_REG, SENS_SAR1_DIG_FORCE);
+    set_peri_reg_mask(DPORT_PERIP_CLK_EN0_REG, DPORT_APB_SARADC_CLK_EN);
+    set_peri_reg_bits(SENS_SAR_POWER_XPD_SAR_REG, SENS_FORCE_XPD_SAR, 0, SENS_FORCE_XPD_SAR_S);
+    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+}
+
+fn reg_set_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
+    }
+}
+
+fn reg_write(reg: u32, v: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(v);
+    }
+}
+
+fn reg_get_bit(reg: u32, b: u32) -> u32 {
+    unsafe { (reg as *mut u32).read_volatile() & b }
+}
+
+fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
+    unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
+}
+
+fn reg_clr_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
+    }
+}
+
+fn regi2c_enable_block(block: u8) {
+    reg_set_field(
+        I2C_RTC_CONFIG0,
+        I2C_RTC_MAGIC_CTRL_V,
+        I2C_RTC_MAGIC_CTRL_S,
+        I2C_RTC_MAGIC_DEFAULT,
+    );
+    reg_set_field(
+        I2C_RTC_CONFIG1,
+        I2C_RTC_ALL_MASK_V,
+        I2C_RTC_ALL_MASK_S,
+        I2C_RTC_ALL_MASK_V,
+    );
+
+    reg_set_bit(I2C_RTC_WIFI_CLK_EN, I2C_RTC_CLK_GATE_EN);
+
+    // Before config I2C register, enable corresponding slave.
+    match block {
+        v if v == I2C_APLL => {
+            reg_set_bit(I2C_RTC_CONFIG1, I2C_RTC_APLL_MASK);
+        }
+        v if v == I2C_BBPLL => {
+            reg_set_bit(I2C_RTC_CONFIG1, I2C_RTC_BBPLL_MASK);
+        }
+        v if v == I2C_SAR_ADC => {
+            reg_set_bit(I2C_RTC_CONFIG1, I2C_RTC_SAR_MASK);
+        }
+        v if v == I2C_BOD => {
+            reg_set_bit(I2C_RTC_CONFIG1, I2C_RTC_BOD_MASK);
+        }
+        _ => (),
+    }
+}
+
+fn regi2c_disable_block(block: u8) {
+    match block {
+        v if v == I2C_APLL => {
+            reg_clr_bit(I2C_RTC_CONFIG1, I2C_RTC_APLL_MASK);
+        }
+        v if v == I2C_BBPLL => {
+            reg_clr_bit(I2C_RTC_CONFIG1, I2C_RTC_BBPLL_MASK);
+        }
+        v if v == I2C_SAR_ADC => {
+            reg_clr_bit(I2C_RTC_CONFIG1, I2C_RTC_SAR_MASK);
+        }
+        v if v == I2C_BOD => {
+            reg_clr_bit(I2C_RTC_CONFIG1, I2C_RTC_BOD_MASK);
+        }
+        _ => (),
+    }
+}
+
+pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
+    assert!(msb - lsb < 8);
+    regi2c_enable_block(block);
+
+    // Read the i2c bus register
+    let mut temp: u32 = ((block as u32 & I2C_RTC_SLAVE_ID_V as u32) << I2C_RTC_SLAVE_ID_S as u32)
+        | (reg_add as u32 & I2C_RTC_ADDR_V as u32) << I2C_RTC_ADDR_S as u32;
+    reg_write(I2C_RTC_CONFIG2, temp);
+    while reg_get_bit(I2C_RTC_CONFIG2, I2C_RTC_BUSY) != 0 {}
+    temp = reg_get_field(I2C_RTC_CONFIG2, I2C_RTC_DATA_S, I2C_RTC_DATA_V);
+    // Write the i2c bus register
+    temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
+    temp |= (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
+    temp = ((block as u32 & I2C_RTC_SLAVE_ID_V as u32) << I2C_RTC_SLAVE_ID_S as u32)
+        | ((reg_add as u32 & I2C_RTC_ADDR_V as u32) << I2C_RTC_ADDR_S as u32)
+        | ((0x1 & I2C_RTC_WR_CNTL_V as u32) << I2C_RTC_WR_CNTL_S as u32)
+        | ((temp & I2C_RTC_DATA_V) << I2C_RTC_DATA_S);
+    reg_write(I2C_RTC_CONFIG2, temp);
+    while reg_get_bit(I2C_RTC_CONFIG2, I2C_RTC_BUSY) != 0 {}
+
+    regi2c_disable_block(block);
+}
+
+fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(
+            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
+                | ((value & field_v) << field_s),
+        )
+    }
+}
+
+fn set_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
+    }
+}
+
+fn set_peri_reg_bits(reg: u32, bitmap: u32, value: u32, shift: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(
+            ((reg as *mut u32).read_volatile() & !(bitmap << shift))
+                | ((value & bitmap) << shift),
+        );
+    }
+}
+
+fn clear_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+    }
+}
+
+fn write_peri_reg(reg: u32, val: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(val);
+    }
+}

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -21,6 +21,7 @@ pub mod peripherals;
 #[cfg(psram)]
 pub mod psram;
 pub mod radio_clocks;
+pub mod trng;
 
 pub mod ulp_core;
 

--- a/esp-hal/src/soc/esp32s3/trng.rs
+++ b/esp-hal/src/soc/esp32s3/trng.rs
@@ -1,54 +1,7 @@
 const DR_REG_SYSCON_BASE: u32 = 0x60026000;
-const DR_REG_RTCCNTL_BASE: u32 = 0x60008000;
-const DR_REG_SYSTEM_BASE: u32 = 0x600C0000;
-const DR_REG_APB_SARADC_BASE: u32 = 0x60040000;
-const DR_REG_SENS_BASE: u32 = 0x60008800;
 const SYSTEM_WIFI_CLK_EN_REG: u32 = DR_REG_SYSCON_BASE + 0x14;
 const SYSTEM_WIFI_CLK_RNG_EN: u32 = 1 << 15;
-const RTC_CNTL_CLK_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x74;
-const RTC_CNTL_DIG_CLK8M_EN: u32 = 1 << 10;
-const SYSTEM_PERIP_CLK_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x18;
-const SYSTEM_APB_SARADC_CLK_EN: u32 = 1 << 28;
-const APB_SARADC_APB_ADC_CLKM_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x70;
-const APB_SARADC_CLK_SEL_V: u32 = 0x3;
-const APB_SARADC_CLK_SEL_S: u32 = 21;
-const APB_SARADC_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE;
-const APB_SARADC_CTRL2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x4;
-const APB_SARADC_SAR_CLK_GATED: u32 = 1 << 6;
-const APB_SARADC_CLK_EN: u32 = 1 << 20;
-const APB_SARADC_CLKM_DIV_NUM_V: u32 = 0xFF;
-const APB_SARADC_CLKM_DIV_NUM_S: u32 = 0;
-const APB_SARADC_SAR_CLK_DIV_V: u32 = 0xFF;
-const APB_SARADC_SAR_CLK_DIV_S: u32 = 7;
-const APB_SARADC_TIMER_TARGET_V: u32 = 0xFFF;
-const APB_SARADC_TIMER_TARGET_S: u32 = 0x12;
-const APB_SARADC_START_FORCE: u32 = 1 << 0;
-const SENS_SAR_POWER_XPD_SAR_REG: u32 = DR_REG_SENS_BASE + 0x3C;
-const SENS_FORCE_XPD_SAR_V: u32 = 0x3;
-const SENS_FORCE_XPD_SAR_S: u32 = 29;
-const APB_SARADC_MEAS_NUM_LIMIT: u32 = 1 << 0;
-const APB_SARADC_WORK_MODE_V: u32 = 0x3;
-const APB_SARADC_WORK_MODE_S: u32 = 0x3;
-const APB_SARADC_SAR2_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x28;
-const APB_SARADC_SAR2_PATT_LEN_V: u32 = 0xF;
-const APB_SARADC_SAR2_PATT_LEN_S: u32 = 19;
-const APB_SARADC_SAR1_PATT_LEN_V: u32 = 0xF;
-const APB_SARADC_SAR1_PATT_LEN_S: u32 = 15;
-const APB_SARADC_SAR1_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x18;
-const SENS_SAR_MEAS1_MUX_REG: u32 = DR_REG_SENS_BASE + 0x10;
-const SENS_SAR1_DIG_FORCE: u32 = 1 << 31;
-const SENS_SAR_MEAS2_MUX_REG: u32 = DR_REG_SENS_BASE + 0x34;
-const SENS_SAR2_RTC_FORCE: u32 = 1 << 31;
-const APB_SARADC_APB_ADC_ARB_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE + 0x38;
-const APB_SARADC_ADC_ARB_GRANT_FORCE: u32 = 1 << 5;
-const APB_SARADC_ADC_ARB_FIX_PRIORITY: u32 = 1 << 12;
-const APB_SARADC_FILTER_CTRL0_REG: u32 = DR_REG_APB_SARADC_BASE + 0x3C;
-const APB_SARADC_FILTER_CHANNEL0_V: u32 = 0x1F;
-const APB_SARADC_FILTER_CHANNEL0_S: u32 = 19;
-const APB_SARADC_FILTER_CHANNEL1_V: u32 = 0x1F;
-const APB_SARADC_FILTER_CHANNEL1_S: u32 = 14;
-const APB_SARADC_TIMER_SEL: u32 = 1 << 11;
-const APB_SARADC_TIMER_EN: u32 = 1 << 24;
+
 const I2C_SAR_ADC: u8 = 0x69;
 const I2C_SAR_ADC_HOSTID: u8 = 1;
 const ADC_SARADC_ENCAL_REF_ADDR: u8 = 0x7;
@@ -63,178 +16,134 @@ const ADC_SARADC_ENT_RTC_ADDR_LSB: u32 = 3;
 const ADC_SARADC_DTEST_RTC_ADDR: u32 = 0x7;
 const ADC_SARADC_DTEST_RTC_ADDR_MSB: u32 = 1;
 const ADC_SARADC_DTEST_RTC_ADDR_LSB: u32 = 0;
-const SYSTEM_PERIP_RST_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x20;
-const SYSTEM_APB_SARADC_RST: u32 = 1 << 28;
 
 use crate::regi2c_write_mask;
 
 pub(crate) fn ensure_randomness() {
-    set_peri_reg_mask(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_RNG_EN);
+    let rtc_cntl = unsafe { &*crate::peripherals::RTC_CNTL::ptr() };
+    let system = unsafe { &*crate::peripherals::SYSTEM::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
+    let sens = unsafe { &*crate::peripherals::SENS::ptr() };
 
-    // Enable 8M clock source for RNG (this is actually enough to produce strong
-    // random results, but enabling the SAR ADC as well adds some insurance.)
-    reg_set_bit(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_DIG_CLK8M_EN);
-
-    // Enable SAR ADC to read a disconnected input for additional entropy
-    set_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, SYSTEM_APB_SARADC_CLK_EN);
-    clear_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, SYSTEM_APB_SARADC_CLK_EN);
-
-    reg_set_field(
-        APB_SARADC_APB_ADC_CLKM_CONF_REG,
-        APB_SARADC_CLK_SEL_V,
-        APB_SARADC_CLK_SEL_S,
-        2,
-    );
-
-    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_CLK_GATED);
-    set_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN);
-
-    reg_set_field(
-        APB_SARADC_APB_ADC_CLKM_CONF_REG,
-        APB_SARADC_CLKM_DIV_NUM_V,
-        APB_SARADC_CLKM_DIV_NUM_S,
-        3,
-    );
-
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR_CLK_DIV_V,
-        APB_SARADC_SAR_CLK_DIV_S,
-        3,
-    );
-
-    reg_set_field(
-        APB_SARADC_CTRL2_REG,
-        APB_SARADC_TIMER_TARGET_V,
-        APB_SARADC_TIMER_TARGET_S,
-        70,
-    );
-
-    clear_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_START_FORCE);
-    reg_set_field(
-        SENS_SAR_POWER_XPD_SAR_REG,
-        SENS_FORCE_XPD_SAR_V,
-        SENS_FORCE_XPD_SAR_S,
-        3,
-    );
-    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_MEAS_NUM_LIMIT);
-
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_WORK_MODE_V,
-        APB_SARADC_WORK_MODE_S,
-        1,
-    );
-
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR2_PATT_LEN_V,
-        APB_SARADC_SAR2_PATT_LEN_S,
-        0,
-    );
-
-    write_peri_reg(APB_SARADC_SAR2_PATT_TAB1_REG, 0xafffff);
-
-    reg_set_field(
-        APB_SARADC_CTRL_REG,
-        APB_SARADC_SAR1_PATT_LEN_V,
-        APB_SARADC_SAR1_PATT_LEN_S,
-        0,
-    );
-
-    write_peri_reg(APB_SARADC_SAR1_PATT_TAB1_REG, 0xafffff);
-
-    set_peri_reg_mask(SENS_SAR_MEAS1_MUX_REG, SENS_SAR1_DIG_FORCE);
-
-    clear_peri_reg_mask(SENS_SAR_MEAS2_MUX_REG, SENS_SAR2_RTC_FORCE);
-
-    clear_peri_reg_mask(
-        APB_SARADC_APB_ADC_ARB_CTRL_REG,
-        APB_SARADC_ADC_ARB_GRANT_FORCE,
-    );
-    clear_peri_reg_mask(
-        APB_SARADC_APB_ADC_ARB_CTRL_REG,
-        APB_SARADC_ADC_ARB_FIX_PRIORITY,
-    );
-
-    reg_set_field(
-        APB_SARADC_FILTER_CTRL0_REG,
-        APB_SARADC_FILTER_CHANNEL0_V,
-        APB_SARADC_FILTER_CHANNEL0_S,
-        0xD,
-    );
-
-    reg_set_field(
-        APB_SARADC_FILTER_CTRL0_REG,
-        APB_SARADC_FILTER_CHANNEL1_V,
-        APB_SARADC_FILTER_CHANNEL1_S,
-        0xD,
-    );
-
-    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_SEL);
-    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
-
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 1);
-
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 1);
-
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 1);
-
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 1);
-}
-
-pub fn revert_trng() {
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 0);
-
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
-
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
-
-    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
-
-    reg_set_field(
-        SENS_SAR_POWER_XPD_SAR_REG,
-        SENS_FORCE_XPD_SAR_V,
-        SENS_FORCE_XPD_SAR_S,
-        0,
-    );
-
-    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
-
-    clear_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, APB_SARADC_CLK_EN);
-
-    set_peri_reg_mask(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_APB_SARADC_RST);
-}
-
-fn reg_set_bit(reg: u32, bit: u32) {
     unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
+        // Temporarily `WIFI_CLK_RNG_EN` is not in PACs
+        set_peri_reg_mask(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_RNG_EN);
+
+        // Enable 8M clock source for RNG (this is actually enough to produce strong
+        // random results, but enabling the SAR ADC as well adds some insurance.)
+        rtc_cntl
+            .clk_conf()
+            .modify(|_, w| w.dig_clk8m_en().set_bit());
+
+        // Enable SAR ADC to read a disconnected input for additional entropy
+        // Reset ADC clock
+        system
+            .perip_clk_en0()
+            .modify(|_, w| w.apb_saradc_clk_en().set_bit());
+
+        system
+            .perip_clk_en0()
+            .modify(|_, w| w.apb_saradc_clk_en().clear_bit());
+
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_sel().bits(2));
+
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_gated().set_bit());
+        apb_saradc.clkm_conf().modify(|_, w| w.clk_en().set_bit());
+
+        apb_saradc
+            .clkm_conf()
+            .modify(|_, w| w.clkm_div_num().bits(3));
+
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_div().bits(3));
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_target().bits(3));
+
+        apb_saradc.ctrl().modify(|_, w| w.sar_clk_div().bits(3));
+
+        sens.sar_power_xpd_sar()
+            .modify(|_, w| w.force_xpd_sar().bits(3));
+
+        apb_saradc
+            .ctrl2()
+            .modify(|_, w| w.meas_num_limit().clear_bit());
+
+        apb_saradc.ctrl().modify(|_, w| w.work_mode().bits(1));
+
+        apb_saradc.ctrl().modify(|_, w| w.sar2_patt_len().bits(0));
+
+        apb_saradc.sar2_patt_tab1().modify(|_, w| w.bits(0xafffff));
+
+        apb_saradc.ctrl().modify(|_, w| w.sar1_patt_len().bits(0));
+
+        apb_saradc.sar1_patt_tab1().modify(|_, w| w.bits(0xafffff));
+
+        sens.sar_meas1_mux()
+            .modify(|_, w| w.sar1_dig_force().set_bit());
+
+        sens.sar_meas2_mux()
+            .modify(|_, w| w.sar2_rtc_force().clear_bit());
+
+        apb_saradc
+            .arb_ctrl()
+            .modify(|_, w| w.grant_force().clear_bit());
+
+        apb_saradc
+            .arb_ctrl()
+            .modify(|_, w| w.fix_priority().clear_bit());
+
+        apb_saradc
+            .filter_ctrl0()
+            .modify(|_, w| w.filter_channel0().bits(0xD));
+
+        apb_saradc
+            .filter_ctrl0()
+            .modify(|_, w| w.filter_channel1().bits(0xD));
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_sel().set_bit());
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().set_bit());
+
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 1);
+
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 1);
+
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 1);
+
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 1);
     }
 }
 
-fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
+pub fn revert_trng() {
+    let system = unsafe { &*crate::peripherals::SYSTEM::ptr() };
+    let apb_saradc = unsafe { &*crate::peripherals::APB_SARADC::ptr() };
+    let sens = unsafe { &*crate::peripherals::SENS::ptr() };
+
     unsafe {
-        (reg as *mut u32).write_volatile(
-            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
-                | ((value & field_v) << field_s),
-        )
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 0);
+
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
+
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
+
+        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
+
+        sens.sar_power_xpd_sar()
+            .modify(|_, w| w.force_xpd_sar().bits(0));
+
+        apb_saradc.ctrl2().modify(|_, w| w.timer_en().clear_bit());
+
+        system
+            .perip_clk_en0()
+            .modify(|_, w| w.apb_saradc_clk_en().clear_bit());
+
+        system
+            .perip_rst_en0()
+            .modify(|_, w| w.apb_saradc_rst().set_bit());
     }
 }
 
 fn set_peri_reg_mask(reg: u32, mask: u32) {
     unsafe {
         (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
-    }
-}
-
-fn clear_peri_reg_mask(reg: u32, mask: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
-    }
-}
-
-fn write_peri_reg(reg: u32, val: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(val);
     }
 }

--- a/esp-hal/src/soc/esp32s3/trng.rs
+++ b/esp-hal/src/soc/esp32s3/trng.rs
@@ -1,0 +1,236 @@
+const DR_REG_SYSCON_BASE: u32 = 0x60026000;
+const DR_REG_RTCCNTL_BASE: u32 = 0x60008000;
+const DR_REG_SYSTEM_BASE: u32 = 0x600C0000;
+const DR_REG_APB_SARADC_BASE: u32 = 0x60040000;
+const DR_REG_SENS_BASE: u32 = 0x60008800;
+const SYSTEM_WIFI_CLK_EN_REG: u32 = DR_REG_SYSCON_BASE + 0x14;
+const SYSTEM_WIFI_CLK_RNG_EN: u32 = 1 << 15;
+const RTC_CNTL_CLK_CONF_REG: u32 = DR_REG_RTCCNTL_BASE + 0x74;
+const RTC_CNTL_DIG_CLK8M_EN: u32 = 1 << 10;
+const SYSTEM_PERIP_CLK_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x18;
+const SYSTEM_APB_SARADC_CLK_EN: u32 = 1 << 28;
+const APB_SARADC_APB_ADC_CLKM_CONF_REG: u32 = DR_REG_APB_SARADC_BASE + 0x70;
+const APB_SARADC_CLK_SEL_V: u32 = 0x3;
+const APB_SARADC_CLK_SEL_S: u32 = 21;
+const APB_SARADC_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE;
+const APB_SARADC_CTRL2_REG: u32 = DR_REG_APB_SARADC_BASE + 0x4;
+const APB_SARADC_SAR_CLK_GATED: u32 = 1 << 6;
+const APB_SARADC_CLK_EN: u32 = 1 << 20;
+const APB_SARADC_CLKM_DIV_NUM_V: u32 = 0xFF;
+const APB_SARADC_CLKM_DIV_NUM_S: u32 = 0;
+const APB_SARADC_SAR_CLK_DIV_V: u32 = 0xFF;
+const APB_SARADC_SAR_CLK_DIV_S: u32 = 7;
+const APB_SARADC_TIMER_TARGET_V: u32 = 0xFFF;
+const APB_SARADC_TIMER_TARGET_S: u32 = 0x12;
+const APB_SARADC_START_FORCE: u32 = 1 << 0;
+const SENS_SAR_POWER_XPD_SAR_REG: u32 = DR_REG_SENS_BASE + 0x3C;
+const SENS_FORCE_XPD_SAR_V: u32 = 0x3;
+const SENS_FORCE_XPD_SAR_S: u32 = 29;
+const APB_SARADC_MEAS_NUM_LIMIT: u32 = 1 << 0;
+const APB_SARADC_WORK_MODE_V: u32 = 0x3;
+const APB_SARADC_WORK_MODE_S: u32 = 0x3;
+const APB_SARADC_SAR2_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x28;
+const APB_SARADC_SAR2_PATT_LEN_V: u32 = 0xF;
+const APB_SARADC_SAR2_PATT_LEN_S: u32 = 19;
+const APB_SARADC_SAR1_PATT_LEN_V: u32 = 0xF;
+const APB_SARADC_SAR1_PATT_LEN_S: u32 = 15;
+const APB_SARADC_SAR1_PATT_TAB1_REG: u32 = DR_REG_APB_SARADC_BASE + 0x18;
+const SENS_SAR_MEAS1_MUX_REG: u32 = DR_REG_SENS_BASE + 0x10;
+const SENS_SAR1_DIG_FORCE: u32 = 1 << 31;
+const SENS_SAR_MEAS2_MUX_REG: u32 = DR_REG_SENS_BASE + 0x34;
+const SENS_SAR2_RTC_FORCE: u32 = 1 << 31;
+const APB_SARADC_APB_ADC_ARB_CTRL_REG: u32 = DR_REG_APB_SARADC_BASE + 0x38;
+const APB_SARADC_ADC_ARB_GRANT_FORCE: u32 = 1 << 5;
+const APB_SARADC_ADC_ARB_FIX_PRIORITY: u32 = 1 << 12;
+const APB_SARADC_FILTER_CTRL0_REG: u32 = DR_REG_APB_SARADC_BASE + 0x3C;
+const APB_SARADC_FILTER_CHANNEL0_V: u32 = 0x1F;
+const APB_SARADC_FILTER_CHANNEL0_S: u32 = 19;
+const APB_SARADC_FILTER_CHANNEL1_V: u32 = 0x1F;
+const APB_SARADC_FILTER_CHANNEL1_S: u32 = 14;
+const APB_SARADC_TIMER_SEL: u32 = 1 << 11;
+const APB_SARADC_TIMER_EN: u32 = 1 << 24;
+const I2C_SAR_ADC: u8 = 0x69;
+const I2C_SAR_ADC_HOSTID: u8 = 1;
+const ADC_SARADC_ENCAL_REF_ADDR: u8 = 0x7;
+const ADC_SARADC_ENCAL_REF_ADDR_MSB: u32 = 4;
+const ADC_SARADC_ENCAL_REF_ADDR_LSB: u32 = 4;
+const ADC_SARADC_ENT_TSENS_ADDR: u32 = 0x7;
+const ADC_SARADC_ENT_TSENS_ADDR_MSB: u32 = 2;
+const ADC_SARADC_ENT_TSENS_ADDR_LSB: u32 = 2;
+const ADC_SARADC_ENT_RTC_ADDR: u32 = 0x7;
+const ADC_SARADC_ENT_RTC_ADDR_MSB: u32 = 3;
+const ADC_SARADC_ENT_RTC_ADDR_LSB: u32 = 3;
+const ADC_SARADC_DTEST_RTC_ADDR: u32 = 0x7;
+const ADC_SARADC_DTEST_RTC_ADDR_MSB: u32 = 1;
+const ADC_SARADC_DTEST_RTC_ADDR_LSB: u32 = 0;
+const SYSTEM_PERIP_RST_EN0_REG: u32 = DR_REG_SYSTEM_BASE + 0x20;
+const SYSTEM_APB_SARADC_RST: u32 = 1 << 28;
+
+use crate::regi2c_write_mask;
+
+pub(crate) fn ensure_randomness() {
+    set_peri_reg_mask(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_RNG_EN);
+
+    // Enable 8M clock source for RNG (this is actually enough to produce strong
+    // random results, but enabling the SAR ADC as well adds some insurance.)
+    reg_set_bit(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_DIG_CLK8M_EN);
+
+    // Enable SAR ADC to read a disconnected input for additional entropy
+    set_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, SYSTEM_APB_SARADC_CLK_EN);
+    clear_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, SYSTEM_APB_SARADC_CLK_EN);
+
+    reg_set_field(
+        APB_SARADC_APB_ADC_CLKM_CONF_REG,
+        APB_SARADC_CLK_SEL_V,
+        APB_SARADC_CLK_SEL_S,
+        2,
+    );
+
+    set_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_SAR_CLK_GATED);
+    set_peri_reg_mask(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_EN);
+
+    reg_set_field(
+        APB_SARADC_APB_ADC_CLKM_CONF_REG,
+        APB_SARADC_CLKM_DIV_NUM_V,
+        APB_SARADC_CLKM_DIV_NUM_S,
+        3,
+    );
+
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR_CLK_DIV_V,
+        APB_SARADC_SAR_CLK_DIV_S,
+        3,
+    );
+
+    reg_set_field(
+        APB_SARADC_CTRL2_REG,
+        APB_SARADC_TIMER_TARGET_V,
+        APB_SARADC_TIMER_TARGET_S,
+        70,
+    );
+
+    clear_peri_reg_mask(APB_SARADC_CTRL_REG, APB_SARADC_START_FORCE);
+    reg_set_field(
+        SENS_SAR_POWER_XPD_SAR_REG,
+        SENS_FORCE_XPD_SAR_V,
+        SENS_FORCE_XPD_SAR_S,
+        3,
+    );
+    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_MEAS_NUM_LIMIT);
+
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_WORK_MODE_V,
+        APB_SARADC_WORK_MODE_S,
+        1,
+    );
+
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR2_PATT_LEN_V,
+        APB_SARADC_SAR2_PATT_LEN_S,
+        0,
+    );
+
+    write_peri_reg(APB_SARADC_SAR2_PATT_TAB1_REG, 0xafffff);
+
+    reg_set_field(
+        APB_SARADC_CTRL_REG,
+        APB_SARADC_SAR1_PATT_LEN_V,
+        APB_SARADC_SAR1_PATT_LEN_S,
+        0,
+    );
+
+    write_peri_reg(APB_SARADC_SAR1_PATT_TAB1_REG, 0xafffff);
+
+    set_peri_reg_mask(SENS_SAR_MEAS1_MUX_REG, SENS_SAR1_DIG_FORCE);
+
+    clear_peri_reg_mask(SENS_SAR_MEAS2_MUX_REG, SENS_SAR2_RTC_FORCE);
+
+    clear_peri_reg_mask(
+        APB_SARADC_APB_ADC_ARB_CTRL_REG,
+        APB_SARADC_ADC_ARB_GRANT_FORCE,
+    );
+    clear_peri_reg_mask(
+        APB_SARADC_APB_ADC_ARB_CTRL_REG,
+        APB_SARADC_ADC_ARB_FIX_PRIORITY,
+    );
+
+    reg_set_field(
+        APB_SARADC_FILTER_CTRL0_REG,
+        APB_SARADC_FILTER_CHANNEL0_V,
+        APB_SARADC_FILTER_CHANNEL0_S,
+        0xD,
+    );
+
+    reg_set_field(
+        APB_SARADC_FILTER_CTRL0_REG,
+        APB_SARADC_FILTER_CHANNEL1_V,
+        APB_SARADC_FILTER_CHANNEL1_S,
+        0xD,
+    );
+
+    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_SEL);
+    set_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 1);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 1);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 1);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 1);
+}
+
+pub fn revert_trng()
+{
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 0);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
+
+    regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
+
+    reg_set_field(SENS_SAR_POWER_XPD_SAR_REG, SENS_FORCE_XPD_SAR_V, SENS_FORCE_XPD_SAR_S, 0);
+
+    clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+
+    clear_peri_reg_mask(SYSTEM_PERIP_CLK_EN0_REG, APB_SARADC_CLK_EN);
+
+    set_peri_reg_mask(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_APB_SARADC_RST);
+}
+
+fn reg_set_bit(reg: u32, bit: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
+    }
+}
+
+fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(
+            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
+                | ((value & field_v) << field_s),
+        )
+    }
+}
+
+fn set_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | mask);
+    }
+}
+
+fn clear_peri_reg_mask(reg: u32, mask: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !mask);
+    }
+}
+
+fn write_peri_reg(reg: u32, val: u32) {
+    unsafe {
+        (reg as *mut u32).write_volatile(val);
+    }
+}

--- a/esp-hal/src/soc/esp32s3/trng.rs
+++ b/esp-hal/src/soc/esp32s3/trng.rs
@@ -183,8 +183,7 @@ pub(crate) fn ensure_randomness() {
     regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 1);
 }
 
-pub fn revert_trng()
-{
+pub fn revert_trng() {
     regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 0);
 
     regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
@@ -193,7 +192,12 @@ pub fn revert_trng()
 
     regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
 
-    reg_set_field(SENS_SAR_POWER_XPD_SAR_REG, SENS_FORCE_XPD_SAR_V, SENS_FORCE_XPD_SAR_S, 0);
+    reg_set_field(
+        SENS_SAR_POWER_XPD_SAR_REG,
+        SENS_FORCE_XPD_SAR_V,
+        SENS_FORCE_XPD_SAR_S,
+        0,
+    );
 
     clear_peri_reg_mask(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
 

--- a/examples/src/bin/rng.rs
+++ b/examples/src/bin/rng.rs
@@ -6,35 +6,13 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{peripherals::Peripherals, prelude::*, rng::{Rng, Secure},
-    analog::adc::{AdcConfig, Attenuation, ADC},
-    clock::ClockControl,
-    delay::Delay,
-    gpio::IO,
-    peripherals::ADC1};
+use esp_hal::{peripherals::Peripherals, prelude::*, rng::Trng};
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut trng = Rng::<Secure>::new(peripherals.RNG, peripherals.ADC1);
-
-    // let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    // cfg_if::cfg_if! {
-    //     if #[cfg(feature = "esp32")] {
-    //         let analog_pin = io.pins.gpio32.into_analog();
-    //     } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
-    //         let analog_pin = io.pins.gpio3.into_analog();
-    //     } else {
-    //         let analog_pin = io.pins.gpio2.into_analog();
-    //     }
-    // }
-
-    // // Create ADC instances
-    // let mut adc1_config = AdcConfig::new();
-    // let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
-    // let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
-
+    let mut trng = Trng::new(peripherals.RNG, peripherals.ADC1);
 
     // Generate a random word (u32):
     println!("Random u32:   {}", trng.random());

--- a/examples/src/bin/rng.rs
+++ b/examples/src/bin/rng.rs
@@ -6,21 +6,38 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{peripherals::Peripherals, prelude::*, rng::Trng};
+use esp_hal::{prelude::*, rng::Trng,
+    analog::adc::{AdcConfig, Attenuation, ADC},
+    clock::ClockControl,
+    delay::Delay,
+    gpio::IO,
+    peripherals::{Peripherals, ADC1}};
+
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut trng = Trng::new(peripherals.RNG, peripherals.ADC1);
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    // Generate a random word (u32):
-    println!("Random u32:   {}", trng.random());
-
+    let analog_pin = io.pins.gpio3.into_analog();
+    let mut adc1_config = AdcConfig::new();
+    let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
+    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
+    let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
+    
+    let mut trng = Trng::new(peripherals.RNG, &mut adc1);
+    
+    let (mut rng, adc1) = trng.downgrade();
+    
     // Fill a buffer with random bytes:
     let mut buf = [0u8; 16];
-    trng.read(&mut buf);
+    // trng.read(&mut buf);
     println!("Random bytes: {:?}", buf);
 
-    loop {}
+    loop {
+        println!("Random u32:   {}", rng.random());
+        let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
+        println!("ADC reading = {}", pin_value);
+    }
 }

--- a/examples/src/bin/rng.rs
+++ b/examples/src/bin/rng.rs
@@ -6,30 +6,32 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{prelude::*, rng::Trng,
-    analog::adc::{AdcConfig, Attenuation, ADC},
+use esp_hal::{
+    analog::adc::{Adc, AdcConfig, Attenuation},
     clock::ClockControl,
     delay::Delay,
-    gpio::IO,
-    peripherals::{Peripherals, ADC1}};
-
+    gpio::Io,
+    peripherals::{Peripherals, ADC1},
+    prelude::*,
+    rng::Trng,
+};
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let analog_pin = io.pins.gpio3.into_analog();
     let mut adc1_config = AdcConfig::new();
     let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
-    let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
+    let mut adc1 = Adc::<ADC1>::new(peripherals.ADC1, adc1_config);
     let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
-    
+
     let mut trng = Trng::new(peripherals.RNG, &mut adc1);
-    
+
     let (mut rng, adc1) = trng.downgrade();
-    
+
     // Fill a buffer with random bytes:
     let mut buf = [0u8; 16];
     // trng.read(&mut buf);

--- a/examples/src/bin/rng.rs
+++ b/examples/src/bin/rng.rs
@@ -6,20 +6,42 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{peripherals::Peripherals, prelude::*, rng::Rng};
+use esp_hal::{peripherals::Peripherals, prelude::*, rng::{Rng, Secure},
+    analog::adc::{AdcConfig, Attenuation, ADC},
+    clock::ClockControl,
+    delay::Delay,
+    gpio::IO,
+    peripherals::ADC1};
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let mut rng = Rng::new(peripherals.RNG);
+    let mut trng = Rng::<Secure>::new(peripherals.RNG, peripherals.ADC1);
+
+    // let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    // cfg_if::cfg_if! {
+    //     if #[cfg(feature = "esp32")] {
+    //         let analog_pin = io.pins.gpio32.into_analog();
+    //     } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
+    //         let analog_pin = io.pins.gpio3.into_analog();
+    //     } else {
+    //         let analog_pin = io.pins.gpio2.into_analog();
+    //     }
+    // }
+
+    // // Create ADC instances
+    // let mut adc1_config = AdcConfig::new();
+    // let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
+    // let mut adc1 = ADC::<ADC1>::new(peripherals.ADC1, adc1_config);
+
 
     // Generate a random word (u32):
-    println!("Random u32:   {}", rng.random());
+    println!("Random u32:   {}", trng.random());
 
     // Fill a buffer with random bytes:
     let mut buf = [0u8; 16];
-    rng.read(&mut buf);
+    trng.read(&mut buf);
     println!("Random bytes: {:?}", buf);
 
     loop {}


### PR DESCRIPTION
closes #1499

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.\

### Pull Request Details 📖

#### Description
Based on what's discussed in #1499 and previous related issues, created a TRNG struct, which takes RNG peripheral and ADC instance. Working on using ADC peripheral instead of instance, this will be draft until it's done

#### Testing
```rust
#![no_std]
#![no_main]

use esp_backtrace as _;
use esp_hal::{prelude::*, rng::Trng,
    analog::adc::{AdcConfig, Attenuation, Add},
    clock::ClockControl,
    delay::Delay,
    gpio::Io,
    peripherals::{Peripherals, ADC1}};

use esp_println::println;

#[entry]
fn main() -> ! {
    let peripherals = Peripherals::take();
    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);

    let analog_pin = io.pins.gpio3.into_analog();
    let mut adc1_config = AdcConfig::new();
    let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
    let mut adc1 = Add::<ADC1>::new(peripherals.ADC1, adc1_config);
    let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
    
    let mut trng = Trng::new(peripherals.RNG, &mut adc1);
    
    let (mut rng, adc1) = trng.downgrade();
    
    // Fill a buffer with random bytes:
    let (mut rng, adc1) = trng.downgrade();
    
    // Fill a buffer with random bytes:
    let mut buf = [0u8; 16];
    // trng.read(&mut buf); // Compile-time error
    rng.read(&mut buf);
    println!("Random bytes: {:?}", buf);
    println!("Random u32:   {}", rng.random());
    println!("ADC reading = {}", nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap());

    loop {}
}
```
