### PR TITLE
Additional move base dma api

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - uart: Added `UartTx` and `UartRx` constructors (#1592)
 - Add Flex / AnyFlex GPIO pin driver (#1659)
 - Add new `DmaError::UnsupportedMemoryRegion` - used memory regions are checked when preparing a transfer now (#1670)
-- Add DmaTransactionTxOwned, DmaTransactionRxOwned, DmaTransactionTxRxOwned, functions to do owning transfers added to SPI half-duplex
+- Add DmaTransactionTxOwned, DmaTransactionRxOwned, DmaTransactionTxRxOwned, functions to do owning transfers added to SPI half-duplex (#1672)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - uart: Constructors now require TX and RX pins (#1592)
 - uart: Added `Uart::new_with_default_pins` constructor (#1592)
 - uart: Added `UartTx` and `UartRx` constructors (#1592)
-
 - Add Flex / AnyFlex GPIO pin driver (#1659)
 - Add new `DmaError::UnsupportedMemoryRegion` - used memory regions are checked when preparing a transfer now (#1670)
+- Add DmaTransactionTxOwned, DmaTransactionRxOwned, DmaTransactionTxRxOwned, functions to do owning transfers added to SPI half-duplex
 
 ### Fixed
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1711,7 +1711,6 @@ where
 
     /// Wait for the transfer to finish and return the peripheral and the
     /// buffer.
-    #[must_use]
     pub fn wait(mut self) -> Result<(I, T), (DmaError, I, T)> {
         self.instance.peripheral_wait_dma(true, false);
 
@@ -1858,7 +1857,7 @@ where
 
     /// Wait for the transfer to finish and return the peripheral and the
     /// buffers.
-    #[must_use]
+    #[allow(clippy::type_complexity)]
     pub fn wait(mut self) -> Result<(I, T, R), (DmaError, I, T, R)> {
         self.instance.peripheral_wait_dma(true, true);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This solves the original problem of #1512 (but doesn't close it since there is more discussed there now). It shouldn't cause any problems implementing the ideas outlined there

Initially I tried to not have dedicated `DmaTransferX` structs by using an `OwnedOrBorrowed` enum which worked but the resulting code was not easy to read and maintain so I decided having dedicated structs is the better and easier solution.

I didn't add `DmaTransferXCircularOwned` because I don't think something like this is very useful for circular DMA transfers.

I only added functions do use the new structs to SPI full-duplex for now. Adding it to more drivers would be easy but I think it's better to do that if we know there is a use-case for it - not just to have it

#### Testing
The HIL test now also tests the owning transfer. Additionally, I tested this with the original code mentioned in the original issue.
