### PR TITLE
New package releases

### DIFF
--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-alloc"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 rust-version = "1.68"
 description  = "A heap allocator for Espressif devices"
@@ -23,7 +23,7 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["nightly"]
 
 [dependencies]
-critical-section      = "1.1.1"
+critical-section      = "1.1.2"
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 
 [features]

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-backtrace"
-version      = "0.11.1"
+version      = "0.12.0"
 edition      = "2021"
 rust-version = "1.76.0"
 description  = "Bare-metal backtrace support for ESP32"
@@ -12,9 +12,9 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["esp32c3", "panic-handler", "exception-handler", "println", "esp-println/uart"]
 
 [dependencies]
-defmt       = { version = "0.3.6", optional = true }
-esp-println = { version = "0.9.1", optional = true, default-features = false, path = "../esp-println" }
-semihosting = { version = "0.1.7", optional = true }
+defmt       = { version = "0.3.8",  optional = true }
+esp-println = { version = "0.9.1",  optional = true, default-features = false, path = "../esp-println" }
+semihosting = { version = "0.1.10", optional = true }
 
 [build-dependencies]
 esp-build = { version = "0.1.0", path = "../esp-build" }

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -17,13 +17,13 @@ defmt               = { version = "0.3.8", optional = true }
 document-features   = "0.2.8"
 embassy-executor    = "0.5.0"
 embassy-time-driver = "0.1.0"
-esp-hal             = { version = "0.17.0", path = "../esp-hal" }
+esp-hal             = { version = "0.18.0", path = "../esp-hal" }
 portable-atomic     = "1.6.0"
 
 [build-dependencies]
 cfg-if       = "1.0.0"
 esp-build    = { version = "0.1.0", path = "../esp-build" }
-esp-metadata = { version = "0.1.0", path = "../esp-metadata" }
+esp-metadata = { version = "0.1.1", path = "../esp-metadata" }
 
 [features]
 esp32   = ["esp-hal/esp32"]

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-hal-procmacros"
-version      = "0.10.0"
+version      = "0.11.0"
 edition      = "2021"
 rust-version = "1.76.0"
 description  = "Procedural macros for esp-hal"
@@ -14,15 +14,15 @@ features = ["embassy", "has-ulp-core", "interrupt", "ram", "is-ulp-core"]
 proc-macro = true
 
 [dependencies]
-darling           = "0.20.8"
+darling           = "0.20.9"
 document-features = "0.2.8"
 litrs             = "0.4.1"
-object            = { version = "0.35.0", optional = true }
+object            = { version = "0.36.0", optional = true }
 proc-macro-crate  = "3.1.0"
 proc-macro-error  = "1.0.4"
-proc-macro2       = "1.0.80"
+proc-macro2       = "1.0.84"
 quote             = "1.0.36"
-syn               = { version = "2.0.59", features = ["extra-traits", "full"] }
+syn               = { version = "2.0.66", features = ["extra-traits", "full"] }
 
 [features]
 ## Provide a `#[main]` procmacro to mark the entry point for Embassy applications.

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-hal-smartled"
-version      = "0.10.0"
+version      = "0.11.0"
 edition      = "2021"
 rust-version = "1.76.0"
 description  = "RMT adapter for smartleds"
@@ -12,9 +12,9 @@ features = ["esp32c3"]
 targets  = ["riscv32imc-unknown-none-elf"]
 
 [dependencies]
-defmt             = { version = "0.3.6", optional = true }
+defmt             = { version = "0.3.8", optional = true }
 document-features = "0.2.8"
-esp-hal           = { version = "0.17.0", path = "../esp-hal" }
+esp-hal           = { version = "0.18.0", path = "../esp-hal" }
 fugit             = "0.3.7"
 smart-leds-trait  = "0.3.0"
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.18.0] - 2024-06-04
 
 ### Added
 
@@ -580,7 +580,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2022-08-05
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/v0.17.0...HEAD
+[0.18.0]: https://github.com/esp-rs/esp-hal/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/esp-rs/esp-hal/compare/v0.16.1...v0.17.0
 [0.16.1]: https://github.com/esp-rs/esp-hal/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/esp-rs/esp-hal/compare/v0.15.0...v0.16.0

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal"
-version       = "0.17.0"
+version       = "0.18.0"
 edition       = "2021"
 rust-version  = "1.76.0"
 description   = "Bare-metal HAL for Espressif devices"
@@ -19,11 +19,11 @@ bitflags                 = "2.5.0"
 bitfield                 = "0.15.0"
 cfg-if                   = "1.0.0"
 critical-section         = "1.1.2"
-defmt                    = { version = "0.3.6", optional = true }
+defmt                    = { version = "0.3.8", optional = true }
 delegate                 = "0.12.0"
 document-features        = "0.2.8"
 embassy-futures          = { version = "0.1.1", optional = true }
-embassy-sync             = { version = "0.5.0", optional = true }
+embassy-sync             = { version = "0.6.0", optional = true }
 embassy-usb-driver       = { version = "0.1.0", optional = true }
 embassy-usb-synopsys-otg = { version = "0.1.0", optional = true }
 embedded-can             = { version = "0.4.1", optional = true }
@@ -39,9 +39,9 @@ esp-synopsys-usb-otg     = { version = "0.4.1", optional = true, features = ["fs
 fugit                    = "0.3.7"
 log                      = { version = "0.4.21", optional = true }
 nb                       = "1.1.0"
-paste                    = "1.0.14"
+paste                    = "1.0.15"
 portable-atomic          = { version = "1.6.0", default-features = false }
-procmacros               = { version = "0.10.0", features = ["embassy", "enum-dispatch", "interrupt", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+procmacros               = { version = "0.11.0", features = ["embassy", "enum-dispatch", "interrupt", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 riscv                    = { version = "0.11.1", optional = true }
 strum                    = { version = "0.26.2", default-features = false, features = ["derive"] }
 void                     = { version = "1.0.2", default-features = false }
@@ -71,8 +71,8 @@ xtensa-lx-rt = "0.16.0"
 basic-toml   = "0.1.9"
 cfg-if       = "1.0.0"
 esp-build    = { version = "0.1.0", path = "../esp-build" }
-esp-metadata = { version = "0.1.0", path = "../esp-metadata" }
-serde        = { version = "1.0.197", features = ["derive"] }
+esp-metadata = { version = "0.1.1", path = "../esp-metadata" }
+serde        = { version = "1.0.203", features = ["derive"] }
 
 [features]
 default = ["embedded-hal"]

--- a/esp-ieee802154/Cargo.toml
+++ b/esp-ieee802154/Cargo.toml
@@ -18,7 +18,7 @@ test  = false
 [dependencies]
 byte             = "0.2.7"
 critical-section = "1.1.2"
-esp-hal          = { version = "0.17.0", path = "../esp-hal" }
+esp-hal          = { version = "0.18.0", path = "../esp-hal" }
 esp-wifi-sys     = { git = "https://github.com/esp-rs/esp-wifi", rev = "2ceb4b3" }
 heapless         = "0.8.0"
 ieee802154       = "0.6.1"

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-metadata"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = "2021"
 rust-version = "1.60.0"
 description  = "Metadata for Espressif devices"
@@ -8,7 +8,7 @@ repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 
 [dependencies]
-basic-toml  = "0.1.8"
+basic-toml  = "0.1.9"
 lazy_static = "1.4.0"
-serde       = { version = "1.0.197", features = ["derive"] }
-strum       = { version = "0.26.1",  features = ["derive"] }
+serde       = { version = "1.0.203", features = ["derive"] }
+strum       = { version = "0.26.2",  features = ["derive"] }

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -5,15 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-### Fixed
-
-### Changed
+## [0.6.0]
 
 ### Removed
+
 - Removed embedded-hal v0.2 dependency
 
 ## [0.5.1] - 2024-04-22
@@ -22,27 +17,17 @@ Patch release to fix docs.rs build
 
 ## [0.5.0] - 2024-04-19
 
-### Added
-
 ### Fixed
+
 - Fix compile error when using smoltcp `DNS_MAX_RESULT_COUNT` values other than 1
-
-### Changed
-
-### Removed
 
 ## [0.4.0] - 2024-03-12
 
-### Added
-
-### Fixed
-
 ### Changed
+
 - Users don't need embedded-svc to control wifi anymore. The wifi trait is optionally implemented now. (#429)
 - Better network performance by forced yielding of the task when buffers are full / empty. (#430)
 - Depend on esp-hal 0.16.1, update other dependencies
-
-### Removed
 
 ## [0.3.0] - 2024-01-29
 

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -1,51 +1,51 @@
 [package]
 name = "esp-wifi"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["The ESP-RS team"]
 description = "A WiFi, Bluetooth and ESP-NOW driver for use with Espressif chips and bare-metal Rust"
-repository = "https://github.com/esp-rs/esp-wifi"
+repository = "https://github.com/esp-rs/esp-hal"
 license = "MIT OR Apache-2.0"
 
 keywords = ["wifi", "bluetooth", "esp", "no-std"]
 categories = ["embedded", "hardware-support", "no-std"]
 
 [dependencies]
-defmt = { version = "0.3.6", optional = true }
-esp-hal = { version = "0.17.0", path = "../esp-hal", default-features = false }
+defmt = { version = "0.3.8", optional = true }
+esp-hal = { version = "0.18.0", path = "../esp-hal", default-features = false }
 esp-hal-embassy = { version = "0.1.0", path = "../esp-hal-embassy", optional = true }
 smoltcp = { version = "0.11.0", default-features = false, features = [
   "medium-ethernet",
   "socket-raw",
 ], optional = true }
-critical-section = "1.1.1"
-log = { version = "0.4.20", optional = true }
-embedded-svc = { version = "0.27.0", default-features = false, features = [
+critical-section = "1.1.2"
+log = { version = "0.4.21", optional = true }
+embedded-svc = { version = "0.27.1", default-features = false, features = [
 ], optional = true }
 enumset = { version = "1.1.3", default-features = false, optional = true }
 linked_list_allocator = { version = "0.10.5", default-features = false, features = [
   "const_mut_refs",
 ] }
 embedded-io = { version = "0.6.1", default-features = false }
-embedded-io-async = { version = "0.6.0", optional = true }
+embedded-io-async = { version = "0.6.1", optional = true }
 fugit = "0.3.7"
-heapless = { version = "0.8", default-features = false, features = [
+heapless = { version = "0.8.0", default-features = false, features = [
   "portable-atomic",
 ] }
-num-derive = { version = "0.4" }
-num-traits = { version = "0.2", default-features = false }
+num-derive = { version = "0.4.2" }
+num-traits = { version = "0.2.19", default-features = false }
 no-std-net = { version = "0.6.0", optional = true }
 esp-wifi-sys = { version = "0.3.0" }
-embassy-sync = { version = "0.5.0", optional = true }
-embassy-futures = { version = "0.1.0", optional = true }
-embassy-net-driver = { version = "0.2", optional = true }
+embassy-sync = { version = "0.6.0", optional = true }
+embassy-futures = { version = "0.1.1", optional = true }
+embassy-net-driver = { version = "0.2.0", optional = true }
 toml-cfg = "0.2.0"
-libm = "0.2.7"
+libm = "0.2.8"
 cfg-if = "1.0.0"
-portable-atomic = { version = "1.5", default-features = false }
-portable_atomic_enum = { version = "0.3.0", features = ["portable-atomic"] }
+portable-atomic = { version = "1.6.0", default-features = false }
+portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
 
-futures-util = { version = "0.3.28", default-features = false, features = [
+futures-util = { version = "0.3.30", default-features = false, features = [
   "portable-atomic",
 ] }
 atomic-waker = { version = "1.1.2", default-features = false, features = [


### PR DESCRIPTION
The following packages will be published:

- `esp-alloc`
- `esp-backtrace`
- `esp-hal`
- `esp-hal-embassy`
- `esp-hal-procmacros`
- `esp-hal-smartled`
- `esp-metadata`
- `esp-wifi`