### PR TITLE
Add auto-detection feature to `esp-println`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,53 @@ jobs:
       - name: Build esp-riscv-rt (riscv32imac, all features)
         run: cd esp-riscv-rt/ && cargo build --target=riscv32imac-unknown-none-elf --features=ci
 
+  esp-println:
+    name: esp-println (${{ matrix.device.soc }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        device: [
+            # RISC-V devices:
+            { soc: "esp32c2", target: "riscv32imc-unknown-none-elf" },
+            { soc: "esp32c3", target: "riscv32imc-unknown-none-elf" },
+            { soc: "esp32c6", target: "riscv32imac-unknown-none-elf" },
+            { soc: "esp32h2", target: "riscv32imac-unknown-none-elf" },
+            # Xtensa devices:
+            { soc: "esp32", target: "xtensa-esp32-none-elf" },
+            { soc: "esp32s2", target: "xtensa-esp32s2-none-elf" },
+            { soc: "esp32s3", target: "xtensa-esp32s3-none-elf" },
+          ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install the Rust toolchain for RISC-V devices:
+      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
+          toolchain: stable
+          components: rust-src
+      # Install the Rust toolchain for Xtensa devices:
+      - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc)
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          buildtargets: ${{ matrix.device.soc }}
+          default: true
+          ldproxy: false
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Make sure we're able to build with the default features and most common features enabled
+      - name: Build (no features)
+        run: |
+          cargo xtask build-package \
+            --features=${{ matrix.device.soc }},log \
+            --target=${{ matrix.device.target }} \
+            esp-println
+        
   extras:
     runs-on: ubuntu-latest
 

--- a/esp-println/.cargo/config.toml
+++ b/esp-println/.cargo/config.toml
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["alloc", "core"]

--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `auto` feature to auto-detect Serial-JTAG/UART communication
+- Add `auto` feature to auto-detect Serial-JTAG/UART communication (#1658)
 
 ### Fixed
 
 ### Changed
 
-- `auto` is the default communication method
+- `auto` is the default communication method (#1658)
 
 ### Removed
 

--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add `auto` feature to auto-detect Serial-JTAG/UART communication
+
+### Fixed
+
+### Changed
+
+- `auto` is the default communication method
+
+### Removed
+
+## [0.9.1] - 2024-03-11
+
+### Changed
+
+- Un-pinned the defmt package's version number
+
+## [0.9.0] - 2024-02-07
+
+### Added
+
+- Add support for ESP32-P4
+
+### Removed
+
+- Remove ESP 8266 support
+
+## [0.8.0] - 2023-12-21
+
+### Removed
+
+- Remove RTT and defmt-raw support
+

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -22,7 +22,7 @@ portable-atomic  = { version = "1.6.0",  optional = true, default-features = fal
 esp-build = { version = "0.1.0", path = "../esp-build" }
 
 [features]
-default = ["dep:critical-section", "colors", "uart"]
+default = ["dep:critical-section", "colors", "auto"]
 log     = ["dep:log"]
 
 # You must enable exactly 1 of the below features to support the correct chip:
@@ -36,10 +36,13 @@ esp32s2 = []
 esp32s3 = []
 
 # You must enable exactly 1 of the below features to enable to intended
-# communication method (note that "uart" is enabled by default):
+# communication method (note that "auto" is enabled by default):
 jtag-serial = ["dep:portable-atomic"] # C3, C6, H2, P4, and S3 only!
-no-op       = []
 uart        = []
+auto        = ["dep:portable-atomic"]
+
+# Don't print anything
+no-op       = []
 
 # Enables a `defmt` backend usable with espflash. We force rzcobs encoding to simplify implementation
 defmt-espflash = ["dep:defmt", "defmt?/encoding-rzcobs"]

--- a/esp-println/README.md
+++ b/esp-println/README.md
@@ -41,11 +41,11 @@ You can now `println!("Hello world")` as usual.
   - Only one of these features can be enabled at a time.
 - There is one feature for each supported communication method: `uart`, `jtag-serial` and `auto`.
   - Only one of these features can be enabled at a time.
-- `no-op`: don't print anything
+- `no-op`: Don't print anything.
 - `log`: Enables logging using [`log` crate].
-- `colors` enable colored logging.
+- `colors`: Enable colored logging.
   - Only effective when using the `log` feature.
-- `critical-section` enables critical sections.
+- `critical-section`: Enables critical sections.
 - `defmt-espflash`: This is intended to be used with [`espflash`], see `-L/--log-format` argument
   of `flash` or `monitor` subcommands of `espflash` and `cargo-espflash`. Uses [rzCOBS] encoding
   and adds framing.

--- a/esp-println/README.md
+++ b/esp-println/README.md
@@ -39,8 +39,9 @@ You can now `println!("Hello world")` as usual.
   `esp32c3`, `esp32c6`, `esp32h2`, `esp32s2`, and `esp32s3`.
   - One of these features must be enabled.
   - Only one of these features can be enabled at a time.
-- There is one feature for each supported communication method: `uart`, `jtag-serial` and `no-op`.
+- There is one feature for each supported communication method: `uart`, `jtag-serial` and `auto`.
   - Only one of these features can be enabled at a time.
+- `no-op`: don't print anything
 - `log`: Enables logging using [`log` crate].
 - `colors` enable colored logging.
   - Only effective when using the `log` feature.
@@ -51,10 +52,10 @@ You can now `println!("Hello world")` as usual.
 
 ## Default Features
 
-By default, we use the `uart`, `critial-section` and `colors` features.
-Which means that it will print to the UART, use critical sections and output
+By default, we use the `auto`, `critial-section` and `colors` features.
+Which means that it will auto-detect if it needs to print to the UART or JTAG-Serial, use critical sections and output
 messages will be colored.
-If we want to use a communication method that is not `uart`, the default
+If we want to use a communication method that is not `auto`, the default
 one, we need to [disable the default features].
 
 ## Logging

--- a/esp-println/build.rs
+++ b/esp-println/build.rs
@@ -7,7 +7,7 @@ fn main() {
     );
 
     // Ensure that only a single communication method is specified
-    assert_unique_used_features!("jtag-serial", "uart");
+    assert_unique_used_features!("jtag-serial", "uart", "auto");
 
     // Ensure that, if the `jtag-serial` communication method feature is enabled,
     // either the `esp32c3`, `esp32c6`, `esp32h2`, or `esp32s3` chip feature is


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1576 

Using the ROM function didn't work for me - `buf_uart_no` was always 0 for me but in general I think using SOF-interrupt-flag is a better way to do what we need here.

I also added a CHANGELOG.md for `esp-println` (but no CI checks for that in this PR)

#### Testing
Running the examples which use `esp-println` should print to UART or Serial-JTAG without reconfiguration (or re-compilation).