### PR TITLE
Fix broken link to embassy book

### DIFF
--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -19,7 +19,7 @@
 //! traditional RTOS. More information can be found in the [Embassy
 //! documentation].
 //!
-//! [embassy documentation]: https://embassy.dev/book/dev/runtime.html
+//! [embassy documentation]: https://embassy.dev/book/
 //!
 //! ## Initialization
 //!


### PR DESCRIPTION
### Pull Request Details 📖

Minor fix to link to the embassy book.

Based on https://web.archive.org/web/20240000000000*/https://embassy.dev/book/dev/runtime.html it looks like the closest fragment may be https://embassy.dev/book/#_embassy_executor.but it seemed that linking to the main landing page of the book was more appropriate.