### PR TITLE
implement `embedded_io::ReadReady` for `Uart` & `UartRx`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Flex / AnyFlex GPIO pin driver (#1659)
 - Add new `DmaError::UnsupportedMemoryRegion` - used memory regions are checked when preparing a transfer now (#1670)
 - Add DmaTransactionTxOwned, DmaTransactionRxOwned, DmaTransactionTxRxOwned, functions to do owning transfers added to SPI half-duplex (#1672)
+- uart: Implement `embedded_io::ReadReady` for `Uart` and `UartRx` (#1702)
 
 ### Fixed
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1663,6 +1663,28 @@ where
 }
 
 #[cfg(feature = "embedded-io")]
+impl<T, M> embedded_io::ReadReady for Uart<'_, T, M>
+where
+    T: Instance,
+    M: Mode,
+{
+    fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        self.rx.read_ready()
+    }
+}
+
+#[cfg(feature = "embedded-io")]
+impl<T, M> embedded_io::ReadReady for UartRx<'_, T, M>
+where
+    T: Instance,
+    M: Mode,
+{
+    fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        Ok(T::get_rx_fifo_count() > 0)
+    }
+}
+
+#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::Write for Uart<'_, T, M>
 where
     T: Instance,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

I want to use the `embedded_io::Read` trait to read from a serial port in a non-blocking fashion. I therefore needed the `Uart` / `UartRx` types to implement the `embedded_io::ReadReady`. I took a look into the code and found it pretty straight-forward to implement the trait. 

#### Testing

I'm not sure if I'd make sense to write an example for this use-case. I've tested the change locally with a board that receives data via uart and toggles an LED in parallel. Something like this:

```rust
loop {
    if pin.read_ready().unwrap() {
        let mut b = 0u8;
        pin.read(slice::from_mut(&mut b)).unwrap();
        led_2.toggle();
    }
    led.toggle();
}
```

Looking at the LEDs, I can see that `led` is toggled even when there's no data being received via uart. `led_2` toggles when data is being received, as expected. While that is the case, `led` gets slightly darker / lighter due to the changed timing in the loop.

Feel free to make suggestions for a better test / example.