### PR TITLE
Improve DMA `pop` implementation

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - uart: Removed `configure_pins` methods (#1592)
+- Removed `DmaError::Exhausted` error by improving the implementation of the `pop` function
 
 ## [0.18.0] - 2024-06-04
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - uart: Removed `configure_pins` methods (#1592)
-- Removed `DmaError::Exhausted` error by improving the implementation of the `pop` function
 - Removed `DmaError::Exhausted` error by improving the implementation of the `pop` function (#1664)
 
 ## [0.18.0] - 2024-06-04

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - uart: Removed `configure_pins` methods (#1592)
 - Removed `DmaError::Exhausted` error by improving the implementation of the `pop` function
+- Removed `DmaError::Exhausted` error by improving the implementation of the `pop` function (#1664)
 
 ## [0.18.0] - 2024-06-04
 

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -282,10 +282,6 @@ impl<const N: u8> RegisterAccess for Channel<N> {
         Self::in_int().raw().read().in_suc_eof().bit()
     }
 
-    fn last_in_dscr_address() -> usize {
-        Self::ch().in_dscr_bf0().read().inlink_dscr_bf0().bits() as _
-    }
-
     fn is_listening_in_eof() -> bool {
         Self::in_int().ena().read().in_suc_eof().bit_is_set()
     }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -618,10 +618,6 @@ where
         R::is_in_done()
     }
 
-    fn last_in_dscr_address(&self) -> usize {
-        R::last_in_dscr_address()
-    }
-
     #[cfg(feature = "async")]
     fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker;
 }
@@ -1419,7 +1415,6 @@ pub trait RegisterAccess: crate::private::Sealed {
     fn set_in_peripheral(peripheral: u8);
     fn start_in();
     fn is_in_done() -> bool;
-    fn last_in_dscr_address() -> usize;
 
     fn is_listening_in_eof() -> bool;
     fn is_listening_out_eof() -> bool;

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -93,10 +93,6 @@ impl DmaDescriptor {
         self.flags.length() as usize
     }
 
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     fn set_suc_eof(&mut self, suc_eof: bool) {
         self.flags.set_suc_eof(suc_eof)
     }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -754,7 +754,7 @@ where
             unsafe { self.last_seen_handled_descriptor_ptr.read_volatile() }.next;
         let mut current_in_descr = unsafe { current_in_descr_ptr.read_volatile() };
 
-        while !current_in_descr.is_empty() && current_in_descr.owner() == Owner::Cpu {
+        while current_in_descr.owner() == Owner::Cpu {
             self.available += current_in_descr.len();
             self.last_seen_handled_descriptor_ptr = current_in_descr_ptr;
 

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -231,11 +231,6 @@ macro_rules! ImplSpiChannel {
                     spi.dma_int_raw().read().in_done().bit()
                 }
 
-                fn last_in_dscr_address() -> usize {
-                    let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
-                    spi.inlink_dscr_bf0().read().dma_inlink_dscr_bf0().bits() as usize
-                }
-
                 fn is_listening_in_eof() -> bool {
                     let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
                     spi.dma_int_ena().read().in_suc_eof().bit_is_set()
@@ -631,11 +626,6 @@ macro_rules! ImplI2sChannel {
                 fn is_in_done() -> bool {
                     let reg_block = unsafe { &*crate::peripherals::[<$peripheral>]::PTR };
                     reg_block.int_raw().read().in_done().bit()
-                }
-
-                fn last_in_dscr_address() -> usize {
-                    let reg_block = unsafe { &*crate::peripherals::[<$peripheral>]::PTR };
-                    reg_block.inlink_dscr_bf0().read().inlink_dscr_bf0().bits() as usize
                 }
 
                 fn is_listening_in_eof() -> bool {

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -138,8 +138,10 @@ mod tests {
                 );
 
                 rcv.fill(0);
-                rx_transfer.pop(&mut rcv[..rx_avail]).unwrap();
-                for &b in &rcv[..rx_avail] {
+                let len = rx_transfer.pop(&mut rcv).unwrap();
+                assert!(len > 0);
+
+                for &b in &rcv[..len] {
                     if b != check_i {
                         failed = true;
                         break 'outer;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1482 

#### Testing
We have a HIL test for I2S which is using this. It still works and even works when changing the code forcing it to get more than one descriptor's buffer
