### PR TITLE
Add RtcI2c driver for ESP32-S3

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Flex / AnyFlex GPIO pin driver (#1659)
 - Add new `DmaError::UnsupportedMemoryRegion` - used memory regions are checked when preparing a transfer now (#1670)
+- ESP32-S3: Add RtcI2c driver (#0000)
 
 ### Fixed
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -152,6 +152,8 @@ pub enum AlternateFunction {
 pub enum RtcFunction {
     Rtc     = 0,
     Digital = 1,
+    #[cfg(rtc_i2c)]
+    I2c     = 3,
 }
 
 /// Trait implemented by RTC pins

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -491,3 +491,25 @@ impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
 // implement marker traits on USB pins
 impl crate::otg_fs::UsbDp for Gpio19 {}
 impl crate::otg_fs::UsbDm for Gpio20 {}
+
+impl crate::i2c::rtc_i2c::RtcI2cSda for Gpio1 {
+    fn selector(&self) -> u8 {
+        0
+    }
+}
+impl crate::i2c::rtc_i2c::RtcI2cSda for Gpio3 {
+    fn selector(&self) -> u8 {
+        1
+    }
+}
+
+impl crate::i2c::rtc_i2c::RtcI2cScl for Gpio0 {
+    fn selector(&self) -> u8 {
+        0
+    }
+}
+impl crate::i2c::rtc_i2c::RtcI2cScl for Gpio2 {
+    fn selector(&self) -> u8 {
+        1
+    }
+}

--- a/examples/src/bin/rtc_i2c.rs
+++ b/examples/src/bin/rtc_i2c.rs
@@ -1,0 +1,46 @@
+//! Uses the RTC I2C peripheral from the main CPU
+
+//% CHIPS: esp32s3
+
+#![no_std]
+#![no_main]
+
+use core::time::Duration;
+
+use esp_backtrace as _;
+use esp_hal::{
+    clock::ClockControl,
+    delay::Delay,
+    gpio::Io,
+    i2c::rtc_i2c::{RtcI2c, Timing},
+    peripherals::Peripherals,
+    prelude::*,
+    system::SystemControl,
+};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = SystemControl::new(peripherals.SYSTEM);
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let i2c = RtcI2c::new(
+        peripherals.RTC_I2C,
+        io.pins.gpio1,
+        io.pins.gpio2,
+        Timing::standard_mode(),
+        Duration::from_micros(100),
+    );
+
+    let delay = Delay::new(&clocks);
+
+    loop {
+        let mut data = [0; 10];
+
+        i2c.read(0x43, 5, &mut data).unwrap();
+
+        esp_println::println!("I2C data {:?}", data);
+        delay.delay_millis(1000);
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Added a RtcI2c driver for the ESP32-S3's main CPU.
In a follow up PR I'll more/less copy the code to the lp-hal for the ULP core to use.

ESP32-S2 support could be added but I don't have one to test with.

#### Description
See #1030 .

My main blocker is I need to write an example someone on the team can run... Anyone have any register based I2C devices? :sweat_smile: 

I've got these:
- https://wiki.seeedstudio.com/Grove-LCD_RGB_Backlight/
- https://shop.m5stack.com/products/i-o-hub-1-to-6-expansion-unit-stm32f0
- https://shop.m5stack.com/products/extend-i-o-unit-2-stm32f0
- https://shop.m5stack.com/products/i2c-hub-1-to-6-expansion-unit-pca9548apw

#### Testing
I've ran the code (before I refactored it for this PR) with an ESP32-S3 + [I2C 16x2 LCD](https://wiki.seeedstudio.com/Grove-LCD_RGB_Backlight/), from both the main core and ulp core.