### PR TITLE
Remove pin generics from PARL_IO

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Timer abstraction: refactor `systimer` and `timer` modules into a common `timer` module (#1527)
 - Refactoring of GPIO module, have drivers for Input,Output,OutputOpenDrain, all drivers setup their GPIOs correctly (#1542)
 - DMA transactions are now found in the `dma` module (#1550)
+- Remove unnecessary generics from PARL_IO driver (#1545)
 
 ### Removed
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1460,12 +1460,10 @@ where
     }
 }
 
-impl<'d, CH, P, CP, DM> DmaSupport for ParlIoTx<'d, CH, P, CP, DM>
+impl<'d, CH, DM> DmaSupport for ParlIoTx<'d, CH, DM>
 where
     CH: ChannelTypes,
     CH::P: ParlIoPeripheral,
-    P: TxPins + ConfigurePins,
-    CP: TxClkPin,
     DM: Mode,
 {
     fn peripheral_wait_dma(&mut self, _is_tx: bool, _is_rx: bool) {
@@ -1479,12 +1477,10 @@ where
     }
 }
 
-impl<'d, CH, P, CP, DM> DmaSupportTx for ParlIoTx<'d, CH, P, CP, DM>
+impl<'d, CH, DM> DmaSupportTx for ParlIoTx<'d, CH, DM>
 where
     CH: ChannelTypes,
     CH::P: ParlIoPeripheral,
-    P: TxPins + ConfigurePins,
-    CP: TxClkPin,
     DM: Mode,
 {
     type TX = CH::Tx<'d>;
@@ -1494,7 +1490,7 @@ where
     }
 }
 
-impl<'d, CH, P, CP, DM> ParlIoRx<'d, CH, P, CP, DM>
+impl<'d, CH, DM> ParlIoRx<'d, CH, DM>
 where
     CH: ChannelTypes,
     CH::P: ParlIoPeripheral,
@@ -1553,12 +1549,10 @@ where
     }
 }
 
-impl<'d, CH, P, CP, DM> DmaSupport for ParlIoRx<'d, CH, P, CP, DM>
+impl<'d, CH, DM> DmaSupport for ParlIoRx<'d, CH, DM>
 where
     CH: ChannelTypes,
     CH::P: ParlIoPeripheral,
-    P: RxPins + ConfigurePins,
-    CP: RxClkPin,
     DM: Mode,
 {
     fn peripheral_wait_dma(&mut self, _is_tx: bool, _is_rx: bool) {
@@ -1579,12 +1573,10 @@ where
     }
 }
 
-impl<'d, CH, P, CP, DM> DmaSupportRx for ParlIoRx<'d, CH, P, CP, DM>
+impl<'d, CH, DM> DmaSupportRx for ParlIoRx<'d, CH, DM>
 where
     CH: ChannelTypes,
     CH::P: ParlIoPeripheral,
-    P: RxPins + ConfigurePins,
-    CP: RxClkPin,
     DM: Mode,
 {
     type RX = CH::Rx<'d>;

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -17,7 +17,7 @@
 //! let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
 //!
 //! // configure the valid pin which will be driven high during a TX transfer
-//! let pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.pins.gpio5);
+//! let mut pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.pins.gpio5);
 //!
 //! let mut parl_io = ParlIoTxOnly::new(
 //!     peripherals.PARL_IO,
@@ -33,11 +33,17 @@
 //! .unwrap();
 //!
 //! // configure a pin for the clock signal
-//! let cp = ClkOutPin::new(io.pins.gpio6);
+//! let mut cp = ClkOutPin::new(io.pins.gpio6);
 //!
 //! let mut parl_io_tx = parl_io
 //!     .tx
-//!     .with_config(pin_conf, cp, 0, SampleEdge::Normal, BitPackOrder::Msb)
+//!     .with_config(
+//!         &mut pin_conf,
+//!         &mut cp,
+//!         0,
+//!         SampleEdge::Normal,
+//!         BitPackOrder::Msb,
+//!     )
 //!     .unwrap();
 //! ```
 //!
@@ -50,7 +56,7 @@
 //!
 //! ### Initialization for RX
 //! ```no_run
-//! let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
+//! let mut rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
 //!
 //! let parl_io = ParlIoRxOnly::new(
 //!     peripherals.PARL_IO,
@@ -67,7 +73,7 @@
 //!
 //! let mut parl_io_rx = parl_io
 //!     .rx
-//!     .with_config(rx_pins, NoClkPin, BitPackOrder::Msb, Some(0xfff))
+//!     .with_config(&mut rx_pins, no_clk_pin(), BitPackOrder::Msb, Some(0xfff))
 //!     .unwrap();
 //! ```
 //!
@@ -318,6 +324,12 @@ impl RxClkPin for NoClkPin {
     fn configure(&mut self) {
         // nothing
     }
+}
+
+/// This can be used to pass to the `with_config` functions
+pub fn no_clk_pin() -> &'static mut NoClkPin {
+    static mut NO_CLK: NoClkPin = NoClkPin;
+    unsafe { &mut *core::ptr::addr_of_mut!(NO_CLK) }
 }
 
 /// Wraps a GPIO pin which will be used as the clock output signal
@@ -889,7 +901,7 @@ where
         idle_value: u16,
         sample_edge: SampleEdge,
         bit_order: BitPackOrder,
-    ) -> Result<ParlIoTx<'d, CH, P, CP, DM>, Error>
+    ) -> Result<ParlIoTx<'d, CH, DM>, Error>
     where
         P: FullDuplex + TxPins + ConfigurePins,
         CP: TxClkPin,
@@ -903,8 +915,6 @@ where
 
         Ok(ParlIoTx {
             tx_channel: self.tx_channel,
-            _pins: tx_pins,
-            _clk_pin: clk_pin,
             phantom: PhantomData,
         })
     }
@@ -918,12 +928,12 @@ where
     /// Configure TX to use the given pins and settings
     pub fn with_config<P, CP>(
         self,
-        mut tx_pins: P,
-        mut clk_pin: CP,
+        tx_pins: &'d mut P,
+        clk_pin: &'d mut CP,
         idle_value: u16,
         sample_edge: SampleEdge,
         bit_order: BitPackOrder,
-    ) -> Result<ParlIoTx<'d, CH, P, CP, DM>, Error>
+    ) -> Result<ParlIoTx<'d, CH, DM>, Error>
     where
         P: TxPins + ConfigurePins,
         CP: TxClkPin,
@@ -937,32 +947,24 @@ where
 
         Ok(ParlIoTx {
             tx_channel: self.tx_channel,
-            _pins: tx_pins,
-            _clk_pin: clk_pin,
             phantom: PhantomData,
         })
     }
 }
 
 /// Parallel IO TX channel
-pub struct ParlIoTx<'d, CH, P, CP, DM>
+pub struct ParlIoTx<'d, CH, DM>
 where
     CH: ChannelTypes,
-    P: TxPins + ConfigurePins,
-    CP: TxClkPin,
     DM: Mode,
 {
     tx_channel: CH::Tx<'d>,
-    _pins: P,
-    _clk_pin: CP,
     phantom: PhantomData<DM>,
 }
 
-impl<'d, CH, P, CP, DM> core::fmt::Debug for ParlIoTx<'d, CH, P, CP, DM>
+impl<'d, CH, DM> core::fmt::Debug for ParlIoTx<'d, CH, DM>
 where
     CH: ChannelTypes,
-    P: TxPins + ConfigurePins,
-    CP: TxClkPin,
     DM: Mode,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -978,11 +980,11 @@ where
     /// Configure RX to use the given pins and settings
     pub fn with_config<P, CP>(
         self,
-        mut rx_pins: P,
-        mut clk_pin: CP,
+        rx_pins: &'d mut P,
+        clk_pin: &'d mut CP,
         bit_order: BitPackOrder,
         timeout_ticks: Option<u16>,
-    ) -> Result<ParlIoRx<'d, CH, P, CP, DM>, Error>
+    ) -> Result<ParlIoRx<'d, CH, DM>, Error>
     where
         P: FullDuplex + RxPins + ConfigurePins,
         CP: RxClkPin,
@@ -995,8 +997,6 @@ where
 
         Ok(ParlIoRx {
             rx_channel: self.rx_channel,
-            _pins: rx_pins,
-            _clk_pin: clk_pin,
             phantom: PhantomData,
         })
     }
@@ -1010,11 +1010,11 @@ where
     /// Configure RX to use the given pins and settings
     pub fn with_config<P, CP>(
         self,
-        mut rx_pins: P,
-        mut clk_pin: CP,
+        rx_pins: &'d mut P,
+        clk_pin: &'d mut CP,
         bit_order: BitPackOrder,
         timeout_ticks: Option<u16>,
-    ) -> Result<ParlIoRx<'d, CH, P, CP, DM>, Error>
+    ) -> Result<ParlIoRx<'d, CH, DM>, Error>
     where
         P: RxPins + ConfigurePins,
         CP: RxClkPin,
@@ -1027,32 +1027,24 @@ where
 
         Ok(ParlIoRx {
             rx_channel: self.rx_channel,
-            _pins: rx_pins,
-            _clk_pin: clk_pin,
             phantom: PhantomData,
         })
     }
 }
 
 /// Parallel IO RX channel
-pub struct ParlIoRx<'d, CH, P, CP, DM>
+pub struct ParlIoRx<'d, CH, DM>
 where
     CH: ChannelTypes,
-    P: RxPins + ConfigurePins,
-    CP: RxClkPin,
     DM: Mode,
 {
     rx_channel: CH::Rx<'d>,
-    _pins: P,
-    _clk_pin: CP,
     phantom: PhantomData<DM>,
 }
 
-impl<'d, CH, P, CP, DM> core::fmt::Debug for ParlIoRx<'d, CH, P, CP, DM>
+impl<'d, CH, DM> core::fmt::Debug for ParlIoRx<'d, CH, DM>
 where
     CH: ChannelTypes,
-    P: RxPins + ConfigurePins,
-    CP: RxClkPin,
     DM: Mode,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -1412,12 +1404,10 @@ where
     Ok(())
 }
 
-impl<'d, CH, P, CP, DM> ParlIoTx<'d, CH, P, CP, DM>
+impl<'d, CH, DM> ParlIoTx<'d, CH, DM>
 where
     CH: ChannelTypes,
     CH::P: ParlIoPeripheral,
-    P: TxPins + ConfigurePins,
-    CP: TxClkPin,
     DM: Mode,
 {
     /// Perform a DMA write.
@@ -1508,8 +1498,6 @@ impl<'d, CH, P, CP, DM> ParlIoRx<'d, CH, P, CP, DM>
 where
     CH: ChannelTypes,
     CH::P: ParlIoPeripheral,
-    P: RxPins + ConfigurePins,
-    CP: RxClkPin,
     DM: Mode,
 {
     /// Perform a DMA read.
@@ -1654,13 +1642,7 @@ pub mod asynch {
     use embassy_sync::waitqueue::AtomicWaker;
     use procmacros::handler;
 
-    use super::{
-        private::{ConfigurePins, Instance, RxClkPin, RxPins, TxClkPin, TxPins},
-        Error,
-        ParlIoRx,
-        ParlIoTx,
-        MAX_DMA_SIZE,
-    };
+    use super::{private::Instance, Error, ParlIoRx, ParlIoTx, MAX_DMA_SIZE};
     use crate::{
         dma::{asynch::DmaRxDoneChFuture, ChannelTypes, ParlIoPeripheral},
         peripherals::Interrupt,
@@ -1716,12 +1698,10 @@ pub mod asynch {
         }
     }
 
-    impl<'d, CH, P, CP> ParlIoTx<'d, CH, P, CP, crate::Async>
+    impl<'d, CH> ParlIoTx<'d, CH, crate::Async>
     where
         CH: ChannelTypes,
         CH::P: ParlIoPeripheral,
-        P: TxPins + ConfigurePins,
-        CP: TxClkPin,
     {
         /// Perform a DMA write.
         ///
@@ -1741,12 +1721,10 @@ pub mod asynch {
         }
     }
 
-    impl<'d, CH, P, CP> ParlIoRx<'d, CH, P, CP, crate::Async>
+    impl<'d, CH> ParlIoRx<'d, CH, crate::Async>
     where
         CH: ChannelTypes,
         CH::P: ParlIoPeripheral,
-        P: RxPins + ConfigurePins,
-        CP: RxClkPin,
     {
         /// Perform a DMA write.
         ///

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -18,7 +18,7 @@ use esp_hal::{
     dma_buffers,
     embassy,
     gpio::Io,
-    parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
+    parl_io::{no_clk_pin, BitPackOrder, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
@@ -43,7 +43,7 @@ async fn main(_spawner: Spawner) {
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
+    let mut rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,
@@ -60,7 +60,7 @@ async fn main(_spawner: Spawner) {
 
     let mut parl_io_rx = parl_io
         .rx
-        .with_config(rx_pins, NoClkPin, BitPackOrder::Msb, Some(0xfff))
+        .with_config(&mut rx_pins, no_clk_pin(), BitPackOrder::Msb, Some(0xfff))
         .unwrap();
 
     let buffer = rx_buffer;

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -56,7 +56,7 @@ async fn main(_spawner: Spawner) {
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
 
-    let pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.pins.gpio5);
+    let mut pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.pins.gpio5);
 
     let parl_io = ParlIoTxOnly::new(
         peripherals.PARL_IO,
@@ -71,13 +71,13 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let clock_pin = ClkOutPin::new(io.pins.gpio8);
+    let mut clock_pin = ClkOutPin::new(io.pins.gpio8);
 
     let mut parl_io_tx = parl_io
         .tx
         .with_config(
-            pin_conf,
-            clock_pin,
+            &mut pin_conf,
+            &mut clock_pin,
             0,
             SampleEdge::Normal,
             BitPackOrder::Msb,

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -15,7 +15,7 @@ use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::Io,
-    parl_io::{BitPackOrder, NoClkPin, ParlIoRxOnly, RxFourBits},
+    parl_io::{no_clk_pin, BitPackOrder, ParlIoRxOnly, RxFourBits},
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
@@ -35,7 +35,7 @@ fn main() -> ! {
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
+    let mut rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,
@@ -52,7 +52,7 @@ fn main() -> ! {
 
     let mut parl_io_rx = parl_io
         .rx
-        .with_config(rx_pins, NoClkPin, BitPackOrder::Msb, Some(0xfff))
+        .with_config(&mut rx_pins, no_clk_pin(), BitPackOrder::Msb, Some(0xfff))
         .unwrap();
 
     let mut buffer = rx_buffer;

--- a/examples/src/bin/parl_io_tx.rs
+++ b/examples/src/bin/parl_io_tx.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
 
     let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
 
-    let pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.pins.gpio5);
+    let mut pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.pins.gpio5);
 
     let parl_io = ParlIoTxOnly::new(
         peripherals.PARL_IO,
@@ -63,13 +63,13 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let clock_pin = ClkOutPin::new(io.pins.gpio6);
+    let mut clock_pin = ClkOutPin::new(io.pins.gpio6);
 
     let mut parl_io_tx = parl_io
         .tx
         .with_config(
-            pin_conf,
-            clock_pin,
+            &mut pin_conf,
+            &mut clock_pin,
             0,
             SampleEdge::Normal,
             BitPackOrder::Msb,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
`ParlIoTx` and `ParlIoRx` where generic over the pins.

It looked like this: `ParlIoTx<Channel<0>, TxPinConfigWithValidPin<TxFourBits<GpioPin<Unknown, 1>, GpioPin<Unknown, 2>, GpioPin<Unknown, 3>, GpioPin<Unknown, 4>>, GpioPin<Unknown, 5>>, ClkOutPin<GpioPin<Unknown, 6>>, Blocking>`

This was unnecessary and is now reduced to this: `ParlIoTx<Channel<0>, Async>`

The signatures of the `with_config`  functions had to be changed to take a mutable borrow of the pin-struct.

#### Testing
The adapted examples work as before and it's not possible to use a pin currently in use by the driver.

