### PR TITLE
Fix: allow `defmt-espflash` + `auto` configuration @ esp-println

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,15 @@ jobs:
             --features=${{ matrix.device.soc }},log \
             --target=${{ matrix.device.target }} \
             esp-println
-        
+
+      # So #1678 doesn't reoccur ('defmt-espflash,auto')
+      - name: Build (with feature 'defmt-espflash')
+        run: |
+          cargo xtask build-package \
+            --features=${{ matrix.device.soc }},log,defmt-espflash \
+            --target=${{ matrix.device.target }} \
+            esp-println
+
   extras:
     runs-on: ubuntu-latest
 

--- a/esp-println/build.rs
+++ b/esp-println/build.rs
@@ -10,8 +10,7 @@ fn main() {
     assert_unique_used_features!("jtag-serial", "uart", "auto");
 
     // Ensure that, if the `jtag-serial` communication method feature is enabled,
-    // either the `esp32c3`, `esp32c6`, `esp32h2`, or `esp32s3` chip feature is
-    // enabled.
+    // a compatible chip feature is also enabled.
     if cfg!(feature = "jtag-serial")
         && !(cfg!(feature = "esp32c3")
             || cfg!(feature = "esp32c6")

--- a/esp-println/src/defmt.rs
+++ b/esp-println/src/defmt.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "critical-section")]
 use critical_section::RestoreState;
 
-use super::Printer;
+use super::PrinterImpl;
 
 /// Global logger lock.
 #[cfg(feature = "critical-section")]
@@ -52,7 +52,7 @@ unsafe impl defmt::Logger for Logger {
         // section.
         ENCODER.end_frame(do_write);
 
-        Printer.flush();
+        Self::flush();
 
         #[cfg(feature = "critical-section")]
         {
@@ -74,7 +74,7 @@ unsafe impl defmt::Logger for Logger {
     }
 
     unsafe fn flush() {
-        Printer.flush();
+        PrinterImpl::flush();
     }
 
     unsafe fn write(bytes: &[u8]) {
@@ -85,5 +85,5 @@ unsafe impl defmt::Logger for Logger {
 }
 
 fn do_write(bytes: &[u8]) {
-    Printer.write_bytes_assume_cs(bytes)
+    PrinterImpl::write_bytes_assume_cs(bytes)
 }

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -89,15 +89,15 @@ impl core::fmt::Write for Printer {
     }
 }
 
-#[cfg(feature="auto")]
+#[cfg(feature = "auto")]
 pub struct PrinterAuto;
 
 #[cfg(feature = "auto")]
 type PrinterImpl = PrinterAuto;
 
-#[cfg(feature="auto")]
+#[cfg(feature = "auto")]
 mod auto_printer {
-    use super::{ with, PrinterSerialJtag, PrinterUart };
+    use super::{with, PrinterSerialJtag, PrinterUart};
 
     impl super::PrinterAuto {
         fn use_jtag() -> bool {
@@ -138,7 +138,9 @@ mod auto_printer {
                 feature = "esp32p4",
                 feature = "esp32s3"
             )))]
-            { false }
+            {
+                false
+            }
         }
 
         pub fn write_bytes_assume_cs(bytes: &[u8]) {
@@ -164,7 +166,6 @@ mod auto_printer {
                 })
             }
         }
-
     }
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
<!--Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.-->

With the recent addition of `auto` mode to `esp-println`, ability to use `defmt-espflash` feature was affected. This PR fixes that.

I tried to *only* fix the problem at hand. In addition, there are *some* references to P4 hw, which I noticed `esp-println/build.rs` refers to but the existing code didn't. I'm happy to remove these, if that is requested (personally, I think they can remain, or rather the work on P4 logging support could be finished before 0.19.0). 

There are other aspects I would feel deserve attention. E.g. currently, the auto mode evaluates its method at every print call, which feels excessive, but I don't know enough specifics to be sure. Anyhow, it deserves to be a separate PR - now it would be important to fix the "auto" functionality before it gets into a released version.

I chose not to edit `CHANGELOG.md` because the "auto" feature already has an entry there, and this is simply a patch for that entry. Do you think this is okay?

#### Testing
<!--Describe how you tested your changes.-->

Tested compilation with:

```
$ cargo check --features=esp32c3
$ cargo check --features=esp32
$ cargo check --features=esp32c3,defmt-espflash
$ cargo check --features=esp32c3,defmt-espflash,jtag-serial --no-default-features
$ cargo check --features=esp32c3,defmt-espflash,uart --no-default-features
```

Tested the output on a C6 board (both UART and JTAG-serial connectors):

```
$ cargo xtask run-example esp-hal esp32c6 embassy_hello_world
```

...with, in examples/Cargo.toml:

```
esp-println         = { path = "../esp-println", features = ["log"] }  # ORIGINAL
esp-println         = { path = "../esp-println", default-features=false, features = ["log", "jtag-serial", "defmt-espflash"] }
esp-println         = { path = "../esp-println", default-features=false, features = ["log", "auto", "defmt-espflash"] }
esp-println         = { path = "../esp-println", default-features=false, features = ["log", "uart", "defmt-espflash"] }
```

On the "auto" option, I ran it twice (from both UART and jtag-serial ports by `espflash`). Output seen, as expected.

Fixes #1678