### PR TITLE
Fix `set_protocol`

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add support for `Protocol::P802D11BGNAX` (#1742)
 
 ### Fixed
+- Fixed `set_mode` functionality (#1742)
 
 ### Changed
-
 - `esp_wifi::initialize` no longer requires running maximum CPU clock, instead check it runs above 80MHz. (#1688)
+- Rename `set_mode` to `set_protocol`, also available in esp-now API (#1742)
 
 ### Removed
 

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -312,10 +312,10 @@ impl<'d> EspNowManager<'d> {
         check_error!({ esp_wifi_get_mode(&mut mode) })?;
 
         if mode == wifi_mode_t_WIFI_MODE_STA || mode == wifi_mode_t_WIFI_MODE_APSTA {
-            check_error!({ esp_wifi_set_protocol(wifi_interface_t_WIFI_IF_STA, protocol as u8) })?;
+            check_error!({ esp_wifi_set_protocol(wifi_interface_t_WIFI_IF_STA, protocol) })?;
         }
         if mode == wifi_mode_t_WIFI_MODE_AP || mode == wifi_mode_t_WIFI_MODE_APSTA {
-            check_error!({ esp_wifi_set_protocol(wifi_interface_t_WIFI_IF_AP, protocol as u8) })?;
+            check_error!({ esp_wifi_set_protocol(wifi_interface_t_WIFI_IF_AP, protocol) })?;
         }
 
         Ok(())

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1845,12 +1845,12 @@ impl<'d> WifiController<'d> {
 
         if mode == wifi_mode_t_WIFI_MODE_STA || mode == wifi_mode_t_WIFI_MODE_APSTA {
             esp_wifi_result!(unsafe {
-                esp_wifi_set_protocol(wifi_interface_t_WIFI_IF_STA, protocol as u8)
+                esp_wifi_set_protocol(wifi_interface_t_WIFI_IF_STA, protocol)
             })?;
         }
         if mode == wifi_mode_t_WIFI_MODE_AP || mode == wifi_mode_t_WIFI_MODE_APSTA {
             esp_wifi_result!(unsafe {
-                esp_wifi_set_protocol(wifi_interface_t_WIFI_IF_AP, protocol as u8)
+                esp_wifi_set_protocol(wifi_interface_t_WIFI_IF_AP, protocol)
             })?;
         }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1704 

Renames `set_mode` to more suitable `set_protocol`. Also exposes this functionality in esp-now only mode.

As a bonus also enables setting `802.11AX` on supported devices

![image](https://github.com/esp-rs/esp-hal/assets/5682593/3f48d472-ad7d-48b0-b863-db65d6467886)


#### Testing
Change the esp-wifi examples to set a valid protocol and check e.g. with your router UI
