### PR TITLE
Add Flex/AnyFlex pin drivers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Flex / AnyFlex GPIO pin driver
+
 ### Fixed
 
 ### Changed

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add Flex / AnyFlex GPIO pin driver
+- Add Flex / AnyFlex GPIO pin driver (#1659)
 
 ### Fixed
 

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -71,7 +71,7 @@ pub fn interrupt_handler() {
 mod tests {
     use defmt::assert_eq;
     use embassy_time::{Duration, Timer};
-    use esp_hal::gpio::{Event, OutputOpenDrain};
+    use esp_hal::gpio::{Event, Flex, OutputOpenDrain};
     use portable_atomic::{AtomicUsize, Ordering};
 
     use super::*;
@@ -225,5 +225,45 @@ mod tests {
 
         assert_eq!(io2.is_low(), true);
         assert_eq!(io4.is_low(), true);
+    }
+
+    #[test]
+    fn test_gpio_flex(ctx: Context<'static>) {
+        let mut io2 = Flex::new(unsafe { GpioPin::<2>::steal() });
+        let mut io4 = Flex::new(unsafe { GpioPin::<4>::steal() });
+
+        io2.set_high();
+        io2.set_as_output();
+        io4.set_as_input(Pull::None);
+
+        ctx.delay.delay_millis(1);
+
+        assert_eq!(io2.is_set_high(), true);
+        assert_eq!(io4.is_high(), true);
+
+        io2.set_low();
+        ctx.delay.delay_millis(1);
+
+        assert_eq!(io2.is_set_high(), false);
+        assert_eq!(io4.is_high(), false);
+
+        io2.set_as_input(Pull::None);
+        io4.set_as_output();
+        ctx.delay.delay_millis(1);
+
+        assert_eq!(io2.is_high(), false);
+        assert_eq!(io4.is_set_high(), false);
+
+        io4.set_high();
+        ctx.delay.delay_millis(1);
+
+        assert_eq!(io2.is_high(), true);
+        assert_eq!(io4.is_set_high(), true);
+
+        io4.set_low();
+        ctx.delay.delay_millis(1);
+
+        assert_eq!(io2.is_low(), true);
+        assert_eq!(io4.is_set_low(), true);
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This adds a Flex/AnyFlex pin driver to fix #740 

#### Testing
The GPIO HIL-test exercises the new driver. Doesn't seem to deserve a dedicated example
