### PR TITLE
Improve RISC-V interrupt latency

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor `Dac1`/`Dac2` drivers into a single `Dac` driver (#1661)
 - esp-hal-embassy: make executor code optional (but default) again
+- Improved interrupt latency on RISC-V based chips (#1679)
 
 ### Removed
 - uart: Removed `configure_pins` methods (#1592)

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -29,6 +29,7 @@
 use core::{cell::Cell, marker::PhantomData};
 
 use critical_section::Mutex;
+use procmacros::ram;
 
 #[cfg(any(adc, dac))]
 pub(crate) use crate::analog;
@@ -1179,6 +1180,7 @@ impl Io {
     }
 }
 
+#[ram]
 extern "C" fn gpio_interrupt_handler() {
     if let Some(user_handler) = critical_section::with(|cs| USER_INTERRUPT_HANDLER.borrow(cs).get())
     {
@@ -2608,6 +2610,7 @@ mod asynch {
         });
     }
 
+    #[ram]
     pub(super) fn handle_gpio_interrupt() {
         let intrs_bank0 = InterruptStatusRegisterAccessBank0::interrupt_status_read();
 

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -279,19 +279,18 @@ impl InterruptStatus {
 
     /// Is the given interrupt bit set
     pub fn is_set(&self, interrupt: u16) -> bool {
-        (self.status[interrupt as usize / 32] & (1 << interrupt as u32 % 32)) != 0
+        (self.status[interrupt as usize / 32] & (1 << (interrupt as u32 % 32))) != 0
     }
 
     /// Set the given interrupt status bit
     pub fn set(&mut self, interrupt: u16) {
-        self.status[interrupt as usize / 32] =
-            self.status[interrupt as usize / 32] | (1 << interrupt as u32 % 32);
+        self.status[interrupt as usize / 32] |= 1 << (interrupt as u32 % 32);
     }
 
     /// Return an iterator over the set interrupt status bits
     pub fn iterator(&self) -> InterruptStatusIterator {
         InterruptStatusIterator {
-            status: self.clone(),
+            status: *self,
             idx: 0,
         }
     }

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -237,6 +237,7 @@ pub enum Cpu {
 }
 
 /// Which core the application is currently executing on
+#[inline(always)]
 pub fn get_core() -> Cpu {
     // This works for both RISCV and Xtensa because both
     // get_raw_core functions return zero, _or_ something
@@ -256,8 +257,15 @@ pub fn get_core() -> Cpu {
 ///
 /// Safety: This method should never return UNUSED_THREAD_ID_VALUE
 #[cfg(riscv)]
+#[inline(always)]
 fn get_raw_core() -> usize {
-    riscv::register::mhartid::read()
+    #[cfg(multi_core)]
+    {
+        riscv::register::mhartid::read()
+    }
+
+    #[cfg(not(multi_core))]
+    0
 }
 
 /// Returns the result of reading the PRID register logically ANDed with 0x2000,
@@ -268,6 +276,7 @@ fn get_raw_core() -> usize {
 ///
 /// Safety: This method should never return UNUSED_THREAD_ID_VALUE
 #[cfg(xtensa)]
+#[inline(always)]
 fn get_raw_core() -> usize {
     (xtensa_lx::get_processor_id() & 0x2000) as usize
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This improves interrupt latency on RISC-V based chips.

#### Testing
All interrupt, embassy and esp-wifi examples still work.

To test the latency, I modified the `gpio_interrupt.rs` example like this:
```rust
//! GPIO interrupt
//!
//! This prints "Interrupt" when the boot button is pressed.
//! It also blinks an LED like the blinky example.

//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3

#![no_std]
#![no_main]

use core::cell::RefCell;

use critical_section::Mutex;
use esp_backtrace as _;
use esp_hal::{
    clock::ClockControl,
    delay::Delay,
    gpio::{self, Event, Input, Io, Level, Output, Pull},
    macros::ram,
    peripherals::Peripherals,
    prelude::*,
    system::SystemControl,
};

#[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
static BUTTON: Mutex<RefCell<Option<Input<gpio::Gpio0>>>> = Mutex::new(RefCell::new(None));
#[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
static BUTTON: Mutex<RefCell<Option<Input<gpio::Gpio9>>>> = Mutex::new(RefCell::new(None));

static LED: Mutex<RefCell<Option<Output<gpio::Gpio2>>>> = Mutex::new(RefCell::new(None));

#[entry]
fn main() -> ! {
    let peripherals = Peripherals::take();
    let system = SystemControl::new(peripherals.SYSTEM);
    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    // Set GPIO2 as an output, and set its state high initially.
    let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
    io.set_interrupt_handler(user_gpio_handler);
    let mut led = Output::new(io.pins.gpio2, Level::Low);

    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
    let button = io.pins.gpio0;
    #[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
    let button = io.pins.gpio9;

    let mut button = Input::new(button, Pull::Up);

    critical_section::with(|cs| {
        LED.borrow_ref_mut(cs).replace(led);

        button.listen(Event::FallingEdge);
        BUTTON.borrow_ref_mut(cs).replace(button);
    });

    let delay = Delay::new(&clocks);

    loop {}
}

#[handler]
#[ram]
fn user_gpio_handler() {
    critical_section::with(|cs| {
        LED.borrow_ref_mut(cs).as_mut().unwrap().toggle();

        BUTTON
            .borrow_ref_mut(cs)
            .as_mut()
            .unwrap()
            .clear_interrupt()
    });
}
```

Then use a logic-analyzer triggering on GPIO 9 and measure the time from the falling edge of GPIO 9 to the changing edge on GPIO 2. This obviously includes more than just the time to trigger the interrupt but it's also a somewhat realistic test.

Here is what I measured:
(all measured at boot defaults / 40MHz flash frequency, used rustc 1.80.0-nightly (79734f1db 2024-05-02))

C2
before	31.692 / 12.40
after	        18.517 / 5.64


C3
before	21.432 / 10.572
after	        11.79 / 4.99


C6
before	17.125 / 10.71
after	        8.95 / 5.94

H2
before	25.335 / 11.36
after	        14.27 / 5.44

I'm quite happy with the improvement!

The first triggering is still much slower which is because there are cache misses (see #1162 - originally, I wanted to address the things there, will add a comment why I didn't there - see https://github.com/esp-rs/esp-hal/issues/1162#issuecomment-2167494904)

We should probably try something similar for Xtensa