### PR TITLE
Documentation and housekeeping for `esp-ieee802154`

### DIFF
--- a/esp-ieee802154/Cargo.toml
+++ b/esp-ieee802154/Cargo.toml
@@ -16,19 +16,19 @@ bench = false
 test  = false
 
 [dependencies]
-byte             = "0.2.7"
-critical-section = "1.1.2"
-esp-hal          = { version = "0.18.0", path = "../esp-hal" }
-esp-wifi-sys     = { git = "https://github.com/esp-rs/esp-wifi", rev = "2ceb4b3" }
-heapless         = "0.8.0"
-ieee802154       = "0.6.1"
-log              = "0.4.21"
-vcell            = "0.1.3"
+byte              = "0.2.7"
+critical-section  = "1.1.2"
+document-features = "0.2.8"
+esp-hal           = { version = "0.18.0", path = "../esp-hal" }
+esp-wifi-sys      = { git = "https://github.com/esp-rs/esp-wifi", rev = "2ceb4b3" }
+heapless          = "0.8.0"
+ieee802154        = "0.6.1"
+log               = "0.4.21"
+vcell             = "0.1.3"
 
 [features]
-default = []
 esp32c6 = ["esp-hal/esp32c6", "esp-wifi-sys/esp32c6"]
 esp32h2 = ["esp-hal/esp32h2", "esp-wifi-sys/esp32h2"]
 
-## Output logging from the phy blobs. Requires nightly
+## Output logging from the PHY blobs. Requires nightly.
 binary-logs = []

--- a/esp-ieee802154/src/frame.rs
+++ b/esp-ieee802154/src/frame.rs
@@ -11,7 +11,7 @@ const FRAME_VERSION_OFFSET: usize = 2;
 const FRAME_VERSION_MASK: u8 = 0x30;
 
 /// IEEE 802.15.4 MAC frame
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Frame {
     /// Header
     pub header: Header,
@@ -24,7 +24,7 @@ pub struct Frame {
 }
 
 /// IEEE 802.15.4 MAC frame which has been received
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReceivedFrame {
     /// Frame
     pub frame: Frame,

--- a/esp-ieee802154/src/lib.rs
+++ b/esp-ieee802154/src/lib.rs
@@ -39,7 +39,7 @@ extern "C" fn rtc_clk_xtal_freq_get() -> i32 {
 }
 
 /// IEEE 802.15.4 errors
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
     /// The requested data is bigger than available range, and/or the offset is
     /// invalid
@@ -58,7 +58,7 @@ impl From<byte::Error> for Error {
 }
 
 /// IEEE 802.15.4 driver configuration
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Config {
     pub auto_ack_tx: bool,
     pub auto_ack_rx: bool,

--- a/esp-ieee802154/src/lib.rs
+++ b/esp-ieee802154/src/lib.rs
@@ -4,9 +4,12 @@
 //! supports sending and receiving of raw frames.
 //!
 //! [IEEE 802.15.4]: https://en.wikipedia.org/wiki/IEEE_802.15.4
-
-#![no_std]
+//!
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
+#![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![cfg_attr(feature = "binary-logs", feature(c_variadic))]
+#![no_std]
 
 use core::{cell::RefCell, marker::PhantomData};
 

--- a/esp-ieee802154/src/pib.rs
+++ b/esp-ieee802154/src/pib.rs
@@ -28,7 +28,7 @@ const IEEE802154_MULTIPAN_MAX: usize = 4;
 static PIB: Mutex<RefCell<Option<Pib>>> = Mutex::new(RefCell::new(None));
 
 /// Frame pending mode
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum PendingMode {
     /// Frame pending bit always set to 1 in the ack to Data Request
     #[default]
@@ -44,7 +44,7 @@ pub enum PendingMode {
 }
 
 /// CCA mode
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum CcaMode {
     /// Carrier only
     #[default]

--- a/esp-ieee802154/src/raw.rs
+++ b/esp-ieee802154/src/raw.rs
@@ -63,7 +63,7 @@ enum Ieee802154TxRxScene {
 }
 
 /// A raw payload received on some channel
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RawReceived {
     /// Payload
     pub data: [u8; FRAME_SIZE],


### PR DESCRIPTION
With the exception of the one remaining git dependency for `esp-wifi-sys` (which should be published soon, see: https://github.com/esp-rs/esp-wifi-sys/pull/473), I think this should be good to publish following this PR.

Basically just:

- Derived some more traits for public types
- Improved documentation, document the one Cargo feature

Progress toward https://github.com/esp-rs/esp-hal/issues/1655.