### PR TITLE
[1/3] DMA Move API: Pull out driver specific state in DMA driver into…

### DIFF
--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -504,9 +504,12 @@ macro_rules! impl_channel {
                     let mut rx_impl = ChannelRxImpl {};
                     rx_impl.init(burst_mode, priority);
 
+                    let tx_chain = DescriptorChain::new(tx_descriptors);
+                    let rx_chain = DescriptorChain::new(rx_descriptors);
+
                     crate::dma::Channel {
-                        tx: ChannelTx::new(tx_descriptors, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_descriptors, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }
@@ -529,11 +532,14 @@ macro_rules! impl_channel {
                     let mut rx_impl = ChannelRxImpl {};
                     rx_impl.init(burst_mode, priority);
 
+                    let tx_chain = DescriptorChain::new(tx_descriptors);
+                    let rx_chain = DescriptorChain::new(rx_descriptors);
+
                     <Channel<$num> as ChannelTypes>::Binder::set_isr($async_handler);
 
                     crate::dma::Channel {
-                        tx: ChannelTx::new(tx_descriptors, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_descriptors, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -397,9 +397,12 @@ macro_rules! ImplSpiChannel {
                     let mut rx_impl = [<Spi $num DmaChannelRxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
+                    let tx_chain = DescriptorChain::new(tx_descriptors);
+                    let rx_chain = DescriptorChain::new(rx_descriptors);
+
                     Channel {
-                        tx: ChannelTx::new(tx_descriptors, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_descriptors, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }
@@ -422,11 +425,14 @@ macro_rules! ImplSpiChannel {
                     let mut rx_impl = [<Spi $num DmaChannelRxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
+                    let tx_chain = DescriptorChain::new(tx_descriptors);
+                    let rx_chain = DescriptorChain::new(rx_descriptors);
+
                     <[<Spi $num DmaChannel>] as ChannelTypes>::Binder::set_isr(super::asynch::interrupt::[< interrupt_handler_spi $num _dma >]);
 
                     Channel {
-                        tx: ChannelTx::new(tx_descriptors, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_descriptors, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }
@@ -791,9 +797,12 @@ macro_rules! ImplI2sChannel {
                     let mut rx_impl = [<I2s $num DmaChannelRxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
+                    let tx_chain = DescriptorChain::new(tx_descriptors);
+                    let rx_chain = DescriptorChain::new(rx_descriptors);
+
                     Channel {
-                        tx: ChannelTx::new(tx_descriptors, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_descriptors, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }
@@ -816,11 +825,14 @@ macro_rules! ImplI2sChannel {
                     let mut rx_impl = [<I2s $num DmaChannelRxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
+                    let tx_chain = DescriptorChain::new(tx_descriptors);
+                    let rx_chain = DescriptorChain::new(rx_descriptors);
+
                     <[<I2s $num DmaChannel>] as ChannelTypes>::Binder::set_isr(super::asynch::interrupt::[< interrupt_handler_i2s $num >]);
 
                     Channel {
-                        tx: ChannelTx::new(tx_descriptors, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_descriptors, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }


### PR DESCRIPTION
… separate structs

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This part of #1512.
This is a no-op refactor of the DMA driver to move (what will eventually become) driver specific state to separate structs.
The new structs are:
- `DescriptorChain` - Each DMA capable driver will own either one or two chains. One for RX and one for TX.
- `TxCircularState`/`RxCircularState` - This will be owned by the `DmaTransfer(Tx|Rx)Circular` (and the custom I2S transfer) structs.

These new structs are currently `pub` due to other structs using them being `pub` too. After the 2nd PR, they become `pub(crate)`.

I've split up this work into 3 PRs.
1. Refactor driver to pull out driver specific state. (No breaking changes in public API)
2. Move the new structs to their new homes. This also means the slice of DMA descriptors that were used to configure the DMA channels will now be passed to the individual peripheral drivers themselves. (Breaking change in public API).
3. Specialize the SPI DMA APIs to implement the ideas in #1512. Now that drivers own their DMA descriptors this is now very possible.

The reason I've split up this work into multiple PRs is to make this easier to review and to make my life much easier when I (inevitably) have to rebase on top of other breaking changes.

#### Testing
HIL in CI
