### PR TITLE
Fix feeding of `RWDT`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - spi: fix dma wrong mode when using eh1 blocking api (#1541)
 - uart: make `uart::UartRx::read_byte` public (#1547)
 - Fix async serial-usb-jtag (#1561)
+- Feeding `RWDT` now actually works (#1645)
 
 ### Changed
 
@@ -44,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactoring of GPIO module, have drivers for Input,Output,OutputOpenDrain, all drivers setup their GPIOs correctly (#1542)
 - DMA transactions are now found in the `dma` module (#1550)
 - Remove unnecessary generics from PARL_IO driver (#1545)
-- Use `Level enum` in GPIO constructors instead of plain bools (#1574) 
+- Use `Level enum` in GPIO constructors instead of plain bools (#1574)
 - rmt: make ChannelCreator public (#1597)
 
 ### Removed

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -788,7 +788,10 @@ impl Rwdt {
         let rtc_cntl = unsafe { &*LP_WDT::PTR };
 
         self.set_write_protection(false);
-        rtc_cntl.wdtfeed().write(|w| unsafe { w.bits(1) });
+        #[cfg(any(esp32c6, esp32h2))]
+        rtc_cntl.wdtfeed().write(|w| w.rtc_wdt_feed().set_bit());
+        #[cfg(not(any(esp32c6, esp32h2)))]
+        rtc_cntl.wdtfeed().write(|w| w.wdt_feed().set_bit());
         self.set_write_protection(true);
     }
 


### PR DESCRIPTION
The feed bit is the highest bit, so I guess that the previous implementation was setting the lowest bit instead.

Closes #1534