### PR TITLE
Improve `xtask` on Windows

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -7,6 +7,8 @@ use std::{
 
 use anyhow::{bail, Result};
 
+use crate::windows_safe_path;
+
 #[derive(Debug, PartialEq)]
 pub enum CargoAction {
     Build,
@@ -23,8 +25,7 @@ pub fn run(args: &[String], cwd: &Path) -> Result<()> {
     // That would make `OUT_DIR` a UNC which will trigger things like the one fixed in https://github.com/dtolnay/rustversion/pull/51
     // While it's fixed in `rustversion` it's not fixed for other crates we are
     // using now or in future!
-    #[cfg(target_os = "windows")]
-    let cwd = cwd.to_string_lossy().replace("\\\\?\\", "");
+    let cwd = windows_safe_path(cwd);
 
     let status = Command::new(get_cargo())
         .args(args)


### PR DESCRIPTION
`lint-packages` wasn't working on Windows because `OUT_DIR` was set to a UNC-path (Which causes problems like this one:  https://github.com/dtolnay/rustversion/pull/50#issue-2294817485

While `include!`'s docs say:
_The provided path is interpreted in a platform-specific way at compile time. So, for instance, an invocation with a Windows path containing backslashes \ would not compile correctly on Unix._ (See https://doc.rust-lang.org/std/macro.include.html) 

it often works with `/` on Windows because of https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry (_File I/O functions in the Windows API convert "/" to "\" as part of converting the name to an NT-style name, except when using the "\\?\" prefix_)

While `rustversion` already fixed that, other crates didn't and running `cargo xtask lint-packages` didn't work on Windows. Even if the currently used crates would all be fixed, we might start using an unfixed one in future.
