### PR TITLE
Update PACs and fix resulting errors, convert `IEEE802154` from virtual to real peripheral

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -54,13 +54,13 @@ xtensa-lx                = { version = "0.9.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { git = "https://github.com/esp-rs/esp-pacs/", rev = "c90dc69", features = ["critical-section", "rt"], optional = true }
-esp32c2 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "c90dc69", features = ["critical-section", "rt"], optional = true }
-esp32c3 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "c90dc69", features = ["critical-section", "rt"], optional = true }
-esp32c6 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "c90dc69", features = ["critical-section", "rt"], optional = true }
-esp32h2 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "c90dc69",  features = ["critical-section", "rt"], optional = true }
-esp32s2 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "c90dc69", features = ["critical-section", "rt"], optional = true }
-esp32s3 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "c90dc69", features = ["critical-section", "rt"], optional = true }
+esp32   = { git = "https://github.com/esp-rs/esp-pacs/", rev = "87d1e5b", features = ["critical-section", "rt"], optional = true }
+esp32c2 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "87d1e5b", features = ["critical-section", "rt"], optional = true }
+esp32c3 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "87d1e5b", features = ["critical-section", "rt"], optional = true }
+esp32c6 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "87d1e5b", features = ["critical-section", "rt"], optional = true }
+esp32h2 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "87d1e5b", features = ["critical-section", "rt"], optional = true }
+esp32s2 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "87d1e5b", features = ["critical-section", "rt"], optional = true }
+esp32s3 = { git = "https://github.com/esp-rs/esp-pacs/", rev = "87d1e5b", features = ["critical-section", "rt"], optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 esp-riscv-rt = { version = "0.8.0", path = "../esp-riscv-rt" }

--- a/esp-hal/src/aes/esp32cX.rs
+++ b/esp-hal/src/aes/esp32cX.rs
@@ -20,13 +20,13 @@ impl<'d> Aes<'d> {
         debug_assert!(key.len() <= 8 * ALIGN_SIZE);
         debug_assert_eq!(key.len() % ALIGN_SIZE, 0);
         self.alignment_helper
-            .volatile_write_regset(self.aes.key_0().as_ptr(), key, 8);
+            .volatile_write_regset(self.aes.key(0).as_ptr(), key, 8);
     }
 
     pub(super) fn write_block(&mut self, block: &[u8]) {
         debug_assert_eq!(block.len(), 4 * ALIGN_SIZE);
         self.alignment_helper
-            .volatile_write_regset(self.aes.text_in_0().as_ptr(), block, 4);
+            .volatile_write_regset(self.aes.text_in(0).as_ptr(), block, 4);
     }
 
     pub(super) fn write_mode(&mut self, mode: u32) {
@@ -44,7 +44,7 @@ impl<'d> Aes<'d> {
     pub(super) fn read_block(&self, block: &mut [u8]) {
         debug_assert_eq!(block.len(), 4 * ALIGN_SIZE);
         self.alignment_helper
-            .volatile_read_regset(self.aes.text_out_0().as_ptr(), block, 4);
+            .volatile_read_regset(self.aes.text_out(0).as_ptr(), block, 4);
     }
 }
 

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -619,7 +619,7 @@ mod classic {
     pub unsafe fn set_priority(_core: Cpu, which: CpuInterrupt, priority: Priority) {
         let intr = &*crate::peripherals::INTERRUPT_CORE0::PTR;
         let cpu_interrupt_number = which as isize;
-        let intr_prio_base = intr.cpu_int_pri_0().as_ptr();
+        let intr_prio_base = intr.cpu_int_pri(0).as_ptr();
 
         intr_prio_base
             .offset(cpu_interrupt_number)
@@ -647,7 +647,7 @@ mod classic {
     #[inline]
     pub(super) unsafe extern "C" fn get_priority(cpu_interrupt: CpuInterrupt) -> Priority {
         let intr = &*crate::peripherals::INTERRUPT_CORE0::PTR;
-        let intr_prio_base = intr.cpu_int_pri_0().as_ptr();
+        let intr_prio_base = intr.cpu_int_pri(0).as_ptr();
 
         let prio = intr_prio_base
             .offset(cpu_interrupt as isize)
@@ -661,7 +661,7 @@ mod classic {
         let interrupt_id: usize = mcause::read().code(); // MSB is whether its exception or interrupt.
         let intr = &*crate::peripherals::INTERRUPT_CORE0::PTR;
         let interrupt_priority = intr
-            .cpu_int_pri_0()
+            .cpu_int_pri(0)
             .as_ptr()
             .add(interrupt_id)
             .read_volatile();

--- a/esp-hal/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal/src/soc/esp32c6/peripherals.rs
@@ -38,7 +38,7 @@ crate::peripherals! {
     HP_SYS <= HP_SYS,
     I2C0 <= I2C0,
     I2S0 <= I2S0 (I2S0),
-    IEEE802154 <= virtual,
+    IEEE802154 <= IEEE802154,
     INTERRUPT_CORE0 <= INTERRUPT_CORE0,
     INTPRI <= INTPRI,
     IO_MUX <= IO_MUX,

--- a/esp-hal/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal/src/soc/esp32h2/peripherals.rs
@@ -36,7 +36,7 @@ crate::peripherals! {
     I2C0 <= I2C0,
     I2C1 <= I2C1,
     I2S0 <= I2S0 (I2S0),
-    IEEE802154 <= virtual,
+    IEEE802154 <= IEEE802154,
     INTERRUPT_CORE0 <= INTERRUPT_CORE0,
     INTPRI <= INTPRI,
     IO_MUX <= IO_MUX,


### PR DESCRIPTION
The `IEEE802154` registers are now in the PACs, so we can use this peripheral like any other now.