### PR TITLE
Avoid using a macro for default UART0 pins

### DIFF
--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -143,42 +143,6 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Returns the default TX and RX pins for Uart/Serial communication (UART0)
-#[macro_export]
-macro_rules! default_uart0_pins {
-    ($io:expr) => {{
-        let io = $io;
-        #[cfg(feature = "esp32")]
-        {
-            (io.pins.gpio1, io.pins.gpio3)
-        }
-        #[cfg(feature = "esp32c2")]
-        {
-            (io.pins.gpio20, io.pins.gpio19)
-        }
-        #[cfg(feature = "esp32c3")]
-        {
-            (io.pins.gpio21, io.pins.gpio20)
-        }
-        #[cfg(feature = "esp32c6")]
-        {
-            (io.pins.gpio16, io.pins.gpio17)
-        }
-        #[cfg(feature = "esp32h2")]
-        {
-            (io.pins.gpio24, io.pins.gpio23)
-        }
-        #[cfg(feature = "esp32s2")]
-        {
-            (io.pins.gpio43, io.pins.gpio44)
-        }
-        #[cfg(feature = "esp32s3")]
-        {
-            (io.pins.gpio43, io.pins.gpio44)
-        }
-    }};
-}
-
 /// UART Error
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -14,7 +14,6 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
-    default_uart0_pins,
     gpio::Io,
     peripherals::{Peripherals, UART0},
     prelude::*,
@@ -92,7 +91,20 @@ async fn main(spawner: Spawner) {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Default pins for Uart/Serial communication
-    let (tx_pin, rx_pin) = default_uart0_pins!(io);
+    #[cfg(feature = "esp32")]
+    let (tx_pin, rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+    #[cfg(feature = "esp32c2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+    #[cfg(feature = "esp32c3")]
+    let (tx_pin, rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+    #[cfg(feature = "esp32c6")]
+    let (tx_pin, rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+    #[cfg(feature = "esp32h2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+    #[cfg(feature = "esp32s2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    #[cfg(feature = "esp32s3")]
+    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
 
     let config = Config::default();
     config.rx_fifo_full_threshold(READ_BUF_SIZE as u16);

--- a/examples/src/bin/hello_world.rs
+++ b/examples/src/bin/hello_world.rs
@@ -17,7 +17,6 @@ use core::fmt::Write;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
-    default_uart0_pins,
     delay::Delay,
     gpio::Io,
     peripherals::Peripherals,
@@ -37,7 +36,20 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Default pins for Uart/Serial communication
-    let (mut tx_pin, mut rx_pin) = default_uart0_pins!(io);
+    #[cfg(feature = "esp32")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+    #[cfg(feature = "esp32c2")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+    #[cfg(feature = "esp32c3")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+    #[cfg(feature = "esp32c6")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+    #[cfg(feature = "esp32h2")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+    #[cfg(feature = "esp32s2")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    #[cfg(feature = "esp32s3")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);
 
     let mut uart0 =
         Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin).unwrap();

--- a/examples/src/bin/ieee802154_sniffer.rs
+++ b/examples/src/bin/ieee802154_sniffer.rs
@@ -10,7 +10,6 @@
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
-    default_uart0_pins,
     gpio::Io,
     peripherals::Peripherals,
     prelude::*,
@@ -30,7 +29,10 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Default pins for Uart/Serial communication
-    let (mut tx_pin, mut rx_pin) = default_uart0_pins!(io);
+    #[cfg(feature = "esp32c6")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+    #[cfg(feature = "esp32h2")]
+    let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
 
     let mut uart0 =
         Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin).unwrap();

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -13,7 +13,6 @@ use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
-    default_uart0_pins,
     delay::Delay,
     gpio::Io,
     peripherals::{Peripherals, UART0},
@@ -39,8 +38,20 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     // Default pins for Uart/Serial communication
-    let (tx_pin, rx_pin) = default_uart0_pins!(io);
-
+    #[cfg(feature = "esp32")]
+    let (tx_pin, rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+    #[cfg(feature = "esp32c2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+    #[cfg(feature = "esp32c3")]
+    let (tx_pin, rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+    #[cfg(feature = "esp32c6")]
+    let (tx_pin, rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+    #[cfg(feature = "esp32h2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+    #[cfg(feature = "esp32s2")]
+    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+    #[cfg(feature = "esp32s3")]
+    let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
     let config = Config::default();
     config.rx_fifo_full_threshold(30);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Reverts using the `default_uart0_pins` macro. 

#### Testing
`hello_world` example keeps working as expected