### PR TITLE
Enable `i2s` HIL test for `esp32h2`

### DIFF
--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -5,9 +5,7 @@
 //! This test uses I2S TX to transmit known data to I2S RX (forced to slave mode
 //! with loopback mode enabled). It's using circular DMA mode
 
-//! H2 is disabled because of https://github.com/esp-rs/esp-hal/issues/1637
-
-//% CHIPS: esp32c3 esp32c6 esp32s3
+//% CHIPS: esp32c3 esp32c6 esp32s3 esp32h2
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
### Pull Request Details 📖

#### Description
Since https://github.com/esp-rs/esp-hal/issues/1637 is not an issue anymore and `I2S` HIL test runs perfect on `ESP32H2`, we should enable the aforementioned test for this chip. 

#### Testing
Executed it locally, did a comparison between current state of `esp-hal` and on #1635 PR, when `I2S` test was added. Works faster (was ~1 min, 2 seconds now). Logic Analyzer also doesn't show any anomalies.

Also for more context check related issue #1637 
