### PR TITLE
[2/3] DMA Move API: Move DMA descriptors to peripheral drivers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - esp-hal-embassy: make executor code optional (but default) again
 - Improved interrupt latency on RISC-V based chips (#1679)
 - `esp_wifi::initialize` no longer requires running maximum CPU clock, instead check it runs above 80MHz. (#1688)
+- Move DMA descriptors from DMA Channel to each individual peripheral driver. (#1719)
 
 ### Removed
 - uart: Removed `configure_pins` methods (#1592)

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -494,8 +494,6 @@ macro_rules! impl_channel {
                 pub fn configure<'a>(
                     self,
                     burst_mode: bool,
-                    tx_descriptors: &'a mut [DmaDescriptor],
-                    rx_descriptors: &'a mut [DmaDescriptor],
                     priority: DmaPriority,
                 ) -> crate::dma::Channel<'a, Channel<$num>, crate::Blocking> {
                     let mut tx_impl = ChannelTxImpl {};
@@ -504,12 +502,9 @@ macro_rules! impl_channel {
                     let mut rx_impl = ChannelRxImpl {};
                     rx_impl.init(burst_mode, priority);
 
-                    let tx_chain = DescriptorChain::new(tx_descriptors);
-                    let rx_chain = DescriptorChain::new(rx_descriptors);
-
                     crate::dma::Channel {
-                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }
@@ -522,8 +517,6 @@ macro_rules! impl_channel {
                 pub fn configure_for_async<'a>(
                     self,
                     burst_mode: bool,
-                    tx_descriptors: &'a mut [DmaDescriptor],
-                    rx_descriptors: &'a mut [DmaDescriptor],
                     priority: DmaPriority,
                 ) -> crate::dma::Channel<'a, Channel<$num>, $crate::Async> {
                     let mut tx_impl = ChannelTxImpl {};
@@ -532,14 +525,11 @@ macro_rules! impl_channel {
                     let mut rx_impl = ChannelRxImpl {};
                     rx_impl.init(burst_mode, priority);
 
-                    let tx_chain = DescriptorChain::new(tx_descriptors);
-                    let rx_chain = DescriptorChain::new(rx_descriptors);
-
                     <Channel<$num> as ChannelTypes>::Binder::set_isr($async_handler);
 
                     crate::dma::Channel {
-                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -387,8 +387,6 @@ macro_rules! ImplSpiChannel {
                 pub fn configure<'a>(
                     self,
                     burst_mode: bool,
-                    tx_descriptors: &'a mut [DmaDescriptor],
-                    rx_descriptors: &'a mut [DmaDescriptor],
                     priority: DmaPriority,
                 ) -> Channel<'a, [<Spi $num DmaChannel>], $crate::Blocking> {
                     let mut tx_impl = [<Spi $num DmaChannelTxImpl>] {};
@@ -397,12 +395,9 @@ macro_rules! ImplSpiChannel {
                     let mut rx_impl = [<Spi $num DmaChannelRxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
-                    let tx_chain = DescriptorChain::new(tx_descriptors);
-                    let rx_chain = DescriptorChain::new(rx_descriptors);
-
                     Channel {
-                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }
@@ -415,8 +410,6 @@ macro_rules! ImplSpiChannel {
                 pub fn configure_for_async<'a>(
                     self,
                     burst_mode: bool,
-                    tx_descriptors: &'a mut [DmaDescriptor],
-                    rx_descriptors: &'a mut [DmaDescriptor],
                     priority: DmaPriority,
                 ) -> Channel<'a, [<Spi $num DmaChannel>], $crate::Async> {
                     let mut tx_impl = [<Spi $num DmaChannelTxImpl>] {};
@@ -425,14 +418,11 @@ macro_rules! ImplSpiChannel {
                     let mut rx_impl = [<Spi $num DmaChannelRxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
-                    let tx_chain = DescriptorChain::new(tx_descriptors);
-                    let rx_chain = DescriptorChain::new(rx_descriptors);
-
                     <[<Spi $num DmaChannel>] as ChannelTypes>::Binder::set_isr(super::asynch::interrupt::[< interrupt_handler_spi $num _dma >]);
 
                     Channel {
-                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }
@@ -787,8 +777,6 @@ macro_rules! ImplI2sChannel {
                 pub fn configure<'a>(
                     self,
                     burst_mode: bool,
-                    tx_descriptors: &'a mut [DmaDescriptor],
-                    rx_descriptors: &'a mut [DmaDescriptor],
                     priority: DmaPriority,
                 ) -> Channel<'a, [<I2s $num DmaChannel>], $crate::Blocking> {
                     let mut tx_impl = [<I2s $num DmaChannelTxImpl>] {};
@@ -797,12 +785,9 @@ macro_rules! ImplI2sChannel {
                     let mut rx_impl = [<I2s $num DmaChannelRxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
-                    let tx_chain = DescriptorChain::new(tx_descriptors);
-                    let rx_chain = DescriptorChain::new(rx_descriptors);
-
                     Channel {
-                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }
@@ -815,8 +800,6 @@ macro_rules! ImplI2sChannel {
                 pub fn configure_for_async<'a>(
                     self,
                     burst_mode: bool,
-                    tx_descriptors: &'a mut [DmaDescriptor],
-                    rx_descriptors: &'a mut [DmaDescriptor],
                     priority: DmaPriority,
                 ) -> Channel<'a, [<I2s $num DmaChannel>], $crate::Async> {
                     let mut tx_impl = [<I2s $num DmaChannelTxImpl>] {};
@@ -825,14 +808,11 @@ macro_rules! ImplI2sChannel {
                     let mut rx_impl = [<I2s $num DmaChannelRxImpl>] {};
                     rx_impl.init(burst_mode, priority);
 
-                    let tx_chain = DescriptorChain::new(tx_descriptors);
-                    let rx_chain = DescriptorChain::new(rx_descriptors);
-
                     <[<I2s $num DmaChannel>] as ChannelTypes>::Binder::set_isr(super::asynch::interrupt::[< interrupt_handler_i2s $num >]);
 
                     Channel {
-                        tx: ChannelTx::new(tx_chain, tx_impl, burst_mode),
-                        rx: ChannelRx::new(rx_chain, rx_impl, burst_mode),
+                        tx: ChannelTx::new(tx_impl, burst_mode),
+                        rx: ChannelRx::new(rx_impl, burst_mode),
                         phantom: PhantomData,
                     }
                 }

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -50,19 +50,16 @@ async fn main(_spawner: Spawner) {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4092 * 4);
+    let (_, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(0, 4092 * 4);
 
     let i2s = I2s::new(
         peripherals.I2S0,
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
-        dma_channel.configure_for_async(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ),
+        dma_channel.configure_for_async(false, DmaPriority::Priority0),
+        tx_descriptors,
+        rx_descriptors,
         &clocks,
     );
 

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -73,19 +73,16 @@ async fn main(_spawner: Spawner) {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
+    let (tx_buffer, tx_descriptors, _, rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
-        dma_channel.configure_for_async(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ),
+        dma_channel.configure_for_async(false, DmaPriority::Priority0),
+        tx_descriptors,
+        rx_descriptors,
         &clocks,
     );
 

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -37,7 +37,7 @@ async fn main(_spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
+    let (_, _, rx_buffer, rx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -46,12 +46,8 @@ async fn main(_spawner: Spawner) {
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,
-        dma_channel.configure_for_async(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ),
+        dma_channel.configure_for_async(false, DmaPriority::Priority0),
+        rx_descriptors,
         1.MHz(),
         &clocks,
     )

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -48,7 +48,7 @@ async fn main(_spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
+    let (tx_buffer, mut tx_descriptors, _, _) = dma_buffers!(32000, 0);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -59,12 +59,8 @@ async fn main(_spawner: Spawner) {
 
     let parl_io = ParlIoTxOnly::new(
         peripherals.PARL_IO,
-        dma_channel.configure_for_async(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ),
+        dma_channel.configure_for_async(false, DmaPriority::Priority0),
+        tx_descriptors,
         1.MHz(),
         &clocks,
     )

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -61,16 +61,15 @@ async fn main(_spawner: Spawner) {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
+    let (descriptors, rx_descriptors) = dma_descriptors!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
-        .with_dma(dma_channel.configure_for_async(
-            false,
-            &mut descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ));
+        .with_dma(
+            dma_channel.configure_for_async(false, DmaPriority::Priority0),
+            descriptors,
+            rx_descriptors,
+        );
 
     let send_buffer = [0, 1, 2, 3, 4, 5, 6, 7];
     loop {

--- a/examples/src/bin/i2s_read.rs
+++ b/examples/src/bin/i2s_read.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (_, mut tx_descriptors, mut rx_buffer, mut rx_descriptors) = dma_buffers!(0, 4 * 4092);
+    let (_, tx_descriptors, mut rx_buffer, rx_descriptors) = dma_buffers!(0, 4 * 4092);
 
     // Here we test that the type is
     // 1) reasonably simple (or at least this will flag changes that may make it
@@ -54,12 +54,9 @@ fn main() -> ! {
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100.Hz(),
-        dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ),
+        dma_channel.configure(false, DmaPriority::Priority0),
+        tx_descriptors,
+        rx_descriptors,
         &clocks,
     );
 

--- a/examples/src/bin/i2s_sound.rs
+++ b/examples/src/bin/i2s_sound.rs
@@ -65,19 +65,16 @@ fn main() -> ! {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
+    let (tx_buffer, tx_descriptors, _, rx_descriptors) = dma_buffers!(32000, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100.Hz(),
-        dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ),
+        dma_channel.configure(false, DmaPriority::Priority0),
+        tx_descriptors,
+        rx_descriptors,
         &clocks,
     );
 

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -54,14 +54,9 @@ fn main() -> ! {
     let dma = Dma::new(peripherals.DMA);
     let channel = dma.channel0;
 
-    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32678);
+    let (_, _, rx_buffer, rx_descriptors) = dma_buffers!(0, 32678);
 
-    let channel = channel.configure(
-        false,
-        &mut tx_descriptors,
-        &mut rx_descriptors,
-        DmaPriority::Priority0,
-    );
+    let channel = channel.configure(false, DmaPriority::Priority0);
 
     let cam_siod = io.pins.gpio4;
     let cam_sioc = io.pins.gpio5;
@@ -81,9 +76,16 @@ fn main() -> ! {
     );
 
     let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
-    let mut camera = Camera::new(lcd_cam.cam, channel.rx, cam_data_pins, 20u32.MHz(), &clocks)
-        .with_master_clock(cam_xclk)
-        .with_ctrl_pins(cam_vsync, cam_href, cam_pclk);
+    let mut camera = Camera::new(
+        lcd_cam.cam,
+        channel.rx,
+        rx_descriptors,
+        cam_data_pins,
+        20u32.MHz(),
+        &clocks,
+    )
+    .with_master_clock(cam_xclk)
+    .with_ctrl_pins(cam_vsync, cam_href, cam_pclk);
 
     let delay = Delay::new(&clocks);
 

--- a/examples/src/bin/lcd_i8080.rs
+++ b/examples/src/bin/lcd_i8080.rs
@@ -56,14 +56,9 @@ fn main() -> ! {
     let dma = Dma::new(peripherals.DMA);
     let channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32678, 0);
+    let (tx_buffer, tx_descriptors, _, _) = dma_buffers!(32678, 0);
 
-    let channel = channel.configure(
-        false,
-        &mut tx_descriptors,
-        &mut rx_descriptors,
-        DmaPriority::Priority0,
-    );
+    let channel = channel.configure(false, DmaPriority::Priority0);
 
     let delay = Delay::new(&clocks);
 
@@ -85,6 +80,7 @@ fn main() -> ! {
     let mut i8080 = I8080::new(
         lcd_cam.lcd,
         channel.tx,
+        tx_descriptors,
         tx_pins,
         20.MHz(),
         Config::default(),

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(0, 32000);
+    let (_, _, rx_buffer, rx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -39,12 +39,8 @@ fn main() -> ! {
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,
-        dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ),
+        dma_channel.configure(false, DmaPriority::Priority0),
+        rx_descriptors,
         1.MHz(),
         &clocks,
     )

--- a/examples/src/bin/parl_io_tx.rs
+++ b/examples/src/bin/parl_io_tx.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(32000, 0);
+    let (tx_buffer, tx_descriptors, _, _) = dma_buffers!(32000, 0);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
@@ -52,12 +52,8 @@ fn main() -> ! {
 
     let parl_io = ParlIoTxOnly::new(
         peripherals.PARL_IO,
-        dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ),
+        dma_channel.configure(false, DmaPriority::Priority0),
+        tx_descriptors,
         1.MHz(),
         &clocks,
     )

--- a/examples/src/bin/qspi_flash.rs
+++ b/examples/src/bin/qspi_flash.rs
@@ -76,7 +76,7 @@ fn main() -> ! {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(256, 320);
+    let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(256, 320);
 
     let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(
@@ -87,12 +87,11 @@ fn main() -> ! {
             Some(sio3),
             Some(cs),
         )
-        .with_dma(dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ));
+        .with_dma(
+            dma_channel.configure(false, DmaPriority::Priority0),
+            tx_descriptors,
+            rx_descriptors,
+        );
 
     let delay = Delay::new(&clocks);
 

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -54,16 +54,15 @@ fn main() -> ! {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
+    let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
-        .with_dma(dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ));
+        .with_dma(
+            dma_channel.configure(false, DmaPriority::Priority0),
+            tx_descriptors,
+            rx_descriptors,
+        );
 
     let delay = Delay::new(&clocks);
 

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -74,7 +74,7 @@ fn main() -> ! {
         }
     }
 
-    let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(32000);
+    let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(32000);
 
     let mut spi = Spi::new(
         peripherals.SPI2,
@@ -84,12 +84,11 @@ fn main() -> ! {
         slave_cs,
         SpiMode::Mode0,
     )
-    .with_dma(dma_channel.configure(
-        false,
-        &mut tx_descriptors,
-        &mut rx_descriptors,
-        DmaPriority::Priority0,
-    ));
+    .with_dma(
+        dma_channel.configure(false, DmaPriority::Priority0),
+        tx_descriptors,
+        rx_descriptors,
+    );
 
     let delay = Delay::new(&clocks);
 

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -38,15 +38,13 @@ mod tests {
         let dma = Dma::new(peripherals.DMA);
         let dma_channel = dma.channel0;
 
-        let (input, mut tx_descriptors, mut output, mut rx_descriptors) =
-            dma_buffers!(DMA_BUFFER_SIZE);
+        let (input, tx_descriptors, mut output, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
-        let mut aes = Aes::new(peripherals.AES).with_dma(dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ));
+        let mut aes = Aes::new(peripherals.AES).with_dma(
+            dma_channel.configure(false, DmaPriority::Priority0),
+            tx_descriptors,
+            rx_descriptors,
+        );
 
         let keytext = "SUp4SeCp@sSw0rd".as_bytes();
         let mut keybuf = [0_u8; 16];
@@ -84,15 +82,13 @@ mod tests {
         let dma = Dma::new(peripherals.DMA);
         let dma_channel = dma.channel0;
 
-        let (input, mut tx_descriptors, mut output, mut rx_descriptors) =
-            dma_buffers!(DMA_BUFFER_SIZE);
+        let (input, tx_descriptors, mut output, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
-        let mut aes = Aes::new(peripherals.AES).with_dma(dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ));
+        let mut aes = Aes::new(peripherals.AES).with_dma(
+            dma_channel.configure(false, DmaPriority::Priority0),
+            tx_descriptors,
+            rx_descriptors,
+        );
 
         let keytext = "SUp4SeCp@sSw0rd".as_bytes();
         let mut keybuf = [0_u8; 16];
@@ -129,15 +125,13 @@ mod tests {
         let dma = Dma::new(peripherals.DMA);
         let dma_channel = dma.channel0;
 
-        let (input, mut tx_descriptors, mut output, mut rx_descriptors) =
-            dma_buffers!(DMA_BUFFER_SIZE);
+        let (input, tx_descriptors, mut output, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
-        let mut aes = Aes::new(peripherals.AES).with_dma(dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ));
+        let mut aes = Aes::new(peripherals.AES).with_dma(
+            dma_channel.configure(false, DmaPriority::Priority0),
+            tx_descriptors,
+            rx_descriptors,
+        );
 
         let keytext = "SUp4SeCp@sSw0rd".as_bytes();
         let mut keybuf = [0_u8; 16];
@@ -175,15 +169,13 @@ mod tests {
         let dma = Dma::new(peripherals.DMA);
         let dma_channel = dma.channel0;
 
-        let (input, mut tx_descriptors, mut output, mut rx_descriptors) =
-            dma_buffers!(DMA_BUFFER_SIZE);
+        let (input, tx_descriptors, mut output, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
-        let mut aes = Aes::new(peripherals.AES).with_dma(dma_channel.configure(
-            false,
-            &mut tx_descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ));
+        let mut aes = Aes::new(peripherals.AES).with_dma(
+            dma_channel.configure(false, DmaPriority::Priority0),
+            tx_descriptors,
+            rx_descriptors,
+        );
 
         let keytext = "SUp4SeCp@sSw0rd".as_bytes();
         let mut keybuf = [0_u8; 16];

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -53,20 +53,16 @@ mod tests {
         let dma = Dma::new(peripherals.DMA);
         let dma_channel = dma.channel0;
 
-        let (tx_buffer, mut tx_descriptors, mut rx_buffer, mut rx_descriptors) =
-            dma_buffers!(16000, 16000);
+        let (tx_buffer, tx_descriptors, mut rx_buffer, rx_descriptors) = dma_buffers!(16000, 16000);
 
         let i2s = I2s::new(
             peripherals.I2S0,
             Standard::Philips,
             DataFormat::Data16Channel16,
             16000.Hz(),
-            dma_channel.configure(
-                false,
-                &mut tx_descriptors,
-                &mut rx_descriptors,
-                DmaPriority::Priority0,
-            ),
+            dma_channel.configure(false, DmaPriority::Priority0),
+            tx_descriptors,
+            rx_descriptors,
             &clocks,
         );
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -58,17 +58,15 @@ mod tests {
         #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
-        let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) =
-            dma_buffers!(DMA_BUFFER_SIZE);
+        let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
         let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
             .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
-            .with_dma(dma_channel.configure(
-                false,
-                &mut tx_descriptors,
-                &mut rx_descriptors,
-                DmaPriority::Priority0,
-            ));
+            .with_dma(
+                dma_channel.configure(false, DmaPriority::Priority0),
+                tx_descriptors,
+                rx_descriptors,
+            );
 
         // DMA buffer require a static life-time
         let mut send = tx_buffer;
@@ -101,16 +99,15 @@ mod tests {
         #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
-        let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(4, 2);
+        let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(4, 2);
 
         let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
             .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
-            .with_dma(dma_channel.configure(
-                false,
-                &mut tx_descriptors,
-                &mut rx_descriptors,
-                DmaPriority::Priority0,
-            ));
+            .with_dma(
+                dma_channel.configure(false, DmaPriority::Priority0),
+                tx_descriptors,
+                rx_descriptors,
+            );
 
         // DMA buffer require a static life-time
         let mut send = tx_buffer;
@@ -145,17 +142,15 @@ mod tests {
         #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
-        let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) =
-            dma_buffers!(DMA_BUFFER_SIZE);
+        let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
         let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
             .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
-            .with_dma(dma_channel.configure(
-                false,
-                &mut tx_descriptors,
-                &mut rx_descriptors,
-                DmaPriority::Priority0,
-            ));
+            .with_dma(
+                dma_channel.configure(false, DmaPriority::Priority0),
+                tx_descriptors,
+                rx_descriptors,
+            );
 
         // DMA buffer require a static life-time
         let mut send = tx_buffer;
@@ -193,7 +188,7 @@ mod tests {
         #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
-        let (_, mut tx_descriptors, rx_buffer, mut rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let (_, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
         let tx_buffer = {
             // using `static`, not `static mut`, places the array in .rodata
@@ -203,12 +198,11 @@ mod tests {
 
         let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
             .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
-            .with_dma(dma_channel.configure(
-                false,
-                &mut tx_descriptors,
-                &mut rx_descriptors,
-                DmaPriority::Priority0,
-            ));
+            .with_dma(
+                dma_channel.configure(false, DmaPriority::Priority0),
+                tx_descriptors,
+                rx_descriptors,
+            );
 
         let mut receive = rx_buffer;
 
@@ -242,7 +236,7 @@ mod tests {
         #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
-        let (tx_buffer, mut tx_descriptors, _, mut rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let (tx_buffer, tx_descriptors, _, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
         let rx_buffer = {
             // using `static`, not `static mut`, places the array in .rodata
@@ -252,12 +246,11 @@ mod tests {
 
         let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
             .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
-            .with_dma(dma_channel.configure(
-                false,
-                &mut tx_descriptors,
-                &mut rx_descriptors,
-                DmaPriority::Priority0,
-            ));
+            .with_dma(
+                dma_channel.configure(false, DmaPriority::Priority0),
+                tx_descriptors,
+                rx_descriptors,
+            );
 
         let mut receive = rx_buffer;
         assert!(matches!(
@@ -290,17 +283,15 @@ mod tests {
         #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
-        let (tx_buffer, mut tx_descriptors, rx_buffer, mut rx_descriptors) =
-            dma_buffers!(DMA_BUFFER_SIZE);
+        let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
         let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
             .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
-            .with_dma(dma_channel.configure(
-                false,
-                &mut tx_descriptors,
-                &mut rx_descriptors,
-                DmaPriority::Priority0,
-            ));
+            .with_dma(
+                dma_channel.configure(false, DmaPriority::Priority0),
+                tx_descriptors,
+                rx_descriptors,
+            );
 
         // DMA buffer require a static life-time
         let send = tx_buffer;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This is part of #1512 .

This is breaking change to move the DMA descriptors from the DMA channel to the individual DMA capable peripheral drivers.
Besides the actual descriptor move, there's another change which is to mandate that the descriptors are now `'static`.
I tried not to mandate this but the borrow checker was fussing so I did it to save some hair.
This was going to be required eventually for soundness anyway and the impact to users will be negligible since most of them will be using the `dma_buffer` macros, which will do the right thing. So this I think this is fine.

#### Testing
HIL in CI
