### PR TITLE
Add UART wakeup source

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - uart: Implement `embedded_io::ReadReady` for `Uart` and `UartRx` (#1702)
 - ESP32-C6: Support lp-core as wake-up source (#1723)
 - Add support for GPIO wake-up source (#1724)
+- Add `uart` wake source (#1727)
 
 ### Fixed
 

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -181,6 +181,71 @@ impl WakeSource for GpioWakeupSource {
     }
 }
 
+macro_rules! uart_wakeup_impl {
+    ($num:literal) => {
+        paste::paste! {
+            #[doc = concat!("UART", $num, " wakeup source")]
+            ///
+            /// The chip can be woken up by reverting RXD for multiple cycles until the
+            /// number of rising edges is equal to or greater than the given value.
+            ///
+            /// Note that the character which triggers wakeup (and any characters before
+            /// it) will not be received by the UART after wakeup. This means that the
+            /// external device typically needs to send an extra character to trigger
+            /// wakeup before sending the data.
+            ///
+            /// After waking-up from UART, you should send some extra data through the UART
+            /// port in Active mode, so that the internal wakeup indication signal can be
+            /// cleared. Otherwise, the next UART wake-up would trigger with two less
+            /// rising edges than the configured threshold value.
+            ///
+            /// Wakeup from light sleep takes some time, so not every character sent to the
+            /// UART can be received by the application.
+            ///
+            /// This wakeup source can be used to wake up from light sleep only.
+            pub struct [< Uart $num WakeupSource >] {
+                threshold: u16,
+            }
+
+            impl [< Uart $num WakeupSource >] {
+                #[doc = concat!("Create a new instance of UART", $num, " wakeup source>") ]
+                ///
+                /// # Panics
+                ///
+                /// Panics if `threshold` is out of bounds.
+                pub fn new(threshold: u16) -> Self {
+                    if threshold > 1023 {
+                        panic!("Invalid threshold");
+                    }
+                    Self { threshold }
+                }
+            }
+
+            impl WakeSource for [< Uart $num WakeupSource >] {
+                fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+                    triggers.[< set_uart $num >](true);
+                    let uart = unsafe { crate::peripherals::[< UART $num >]::steal() };
+
+                    #[cfg(any(esp32, esp32s2, esp32s3, esp32c2, esp32c3))]
+                    uart.sleep_conf()
+                        .modify(|_, w| unsafe { w.active_threshold().bits(self.threshold) });
+
+                    #[cfg(not(any(esp32, esp32s2, esp32s3, esp32c2, esp32c3)))]
+                    uart.sleep_conf2().modify(|_, w| unsafe {
+                        w.wk_mode_sel()
+                            .bits(0)
+                            .active_threshold()
+                            .bits(self.threshold)
+                    });
+                }
+            }
+        }
+    };
+}
+
+uart_wakeup_impl!(0);
+uart_wakeup_impl!(1);
+
 #[cfg(not(pmu))]
 bitfield::bitfield! {
     #[derive(Default, Clone, Copy)]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This adds uart as a wake-up source. Like with #1724 this adds it for all chips but anything besides ESP32-C6 currently seems to have light-sleep issues.

Starting with C6 there are more ways to configure UART-wake-up but those additional options didn't "just work" for me and they are apparently not available in ESP-IDF - so let's keep that for later when we can see what is really needed to make them work.

#### Testing
Use this example
```rust
//! Demonstrates light sleep with uart wake-up

//% CHIPS: esp32 esp32c3 esp32c6 esp32s3

#![no_std]
#![no_main]

use core::fmt::Write;

use esp_backtrace as _;
use esp_hal::{
    clock::ClockControl,
    delay::Delay,
    entry,
    gpio::Io,
    peripherals::Peripherals,
    rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::Uart0WakeupSource, Rtc, SocResetReason},
    system::SystemControl,
    uart::Uart,
    Cpu,
};

#[entry]
fn main() -> ! {
    let peripherals = Peripherals::take();
    let system = SystemControl::new(peripherals.SYSTEM);
    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();

    let mut delay = Delay::new(&clocks);
    let mut rtc = Rtc::new(peripherals.LPWR, None);

    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);

    // Default pins for Uart/Serial communication
    #[cfg(feature = "esp32")]
    let (mut tx_pin, mut rx_pin) = (io.pins.gpio1, io.pins.gpio3);
    #[cfg(feature = "esp32c2")]
    let (mut tx_pin, mut rx_pin) = (io.pins.gpio20, io.pins.gpio19);
    #[cfg(feature = "esp32c3")]
    let (mut tx_pin, mut rx_pin) = (io.pins.gpio21, io.pins.gpio20);
    #[cfg(feature = "esp32c6")]
    let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
    #[cfg(feature = "esp32h2")]
    let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
    #[cfg(feature = "esp32s2")]
    let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);
    #[cfg(feature = "esp32s3")]
    let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);

    let mut uart0 =
        Uart::new_with_default_pins(peripherals.UART0, &clocks, &mut tx_pin, &mut rx_pin).unwrap();

    writeln!(uart0, "up and runnning!").ok();
    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
    writeln!(uart0, "reset reason: {:?}", reason).ok();
    let wake_reason = get_wakeup_cause();
    writeln!(uart0, "wake reason: {:?}", wake_reason).ok();

    loop {
        let gpio_wakeup = Uart0WakeupSource::new(9);
        writeln!(uart0, "sleeping!").ok();
        rtc.sleep_light(&[&gpio_wakeup], &mut delay);

        writeln!(uart0, "welcome back!!!!!").ok();
        delay.delay_millis(250);
        for _ in 0..10 {
            let res = uart0.read_byte();
            writeln!(uart0, "{:?}", res).ok();
        }
    }
}
```
