### PR TITLE
Support for inverting UART lines

### DIFF
--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -52,8 +52,8 @@ fn main() -> ! {
     let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
     #[cfg(feature = "esp32s3")]
     let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
-    let config = Config::default();
-    config.rx_fifo_full_threshold(30);
+
+    let config = Config::default().rx_fifo_full_threshold(30);
 
     let mut uart0 = Uart::new_with_config(
         peripherals.UART0,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds support for inverting UART signals. See https://github.com/esp-rs/esp-hal/issues/1216

#### Testing


```rust
    let inverted_signals = InvertedSignals {
        rx: true,
        tx: true,
        rts: false,
        cts: false,
    };

    let mut uart1 = UartTx::new(peripherals.UART1, &clocks, None, io.pins.gpio5).unwrap();
    uart1.set_inverted_signals(inverted_signals);
    let mut uart0 = UartRx::new(peripherals.UART0, &clocks, None, io.pins.gpio4).unwrap();
    uart0.set_inverted_signals(inverted_signals);

    loop {
        uart1.write_bytes(&[0x42]).ok();
        delay.delay_millis(250);

        let read = block!(uart0.read_byte());

        match read {
            Ok(read) => println!("Read 0x{:02x}", read),
            Err(err) => println!("Error {:?}", err),
        }
    }
```
- On H2, using `rx: true` and `tx: true`, it works fine (it reads `0x42`), and if we use `rx: false` and `tx: true` it reads what I expect (`0x2f`)
- On C3, using `rx: true` and `tx: true`, it works fine (it reads `0x42`), but if we use `rx: false` and `tx: true` it also reads (`0x42`) which I think its wrong.

```rust
    let inverted_signals = InvertedSignals {
        rx: true,
        tx: true,
        rts: false,
        cts: false,
    };
    let mut uart = Uart::new(peripherals.UART1, &clocks, io.pins.gpio4, io.pins.gpio5).unwrap();
    uart.set_inverted_signals(inverted_signals);
    loop {
        uart.write_byte(0x42).ok();
        let read = block!(uart.read_byte());
        match read {
            Ok(read) => println!("Read 0x{:02x}", read),
            Err(err) => println!("Error {:?}", err),
        }

        delay.delay_millis(250);
    }
```
When running this example on H2, I also read `0x2f` (the inverted `0x42`) even when using `rx: true` and `tx: true`. Which is wrong. 

My guess is that it has to do with `sync_regs()` as the order of calling:
```
        self.rx.set_inverted_signals(inverted_signals);
        self.tx.set_inverted_signals(inverted_signals);
```

affects the results. I also did some other test of changing the order in which we set the register and sync them, but no luck so far.

Other things/approaches I tried:
- Tried to invert the signals using `connect_peripheral_to_output_with_options` instead of `connect_peripheral_to_output`  and setting the `invert` value to `true`, but when doing this, the TX would just not send anything.
- Tried to make `InvertSignals` struct part of the `Config` and update the inverted signals in the constructor (you would need to use `new_with_config()`. But ESP-IDF does not make inverted signals part of the conifg and has some public methods to set them, so I discarded this approach.