### PR TITLE
Update probe-rs arguments for run-elfs subcommand

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -585,12 +585,30 @@ fn run_elfs(args: RunElfArgs) -> Result<()> {
 
         log::info!("Running test '{}' for '{}'", elf_name, args.chip);
 
-        let command = Command::new("probe-rs")
-            .arg("run")
-            .arg("--chip")
-            .arg(args.chip.to_string())
-            .arg(elf_path)
-            .output()?;
+        let command = if args.chip == Chip::Esp32 {
+            Command::new("probe-rs")
+                .arg("run")
+                .arg("--chip")
+                .arg("esp32-3.3v")
+                .arg(elf_path)
+                .output()?
+        } else if args.chip == Chip::Esp32c2 {
+            Command::new("probe-rs")
+                .arg("run")
+                .arg("--chip")
+                .arg(args.chip.to_string())
+                .arg("--speed")
+                .arg("15000")
+                .arg(elf_path)
+                .output()?
+        } else {
+            Command::new("probe-rs")
+                .arg("run")
+                .arg("--chip")
+                .arg(args.chip.to_string())
+                .arg(elf_path)
+                .output()?
+        };
 
         println!(
             "{}\n{}",


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Now that we fix the C2 HIL setup, probe-rs was failing to flash the tests after the first test, this should make C2 HIL tests pass. 

#### Testing
I've downloaded the C2 test artifacts from the CI and run them using `cargo xtask run-elfs esp32c2 /home/sergio/Downloads/tests-esp32c2` (without the changes on this PR, it fails the same way).