### PR TITLE
esp-wifi: enforce minimum clock, rather than maximum

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `Dac1`/`Dac2` drivers into a single `Dac` driver (#1661)
 - esp-hal-embassy: make executor code optional (but default) again
 - Improved interrupt latency on RISC-V based chips (#1679)
+- `esp_wifi::initialize` no longer requires running maximum CPU clock, instead check it runs above 80MHz. (#1688)
 
 ### Removed
 - uart: Removed `configure_pins` methods (#1592)

--- a/esp-hal/src/clock/clocks_ll/esp32s3.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32s3.rs
@@ -1,4 +1,9 @@
-use crate::clock::CpuClock;
+use core::ops::Div;
+
+use crate::{
+    clock::{Clock, CpuClock},
+    rom,
+};
 
 pub(crate) fn set_cpu_clock(cpu_clock_speed: CpuClock) {
     let system_control = unsafe { &*crate::peripherals::SYSTEM::PTR };
@@ -18,4 +23,7 @@ pub(crate) fn set_cpu_clock(cpu_clock_speed: CpuClock) {
                 })
         });
     }
+
+    let ticks_per_us = cpu_clock_speed.frequency().div(1_000_000);
+    rom::ets_update_cpu_frequency_rom(ticks_per_us.raw());
 }

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `esp_wifi::initialize` no longer requires running maximum CPU clock, instead check it runs above 80MHz. (#1688)
+
 ### Removed
 
 ## [0.6.0] - 2024-06-04

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -670,7 +670,6 @@ pub(crate) static DATA_QUEUE_RX_STA: Mutex<
 pub enum WifiError {
     NotInitialized,
     InternalError(InternalWifiError),
-    WrongClockConfig,
     Disconnected,
     UnknownWifiMode,
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

- During WiFI initialization, validate that the CPU is not running below 80MHz.
- Remove unused enum variant  `WrongClockConfig` on `WifiError`
  - The validation triggers during initialization, which returns `InitializationError` instead.
- Update `CONTRIBUTING.md` to fix the command that formats the codebase.

#### Description

- Relates to https://github.com/esp-rs/esp-hal/issues/1685 where it seems that the minimum operating CPU clock for WiFI should be 80MHz. In order to make it low power friendly, do not enforce the chip to run at max clock, and enforce the bare minimum clock speed instead. The motivation for the change is that I want to run BLE at the minimum clock speed.

#### Testing

- [x] The removal of the clock several days on an `esp32s3`, correctly sending BLE data to my computer at 15 minutes interval.
- [ ] Not tested with WiFI connectivity
