### PR TITLE
ESP32-S2: Add SPI Slave support

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `time::current_time` API (#1503)
 - ESP32-S3: Add LCD_CAM Camera driver (#1483)
 - `embassy-usb` support (#1517)
-- SPI Slave support for ESP32-S2 (#1514)
+- SPI Slave support for ESP32-S2 (#1562)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `time::current_time` API (#1503)
 - ESP32-S3: Add LCD_CAM Camera driver (#1483)
 - `embassy-usb` support (#1517)
+- SPI Slave support for ESP32, ESP32-S2 (#1514)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `time::current_time` API (#1503)
 - ESP32-S3: Add LCD_CAM Camera driver (#1483)
 - `embassy-usb` support (#1517)
-- SPI Slave support for ESP32, ESP32-S2 (#1514)
+- SPI Slave support for ESP32-S2 (#1514)
 
 ### Fixed
 

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -7,7 +7,6 @@
 use crate::dma::DmaError;
 
 pub mod master;
-#[cfg(all(any(spi0, spi1, spi2, spi3), not(pdma)))]
 pub mod slave;
 
 /// SPI errors

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -7,6 +7,7 @@
 use crate::dma::DmaError;
 
 pub mod master;
+#[cfg(not(esp32))]
 pub mod slave;
 
 /// SPI errors

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -408,29 +408,22 @@ where
 
         reset_dma_before_load_dma_dscr(reg_block);
 
-        rx.prepare_transfer_without_start(
-            false,
-            self.dma_peripheral(),
-            read_buffer_ptr,
-            read_buffer_len,
-        )?;
-        #[cfg(esp32s2)]
-        rx.start_transfer()?;
-
         tx.prepare_transfer_without_start(
             self.dma_peripheral(),
             false,
             write_buffer_ptr,
             write_buffer_len,
         )?;
-        #[cfg(esp32s2)]
-        tx.start_transfer()?;
+
+        rx.prepare_transfer_without_start(
+            false,
+            self.dma_peripheral(),
+            read_buffer_ptr,
+            read_buffer_len,
+        )?;
 
         reset_dma_before_usr_cmd(reg_block);
 
-        // Note: On the esp32, all full-duplex transfers are single, and all half-duplex
-        // transfers use the cmd/addr/dummy/data sequence (but are still
-        // single).
         reg_block
             .dma_conf()
             .modify(|_, w| w.dma_slv_seg_trans_en().clear_bit());
@@ -439,11 +432,8 @@ where
         self.setup_for_flush();
         reg_block.cmd().modify(|_, w| w.usr().set_bit());
 
-        #[cfg(not(esp32s2))]
-        {
-            rx.start_transfer()?;
-            tx.start_transfer()?;
-        }
+        rx.start_transfer()?;
+        tx.start_transfer()?;
 
         Ok(())
     }
@@ -463,14 +453,9 @@ where
         reset_dma_before_load_dma_dscr(reg_block);
 
         tx.prepare_transfer_without_start(self.dma_peripheral(), false, ptr, len)?;
-        #[cfg(esp32s2)]
-        tx.start_transfer()?;
 
         reset_dma_before_usr_cmd(reg_block);
 
-        // Note: On the esp32, all full-duplex transfers are single, and all half-duplex
-        // transfers use the cmd/addr/dummy/data sequence (but are still
-        // single).
         reg_block
             .dma_conf()
             .modify(|_, w| w.dma_slv_seg_trans_en().clear_bit());
@@ -479,10 +464,7 @@ where
         self.setup_for_flush();
         reg_block.cmd().modify(|_, w| w.usr().set_bit());
 
-        #[cfg(not(esp32s2))]
-        {
-            tx.start_transfer()?;
-        }
+        tx.start_transfer()?;
 
         Ok(())
     }
@@ -501,14 +483,9 @@ where
 
         reset_dma_before_load_dma_dscr(reg_block);
         rx.prepare_transfer_without_start(false, self.dma_peripheral(), ptr, len)?;
-        #[cfg(esp32s2)]
-        rx.start_transfer()?;
 
         reset_dma_before_usr_cmd(reg_block);
 
-        // Note: On the esp32, all full-duplex transfers are single, and all half-duplex
-        // transfers use the cmd/addr/dummy/data sequence (but are still
-        // single).
         reg_block
             .dma_conf()
             .modify(|_, w| w.dma_slv_seg_trans_en().clear_bit());
@@ -517,10 +494,7 @@ where
         self.setup_for_flush();
         reg_block.cmd().modify(|_, w| w.usr().set_bit());
 
-        #[cfg(not(esp32s2))]
-        {
-            rx.start_transfer()?;
-        }
+        rx.start_transfer()?;
 
         Ok(())
     }

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -646,13 +646,13 @@ fn reset_dma_before_usr_cmd(reg_block: &RegisterBlock) {
     });
 }
 
-#[cfg(any(esp32))]
+#[cfg(esp32)]
 fn reset_dma_before_usr_cmd(reg_block: &RegisterBlock) {
     reg_block.slave().modify(|_, w| w.sync_reset().set_bit());
     reg_block.slave().modify(|_, w| w.sync_reset().clear_bit());
 }
 
-#[cfg(any(esp32s2))]
+#[cfg(esp32s2)]
 fn reset_dma_before_usr_cmd(reg_block: &RegisterBlock) {
     reg_block.slave().modify(|_, w| w.soft_reset().set_bit());
     reg_block.slave().modify(|_, w| w.soft_reset().clear_bit());

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -1,6 +1,20 @@
 //! SPI slave loopback test using DMA
 //!
+//! ESP32 / ESP32-S2
 //! Following pins are used for the slave:
+//! SCLK    GPIO2
+//! MISO    GPIO4
+//! MOSI    GPIO15
+//! CS      GPIO17
+//!
+//! Following pins are used for the (bitbang) master:
+//! SCLK    GPIO0
+//! MISO    GPIO5
+//! MOSI    GPIO16
+//! CS      GPIO18
+//!
+//! Other chips:
+//!
 //! SCLK    GPIO0
 //! MISO    GPIO1
 //! MOSI    GPIO2
@@ -23,10 +37,11 @@
 //! pins except SCLK. SCLK is between MOSI and VDD3P3_RTC on the barebones chip,
 //! so no immediate neighbor is available.
 
-//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
+//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s3 esp32 esp32s2
 
 #![no_std]
 #![no_main]
+#![feature(asm_experimental_arch)]
 
 use esp_backtrace as _;
 use esp_hal::{
@@ -44,6 +59,20 @@ use esp_hal::{
     system::SystemControl,
 };
 use esp_println::println;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+        const MASTER_CS: u8 = 18;
+        const MASTER_MOSI: u8 = 16;
+        const MASTER_SCLK: u8 = 0;
+        const MASTER_MISO: u8 = 5;
+    } else {
+        const MASTER_CS: u8 = 9;
+        const MASTER_MOSI: u8 = 8;
+        const MASTER_SCLK: u8 = 4;
+        const MASTER_MISO: u8 = 5;
+    }
+}
 
 #[entry]
 fn main() -> ! {
@@ -65,7 +94,13 @@ fn main() -> ! {
     master_mosi.set_low();
 
     let dma = Dma::new(peripherals.DMA);
-    let dma_channel = dma.channel0;
+    cfg_if::cfg_if! {
+        if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+            let dma_channel = dma.spi2channel;
+        } else {
+            let dma_channel = dma.channel0;
+        }
+    }
 
     let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
 
@@ -108,39 +143,23 @@ fn main() -> ! {
         slave_receive.fill(0xff);
         i = i.wrapping_add(1);
 
+        println!("Iteration {i}");
+
+        println!("Do `dma_transfer`");
+
         let transfer = spi
             .dma_transfer(&mut slave_send, &mut slave_receive)
             .unwrap();
-        // Bit-bang out the contents of master_send and read into master_receive
-        // as quickly as manageable. MSB first. Mode 0, so sampled on the rising
-        // edge and set on the falling edge.
-        master_cs.set_low();
-        for (j, v) in master_send.iter().enumerate() {
-            let mut b = *v;
-            let mut rb = 0u8;
-            for _ in 0..8 {
-                if b & 128 != 0 {
-                    master_mosi.set_high();
-                } else {
-                    master_mosi.set_low();
-                }
-                master_sclk.set_low();
-                b <<= 1;
-                rb <<= 1;
-                // NB: adding about 24 NOPs here makes the clock's duty cycle
-                // run at about 50% ... but we don't strictly need the delay,
-                // either.
-                master_sclk.set_high();
-                if master_miso.is_high() {
-                    rb |= 1;
-                }
-            }
-            master_receive[j] = rb;
-        }
-        master_cs.set_high();
-        master_sclk.set_low();
-        // the buffers and spi is moved into the transfer and we can get it back via
-        // `wait`
+
+        bitbang_master(
+            master_send,
+            master_receive,
+            &mut master_cs,
+            &mut master_mosi,
+            &mut master_sclk,
+            &master_miso,
+        );
+
         transfer.wait().unwrap();
         println!(
             "slave got {:x?} .. {:x?}, master got {:x?} .. {:x?}",
@@ -152,25 +171,19 @@ fn main() -> ! {
 
         delay.delay_millis(250);
 
+        println!("Do `dma_read`");
         slave_receive.fill(0xff);
         let transfer = spi.dma_read(&mut slave_receive).unwrap();
-        master_cs.set_high();
 
-        master_cs.set_low();
-        for v in master_send.iter() {
-            let mut b = *v;
-            for _ in 0..8 {
-                if b & 128 != 0 {
-                    master_mosi.set_high();
-                } else {
-                    master_mosi.set_low();
-                }
-                b <<= 1;
-                master_sclk.set_low();
-                master_sclk.set_high();
-            }
-        }
-        master_cs.set_high();
+        bitbang_master(
+            master_send,
+            master_receive,
+            &mut master_cs,
+            &mut master_mosi,
+            &mut master_sclk,
+            &master_miso,
+        );
+
         transfer.wait().unwrap();
         println!(
             "slave got {:x?} .. {:x?}",
@@ -179,31 +192,70 @@ fn main() -> ! {
         );
 
         delay.delay_millis(250);
+
+        println!("Do `dma_write`");
         let transfer = spi.dma_write(&mut slave_send).unwrap();
 
         master_receive.fill(0);
 
-        master_cs.set_low();
-        for (j, _) in master_send.iter().enumerate() {
-            let mut rb = 0u8;
-            for _ in 0..8 {
-                master_sclk.set_low();
-                rb <<= 1;
-                master_sclk.set_high();
-                if master_miso.is_high() {
-                    rb |= 1;
-                }
-            }
-            master_receive[j] = rb;
-        }
-        master_cs.set_high();
-        transfer.wait().unwrap();
+        bitbang_master(
+            master_send,
+            master_receive,
+            &mut master_cs,
+            &mut master_mosi,
+            &mut master_sclk,
+            &master_miso,
+        );
 
+        transfer.wait().unwrap();
         println!(
             "master got {:x?} .. {:x?}",
             &master_receive[..10],
             &master_receive[master_receive.len() - 10..],
         );
+
+        delay.delay_millis(250);
+
         println!();
     }
+}
+
+fn bitbang_master(
+    master_send: &[u8],
+    master_receive: &mut [u8],
+    master_cs: &mut GpioPin<Output<PushPull>, MASTER_CS>,
+    master_mosi: &mut GpioPin<Output<PushPull>, MASTER_MOSI>,
+    master_sclk: &mut GpioPin<Output<PushPull>, MASTER_SCLK>,
+    master_miso: &GpioPin<Input<Floating>, MASTER_MISO>,
+) {
+    // Bit-bang out the contents of master_send and read into master_receive
+    // as quickly as manageable. MSB first. Mode 0, so sampled on the rising
+    // edge and set on the falling edge.
+    master_cs.set_low();
+    for (j, v) in master_send.iter().enumerate() {
+        let mut b = *v;
+        let mut rb = 0u8;
+        for _ in 0..8 {
+            if b & 128 != 0 {
+                master_mosi.set_high();
+            } else {
+                master_mosi.set_low();
+            }
+            master_sclk.set_low();
+            b <<= 1;
+            rb <<= 1;
+            // NB: adding about 24 NOPs here makes the clock's duty cycle
+            // run at about 50% ... but we don't strictly need the delay,
+            // either.
+            master_sclk.set_high();
+            if master_miso.is_high() {
+                rb |= 1;
+            }
+        }
+        master_receive[j] = rb;
+    }
+    master_sclk.set_low();
+
+    master_cs.set_high();
+    master_sclk.set_low();
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds SPI Slave for ESP32S2 and removes ESP32 parts from it.

#### Testing
Tested with `spi_slave_dma` example.

Builds on top of #1514 but removed all ESP32-related changes from the driver. After discussion with @bjoernQ, we agreed it makes sense to add _just_ S2 and remove ESP32 parts, we've burnt so much time on that and the thing doesn't work.

