### PR TITLE
Add a lint exception rule for `unexpected_cfgs`

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -219,3 +219,6 @@ ci = [
 
 [lints.clippy]
 mixed_attributes_style = "allow"
+
+[lints.rust]
+unexpected_cfgs = "allow"

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -66,6 +66,9 @@ required-features = ["embedded-hal-02", "esp32c6"]
 name              = "i2c"
 required-features = ["embedded-hal-02", "esp32c6"]
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [patch.crates-io]
 esp32s2-ulp = { git = "https://github.com/esp-rs/esp-pacs", rev = "bcab40a" }
 esp32s3-ulp = { git = "https://github.com/esp-rs/esp-pacs", rev = "bcab40a" }


### PR DESCRIPTION
Fixes our `clippy` checks on RISC-V