### PR TITLE
Add SPI Half Duplex Read HIL test

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -57,6 +57,10 @@ name    = "spi_full_duplex_dma"
 harness = false
 
 [[test]]
+name    = "spi_half_duplex_read"
+harness = false
+
+[[test]]
 name    = "pcnt"
 harness = false
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -1,0 +1,108 @@
+//! SPI Half Duplex Read Test
+//!
+//! Folowing pins are used:
+//! SCLK    GPIO0
+//! MISO    GPIO2
+//!
+//! GPIO    GPIO3
+//!
+//! Connect MISO (GPIO2) and GPIO (GPIO3) pins.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use esp_backtrace as _;
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use esp_hal::{
+        clock::ClockControl,
+        dma::{Dma, DmaPriority},
+        dma_buffers,
+        gpio::{Io, Level, Output},
+        peripherals::Peripherals,
+        prelude::_fugit_RateExtU32,
+        spi::{
+            master::{prelude::*, Address, Command, Spi},
+            SpiDataMode,
+            SpiMode,
+        },
+        system::SystemControl,
+    };
+
+    #[init]
+    fn init() {}
+
+    #[test]
+    #[timeout(3)]
+    fn test_spi_reads_correctly_from_gpio_pin() {
+        const DMA_BUFFER_SIZE: usize = 4;
+
+        let peripherals = Peripherals::take();
+        let system = SystemControl::new(peripherals.SYSTEM);
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let sclk = io.pins.gpio0;
+        let miso = io.pins.gpio2;
+
+        let mut miso_mirror = Output::new(io.pins.gpio3, Level::High);
+
+        let dma = Dma::new(peripherals.DMA);
+
+        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        let dma_channel = dma.spi2channel;
+        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        let dma_channel = dma.channel0;
+
+        let (_, tx_descriptors, mut rx_buffer, rx_descriptors) = dma_buffers!(0, DMA_BUFFER_SIZE);
+
+        let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_sck(sclk)
+            .with_miso(miso)
+            .with_dma(
+                dma_channel.configure(false, DmaPriority::Priority0),
+                tx_descriptors,
+                rx_descriptors,
+            );
+
+        // Fill with neither 0x00 nor 0xFF.
+        rx_buffer.fill(5);
+
+        // SPI should read '0's from the MISO pin
+        miso_mirror.set_low();
+
+        let transfer = spi
+            .read(
+                SpiDataMode::Single,
+                Command::None,
+                Address::None,
+                0,
+                &mut rx_buffer,
+            )
+            .unwrap();
+        transfer.wait().unwrap();
+
+        assert_eq!(rx_buffer, &[0x00; DMA_BUFFER_SIZE]);
+
+        // SPI should read '1's from the MISO pin
+        miso_mirror.set_high();
+
+        let transfer = spi
+            .read(
+                SpiDataMode::Single,
+                Command::None,
+                Address::None,
+                0,
+                &mut rx_buffer,
+            )
+            .unwrap();
+        transfer.wait().unwrap();
+
+        assert_eq!(rx_buffer, &[0xFF; DMA_BUFFER_SIZE]);
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds a simple HIL test for SPI Half Duplex reads.
It just sets the miso pin high/low and read several bytes to show the spi driver can see the correct value.
The test is rather simple but it's better than no test at all :smile:. (I thought of more thorough tests but they'd only work on a subset of the devices supported by the HAL)

I've also written a half duplex write test but it depends on #1765, so I'll open it once it lands.

I skipped the changelog since this is a HIL test

#### Testing
I ran the HIL test on the real device and the assertion succeed.
