### PR TITLE
Use `esp` toolchain for all `clippy` checks, add `--check` option to `fmt-packages` subcommand in `xtask`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,43 +220,7 @@ jobs:
   # --------------------------------------------------------------------------
   # Lint
 
-  clippy-riscv:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: nightly
-          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
-          components: clippy,rust-src
-      - uses: Swatinem/rust-cache@v2
-
-      # Run 'cargo clippy' on all packages targeting RISC-V:
-      ## esp-hal:
-      - name: clippy (esp-hal, esp32c2)
-        run: cd esp-hal && cargo clippy --features=esp32c2 --target=riscv32imc-unknown-none-elf -- -D warnings
-      - name: clippy (esp-hal, esp32c3)
-        run: cd esp-hal && cargo clippy --features=esp32c3 --target=riscv32imc-unknown-none-elf -- -D warnings
-      - name: clippy (esp-hal, esp32c6)
-        run: cd esp-hal && cargo clippy --features=esp32c6 --target=riscv32imac-unknown-none-elf -- -D warnings
-      - name: clippy (esp-hal, esp32h2)
-        run: cd esp-hal && cargo clippy --features=esp32h2 --target=riscv32imac-unknown-none-elf -- -D warnings
-      ## esp-hal-smartled:
-      - name: clippy (esp-hal-smartled)
-        run: cd esp-hal-smartled && cargo clippy --features=esp32c6 --target=riscv32imac-unknown-none-elf -- -D warnings
-      ## esp-lp-hal:
-      - name: clippy (esp-lp-hal, esp32c6)
-        run: cd esp-lp-hal && cargo clippy --features=esp32c6 --target=riscv32imac-unknown-none-elf -- -D warnings
-      - name: clippy (esp-lp-hal, esp32s2)
-        run: cd esp-lp-hal && cargo clippy --features=esp32s2 --target=riscv32imc-unknown-none-elf -- -D warnings
-      - name: clippy (esp-lp-hal, esp32s3)
-        run: cd esp-lp-hal && cargo clippy --features=esp32s3 --target=riscv32imc-unknown-none-elf -- -D warnings
-      # esp-riscv-rt:
-      - name: clippy (esp-riscv-rt)
-        run: cd esp-riscv-rt && cargo clippy --target=riscv32imc-unknown-none-elf -- -D warnings
-
-  clippy-xtensa:
+  clippy:
     runs-on: ubuntu-latest
 
     steps:
@@ -267,13 +231,34 @@ jobs:
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
 
-      # Run 'cargo clippy' on all packages targeting Xtensa:
+      ## esp-hal:
       - name: clippy (esp-hal, esp32)
         run: cd esp-hal && cargo clippy -Zbuild-std=core --features=esp32 --target=xtensa-esp32-none-elf -- -D warnings
+      - name: clippy (esp-hal, esp32c2)
+        run: cd esp-hal && cargo clippy -Zbuild-std=core --features=esp32c2 --target=riscv32imc-unknown-none-elf -- -D warnings
+      - name: clippy (esp-hal, esp32c3)
+        run: cd esp-hal && cargo clippy -Zbuild-std=core --features=esp32c3 --target=riscv32imc-unknown-none-elf -- -D warnings
+      - name: clippy (esp-hal, esp32c6)
+        run: cd esp-hal && cargo clippy -Zbuild-std=core --features=esp32c6 --target=riscv32imac-unknown-none-elf -- -D warnings
+      - name: clippy (esp-hal, esp32h2)
+        run: cd esp-hal && cargo clippy -Zbuild-std=core --features=esp32h2 --target=riscv32imac-unknown-none-elf -- -D warnings
       - name: clippy (esp-hal, esp32s2)
         run: cd esp-hal && cargo clippy -Zbuild-std=core --features=esp32s2 --target=xtensa-esp32s2-none-elf -- -D warnings
       - name: clippy (esp-hal, esp32s3)
         run: cd esp-hal && cargo clippy -Zbuild-std=core --features=esp32s3 --target=xtensa-esp32s3-none-elf -- -D warnings
+      ## esp-hal-smartled:
+      - name: clippy (esp-hal-smartled)
+        run: cd esp-hal-smartled && cargo clippy -Zbuild-std=core --features=esp32c6 --target=riscv32imac-unknown-none-elf -- -D warnings
+      ## esp-lp-hal:
+      - name: clippy (esp-lp-hal, esp32c6)
+        run: cd esp-lp-hal && cargo clippy -Zbuild-std=core --features=esp32c6 --target=riscv32imac-unknown-none-elf -- -D warnings
+      - name: clippy (esp-lp-hal, esp32s2)
+        run: cd esp-lp-hal && cargo clippy -Zbuild-std=core --features=esp32s2 --target=riscv32imc-unknown-none-elf -- -D warnings
+      - name: clippy (esp-lp-hal, esp32s3)
+        run: cd esp-lp-hal && cargo clippy -Zbuild-std=core --features=esp32s3 --target=riscv32imc-unknown-none-elf -- -D warnings
+      # esp-riscv-rt:
+      - name: clippy (esp-riscv-rt)
+        run: cd esp-riscv-rt && cargo clippy -Zbuild-std=core --target=riscv32imc-unknown-none-elf -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,18 +289,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       # Check the formatting of all packages:
-      - name: rustfmt (esp-hal)
-        run: cargo fmt --all --manifest-path=esp-hal/Cargo.toml -- --check
-      - name: rustfmt (esp-hal-procmacros)
-        run: cargo fmt --all --manifest-path=esp-hal-procmacros/Cargo.toml -- --check
-      - name: rustfmt (esp-hal-smartled)
-        run: cargo fmt --all --manifest-path=esp-hal-smartled/Cargo.toml -- --check
-      - name: rustfmt (esp-lp-hal)
-        run: cargo fmt --all --manifest-path=esp-lp-hal/Cargo.toml -- --check
-      - name: rustfmt (esp-riscv-rt)
-        run: cargo fmt --all --manifest-path=esp-riscv-rt/Cargo.toml -- --check
-      - name: rustfmt (examples)
-        run: cargo fmt --all --manifest-path=examples/Cargo.toml -- --check
+      - run: cargo xtask fmt-packages --check
+
+  # --------------------------------------------------------------------------
+  # Tests
 
   hil:
     name: HIL Test | ${{ matrix.target.soc }}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -545,6 +545,24 @@ pub fn generate_efuse_table(
 // ----------------------------------------------------------------------------
 // Helper Functions
 
+/// Return a (sorted) list of paths to each valid Cargo package in the
+/// workspace.
+pub fn package_paths(workspace: &Path) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(workspace)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            if entry.path().join("Cargo.toml").exists() {
+                paths.push(entry.path());
+            }
+        }
+    }
+
+    paths.sort();
+
+    Ok(paths)
+}
+
 /// Parse the version from the specified package's Cargo manifest.
 pub fn package_version(workspace: &Path, package: Package) -> Result<semver::Version> {
     #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
I had planned on creating an `xtask` subcommand to run our `clippy` lints as well, however this will be a bit more involved than I initially anticipated so will be in a subsequent PR. Just opening this PR to get CI green again.
