### PR TITLE
esp-backtrace: Fix for nightly after 2024-06-12

### DIFF
--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -18,6 +18,7 @@ semihosting = { version = "0.1.10", optional = true }
 
 [build-dependencies]
 esp-build = { version = "0.1.0", path = "../esp-build" }
+rustversion = "1.0.17"
 
 [features]
 default = ["colors"]

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -13,20 +13,18 @@ fn main() {
         panic!("Only one of `custom-halt` and `halt-cores` can be enabled");
     }
 
-    if is_nightly() {
-        println!("cargo:rustc-cfg=nightly");
-    }
+    check_nightly();
 }
 
-fn is_nightly() -> bool {
-    let version_output = std::process::Command::new(
-        std::env::var_os("RUSTC").unwrap_or_else(|| std::ffi::OsString::from("rustc")),
-    )
-    .arg("-V")
-    .output()
-    .unwrap()
-    .stdout;
-    let version_string = String::from_utf8_lossy(&version_output);
-
-    version_string.contains("nightly")
+#[rustversion::before(2024-06-12)]
+fn check_nightly() {
+    println!("cargo:rustc-cfg=nightly_before_2024_06_12");
 }
+
+#[rustversion::since(2024-06-12)]
+fn check_nightly() {
+    println!("cargo:rustc-cfg=nightly_since_2024_06_12");
+}
+
+#[rustversion::stable]
+fn check_nightly() {}

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -16,7 +16,7 @@ fn main() {
     check_nightly();
 }
 
-#[rustversion::before(2024-06-12)]
+#[rustversion::all(not(stable),not(since(2024-06-12)))]
 fn check_nightly() {
     println!("cargo:rustc-cfg=nightly_before_2024_06_12");
 }

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -95,7 +95,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
         println!("{}", message);
 
         #[cfg(feature = "defmt")]
-        println!("{}", defmt::Display2Format(message));
+        println!("{}", defmt::Display2Format(&message));
     }
 
     println!("");

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -1,5 +1,8 @@
 #![allow(rustdoc::bare_urls, unused_macros)]
-#![cfg_attr(nightly, feature(panic_info_message))]
+#![cfg_attr(
+    any(nightly_before_2024_06_12, nightly_since_2024_06_12),
+    feature(panic_info_message)
+)]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
@@ -65,7 +68,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
         println!("!! A panic occured at an unknown location:");
     }
 
-    #[cfg(not(nightly))]
+    #[cfg(not(any(nightly_before_2024_06_12, nightly_since_2024_06_12)))]
     {
         #[cfg(not(feature = "defmt"))]
         println!("{:#?}", info);
@@ -74,7 +77,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
         println!("{:#?}", defmt::Display2Format(info));
     }
 
-    #[cfg(nightly)]
+    #[cfg(nightly_before_2024_06_12)]
     {
         if let Some(message) = info.message() {
             #[cfg(not(feature = "defmt"))]
@@ -83,6 +86,16 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
             #[cfg(feature = "defmt")]
             println!("{}", defmt::Display2Format(message));
         }
+    }
+
+    #[cfg(nightly_since_2024_06_12)]
+    {
+        let message = info.message();
+        #[cfg(not(feature = "defmt"))]
+        println!("{}", message);
+
+        #[cfg(feature = "defmt")]
+        println!("{}", defmt::Display2Format(message));
     }
 
     println!("");


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fix the compilation error.

#### Testing
Build doesn't fail
