### PR TITLE
Enable gpio::test_gpio_interrupt for Xtensa targets.

### DIFF
--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -21,7 +21,7 @@ We use [probe-rs] for flashing and running the tests on a target device, however
 ```text
 cargo install probe-rs-tools \
   --git https://github.com/probe-rs/probe-rs \
-  --rev 4dc1701 --force --locked
+  --rev a6dd038 --force --locked
 ```
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
@@ -89,7 +89,7 @@ source "$HOME/.cargo/env"
 # Install dependencies
 sudo apt install -y pkg-config libudev-dev
 # Install probe-rs
-cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev 4dc1701 --force
+cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev a6dd038 --force
 # Add the udev rules
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -150,7 +150,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
     fn test_gpio_interrupt(mut ctx: Context<'static>) {
         critical_section::with(|cs| {
             *COUNTER.borrow_ref_mut(cs) = 0;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Enable `gpio::test_gpio_interrupt` for Xtensa targets, it was disabled due to https://github.com/esp-rs/esp-hal/issues/1413. I've also updated the runners `probe-rs` to rev `a6dd038` which includes the fix.

#### Testing
Manually triggered the HIL CI workflow:  https://github.com/esp-rs/esp-hal/actions/runs/9092616672
On S3:
```
test tests::test_gpio_interrupt ... ok
```
