### PR TITLE
Fix ESP32-S3 ROM address of ets_update_cpu_frequency_rom

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - TIMG: Fix interrupt handler setup (#1714)
+- ROM Functions: Fix address of `ets_update_cpu_frequency_rom` (#1722)
 
 ### Changed
 

--- a/esp-hal/ld/esp32s3/rom-functions.x
+++ b/esp-hal/ld/esp32s3/rom-functions.x
@@ -1,5 +1,5 @@
 PROVIDE(ets_delay_us = 0x40000600);
-PROVIDE(ets_update_cpu_frequency_rom = 0x40043164);
+PROVIDE(ets_update_cpu_frequency_rom = 0x40001a4c);
 PROVIDE(rom_i2c_writeReg = 0x40005d60);
 PROVIDE(rom_i2c_writeReg_Mask = 0x40005d6c);
 PROVIDE(rtc_get_reset_reason = 0x4000057c);


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.
