### PR TITLE
ESP32-C6: Support wake-up from lp-core

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new `DmaError::UnsupportedMemoryRegion` - used memory regions are checked when preparing a transfer now (#1670)
 - Add DmaTransactionTxOwned, DmaTransactionRxOwned, DmaTransactionTxRxOwned, functions to do owning transfers added to SPI half-duplex (#1672)
 - uart: Implement `embedded_io::ReadReady` for `Uart` and `UartRx` (#1702)
+- ESP32-C6: Support lp-core as wake-up source (#1723)
 
 ### Fixed
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -17,7 +17,14 @@ use crate::{
             RtcCalSel,
             SavedClockConfig,
         },
-        sleep::{Ext1WakeupSource, TimerWakeupSource, WakeSource, WakeTriggers, WakeupLevel},
+        sleep::{
+            Ext1WakeupSource,
+            TimerWakeupSource,
+            WakeFromLpCoreWakeupSource,
+            WakeSource,
+            WakeTriggers,
+            WakeupLevel,
+        },
         Rtc,
         RtcClock,
     },
@@ -29,7 +36,7 @@ impl WakeSource for TimerWakeupSource {
 
         let lp_timer = unsafe { &*esp32c6::LP_TIMER::ptr() };
         let clock_freq = RtcClock::get_slow_freq();
-        // TODO: maybe add sleep time adjustlemnt like idf
+        // TODO: maybe add sleep time adjustment like idf
         // TODO: maybe add check to prevent overflow?
         let clock_hz = clock_freq.frequency().to_Hz() as u64;
         let ticks = self.duration.as_micros() as u64 * clock_hz / 1_000_000u64;
@@ -129,6 +136,12 @@ impl Drop for Ext1WakeupSource<'_, '_> {
         for (pin, _level) in pins.iter_mut() {
             pin.rtc_set_config(true, false, RtcFunction::Rtc);
         }
+    }
+}
+
+impl WakeSource for WakeFromLpCoreWakeupSource {
+    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+        triggers.set_lp_core(true);
     }
 }
 

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -146,6 +146,13 @@ impl WakeFromLpCoreWakeupSource {
     }
 }
 
+#[cfg(esp32c6)]
+impl Default for WakeFromLpCoreWakeupSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(not(pmu))]
 bitfield::bitfield! {
     #[derive(Default, Clone, Copy)]

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -131,6 +131,21 @@ impl<'a, 'b> RtcioWakeupSource<'a, 'b> {
     }
 }
 
+/// LP Core wakeup source
+///
+/// Wake up from LP core. This wakeup source
+/// can be used to wake up from both light and deep sleep.
+#[cfg(esp32c6)]
+pub struct WakeFromLpCoreWakeupSource {}
+
+#[cfg(esp32c6)]
+impl WakeFromLpCoreWakeupSource {
+    /// Create a new instance of [LpCoreWakeupSource]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
 #[cfg(not(pmu))]
 bitfield::bitfield! {
     #[derive(Default, Clone, Copy)]

--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add LP_UART basic driver (#1113)
 - Added basic `LP-I2C` driver for C6 (#1185)
 - Add remaining GPIO pins for ESP32-S2/S3 (#1695)
+- Add `wake_hp_core` for ESP32-C6 (#1723)
 
 ### Changed
 

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -24,9 +24,9 @@ categories = [
 cfg-if          = "1.0.0"
 embedded-hal-02 = { version = "0.2.7", package = "embedded-hal", optional = true, features = ["unproven"] }
 embedded-hal-1  = { version = "1.0.0", package = "embedded-hal", optional = true }
-esp32c6-lp      = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32s2-ulp     = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
-esp32s3-ulp     = { git = "https://github.com/esp-rs/esp-pacs", rev = "a8a8340", features = ["critical-section"], optional = true }
+esp32c6-lp      = { git = "https://github.com/esp-rs/esp-pacs", rev = "f5429637f079337eb77bad44fb80bded58478619", features = ["critical-section"], optional = true }
+esp32s2-ulp     = { git = "https://github.com/esp-rs/esp-pacs", rev = "f5429637f079337eb77bad44fb80bded58478619", features = ["critical-section"], optional = true }
+esp32s3-ulp     = { git = "https://github.com/esp-rs/esp-pacs", rev = "f5429637f079337eb77bad44fb80bded58478619", features = ["critical-section"], optional = true }
 nb              = { version = "1.1.0",  optional = true }
 paste           = { version = "1.0.14", optional = true }
 procmacros      = { package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
@@ -68,7 +68,3 @@ required-features = ["embedded-hal-02", "esp32c6"]
 
 [lints.rust]
 unexpected_cfgs = "allow"
-
-[patch.crates-io]
-esp32s2-ulp = { git = "https://github.com/esp-rs/esp-pacs", rev = "bcab40a" }
-esp32s3-ulp = { git = "https://github.com/esp-rs/esp-pacs", rev = "bcab40a" }

--- a/esp-lp-hal/src/gpio.rs
+++ b/esp-lp-hal/src/gpio.rs
@@ -33,11 +33,11 @@ impl<const PIN: u8> Output<PIN> {
         if on {
             unsafe { &*LpIo::PTR }
                 .out_w1ts()
-                .write(|w| w.out_data_w1ts().variant(1 << PIN));
+                .write(|w| unsafe { w.out_data_w1ts().bits(1 << PIN) });
         } else {
             unsafe { &*LpIo::PTR }
                 .out_w1tc()
-                .write(|w| w.out_data_w1tc().variant(1 << PIN));
+                .write(|w| unsafe { w.out_data_w1tc().bits(1 << PIN) });
         }
     }
 }

--- a/esp-lp-hal/src/i2c.rs
+++ b/esp-lp-hal/src/i2c.rs
@@ -510,43 +510,43 @@ impl LpI2c {
         match *command_register {
             CommandRegister::COMD0 => {
                 self.i2c
-                    .comd0()
-                    .write(|w| unsafe { w.command0().bits(command.into()) });
+                    .comd(0)
+                    .write(|w| unsafe { w.command().bits(command.into()) });
             }
             CommandRegister::COMD1 => {
                 self.i2c
-                    .comd1()
-                    .write(|w| unsafe { w.command1().bits(command.into()) });
+                    .comd(1)
+                    .write(|w| unsafe { w.command().bits(command.into()) });
             }
             CommandRegister::COMD2 => {
                 self.i2c
-                    .comd2()
-                    .write(|w| unsafe { w.command2().bits(command.into()) });
+                    .comd(2)
+                    .write(|w| unsafe { w.command().bits(command.into()) });
             }
             CommandRegister::COMD3 => {
                 self.i2c
-                    .comd3()
-                    .write(|w| unsafe { w.command3().bits(command.into()) });
+                    .comd(3)
+                    .write(|w| unsafe { w.command().bits(command.into()) });
             }
             CommandRegister::COMD4 => {
                 self.i2c
-                    .comd4()
-                    .write(|w| unsafe { w.command4().bits(command.into()) });
+                    .comd(4)
+                    .write(|w| unsafe { w.command().bits(command.into()) });
             }
             CommandRegister::COMD5 => {
                 self.i2c
-                    .comd5()
-                    .write(|w| unsafe { w.command5().bits(command.into()) });
+                    .comd(5)
+                    .write(|w| unsafe { w.command().bits(command.into()) });
             }
             CommandRegister::COMD6 => {
                 self.i2c
-                    .comd6()
-                    .write(|w| unsafe { w.command6().bits(command.into()) });
+                    .comd(6)
+                    .write(|w| unsafe { w.command().bits(command.into()) });
             }
             CommandRegister::COMD7 => {
                 self.i2c
-                    .comd7()
-                    .write(|w| unsafe { w.command7().bits(command.into()) });
+                    .comd(7)
+                    .write(|w| unsafe { w.command().bits(command.into()) });
             }
         }
         command_register.advance();

--- a/esp-lp-hal/src/lib.rs
+++ b/esp-lp-hal/src/lib.rs
@@ -37,6 +37,16 @@ cfg_if::cfg_if! {
 
 pub static mut CPU_CLOCK: u32 = LP_FAST_CLK_HZ;
 
+/// Wake up the HP core
+#[cfg(feature = "esp32c6")]
+pub fn wake_hp_core() {
+    // TODO add PMU to the SVD
+    let hp_lp_cpu_comm = 0x600b0184 as *mut u32;
+    unsafe {
+        hp_lp_cpu_comm.write_volatile(1 << 30);
+    }
+}
+
 #[cfg(feature = "esp32c6")]
 global_asm!(
     r#"

--- a/esp-lp-hal/src/lib.rs
+++ b/esp-lp-hal/src/lib.rs
@@ -40,11 +40,8 @@ pub static mut CPU_CLOCK: u32 = LP_FAST_CLK_HZ;
 /// Wake up the HP core
 #[cfg(feature = "esp32c6")]
 pub fn wake_hp_core() {
-    // TODO add PMU to the SVD
-    let hp_lp_cpu_comm = 0x600b0184 as *mut u32;
-    unsafe {
-        hp_lp_cpu_comm.write_volatile(1 << 30);
-    }
+    let pmu = unsafe { esp32c6_lp::PMU::steal() };
+    pmu.hp_lp_cpu_comm().write(|w| w.lp_trigger_hp().set_bit());
 }
 
 #[cfg(feature = "esp32c6")]
@@ -149,12 +146,9 @@ unsafe extern "C" fn ulp_riscv_rescue_from_monitor() {
 #[link_section = ".init.rust"]
 #[no_mangle]
 unsafe extern "C" fn ulp_riscv_halt() {
-    unsafe { &*pac::RTC_CNTL::PTR }.cocpu_ctrl().modify(|_, w| {
-        w.cocpu_shut_2_clk_dis()
-            .variant(0x3f)
-            .cocpu_done()
-            .set_bit()
-    });
+    unsafe { &*pac::RTC_CNTL::PTR }
+        .cocpu_ctrl()
+        .modify(|_, w| unsafe { w.cocpu_shut_2_clk_dis().bits(0x3f).cocpu_done().set_bit() });
 
     loop {
         riscv::asm::wfi();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds lp-core as a wakeup source for ESP32-C6

#### Testing
Use this lp-core example
```rust
#![no_std]
#![no_main]

use embedded_hal_02::{blocking::delay::DelayMs, digital::v2::OutputPin};
use esp_lp_hal::{delay::Delay, gpio::Output, prelude::*};
use panic_halt as _;

#[entry]
fn main() -> ! {
    loop {
        Delay.delay_ms(5000);
        esp_lp_hal::wake_hp_core();
    }
}
```

Use this hp-core example
```rust
//! Demonstrates deep sleep with wake-up from lp-core

//% CHIPS: esp32c6

#![no_std]
#![no_main]

use core::time::Duration;

use esp_backtrace as _;
use esp_hal::{
    clock::ClockControl,
    delay::Delay,
    entry,
    lp_core::{LpCore, LpCoreWakeupSource},
    macros::load_lp_code,
    peripherals::Peripherals,
    rtc_cntl::{
        get_reset_reason,
        get_wakeup_cause,
        sleep::{TimerWakeupSource, WakeFromLpCoreWakeupSource},
        Rtc,
        SocResetReason,
    },
    system::SystemControl,
    Cpu,
};
use esp_println::println;

#[entry]
fn main() -> ! {
    let peripherals = Peripherals::take();
    let system = SystemControl::new(peripherals.SYSTEM);
    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    let mut delay = Delay::new(&clocks);
    let mut rtc = Rtc::new(peripherals.LPWR, None);

    println!("up and runnning!");
    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
    println!("reset reason: {:?}", reason);
    let wake_reason = get_wakeup_cause();
    println!("wake reason: {:?}", wake_reason);

    let mut lp_core = LpCore::new(peripherals.LP_CORE);
    lp_core.stop();
    println!("lp core stopped");

    // load code to LP core
    let lp_core_code =
        load_lp_code!("../esp-lp-hal/target/riscv32imac-unknown-none-elf/release/examples/wake");

    // start LP core
    lp_core_code.run(&mut lp_core, LpCoreWakeupSource::HpCpu);
    println!("lpcore run");

    let lp_wake = WakeFromLpCoreWakeupSource::new();
    println!("sleeping!");
    delay.delay_millis(100);
    rtc.sleep_deep(&[&lp_wake], &mut delay);
}
```
