### PR TITLE
esp-hal: ESP32 typo in cfg-gate in embassy_i2s_read example

### DIFF
--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -63,7 +63,7 @@ async fn main(_spawner: Spawner) {
         &clocks,
     );
 
-    #[cfg(not(features = "esp32"))]
+    #[cfg(not(feature = "esp32"))]
     let i2s = i2s.with_mclk(io.pins.gpio0);
 
     let i2s_rx = i2s


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
I made a typo when modifying the `embassy_i2s_read` example and it panics on ESP32. This PR fixes it.

#### Testing
`embassy_i2s_read` on ESP32 runs correctly.
