### PR TITLE
Add `#[ram(persistent)]` to replace `uninitialized`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `embassy-usb` support (#1517)
 - SPI Slave support for ESP32-S2 (#1562)
 - Add new generic `OneShotTimer` and `PeriodicTimer` drivers, plus new `Timer` trait which is implemented for `TIMGx` and `SYSTIMER` (#1570)
+- New `persistent` option for the `ram` macro to replace the unsound `uninitialized` option. This requires wrapping the value in a `esp_hal::persistent::Persistent<T>`, which exposes a method that handles sound initialization before first use.
 
 ### Fixed
 
@@ -52,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed the `SystemExt` trait (#1495)
 - Removed the `GpioExt` trait (#1496)
+- Removed the unsound `uninitialized` option from the `ram` macro in favor of the new `persistent` option.
 
 ## [0.17.0] - 2024-04-18
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -131,6 +131,7 @@ pub mod parl_io;
 #[cfg(pcnt)]
 pub mod pcnt;
 pub mod peripheral;
+pub mod persistent;
 pub mod prelude;
 #[cfg(any(hmac, sha))]
 mod reg_access;

--- a/esp-hal/src/persistent.rs
+++ b/esp-hal/src/persistent.rs
@@ -1,0 +1,86 @@
+#![deny(missing_docs)]
+
+//! Support for statics that persist across resets
+
+use core::{cell::UnsafeCell, mem::MaybeUninit};
+
+use crate::{reset::get_reset_reason, rtc_cntl::SocResetReason};
+
+/// A wrapper type required for `#[ram(persistent)]` statics that handles
+/// initialization after power on and unexpected resets.
+///
+/// # Example
+///
+/// ```rust
+/// #use crate::prelude::*;
+/// #use crate::persistent::Persistent;
+///
+/// #[derive(Debug)]
+/// enum BootMode {
+///     Normal,
+///     Alternate,
+///     // ...
+/// }
+///
+/// let boot_mode = {
+///     #[ram(rtc_fast, persistent)]
+///     static BOOT_MODE: Persistent<BootMode> = Persistent::new();
+///     unsafe { BOOT_MODE.get(BootMode::Normal) }
+/// };
+///
+/// println!("Booted in {boot_mode:?} mode");
+/// ```
+///
+/// Also check the [ram example](https://github.com/esp-rs/esp-hal/blob/main/examples/src/bin/ram.rs).
+#[derive(Debug)]
+pub struct Persistent<T> {
+    inner: UnsafeCell<MaybeUninit<T>>,
+}
+
+// SAFETY: `&Persistent<T>` can be safely sent to another thread since the only
+// way to get access to the internals is through the unsafe get method, which
+// requires the caller to manage synchronization.
+unsafe impl<T: Sync> Sync for Persistent<T> {}
+
+impl<T> Persistent<T> {
+    /// Creates a new, uninitialized instance
+    pub const fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    /// Gets an exclusive, mutable reference to the persistent data,
+    /// initializing it to `init` if necessary.
+    ///
+    /// # Safety
+    ///
+    /// This method must be called *exactly once* before anything that could
+    /// call [`software_reset()`][crate::reset::software_reset]. Multiple calls
+    /// will result in multiple `&mut` references to the same memory. Resetting
+    /// before this is called may result in future calls returning a reference
+    /// to uninitialized memory, which is unsound, even for types that lack
+    /// invalid bit patterns. See the [Initialization Invariant section of the
+    /// docs for `MaybeUninit`][init-invariant].
+    ///
+    /// Ideally, put the `static` and the `.get()` call alone in their own block
+    /// near the beginning of the entry/main function, as is done in the `ram`
+    /// example.
+    ///
+    /// [init-invariant]: https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initialization-invariant
+    pub unsafe fn get(&self, init: T) -> &'static mut T {
+        let inner = unsafe { &mut *self.inner.get() };
+
+        if !matches!(get_reset_reason(), Some(SocResetReason::CoreSw)) {
+            inner.write(init);
+        }
+
+        unsafe { inner.assume_init_mut() }
+    }
+}
+
+impl<T> Default for Persistent<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1110.

This ended up being my [proposed solution №2](https://github.com/esp-rs/esp-hal/issues/1110#issuecomment-2074059718) instead of №3. №3 would have required collecting all uses of `#[ram(persistent)]` and somehow referencing them from generated code in the `entry` macro to handle initialization. Probably doable by someone else with some linker magic, but imo too much complexity just to remove a small, relatively straightforward `unsafe` block from user code, especially for such a niche and low level feature.

The new `#[ram(persistent)]` option requires that the `static`'s value is wrapped in a `esp_hal::persistent::Persistent<T>`. This is verified by the macro with [this technique](https://github.com/nvzqz/impls#how-it-works) from @nvzqz and @Nadrieril. The wrapper exposes an unsafe method that handles initialization if necessary and returns `&'static mut T` (even from a regular non-`mut` `static`—ready for Rust 2024!). Hopefully the safety comments in the code are clear enough on how this is all sound.

If `#[ram(persistent)]` is used on a static without the `Persistent` wrapper, compilation fails with the following error message:
```
error[E0080]: evaluation of constant value failed
  --> src/bin/ram.rs:33:1
   |
33 | #[ram(rtc_fast, persistent)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'persistent statics must be of type esp_hal::persistent::Persistent<T>', src/bin/ram.rs:33:1
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
```

#### Remaining questions
1. Have I missed any remaining soundness holes? *Yes, quite a large one :sweat_smile: see follow-up comment*
2. Are there any other reset reasons that should be added to the list that skip init? Perhaps `CoreDeepSleep` and/or `CpuSw`? They would need to never be triggered by *anything* outside of user code to ensure that it can't happen before the user calls `Persistent::get`.
3. The name `esp_hal::persistent::Persistent` is quite long and redundant. Should I move it into `lib.rs`? Or re-export it from the root?
4. Should `Persistent` also expose methods to unconditionally initialize and to get a reference to the internal value without initializing? This would let users customize the init condition or init multiple persistent statics with one check. IMO, those use-cases are either probably unsound or unnecessary micro-optimizing and are better served by adding the `#[link_section]` attribute manually.

#### Testing
The updated `ram` example ran on an S3 dev board.