### PR TITLE
esp-hal-wifi: make executors optional (again)

### DIFF
--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -15,7 +15,7 @@ features       = ["esp32c6", "time-timg0"]
 critical-section    = "1.1.2"
 defmt               = { version = "0.3.8", optional = true }
 document-features   = "0.2.8"
-embassy-executor    = "0.5.0"
+embassy-executor    = { version = "0.5.0", optional = true }
 embassy-time-driver = "0.1.0"
 esp-hal             = { version = "0.18.0", path = "../esp-hal" }
 portable-atomic     = "1.6.0"
@@ -26,6 +26,8 @@ esp-build    = { version = "0.1.0", path = "../esp-build" }
 esp-metadata = { version = "0.1.1", path = "../esp-metadata" }
 
 [features]
+default = ["executors"]
+
 esp32   = ["esp-hal/esp32"]
 esp32c2 = ["esp-hal/esp32c2"]
 esp32c3 = ["esp-hal/esp32c3"]
@@ -35,9 +37,11 @@ esp32s2 = ["esp-hal/esp32s2"]
 esp32s3 = ["esp-hal/esp32s3"]
 
 ## Implement `defmt::Format` on certain types.
-defmt = ["dep:defmt", "embassy-executor/defmt", "esp-hal/defmt"]
+defmt = ["dep:defmt", "embassy-executor?/defmt", "esp-hal/defmt"]
+## Provide `Executor` and `InterruptExecutor`
+executors = ["dep:embassy-executor"]
 ## Use the executor-integrated `embassy-time` timer queue.
-integrated-timers = ["embassy-executor/integrated-timers"]
+integrated-timers = ["embassy-executor?/integrated-timers"]
 
 #! ### Time Driver Feature Flags
 ## SYSTIMER (16MHz)

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -41,9 +41,11 @@ use core::cell::Cell;
 use embassy_time_driver::{AlarmHandle, Driver};
 use esp_hal::clock::Clocks;
 
+#[cfg(feature = "executors")]
 pub use self::executor::{Executor, InterruptExecutor};
 use self::time_driver::{EmbassyTimer, TimerType};
 
+#[cfg(feature = "executors")]
 mod executor;
 mod time_driver;
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactor `Dac1`/`Dac2` drivers into a single `Dac` driver (#1661)
+- esp-hal-embassy: make executor code optional (but default) again
 
 ### Removed
 - uart: Removed `configure_pins` methods (#1592)

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 [dependencies]
 defmt = { version = "0.3.8", optional = true }
 esp-hal = { version = "0.18.0", path = "../esp-hal", default-features = false }
-esp-hal-embassy = { version = "0.1.0", path = "../esp-hal-embassy", optional = true }
+esp-hal-embassy = { version = "0.1.0", path = "../esp-hal-embassy", default-features = false, optional = true }
 smoltcp = { version = "0.11.0", default-features = false, features = [
   "medium-ethernet",
   "socket-raw",


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

#1485 unconditionally enables inclusion of the embassy executor implementations. That basically blocks use of a custom executor. In [RIOT-rs](https://github.com/future-proof-iot/RIOT-rs), we're using a preemptive scheduler and want to run a custom Executor inside a thread. As `__pender()` needs to be redefined for that use-case, we need an option to disable the `esp-hal-embassy` executor code.

This PR introduces a feature `executors` that gates the corresponding code, and adds that feature to `default`.

#### Testing

This should not change any default behavior. I did test that my change works with our code and not using the executors.
