### PR TITLE
Add remaining GPIO pins for ESP32-S2/S3 ULP

### DIFF
--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the `ulp-riscv-hal` package (#840)
 - Add LP_UART basic driver (#1113)
 - Added basic `LP-I2C` driver for C6 (#1185)
+- Add remaining GPIO pins for ESP32-S2/S3 (#1695)
 
 ### Changed
 

--- a/esp-lp-hal/src/gpio.rs
+++ b/esp-lp-hal/src/gpio.rs
@@ -7,6 +7,11 @@ type LpIo = crate::pac::LP_IO;
 #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
 type LpIo = crate::pac::RTC_IO;
 
+#[cfg(feature = "esp32c6")]
+const MAX_GPIO_PIN: u8 = 7;
+#[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+const MAX_GPIO_PIN: u8 = 21;
+
 #[non_exhaustive]
 pub struct Input<const PIN: u8> {}
 
@@ -40,7 +45,7 @@ impl<const PIN: u8> Output<PIN> {
 // Used by the `entry` procmacro:
 #[doc(hidden)]
 pub unsafe fn conjure_output<const PIN: u8>() -> Option<Output<PIN>> {
-    if PIN > 7 {
+    if PIN > MAX_GPIO_PIN {
         None
     } else {
         Some(Output {})
@@ -50,7 +55,7 @@ pub unsafe fn conjure_output<const PIN: u8>() -> Option<Output<PIN>> {
 // Used by the `entry` procmacro:
 #[doc(hidden)]
 pub unsafe fn conjure_input<const PIN: u8>() -> Option<Input<PIN>> {
-    if PIN > 7 {
+    if PIN > MAX_GPIO_PIN {
         None
     } else {
         Some(Input {})


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The ESP32-S2 and ESP32-S3 have up to 21 RTC capable GPIO pins.

#### Testing
Does reading the ESP-IDF docs count?
- https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32c6/api-reference/peripherals/gpio.html
- https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32s2/api-reference/peripherals/gpio.html
- https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32s3/api-reference/peripherals/gpio.html
