### PR TITLE
Add GPIO as wake-up source

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add DmaTransactionTxOwned, DmaTransactionRxOwned, DmaTransactionTxRxOwned, functions to do owning transfers added to SPI half-duplex (#1672)
 - uart: Implement `embedded_io::ReadReady` for `Uart` and `UartRx` (#1702)
 - ESP32-C6: Support lp-core as wake-up source (#1723)
+- Add support for GPIO wake-up source (#1724)
 
 ### Fixed
 

--- a/esp-hal/src/gpio/any_pin.rs
+++ b/esp-hal/src/gpio/any_pin.rs
@@ -93,6 +93,7 @@ impl<'d> Pin for AnyPin<'d> {
             fn unlisten(&mut self, _internal: private::Internal);
             fn is_interrupt_set(&self, _internal: private::Internal) -> bool;
             fn clear_interrupt(&mut self, _internal: private::Internal);
+            fn wakeup_enable(&mut self, enable: bool, event: WakeEvent, _internal: private::Internal);
         }
     }
 }
@@ -260,6 +261,7 @@ impl<'d> Pin for AnyInputOnlyPin<'d> {
             fn unlisten(&mut self, _internal: private::Internal);
             fn is_interrupt_set(&self, _internal: private::Internal) -> bool;
             fn clear_interrupt(&mut self, _internal: private::Internal);
+            fn wakeup_enable(&mut self, enable: bool, event: WakeEvent, _internal: private::Internal);
         }
     }
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -77,6 +77,15 @@ pub enum Event {
     HighLevel   = 5,
 }
 
+impl From<WakeEvent> for Event {
+    fn from(value: WakeEvent) -> Self {
+        match value {
+            WakeEvent::LowLevel => Event::LowLevel,
+            WakeEvent::HighLevel => Event::HighLevel,
+        }
+    }
+}
+
 /// Event used to wake up from light sleep.
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -85,15 +94,6 @@ pub enum WakeEvent {
     LowLevel  = 4,
     /// Wake on high level
     HighLevel = 5,
-}
-
-impl Into<Event> for WakeEvent {
-    fn into(self) -> Event {
-        match self {
-            WakeEvent::LowLevel => Event::LowLevel,
-            WakeEvent::HighLevel => Event::HighLevel,
-        }
-    }
 }
 
 /// Digital input or output level.

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -153,6 +153,34 @@ impl Default for WakeFromLpCoreWakeupSource {
     }
 }
 
+/// GPIO wakeup source
+///
+/// Wake up from GPIO high or low level. Any pin can be used with this wake up
+/// source. Configure the pin for wake up via
+/// [crate::gpio::Input::wakeup_enable].
+///
+/// This wakeup source can be used to wake up from light sleep only.
+pub struct GpioWakeupSource {}
+
+impl GpioWakeupSource {
+    /// Create a new instance of [LpCoreWakeupSource]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for GpioWakeupSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WakeSource for GpioWakeupSource {
+    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+        triggers.set_gpio(true);
+    }
+}
+
 #[cfg(not(pmu))]
 bitfield::bitfield! {
     #[derive(Default, Clone, Copy)]

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -163,7 +163,7 @@ impl Default for WakeFromLpCoreWakeupSource {
 pub struct GpioWakeupSource {}
 
 impl GpioWakeupSource {
-    /// Create a new instance of [LpCoreWakeupSource]
+    /// Create a new instance of [GpioWakeupSource]
     pub fn new() -> Self {
         Self {}
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This adds GPIO as a wake-up source for light sleep.

The function to configure wake-up for a GPIO is added for all chips. We could make this conditional only for the chips we already have support for sleep added but there shouldn't be any problem with having it available for all chips.

It works fine to wake-up ESP32-C6 but all other sleep implementations (ESP32, ESP32-S3, ESP32-C3) have problems with light sleep in general (i.e. they wake-up and seem to enter light-sleep again but then things go wrong - most probably clock related problems). Since that problem is also reproducible with e.g. the already existing timer wake-up source these problems need to be addresses separately

#### Testing
Use this example to wake-up from light-sleep by pushing the boot button
```rust
//! Demonstrates light sleep with GPIO wake-up

//% CHIPS: esp32 esp32c3 esp32c6 esp32s3

#![no_std]
#![no_main]

use esp_backtrace as _;
use esp_hal::{
    clock::ClockControl,
    delay::Delay,
    entry,
    gpio::{Input, Io, Pull},
    peripherals::Peripherals,
    rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::GpioWakeupSource, Rtc, SocResetReason},
    system::SystemControl,
    Cpu,
};
use esp_println::println;

#[entry]
fn main() -> ! {
    let peripherals = Peripherals::take();
    let system = SystemControl::new(peripherals.SYSTEM);
    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    let mut delay = Delay::new(&clocks);
    let mut rtc = Rtc::new(peripherals.LPWR, None);

    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);

    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
    let button = io.pins.gpio0;
    #[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
    let button = io.pins.gpio9;

    let mut pin = Input::new(button, Pull::Up);
    pin.wakeup_enable(true, esp_hal::gpio::WakeEvent::LowLevel);

    println!("up and runnning!");
    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
    println!("reset reason: {:?}", reason);
    let wake_reason = get_wakeup_cause();
    println!("wake reason: {:?}", wake_reason);

    loop {
        let gpio_wakeup = GpioWakeupSource::new();
        println!("sleeping!");
        rtc.sleep_light(&[&gpio_wakeup], &mut delay);

        println!("welcome back!!!!!");
        delay.delay_millis(250);
    }
}
```
