### PR TITLE
Rework Uart constructors, add UartTx and UartRx constuctors.

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `embassy-usb` support (#1517)
 - SPI Slave support for ESP32-S2 (#1562)
 - Add new generic `OneShotTimer` and `PeriodicTimer` drivers, plus new `Timer` trait which is implemented for `TIMGx` and `SYSTIMER` (#1570)
+- uart: Add `with_pin`s methods to configure TX,RX, CTS, and RTS pins (#1592)
 
 ### Fixed
 
@@ -61,12 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unnecessary generics from PARL_IO driver (#1545)
 - Use `Level enum` in GPIO constructors instead of plain bools (#1574)
 - rmt: make ChannelCreator public (#1597)
+- Use `Level enum` in GPIO constructors instead of plain bools (#1574)
 
 ### Removed
 
 - Removed the `SystemExt` trait (#1495)
 - Removed the `GpioExt` trait (#1496)
 - Embassy support (and all related features) has been removed, now available in the `esp-hal-embassy` package instead (#1595)
+- uart: Removed `configure_pins` methods (#1592)
 
 ## [0.17.0] - 2024-04-18
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- uart: Add `with_cts`/`with_rts`s methods to configure CTS, and RTS pins (#1592)
+- uart: Constructors now require TX and RX pins (#1592)
+- uart: Added `new_with_default_pins` constructors (#1592)
 
 - Add Flex / AnyFlex GPIO pin driver (#1659)
 
@@ -18,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `Dac1`/`Dac2` drivers into a single `Dac` driver (#1661)
 
 ### Removed
+- uart: Removed `configure_pins` methods (#1592)
 
 ## [0.18.0] - 2024-06-04
 
@@ -31,9 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `embassy-usb` support (#1517)
 - SPI Slave support for ESP32-S2 (#1562)
 - Add new generic `OneShotTimer` and `PeriodicTimer` drivers, plus new `Timer` trait which is implemented for `TIMGx` and `SYSTIMER` (#1570)
-- uart: Add `with_cts`/`with_rts`s methods to configure CTS, and RTS pins (#1592)
-- uart: Constructors now require TX and RX pins (#1592)
-- uart: Added `new_with_default_pins` constructors (#1592)
 
 ### Fixed
 
@@ -64,14 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unnecessary generics from PARL_IO driver (#1545)
 - Use `Level enum` in GPIO constructors instead of plain bools (#1574)
 - rmt: make ChannelCreator public (#1597)
-- Use `Level enum` in GPIO constructors instead of plain bools (#1574)
 
 ### Removed
 
 - Removed the `SystemExt` trait (#1495)
 - Removed the `GpioExt` trait (#1496)
 - Embassy support (and all related features) has been removed, now available in the `esp-hal-embassy` package instead (#1595)
-- uart: Removed `configure_pins` methods (#1592)
 
 ## [0.17.0] - 2024-04-18
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- uart: Add `with_cts`/`with_rts`s methods to configure CTS, and RTS pins (#1592)
+- uart: Added `with_cts`/`with_rts`s methods to configure CTS, and RTS pins (#1592)
 - uart: Constructors now require TX and RX pins (#1592)
-- uart: Added `new_with_default_pins` constructors (#1592)
+- uart: Added `Uart::new_with_default_pins` constructor (#1592)
+- uart: Added `UartTx` and `UartRx` constructors (#1592)
 
 - Add Flex / AnyFlex GPIO pin driver (#1659)
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,7 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `embassy-usb` support (#1517)
 - SPI Slave support for ESP32-S2 (#1562)
 - Add new generic `OneShotTimer` and `PeriodicTimer` drivers, plus new `Timer` trait which is implemented for `TIMGx` and `SYSTIMER` (#1570)
-- uart: Add `with_pin`s methods to configure TX,RX, CTS, and RTS pins (#1592)
+- uart: Add `with_cts`/`with_rts`s methods to configure CTS, and RTS pins (#1592)
+- uart: Constructors now require TX and RX pins (#1592)
+- uart: Added `new_with_default_pins` constructors (#1592)
 
 ### Fixed
 

--- a/esp-hal/src/prelude.rs
+++ b/esp-hal/src/prelude.rs
@@ -41,5 +41,5 @@ pub use crate::timer::timg::{
 #[cfg(any(systimer, timg0, timg1))]
 pub use crate::timer::Timer as _esp_hal_timer_Timer;
 #[cfg(any(uart0, uart1, uart2))]
-pub use crate::uart::{Instance as _esp_hal_uart_Instance, UartPins as _esp_hal_uart_UartPins};
+pub use crate::uart::Instance as _esp_hal_uart_Instance;
 pub use crate::{entry, macros::*};

--- a/esp-hal/src/rom/md5.rs
+++ b/esp-hal/src/rom/md5.rs
@@ -32,9 +32,11 @@
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::rom::md5;
 //! # use esp_hal::uart::Uart;
+//! # use esp_hal::gpio::Io;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut uart0 = Uart::new(peripherals.UART0, &clocks, io.pins.gpio1, io.pins.gpio2).unwrap();
 //! # let data = "Dummy";
 //! let d: md5::Digest = md5::compute(&data);
 //! writeln!(uart0, "{}", d);
@@ -46,9 +48,11 @@
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::rom::md5;
 //! # use esp_hal::uart::Uart;
+//! # use esp_hal::gpio::Io;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut uart0 = Uart::new(peripherals.UART0, &clocks, io.pins.gpio1, io.pins.gpio2).unwrap();
 //! # let data0 = "Dummy";
 //! # let data1 = "Dummy";
 //! let mut ctx = md5::Context::new();

--- a/esp-hal/src/soc/esp32/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32/efuse/mod.rs
@@ -22,10 +22,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
+//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32c2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c2/efuse/mod.rs
@@ -22,10 +22,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
+//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32c3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c3/efuse/mod.rs
@@ -22,10 +22,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
+//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32c6/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c6/efuse/mod.rs
@@ -22,10 +22,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
+//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32h2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32h2/efuse/mod.rs
@@ -22,10 +22,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
+//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32s2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32s2/efuse/mod.rs
@@ -22,10 +22,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
+//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32s3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32s3/efuse/mod.rs
@@ -22,10 +22,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
+//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks);
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let mut serial_tx = Uart::new(peripherals.UART0, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1932,6 +1932,21 @@ mod asynch {
             crate::into_ref!(tx);
             tx.set_to_push_pull_output(crate::private::Internal);
             tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+
+            let interrupt = match T::uart_number() {
+                #[cfg(uart0)]
+                0 => uart0,
+                #[cfg(uart1)]
+                1 => uart1,
+                #[cfg(uart2)]
+                2 => uart2,
+                _ => unreachable!(),
+            };
+            unsafe {
+                crate::interrupt::bind_interrupt(T::interrupt(), interrupt.handler());
+                crate::interrupt::enable(T::interrupt(), interrupt.priority()).unwrap();
+            }
+
             Self::new_inner()
         }
 
@@ -1982,6 +1997,21 @@ mod asynch {
             crate::into_ref!(rx);
             rx.set_to_input(crate::private::Internal);
             rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+
+            let interrupt = match T::uart_number() {
+                #[cfg(uart0)]
+                0 => uart0,
+                #[cfg(uart1)]
+                1 => uart1,
+                #[cfg(uart2)]
+                2 => uart2,
+                _ => unreachable!(),
+            };
+            unsafe {
+                crate::interrupt::bind_interrupt(T::interrupt(), interrupt.handler());
+                crate::interrupt::enable(T::interrupt(), interrupt.priority()).unwrap();
+            }
+
             Self::new_inner()
         }
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -116,7 +116,7 @@ use crate::soc::constants::RC_FAST_CLK;
 #[cfg(any(esp32, esp32s2))]
 use crate::soc::constants::REF_TICK;
 
-// Default pins for Uart/Serial communication
+// Default TX and RX pins for Uart/Serial communication (UART0)
 cfg_if::cfg_if! {
     if #[cfg(esp32)] {
         pub type DefaultTxPin = crate::gpio::Gpio1;
@@ -140,6 +140,42 @@ cfg_if::cfg_if! {
         pub type DefaultTxPin = crate::gpio::Gpio43;
         pub type DefaultRxPin = crate::gpio::Gpio44;
     }
+}
+
+/// Returns the default TX and RX pins for Uart/Serial communication (UART0)
+#[macro_export]
+macro_rules! default_uart0_pins {
+    ($io:expr) => {{
+        let io = $io;
+        #[cfg(feature = "esp32")]
+        {
+            (io.pins.gpio1, io.pins.gpio3)
+        }
+        #[cfg(feature = "esp32c2")]
+        {
+            (io.pins.gpio20, io.pins.gpio19)
+        }
+        #[cfg(feature = "esp32c3")]
+        {
+            (io.pins.gpio21, io.pins.gpio20)
+        }
+        #[cfg(feature = "esp32c6")]
+        {
+            (io.pins.gpio16, io.pins.gpio17)
+        }
+        #[cfg(feature = "esp32h2")]
+        {
+            (io.pins.gpio24, io.pins.gpio23)
+        }
+        #[cfg(feature = "esp32s2")]
+        {
+            (io.pins.gpio43, io.pins.gpio44)
+        }
+        #[cfg(feature = "esp32s3")]
+        {
+            (io.pins.gpio43, io.pins.gpio44)
+        }
+    }};
 }
 
 /// UART Error

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1920,10 +1920,21 @@ mod asynch {
         }
     }
 
-    impl<T> UartTx<'_, T, Async>
+    impl<'d, T> UartTx<'d, T, Async>
     where
-        T: Instance,
+        T: Instance + 'd,
     {
+        /// Create a new UART TX instance in [`Async`] mode.
+        pub fn new_async<TX: OutputPin>(
+            _uart: impl Peripheral<P = T> + 'd,
+            tx: impl Peripheral<P = TX> + 'd,
+        ) -> Self {
+            crate::into_ref!(tx);
+            tx.set_to_push_pull_output(crate::private::Internal);
+            tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+            Self::new_inner()
+        }
+
         pub async fn write_async(&mut self, words: &[u8]) -> Result<usize, Error> {
             let mut count = 0;
             let mut offset: usize = 0;
@@ -1959,10 +1970,21 @@ mod asynch {
         }
     }
 
-    impl<T> UartRx<'_, T, Async>
+    impl<'d, T> UartRx<'d, T, Async>
     where
-        T: Instance,
+        T: Instance + 'd,
     {
+        /// Create a new UART RX instance in [`Async`] mode.
+        pub fn new_async<RX: InputPin>(
+            _uart: impl Peripheral<P = T> + 'd,
+            rx: impl Peripheral<P = RX> + 'd,
+        ) -> Self {
+            crate::into_ref!(rx);
+            rx.set_to_input(crate::private::Internal);
+            rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+            Self::new_inner()
+        }
+
         /// Read async to buffer slice `buf`.
         /// Waits until at least one byte is in the Rx FiFo
         /// and one of the following interrupts occurs:

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -102,6 +102,7 @@ use crate::{
         uart0::{fifo::FIFO_SPEC, RegisterBlock},
         Interrupt,
     },
+    private::Internal,
     system::PeripheralClockControl,
     Blocking,
     Mode,
@@ -369,8 +370,8 @@ where
     /// Configure RTS pin
     pub fn with_rts<RTS: OutputPin>(self, rts: impl Peripheral<P = RTS> + 'd) -> Self {
         crate::into_ref!(rts);
-        rts.set_to_push_pull_output(crate::private::Internal);
-        rts.connect_peripheral_to_output(T::rts_signal(), crate::private::Internal);
+        rts.set_to_push_pull_output(Internal);
+        rts.connect_peripheral_to_output(T::rts_signal(), Internal);
 
         self
     }
@@ -416,8 +417,8 @@ where
         tx: impl Peripheral<P = TX> + 'd,
     ) -> Self {
         crate::into_ref!(tx);
-        tx.set_to_push_pull_output(crate::private::Internal);
-        tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+        tx.set_to_push_pull_output(Internal);
+        tx.connect_peripheral_to_output(T::tx_signal(), Internal);
         Self::new_inner()
     }
 }
@@ -438,8 +439,8 @@ where
     /// Configure CTS pin
     pub fn with_cts<CTS: InputPin>(self, cts: impl Peripheral<P = CTS> + 'd) -> Self {
         crate::into_ref!(cts);
-        cts.set_to_input(crate::private::Internal);
-        cts.connect_input_to_peripheral(T::cts_signal(), crate::private::Internal);
+        cts.set_to_input(Internal);
+        cts.connect_input_to_peripheral(T::cts_signal(), Internal);
 
         self
     }
@@ -492,8 +493,8 @@ where
         rx: impl Peripheral<P = RX> + 'd,
     ) -> Self {
         crate::into_ref!(rx);
-        rx.set_to_input(crate::private::Internal);
-        rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+        rx.set_to_input(Internal);
+        rx.connect_input_to_peripheral(T::rx_signal(), Internal);
         Self::new_inner()
     }
 }
@@ -514,11 +515,11 @@ where
     ) -> Self {
         crate::into_ref!(tx);
         crate::into_ref!(rx);
-        tx.set_to_push_pull_output(crate::private::Internal);
-        tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+        tx.set_to_push_pull_output(Internal);
+        tx.connect_peripheral_to_output(T::tx_signal(), Internal);
 
-        rx.set_to_input(crate::private::Internal);
-        rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+        rx.set_to_input(Internal);
+        rx.connect_input_to_peripheral(T::rx_signal(), Internal);
         Self::new_with_config_inner(uart, config, clocks, interrupt)
     }
 
@@ -531,11 +532,11 @@ where
     ) -> Self {
         crate::into_ref!(tx);
         crate::into_ref!(rx);
-        tx.set_to_push_pull_output(crate::private::Internal);
-        tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+        tx.set_to_push_pull_output(Internal);
+        tx.connect_peripheral_to_output(T::tx_signal(), Internal);
 
-        rx.set_to_input(crate::private::Internal);
-        rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+        rx.set_to_input(Internal);
+        rx.connect_input_to_peripheral(T::rx_signal(), Internal);
         Self::new_inner(uart, clocks)
     }
 
@@ -547,11 +548,11 @@ where
         tx: &mut DefaultTxPin,
         rx: &mut DefaultRxPin,
     ) -> Self {
-        tx.set_to_push_pull_output(crate::private::Internal);
-        tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+        tx.set_to_push_pull_output(Internal);
+        tx.connect_peripheral_to_output(T::tx_signal(), Internal);
 
-        rx.set_to_input(crate::private::Internal);
-        rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+        rx.set_to_input(Internal);
+        rx.connect_input_to_peripheral(T::rx_signal(), Internal);
         Self::new_inner(uart, clocks)
     }
 }
@@ -615,8 +616,8 @@ where
     /// Configure CTS pin
     pub fn with_cts<CTS: InputPin>(self, cts: impl Peripheral<P = CTS> + 'd) -> Self {
         crate::into_ref!(cts);
-        cts.set_to_input(crate::private::Internal);
-        cts.connect_input_to_peripheral(T::cts_signal(), crate::private::Internal);
+        cts.set_to_input(Internal);
+        cts.connect_input_to_peripheral(T::cts_signal(), Internal);
 
         self
     }
@@ -624,8 +625,8 @@ where
     /// Configure RTS pin
     pub fn with_rts<RTS: OutputPin>(self, rts: impl Peripheral<P = RTS> + 'd) -> Self {
         crate::into_ref!(rts);
-        rts.set_to_push_pull_output(crate::private::Internal);
-        rts.connect_peripheral_to_output(T::rts_signal(), crate::private::Internal);
+        rts.set_to_push_pull_output(Internal);
+        rts.connect_peripheral_to_output(T::rts_signal(), Internal);
 
         self
     }
@@ -1860,11 +1861,11 @@ mod asynch {
         ) -> Self {
             crate::into_ref!(tx);
             crate::into_ref!(rx);
-            tx.set_to_push_pull_output(crate::private::Internal);
-            tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+            tx.set_to_push_pull_output(Internal);
+            tx.connect_peripheral_to_output(T::tx_signal(), Internal);
 
-            rx.set_to_input(crate::private::Internal);
-            rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+            rx.set_to_input(Internal);
+            rx.connect_input_to_peripheral(T::rx_signal(), Internal);
             Self::new_with_config_inner(
                 uart,
                 config,
@@ -1930,8 +1931,8 @@ mod asynch {
             tx: impl Peripheral<P = TX> + 'd,
         ) -> Self {
             crate::into_ref!(tx);
-            tx.set_to_push_pull_output(crate::private::Internal);
-            tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+            tx.set_to_push_pull_output(Internal);
+            tx.connect_peripheral_to_output(T::tx_signal(), Internal);
 
             let interrupt = match T::uart_number() {
                 #[cfg(uart0)]
@@ -1995,8 +1996,8 @@ mod asynch {
             rx: impl Peripheral<P = RX> + 'd,
         ) -> Self {
             crate::into_ref!(rx);
-            rx.set_to_input(crate::private::Internal);
-            rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+            rx.set_to_input(Internal);
+            rx.connect_input_to_peripheral(T::rx_signal(), Internal);
 
             let interrupt = match T::uart_number() {
                 #[cfg(uart0)]

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -411,21 +411,13 @@ where
     T: Instance + 'd,
 {
     /// Create a new UART TX instance in [`Blocking`] mode.
-    ///
-    /// Use [crate::gpio::NO_PIN] for the `rts` parameter if RTS is not used.
-    pub fn new<TX: OutputPin, RTS: OutputPin>(
+    pub fn new<TX: OutputPin>(
         _uart: impl Peripheral<P = T> + 'd,
         tx: impl Peripheral<P = TX> + 'd,
-        rts: Option<impl Peripheral<P = RTS> + 'd>,
     ) -> Self {
         crate::into_ref!(tx);
         tx.set_to_push_pull_output(crate::private::Internal);
         tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
-        if let Some(rts) = rts {
-            crate::into_ref!(rts);
-            rts.set_to_push_pull_output(crate::private::Internal);
-            rts.connect_peripheral_to_output(T::rts_signal(), crate::private::Internal);
-        }
         Self::new_inner()
     }
 }
@@ -495,21 +487,13 @@ where
     T: Instance + 'd,
 {
     /// Create a new UART RX instance in [`Blocking`] mode.
-    ///
-    /// Use [crate::gpio::NO_PIN] for the `cts` parameter if CTS is not used.
-    pub fn new<RX: InputPin, CTS: InputPin>(
+    pub fn new<RX: InputPin>(
         _uart: impl Peripheral<P = T> + 'd,
         rx: impl Peripheral<P = RX> + 'd,
-        cts: Option<impl Peripheral<P = CTS> + 'd>,
     ) -> Self {
         crate::into_ref!(rx);
         rx.set_to_input(crate::private::Internal);
         rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
-        if let Some(cts) = cts {
-            crate::into_ref!(cts);
-            cts.set_to_input(crate::private::Internal);
-            cts.connect_input_to_peripheral(T::cts_signal(), crate::private::Internal);
-        }
         Self::new_inner()
     }
 }

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -398,7 +398,8 @@ where
         }
     }
 
-    fn flush_tx(&self) -> nb::Result<(), Error> {
+    /// Flush the transmit buffer of the UART
+    pub fn flush_tx(&self) -> nb::Result<(), Error> {
         if T::is_tx_idle() {
             Ok(())
         } else {

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -21,12 +21,13 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use core::option::Option::Some;
-//! # use esp_hal::uart::{config::Config, TxRxPins, Uart};
+//! # use esp_hal::uart::{config::Config, Uart};
 //! use esp_hal::gpio::Io;
 //! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 //!
 //! let mut uart1 = Uart::new(peripherals.UART1, &clocks, io.pins.gpio1,
-//! io.pins.gpio2).unwrap();
+//!     io.pins.gpio2).unwrap();
+//! # }
 //! ```
 //! 
 //! ## Usage
@@ -46,17 +47,17 @@
 //! #### Sending and Receiving Data
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::uart::{config::Config, TxRxPins, Uart};
+//! # use esp_hal::uart::{config::Config, Uart};
 //! use esp_hal::gpio::Io;
 //! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let pins = TxRxPins::new_tx_rx(io.pins.gpio1, io.pins.gpio2);
 //! # let mut uart1 = Uart::new_with_config(
 //! #     peripherals.UART1,
 //! #     Config::default(),
-//! #     Some(pins),
 //! #     &clocks,
 //! #     None,
-//! # );
+//! #     io.pins.gpio1,
+//! #     io.pins.gpio2,
+//! # ).unwrap();
 //! // Write bytes out over the UART:
 //! uart1.write_bytes("Hello, world!".as_bytes()).expect("write error!");
 //! # }
@@ -65,17 +66,17 @@
 //! #### Splitting the UART into TX and RX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::uart::{config::Config, TxRxPins, Uart};
+//! # use esp_hal::uart::{config::Config, Uart};
 //! use esp_hal::gpio::Io;
 //! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let pins = TxRxPins::new_tx_rx(io.pins.gpio1, io.pins.gpio2);
 //! # let mut uart1 = Uart::new_with_config(
 //! #     peripherals.UART1,
 //! #     Config::default(),
-//! #     Some(pins),
 //! #     &clocks,
 //! #     None,
-//! # );
+//! #     io.pins.gpio1,
+//! #     io.pins.gpio2,
+//! # ).unwrap();
 //! // The UART can be split into separate Transmit and Receive components:
 //! let (mut tx, mut rx) = uart1.split();
 //!

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -556,6 +556,85 @@ where
     pub fn new(uart: impl Peripheral<P = T> + 'd, clocks: &Clocks) -> Self {
         Self::new_inner(uart, clocks)
     }
+
+    /// Configure TX and RX pins
+    pub fn with_tx_rx<TX: OutputPin, RX: InputPin>(
+        self,
+        tx: impl Peripheral<P = TX> + 'd,
+        rx: impl Peripheral<P = RX> + 'd,
+    ) -> Self {
+        crate::into_ref!(tx);
+        crate::into_ref!(rx);
+        tx.set_to_push_pull_output(crate::private::Internal);
+        tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+
+        rx.set_to_input(crate::private::Internal);
+        rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+        self
+    }
+
+    /// Configure TX and RX pins
+    pub fn with_pins<TX: OutputPin, RX: InputPin, CTS: InputPin, RTS: OutputPin>(
+        self,
+        tx: impl Peripheral<P = TX> + 'd,
+        rx: impl Peripheral<P = RX> + 'd,
+        cts: impl Peripheral<P = CTS> + 'd,
+        rts: impl Peripheral<P = RTS> + 'd,
+    ) -> Self {
+        crate::into_ref!(tx);
+        crate::into_ref!(rx);
+        crate::into_ref!(cts);
+        crate::into_ref!(rts);
+
+        tx.set_to_push_pull_output(crate::private::Internal);
+        tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+
+        rx.set_to_input(crate::private::Internal);
+        rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+
+        cts.set_to_input(crate::private::Internal);
+        cts.connect_input_to_peripheral(T::cts_signal(), crate::private::Internal);
+
+        rts.set_to_push_pull_output(crate::private::Internal);
+        rts.connect_peripheral_to_output(T::rts_signal(), crate::private::Internal);
+        self
+    }
+
+    /// Configure TX pin
+    pub fn with_tx<TX: OutputPin>(self, tx: impl Peripheral<P = TX> + 'd) -> Self {
+        crate::into_ref!(tx);
+        tx.set_to_push_pull_output(crate::private::Internal);
+        tx.connect_peripheral_to_output(T::tx_signal(), crate::private::Internal);
+
+        self
+    }
+
+    /// Configure RX pin
+    pub fn with_rx<RX: InputPin>(self, rx: impl Peripheral<P = RX> + 'd) -> Self {
+        crate::into_ref!(rx);
+        rx.set_to_input(crate::private::Internal);
+        rx.connect_input_to_peripheral(T::rx_signal(), crate::private::Internal);
+
+        self
+    }
+
+    /// Configure CTS pin
+    pub fn with_cts<CTS: InputPin>(self, cts: impl Peripheral<P = CTS> + 'd) -> Self {
+        crate::into_ref!(cts);
+        cts.set_to_input(crate::private::Internal);
+        cts.connect_input_to_peripheral(T::cts_signal(), crate::private::Internal);
+
+        self
+    }
+
+    /// Configure RTS pin
+    pub fn with_rts<RTS: OutputPin>(self, rts: impl Peripheral<P = RTS> + 'd) -> Self {
+        crate::into_ref!(rts);
+        rts.set_to_push_pull_output(crate::private::Internal);
+        rts.connect_peripheral_to_output(T::rts_signal(), crate::private::Internal);
+
+        self
+    }
 }
 
 impl<'d, T, M> Uart<'d, T, M>

--- a/examples/src/bin/advanced_serial.rs
+++ b/examples/src/bin/advanced_serial.rs
@@ -20,7 +20,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    uart::{config::Config, TxRxPins, Uart},
+    uart::{config::Config, Uart},
 };
 use esp_println::println;
 use nb::block;
@@ -32,15 +32,9 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pins = TxRxPins::new_tx_rx(io.pins.gpio4, io.pins.gpio5);
 
-    let mut serial1 = Uart::new_with_config(
-        peripherals.UART1,
-        Config::default(),
-        Some(pins),
-        &clocks,
-        None,
-    );
+    let mut serial1 = Uart::new_with_config(peripherals.UART1, Config::default(), &clocks, None)
+        .with_tx_rx(io.pins.gpio4, io.pins.gpio5);
 
     let delay = Delay::new(&clocks);
 

--- a/examples/src/bin/advanced_serial.rs
+++ b/examples/src/bin/advanced_serial.rs
@@ -33,8 +33,7 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut serial1 = Uart::new_with_config(peripherals.UART1, Config::default(), &clocks, None)
-        .with_tx_rx(io.pins.gpio4, io.pins.gpio5);
+    let mut serial1 = Uart::new(peripherals.UART1, &clocks, io.pins.gpio4, io.pins.gpio5);
 
     let delay = Delay::new(&clocks);
 

--- a/examples/src/bin/advanced_serial.rs
+++ b/examples/src/bin/advanced_serial.rs
@@ -20,7 +20,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    uart::{config::Config, Uart},
+    uart::Uart,
 };
 use esp_println::println;
 use nb::block;
@@ -33,7 +33,7 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut serial1 = Uart::new(peripherals.UART1, &clocks, io.pins.gpio4, io.pins.gpio5);
+    let mut serial1 = Uart::new(peripherals.UART1, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
 
     let delay = Delay::new(&clocks);
 

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -14,6 +14,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    default_uart0_pins,
     gpio::Io,
     peripherals::{Peripherals, UART0},
     prelude::*,
@@ -86,20 +87,7 @@ async fn main(spawner: Spawner) {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Default pins for Uart/Serial communication
-    #[cfg(feature = "esp32")]
-    let (tx_pin, rx_pin) = (io.pins.gpio1, io.pins.gpio3);
-    #[cfg(feature = "esp32c2")]
-    let (tx_pin, rx_pin) = (io.pins.gpio20, io.pins.gpio19);
-    #[cfg(feature = "esp32c3")]
-    let (tx_pin, rx_pin) = (io.pins.gpio21, io.pins.gpio20);
-    #[cfg(feature = "esp32c6")]
-    let (tx_pin, rx_pin) = (io.pins.gpio16, io.pins.gpio17);
-    #[cfg(feature = "esp32h2")]
-    let (tx_pin, rx_pin) = (io.pins.gpio24, io.pins.gpio23);
-    #[cfg(feature = "esp32s2")]
-    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
-    #[cfg(feature = "esp32s3")]
-    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    let (tx_pin, rx_pin) = default_uart0_pins!(io);
 
     let mut uart0 = Uart::new_async_with_default_pins(peripherals.UART0, &clocks, tx_pin, rx_pin);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -20,7 +20,12 @@ use esp_hal::{
     prelude::*,
     system::SystemControl,
     timer::timg::TimerGroup,
-    uart::{config::AtCmdConfig, Uart, UartRx, UartTx},
+    uart::{
+        config::{AtCmdConfig, Config},
+        Uart,
+        UartRx,
+        UartTx,
+    },
     Async,
 };
 use static_cell::StaticCell;
@@ -89,11 +94,13 @@ async fn main(spawner: Spawner) {
     // Default pins for Uart/Serial communication
     let (tx_pin, rx_pin) = default_uart0_pins!(io);
 
-    let mut uart0 = Uart::new_async_with_default_pins(peripherals.UART0, &clocks, tx_pin, rx_pin);
+    let config = Config::default();
+    config.rx_fifo_full_threshold(READ_BUF_SIZE as u16);
+
+    let mut uart0 =
+        Uart::new_async_with_config(peripherals.UART0, config, &clocks, tx_pin, rx_pin).unwrap();
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
-    uart0
-        .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)
-        .unwrap();
+
     let (tx, rx) = uart0.split();
 
     static SIGNAL: StaticCell<Signal<NoopRawMutex, usize>> = StaticCell::new();

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -14,6 +14,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    gpio::Io,
     peripherals::{Peripherals, UART0},
     prelude::*,
     system::SystemControl,
@@ -82,7 +83,25 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new_async(peripherals.TIMG0, &clocks);
     esp_hal_embassy::init(&clocks, timg0);
 
-    let mut uart0 = Uart::new_async(peripherals.UART0, &clocks);
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    // Default pins for Uart/Serial communication
+    #[cfg(feature = "esp32")]
+    let (tx_pin, rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+    #[cfg(feature = "esp32c2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+    #[cfg(feature = "esp32c3")]
+    let (tx_pin, rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+    #[cfg(feature = "esp32c6")]
+    let (tx_pin, rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+    #[cfg(feature = "esp32h2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+    #[cfg(feature = "esp32s2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    #[cfg(feature = "esp32s3")]
+    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+
+    let mut uart0 = Uart::new_async_with_default_pins(peripherals.UART0, &clocks, tx_pin, rx_pin);
     uart0.set_at_cmd(AtCmdConfig::new(None, None, None, AT_CMD, None));
     uart0
         .set_rx_fifo_full_threshold(READ_BUF_SIZE as u16)

--- a/examples/src/bin/hello_world.rs
+++ b/examples/src/bin/hello_world.rs
@@ -17,6 +17,7 @@ use core::fmt::Write;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    default_uart0_pins,
     delay::Delay,
     gpio::Io,
     peripherals::Peripherals,
@@ -36,20 +37,7 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Default pins for Uart/Serial communication
-    #[cfg(feature = "esp32")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio1, io.pins.gpio3);
-    #[cfg(feature = "esp32c2")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio20, io.pins.gpio19);
-    #[cfg(feature = "esp32c3")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio21, io.pins.gpio20);
-    #[cfg(feature = "esp32c6")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
-    #[cfg(feature = "esp32h2")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
-    #[cfg(feature = "esp32s2")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);
-    #[cfg(feature = "esp32s3")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    let (mut tx_pin, mut rx_pin) = default_uart0_pins!(io);
 
     let mut uart0 =
         Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin);

--- a/examples/src/bin/hello_world.rs
+++ b/examples/src/bin/hello_world.rs
@@ -40,7 +40,7 @@ fn main() -> ! {
     let (mut tx_pin, mut rx_pin) = default_uart0_pins!(io);
 
     let mut uart0 =
-        Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin);
+        Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin).unwrap();
 
     loop {
         writeln!(uart0, "Hello world!").unwrap();

--- a/examples/src/bin/hello_world.rs
+++ b/examples/src/bin/hello_world.rs
@@ -18,6 +18,7 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,
+    gpio::Io,
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
@@ -32,7 +33,26 @@ fn main() -> ! {
 
     let delay = Delay::new(&clocks);
 
-    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    // Default pins for Uart/Serial communication
+    #[cfg(feature = "esp32")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+    #[cfg(feature = "esp32c2")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+    #[cfg(feature = "esp32c3")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+    #[cfg(feature = "esp32c6")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+    #[cfg(feature = "esp32h2")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+    #[cfg(feature = "esp32s2")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    #[cfg(feature = "esp32s3")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+
+    let mut uart0 =
+        Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin);
 
     loop {
         writeln!(uart0, "Hello world!").unwrap();

--- a/examples/src/bin/ieee802154_sniffer.rs
+++ b/examples/src/bin/ieee802154_sniffer.rs
@@ -10,6 +10,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    gpio::Io,
     peripherals::Peripherals,
     prelude::*,
     reset::software_reset,
@@ -25,7 +26,16 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let mut uart0 = Uart::new(peripherals.UART0, &clocks);
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    // Default pins for Uart/Serial communication
+    #[cfg(feature = "esp32c6")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+    #[cfg(feature = "esp32h2")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+
+    let mut uart0 =
+        Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin);
 
     // read two characters which get parsed as the channel
     let mut cnt = 0;

--- a/examples/src/bin/ieee802154_sniffer.rs
+++ b/examples/src/bin/ieee802154_sniffer.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     let (mut tx_pin, mut rx_pin) = default_uart0_pins!(io);
 
     let mut uart0 =
-        Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin);
+        Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin).unwrap();
 
     // read two characters which get parsed as the channel
     let mut cnt = 0;

--- a/examples/src/bin/ieee802154_sniffer.rs
+++ b/examples/src/bin/ieee802154_sniffer.rs
@@ -10,6 +10,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    default_uart0_pins,
     gpio::Io,
     peripherals::Peripherals,
     prelude::*,
@@ -29,10 +30,7 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Default pins for Uart/Serial communication
-    #[cfg(feature = "esp32c6")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
-    #[cfg(feature = "esp32h2")]
-    let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+    let (mut tx_pin, mut rx_pin) = default_uart0_pins!(io);
 
     let mut uart0 =
         Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin);

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -35,8 +35,14 @@ fn main() -> ! {
 
     // Set up (HP) UART1:
 
-    let mut uart1 = Uart::new_with_config(peripherals.UART1, Config::default(), &clocks, None)
-        .with_tx_rx(io.pins.gpio6, io.pins.gpio7);
+    let mut uart1 = Uart::new_with_config(
+        peripherals.UART1,
+        Config::default(),
+        &clocks,
+        None,
+        io.pins.gpio6,
+        io.pins.gpio7,
+    );
 
     // Set up (LP) UART:
     let lp_tx = LowPowerOutput::new(io.pins.gpio5);

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -42,7 +42,8 @@ fn main() -> ! {
         None,
         io.pins.gpio6,
         io.pins.gpio7,
-    );
+    )
+    .unwrap();
 
     // Set up (LP) UART:
     let lp_tx = LowPowerOutput::new(io.pins.gpio5);

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -21,7 +21,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    uart::{config::Config, lp_uart::LpUart, TxRxPins, Uart},
+    uart::{config::Config, lp_uart::LpUart, Uart},
 };
 use esp_println::println;
 
@@ -35,15 +35,8 @@ fn main() -> ! {
 
     // Set up (HP) UART1:
 
-    let pins = TxRxPins::new_tx_rx(io.pins.gpio6, io.pins.gpio7);
-
-    let mut uart1 = Uart::new_with_config(
-        peripherals.UART1,
-        Config::default(),
-        Some(pins),
-        &clocks,
-        None,
-    );
+    let mut uart1 = Uart::new_with_config(peripherals.UART1, Config::default(), &clocks, None)
+        .with_tx_rx(io.pins.gpio6, io.pins.gpio7);
 
     // Set up (LP) UART:
     let lp_tx = LowPowerOutput::new(io.pins.gpio5);

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -14,7 +14,7 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,
-    gpio,
+    gpio::Io,
     peripherals::{Peripherals, UART0},
     prelude::*,
     system::SystemControl,
@@ -35,11 +35,31 @@ fn main() -> ! {
 
     let delay = Delay::new(&clocks);
 
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    // Default pins for Uart/Serial communication
+    #[cfg(feature = "esp32")]
+    let (tx_pin, rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+    #[cfg(feature = "esp32c2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+    #[cfg(feature = "esp32c3")]
+    let (tx_pin, rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+    #[cfg(feature = "esp32c6")]
+    let (tx_pin, rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+    #[cfg(feature = "esp32h2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+    #[cfg(feature = "esp32s2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    #[cfg(feature = "esp32s3")]
+    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+
     let mut uart0 = Uart::new_with_config(
         peripherals.UART0,
         Config::default(),
         &clocks,
         Some(interrupt_handler),
+        tx_pin,
+        rx_pin,
     );
 
     critical_section::with(|cs| {

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -20,7 +20,6 @@ use esp_hal::{
     system::SystemControl,
     uart::{
         config::{AtCmdConfig, Config},
-        TxRxPins,
         Uart,
     },
     Blocking,
@@ -39,7 +38,6 @@ fn main() -> ! {
     let mut uart0 = Uart::new_with_config(
         peripherals.UART0,
         Config::default(),
-        None::<TxRxPins<gpio::NoPinType, gpio::NoPinType>>,
         &clocks,
         Some(interrupt_handler),
     );

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -41,18 +41,21 @@ fn main() -> ! {
     // Default pins for Uart/Serial communication
     let (tx_pin, rx_pin) = default_uart0_pins!(io);
 
+    let config = Config::default();
+    config.rx_fifo_full_threshold(30);
+
     let mut uart0 = Uart::new_with_config(
         peripherals.UART0,
-        Config::default(),
+        config,
         &clocks,
         Some(interrupt_handler),
         tx_pin,
         rx_pin,
-    );
+    )
+    .unwrap();
 
     critical_section::with(|cs| {
         uart0.set_at_cmd(AtCmdConfig::new(None, None, None, b'#', None));
-        uart0.set_rx_fifo_full_threshold(30).unwrap();
         uart0.listen_at_cmd();
         uart0.listen_rx_fifo_full();
 

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -13,6 +13,7 @@ use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
+    default_uart0_pins,
     delay::Delay,
     gpio::Io,
     peripherals::{Peripherals, UART0},
@@ -38,20 +39,7 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Default pins for Uart/Serial communication
-    #[cfg(feature = "esp32")]
-    let (tx_pin, rx_pin) = (io.pins.gpio1, io.pins.gpio3);
-    #[cfg(feature = "esp32c2")]
-    let (tx_pin, rx_pin) = (io.pins.gpio20, io.pins.gpio19);
-    #[cfg(feature = "esp32c3")]
-    let (tx_pin, rx_pin) = (io.pins.gpio21, io.pins.gpio20);
-    #[cfg(feature = "esp32c6")]
-    let (tx_pin, rx_pin) = (io.pins.gpio16, io.pins.gpio17);
-    #[cfg(feature = "esp32h2")]
-    let (tx_pin, rx_pin) = (io.pins.gpio24, io.pins.gpio23);
-    #[cfg(feature = "esp32s2")]
-    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
-    #[cfg(feature = "esp32s3")]
-    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    let (tx_pin, rx_pin) = default_uart0_pins!(io);
 
     let mut uart0 = Uart::new_with_config(
         peripherals.UART0,

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -73,6 +73,16 @@ name              = "uart_async"
 harness           = false
 required-features = ["async", "embassy"]
 
+[[test]]
+name    = "uart_tx_rx"
+harness = false
+
+
+[[test]]
+name    = "uart_tx_rx_async"
+harness = false
+
+
 [dependencies]
 cfg-if             = "1.0.0"
 critical-section   = "1.1.2"

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -17,7 +17,7 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::{ClockControl, Clocks},
     gpio::Io,
-    peripherals::{Peripherals, UART0},
+    peripherals::{Peripherals, UART1},
     prelude::*,
     system::SystemControl,
     uart::{ClockSource, Uart},
@@ -27,7 +27,7 @@ use nb::block;
 
 struct Context {
     clocks: Clocks<'static>,
-    uart: Uart<'static, UART0, Blocking>,
+    uart: Uart<'static, UART1, Blocking>,
 }
 
 impl Context {
@@ -38,7 +38,7 @@ impl Context {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let uart = Uart::new(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio4);
+        let uart = Uart::new(peripherals.UART1, &clocks, io.pins.gpio2, io.pins.gpio4);
 
         Context { clocks, uart }
     }

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -20,7 +20,7 @@ use esp_hal::{
     peripherals::{Peripherals, UART0},
     prelude::*,
     system::SystemControl,
-    uart::{config::Config, ClockSource, TxRxPins, Uart},
+    uart::{config::Config, ClockSource, Uart},
     Blocking,
 };
 use nb::block;
@@ -37,15 +37,9 @@ impl Context {
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let pins = TxRxPins::new_tx_rx(io.pins.gpio2, io.pins.gpio4);
 
-        let uart = Uart::new_with_config(
-            peripherals.UART0,
-            Config::default(),
-            Some(pins),
-            &clocks,
-            None,
-        );
+        let uart = Uart::new_with_config(peripherals.UART0, Config::default(), &clocks, None)
+            .with_tx_rx(io.pins.gpio2, io.pins.gpio4);
 
         Context { clocks, uart }
     }

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -20,7 +20,7 @@ use esp_hal::{
     peripherals::{Peripherals, UART0},
     prelude::*,
     system::SystemControl,
-    uart::{config::Config, ClockSource, Uart},
+    uart::{ClockSource, Uart},
     Blocking,
 };
 use nb::block;

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -38,7 +38,7 @@ impl Context {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let uart = Uart::new(peripherals.UART1, &clocks, io.pins.gpio2, io.pins.gpio4);
+        let uart = Uart::new(peripherals.UART1, &clocks, io.pins.gpio2, io.pins.gpio4).unwrap();
 
         Context { clocks, uart }
     }

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -38,8 +38,7 @@ impl Context {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let uart = Uart::new_with_config(peripherals.UART0, Config::default(), &clocks, None)
-            .with_tx_rx(io.pins.gpio2, io.pins.gpio4);
+        let uart = Uart::new(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio4);
 
         Context { clocks, uart }
     }

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -34,11 +34,8 @@ impl Context {
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let uart =
-            Uart::new_async_with_config(peripherals.UART0, Config::default(), &clocks).with_tx_rx(
-                io.pins.gpio2,
-                io.pins.gpio4,
-            );
+        let uart = Uart::new_async_with_config(peripherals.UART0, Config::default(), &clocks)
+            .with_tx_rx(io.pins.gpio2, io.pins.gpio4);
         let (tx, rx) = uart.split();
 
         Context { rx, tx }

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -18,7 +18,7 @@ use esp_hal::{
     gpio::Io,
     peripherals::{Peripherals, UART0},
     system::SystemControl,
-    uart::{config::Config, TxRxPins, Uart, UartRx, UartTx},
+    uart::{config::Config, Uart, UartRx, UartTx},
     Async,
 };
 
@@ -33,10 +33,12 @@ impl Context {
         let system = SystemControl::new(peripherals.SYSTEM);
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let pins = TxRxPins::new_tx_rx(io.pins.gpio2, io.pins.gpio4);
 
         let uart =
-            Uart::new_async_with_config(peripherals.UART0, Config::default(), Some(pins), &clocks);
+            Uart::new_async_with_config(peripherals.UART0, Config::default(), &clocks).with_tx_rx(
+                io.pins.gpio2,
+                io.pins.gpio4,
+            );
         let (tx, rx) = uart.split();
 
         Context { rx, tx }

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -34,8 +34,7 @@ impl Context {
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let uart = Uart::new_async_with_config(peripherals.UART0, Config::default(), &clocks)
-            .with_tx_rx(io.pins.gpio2, io.pins.gpio4);
+        let uart = Uart::new_async(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio4);
         let (tx, rx) = uart.split();
 
         Context { rx, tx }

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -33,7 +33,8 @@ impl Context {
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let uart = Uart::new_async(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio4);
+        let uart =
+            Uart::new_async(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio4).unwrap();
 
         Context { uart }
     }

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -1,0 +1,68 @@
+//! UART TX/RX Test
+//!
+//! Folowing pins are used:
+//! TX    GPIP2
+//! RX    GPIO4
+//!
+//! Connect TX (GPIO2) and RX (GPIO4) pins.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use esp_backtrace as _;
+use esp_hal::{
+    gpio::Io,
+    peripherals::{Peripherals, UART0, UART1},
+    prelude::*,
+    system::SystemControl,
+    uart::{UartRx, UartTx},
+    Blocking,
+};
+use nb::block;
+
+struct Context {
+    tx: UartTx<'static, UART0, Blocking>,
+    rx: UartRx<'static, UART1, Blocking>,
+}
+
+impl Context {
+    pub fn init() -> Self {
+        let peripherals = Peripherals::take();
+        let _system = SystemControl::new(peripherals.SYSTEM);
+
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+        let tx = UartTx::new(peripherals.UART0, io.pins.gpio2);
+        let rx = UartRx::new(peripherals.UART1, io.pins.gpio4);
+
+        Context { tx, rx }
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use defmt::assert_eq;
+
+    use super::*;
+
+    #[init]
+    fn init() -> Context {
+        Context::init()
+    }
+
+    #[test]
+    #[timeout(3)]
+    fn test_send_receive(mut ctx: Context) {
+        let byte = [0x42];
+
+        ctx.tx.flush_tx().unwrap();
+        ctx.tx.write_bytes(&byte).unwrap();
+        let read = block!(ctx.rx.read_byte());
+
+        assert_eq!(read, Ok(0x42));
+    }
+}

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -14,6 +14,7 @@
 use defmt_rtt as _;
 use esp_backtrace as _;
 use esp_hal::{
+    clock::ClockControl,
     gpio::Io,
     peripherals::{Peripherals, UART0, UART1},
     prelude::*,
@@ -31,12 +32,13 @@ struct Context {
 impl Context {
     pub fn init() -> Self {
         let peripherals = Peripherals::take();
-        let _system = SystemControl::new(peripherals.SYSTEM);
+        let system = SystemControl::new(peripherals.SYSTEM);
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let tx = UartTx::new(peripherals.UART0, io.pins.gpio2);
-        let rx = UartRx::new(peripherals.UART1, io.pins.gpio4);
+        let tx = UartTx::new(peripherals.UART0, &clocks, None, io.pins.gpio2);
+        let rx = UartRx::new(peripherals.UART1, &clocks, None, io.pins.gpio4);
 
         Context { tx, rx }
     }

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -37,8 +37,8 @@ impl Context {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let tx = UartTx::new(peripherals.UART0, &clocks, None, io.pins.gpio2);
-        let rx = UartRx::new(peripherals.UART1, &clocks, None, io.pins.gpio4);
+        let tx = UartTx::new(peripherals.UART0, &clocks, None, io.pins.gpio2).unwrap();
+        let rx = UartRx::new(peripherals.UART1, &clocks, None, io.pins.gpio4).unwrap();
 
         Context { tx, rx }
     }

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -43,7 +43,7 @@ impl Context {
 }
 
 #[cfg(test)]
-#[embedded_test::tests(executor = esp_hal::embassy::executor::Executor::new())]
+#[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
     use defmt::assert_eq;
 

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -18,7 +18,7 @@ use esp_hal::{
     gpio::Io,
     peripherals::{Peripherals, UART0, UART1},
     system::SystemControl,
-    uart::{UartRx, UartTx, Uart},
+    uart::{UartRx, UartTx},
     Async,
 };
 
@@ -34,9 +34,6 @@ impl Context {
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-
-        // let uart = Uart::new_async(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio4);
-        // let (tx, rx) = uart.split();
 
         let tx = UartTx::new_async(peripherals.UART0, &clocks, io.pins.gpio2);
         let rx = UartRx::new_async(peripherals.UART1, &clocks, io.pins.gpio4);

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -1,0 +1,67 @@
+//! UART TX/RX Async Test
+//!
+//! Folowing pins are used:
+//! TX    GPIP2
+//! RX    GPIO4
+//!
+//! Connect TX (GPIO2) and RX (GPIO4) pins.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use esp_backtrace as _;
+use esp_hal::{
+    gpio::Io,
+    peripherals::{Peripherals, UART0, UART1},
+    system::SystemControl,
+    uart::{UartRx, UartTx},
+    Async,
+};
+
+struct Context {
+    tx: UartTx<'static, UART0, Async>,
+    rx: UartRx<'static, UART1, Async>,
+}
+
+impl Context {
+    pub fn init() -> Self {
+        let peripherals = Peripherals::take();
+        let _system = SystemControl::new(peripherals.SYSTEM);
+
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+        let tx = UartTx::new_async(peripherals.UART0, io.pins.gpio2);
+        let rx = UartRx::new_async(peripherals.UART1, io.pins.gpio4);
+
+        Context { tx, rx }
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests(executor = esp_hal::embassy::executor::Executor::new())]
+mod tests {
+    use defmt::assert_eq;
+
+    use super::*;
+
+    #[init]
+    async fn init() -> Context {
+        Context::init()
+    }
+
+    #[test]
+    #[timeout(3)]
+    async fn test_send_receive(mut ctx: Context) {
+        let byte = [0x42];
+        let mut read = [0u8; 1];
+
+        ctx.tx.flush_async().await.unwrap();
+        ctx.tx.write_async(&byte).await.unwrap();
+        let read = ctx.rx.read_async(&mut read).await;
+
+        assert_eq!(read, Ok(0x42));
+    }
+}

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -35,8 +35,8 @@ impl Context {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let tx = UartTx::new_async(peripherals.UART0, &clocks, io.pins.gpio2);
-        let rx = UartRx::new_async(peripherals.UART1, &clocks, io.pins.gpio4);
+        let tx = UartTx::new_async(peripherals.UART0, &clocks, io.pins.gpio2).unwrap();
+        let rx = UartRx::new_async(peripherals.UART1, &clocks, io.pins.gpio4).unwrap();
 
         Context { tx, rx }
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [X] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- `Uart` constructors now take tx and rx pins. 
- Added `new_with_default_pins` constructor which uses the defaults Serial/UART gpios.
  - This made some examples/tests a bit noisy with some cfgs arrounds.
- Added constructor for `UartTx` and UartRx`.
- Introduced the following methods:  `with_cts`, `with_rts`
- Removed  the `configure_pin`s methods.
- Fix https://github.com/esp-rs/esp-hal/issues/1544 

#### Testing
- Tested that #1544 is fixed with the following reproducer:

<details>
<summary>Reproducer example</summary>

```rust
//! Issue 1544

//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
#![no_std]
#![no_main]

use esp_backtrace as _;
use esp_hal::{
    clock::ClockControl,
    delay::Delay,
    gpio::{Io, Level, Output},
    peripherals::Peripherals,
    prelude::*,
    system::SystemControl,
    uart::{config::Config, Uart},
};
use esp_println::println;
use nb::block;

#[entry]
fn main() -> ! {
    let peripherals = Peripherals::take();
    let system = SystemControl::new(peripherals.SYSTEM);
    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);

    // Issue - This built before
    // let pins = TxRxPins::new_tx_rx(&mut io.pins.gpio4, &mut io.pins.gpio2);
    // let mut serial1 = Uart::new_with_config(
    //     peripherals.UART1,
    //     Config::default(),
    //     Some(pins),
    //     &clocks,
    //     None,
    // );
    // let _led = Output::new(io.pins.gpio4, Level::High);

    // Solution
    let mut serial1 = Uart::new(peripherals.UART1, &clocks, io.pins.gpio4, io.pins.gpio2);

    // let _led = Output::new(io.pins.gpio4, Level::High); // This fails to build

    let delay = Delay::new(&clocks);

    println!("Start");
    loop {
        serial1.write_byte(0x42).ok();
        let read = block!(serial1.read_byte());

        match read {
            Ok(read) => println!("Read 0x{:02x}", read),
            Err(err) => println!("Error {:?}", err),
        }

        delay.delay_millis(250);
    }
}
```
</details>

- Run HIL workflow: https://github.com/esp-rs/esp-hal/actions/runs/9399078057
  - `uart` test is failing for Xtensa devices (S2 and S3)
- Locally tested the `uart`, `uart_async`, `uart_tx_rx`, and `uart_tx_rx_async` test for H2. 
