### PR TITLE
Housekeeping

### DIFF
--- a/esp-alloc/README.md
+++ b/esp-alloc/README.md
@@ -1,10 +1,10 @@
 # esp-alloc
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/esp-rs/esp-alloc/ci.yml?label=CI&logo=github&style=flat-square)
-[![Crates.io](https://img.shields.io/crates/v/esp-alloc?color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-alloc)
-[![docs.rs](https://img.shields.io/docsrs/esp-alloc?color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-alloc)
-![MSRV](https://img.shields.io/badge/MSRV-1.68-blue?style=flat-square)
-![Crates.io](https://img.shields.io/crates/l/esp-alloc?style=flat-square)
+[![Crates.io](https://img.shields.io/crates/v/esp-alloc?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-alloc)
+[![docs.rs](https://img.shields.io/docsrs/esp-alloc?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-alloc)
+![MSRV](https://img.shields.io/badge/MSRV-1.68-blue?labelColor=1C2C2E&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-alloc?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
 A simple `no_std` heap allocator for RISC-V and Xtensa processors from Espressif. Supports all currently available ESP32 devices.
 

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name        = "esp-backtrace"
-version     = "0.11.1"
-edition     = "2021"
-description = "Bare-metal backtrace support for ESP32"
-repository  = "https://github.com/esp-rs/esp-hal"
-license     = "MIT OR Apache-2.0"
+name         = "esp-backtrace"
+version      = "0.11.1"
+edition      = "2021"
+rust-version = "1.76.0"
+description  = "Bare-metal backtrace support for ESP32"
+repository   = "https://github.com/esp-rs/esp-hal"
+license      = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"

--- a/esp-backtrace/README.md
+++ b/esp-backtrace/README.md
@@ -1,5 +1,11 @@
 # esp-backtrace - backtrace for ESP32 bare-metal
 
+[![Crates.io](https://img.shields.io/crates/v/esp-backtrace?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-backtrace)
+[![docs.rs](https://img.shields.io/docsrs/esp-backtrace?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-backtrace)
+![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-backtrace?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
+
 Supports the ESP32, ESP32-C2/C3/C6, ESP32-H2, ESP32-P4, and ESP32-S2/S3. Optional exception and panic handlers are included, both of which can be enabled via their respective features.
 
 Please note that when targeting a RISC-V device, you **need** to force frame pointers (i.e. `"-C", "force-frame-pointers",` in your `.cargo/config.toml`); this is **not** required for Xtensa.
@@ -12,7 +18,7 @@ When using the panic and/or exception handler make sure to include `use esp_back
 ## Features
 
 | Feature           | Description                                                                                                        |
-|-------------------| ------------------------------------------------------------------------------------------------------------------ |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
 | esp32             | Target ESP32                                                                                                       |
 | esp32c2           | Target ESP32-C2                                                                                                    |
 | esp32c3           | Target ESP32-C3                                                                                                    |

--- a/esp-ieee802154/README.md
+++ b/esp-ieee802154/README.md
@@ -1,9 +1,9 @@
 # esp-ieee802154
 
-[![Crates.io](https://img.shields.io/crates/v/esp-ieee802154?color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-ieee802154)
-[![docs.rs](https://img.shields.io/docsrs/esp-ieee802154?color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-ieee802154)
+[![Crates.io](https://img.shields.io/crates/v/esp-ieee802154?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-ieee802154)
+[![docs.rs](https://img.shields.io/docsrs/esp-ieee802154?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-ieee802154)
 ![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
-![Crates.io](https://img.shields.io/crates/l/esp-ieee802154?style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-ieee802154?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
 Low-level [IEEE 802.15.4] driver for the ESP32-C6 and ESP32-H2.

--- a/esp-metadata/README.md
+++ b/esp-metadata/README.md
@@ -1,9 +1,9 @@
 # esp-metadata
 
-[![Crates.io](https://img.shields.io/crates/v/esp-metadata?color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-metadata)
-[![docs.rs](https://img.shields.io/docsrs/esp-metadata?color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-metadata)
+[![Crates.io](https://img.shields.io/crates/v/esp-metadata?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-metadata)
+[![docs.rs](https://img.shields.io/docsrs/esp-metadata?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-metadata)
 ![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?labelColor=1C2C2E&style=flat-square)
-![Crates.io](https://img.shields.io/crates/l/esp-metadata?style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-metadata?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
 Metadata for Espressif devices, intended for use in [build scripts].

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name        = "esp-println"
-version     = "0.9.1"
-edition     = "2021"
-description = "Provides `print!` and `println!` implementations various Espressif devices"
-repository  = "https://github.com/esp-rs/esp-hal"
-license     = "MIT OR Apache-2.0"
+name         = "esp-println"
+version      = "0.9.1"
+edition      = "2021"
+rust-version = "1.76.0"
+description  = "Provides `print!` and `println!` implementations various Espressif devices"
+repository   = "https://github.com/esp-rs/esp-hal"
+license      = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 cargo-args     = ["-Z", "build-std=core"]

--- a/esp-println/README.md
+++ b/esp-println/README.md
@@ -1,5 +1,11 @@
 # esp-println
 
+[![Crates.io](https://img.shields.io/crates/v/esp-println?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-println)
+[![docs.rs](https://img.shields.io/docsrs/esp-println?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-println)
+![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-println?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
+
 A library that provides `print!`, `println!`, `dbg!` implementations and
 logging capabilities for Espressif devices.
 

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -214,7 +214,6 @@ mod uart_printer {
 
 #[cfg(all(feature = "uart", feature = "esp32s2"))]
 mod uart_printer {
-    const UART_TX_ONE_CHAR: usize = 0x4000_9200;
     impl super::Printer {
         pub fn write_bytes_assume_cs(&mut self, bytes: &[u8]) {
             // On ESP32-S2 the UART_TX_ONE_CHAR ROM-function seems to have some issues.

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -2,6 +2,7 @@
 name = "esp-storage"
 version = "0.3.0"
 edition = "2021"
+rust-version = "1.76.0"
 authors = [
     "The ESP-RS team",
     "Björn Quentin <bjoern.quentin@mobile-j.de>",

--- a/esp-storage/README.md
+++ b/esp-storage/README.md
@@ -1,5 +1,11 @@
 # esp-storage
 
+[![Crates.io](https://img.shields.io/crates/v/esp-storage?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-storage)
+[![docs.rs](https://img.shields.io/docsrs/esp-storage?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-storage)
+![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-storage?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
+
 This implements [`embedded-storage`](https://github.com/rust-embedded-community/embedded-storage) traits to access unencrypted ESP32 flash.
 
 ## Current support

--- a/esp-wifi/README.md
+++ b/esp-wifi/README.md
@@ -1,5 +1,11 @@
 # esp-wifi
 
+[![Crates.io](https://img.shields.io/crates/v/esp-wifi?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-wifi)
+[![docs.rs](https://img.shields.io/docsrs/esp-wifi?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.esp-rs.org/esp-wifi)
+![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/esp-wifi?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
+
 A WiFi, BLE and ESP-NOW driver for Espressif microcontrollers.
 
 ## Current support
@@ -41,8 +47,8 @@ rustflags = [
     "-C", "link-arg=-Trom_functions.x",
 ]
 ```
-At the time of writing, you will already have the `linkall` flag if you used `cargo generate`. Generating from a template does not include the `rom_functions` flag.
 
+At the time of writing, you will already have the `linkall` flag if you used `cargo generate`. Generating from a template does not include the `rom_functions` flag.
 
 ### Optimization Level
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,14 +28,14 @@ embedded-hal-bus    = "0.1.0"
 embedded-io         = { version = "0.6.1", default-features = false }
 embedded-io-async   = "0.6.1"
 embedded-storage    = "0.3.0"
-esp-alloc           = { version = "0.3.0",  path = "../esp-alloc" }
-esp-backtrace       = { version = "0.11.1", path = "../esp-backtrace", features = ["exception-handler", "panic-handler", "println"] }
-esp-hal             = { version = "0.17.0", path = "../esp-hal", features = ["log"] }
-esp-hal-smartled    = { version = "0.10.0", path = "../esp-hal-smartled", optional = true }
-esp-ieee802154      = { version = "0.1.0",  path = "../esp-ieee802154", optional = true }
-esp-println         = { version = "0.9.1",  path = "../esp-println", features = ["log"] }
-esp-storage         = { version = "0.3.0",  path = "../esp-storage", optional = true }
-esp-wifi            = { version = "0.5.1",  path = "../esp-wifi", optional = true }
+esp-alloc           = { path = "../esp-alloc" }
+esp-backtrace       = { path = "../esp-backtrace", features = ["exception-handler", "panic-handler", "println"] }
+esp-hal             = { path = "../esp-hal", features = ["log"] }
+esp-hal-smartled    = { path = "../esp-hal-smartled", optional = true }
+esp-ieee802154      = { path = "../esp-ieee802154", optional = true }
+esp-println         = { path = "../esp-println", features = ["log"] }
+esp-storage         = { path = "../esp-storage", optional = true }
+esp-wifi            = { path = "../esp-wifi", optional = true }
 fugit               = "0.3.7"
 heapless            = "0.8.0"
 hex-literal         = "0.4.1"

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -80,9 +80,9 @@ embedded-hal       = "1.0.0"
 embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = ["unproven"] }
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-hal-nb    = { version = "1.0.0", optional = true }
-esp-backtrace      = { version = "0.11.1", path = "../esp-backtrace", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
+esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
 esp-hal            = { path = "../esp-hal", features = ["defmt", "embedded-hal", "embedded-hal-02"], optional = true }
-portable-atomic = "1.6.0"
+portable-atomic    = "1.6.0"
 
 [dev-dependencies]
 crypto-bigint       = { version = "0.5.5", default-features = false }


### PR DESCRIPTION
Nothing particularly interesting here, just various little things I wanted to clean up before the release:

- `README.md` files have consistent badges now
- Fixed a build warning in `esp-println` when targeting ESP32-S2
- Removed versions from `examples`/`hil-test` packages for path dependencies (suggested by @SergioGasquez in another PR)