### PR TITLE
Remove unnecessary build dependency from `esp-backtrace`

### DIFF
--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -18,7 +18,6 @@ semihosting = { version = "0.1.12", optional = true }
 
 [build-dependencies]
 esp-build = { version = "0.1.0", path = "../esp-build" }
-rustversion = "1.0.17"
 
 [features]
 default = ["colors"]

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -12,19 +12,4 @@ fn main() {
     if cfg!(feature = "custom-halt") && cfg!(feature = "halt-cores") {
         panic!("Only one of `custom-halt` and `halt-cores` can be enabled");
     }
-
-    check_nightly();
 }
-
-#[rustversion::all(not(stable),not(since(2024-06-12)))]
-fn check_nightly() {
-    println!("cargo:rustc-cfg=nightly_before_2024_06_12");
-}
-
-#[rustversion::since(2024-06-12)]
-fn check_nightly() {
-    println!("cargo:rustc-cfg=nightly_since_2024_06_12");
-}
-
-#[rustversion::stable]
-fn check_nightly() {}


### PR DESCRIPTION
Forgot to do this in #1786 😅 