### PR TITLE
esp-backtrace: Fix warning when using `semihosting` feature

### DIFF
--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -110,6 +110,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     #[cfg(feature = "semihosting")]
     semihosting::process::abort();
 
+    #[cfg(not(feature = "semihosting"))]
     halt();
 }
 
@@ -221,6 +222,7 @@ fn exception_handler(context: &arch::TrapFrame) -> ! {
     #[cfg(feature = "semihosting")]
     semihosting::process::abort();
 
+    #[cfg(not(feature = "semihosting"))]
     halt();
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This fixes a "unreachable statement" warning when using the "semihosting" feature. e.g. when running HIL tests

#### Testing
Compile a HIL test and see the warning disappeared
