### PR TITLE
Prevent multiple versions of `esp-println` from being included in the dependency tree

### DIFF
--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `auto` is the default communication method (#1658)
+- Add the `links` field to Cargo.toml so that only one version of the package can be included (#1761)
 
 ### Removed
 

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.76.0"
 description  = "Provides `print!` and `println!` implementations various Espressif devices"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
+links        = "esp-println"
 
 [package.metadata.docs.rs]
 cargo-args     = ["-Z", "build-std=core"]


### PR DESCRIPTION
Closes #1731