### PR TITLE
Fix UsbDm and UsbDp for Gpio19 and Gpio20

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `sleep_light` for ESP32-C6 (#1720)
 - ROM Functions: Fix address of `ets_update_cpu_frequency_rom` (#1722)
 - Fix `regi2c_*` functions for `esp32h2` (#1737)
+- EESP32-S2 / ESP32-S3: Fix UsbDm and UsbDp for Gpio19 and Gpio20
 
 ### Changed
 

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -555,5 +555,5 @@ impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
 }
 
 // implement marker traits on USB pins
-impl crate::otg_fs::UsbDp for Gpio19 {}
-impl crate::otg_fs::UsbDm for Gpio20 {}
+impl crate::otg_fs::UsbDm for Gpio19 {}
+impl crate::otg_fs::UsbDp for Gpio20 {}

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -489,5 +489,5 @@ impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank1 {
 }
 
 // implement marker traits on USB pins
-impl crate::otg_fs::UsbDp for Gpio19 {}
-impl crate::otg_fs::UsbDm for Gpio20 {}
+impl crate::otg_fs::UsbDm for Gpio19 {}
+impl crate::otg_fs::UsbDp for Gpio20 {}

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -39,7 +39,7 @@ async fn main(_spawner: Spawner) -> () {
     esp_hal_embassy::init(&clocks, TimerGroup::new_async(peripherals.TIMG0, &clocks));
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let usb = Usb::new(peripherals.USB0, io.pins.gpio19, io.pins.gpio20);
+    let usb = Usb::new(peripherals.USB0, io.pins.gpio20, io.pins.gpio19);
 
     // Create the driver, from the HAL.
     let mut ep_out_buffer = [0u8; 1024];

--- a/examples/src/bin/usb_serial.rs
+++ b/examples/src/bin/usb_serial.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let usb = Usb::new(peripherals.USB0, io.pins.gpio19, io.pins.gpio20);
+    let usb = Usb::new(peripherals.USB0, io.pins.gpio20, io.pins.gpio19);
     let usb_bus = UsbBus::new(usb, unsafe { &mut *addr_of_mut!(EP_MEMORY) });
 
     let mut serial = SerialPort::new(&usb_bus);


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
GPIO pins 19 and 20 had USB D- and D+ swapped. This change fixes which pin is which USB data line according to the pin descriptions in the ESP32-S2 and ESP32-S3 data sheets (sections 2.2 and 2.3.2 respectively). Since these GpioPins are only used by Usb for lifetime tracking, and UsbDp and UsbDm are always used as a pair, this change is only semantic and doesn't affect functionality.

#### Testing
I checked that the updated usb_serial and embassy_usb_serial examples build with the esp-hal changes.