### PR TITLE
Update embedded-tests and wiring docs

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -90,7 +90,7 @@ crypto-bigint       = { version = "0.5.5", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
 embassy-executor    = { version = "0.5.0", default-features = false }
 # Add the `embedded-test/defmt` feature for more verbose testing
-embedded-test       = { git = "https://github.com/probe-rs/embedded-test", rev = "1aa5a426d6b29ae2b509c5876dd33523b03e107c", default-features = false }
+embedded-test       = { version = "0.4.0", default-features = false }
 hex-literal         = "0.4.1"
 nb                  = "1.1.0"
 p192                = { version = "0.13.0", default-features = false, features = ["arithmetic"] }

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -19,7 +19,9 @@ We use [embedded-test] as our testing framework, which relies on [defmt] interna
 We use [probe-rs] for flashing and running the tests on a target device, however, this **MUST** be installed from the correct revision, and with the correct features enabled:
 
 ```text
-cargo install probe-rs-tools@0.24.0 --git https://github.com/probe-rs/probe-rs --locked
+cargo install probe-rs-tools \
+  --git https://github.com/probe-rs/probe-rs \
+  --rev a6dd038 --force --locked
 ```
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
@@ -87,7 +89,7 @@ source "$HOME/.cargo/env"
 # Install dependencies
 sudo apt install -y pkg-config libudev-dev
 # Install probe-rs
-cargo install probe-rs-tools@0.24.0 --git https://github.com/probe-rs/probe-rs --locked
+cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev a6dd038 --force
 # Add the udev rules
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -90,7 +90,7 @@ Our Virtual Machines have the following setup:
 # Install Rust:
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y --profile minimal
 # Source the current shell:
-source "$HOME/.cargo/env"
+. "$HOME/.cargo/env"
 # Install dependencies
 sudo apt install -y pkg-config libudev-dev
 # Install probe-rs

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -59,23 +59,28 @@ Our Virtual Machines have the following setup:
 - ESP32-C3 (`rustboard`):
   - Devkit: `ESP32-C3-DevKit-RUST-1` connected via USB-Serial-JTAG.
     - `GPIO2` and `GPIO4` are connected.
+    - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-C6 (`esp32c6-usb`):
   - Devkit: `ESP32-C6-DevKitC-1 V1.2` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
+    - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-H2 (`esp32h2-usb`):
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO4` are connected.
+    - `GPIO5` and `GPIO8` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-S2 (`esp32s2-jtag`):
   - Devkit: `ESP32-S2-Saola-1` connected via UART.
     - `GPIO2` and `GPIO4` are connected.
+    - `GPIO5` and `GPIO6` are connected.
   - Probe: `ESP-Prog` connected with the [following connections](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware)
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-S3 (`esp32s3-usb`):
   - Devkit: `ESP32-S3-DevKitC-1` connected via USB-Serial-JTAG.
     - `GPIO2` and `GPIO4` are connected.
+    - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -19,9 +19,7 @@ We use [embedded-test] as our testing framework, which relies on [defmt] interna
 We use [probe-rs] for flashing and running the tests on a target device, however, this **MUST** be installed from the correct revision, and with the correct features enabled:
 
 ```text
-cargo install probe-rs-tools \
-  --git https://github.com/probe-rs/probe-rs \
-  --rev a6dd038 --force --locked
+cargo install probe-rs-tools@0.24.0 --git https://github.com/probe-rs/probe-rs --locked
 ```
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
@@ -89,7 +87,7 @@ source "$HOME/.cargo/env"
 # Install dependencies
 sudo apt install -y pkg-config libudev-dev
 # Install probe-rs
-cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev a6dd038 --force
+cargo install probe-rs-tools@0.24.0 --git https://github.com/probe-rs/probe-rs --locked
 # Add the udev rules
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- ~Update probe-rs in our self-hosted-runners~
  - Reverted this as it was causing issues on H2.
- Use the [new `embedded-test` release](https://github.com/probe-rs/embedded-test/releases/tag/v0.4.0)
- Updated the wiring on the RPi runners

#### Testing
Triggered the HIL workflow: https://github.com/esp-rs/esp-hal/actions/runs/9397776874
