### PR TITLE
esp-wifi: fix unused timer result

### DIFF
--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -268,7 +268,7 @@ pub fn initialize(
     init_radio_clock_control(radio_clocks);
     init_rng(rng);
     init_tasks();
-    setup_timer_isr(timer);
+    setup_timer_isr(timer)?;
     wifi_set_log_verbose();
     init_clocks();
 
@@ -314,6 +314,13 @@ pub enum InitializationError {
     #[cfg(feature = "wifi")]
     WifiError(WifiError),
     WrongClockConfig,
+    Timer(hal::timer::Error),
+}
+
+impl From<hal::timer::Error> for InitializationError {
+    fn from(value: hal::timer::Error) -> Self {
+        InitializationError::Timer(value)
+    }
 }
 
 #[cfg(feature = "wifi")]

--- a/esp-wifi/src/timer/mod.rs
+++ b/esp-wifi/src/timer/mod.rs
@@ -14,14 +14,15 @@ mod arch_specific;
 pub use arch_specific::*;
 pub use chip_specific::*;
 
-pub fn setup_timer_isr(timebase: TimeBase) {
+pub fn setup_timer_isr(timebase: TimeBase) -> Result<(), esp_hal::timer::Error> {
     setup_radio_isr();
 
-    setup_timer(timebase);
+    setup_timer(timebase)?;
 
     setup_multitasking();
 
     yield_task();
+    Ok(())
 }
 
 #[allow(unused)]

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -26,7 +26,7 @@ const TIMESLICE_FREQUENCY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CO
 // Time keeping
 pub const TICKS_PER_SECOND: u64 = 1_000_000;
 
-pub fn setup_timer(systimer: TimeBase) {
+pub fn setup_timer(systimer: TimeBase) -> Result<(), esp_hal::timer::Error> {
     // make sure the scheduling won't start before everything is setup
     riscv::interrupt::disable();
 
@@ -50,6 +50,7 @@ pub fn setup_timer(systimer: TimeBase) {
         Interrupt::SYSTIMER_TARGET0,
         interrupt::Priority::Priority1,
     ));
+    Ok(())
 }
 
 pub fn setup_multitasking() {

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -30,7 +30,7 @@ pub fn get_systimer_count() -> u64 {
     esp_hal::time::current_time().ticks()
 }
 
-pub fn setup_timer(timer1: TimeBase) {
+pub fn setup_timer(timer1: TimeBase) -> Result<(), esp_hal::timer::Error> {
     unsafe {
         interrupt::bind_interrupt(
             peripherals::Interrupt::TG1_T0_LEVEL,
@@ -44,11 +44,12 @@ pub fn setup_timer(timer1: TimeBase) {
     ));
 
     timer1.listen();
-    timer1.load_value(TIMESLICE_FREQUENCY.into_duration());
+    timer1.load_value(TIMESLICE_FREQUENCY.into_duration())?;
     timer1.start();
     critical_section::with(|cs| {
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
+    Ok(())
 }
 
 pub fn setup_multitasking() {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
With the latest Timer updates load_value() on xtensa now returns a possible error.  This PR propagates that error and eliminates a warning about unused result.

#### Testing
Run on esp32-s3
