### PR TITLE
esp-bracktrace: only print float registers on chips that have them

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+- esp-backtrace only prints float registers on targets which have them.
+
+### Changed
+
+### Removed
+

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -24,20 +24,22 @@ rustversion = "1.0.17"
 default = ["colors"]
 
 # You must enable exactly one of the below features to support the correct chip:
-esp32   = ["esp-println?/esp32", "semihosting?/openocd-semihosting"]
+esp32   = ["esp-println?/esp32", "semihosting?/openocd-semihosting", "print-float-registers"]
 esp32c2 = ["esp-println?/esp32c2"]
 esp32c3 = ["esp-println?/esp32c3"]
 esp32c6 = ["esp-println?/esp32c6"]
 esp32h2 = ["esp-println?/esp32h2"]
 esp32p4 = ["esp-println?/esp32p4"]
 esp32s2 = ["esp-println?/esp32s2", "semihosting?/openocd-semihosting"]
-esp32s3 = ["esp-println?/esp32s3", "semihosting?/openocd-semihosting"]
+esp32s3 = ["esp-println?/esp32s3", "semihosting?/openocd-semihosting", "print-float-registers"]
 
 # Use esp-println
 println = ["dep:esp-println"]
 
 # Use defmt
 defmt = ["dep:defmt"]
+
+print-float-registers = [] # TODO support esp32p4
 
 # You may optionally enable one or more of the below features to provide
 # additional functionality:

--- a/esp-backtrace/src/xtensa.rs
+++ b/esp-backtrace/src/xtensa.rs
@@ -137,26 +137,47 @@ pub struct Context {
     pub M1: u32,
     pub M2: u32,
     pub M3: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F64R_LO: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F64R_HI: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F64S: u32,
+    #[cfg(feature = "print-float-registers")]
     pub FCR: u32,
+    #[cfg(feature = "print-float-registers")]
     pub FSR: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F0: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F1: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F2: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F3: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F4: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F5: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F6: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F7: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F8: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F9: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F10: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F11: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F12: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F13: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F14: u32,
+    #[cfg(feature = "print-float-registers")]
     pub F15: u32,
 }
 
@@ -178,12 +199,6 @@ SCOMPARE1=0x{:08x}
 BR=0x{:08x}
 ACCLO=0x{:08x}    ACCHI=0x{:08x}
 M0=0x{:08x}       M1=0x{:08x}       M2=0x{:08x}       M3=0x{:08x}
-F64R_LO=0x{:08x}  F64R_HI=0x{:08x}  F64S=0x{:08x}
-FCR=0x{:08x}      FSR=0x{:08x}
-F0=0x{:08x}       F1=0x{:08x}       F2=0x{:08x}       F3=0x{:08x}       F4=0x{:08x}
-F5=0x{:08x}       F6=0x{:08x}       F7=0x{:08x}       F8=0x{:08x}       F9=0x{:08x}
-F10=0x{:08x}      F11=0x{:08x}      F12=0x{:08x}      F13=0x{:08x}      F14=0x{:08x}
-F15=0x{:08x}
 ",
             self.PC,
             self.PS,
@@ -218,6 +233,16 @@ F15=0x{:08x}
             self.M1,
             self.M2,
             self.M3,
+        )?;
+        #[cfg(feature = "print-float-registers")]
+        write!(
+            fmt,
+            "F64R_LO=0x{:08x}  F64R_HI=0x{:08x}  F64S=0x{:08x}
+FCR=0x{:08x}      FSR=0x{:08x}
+F0=0x{:08x}       F1=0x{:08x}       F2=0x{:08x}       F3=0x{:08x}       F4=0x{:08x}
+F5=0x{:08x}       F6=0x{:08x}       F7=0x{:08x}       F8=0x{:08x}       F9=0x{:08x}
+F10=0x{:08x}      F11=0x{:08x}      F12=0x{:08x}      F13=0x{:08x}      F14=0x{:08x}
+F15=0x{:08x}",
             self.F64R_LO,
             self.F64R_HI,
             self.F64S,
@@ -239,7 +264,9 @@ F15=0x{:08x}
             self.F13,
             self.F14,
             self.F15,
-        )
+        )?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Ensures that we don't print garbage on targets without float registers.

Closes #1587 
