### PR TITLE
Expose optional HSYNC input in LCD_CAM

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new `DmaError::UnsupportedMemoryRegion` - used memory regions are checked when preparing a transfer now (#1670)
 - Add DmaTransactionTxOwned, DmaTransactionRxOwned, DmaTransactionTxRxOwned, functions to do owning transfers added to SPI half-duplex (#1672)
 - uart: Implement `embedded_io::ReadReady` for `Uart` and `UartRx` (#1702)
+- ESP32-S3: Expose optional HSYNC input in LCD_CAM (#1707)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ESP32-S3: Fix DMA waiting check in LCD_CAM (#1707)
+
 ### Changed
 
 - Refactor `Dac1`/`Dac2` drivers into a single `Dac` driver (#1661)

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -203,14 +203,22 @@ where
 
 impl<'d, RX: Rx> DmaSupport for Camera<'d, RX> {
     fn peripheral_wait_dma(&mut self, _is_tx: bool, _is_rx: bool) {
-        while !
-        // Wait for IN_SUC_EOF (i.e. VSYNC)
-        self.rx_channel.is_done() ||
-        // Or for IN_DSCR_EMPTY (i.e. No more buffer space)
-        self.rx_channel.has_dscr_empty_error() ||
-        // Or for IN_DSCR_ERR (i.e. bad descriptor)
-        self.rx_channel.has_error()
-        {}
+        loop {
+            // Wait for IN_SUC_EOF (i.e. VSYNC)
+            if self.rx_channel.is_done() {
+                break;
+            }
+
+            // Or for IN_DSCR_EMPTY (i.e. No more buffer space)
+            if self.rx_channel.has_dscr_empty_error() {
+                break;
+            }
+
+            // Or for IN_DSCR_ERR (i.e. bad descriptor)
+            if self.rx_channel.has_error() {
+                break;
+            }
+        }
     }
 
     fn peripheral_dma_stop(&mut self) {

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -83,7 +83,8 @@ fn main() -> ! {
     let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
     let mut camera = Camera::new(lcd_cam.cam, channel.rx, cam_data_pins, 20u32.MHz(), &clocks)
         .with_master_clock(cam_xclk)
-        .with_ctrl_pins(cam_vsync, cam_href, cam_pclk);
+        .with_pixel_clock(cam_pclk)
+        .with_ctrl_pins(cam_vsync, cam_href);
 
     let delay = Delay::new(&clocks);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
There's an optional HSYNC input signal that wasn't exposed, this PR exposes it.

#### Testing
Ran the modified example
