### PR TITLE
TIMG: Fix interrupt handler setup

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TIMG: Fix interrupt handler setup (#1714)
+
 ### Changed
 
 - Refactor `Dac1`/`Dac2` drivers into a single `Dac` driver (#1661)

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -32,7 +32,7 @@
 //!     peripherals.TIMG0,
 //!     &clocks,
 //!     Some(TimerInterrupts {
-//!         timer0_t0: Some(tg0_t0_level),
+//!         timer0: Some(tg0_t0_level),
 //!         ..Default::default()
 //!     }),
 //! );

--- a/examples/src/bin/etm_timer.rs
+++ b/examples/src/bin/etm_timer.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
         peripherals.TIMG0,
         &clocks,
         Some(TimerInterrupts {
-            timer0_t0: Some(tg0_t0_level),
+            timer0: Some(tg0_t0_level),
             ..Default::default()
         }),
     );

--- a/examples/src/bin/timer_interrupt.rs
+++ b/examples/src/bin/timer_interrupt.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
         peripherals.TIMG0,
         &clocks,
         Some(TimerInterrupts {
-            timer0_t0: Some(tg0_t0_level),
+            timer0: Some(tg0_t0_level),
             ..Default::default()
         }),
     );


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1711 .
Previously the driver allowed users to set an isr handler for a different group.
I've modified the driver to only support setting the handler for the group driver being created.

#### Testing
Ran the example on an AtomS3.
(There's a disappointing amount of drift but it's likely due to using one shot timers instead a periodic one)