### PR TITLE
Improve PCNT API (with HIL tests)

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `esp_wifi::initialize` no longer requires running maximum CPU clock, instead check it runs above 80MHz. (#1688)
 - Move DMA descriptors from DMA Channel to each individual peripheral driver. (#1719)
 - Improved interrupt latency on Xtensa based chips (#1735)
+- Improve PCNT api (#1765)
 
 ### Removed
 - uart: Removed `configure_pins` methods (#1592)

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -8,7 +8,8 @@
 //! individual channels of the `PCNT` peripheral of pulse counting and signal
 //! edge detection on ESP chips.
 
-use super::unit;
+use core::marker::PhantomData;
+
 use crate::{
     gpio::{InputPin, InputSignal, Pull, ONE_INPUT, ZERO_INPUT},
     peripheral::Peripheral,
@@ -29,47 +30,13 @@ impl Default for PcntInputConfig {
     }
 }
 
-/// Channel number
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
-pub enum Number {
-    Channel0 = 0,
-    Channel1 = 1,
-}
-
 pub use crate::peripherals::pcnt::unit::conf0::{CTRL_MODE as CtrlMode, EDGE_MODE as EdgeMode};
-
-/// Pulse Counter configuration for a single channel
-#[derive(Debug, Copy, Clone)]
-pub struct Config {
-    /// PCNT low control mode
-    pub lctrl_mode: CtrlMode,
-    /// PCNT high control mode
-    pub hctrl_mode: CtrlMode,
-    /// PCNT signal positive edge count mode
-    pub pos_edge: EdgeMode,
-    /// PCNT signal negative edge count mode
-    pub neg_edge: EdgeMode,
-    pub invert_ctrl: bool,
-    pub invert_sig: bool,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            lctrl_mode: CtrlMode::Reverse,
-            hctrl_mode: CtrlMode::Reverse,
-            pos_edge: EdgeMode::Increment,
-            neg_edge: EdgeMode::Increment,
-            invert_ctrl: false,
-            invert_sig: false,
-        }
-    }
-}
 
 /// PcntPin can be always high, always low, or an actual pin
 #[derive(Clone, Copy)]
 pub struct PcntSource {
     source: u8,
+    inverted: bool,
 }
 
 impl PcntSource {
@@ -87,83 +54,127 @@ impl PcntSource {
 
         Self {
             source: pin.number(crate::private::Internal),
+            inverted: false,
         }
     }
     pub fn always_high() -> Self {
-        Self { source: ONE_INPUT }
+        Self {
+            source: ONE_INPUT,
+            inverted: false,
+        }
     }
     pub fn always_low() -> Self {
-        Self { source: ZERO_INPUT }
+        Self {
+            source: ZERO_INPUT,
+            inverted: false,
+        }
+    }
+
+    pub fn invert(self) -> Self {
+        Self {
+            source: self.source,
+            inverted: !self.inverted,
+        }
     }
 }
 
-pub struct Channel {
-    unit: unit::Number,
-    channel: Number,
+pub struct Channel<'d, const UNIT: usize, const NUM: usize> {
+    _phantom: PhantomData<&'d ()>,
+    // Individual channels are not Send, since they share registers.
+    _not_send: PhantomData<*const ()>,
 }
 
-impl Channel {
+impl<'d, const UNIT: usize, const NUM: usize> Channel<'d, UNIT, NUM> {
     /// return a new Channel
-    pub(super) fn new(unit: unit::Number, channel: Number) -> Self {
-        Self { unit, channel }
+    pub(super) fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+            _not_send: PhantomData,
+        }
     }
 
-    /// Configure the channel
-    pub fn configure(&mut self, ctrl_signal: PcntSource, edge_signal: PcntSource, config: Config) {
+    /// Configures how the channel behaves based on the level of the control
+    /// signal.
+    ///
+    /// * `low` - The behaviour of the channel when the control signal is low.
+    /// * `high` - The behaviour of the channel when the control signal is high.
+    pub fn set_ctrl_mode(&self, low: CtrlMode, high: CtrlMode) {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
-        let conf0 = pcnt.unit(self.unit as usize).conf0();
+        let conf0 = pcnt.unit(UNIT).conf0();
 
         conf0.modify(|_, w| {
-            w.ch_hctrl_mode(self.channel as u8)
-                .variant(config.hctrl_mode);
-            w.ch_lctrl_mode(self.channel as u8)
-                .variant(config.lctrl_mode);
-            w.ch_neg_mode(self.channel as u8).variant(config.neg_edge);
-            w.ch_pos_mode(self.channel as u8).variant(config.pos_edge)
+            w.ch_hctrl_mode(NUM as u8)
+                .variant(high)
+                .ch_lctrl_mode(NUM as u8)
+                .variant(low)
         });
-        self.set_ctrl_signal(ctrl_signal, config.invert_ctrl);
-        self.set_edge_signal(edge_signal, config.invert_sig);
+    }
+
+    /// Configures how the channel affects the counter based on the transition
+    /// made by the input signal.
+    ///
+    /// * `neg_edge` - The effect on the counter when the input signal goes 1 ->
+    ///   0.
+    /// * `pos_edge` - The effect on the counter when the input signal goes 0 ->
+    ///   1.
+    pub fn set_input_mode(&self, neg_edge: EdgeMode, pos_edge: EdgeMode) {
+        let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
+        let conf0 = pcnt.unit(UNIT).conf0();
+
+        conf0.modify(|_, w| {
+            w.ch_neg_mode(NUM as u8).variant(neg_edge);
+            w.ch_pos_mode(NUM as u8).variant(pos_edge)
+        });
     }
 
     /// Set the control signal (pin/high/low) for this channel
-    pub fn set_ctrl_signal(&self, source: PcntSource, invert: bool) -> &Self {
-        let signal = match self.unit {
-            unit::Number::Unit0 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT0_CTRL_CH0,
-                Number::Channel1 => InputSignal::PCNT0_CTRL_CH1,
+    pub fn set_ctrl_signal(&self, source: PcntSource) -> &Self {
+        let signal = match UNIT {
+            0 => match NUM {
+                0 => InputSignal::PCNT0_CTRL_CH0,
+                1 => InputSignal::PCNT0_CTRL_CH1,
+                _ => unreachable!(),
             },
-            unit::Number::Unit1 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT1_CTRL_CH0,
-                Number::Channel1 => InputSignal::PCNT1_CTRL_CH1,
+            1 => match NUM {
+                0 => InputSignal::PCNT1_CTRL_CH0,
+                1 => InputSignal::PCNT1_CTRL_CH1,
+                _ => unreachable!(),
             },
-            unit::Number::Unit2 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT2_CTRL_CH0,
-                Number::Channel1 => InputSignal::PCNT2_CTRL_CH1,
+            2 => match NUM {
+                0 => InputSignal::PCNT2_CTRL_CH0,
+                1 => InputSignal::PCNT2_CTRL_CH1,
+                _ => unreachable!(),
             },
-            unit::Number::Unit3 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT3_CTRL_CH0,
-                Number::Channel1 => InputSignal::PCNT3_CTRL_CH1,
-            },
-            #[cfg(esp32)]
-            unit::Number::Unit4 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT4_CTRL_CH0,
-                Number::Channel1 => InputSignal::PCNT4_CTRL_CH1,
-            },
-            #[cfg(esp32)]
-            unit::Number::Unit5 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT5_CTRL_CH0,
-                Number::Channel1 => InputSignal::PCNT5_CTRL_CH1,
+            3 => match NUM {
+                0 => InputSignal::PCNT3_CTRL_CH0,
+                1 => InputSignal::PCNT3_CTRL_CH1,
+                _ => unreachable!(),
             },
             #[cfg(esp32)]
-            unit::Number::Unit6 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT6_CTRL_CH0,
-                Number::Channel1 => InputSignal::PCNT6_CTRL_CH1,
+            4 => match NUM {
+                0 => InputSignal::PCNT4_CTRL_CH0,
+                1 => InputSignal::PCNT4_CTRL_CH1,
+                _ => unreachable!(),
             },
             #[cfg(esp32)]
-            unit::Number::Unit7 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT7_CTRL_CH0,
-                Number::Channel1 => InputSignal::PCNT7_CTRL_CH1,
+            5 => match NUM {
+                0 => InputSignal::PCNT5_CTRL_CH0,
+                1 => InputSignal::PCNT5_CTRL_CH1,
+                _ => unreachable!(),
             },
+            #[cfg(esp32)]
+            6 => match NUM {
+                0 => InputSignal::PCNT6_CTRL_CH0,
+                1 => InputSignal::PCNT6_CTRL_CH1,
+                _ => unreachable!(),
+            },
+            #[cfg(esp32)]
+            7 => match NUM {
+                0 => InputSignal::PCNT7_CTRL_CH0,
+                1 => InputSignal::PCNT7_CTRL_CH1,
+                _ => unreachable!(),
+            },
+            _ => unreachable!(),
         };
 
         if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
@@ -171,7 +182,7 @@ impl Channel {
                 .func_in_sel_cfg(signal as usize)
                 .modify(|_, w| unsafe {
                     w.sel().set_bit();
-                    w.in_inv_sel().bit(invert);
+                    w.in_inv_sel().bit(source.inverted);
                     w.in_sel().bits(source.source)
                 });
         }
@@ -179,44 +190,53 @@ impl Channel {
     }
 
     /// Set the edge signal (pin/high/low) for this channel
-    pub fn set_edge_signal(&self, source: PcntSource, invert: bool) -> &Self {
-        let signal = match self.unit {
-            unit::Number::Unit0 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT0_SIG_CH0,
-                Number::Channel1 => InputSignal::PCNT0_SIG_CH1,
+    pub fn set_edge_signal(&self, source: PcntSource) -> &Self {
+        let signal = match UNIT {
+            0 => match NUM {
+                0 => InputSignal::PCNT0_SIG_CH0,
+                1 => InputSignal::PCNT0_SIG_CH1,
+                _ => unreachable!(),
             },
-            unit::Number::Unit1 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT1_SIG_CH0,
-                Number::Channel1 => InputSignal::PCNT1_SIG_CH1,
+            1 => match NUM {
+                0 => InputSignal::PCNT1_SIG_CH0,
+                1 => InputSignal::PCNT1_SIG_CH1,
+                _ => unreachable!(),
             },
-            unit::Number::Unit2 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT2_SIG_CH0,
-                Number::Channel1 => InputSignal::PCNT2_SIG_CH1,
+            2 => match NUM {
+                0 => InputSignal::PCNT2_SIG_CH0,
+                1 => InputSignal::PCNT2_SIG_CH1,
+                _ => unreachable!(),
             },
-            unit::Number::Unit3 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT3_SIG_CH0,
-                Number::Channel1 => InputSignal::PCNT3_SIG_CH1,
-            },
-            #[cfg(esp32)]
-            unit::Number::Unit4 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT4_SIG_CH0,
-                Number::Channel1 => InputSignal::PCNT4_SIG_CH1,
-            },
-            #[cfg(esp32)]
-            unit::Number::Unit5 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT5_SIG_CH0,
-                Number::Channel1 => InputSignal::PCNT5_SIG_CH1,
+            3 => match NUM {
+                0 => InputSignal::PCNT3_SIG_CH0,
+                1 => InputSignal::PCNT3_SIG_CH1,
+                _ => unreachable!(),
             },
             #[cfg(esp32)]
-            unit::Number::Unit6 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT6_SIG_CH0,
-                Number::Channel1 => InputSignal::PCNT6_SIG_CH1,
+            4 => match NUM {
+                0 => InputSignal::PCNT4_SIG_CH0,
+                1 => InputSignal::PCNT4_SIG_CH1,
+                _ => unreachable!(),
             },
             #[cfg(esp32)]
-            unit::Number::Unit7 => match self.channel {
-                Number::Channel0 => InputSignal::PCNT7_SIG_CH0,
-                Number::Channel1 => InputSignal::PCNT7_SIG_CH1,
+            5 => match NUM {
+                0 => InputSignal::PCNT5_SIG_CH0,
+                1 => InputSignal::PCNT5_SIG_CH1,
+                _ => unreachable!(),
             },
+            #[cfg(esp32)]
+            6 => match NUM {
+                0 => InputSignal::PCNT6_SIG_CH0,
+                1 => InputSignal::PCNT6_SIG_CH1,
+                _ => unreachable!(),
+            },
+            #[cfg(esp32)]
+            7 => match NUM {
+                0 => InputSignal::PCNT7_SIG_CH0,
+                1 => InputSignal::PCNT7_SIG_CH1,
+                _ => unreachable!(),
+            },
+            _ => unreachable!(),
         };
 
         if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
@@ -224,7 +244,7 @@ impl Channel {
                 .func_in_sel_cfg(signal as usize)
                 .modify(|_, w| unsafe {
                     w.sel().set_bit();
-                    w.in_inv_sel().bit(invert);
+                    w.in_inv_sel().bit(source.inverted);
                     w.in_sel().bits(source.source)
                 });
         }

--- a/esp-hal/src/pcnt/mod.rs
+++ b/esp-hal/src/pcnt/mod.rs
@@ -49,6 +49,27 @@ pub mod unit;
 
 pub struct Pcnt<'d> {
     _instance: PeripheralRef<'d, peripherals::PCNT>,
+
+    /// Unit 0
+    pub unit0: Unit<'d, 0>,
+    /// Unit 1
+    pub unit1: Unit<'d, 1>,
+    /// Unit 2
+    pub unit2: Unit<'d, 2>,
+    /// Unit 3
+    pub unit3: Unit<'d, 3>,
+    #[cfg(esp32)]
+    /// Unit 4
+    pub unit4: Unit<'d, 4>,
+    #[cfg(esp32)]
+    /// Unit 5
+    pub unit5: Unit<'d, 5>,
+    #[cfg(esp32)]
+    /// Unit 6
+    pub unit6: Unit<'d, 6>,
+    #[cfg(esp32)]
+    /// Unit 7
+    pub unit7: Unit<'d, 7>,
 }
 
 impl<'d> Pcnt<'d> {
@@ -59,6 +80,7 @@ impl<'d> Pcnt<'d> {
     ) -> Self {
         crate::into_ref!(_instance);
         // Enable the PCNT peripherals clock in the system peripheral
+        PeripheralClockControl::reset(crate::system::Peripheral::Pcnt);
         PeripheralClockControl::enable(crate::system::Peripheral::Pcnt);
 
         if let Some(interrupt) = interrupt {
@@ -68,11 +90,44 @@ impl<'d> Pcnt<'d> {
             }
         }
 
-        Pcnt { _instance }
-    }
+        let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
 
-    /// Return a unit
-    pub fn get_unit(&self, number: unit::Number) -> Unit {
-        Unit::new(number)
+        // disable filter, all events, and channel settings
+        for unit in pcnt.unit_iter() {
+            unit.conf0().write(|w| unsafe {
+                // All bits are accounted for in the TRM.
+                w.bits(0)
+            });
+        }
+
+        // Remove reset bit from units.
+        pcnt.ctrl().modify(|_, w| {
+            #[cfg(not(esp32))]
+            let unit_count = 4;
+            #[cfg(esp32)]
+            let unit_count = 8;
+
+            for i in 0..unit_count {
+                w.cnt_rst_u(i).clear_bit();
+            }
+
+            w.clk_en().set_bit()
+        });
+
+        Pcnt {
+            _instance,
+            unit0: Unit::new(),
+            unit1: Unit::new(),
+            unit2: Unit::new(),
+            unit3: Unit::new(),
+            #[cfg(esp32)]
+            unit4: Unit::new(),
+            #[cfg(esp32)]
+            unit5: Unit::new(),
+            #[cfg(esp32)]
+            unit6: Unit::new(),
+            #[cfg(esp32)]
+            unit7: Unit::new(),
+        }
     }
 }

--- a/esp-hal/src/pcnt/unit.rs
+++ b/esp-hal/src/pcnt/unit.rs
@@ -10,38 +10,26 @@
 //! settings, like low and high limits, thresholds, and optional filtering.
 //! Users can easily configure these units based on their requirements.
 
+use core::marker::PhantomData;
+
 use critical_section::CriticalSection;
 
-use super::channel;
+use crate::pcnt::channel::Channel;
 
-/// Unit number
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
-pub enum Number {
-    Unit0 = 0,
-    Unit1 = 1,
-    Unit2 = 2,
-    Unit3 = 3,
-    #[cfg(esp32)]
-    Unit4 = 4,
-    #[cfg(esp32)]
-    Unit5 = 5,
-    #[cfg(esp32)]
-    Unit6 = 6,
-    #[cfg(esp32)]
-    Unit7 = 7,
-}
-
-/// Unit errors
+/// Invalid filter threshold value
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Error {
-    /// Invalid filter threshold value
-    InvalidFilterThresh,
-    /// Invalid low limit - must be < 0
-    InvalidLowLimit,
-    /// Invalid high limit - must be > 0
-    InvalidHighLimit,
-}
+pub struct InvalidFilterThreshold;
+
+/// Invalid low limit - must be < 0
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct InvalidLowLimit;
+
+/// Invalid high limit - must be > 0
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct InvalidHighLimit;
 
 /// the current status of the counter.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -53,7 +41,7 @@ pub enum ZeroMode {
     /// pulse counter increases from negative to 0
     NegZero  = 1,
     /// pulse counter is negative (not implemented?)
-    Negitive = 2,
+    Negative = 2,
     /// pulse counter is positive (not implemented?)
     Positive = 3,
 }
@@ -63,9 +51,9 @@ impl From<u8> for ZeroMode {
         match value {
             0 => Self::PosZero,
             1 => Self::NegZero,
-            2 => Self::Negitive,
+            2 => Self::Negative,
             3 => Self::Positive,
-            _ => unreachable!(), // TODO: is this good enoough?  should we use some default?
+            _ => unreachable!(), // TODO: is this good enough?  should we use some default?
         }
     }
 }
@@ -76,95 +64,155 @@ impl From<u8> for ZeroMode {
 pub struct Events {
     pub low_limit: bool,
     pub high_limit: bool,
-    pub thresh0: bool,
-    pub thresh1: bool,
+    pub threshold0: bool,
+    pub threshold1: bool,
     pub zero: bool,
 }
 
-/// Unit configuration
-#[derive(Copy, Clone, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Config {
-    pub low_limit: i16,
-    pub high_limit: i16,
-    pub thresh0: i16,
-    pub thresh1: i16,
-    pub filter: Option<u16>,
+#[non_exhaustive]
+pub struct Unit<'d, const NUM: usize> {
+    pub counter: Counter<'d, NUM>,
+    pub channel0: Channel<'d, NUM, 0>,
+    pub channel1: Channel<'d, NUM, 1>,
 }
 
-pub struct Unit {
-    number: Number,
-}
-
-impl Unit {
+impl<'d, const NUM: usize> Unit<'d, NUM> {
     /// return a new Unit
-    pub(super) fn new(number: Number) -> Self {
-        let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
-        // disable filter and all events
-        pcnt.unit(number as usize).conf0().modify(|_, w| {
-            w.filter_en().clear_bit();
-            unsafe {
-                w.filter_thres().bits(0);
-            }
-            w.thr_l_lim_en().clear_bit();
-            w.thr_h_lim_en().clear_bit();
-            w.thr_thres0_en().clear_bit();
-            w.thr_thres1_en().clear_bit();
-            w.thr_zero_en().clear_bit()
-        });
-        Self { number }
+    pub(super) fn new() -> Self {
+        Self {
+            counter: Counter::new(),
+            channel0: Channel::new(),
+            channel1: Channel::new(),
+        }
     }
 
-    pub fn configure(&mut self, config: Config) -> Result<(), Error> {
-        // low limit must be >= or the limit is -32768 and when thats
-        // hit the event status claims it was the high limit.
-        // tested on an esp32s3
-        if config.low_limit >= 0 {
-            return Err(Error::InvalidLowLimit);
-        }
-        if config.high_limit <= 0 {
-            return Err(Error::InvalidHighLimit);
-        }
-        let (filter_en, filter) = match config.filter {
-            Some(filter) => (true, filter),
-            None => (false, 0),
-        };
-        // filter must be less than 1024
-        if filter > 1023 {
-            return Err(Error::InvalidFilterThresh);
-        }
-
+    /// Configures a lower limit to the count value.
+    ///
+    /// When the count drops to this value:
+    /// - A low limit interrupt is triggered.
+    /// - The count is reset to 0.
+    ///
+    /// If None is specified, then no interrupt is triggered and
+    /// the count wraps around after [i16::MIN].
+    ///
+    /// Note: The specified value must be negative.
+    pub fn set_low_limit(&self, value: Option<i16>) -> Result<(), InvalidLowLimit> {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
-        let unit = pcnt.unit(self.number as usize);
-        unit.conf2().write(|w| unsafe {
-            w.cnt_l_lim().bits(config.low_limit as u16);
-            w.cnt_h_lim().bits(config.high_limit as u16)
-        });
-        unit.conf1().write(|w| unsafe {
-            w.cnt_thres0().bits(config.thresh0 as u16);
-            w.cnt_thres1().bits(config.thresh1 as u16)
-        });
-        unit.conf0().modify(|_, w| unsafe {
-            w.filter_thres().bits(filter);
-            w.filter_en().bit(filter_en)
-        });
-        self.pause();
-        self.clear();
+        let unit = pcnt.unit(NUM);
+
+        if let Some(value) = value {
+            // low limit must be >= or the limit is -32768 and when that's
+            // hit the event status claims it was the high limit.
+            // tested on an esp32s3
+            if !value.is_negative() {
+                return Err(InvalidLowLimit);
+            } else {
+                unit.conf2()
+                    .modify(|_, w| unsafe { w.cnt_l_lim().bits(value as u16) });
+                unit.conf0().modify(|_, w| w.thr_l_lim_en().set_bit());
+            }
+        } else {
+            unit.conf0().modify(|_, w| w.thr_l_lim_en().clear_bit());
+        }
         Ok(())
     }
 
-    pub fn get_channel(&self, number: channel::Number) -> super::channel::Channel {
-        super::channel::Channel::new(self.number, number)
+    /// Configures a high limit to the count value.
+    ///
+    /// When the count rises to this value:
+    /// - A high limit interrupt is triggered.
+    /// - The count is reset to 0.
+    ///
+    /// If None is specified, then no interrupt is triggered and
+    /// the count wraps around after [i16::MAX].
+    ///
+    /// Note: The specified value must be positive.
+    pub fn set_high_limit(&self, value: Option<i16>) -> Result<(), InvalidHighLimit> {
+        let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
+        let unit = pcnt.unit(NUM);
+
+        if let Some(value) = value {
+            if !value.is_positive() {
+                return Err(InvalidHighLimit);
+            } else {
+                unit.conf2()
+                    .modify(|_, w| unsafe { w.cnt_h_lim().bits(value as u16) });
+                unit.conf0().modify(|_, w| w.thr_h_lim_en().set_bit());
+            }
+        } else {
+            unit.conf0().modify(|_, w| w.thr_h_lim_en().clear_bit());
+        }
+        Ok(())
     }
 
+    /// Configures a threshold value to trigger an interrupt.
+    ///
+    /// When the count equals this value a threshold0 interrupt is triggered.
+    /// If None is specified, then no interrupt is triggered.
+    pub fn set_threshold0(&self, value: Option<i16>) {
+        let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
+        let unit = pcnt.unit(NUM);
+
+        if let Some(value) = value {
+            unit.conf1()
+                .modify(|_, w| unsafe { w.cnt_thres0().bits(value as u16) });
+            unit.conf0().modify(|_, w| w.thr_thres0_en().set_bit());
+        } else {
+            unit.conf0().modify(|_, w| w.thr_thres0_en().clear_bit());
+        }
+    }
+
+    /// Configures a threshold value to trigger an interrupt.
+    ///
+    /// When the count equals this value a threshold1 interrupt is triggered.
+    /// If None is specified, then no interrupt is triggered.
+    pub fn set_threshold1(&self, value: Option<i16>) {
+        let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
+        let unit = pcnt.unit(NUM);
+
+        if let Some(value) = value {
+            unit.conf1()
+                .modify(|_, w| unsafe { w.cnt_thres1().bits(value as u16) });
+            unit.conf0().modify(|_, w| w.thr_thres1_en().set_bit());
+        } else {
+            unit.conf0().modify(|_, w| w.thr_thres1_en().clear_bit());
+        }
+    }
+
+    /// Configures the glitch filter hardware of the unit.
+    ///
+    /// `threshold` is the minimum number of APB_CLK cycles for a pulse to be
+    /// considered valid. If it is None, the filter is disabled.
+    ///
+    /// Note: This maximum possible threshold is 1023.
+    pub fn set_filter(&self, threshold: Option<u16>) -> Result<(), InvalidFilterThreshold> {
+        let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
+        let unit = pcnt.unit(NUM);
+
+        match threshold {
+            None => {
+                unit.conf0().modify(|_, w| w.filter_en().clear_bit());
+            }
+            Some(threshold) => {
+                if threshold > 1023 {
+                    return Err(InvalidFilterThreshold);
+                }
+                unit.conf0().modify(|_, w| unsafe {
+                    w.filter_thres().bits(threshold).filter_en().set_bit()
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Resets the counter value to zero.
     pub fn clear(&self) {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         critical_section::with(|_cs| {
-            pcnt.ctrl()
-                .modify(|_, w| w.cnt_rst_u(self.number as u8).set_bit());
+            pcnt.ctrl().modify(|_, w| w.cnt_rst_u(NUM as u8).set_bit());
             // TODO: does this need a delay? (liebman / Jan 2 2023)
             pcnt.ctrl()
-                .modify(|_, w| w.cnt_rst_u(self.number as u8).clear_bit());
+                .modify(|_, w| w.cnt_rst_u(NUM as u8).clear_bit());
         });
     }
 
@@ -173,7 +221,7 @@ impl Unit {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         critical_section::with(|_cs| {
             pcnt.ctrl()
-                .modify(|_, w| w.cnt_pause_u(self.number as u8).set_bit());
+                .modify(|_, w| w.cnt_pause_u(NUM as u8).set_bit());
         });
     }
 
@@ -182,32 +230,20 @@ impl Unit {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         critical_section::with(|_cs| {
             pcnt.ctrl()
-                .modify(|_, w| w.cnt_pause_u(self.number as u8).clear_bit());
-        });
-    }
-
-    /// Enable which events generate interrupts on this unit.
-    pub fn events(&self, events: Events) {
-        let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
-        pcnt.unit(self.number as usize).conf0().modify(|_, w| {
-            w.thr_l_lim_en().bit(events.low_limit);
-            w.thr_h_lim_en().bit(events.high_limit);
-            w.thr_thres0_en().bit(events.thresh0);
-            w.thr_thres1_en().bit(events.thresh1);
-            w.thr_zero_en().bit(events.zero)
+                .modify(|_, w| w.cnt_pause_u(NUM as u8).clear_bit());
         });
     }
 
     /// Get the latest events for this unit.
     pub fn get_events(&self) -> Events {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
-        let status = pcnt.u_status(self.number as usize).read();
+        let status = pcnt.u_status(NUM).read();
 
         Events {
             low_limit: status.l_lim().bit(),
             high_limit: status.h_lim().bit(),
-            thresh0: status.thres0().bit(),
-            thresh1: status.thres1().bit(),
+            threshold0: status.thres0().bit(),
+            threshold1: status.thres1().bit(),
             zero: status.zero().bit(),
         }
     }
@@ -215,11 +251,7 @@ impl Unit {
     /// Get the mode of the last zero crossing
     pub fn get_zero_mode(&self) -> ZeroMode {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
-        pcnt.u_status(self.number as usize)
-            .read()
-            .zero_mode()
-            .bits()
-            .into()
+        pcnt.u_status(NUM).read().zero_mode().bits().into()
     }
 
     /// Enable interrupts for this unit.
@@ -227,7 +259,7 @@ impl Unit {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         critical_section::with(|_cs| {
             pcnt.int_ena()
-                .modify(|_, w| w.cnt_thr_event_u(self.number as u8).set_bit());
+                .modify(|_, w| w.cnt_thr_event_u(NUM as u8).set_bit());
         });
     }
 
@@ -236,17 +268,14 @@ impl Unit {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         critical_section::with(|_cs| {
             pcnt.int_ena()
-                .write(|w| w.cnt_thr_event_u(self.number as u8).clear_bit());
+                .modify(|_, w| w.cnt_thr_event_u(NUM as u8).clear_bit());
         });
     }
 
     /// Returns true if an interrupt is active for this unit.
-    pub fn interrupt_set(&self) -> bool {
+    pub fn interrupt_is_set(&self) -> bool {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
-        pcnt.int_st()
-            .read()
-            .cnt_thr_event_u(self.number as u8)
-            .bit()
+        pcnt.int_raw().read().cnt_thr_event_u(NUM as u8).bit()
     }
 
     /// Clear the interrupt bit for this unit.
@@ -254,13 +283,40 @@ impl Unit {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         critical_section::with(|_cs| {
             pcnt.int_clr()
-                .write(|w| w.cnt_thr_event_u(self.number as u8).set_bit());
+                .write(|w| w.cnt_thr_event_u(NUM as u8).set_bit());
         });
     }
 
     /// Get the current counter value.
     pub fn get_value(&self) -> i16 {
+        self.counter.get()
+    }
+}
+
+impl<'d, const NUM: usize> Drop for Unit<'d, NUM> {
+    fn drop(&mut self) {
+        // This is here to prevent the destructuring of Unit.
+    }
+}
+
+// The entire Unit is Send but the individual channels are not.
+unsafe impl<'d, const NUM: usize> Send for Unit<'d, NUM> {}
+
+#[derive(Clone)]
+pub struct Counter<'d, const NUM: usize> {
+    _phantom: PhantomData<&'d ()>,
+}
+
+impl<'d, const NUM: usize> Counter<'d, NUM> {
+    fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Get the current counter value.
+    pub fn get(&self) -> i16 {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
-        pcnt.u_cnt(self.number as usize).read().cnt().bits() as i16
+        pcnt.u_cnt(NUM).read().cnt().bits() as i16
     }
 }

--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -29,7 +29,7 @@ use esp_hal::{
 use esp_println::println;
 use portable_atomic::AtomicI32;
 
-static UNIT0: Mutex<RefCell<Option<unit::Unit>>> = Mutex::new(RefCell::new(None));
+static UNIT0: Mutex<RefCell<Option<unit::Unit<'static, 1>>>> = Mutex::new(RefCell::new(None));
 static VALUE: AtomicI32 = AtomicI32::new(0);
 
 #[entry]
@@ -41,74 +41,57 @@ fn main() -> ! {
     // Set up a pulse counter:
     println!("setup pulse counter unit 0");
     let pcnt = Pcnt::new(peripherals.PCNT, Some(interrupt_handler));
-    let mut u0 = pcnt.get_unit(unit::Number::Unit1);
-    u0.configure(unit::Config {
-        low_limit: -100,
-        high_limit: 100,
-        filter: Some(min(10u16 * 80, 1023u16)),
-        ..Default::default()
-    })
-    .unwrap();
+    let mut u0 = pcnt.unit1;
+    u0.set_low_limit(Some(-100)).unwrap();
+    u0.set_high_limit(Some(100)).unwrap();
+    u0.set_filter(Some(min(10u16 * 80, 1023u16))).unwrap();
+    u0.clear();
 
     println!("setup channel 0");
-    let mut ch0 = u0.get_channel(channel::Number::Channel0);
+    let mut ch0 = &u0.channel0;
     let mut pin_a = io.pins.gpio4;
     let mut pin_b = io.pins.gpio5;
 
-    ch0.configure(
-        PcntSource::from_pin(&mut pin_a, PcntInputConfig { pull: Pull::Up }),
-        PcntSource::from_pin(&mut pin_b, PcntInputConfig { pull: Pull::Up }),
-        channel::Config {
-            lctrl_mode: channel::CtrlMode::Reverse,
-            hctrl_mode: channel::CtrlMode::Keep,
-            pos_edge: channel::EdgeMode::Decrement,
-            neg_edge: channel::EdgeMode::Increment,
-            invert_ctrl: false,
-            invert_sig: false,
-        },
-    );
+    ch0.set_ctrl_signal(PcntSource::from_pin(
+        &mut pin_a,
+        PcntInputConfig { pull: Pull::Up },
+    ));
+    ch0.set_edge_signal(PcntSource::from_pin(
+        &mut pin_b,
+        PcntInputConfig { pull: Pull::Up },
+    ));
+    ch0.set_ctrl_mode(channel::CtrlMode::Reverse, channel::CtrlMode::Keep);
+    ch0.set_input_mode(channel::EdgeMode::Increment, channel::EdgeMode::Decrement);
 
     println!("setup channel 1");
-    let mut ch1 = u0.get_channel(channel::Number::Channel1);
-    ch1.configure(
-        PcntSource::from_pin(&mut pin_b, PcntInputConfig { pull: Pull::Up }),
-        PcntSource::from_pin(&mut pin_a, PcntInputConfig { pull: Pull::Up }),
-        channel::Config {
-            lctrl_mode: channel::CtrlMode::Reverse,
-            hctrl_mode: channel::CtrlMode::Keep,
-            pos_edge: channel::EdgeMode::Increment,
-            neg_edge: channel::EdgeMode::Decrement,
-            invert_ctrl: false,
-            invert_sig: false,
-        },
-    );
-    println!("subscribing to events");
-    u0.events(unit::Events {
-        low_limit: true,
-        high_limit: true,
-        thresh0: false,
-        thresh1: false,
-        zero: false,
-    });
+    let mut ch1 = &u0.channel1;
+    ch1.set_ctrl_signal(PcntSource::from_pin(
+        &mut pin_b,
+        PcntInputConfig { pull: Pull::Up },
+    ));
+    ch1.set_edge_signal(PcntSource::from_pin(
+        &mut pin_a,
+        PcntInputConfig { pull: Pull::Up },
+    ));
+    ch1.set_ctrl_mode(channel::CtrlMode::Reverse, channel::CtrlMode::Keep);
+    ch1.set_input_mode(channel::EdgeMode::Decrement, channel::EdgeMode::Increment);
 
     println!("enabling interrupts");
     u0.listen();
     println!("resume pulse counter unit 0");
     u0.resume();
 
+    let counter = u0.counter.clone();
+
     critical_section::with(|cs| UNIT0.borrow_ref_mut(cs).replace(u0));
 
     let mut last_value: i32 = 0;
     loop {
-        critical_section::with(|cs| {
-            let mut u0 = UNIT0.borrow_ref_mut(cs);
-            let u0 = u0.as_mut().unwrap();
-            let value: i32 = u0.get_value() as i32 + VALUE.load(Ordering::SeqCst);
-            if value != last_value {
-                println!("value: {value}");
-                last_value = value;
-            }
-        });
+        let value: i32 = counter.get() as i32 + VALUE.load(Ordering::SeqCst);
+        if value != last_value {
+            println!("value: {value}");
+            last_value = value;
+        }
     }
 }
 
@@ -117,7 +100,7 @@ fn interrupt_handler() {
     critical_section::with(|cs| {
         let mut u0 = UNIT0.borrow_ref_mut(cs);
         let u0 = u0.as_mut().unwrap();
-        if u0.interrupt_set() {
+        if u0.interrupt_is_set() {
             let events = u0.get_events();
             if events.high_limit {
                 VALUE.fetch_add(100, Ordering::SeqCst);

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -7,8 +7,6 @@
 #![no_std]
 #![no_main]
 
-use core::ops::Deref;
-
 use defmt_rtt as _;
 use esp_backtrace as _;
 use esp_hal::{delay::Delay, gpio::GpioPin, pcnt::Pcnt};
@@ -44,7 +42,7 @@ mod tests {
         let system = SystemControl::new(peripherals.SYSTEM);
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-        let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
         Context {
             pcnt: Pcnt::new(peripherals.PCNT, None),
@@ -56,41 +54,15 @@ mod tests {
 
     #[test]
     fn test_increment_on_pos_edge(ctx: Context<'static>) {
-        let mut unit = ctx.pcnt.get_unit(unit::Number::Unit0);
-        unit.configure(unit::Config {
-            low_limit: -100,
-            high_limit: 100,
-            ..Default::default()
-        })
-        .unwrap();
+        let unit = ctx.pcnt.unit0;
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
-        unit.get_channel(channel::Number::Channel0).configure(
-            PcntSource::always_high(),
-            PcntSource::from_pin(ctx.gpio2, PcntInputConfig { pull: Pull::Down }),
-            channel::Config {
-                lctrl_mode: CtrlMode::Keep,
-                hctrl_mode: CtrlMode::Keep,
-                pos_edge: EdgeMode::Increment,
-                neg_edge: EdgeMode::Hold,
-                invert_ctrl: false,
-                invert_sig: false,
-            },
-        );
-
-        // Disable channel 1.
-        unit.get_channel(channel::Number::Channel1).configure(
-            PcntSource::always_high(),
-            PcntSource::always_high(),
-            channel::Config {
-                lctrl_mode: CtrlMode::Keep,
-                hctrl_mode: CtrlMode::Keep,
-                pos_edge: EdgeMode::Hold,
-                neg_edge: EdgeMode::Hold,
-                invert_ctrl: false,
-                invert_sig: false,
-            },
-        );
+        unit.channel0.set_edge_signal(PcntSource::from_pin(
+            ctx.gpio2,
+            PcntInputConfig { pull: Pull::Down },
+        ));
+        unit.channel0
+            .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
         let mut output = Output::new(ctx.gpio3, Level::Low);
 
@@ -117,5 +89,277 @@ mod tests {
         ctx.delay.delay_micros(1);
 
         assert_eq!(2, unit.get_value());
+    }
+
+    #[test]
+    fn test_increment_on_neg_edge(ctx: Context<'static>) {
+        let unit = ctx.pcnt.unit1;
+
+        // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
+        unit.channel0.set_edge_signal(PcntSource::from_pin(
+            ctx.gpio2,
+            PcntInputConfig { pull: Pull::Up },
+        ));
+        unit.channel0
+            .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
+
+        let mut output = Output::new(ctx.gpio3, Level::High);
+
+        unit.resume();
+
+        assert_eq!(0, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(1, unit.get_value());
+
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(1, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(2, unit.get_value());
+
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(2, unit.get_value());
+    }
+
+    #[test]
+    fn test_increment_past_high_limit(ctx: Context<'static>) {
+        let unit = ctx.pcnt.unit3;
+
+        unit.set_high_limit(Some(3)).unwrap();
+
+        // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
+        unit.channel0.set_edge_signal(PcntSource::from_pin(
+            ctx.gpio2,
+            PcntInputConfig { pull: Pull::Up },
+        ));
+        unit.channel0
+            .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
+
+        let mut output = Output::new(ctx.gpio3, Level::High);
+
+        unit.resume();
+
+        assert_eq!(0, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(1, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(2, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(0, unit.get_value());
+        assert!(unit.get_events().high_limit);
+        assert!(unit.interrupt_is_set());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(1, unit.get_value());
+
+        // high limit event remains after next increment.
+        assert!(unit.get_events().high_limit);
+
+        unit.reset_interrupt();
+        assert!(!unit.interrupt_is_set());
+
+        // high limit event remains after interrupt is cleared.
+        assert!(unit.get_events().high_limit);
+    }
+
+    #[test]
+    fn test_increment_past_thresholds(ctx: Context<'static>) {
+        let unit = ctx.pcnt.unit0;
+
+        unit.set_threshold0(Some(2));
+        unit.set_threshold1(Some(4));
+        // For some reason this is needed for the above thresholds to apply.
+        unit.clear();
+
+        // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
+        unit.channel0.set_edge_signal(PcntSource::from_pin(
+            ctx.gpio2,
+            PcntInputConfig { pull: Pull::Up },
+        ));
+        unit.channel0
+            .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
+
+        let mut output = Output::new(ctx.gpio3, Level::High);
+
+        unit.resume();
+
+        assert_eq!(0, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(1, unit.get_value());
+        assert!(!unit.interrupt_is_set());
+        assert!(!unit.get_events().threshold0);
+        assert!(!unit.get_events().threshold1);
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(2, unit.get_value());
+        assert!(unit.interrupt_is_set());
+        assert!(unit.get_events().threshold0);
+        assert!(!unit.get_events().threshold1);
+
+        unit.reset_interrupt();
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(3, unit.get_value());
+        assert!(!unit.interrupt_is_set());
+        // threshold event remains after next increment and after interrupt is cleared.
+        assert!(unit.get_events().threshold0);
+        assert!(!unit.get_events().threshold1);
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(4, unit.get_value());
+        assert!(unit.interrupt_is_set());
+        // threshold event cleared after new event occurs.
+        assert!(!unit.get_events().threshold0);
+        assert!(unit.get_events().threshold1);
+    }
+
+    #[test]
+    fn test_decrement_past_low_limit(ctx: Context<'static>) {
+        let unit = ctx.pcnt.unit0;
+
+        unit.set_low_limit(Some(-3)).unwrap();
+        // For some reason this is needed for the above limit to apply.
+        unit.clear();
+
+        // Setup channel 0 to decrement the count when gpio2 does LOW -> HIGH
+        unit.channel0.set_edge_signal(PcntSource::from_pin(
+            ctx.gpio2,
+            PcntInputConfig { pull: Pull::Up },
+        ));
+        unit.channel0
+            .set_input_mode(EdgeMode::Decrement, EdgeMode::Hold);
+
+        let mut output = Output::new(ctx.gpio3, Level::High);
+
+        unit.resume();
+
+        assert_eq!(0, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(-1, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(-2, unit.get_value());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(0, unit.get_value());
+        assert!(unit.get_events().low_limit);
+        assert!(unit.interrupt_is_set());
+
+        output.set_low();
+        ctx.delay.delay_micros(1);
+        output.set_high();
+        ctx.delay.delay_micros(1);
+
+        assert_eq!(-1, unit.get_value());
+
+        // low limit event remains after next increment.
+        assert!(unit.get_events().low_limit);
+
+        unit.reset_interrupt();
+        assert!(!unit.interrupt_is_set());
+
+        // low limit event remains after interrupt is cleared.
+        assert!(unit.get_events().low_limit);
+    }
+
+    #[test]
+    fn test_unit_count_range(ctx: Context<'static>) {
+        let unit = ctx.pcnt.unit2;
+
+        // Setup channel 1 to increment the count when gpio2 does LOW -> HIGH
+        unit.channel1.set_edge_signal(PcntSource::from_pin(
+            ctx.gpio2,
+            PcntInputConfig { pull: Pull::Up },
+        ));
+        unit.channel1
+            .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
+
+        let mut output = Output::new(ctx.gpio3, Level::High);
+
+        unit.resume();
+
+        assert_eq!(0, unit.get_value());
+
+        for i in (0..=i16::MAX).chain(i16::MIN..0) {
+            assert_eq!(i, unit.get_value());
+
+            output.set_low();
+            ctx.delay.delay_micros(1);
+            output.set_high();
+            ctx.delay.delay_micros(1);
+        }
+
+        assert_eq!(0, unit.get_value());
+
+        // Channel 1 should now decrement.
+        unit.channel1
+            .set_input_mode(EdgeMode::Decrement, EdgeMode::Hold);
+
+        for i in (0..=i16::MAX).chain(i16::MIN..=0).rev() {
+            assert_eq!(i, unit.get_value());
+
+            output.set_low();
+            ctx.delay.delay_micros(1);
+            output.set_high();
+            ctx.delay.delay_micros(1);
+        }
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
I've made a couple improvements to the API.
- Move pin inversion logic from config into the `PcntSource` struct.
- Lifetime of unit now restricted to the lifetime of the borrowed peripheral.
- Tie the configuration of limits/thresholds with the enabling of the event. The limits do nothing if the event is disabled.
- Provide separate unit objects so that Rust borrow checking can be taken advantage of.
- Split out upfront config object into multiple optional methods.
- Move counter to separate object which can be cloned. Eliminating the need for the critical section in the example.
- Fixed the use of `write` when disabling interrupts.
- Changed the interrupt check to look at INT_RAW instead of INT_ST.

#### Testing
I ran the HIL tests locally but CI should be good as well.
I'm unable to run the example.
