### PR TITLE
Properly update the Uart config in examples

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for GPIO wake-up source (#1724)
 - dma: add Mem2Mem to support memory to memory transfer (#1738)
 - Add `uart` wake source (#1727)
+- uart: Make `rx_timeout` optional in Config struct (#1759)
 
 ### Fixed
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -29,7 +29,7 @@
 //!     io.pins.gpio2).unwrap();
 //! # }
 //! ```
-//!
+//! 
 //! The UART controller can be configured to invert the polarity of the pins.
 //! This is achived by inverting the desired pins, and then constucting the
 //! UART instance using the inverted pins.
@@ -66,7 +66,7 @@
 //! uart1.write_bytes("Hello, world!".as_bytes()).expect("write error!");
 //! # }
 //! ```
-//!
+//! 
 //! #### Splitting the UART into TX and RX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -89,7 +89,7 @@
 //! let byte = rx.read_byte().expect("read error!");
 //! # }
 //! ```
-//!
+//! 
 //! #### Inverting TX and RX Pins
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -102,7 +102,7 @@
 //! let mut uart1 = Uart::new(peripherals.UART1, &clocks, tx, rx).unwrap();
 //! # }
 //! ```
-//!
+//! 
 //! #### Constructing TX and RX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -116,7 +116,7 @@
 //!     io.pins.gpio2).unwrap();
 //! # }
 //! ```
-//!
+//! 
 //! [embedded-hal]: https://docs.rs/embedded-hal/latest/embedded_hal/
 //! [embedded-io]: https://docs.rs/embedded-io/latest/embedded_io/
 //! [embedded-hal-async]: https://docs.rs/embedded-hal-async/latest/embedded_hal_async/

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -29,7 +29,7 @@
 //!     io.pins.gpio2).unwrap();
 //! # }
 //! ```
-//! 
+//!
 //! The UART controller can be configured to invert the polarity of the pins.
 //! This is achived by inverting the desired pins, and then constucting the
 //! UART instance using the inverted pins.
@@ -66,7 +66,7 @@
 //! uart1.write_bytes("Hello, world!".as_bytes()).expect("write error!");
 //! # }
 //! ```
-//! 
+//!
 //! #### Splitting the UART into TX and RX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -89,7 +89,7 @@
 //! let byte = rx.read_byte().expect("read error!");
 //! # }
 //! ```
-//! 
+//!
 //! #### Inverting TX and RX Pins
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -102,7 +102,7 @@
 //! let mut uart1 = Uart::new(peripherals.UART1, &clocks, tx, rx).unwrap();
 //! # }
 //! ```
-//! 
+//!
 //! #### Constructing TX and RX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -116,7 +116,7 @@
 //!     io.pins.gpio2).unwrap();
 //! # }
 //! ```
-//! 
+//!
 //! [embedded-hal]: https://docs.rs/embedded-hal/latest/embedded_hal/
 //! [embedded-io]: https://docs.rs/embedded-io/latest/embedded_io/
 //! [embedded-hal-async]: https://docs.rs/embedded-hal-async/latest/embedded_hal_async/
@@ -274,7 +274,7 @@ pub mod config {
         pub stop_bits: StopBits,
         pub clock_source: super::ClockSource,
         pub rx_fifo_full_threshold: u16,
-        pub rx_timeout: u8,
+        pub rx_timeout: Option<u8>,
     }
 
     impl Config {
@@ -337,7 +337,7 @@ pub mod config {
             self
         }
 
-        pub fn rx_timeout(mut self, timeout: u8) -> Self {
+        pub fn rx_timeout(mut self, timeout: Option<u8>) -> Self {
             self.rx_timeout = timeout;
             self
         }
@@ -355,7 +355,7 @@ pub mod config {
                 #[cfg(not(any(esp32c6, esp32h2, lp_uart)))]
                 clock_source: super::ClockSource::Apb,
                 rx_fifo_full_threshold: UART_FULL_THRESH_DEFAULT,
-                rx_timeout: UART_TOUT_THRESH_DEFAULT,
+                rx_timeout: Some(UART_TOUT_THRESH_DEFAULT),
             }
         }
     }
@@ -764,7 +764,7 @@ where
         serial
             .rx
             .set_rx_fifo_full_threshold(config.rx_fifo_full_threshold)?;
-        serial.rx.set_rx_timeout(Some(config.rx_timeout))?;
+        serial.rx.set_rx_timeout(config.rx_timeout)?;
         serial.change_baud_internal(config.baudrate, config.clock_source, clocks);
         serial.change_data_bits(config.data_bits);
         serial.change_parity(config.parity);

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -106,8 +106,7 @@ async fn main(spawner: Spawner) {
     #[cfg(feature = "esp32s3")]
     let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
 
-    let config = Config::default();
-    config.rx_fifo_full_threshold(READ_BUF_SIZE as u16);
+    let config = Config::default().rx_fifo_full_threshold(READ_BUF_SIZE as u16);
 
     let mut uart0 =
         Uart::new_async_with_config(peripherals.UART0, config, &clocks, tx_pin, rx_pin).unwrap();

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -52,8 +52,7 @@ fn main() -> ! {
     let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
     #[cfg(feature = "esp32s3")]
     let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
-    let config = Config::default();
-    config.rx_fifo_full_threshold(30);
+    let config = Config::default().rx_fifo_full_threshold(30);
 
     let mut uart0 = Uart::new_with_config(
         peripherals.UART0,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- [ `rx_fifo_full_threshold`](https://github.com/esp-rs/esp-hal/blob/163f45076e0370fb618f31c0b279e9bb77a3aa37/esp-hal/src/uart.rs#L335) returns a Config with the updated value, and it was not being stored, so we were using default values. 
- `rx_timeout` is now an option in the `Config` struct, see https://github.com/esp-rs/esp-hal/issues/1700#issuecomment-2210809685

#### Testing
Tested the examples