### PR TITLE
Improve the top level crate documentation

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -104,11 +104,13 @@
 //!
 //! ## PeripheralRef Pattern
 //!
-//! Generally drivers take pins as [peripheral::PeripheralRef]. This
-//! means you can pass the pin or a mutable reference to the pin.
+//! Generally drivers take pins and peripherals as [peripheral::PeripheralRef].
+//! This means you can pass the pin/peripheral or a mutable reference to the
+//! pin/peripheral.
 //!
 //! The later can be used to regain access to the pin when the driver gets
-//! dropped. Then it's possible to reuse the pin for a different purpose.
+//! dropped. Then it's possible to reuse the pin/peripheral for a different
+//! purpose.
 //!
 //! [documentation]: https://docs.esp-rs.org/esp-hal
 //! [examples]: https://github.com/esp-rs/esp-hal/tree/main/examples

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -49,6 +49,67 @@
 //! cargo generate -a esp-rs/esp-template
 //! ```
 //!
+//! ## Commonly used setup
+//!
+//! Some minimal code to blink an LED looks like this
+//!
+//! ```rust, no_run
+//! #![no_std]
+//! #![no_main]
+//!
+//! // A panic - handler e.g. `use esp_backtrace as _;`
+//!
+//! use esp_hal::{
+//!     clock::ClockControl,
+//!     delay::Delay,
+//!     gpio::{Io, Level, Output},
+//!     peripherals::Peripherals,
+//!     prelude::*,
+//!     system::SystemControl,
+//! };
+//! # #[panic_handler]
+//! # fn panic(_ : &core::panic::PanicInfo) -> ! {
+//! #     loop {}
+//! # }
+//!
+//! #[entry]
+//! fn main() -> ! {
+//!     let peripherals = Peripherals::take();
+//!     let system = SystemControl::new(peripherals.SYSTEM);
+//!     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+//!
+//!     // Set GPIO0 as an output, and set its state high initially.
+//!     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//!     let mut led = Output::new(io.pins.gpio0, Level::High);
+//!
+//!     let delay = Delay::new(&clocks);
+//!
+//!     loop {
+//!         led.toggle();
+//!         delay.delay_millis(1000);
+//!     }
+//! }
+//! ```
+//!
+//! The steps here are:
+//! - take all the peripherals from the PAC to pass them to the HAL drivers
+//!   later
+//! - create [system::SystemControl]
+//! - configure the system clocks - in this case use the boot defaults
+//! - create [gpio::Io] which provides access to the GPIO pins
+//! - create an [gpio::Output] pin driver which lets us control the logical
+//!   level of an output pin
+//! - create a [delay::Delay] driver
+//! - in a loop, toggle the output pin's logical level with a delay of 1000 ms
+//!
+//! ## PeripheralRef Pattern
+//!
+//! Generally drivers take pins as [peripheral::PeripheralRef]. This
+//! means you can pass the pin or a mutable reference to the pin.
+//!
+//! The later can be used to regain access to the pin when the driver gets
+//! dropped. Then it's possible to reuse the pin for a different purpose.
+//!
 //! [documentation]: https://docs.esp-rs.org/esp-hal
 //! [examples]: https://github.com/esp-rs/esp-hal/tree/main/examples
 //! [embedded-hal]: https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Show how to write "blinky" in the top-level crate docs.  While we have module level documentation, figuring out how real code looks like required the user to visit "The Book" or "no-std training" (or generate from the template).

Additionally, briefly explain the PeripheralRef pattern (see #1729)

Not really sure if we want this, since it partly duplicates information from "The Book" and the training but for me at least it's always nice to see some code on the docs' welcome page without much effort (assuming most new users will first discover the crate on crates.io).

#### Testing
`cargo xtask build-documentation --packages esp-hal --chips esp32c6`
`cargo xtask run-doc-test esp-hal esp32c6`
