### PR TITLE
spi: fix dma wrong mode when using eh1 blocking api

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed division by zero in ledc embedded_hal::pwm set_duty_cycle function and converted to set_duty_hw instead of set_duty to eliminate loss of granularity. (#1441)
 - Embassy examples now build on stable (#1485)
 - Fix delay on esp32h2 (#1535)
+- spi: fix dma wrong mode when using eh1 blocking api (#1541)
 
 ### Changed
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1448,9 +1448,21 @@ pub mod dma {
 
     #[cfg(feature = "async")]
     mod asynch {
+        use embedded_hal_async::spi::{ErrorType, SpiBus};
+
         use super::*;
 
-        impl<'d, T, C, M> embedded_hal_async::spi::SpiBus for SpiDma<'d, T, C, M, crate::Async>
+        impl<'d, T, C, M> ErrorType for SpiDma<'d, T, C, M, crate::Async>
+        where
+            T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+            C: ChannelTypes,
+            C::P: SpiPeripheral,
+            M: IsFullDuplex,
+        {
+            type Error = Error;
+        }
+
+        impl<'d, T, C, M> SpiBus for SpiDma<'d, T, C, M, crate::Async>
         where
             T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
             C: ChannelTypes,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1448,21 +1448,9 @@ pub mod dma {
 
     #[cfg(feature = "async")]
     mod asynch {
-        use embedded_hal_async::spi::{ErrorType, SpiBus};
-
         use super::*;
 
-        impl<'d, T, C, M> ErrorType for SpiDma<'d, T, C, M, crate::Async>
-        where
-            T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-            C: ChannelTypes,
-            C::P: SpiPeripheral,
-            M: IsFullDuplex,
-        {
-            type Error = Error;
-        }
-
-        impl<'d, T, C, M> SpiBus for SpiDma<'d, T, C, M, crate::Async>
+        impl<'d, T, C, M> embedded_hal_async::spi::SpiBus for SpiDma<'d, T, C, M, crate::Async>
         where
             T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
             C: ChannelTypes,
@@ -1626,12 +1614,13 @@ pub mod dma {
 
         use super::*;
 
-        impl<'d, T, C, M> ErrorType for SpiDma<'d, T, C, M, crate::Blocking>
+        impl<'d, T, C, M, DmaMode> ErrorType for SpiDma<'d, T, C, M, DmaMode>
         where
             T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
             C: ChannelTypes,
             C::P: SpiPeripheral,
             M: IsFullDuplex,
+            DmaMode: Mode,
         {
             type Error = Error;
         }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1614,7 +1614,7 @@ pub mod dma {
 
         use super::*;
 
-        impl<'d, T, C, M> ErrorType for SpiDma<'d, T, C, M, crate::Async>
+        impl<'d, T, C, M> ErrorType for SpiDma<'d, T, C, M, crate::Blocking>
         where
             T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
             C: ChannelTypes,
@@ -1624,7 +1624,7 @@ pub mod dma {
             type Error = Error;
         }
 
-        impl<'d, T, C, M> SpiBus for SpiDma<'d, T, C, M, crate::Async>
+        impl<'d, T, C, M> SpiBus for SpiDma<'d, T, C, M, crate::Blocking>
         where
             T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
             C: ChannelTypes,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
When using spi with dma with eh1 blocking api, the dma mode should be `Blocking`, since we define dma channel `Blocking` when using eh1 blocking api in `gdma.rs`. Or there will be some compiling errors.
#### Description
1. Change dma mode from `Async` to `Blocking` when using eh1 blocking api.
2. Add missing ErrorType for `Async` spidma.

#### Testing
Compiled on esp32c3
