### PR TITLE
Refactor and clean up `xtask` package

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -22,8 +22,9 @@ pub fn run(args: &[String], cwd: &Path) -> Result<()> {
     let status = Command::new(get_cargo())
         .args(args)
         .current_dir(cwd)
-        .stdout(Stdio::piped())
+        .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
+        .stdin(Stdio::inherit())
         .status()?;
 
     // Make sure that we return an appropriate exit code here, as Github Actions
@@ -32,27 +33,6 @@ pub fn run(args: &[String], cwd: &Path) -> Result<()> {
         Ok(())
     } else {
         bail!("Failed to execute cargo subcommand")
-    }
-}
-
-/// Execute cargo with the given arguments and from the specified directory.
-pub fn run_with_input(args: &[String], cwd: &Path) -> Result<()> {
-    if !cwd.is_dir() {
-        bail!("The `cwd` argument MUST be a directory");
-    }
-
-    let status = Command::new(get_cargo())
-        .args(args)
-        .current_dir(cwd)
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .stdin(std::process::Stdio::inherit())
-        .status()?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!("Failed to execute cargo subcommand"))
     }
 }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -294,7 +294,7 @@ pub fn execute_app(
     let args = builder.build();
     log::debug!("{args:#?}");
 
-    cargo::run_with_input(&args, package_path)
+    cargo::run(&args, package_path)
 }
 
 /// Build the specified package, using the given toolchain/target/features if


### PR DESCRIPTION
Nothing too major here, mostly just reducing duplication and some other minor reworks attempting to introduce some new patterns (we'll see if they stick). Notable new features are the ability to build a single example, and now all examples/tests are sorted by name when building/running.

I did test a handful of subcommands locally, everything seems to be working correctly as far as I can tell.