### PR TITLE
Fix `mk_static` macro

### DIFF
--- a/examples/src/bin/esp_wifi_embassy_access_point.rs
+++ b/examples/src/bin/esp_wifi_embassy_access_point.rs
@@ -51,7 +51,7 @@ use esp_wifi::{
 };
 
 macro_rules! mk_static {
-    ($t:path,$val:expr) => {{
+    ($t:ty,$val:expr) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
         #[deny(unused_attributes)]
         let x = STATIC_CELL.uninit().write(($val));

--- a/examples/src/bin/esp_wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/esp_wifi_embassy_access_point_with_sta.rs
@@ -59,7 +59,7 @@ const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 
 macro_rules! mk_static {
-    ($t:path,$val:expr) => {{
+    ($t:ty,$val:expr) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
         #[deny(unused_attributes)]
         let x = STATIC_CELL.uninit().write(($val));

--- a/examples/src/bin/esp_wifi_embassy_bench.rs
+++ b/examples/src/bin/esp_wifi_embassy_bench.rs
@@ -45,7 +45,7 @@ use esp_wifi::{
 };
 
 macro_rules! mk_static {
-    ($t:path,$val:expr) => {{
+    ($t:ty,$val:expr) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
         #[deny(unused_attributes)]
         let x = STATIC_CELL.uninit().write(($val));

--- a/examples/src/bin/esp_wifi_embassy_dhcp.rs
+++ b/examples/src/bin/esp_wifi_embassy_dhcp.rs
@@ -41,7 +41,7 @@ use esp_wifi::{
 };
 
 macro_rules! mk_static {
-    ($t:path,$val:expr) => {{
+    ($t:ty,$val:expr) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
         #[deny(unused_attributes)]
         let x = STATIC_CELL.uninit().write(($val));

--- a/examples/src/bin/esp_wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/esp_wifi_embassy_esp_now_duplex.rs
@@ -30,7 +30,7 @@ use esp_wifi::{
 };
 
 macro_rules! mk_static {
-    ($t:path,$val:expr) => {{
+    ($t:ty,$val:expr) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
         #[deny(unused_attributes)]
         let x = STATIC_CELL.uninit().write(($val));


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Improves the `mk_static` macro contained in some examples. It was good enough before but a user on Matrix tried to use it in a different way and was running into a problem

#### Testing
Still compiles
