### PR TITLE
esp-hal: rmt: make ChannelCreator public

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DMA transactions are now found in the `dma` module (#1550)
 - Remove unnecessary generics from PARL_IO driver (#1545)
 - Use `Level enum` in GPIO constructors instead of plain bools (#1574) 
+- rmt: make ChannelCreator public (#1597)
 
 ### Removed
 

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -209,6 +209,7 @@ pub struct RxChannelConfig {
 }
 
 pub use impl_for_chip::Rmt;
+pub use impl_for_chip::ChannelCreator;
 
 #[cfg(feature = "async")]
 use self::asynch::{RxChannelAsync, TxChannelAsync};
@@ -949,6 +950,8 @@ mod impl_for_chip {
         }
     }
 
+    /// RMT Channel Creator
+    #[allow(missing_docs)]
     pub struct ChannelCreator<M, const CHANNEL: u8>
     where
         M: crate::Mode,

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -684,6 +684,8 @@ mod impl_for_chip {
         }
     }
 
+    /// RMT Channel Creator
+    #[allow(missing_docs)]
     pub struct ChannelCreator<M, const CHANNEL: u8>
     where
         M: crate::Mode,
@@ -767,6 +769,8 @@ mod impl_for_chip {
         }
     }
 
+    /// RMT Channel Creator
+    #[allow(missing_docs)]
     pub struct ChannelCreator<M, const CHANNEL: u8>
     where
         M: crate::Mode,
@@ -858,6 +862,8 @@ mod impl_for_chip {
         }
     }
 
+    /// RMT Channel Creator
+    #[allow(missing_docs)]
     pub struct ChannelCreator<M, const CHANNEL: u8>
     where
         M: crate::Mode,

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -685,7 +685,6 @@ mod impl_for_chip {
     }
 
     /// RMT Channel Creator
-    #[allow(missing_docs)]
     pub struct ChannelCreator<M, const CHANNEL: u8>
     where
         M: crate::Mode,
@@ -770,7 +769,6 @@ mod impl_for_chip {
     }
 
     /// RMT Channel Creator
-    #[allow(missing_docs)]
     pub struct ChannelCreator<M, const CHANNEL: u8>
     where
         M: crate::Mode,
@@ -863,7 +861,6 @@ mod impl_for_chip {
     }
 
     /// RMT Channel Creator
-    #[allow(missing_docs)]
     pub struct ChannelCreator<M, const CHANNEL: u8>
     where
         M: crate::Mode,
@@ -956,7 +953,6 @@ mod impl_for_chip {
     }
 
     /// RMT Channel Creator
-    #[allow(missing_docs)]
     pub struct ChannelCreator<M, const CHANNEL: u8>
     where
         M: crate::Mode,

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -208,8 +208,7 @@ pub struct RxChannelConfig {
     pub idle_threshold: u16,
 }
 
-pub use impl_for_chip::Rmt;
-pub use impl_for_chip::ChannelCreator;
+pub use impl_for_chip::{ChannelCreator, Rmt};
 
 #[cfg(feature = "async")]
 use self::asynch::{RxChannelAsync, TxChannelAsync};


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
When using an Rmt channel you access `rmt.channel0` to grab channel 0.  However its type `ChannelCreator<>` is not public and can't be named as a function arg or struct member.  This PR makes that public.

#### Testing
Compiled/Run in a local project where I add the rmt channels as struct members.
