### PR TITLE
De-duplicate DMA transfer implementations

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Software interrupt 3 is now used instead of software interrupt 0 on the thread aware executor on multicore systems (#1485)
 - Timer abstraction: refactor `systimer` and `timer` modules into a common `timer` module (#1527)
 - Refactoring of GPIO module, have drivers for Input,Output,OutputOpenDrain, all drivers setup their GPIOs correctly (#1542)
+- DMA transactions are now found in the `dma` module (#1550)
 
 ### Removed
 

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -281,7 +281,7 @@ pub mod dma {
             Channel,
             ChannelTypes,
             DmaPeripheral,
-            DmaTransferTxRxImpl,
+            DmaTransferTxRx,
             RxPrivate,
             TxPrivate,
         },
@@ -426,7 +426,7 @@ pub mod dma {
             mode: Mode,
             cipher_mode: CipherMode,
             key: K,
-        ) -> Result<DmaTransferTxRxImpl<Self>, crate::dma::DmaError>
+        ) -> Result<DmaTransferTxRx<Self>, crate::dma::DmaError>
         where
             K: Into<Key>,
             TXBUF: ReadBuffer<Word = u8>,
@@ -445,7 +445,7 @@ pub mod dma {
                 key.into(),
             )?;
 
-            Ok(DmaTransferTxRxImpl::new(self))
+            Ok(DmaTransferTxRx::new(self))
         }
 
         #[allow(clippy::too_many_arguments)]

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -373,8 +373,8 @@ pub mod dma {
     {
         type TX = C::Tx<'d>;
 
-        fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
-            f(&mut self.channel.tx)
+        fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+            &mut self.channel.tx
         }
     }
 
@@ -385,8 +385,8 @@ pub mod dma {
     {
         type RX = C::Rx<'d>;
 
-        fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
-            f(&mut self.channel.rx)
+        fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+            &mut self.channel.rx
         }
     }
 

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -373,7 +373,7 @@ pub mod dma {
     {
         type TX = C::Tx<'d>;
 
-        fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+        fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
         }
     }
@@ -385,7 +385,7 @@ pub mod dma {
     {
         type RX = C::Rx<'d>;
 
-        fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+        fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx
         }
     }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1523,14 +1523,14 @@ pub(crate) mod dma_private {
 /// DMA transaction for TX only transfers
 #[non_exhaustive]
 #[must_use]
-pub struct DmaTransferTxImpl<'a, I>
+pub struct DmaTransferTx<'a, I>
 where
     I: dma_private::DmaSupportTx,
 {
     instance: &'a mut I,
 }
 
-impl<'a, I> DmaTransferTxImpl<'a, I>
+impl<'a, I> DmaTransferTx<'a, I>
 where
     I: dma_private::DmaSupportTx,
 {
@@ -1555,7 +1555,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferTxImpl<'a, I>
+impl<'a, I> Drop for DmaTransferTx<'a, I>
 where
     I: dma_private::DmaSupportTx,
 {
@@ -1567,14 +1567,14 @@ where
 /// DMA transaction for RX only transfers
 #[non_exhaustive]
 #[must_use]
-pub struct DmaTransferRxImpl<'a, I>
+pub struct DmaTransferRx<'a, I>
 where
     I: dma_private::DmaSupportRx,
 {
     instance: &'a mut I,
 }
 
-impl<'a, I> DmaTransferRxImpl<'a, I>
+impl<'a, I> DmaTransferRx<'a, I>
 where
     I: dma_private::DmaSupportRx,
 {
@@ -1599,7 +1599,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferRxImpl<'a, I>
+impl<'a, I> Drop for DmaTransferRx<'a, I>
 where
     I: dma_private::DmaSupportRx,
 {
@@ -1611,14 +1611,14 @@ where
 /// DMA transaction for TX+RX transfers
 #[non_exhaustive]
 #[must_use]
-pub struct DmaTransferTxRxImpl<'a, I>
+pub struct DmaTransferTxRx<'a, I>
 where
     I: dma_private::DmaSupportTx + dma_private::DmaSupportRx,
 {
     instance: &'a mut I,
 }
 
-impl<'a, I> DmaTransferTxRxImpl<'a, I>
+impl<'a, I> DmaTransferTxRx<'a, I>
 where
     I: dma_private::DmaSupportTx + dma_private::DmaSupportRx,
 {
@@ -1644,7 +1644,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferTxRxImpl<'a, I>
+impl<'a, I> Drop for DmaTransferTxRx<'a, I>
 where
     I: dma_private::DmaSupportTx + dma_private::DmaSupportRx,
 {
@@ -1653,22 +1653,21 @@ where
     }
 }
 
-// ~~~~~~~~~~~~~~~~~~ circular
-
 /// DMA transaction for TX only circular transfers
 #[non_exhaustive]
 #[must_use]
-pub struct DmaTransferTxCircularImpl<'a, I>
+pub struct DmaTransferTxCircular<'a, I>
 where
     I: dma_private::DmaSupportTx,
 {
     instance: &'a mut I,
 }
 
-impl<'a, I> DmaTransferTxCircularImpl<'a, I>
+impl<'a, I> DmaTransferTxCircular<'a, I>
 where
     I: dma_private::DmaSupportTx,
 {
+    #[allow(unused)] // currently used by peripherals not available on all chips
     pub(crate) fn new(instance: &'a mut I) -> Self {
         Self { instance }
     }
@@ -1704,7 +1703,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferTxCircularImpl<'a, I>
+impl<'a, I> Drop for DmaTransferTxCircular<'a, I>
 where
     I: dma_private::DmaSupportTx,
 {
@@ -1716,17 +1715,18 @@ where
 /// DMA transaction for RX only circular transfers
 #[non_exhaustive]
 #[must_use]
-pub struct DmaTransferRxCircularImpl<'a, I>
+pub struct DmaTransferRxCircular<'a, I>
 where
     I: dma_private::DmaSupportRx,
 {
     instance: &'a mut I,
 }
 
-impl<'a, I> DmaTransferRxCircularImpl<'a, I>
+impl<'a, I> DmaTransferRxCircular<'a, I>
 where
     I: dma_private::DmaSupportRx,
 {
+    #[allow(unused)] // currently used by peripherals not available on all chips
     pub(crate) fn new(instance: &'a mut I) -> Self {
         Self { instance }
     }
@@ -1742,7 +1742,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferRxCircularImpl<'a, I>
+impl<'a, I> Drop for DmaTransferRxCircular<'a, I>
 where
     I: dma_private::DmaSupportRx,
 {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1514,13 +1514,13 @@ pub(crate) mod dma_private {
     pub trait DmaSupportTx: DmaSupport {
         type TX: Tx;
 
-        fn tx<'a>(&'a mut self) -> &'a mut Self::TX;
+        fn tx(&mut self) -> &mut Self::TX;
     }
 
     pub trait DmaSupportRx: DmaSupport {
         type RX: Rx;
 
-        fn rx<'a>(&'a mut self) -> &'a mut Self::RX;
+        fn rx(&mut self) -> &mut Self::RX;
     }
 }
 

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -80,10 +80,10 @@ use crate::{
         Channel,
         ChannelTypes,
         DmaError,
-        DmaTransferRxCircularImpl,
-        DmaTransferRxImpl,
-        DmaTransferTxCircularImpl,
-        DmaTransferTxImpl,
+        DmaTransferRx,
+        DmaTransferRxCircular,
+        DmaTransferTx,
+        DmaTransferTxCircular,
         I2s0Peripheral,
         I2sPeripheral,
         RxPrivate,
@@ -230,7 +230,7 @@ where
     /// Write I2S.
     /// Returns [I2sWriteDmaTransfer] which represents the in-progress DMA
     /// transfer
-    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTxImpl<Self>, Error>
+    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<Self>, Error>
     where
         TXBUF: ReadBuffer<Word = u8>;
 
@@ -239,7 +239,7 @@ where
     fn write_dma_circular<'t>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTxCircularImpl<Self>, Error>
+    ) -> Result<DmaTransferTxCircular<Self>, Error>
     where
         TXBUF: ReadBuffer<Word = u8>;
 }
@@ -260,7 +260,7 @@ where
     /// Read I2S.
     /// Returns [I2sReadDmaTransfer] which represents the in-progress DMA
     /// transfer
-    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRxImpl<Self>, Error>
+    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<Self>, Error>
     where
         RXBUF: WriteBuffer<Word = u8>;
 
@@ -270,7 +270,7 @@ where
     fn read_dma_circular<'t>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircularImpl<Self>, Error>
+    ) -> Result<DmaTransferRxCircular<Self>, Error>
     where
         RXBUF: WriteBuffer<Word = u8>;
 }
@@ -566,23 +566,23 @@ where
     CH: ChannelTypes,
     DmaMode: Mode,
 {
-    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTxImpl<Self>, Error>
+    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<Self>, Error>
     where
         TXBUF: ReadBuffer<Word = u8>,
     {
         self.start_tx_transfer(words, false)?;
-        Ok(DmaTransferTxImpl::new(self))
+        Ok(DmaTransferTx::new(self))
     }
 
     fn write_dma_circular<'t>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTxCircularImpl<Self>, Error>
+    ) -> Result<DmaTransferTxCircular<Self>, Error>
     where
         TXBUF: ReadBuffer<Word = u8>,
     {
         self.start_tx_transfer(words, true)?;
-        Ok(DmaTransferTxCircularImpl::new(self))
+        Ok(DmaTransferTxCircular::new(self))
     }
 }
 
@@ -739,23 +739,23 @@ where
     DmaMode: Mode,
     Self: DmaSupportRx + Sized,
 {
-    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRxImpl<Self>, Error>
+    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<Self>, Error>
     where
         RXBUF: WriteBuffer<Word = u8>,
     {
         self.start_rx_transfer(words, false)?;
-        Ok(DmaTransferRxImpl::new(self))
+        Ok(DmaTransferRx::new(self))
     }
 
     fn read_dma_circular<'t>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircularImpl<Self>, Error>
+    ) -> Result<DmaTransferRxCircular<Self>, Error>
     where
         RXBUF: WriteBuffer<Word = u8>,
     {
         self.start_rx_transfer(words, true)?;
-        Ok(DmaTransferRxCircularImpl::new(self))
+        Ok(DmaTransferRxCircular::new(self))
     }
 }
 

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -463,7 +463,7 @@ where
 {
     type TX = CH::Tx<'d>;
 
-    fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+    fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
     }
 }
@@ -632,7 +632,7 @@ where
 {
     type RX = CH::Rx<'d>;
 
-    fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+    fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
     }
 }

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -463,8 +463,8 @@ where
 {
     type TX = CH::Tx<'d>;
 
-    fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
-        f(&mut self.tx_channel)
+    fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+        &mut self.tx_channel
     }
 }
 
@@ -632,8 +632,8 @@ where
 {
     type RX = CH::Rx<'d>;
 
-    fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
-        f(&mut self.rx_channel)
+    fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+        &mut self.rx_channel
     }
 }
 

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -198,8 +198,8 @@ impl<'d, RX: Rx> DmaSupport for Camera<'d, RX> {
 impl<'d, RX: Rx> DmaSupportRx for Camera<'d, RX> {
     type RX = RX;
 
-    fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
-        f(&mut self.rx_channel)
+    fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+        &mut self.rx_channel
     }
 }
 

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -47,8 +47,8 @@ use crate::{
         ChannelTypes,
         DmaError,
         DmaPeripheral,
-        DmaTransferRxCircularImpl,
-        DmaTransferRxImpl,
+        DmaTransferRx,
+        DmaTransferRxCircular,
         LcdCamPeripheral,
         RegisterAccess,
         Rx,
@@ -321,25 +321,25 @@ impl<'d, RX: Rx> Camera<'d, RX> {
     pub fn read_dma<'t, RXBUF: WriteBuffer>(
         &'t mut self,
         buf: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxImpl<Self>, DmaError> {
+    ) -> Result<DmaTransferRx<Self>, DmaError> {
         self.reset_unit_and_fifo();
         // Start DMA to receive incoming transfer.
         self.start_dma(false, buf)?;
         self.start_unit();
 
-        Ok(DmaTransferRxImpl::new(self))
+        Ok(DmaTransferRx::new(self))
     }
 
     pub fn read_dma_circular<'t, RXBUF: WriteBuffer>(
         &'t mut self,
         buf: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircularImpl<Self>, DmaError> {
+    ) -> Result<DmaTransferRxCircular<Self>, DmaError> {
         self.reset_unit_and_fifo();
         // Start DMA to receive incoming transfer.
         self.start_dma(true, buf)?;
         self.start_unit();
 
-        Ok(DmaTransferRxCircularImpl::new(self))
+        Ok(DmaTransferRxCircular::new(self))
     }
 }
 

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -198,7 +198,7 @@ impl<'d, RX: Rx> DmaSupport for Camera<'d, RX> {
 impl<'d, RX: Rx> DmaSupportRx for Camera<'d, RX> {
     type RX = RX;
 
-    fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+    fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
     }
 }

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -42,11 +42,13 @@ use fugit::HertzU32;
 use crate::{
     clock::Clocks,
     dma::{
+        dma_private::{DmaSupport, DmaSupportRx},
         ChannelRx,
         ChannelTypes,
         DmaError,
         DmaPeripheral,
-        DmaTransfer,
+        DmaTransferRxCircularImpl,
+        DmaTransferRxImpl,
         LcdCamPeripheral,
         RegisterAccess,
         Rx,
@@ -54,7 +56,6 @@ use crate::{
         RxPrivate,
     },
     gpio::{InputPin, InputSignal, OutputPin, OutputSignal},
-    i2s::Error,
     lcd_cam::{cam::private::RxPins, private::calculate_clkm, BitOrder, ByteOrder},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
@@ -177,6 +178,31 @@ where
     }
 }
 
+impl<'d, RX: Rx> DmaSupport for Camera<'d, RX> {
+    fn peripheral_wait_dma(&mut self, _is_tx: bool, _is_rx: bool) {
+        while !
+        // Wait for IN_SUC_EOF (i.e. VSYNC)
+        self.rx_channel.is_done() ||
+        // Or for IN_DSCR_EMPTY (i.e. No more buffer space)
+        self.rx_channel.has_dscr_empty_error() ||
+        // Or for IN_DSCR_ERR (i.e. bad descriptor)
+        self.rx_channel.has_error()
+        {}
+    }
+
+    fn peripheral_dma_stop(&mut self) {
+        // TODO: Stop DMA?? self.instance.rx_channel.stop_transfer();
+    }
+}
+
+impl<'d, RX: Rx> DmaSupportRx for Camera<'d, RX> {
+    type RX = RX;
+
+    fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
+        f(&mut self.rx_channel)
+    }
+}
+
 impl<'d, RX: Rx> Camera<'d, RX> {
     pub fn set_byte_order(&mut self, byte_order: ByteOrder) -> &mut Self {
         self.lcd_cam
@@ -295,96 +321,25 @@ impl<'d, RX: Rx> Camera<'d, RX> {
     pub fn read_dma<'t, RXBUF: WriteBuffer>(
         &'t mut self,
         buf: &'t mut RXBUF,
-    ) -> Result<Transfer<'t, 'd, RX>, DmaError> {
+    ) -> Result<DmaTransferRxImpl<Self>, DmaError> {
         self.reset_unit_and_fifo();
         // Start DMA to receive incoming transfer.
         self.start_dma(false, buf)?;
         self.start_unit();
 
-        Ok(Transfer { instance: self })
+        Ok(DmaTransferRxImpl::new(self))
     }
 
     pub fn read_dma_circular<'t, RXBUF: WriteBuffer>(
         &'t mut self,
         buf: &'t mut RXBUF,
-    ) -> Result<Transfer<'t, 'd, RX>, DmaError> {
+    ) -> Result<DmaTransferRxCircularImpl<Self>, DmaError> {
         self.reset_unit_and_fifo();
         // Start DMA to receive incoming transfer.
         self.start_dma(true, buf)?;
         self.start_unit();
 
-        Ok(Transfer { instance: self })
-    }
-}
-
-/// An in-progress transfer
-#[must_use]
-pub struct Transfer<'t, 'd, RX: Rx> {
-    instance: &'t mut Camera<'d, RX>,
-}
-
-impl<'t, 'd, RX: Rx> Transfer<'t, 'd, RX> {
-    /// Amount of bytes which can be popped
-    pub fn available(&mut self) -> usize {
-        self.instance.rx_channel.available()
-    }
-
-    pub fn pop(&mut self, data: &mut [u8]) -> Result<usize, Error> {
-        Ok(self.instance.rx_channel.pop(data)?)
-    }
-
-    /// Wait for the DMA transfer to complete.
-    /// Length of the received data is returned
-    #[allow(clippy::type_complexity)]
-    pub fn wait_receive(self, dst: &mut [u8]) -> Result<usize, (DmaError, usize)> {
-        // Wait for DMA transfer to finish.
-        while !self.is_done() {}
-
-        let len = self
-            .instance
-            .rx_channel
-            .drain_buffer(dst)
-            .map_err(|e| (e, 0))?;
-
-        if self.instance.rx_channel.has_error() {
-            Err((DmaError::DescriptorError, len))
-        } else {
-            Ok(len)
-        }
-    }
-}
-
-impl<'t, 'd, RX: Rx> DmaTransfer for Transfer<'t, 'd, RX> {
-    fn wait(self) -> Result<(), DmaError> {
-        // Wait for DMA transfer to finish.
-        while !self.is_done() {}
-
-        let ch = &self.instance.rx_channel;
-        if ch.has_error() {
-            Err(DmaError::DescriptorError)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn is_done(&self) -> bool {
-        let ch = &self.instance.rx_channel;
-        // Wait for IN_SUC_EOF (i.e. VSYNC)
-        ch.is_done() ||
-        // Or for IN_DSCR_EMPTY (i.e. No more buffer space)
-        ch.has_dscr_empty_error() ||
-        // Or for IN_DSCR_ERR (i.e. bad descriptor)
-        ch.has_error()
-    }
-}
-
-impl<'t, 'd, RX: Rx> Drop for Transfer<'t, 'd, RX> {
-    fn drop(&mut self) {
-        self.instance
-            .lcd_cam
-            .cam_ctrl1()
-            .modify(|_, w| w.cam_start().clear_bit());
-        // TODO: Stop DMA?? self.instance.rx_channel.stop_transfer();
+        Ok(DmaTransferRxCircularImpl::new(self))
     }
 }
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -247,8 +247,8 @@ impl<'d, TX: Tx, P: TxPins> DmaSupport for I8080<'d, TX, P> {
 impl<'d, TX: Tx, P: TxPins> DmaSupportTx for I8080<'d, TX, P> {
     type TX = TX;
 
-    fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
-        f(&mut self.tx_channel)
+    fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+        &mut self.tx_channel
     }
 }
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -247,7 +247,7 @@ impl<'d, TX: Tx, P: TxPins> DmaSupport for I8080<'d, TX, P> {
 impl<'d, TX: Tx, P: TxPins> DmaSupportTx for I8080<'d, TX, P> {
     type TX = TX;
 
-    fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+    fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
     }
 }

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -43,10 +43,12 @@ use fugit::HertzU32;
 use crate::{
     clock::Clocks,
     dma::{
+        dma_private::{DmaSupport, DmaSupportTx},
         ChannelTx,
         ChannelTypes,
         DmaError,
         DmaPeripheral,
+        DmaTransferTxImpl,
         LcdCamPeripheral,
         RegisterAccess,
         Tx,
@@ -229,6 +231,27 @@ where
     }
 }
 
+impl<'d, TX: Tx, P: TxPins> DmaSupport for I8080<'d, TX, P> {
+    fn peripheral_wait_dma(&mut self, _is_tx: bool, _is_rx: bool) {
+        let dma_int_raw = self.lcd_cam.lc_dma_int_raw();
+        // Wait until LCD_TRANS_DONE is set.
+        while dma_int_raw.read().lcd_trans_done_int_raw().bit_is_clear() {}
+        self.tear_down_send();
+    }
+
+    fn peripheral_dma_stop(&mut self) {
+        unreachable!("unsupported")
+    }
+}
+
+impl<'d, TX: Tx, P: TxPins> DmaSupportTx for I8080<'d, TX, P> {
+    type TX = TX;
+
+    fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
+        f(&mut self.tx_channel)
+    }
+}
+
 impl<'d, TX: Tx, P: TxPins> I8080<'d, TX, P>
 where
     P::Word: Into<u16>,
@@ -301,7 +324,7 @@ where
         cmd: impl Into<Command<P::Word>>,
         dummy: u8,
         data: &'t TXBUF,
-    ) -> Result<Transfer<'t, 'd, TX, P>, DmaError>
+    ) -> Result<DmaTransferTxImpl<Self>, DmaError>
     where
         TXBUF: ReadBuffer<Word = P::Word>,
     {
@@ -311,9 +334,7 @@ where
         self.start_write_bytes_dma(ptr as _, len * size_of::<P::Word>())?;
         self.start_send();
 
-        Ok(Transfer {
-            instance: Some(self),
-        })
+        Ok(DmaTransferTxImpl::new(self))
     }
 }
 
@@ -431,54 +452,6 @@ impl<'d, TX: Tx, P> I8080<'d, TX, P> {
 impl<'d, TX, P> core::fmt::Debug for I8080<'d, TX, P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("I8080").finish()
-    }
-}
-
-/// An in-progress transfer
-#[must_use]
-pub struct Transfer<'t, 'd, TX: Tx, P> {
-    instance: Option<&'t mut I8080<'d, TX, P>>,
-}
-
-impl<'t, 'd, TX: Tx, P> Transfer<'t, 'd, TX, P> {
-    #[allow(clippy::type_complexity)]
-    pub fn wait(mut self) -> Result<(), DmaError> {
-        let instance = self
-            .instance
-            .take()
-            .expect("instance must be available throughout object lifetime");
-
-        {
-            let dma_int_raw = instance.lcd_cam.lc_dma_int_raw();
-            // Wait until LCD_TRANS_DONE is set.
-            while dma_int_raw.read().lcd_trans_done_int_raw().bit_is_clear() {}
-            instance.tear_down_send();
-        }
-
-        if instance.tx_channel.has_error() {
-            Err(DmaError::DescriptorError)
-        } else {
-            Ok(())
-        }
-    }
-
-    pub fn is_done(&self) -> bool {
-        let int_raw = self
-            .instance
-            .as_ref()
-            .expect("instance must be available throughout object lifetime")
-            .lcd_cam
-            .lc_dma_int_raw();
-        int_raw.read().lcd_trans_done_int_raw().bit_is_set()
-    }
-}
-
-impl<'t, 'd, TX: Tx, P> Drop for Transfer<'t, 'd, TX, P> {
-    fn drop(&mut self) {
-        if let Some(instance) = self.instance.as_mut() {
-            // This will cancel the transfer.
-            instance.tear_down_send();
-        }
     }
 }
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -48,7 +48,7 @@ use crate::{
         ChannelTypes,
         DmaError,
         DmaPeripheral,
-        DmaTransferTxImpl,
+        DmaTransferTx,
         LcdCamPeripheral,
         RegisterAccess,
         Tx,
@@ -324,7 +324,7 @@ where
         cmd: impl Into<Command<P::Word>>,
         dummy: u8,
         data: &'t TXBUF,
-    ) -> Result<DmaTransferTxImpl<Self>, DmaError>
+    ) -> Result<DmaTransferTx<Self>, DmaError>
     where
         TXBUF: ReadBuffer<Word = P::Word>,
     {
@@ -334,7 +334,7 @@ where
         self.start_write_bytes_dma(ptr as _, len * size_of::<P::Word>())?;
         self.start_send();
 
-        Ok(DmaTransferTxImpl::new(self))
+        Ok(DmaTransferTx::new(self))
     }
 }
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1499,7 +1499,7 @@ where
 {
     type TX = CH::Tx<'d>;
 
-    fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+    fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
     }
 }
@@ -1601,7 +1601,7 @@ where
 {
     type RX = CH::Rx<'d>;
 
-    fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+    fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
     }
 }

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1499,8 +1499,8 @@ where
 {
     type TX = CH::Tx<'d>;
 
-    fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
-        f(&mut self.tx_channel)
+    fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+        &mut self.tx_channel
     }
 }
 
@@ -1601,8 +1601,8 @@ where
 {
     type RX = CH::Rx<'d>;
 
-    fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
-        f(&mut self.rx_channel)
+    fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+        &mut self.rx_channel
     }
 }
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -88,7 +88,18 @@ use private::*;
 
 use crate::{
     clock::Clocks,
-    dma::{Channel, ChannelTypes, DmaError, DmaPeripheral, ParlIoPeripheral, RxPrivate, TxPrivate},
+    dma::{
+        dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
+        Channel,
+        ChannelTypes,
+        DmaError,
+        DmaPeripheral,
+        DmaTransferRxImpl,
+        DmaTransferTxImpl,
+        ParlIoPeripheral,
+        RxPrivate,
+        TxPrivate,
+    },
     gpio::{InputPin, OutputPin},
     interrupt::InterruptHandler,
     peripheral::{self, Peripheral},
@@ -1417,7 +1428,7 @@ where
     pub fn write_dma<'t, TXBUF>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransfer<'t, 'd, CH, P, CP, DM>, Error>
+    ) -> Result<DmaTransferTxImpl<Self>, Error>
     where
         TXBUF: ReadBuffer<Word = u8>,
     {
@@ -1429,7 +1440,7 @@ where
 
         self.start_write_bytes_dma(ptr, len)?;
 
-        Ok(DmaTransfer { instance: self })
+        Ok(DmaTransferTxImpl::new(self))
     }
 
     fn start_write_bytes_dma(&mut self, ptr: *const u8, len: usize) -> Result<(), Error> {
@@ -1459,47 +1470,37 @@ where
     }
 }
 
-/// An in-progress DMA transfer.
-#[must_use]
-pub struct DmaTransfer<'t, 'd, C, P, CP, DM>
+impl<'d, CH, P, CP, DM> DmaSupport for ParlIoTx<'d, CH, P, CP, DM>
 where
-    C: ChannelTypes,
-    C::P: ParlIoPeripheral,
+    CH: ChannelTypes,
+    CH::P: ParlIoPeripheral,
     P: TxPins + ConfigurePins,
     CP: TxClkPin,
     DM: Mode,
 {
-    instance: &'t mut ParlIoTx<'d, C, P, CP, DM>,
-}
-
-impl<'t, 'd, C, P, CP, DM> DmaTransfer<'t, 'd, C, P, CP, DM>
-where
-    C: ChannelTypes,
-    C::P: ParlIoPeripheral,
-    P: TxPins + ConfigurePins,
-    CP: TxClkPin,
-    DM: Mode,
-{
-    /// Wait for the DMA transfer to complete
-    #[allow(clippy::type_complexity)]
-    pub fn wait(self) -> Result<(), DmaError> {
-        // Waiting for the DMA transfer is not enough. We need to wait for the
-        // peripheral to finish flushing its buffers, too.
+    fn peripheral_wait_dma(&mut self, _is_tx: bool, _is_rx: bool) {
         while !Instance::is_tx_eof() {}
 
         Instance::set_tx_start(false);
-
-        if self.instance.tx_channel.has_error() {
-            Err(DmaError::DescriptorError)
-        } else {
-            Ok(())
-        }
     }
 
-    /// Check if the DMA transfer is complete
-    pub fn is_done(&self) -> bool {
-        let ch = &self.instance.tx_channel;
-        ch.is_done()
+    fn peripheral_dma_stop(&mut self) {
+        unreachable!("unsupported")
+    }
+}
+
+impl<'d, CH, P, CP, DM> DmaSupportTx for ParlIoTx<'d, CH, P, CP, DM>
+where
+    CH: ChannelTypes,
+    CH::P: ParlIoPeripheral,
+    P: TxPins + ConfigurePins,
+    CP: TxClkPin,
+    DM: Mode,
+{
+    type TX = CH::Tx<'d>;
+
+    fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
+        f(&mut self.tx_channel)
     }
 }
 
@@ -1522,7 +1523,7 @@ where
     pub fn read_dma<'t, RXBUF>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<RxDmaTransfer<'t, 'd, CH, P, CP, DM>, Error>
+    ) -> Result<DmaTransferRxImpl<Self>, Error>
     where
         RXBUF: WriteBuffer<Word = u8>,
     {
@@ -1534,7 +1535,7 @@ where
 
         Self::start_receive_bytes_dma(&mut self.rx_channel, ptr, len)?;
 
-        Ok(RxDmaTransfer { instance: self })
+        Ok(DmaTransferRxImpl::new(self))
     }
 
     fn start_receive_bytes_dma(
@@ -1564,55 +1565,44 @@ where
     }
 }
 
-/// An in-progress DMA transfer.
-pub struct RxDmaTransfer<'t, 'd, C, P, CP, DM>
+impl<'d, CH, P, CP, DM> DmaSupport for ParlIoRx<'d, CH, P, CP, DM>
 where
-    C: ChannelTypes,
-    C::P: ParlIoPeripheral,
+    CH: ChannelTypes,
+    CH::P: ParlIoPeripheral,
     P: RxPins + ConfigurePins,
     CP: RxClkPin,
     DM: Mode,
 {
-    instance: &'t mut ParlIoRx<'d, C, P, CP, DM>,
-}
-
-impl<'t, 'd, C, P, CP, DM> RxDmaTransfer<'t, 'd, C, P, CP, DM>
-where
-    C: ChannelTypes,
-    C::P: ParlIoPeripheral,
-    P: RxPins + ConfigurePins,
-    CP: RxClkPin,
-    DM: Mode,
-{
-    /// Wait for the DMA transfer to complete
-    #[allow(clippy::type_complexity)]
-    pub fn wait(self) -> Result<(), DmaError> {
+    fn peripheral_wait_dma(&mut self, _is_tx: bool, _is_rx: bool) {
         loop {
-            if self.is_done() || self.is_eof_error() {
+            if self.rx_channel.is_done()
+                || self.rx_channel.has_eof_error()
+                || self.rx_channel.has_dscr_empty_error()
+            {
                 break;
             }
         }
 
         Instance::set_rx_start(false);
-
-        if self.instance.rx_channel.has_error() {
-            Err(DmaError::DescriptorError)
-        } else {
-            Ok(())
-        }
     }
 
-    /// Check if the DMA transfer is complete
-    pub fn is_done(&self) -> bool {
-        let ch = &self.instance.rx_channel;
-        ch.is_done()
+    fn peripheral_dma_stop(&mut self) {
+        unreachable!("unsupported")
     }
+}
 
-    /// Check if the DMA transfer is completed by buffer full or source EOF
-    /// error
-    pub fn is_eof_error(&self) -> bool {
-        let ch = &self.instance.rx_channel;
-        ch.has_eof_error() || ch.has_dscr_empty_error()
+impl<'d, CH, P, CP, DM> DmaSupportRx for ParlIoRx<'d, CH, P, CP, DM>
+where
+    CH: ChannelTypes,
+    CH::P: ParlIoPeripheral,
+    P: RxPins + ConfigurePins,
+    CP: RxClkPin,
+    DM: Mode,
+{
+    type RX = CH::Rx<'d>;
+
+    fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
+        f(&mut self.rx_channel)
     }
 }
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -94,8 +94,8 @@ use crate::{
         ChannelTypes,
         DmaError,
         DmaPeripheral,
-        DmaTransferRxImpl,
-        DmaTransferTxImpl,
+        DmaTransferRx,
+        DmaTransferTx,
         ParlIoPeripheral,
         RxPrivate,
         TxPrivate,
@@ -1428,7 +1428,7 @@ where
     pub fn write_dma<'t, TXBUF>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTxImpl<Self>, Error>
+    ) -> Result<DmaTransferTx<Self>, Error>
     where
         TXBUF: ReadBuffer<Word = u8>,
     {
@@ -1440,7 +1440,7 @@ where
 
         self.start_write_bytes_dma(ptr, len)?;
 
-        Ok(DmaTransferTxImpl::new(self))
+        Ok(DmaTransferTx::new(self))
     }
 
     fn start_write_bytes_dma(&mut self, ptr: *const u8, len: usize) -> Result<(), Error> {
@@ -1523,7 +1523,7 @@ where
     pub fn read_dma<'t, RXBUF>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxImpl<Self>, Error>
+    ) -> Result<DmaTransferRx<Self>, Error>
     where
         RXBUF: WriteBuffer<Word = u8>,
     {
@@ -1535,7 +1535,7 @@ where
 
         Self::start_receive_bytes_dma(&mut self.rx_channel, ptr, len)?;
 
-        Ok(DmaTransferRxImpl::new(self))
+        Ok(DmaTransferRx::new(self))
     }
 
     fn start_receive_bytes_dma(

--- a/esp-hal/src/prelude.rs
+++ b/esp-hal/src/prelude.rs
@@ -15,11 +15,6 @@ pub use nb;
 
 #[cfg(any(dport, pcr, system))]
 pub use crate::clock::Clock as _esp_hal_clock_Clock;
-#[cfg(any(gdma, pdma))]
-pub use crate::dma::{
-    DmaTransfer as _esp_hal_dma_DmaTransfer,
-    DmaTransferRxTx as _esp_hal_dma_DmaTransferRxTx,
-};
 #[cfg(gpio)]
 pub use crate::gpio::{
     InputPin as _esp_hal_gpio_InputPin,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1026,7 +1026,7 @@ pub mod dma {
     {
         type TX = C::Tx<'d>;
 
-        fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+        fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
         }
     }
@@ -1041,7 +1041,7 @@ pub mod dma {
     {
         type RX = C::Rx<'d>;
 
-        fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+        fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx
         }
     }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1026,8 +1026,8 @@ pub mod dma {
     {
         type TX = C::Tx<'d>;
 
-        fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
-            f(&mut self.channel.tx)
+        fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+            &mut self.channel.tx
         }
     }
 
@@ -1041,8 +1041,8 @@ pub mod dma {
     {
         type RX = C::Rx<'d>;
 
-        fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
-            f(&mut self.channel.rx)
+        fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+            &mut self.channel.rx
         }
     }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -837,12 +837,12 @@ pub mod dma {
     use crate::dma::Spi3Peripheral;
     use crate::{
         dma::{
+            dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
             Channel,
             ChannelTypes,
-            DmaError,
-            DmaTransfer,
-            DmaTransferRxTx,
-            RxPrivate,
+            DmaTransferRxImpl,
+            DmaTransferTxImpl,
+            DmaTransferTxRxImpl,
             Spi2Peripheral,
             SpiPeripheral,
             TxPrivate,
@@ -917,113 +917,6 @@ pub mod dma {
                 channel,
                 _mode: PhantomData,
             }
-        }
-    }
-    /// An in-progress DMA transfer
-    #[must_use]
-    pub struct SpiDmaTransferRxTx<'t, 'd, T, C, M, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
-    {
-        spi_dma: &'t mut SpiDma<'d, T, C, M, DmaMode>,
-    }
-
-    impl<'t, 'd, T, C, M, DmaMode> DmaTransferRxTx for SpiDmaTransferRxTx<'t, 'd, T, C, M, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
-    {
-        /// Wait for the DMA transfer to complete
-        fn wait(self) -> Result<(), DmaError> {
-            // Waiting for the DMA transfer is not enough. We need to wait for the
-            // peripheral to finish flushing its buffers, too.
-            self.spi_dma.spi.flush().ok();
-
-            if self.spi_dma.channel.rx.has_error() || self.spi_dma.channel.tx.has_error() {
-                Err(DmaError::DescriptorError)
-            } else {
-                Ok(())
-            }
-        }
-
-        /// Check if the DMA transfer is complete
-        fn is_done(&self) -> bool {
-            let ch = &self.spi_dma.channel;
-            ch.tx.is_done() && ch.rx.is_done()
-        }
-    }
-
-    impl<'t, 'd, T, C, M, DmaMode> Drop for SpiDmaTransferRxTx<'t, 'd, T, C, M, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
-    {
-        fn drop(&mut self) {
-            self.spi_dma.spi.flush().ok();
-        }
-    }
-
-    /// An in-progress DMA transfer.
-    #[must_use]
-    pub struct SpiDmaTransfer<'t, 'd, T, C, M, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
-    {
-        spi_dma: &'t mut SpiDma<'d, T, C, M, DmaMode>,
-    }
-
-    impl<'t, 'd, T, C, M, DmaMode> DmaTransfer for SpiDmaTransfer<'t, 'd, T, C, M, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
-    {
-        /// Wait for the DMA transfer to complete
-        fn wait(self) -> Result<(), DmaError> {
-            // Waiting for the DMA transfer is not enough. We need to wait for the
-            // peripheral to finish flushing its buffers, too.
-            self.spi_dma.spi.flush().ok();
-
-            if self.spi_dma.channel.rx.has_error() || self.spi_dma.channel.tx.has_error() {
-                Err(DmaError::DescriptorError)
-            } else {
-                Ok(())
-            }
-        }
-
-        /// Check if the DMA transfer is complete
-        fn is_done(&self) -> bool {
-            let ch = &self.spi_dma.channel;
-            ch.tx.is_done() && ch.rx.is_done()
-        }
-    }
-
-    impl<'t, 'd, T, C, M, DmaMode> Drop for SpiDmaTransfer<'t, 'd, T, C, M, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
-    {
-        fn drop(&mut self) {
-            self.spi_dma.spi.flush().ok();
         }
     }
 
@@ -1106,6 +999,53 @@ pub mod dma {
         }
     }
 
+    impl<'d, T, C, M, DmaMode> DmaSupport for SpiDma<'d, T, C, M, DmaMode>
+    where
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+        C: ChannelTypes,
+        C::P: SpiPeripheral,
+        M: DuplexMode,
+        DmaMode: Mode,
+    {
+        fn peripheral_wait_dma(&mut self, _is_tx: bool, _is_rx: bool) {
+            self.spi.flush().ok();
+        }
+
+        fn peripheral_dma_stop(&mut self) {
+            unreachable!("unsupported")
+        }
+    }
+
+    impl<'d, T, C, M, DmaMode> DmaSupportTx for SpiDma<'d, T, C, M, DmaMode>
+    where
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+        C: ChannelTypes,
+        C::P: SpiPeripheral,
+        M: DuplexMode,
+        DmaMode: Mode,
+    {
+        type TX = C::Tx<'d>;
+
+        fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
+            f(&mut self.channel.tx)
+        }
+    }
+
+    impl<'d, T, C, M, DmaMode> DmaSupportRx for SpiDma<'d, T, C, M, DmaMode>
+    where
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+        C: ChannelTypes,
+        C::P: SpiPeripheral,
+        M: DuplexMode,
+        DmaMode: Mode,
+    {
+        type RX = C::Rx<'d>;
+
+        fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
+            f(&mut self.channel.rx)
+        }
+    }
+
     impl<'d, T, C, M, DmaMode> SpiDma<'d, T, C, M, DmaMode>
     where
         T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
@@ -1123,7 +1063,7 @@ pub mod dma {
         pub fn dma_write<'t, TXBUF>(
             &'t mut self,
             words: &'t TXBUF,
-        ) -> Result<SpiDmaTransfer<'t, 'd, T, C, M, DmaMode>, super::Error>
+        ) -> Result<DmaTransferTxImpl<Self>, super::Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
         {
@@ -1135,7 +1075,7 @@ pub mod dma {
 
             self.spi
                 .start_write_bytes_dma(ptr, len, &mut self.channel.tx, false)?;
-            Ok(SpiDmaTransfer { spi_dma: self })
+            Ok(DmaTransferTxImpl::new(self))
         }
 
         /// Perform a DMA read.
@@ -1147,7 +1087,7 @@ pub mod dma {
         pub fn dma_read<'t, RXBUF>(
             &'t mut self,
             words: &'t mut RXBUF,
-        ) -> Result<SpiDmaTransfer<'t, 'd, T, C, M, DmaMode>, super::Error>
+        ) -> Result<DmaTransferRxImpl<Self>, super::Error>
         where
             RXBUF: WriteBuffer<Word = u8>,
         {
@@ -1161,7 +1101,7 @@ pub mod dma {
                 self.spi
                     .start_read_bytes_dma(ptr, len, &mut self.channel.rx, false)?;
             }
-            Ok(SpiDmaTransfer { spi_dma: self })
+            Ok(DmaTransferRxImpl::new(self))
         }
 
         /// Perform a DMA transfer.
@@ -1173,7 +1113,7 @@ pub mod dma {
             &'t mut self,
             words: &'t TXBUF,
             read_buffer: &'t mut RXBUF,
-        ) -> Result<SpiDmaTransferRxTx<'t, 'd, T, C, M, DmaMode>, super::Error>
+        ) -> Result<DmaTransferTxRxImpl<Self>, super::Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
             RXBUF: WriteBuffer<Word = u8>,
@@ -1195,7 +1135,7 @@ pub mod dma {
                     &mut self.channel.rx,
                 )?;
             }
-            Ok(SpiDmaTransferRxTx { spi_dma: self })
+            Ok(DmaTransferTxRxImpl::new(self))
         }
     }
 
@@ -1215,7 +1155,7 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: &'t mut RXBUF,
-        ) -> Result<SpiDmaTransfer<'t, 'd, T, C, M, DmaMode>, super::Error>
+        ) -> Result<DmaTransferRxImpl<Self>, super::Error>
         where
             RXBUF: WriteBuffer<Word = u8>,
         {
@@ -1279,7 +1219,7 @@ pub mod dma {
                 self.spi
                     .start_read_bytes_dma(ptr, len, &mut self.channel.rx, false)?;
             }
-            Ok(SpiDmaTransfer { spi_dma: self })
+            Ok(DmaTransferRxImpl::new(self))
         }
 
         #[cfg_attr(feature = "place-spi-driver-in-ram", ram)]
@@ -1290,7 +1230,7 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: &'t TXBUF,
-        ) -> Result<SpiDmaTransfer<'t, 'd, T, C, M, DmaMode>, super::Error>
+        ) -> Result<DmaTransferTxImpl<Self>, super::Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
         {
@@ -1352,7 +1292,7 @@ pub mod dma {
 
             self.spi
                 .start_write_bytes_dma(ptr, len, &mut self.channel.tx, false)?;
-            Ok(SpiDmaTransfer { spi_dma: self })
+            Ok(DmaTransferTxImpl::new(self))
         }
     }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -840,9 +840,9 @@ pub mod dma {
             dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
             Channel,
             ChannelTypes,
-            DmaTransferRxImpl,
-            DmaTransferTxImpl,
-            DmaTransferTxRxImpl,
+            DmaTransferRx,
+            DmaTransferTx,
+            DmaTransferTxRx,
             Spi2Peripheral,
             SpiPeripheral,
             TxPrivate,
@@ -1063,7 +1063,7 @@ pub mod dma {
         pub fn dma_write<'t, TXBUF>(
             &'t mut self,
             words: &'t TXBUF,
-        ) -> Result<DmaTransferTxImpl<Self>, super::Error>
+        ) -> Result<DmaTransferTx<Self>, super::Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
         {
@@ -1075,7 +1075,7 @@ pub mod dma {
 
             self.spi
                 .start_write_bytes_dma(ptr, len, &mut self.channel.tx, false)?;
-            Ok(DmaTransferTxImpl::new(self))
+            Ok(DmaTransferTx::new(self))
         }
 
         /// Perform a DMA read.
@@ -1087,7 +1087,7 @@ pub mod dma {
         pub fn dma_read<'t, RXBUF>(
             &'t mut self,
             words: &'t mut RXBUF,
-        ) -> Result<DmaTransferRxImpl<Self>, super::Error>
+        ) -> Result<DmaTransferRx<Self>, super::Error>
         where
             RXBUF: WriteBuffer<Word = u8>,
         {
@@ -1101,7 +1101,7 @@ pub mod dma {
                 self.spi
                     .start_read_bytes_dma(ptr, len, &mut self.channel.rx, false)?;
             }
-            Ok(DmaTransferRxImpl::new(self))
+            Ok(DmaTransferRx::new(self))
         }
 
         /// Perform a DMA transfer.
@@ -1113,7 +1113,7 @@ pub mod dma {
             &'t mut self,
             words: &'t TXBUF,
             read_buffer: &'t mut RXBUF,
-        ) -> Result<DmaTransferTxRxImpl<Self>, super::Error>
+        ) -> Result<DmaTransferTxRx<Self>, super::Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
             RXBUF: WriteBuffer<Word = u8>,
@@ -1135,7 +1135,7 @@ pub mod dma {
                     &mut self.channel.rx,
                 )?;
             }
-            Ok(DmaTransferTxRxImpl::new(self))
+            Ok(DmaTransferTxRx::new(self))
         }
     }
 
@@ -1155,7 +1155,7 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: &'t mut RXBUF,
-        ) -> Result<DmaTransferRxImpl<Self>, super::Error>
+        ) -> Result<DmaTransferRx<Self>, super::Error>
         where
             RXBUF: WriteBuffer<Word = u8>,
         {
@@ -1219,7 +1219,7 @@ pub mod dma {
                 self.spi
                     .start_read_bytes_dma(ptr, len, &mut self.channel.rx, false)?;
             }
-            Ok(DmaTransferRxImpl::new(self))
+            Ok(DmaTransferRx::new(self))
         }
 
         #[cfg_attr(feature = "place-spi-driver-in-ram", ram)]
@@ -1230,7 +1230,7 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: &'t TXBUF,
-        ) -> Result<DmaTransferTxImpl<Self>, super::Error>
+        ) -> Result<DmaTransferTx<Self>, super::Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
         {
@@ -1292,7 +1292,7 @@ pub mod dma {
 
             self.spi
                 .start_write_bytes_dma(ptr, len, &mut self.channel.tx, false)?;
-            Ok(DmaTransferTxImpl::new(self))
+            Ok(DmaTransferTx::new(self))
         }
     }
 

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -137,9 +137,9 @@ pub mod dma {
             dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
             Channel,
             ChannelTypes,
-            DmaTransferRxImpl,
-            DmaTransferTxImpl,
-            DmaTransferTxRxImpl,
+            DmaTransferRx,
+            DmaTransferTx,
+            DmaTransferTxRx,
             RxPrivate,
             Spi2Peripheral,
             SpiPeripheral,
@@ -318,7 +318,7 @@ pub mod dma {
         pub fn dma_write<'t, TXBUF>(
             &'t mut self,
             words: &'t TXBUF,
-        ) -> Result<DmaTransferTxImpl<Self>, Error>
+        ) -> Result<DmaTransferTx<Self>, Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
         {
@@ -330,7 +330,7 @@ pub mod dma {
 
             self.spi
                 .start_write_bytes_dma(ptr, len, &mut self.channel.tx)
-                .map(move |_| DmaTransferTxImpl::new(self))
+                .map(move |_| DmaTransferTx::new(self))
         }
 
         /// Register a buffer for a DMA read.
@@ -343,7 +343,7 @@ pub mod dma {
         pub fn dma_read<'t, RXBUF>(
             &'t mut self,
             words: &'t mut RXBUF,
-        ) -> Result<DmaTransferRxImpl<Self>, Error>
+        ) -> Result<DmaTransferRx<Self>, Error>
         where
             RXBUF: WriteBuffer<Word = u8>,
         {
@@ -356,7 +356,7 @@ pub mod dma {
             unsafe {
                 self.spi
                     .start_read_bytes_dma(ptr, len, &mut self.channel.rx)
-                    .map(move |_| DmaTransferRxImpl::new(self))
+                    .map(move |_| DmaTransferRx::new(self))
             }
         }
 
@@ -372,7 +372,7 @@ pub mod dma {
             &'t mut self,
             words: &'t TXBUF,
             read_buffer: &'t mut RXBUF,
-        ) -> Result<DmaTransferTxRxImpl<Self>, Error>
+        ) -> Result<DmaTransferTxRx<Self>, Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
             RXBUF: WriteBuffer<Word = u8>,
@@ -394,7 +394,7 @@ pub mod dma {
                         &mut self.channel.tx,
                         &mut self.channel.rx,
                     )
-                    .map(move |_| DmaTransferTxRxImpl::new(self))
+                    .map(move |_| DmaTransferTxRx::new(self))
             }
         }
     }

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -282,7 +282,7 @@ pub mod dma {
     {
         type TX = C::Tx<'d>;
 
-        fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+        fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
         }
     }
@@ -296,7 +296,7 @@ pub mod dma {
     {
         type RX = C::Rx<'d>;
 
-        fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+        fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx
         }
     }

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -282,8 +282,8 @@ pub mod dma {
     {
         type TX = C::Tx<'d>;
 
-        fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
-            f(&mut self.channel.tx)
+        fn tx<'a>(&'a mut self) -> &'a mut Self::TX {
+            &mut self.channel.tx
         }
     }
 
@@ -296,8 +296,8 @@ pub mod dma {
     {
         type RX = C::Rx<'d>;
 
-        fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
-            f(&mut self.channel.rx)
+        fn rx<'a>(&'a mut self) -> &'a mut Self::RX {
+            &mut self.channel.rx
         }
     }
 

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -134,11 +134,12 @@ pub mod dma {
     use crate::dma::Spi3Peripheral;
     use crate::{
         dma::{
+            dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
             Channel,
             ChannelTypes,
-            DmaError,
-            DmaTransfer,
-            DmaTransferRxTx,
+            DmaTransferRxImpl,
+            DmaTransferTxImpl,
+            DmaTransferTxRxImpl,
             RxPrivate,
             Spi2Peripheral,
             SpiPeripheral,
@@ -228,164 +229,6 @@ pub mod dma {
             }
         }
     }
-    /// An in-progress DMA transfer
-    #[must_use]
-    pub struct SpiDmaTransferRxTx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        spi_dma: &'t mut SpiDma<'d, T, C, DmaMode>,
-    }
-
-    impl<'t, 'd, T, C, DmaMode> DmaTransferRxTx for SpiDmaTransferRxTx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        /// Wait for the DMA transfer to complete
-        fn wait(self) -> Result<(), DmaError> {
-            // Waiting for the DMA transfer is not enough. We need to wait for the
-            // peripheral to finish flushing its buffers, too.
-            while !self.is_done() {}
-            self.spi_dma.spi.flush().ok();
-
-            if self.spi_dma.channel.rx.has_error() || self.spi_dma.channel.tx.has_error() {
-                Err(DmaError::DescriptorError)
-            } else {
-                Ok(())
-            }
-        }
-
-        /// Check if the DMA transfer is complete
-        fn is_done(&self) -> bool {
-            let ch = &self.spi_dma.channel;
-            ch.tx.is_done() && ch.rx.is_done() && !self.spi_dma.spi.is_bus_busy()
-        }
-    }
-
-    impl<'t, 'd, T, C, DmaMode> Drop for SpiDmaTransferRxTx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        fn drop(&mut self) {
-            while !self.is_done() {}
-            self.spi_dma.spi.flush().ok();
-        }
-    }
-
-    /// An in-progress DMA transfer.
-    #[must_use]
-    pub struct SpiDmaTransferRx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        spi_dma: &'t mut SpiDma<'d, T, C, DmaMode>,
-    }
-
-    impl<'t, 'd, T, C, DmaMode> DmaTransfer for SpiDmaTransferRx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        /// Wait for the DMA transfer to complete
-        fn wait(self) -> Result<(), DmaError> {
-            while !self.is_done() {}
-            self.spi_dma.spi.flush().ok(); // waiting for the DMA transfer is not enough
-
-            if self.spi_dma.channel.rx.has_error() || self.spi_dma.channel.tx.has_error() {
-                Err(DmaError::DescriptorError)
-            } else {
-                Ok(())
-            }
-        }
-
-        /// Check if the DMA transfer is complete
-        fn is_done(&self) -> bool {
-            let ch = &self.spi_dma.channel;
-            ch.rx.is_done()
-        }
-    }
-
-    impl<'t, 'd, T, C, DmaMode> Drop for SpiDmaTransferRx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        fn drop(&mut self) {
-            while !self.is_done() {}
-            self.spi_dma.spi.flush().ok(); // waiting for the DMA transfer is
-                                           // not enough
-        }
-    }
-
-    /// An in-progress DMA transfer.
-    #[must_use]
-    pub struct SpiDmaTransferTx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        spi_dma: &'t mut SpiDma<'d, T, C, DmaMode>,
-    }
-
-    impl<'t, 'd, T, C, DmaMode> DmaTransfer for SpiDmaTransferTx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        /// Wait for the DMA transfer to complete
-        fn wait(self) -> Result<(), DmaError> {
-            // Waiting for the DMA transfer is not enough. We need to wait for the
-            // peripheral to finish flushing its buffers, too.
-            while !self.is_done() {}
-            self.spi_dma.spi.flush().ok();
-
-            if self.spi_dma.channel.rx.has_error() || self.spi_dma.channel.tx.has_error() {
-                Err(DmaError::DescriptorError)
-            } else {
-                Ok(())
-            }
-        }
-
-        /// Check if the DMA transfer is complete
-        fn is_done(&self) -> bool {
-            let ch = &self.spi_dma.channel;
-            ch.tx.is_done()
-        }
-    }
-
-    impl<'t, 'd, T, C, DmaMode> Drop for SpiDmaTransferTx<'t, 'd, T, C, DmaMode>
-    where
-        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
-        C: ChannelTypes,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        fn drop(&mut self) {
-            while !self.is_done() {}
-            self.spi_dma.spi.flush().ok(); // waiting for the DMA transfer is
-                                           // not enough
-        }
-    }
 
     /// A DMA capable SPI instance.
     pub struct SpiDma<'d, T, C, DmaMode>
@@ -409,6 +252,55 @@ pub mod dma {
         }
     }
 
+    impl<'d, T, C, DmaMode> DmaSupport for SpiDma<'d, T, C, DmaMode>
+    where
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+        C: ChannelTypes,
+        C::P: SpiPeripheral,
+        DmaMode: Mode,
+    {
+        fn peripheral_wait_dma(&mut self, is_tx: bool, is_rx: bool) {
+            while !((!is_tx || self.channel.tx.is_done())
+                && (!is_rx || self.channel.rx.is_done())
+                && !self.spi.is_bus_busy())
+            {}
+
+            self.spi.flush().ok();
+        }
+
+        fn peripheral_dma_stop(&mut self) {
+            unreachable!("unsupported")
+        }
+    }
+
+    impl<'d, T, C, DmaMode> DmaSupportTx for SpiDma<'d, T, C, DmaMode>
+    where
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+        C: ChannelTypes,
+        C::P: SpiPeripheral,
+        DmaMode: Mode,
+    {
+        type TX = C::Tx<'d>;
+
+        fn with_tx<R, F: FnOnce(&mut Self::TX) -> R>(&mut self, f: F) -> R {
+            f(&mut self.channel.tx)
+        }
+    }
+
+    impl<'d, T, C, DmaMode> DmaSupportRx for SpiDma<'d, T, C, DmaMode>
+    where
+        T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
+        C: ChannelTypes,
+        C::P: SpiPeripheral,
+        DmaMode: Mode,
+    {
+        type RX = C::Rx<'d>;
+
+        fn with_rx<R, F: FnOnce(&mut Self::RX) -> R>(&mut self, f: F) -> R {
+            f(&mut self.channel.rx)
+        }
+    }
+
     impl<'d, T, C, DmaMode> SpiDma<'d, T, C, DmaMode>
     where
         T: InstanceDma<C::Tx<'d>, C::Rx<'d>>,
@@ -426,7 +318,7 @@ pub mod dma {
         pub fn dma_write<'t, TXBUF>(
             &'t mut self,
             words: &'t TXBUF,
-        ) -> Result<SpiDmaTransferTx<'t, 'd, T, C, DmaMode>, Error>
+        ) -> Result<DmaTransferTxImpl<Self>, Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
         {
@@ -438,7 +330,7 @@ pub mod dma {
 
             self.spi
                 .start_write_bytes_dma(ptr, len, &mut self.channel.tx)
-                .map(move |_| SpiDmaTransferTx { spi_dma: self })
+                .map(move |_| DmaTransferTxImpl::new(self))
         }
 
         /// Register a buffer for a DMA read.
@@ -451,7 +343,7 @@ pub mod dma {
         pub fn dma_read<'t, RXBUF>(
             &'t mut self,
             words: &'t mut RXBUF,
-        ) -> Result<SpiDmaTransferRx<'t, 'd, T, C, DmaMode>, Error>
+        ) -> Result<DmaTransferRxImpl<Self>, Error>
         where
             RXBUF: WriteBuffer<Word = u8>,
         {
@@ -464,7 +356,7 @@ pub mod dma {
             unsafe {
                 self.spi
                     .start_read_bytes_dma(ptr, len, &mut self.channel.rx)
-                    .map(move |_| SpiDmaTransferRx { spi_dma: self })
+                    .map(move |_| DmaTransferRxImpl::new(self))
             }
         }
 
@@ -480,7 +372,7 @@ pub mod dma {
             &'t mut self,
             words: &'t TXBUF,
             read_buffer: &'t mut RXBUF,
-        ) -> Result<SpiDmaTransferRxTx<'t, 'd, T, C, DmaMode>, Error>
+        ) -> Result<DmaTransferTxRxImpl<Self>, Error>
         where
             TXBUF: ReadBuffer<Word = u8>,
             RXBUF: WriteBuffer<Word = u8>,
@@ -502,7 +394,7 @@ pub mod dma {
                         &mut self.channel.tx,
                         &mut self.channel.rx,
                     )
-                    .map(move |_| SpiDmaTransferRxTx { spi_dma: self })
+                    .map(move |_| DmaTransferTxRxImpl::new(self))
             }
         }
     }

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -81,7 +81,7 @@ fn main() -> ! {
         send[send.len() - 1] = i;
         i = i.wrapping_add(1);
 
-        let transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
+        let mut transfer = spi.dma_transfer(&mut send, &mut receive).unwrap();
         // here we could do something else while DMA transfer is in progress
         let mut n = 0;
         // Check is_done until the transfer is almost done (32000 bytes at 100kHz is


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Previously each DMA capable peripheral had its own implementation of DMA transaction. This creates common implementations in the DMA module and the peripherals now use the shared implementation.

#### Testing
All DMA-related examples should work as before.

I cannot test lcd_cam examples (lacking hardware) - the i8080 example still outputs "something" on the pins at least
