### PR TITLE
HIL: Erase flash on failure

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -122,6 +122,11 @@ jobs:
           path: tests-${{ matrix.target.soc }}
 
       - name: Run Tests
+        id: run-tests
         run: |
           export PATH=$PATH:/home/espressif/.cargo/bin
           cargo xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
+
+      - name: Erase Flash on Failure
+        if: steps.run-tests.conclusion == 'failure'
+        run: espflash erase-flash

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -59,7 +59,7 @@ Some tests will require physical connections, please see the current [configurat
 ### Running Tests Remotes (ie. On Self-Hosted Runners)
 The [`hil.yml`] workflow builds the test suite for all our available targets and executes them.
 
-Our self hosted runners have the following setup:
+Our self-hosted runners have the following setup:
 - ESP32-C2 (`esp32c2-jtag`):
   - Devkit: `ESP8684-DevKitM-1` connected via UART.
     - `GPIO2` and `GPIO3` are connected.
@@ -94,10 +94,10 @@ Our self hosted runners have the following setup:
     - `GPIO43 (TX)` and `GPIO45` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 
-[connection_c2]: (https://docs.espressif.com/projects/esp-idf/en/stable/esp32c2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware)
-[connection_s2]: (https://docs.espressif.com/projects/esp-idf/en/stable/esp32s2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware)
+[connection_c2]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32c2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware
+[connection_s2]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml
-[setup]: #vm-setup
+[setup]: #rpi-setup
 
 #### RPi Setup
 ```bash
@@ -113,6 +113,12 @@ cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev a6
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group
 sudo usermod -a -G plugdev $USER
+# Install espflash
+ARCH=$($HOME/.cargo/bin/rustup show | grep "Default host" | sed -e 's/.* //')
+curl -L "https://github.com/esp-rs/espflash/releases/latest/download/espflash-${ARCH}.zip" -o "${HOME}/.cargo/bin/espflash.zip"
+unzip "${HOME}/.cargo/bin/espflash.zip" -d "${HOME}/.cargo/bin/"
+rm "${HOME}/.cargo/bin/espflash.zip"
+chmod u+x "${HOME}/.cargo/bin/espflash"
 # Reboot the VM
 sudo reboot
 ```


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- If running the tests fails, we erase the target flash to avoid subsequent test failures due to a peripheral being in a weird state.
  - This would avoid situations like the one that happened yesterday, where we tried to merge https://github.com/esp-rs/esp-hal/pull/1738, the tests failed on S3 and all subsequent DMA tests were failing until I ssh into the machine and erase the target flash.
- Added docs for installing espflash

#### Testing
Not tested (not sure how I can test it)
