### PR TITLE
Enable C2 HIL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,8 @@ jobs:
       matrix:
         target:
           # RISC-V devices:
+          - soc: esp32c2
+            rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c3
             rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c6

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -27,6 +27,8 @@ jobs:
       matrix:
         target:
           # RISC-V devices:
+          - soc: esp32c2
+            rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c3
             rust-target: riscv32imc-unknown-none-elf
           - soc: esp32c6

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -101,6 +101,8 @@ jobs:
       matrix:
         target:
           # RISC-V devices:
+          - soc: esp32c2
+            runner: esp32c2-jtag
           - soc: esp32c3
             runner: esp32c3-usb
           - soc: esp32c6

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -55,31 +55,36 @@ Some tests will require physical connections, please see the current [configurat
 ### Running Tests Remotes (ie. On Self-Hosted Runners)
 The [`hil.yml`] workflow builds the test suite for all our available targets and executes them.
 
-Our Virtual Machines have the following setup:
+Our self hosted runners have the following setup:
+- ESP32-C2 (`esp32c2-jtag`):
+  - Devkit: `ESP8684-DevKitM-1` connected via UART.
+    - `GPIO2` and `GPIO3` are connected.
+  - Probe: `ESP-Prog` connected with the [following connections](https://docs.espressif.com/projects/esp-idf/en/stable/esp32c2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware)
+  - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-C3 (`rustboard`):
   - Devkit: `ESP32-C3-DevKit-RUST-1` connected via USB-Serial-JTAG.
-    - `GPIO2` and `GPIO4` are connected.
+    - `GPIO2` and `GPIO3` are connected.
     - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-C6 (`esp32c6-usb`):
   - Devkit: `ESP32-C6-DevKitC-1 V1.2` connected via USB-Serial-JTAG (`USB` port).
-    - `GPIO2` and `GPIO4` are connected.
+    - `GPIO2` and `GPIO3` are connected.
     - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-H2 (`esp32h2-usb`):
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).
-    - `GPIO2` and `GPIO4` are connected.
+    - `GPIO2` and `GPIO3` are connected.
     - `GPIO5` and `GPIO8` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-S2 (`esp32s2-jtag`):
   - Devkit: `ESP32-S2-Saola-1` connected via UART.
-    - `GPIO2` and `GPIO4` are connected.
+    - `GPIO2` and `GPIO3` are connected.
     - `GPIO5` and `GPIO6` are connected.
   - Probe: `ESP-Prog` connected with the [following connections](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware)
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 - ESP32-S3 (`esp32s3-usb`):
   - Devkit: `ESP32-S3-DevKitC-1` connected via USB-Serial-JTAG.
-    - `GPIO2` and `GPIO4` are connected.
+    - `GPIO2` and `GPIO3` are connected.
     - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -86,6 +86,8 @@ Our self hosted runners have the following setup:
   - Devkit: `ESP32-S3-DevKitC-1` connected via USB-Serial-JTAG.
     - `GPIO2` and `GPIO3` are connected.
     - `GPIO5` and `GPIO6` are connected.
+    - `GPIO1` and `GPIO21` are connected.
+    - `GPIO43 (TX)` and `GPIO45` are connected.
   - RPi: Raspbian 12 configured with the following [setup](#vm-setup)
 
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -1,6 +1,7 @@
 //! Delay Test
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s3
+// esp32c2 is disabled currently as it fails
+//% CHIPS: esp32  esp32c3 esp32c6 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/get_time.rs
+++ b/hil-test/tests/get_time.rs
@@ -1,6 +1,7 @@
 //! current_time Test
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+// esp32c2 is disabled currently as it fails
+//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -1,6 +1,6 @@
 //! I2S Loopback Test
 //!
-//! It's assumed GPIO2 is connected to GPIO4
+//! It's assumed GPIO2 is connected to GPIO3
 //!
 //! This test uses I2S TX to transmit known data to I2S RX (forced to slave mode
 //! with loopback mode enabled). It's using circular DMA mode
@@ -81,7 +81,7 @@ mod tests {
             .i2s_rx
             .with_bclk(io.pins.gpio0)
             .with_ws(io.pins.gpio1)
-            .with_din(io.pins.gpio4)
+            .with_din(io.pins.gpio3)
             .build();
 
         // enable loopback testing

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -1,6 +1,6 @@
 //! RMT Loopback Test
 //!
-//! It's assumed GPIO2 is connected to GPIO4
+//! It's assumed GPIO2 is connected to GPIO3
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -65,17 +65,17 @@ mod tests {
             if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel1.configure(io.pins.gpio4, rx_config).unwrap()
+                    rmt.channel1.configure(io.pins.gpio3, rx_config).unwrap()
                 };
             } else if #[cfg(feature = "esp32s3")] {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel7.configure(io.pins.gpio4, rx_config).unwrap()
+                    rmt.channel7.configure(io.pins.gpio3, rx_config).unwrap()
                 };
             } else {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel2.configure(io.pins.gpio4, rx_config).unwrap()
+                    rmt.channel2.configure(io.pins.gpio3, rx_config).unwrap()
                 };
             }
         }

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -3,10 +3,10 @@
 //! Folowing pins are used:
 //! SCLK    GPIO0
 //! MISO    GPIO2
-//! MOSI    GPIO4
-//! CS      GPIO5
+//! MOSI    GPIO3
+//! CS      GPIO8
 //!
-//! Connect MISO (GPIO2) and MOSI (GPIO4) pins.
+//! Connect MISO (GPIO2) and MOSI (GPIO3) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -38,8 +38,8 @@ impl Context {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let miso = io.pins.gpio2;
-        let mosi = io.pins.gpio4;
-        let cs = io.pins.gpio5;
+        let mosi = io.pins.gpio3;
+        let cs = io.pins.gpio8;
 
         let spi = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0, &clocks).with_pins(
             Some(sclk),

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -3,10 +3,10 @@
 //! Folowing pins are used:
 //! SCLK    GPIO0
 //! MISO    GPIO2
-//! MOSI    GPIO4
-//! CS      GPIO5
+//! MOSI    GPIO3
+//! CS      GPIO8
 //!
-//! Connect MISO (GPIO2) and MOSI (GPIO4) pins.
+//! Connect MISO (GPIO2) and MOSI (GPIO3) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
 
@@ -48,8 +48,8 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let miso = io.pins.gpio2;
-        let mosi = io.pins.gpio4;
-        let cs = io.pins.gpio5;
+        let mosi = io.pins.gpio3;
+        let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 
@@ -91,8 +91,8 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let miso = io.pins.gpio2;
-        let mosi = io.pins.gpio4;
-        let cs = io.pins.gpio5;
+        let mosi = io.pins.gpio3;
+        let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 
@@ -135,8 +135,8 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let miso = io.pins.gpio2;
-        let mosi = io.pins.gpio4;
-        let cs = io.pins.gpio5;
+        let mosi = io.pins.gpio3;
+        let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 
@@ -183,8 +183,8 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let miso = io.pins.gpio2;
-        let mosi = io.pins.gpio4;
-        let cs = io.pins.gpio5;
+        let mosi = io.pins.gpio3;
+        let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 
@@ -232,8 +232,8 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let miso = io.pins.gpio2;
-        let mosi = io.pins.gpio4;
-        let cs = io.pins.gpio5;
+        let mosi = io.pins.gpio3;
+        let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -280,8 +280,8 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let miso = io.pins.gpio2;
-        let mosi = io.pins.gpio4;
-        let cs = io.pins.gpio5;
+        let mosi = io.pins.gpio3;
+        let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! TX    GPIP2
-//! RX    GPIO4
+//! RX    GPIO3
 //!
-//! Connect TX (GPIO2) and RX (GPIO4) pins.
+//! Connect TX (GPIO2) and RX (GPIO3) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -38,7 +38,7 @@ impl Context {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let uart = Uart::new(peripherals.UART1, &clocks, io.pins.gpio2, io.pins.gpio4).unwrap();
+        let uart = Uart::new(peripherals.UART1, &clocks, io.pins.gpio2, io.pins.gpio3).unwrap();
 
         Context { clocks, uart }
     }
@@ -100,7 +100,7 @@ mod tests {
 
         #[cfg(not(feature = "esp32s2"))]
         {
-            #[cfg(not(feature = "esp32c3"))]
+            #[cfg(not(any(feature = "esp32c3", feature = "esp32c2")))]
             {
                 // 9600 baud, RC FAST clock source:
                 ctx.uart.change_baud(9600, ClockSource::RcFast, &ctx.clocks);

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! TX    GPIP2
-//! RX    GPIO4
+//! RX    GPIO3
 //!
-//! Connect TX (GPIO2) and RX (GPIO4) pins.
+//! Connect TX (GPIO2) and RX (GPIO3) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -34,7 +34,7 @@ impl Context {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
         let uart =
-            Uart::new_async(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio4).unwrap();
+            Uart::new_async(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio3).unwrap();
 
         Context { uart }
     }

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! TX    GPIP2
-//! RX    GPIO4
+//! RX    GPIO3
 //!
-//! Connect TX (GPIO2) and RX (GPIO4) pins.
+//! Connect TX (GPIO2) and RX (GPIO3) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -38,7 +38,7 @@ impl Context {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
         let tx = UartTx::new(peripherals.UART0, &clocks, None, io.pins.gpio2).unwrap();
-        let rx = UartRx::new(peripherals.UART1, &clocks, None, io.pins.gpio4).unwrap();
+        let rx = UartRx::new(peripherals.UART1, &clocks, None, io.pins.gpio3).unwrap();
 
         Context { tx, rx }
     }

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! TX    GPIP2
-//! RX    GPIO4
+//! RX    GPIO3
 //!
-//! Connect TX (GPIO2) and RX (GPIO4) pins.
+//! Connect TX (GPIO2) and RX (GPIO3) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -36,7 +36,7 @@ impl Context {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
         let tx = UartTx::new_async(peripherals.UART0, &clocks, io.pins.gpio2).unwrap();
-        let rx = UartRx::new_async(peripherals.UART1, &clocks, io.pins.gpio4).unwrap();
+        let rx = UartRx::new_async(peripherals.UART1, &clocks, io.pins.gpio3).unwrap();
 
         Context { tx, rx }
     }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -306,6 +306,13 @@ pub fn execute_app(
     if subcommand == "test" {
         if chip == Chip::Esp32 {
             builder = builder.arg("--").arg("--chip").arg("esp32-3.3v");
+        } else if chip == Chip::Esp32c2 {
+            builder = builder
+                .arg("--")
+                .arg("--chip")
+                .arg("esp32c2")
+                .arg("--speed")
+                .arg("15000");
         } else {
             builder = builder.arg("--").arg("--chip").arg(format!("{}", chip));
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- Enables C2 HIL test suite
- Changes the wiring of all the current tests/targets, instead of connecting `GPIO2` and `GPIO4`, we should now use `GPIO2` and `GPIO3
  - This means that we should sync whenever we update the lab targets and when we merge this PR.
- Test that rely on `delay`s are failing, added the error to https://github.com/esp-rs/esp-hal/issues/1524 and disabled them for C2

> [!IMPORTANT]  
> Once merged we need to add the `HIL Test | esp32c2` test to the required checks

#### Testing
Locally run the test suite, modifying the connected pins, without errors for C2, C3, C6, H2, S2 and S3.