### PR TITLE
ESP32-C6: make basic light sleep work

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - TIMG: Fix interrupt handler setup (#1714)
+- Fix `sleep_light` for ESP32-C6 (#1720)
 
 ### Changed
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -715,21 +715,7 @@ impl Default for RtcSleepConfig {
 
         Self {
             deep: false,
-            pd_flags: {
-                let mut pd_flags = PowerDownFlags(0);
-
-                pd_flags.set_pd_lp_periph(true);
-                pd_flags.set_pd_cpu(true);
-                pd_flags.set_pd_xtal32k(true);
-                pd_flags.set_pd_rc32k(true);
-                pd_flags.set_pd_rc_fast(true);
-                pd_flags.set_pd_xtal(true);
-                pd_flags.set_pd_top(true);
-                pd_flags.set_pd_modem(true);
-                pd_flags.set_pd_vddsdio(true);
-
-                pd_flags
-            },
+            pd_flags: PowerDownFlags(0),
         }
     }
 }
@@ -854,6 +840,10 @@ impl RtcSleepConfig {
             self.pd_flags.set_pd_mem(true);
             self.pd_flags.set_pd_xtal(true);
             self.pd_flags.set_pd_hp_aon(true);
+            self.pd_flags.set_pd_lp_periph(true);
+            self.pd_flags.set_pd_xtal32k(true);
+            self.pd_flags.set_pd_rc32k(true);
+            self.pd_flags.set_pd_rc_fast(true);
         }
     }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
`sleep_light` wasn't working for ESP32-C6. This fixes it.

#### Testing
Change the `sleep_timer.rs` example to this
```rust
//! Demonstrates light sleep with timer wakeup

//% CHIPS: esp32 esp32c3 esp32c6 esp32s3

#![no_std]
#![no_main]

use core::time::Duration;

use esp_backtrace as _;
use esp_hal::{
    clock::ClockControl,
    delay::Delay,
    entry,
    peripherals::Peripherals,
    rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, Rtc, SocResetReason},
    system::SystemControl,
    Cpu,
};
use esp_println::println;

#[entry]
fn main() -> ! {
    esp_println::logger::init_logger_from_env();
    
    let peripherals = Peripherals::take();
    let system = SystemControl::new(peripherals.SYSTEM);
    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    let mut delay = Delay::new(&clocks);
    let mut rtc = Rtc::new(peripherals.LPWR, None);

    println!("up and runnning!");
    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
    println!("reset reason: {:?}", reason);
    let wake_reason = get_wakeup_cause();
    println!("wake reason: {:?}", wake_reason);

    loop  {
        let timer = TimerWakeupSource::new(Duration::from_secs(4));
        println!("sleeping!");
        delay.delay_millis(300);
        rtc.sleep_light(&[&timer], &mut delay);

        println!("here");
        delay.delay_millis(2000);
    }
}
```

Power consumption will look like this
![image](https://github.com/esp-rs/esp-hal/assets/5682593/adce2936-d8c1-46f4-bf3a-21d66cd7064b)

