### PR TITLE
Add additional public functions to `esp-lp-hal` for Delay and UART, deny missing documentation

### DIFF
--- a/esp-lp-hal/src/delay.rs
+++ b/esp-lp-hal/src/delay.rs
@@ -8,7 +8,7 @@
 //! ## Examples
 //!
 //! ```rust
-//! esp_lp_hal::delay::Delay.delay_micros(500);
+//! esp_lp_hal::delay::Delay.delay_millis(500);
 //! ```
 
 /// Delay driver
@@ -16,6 +16,20 @@
 pub struct Delay;
 
 impl Delay {
+    /// Delay for at least the number of specific milliseconds.
+    pub fn delay_millis(&self, mut ms: u32) {
+        const MICROS_PER_MILLI: u32 = 1_000;
+        const MAX_MILLIS: u32 = u32::MAX / MICROS_PER_MILLI;
+
+        // Avoid potential overflow if milli -> micro conversion is too large
+        while ms > MAX_MILLIS {
+            ms -= MAX_MILLIS;
+            self.delay_micros(MAX_MILLIS * MICROS_PER_MILLI);
+        }
+
+        self.delay_micros(ms * MICROS_PER_MILLI);
+    }
+
     /// Delay for at least the number of specific microseconds.
     pub fn delay_micros(&self, mut us: u32) {
         const NANOS_PER_MICRO: u32 = 1_000;
@@ -80,7 +94,7 @@ impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
 impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
     #[inline(always)]
     fn delay_ms(&mut self, ms: u32) {
-        self.delay_micros(ms * 1000);
+        self.delay_millis(ms);
     }
 }
 

--- a/esp-lp-hal/src/i2c.rs
+++ b/esp-lp-hal/src/i2c.rs
@@ -21,7 +21,9 @@ pub unsafe fn conjure() -> LpI2c {
     }
 }
 
+// TODO: Document enum variants
 /// I2C-specific transmission errors
+#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
     ExceedingFifo,
@@ -179,6 +181,7 @@ impl CommandRegister {
 // Configure LP_EXT_I2C_CK_EN high to enable the clock source of I2C_SCLK.
 // Adjust the timing registers accordingly when the clock frequency changes.
 
+/// LP-I2C driver
 pub struct LpI2c {
     i2c: LP_I2C0,
 }

--- a/esp-lp-hal/src/lib.rs
+++ b/esp-lp-hal/src/lib.rs
@@ -11,6 +11,7 @@
 #![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![allow(asm_sub_register)]
+#![deny(missing_docs)]
 #![no_std]
 
 use core::arch::global_asm;

--- a/esp-lp-hal/src/uart.rs
+++ b/esp-lp-hal/src/uart.rs
@@ -168,7 +168,8 @@ pub struct LpUart {
 }
 
 impl LpUart {
-    fn read_byte(&mut self) -> nb::Result<u8, Error> {
+    /// Read a single byte from the UART in a non-blocking manner.
+    pub fn read_byte(&mut self) -> nb::Result<u8, Error> {
         if self.get_rx_fifo_count() > 0 {
             let byte = self.uart.fifo().read().rxfifo_rd_byte().bits();
             Ok(byte)
@@ -177,7 +178,8 @@ impl LpUart {
         }
     }
 
-    fn write_byte(&mut self, byte: u8) -> nb::Result<(), Error> {
+    /// Write a single byte to the UART in a non-blocking manner.
+    pub fn write_byte(&mut self, byte: u8) -> nb::Result<(), Error> {
         if self.get_tx_fifo_count() < UART_FIFO_SIZE {
             self.uart
                 .fifo()
@@ -188,7 +190,9 @@ impl LpUart {
         }
     }
 
-    fn write_bytes(&mut self, data: &[u8]) -> Result<usize, Error> {
+    /// Write one or more byte to the UART, blocking until the write has
+    /// completed.
+    pub fn write_bytes(&mut self, data: &[u8]) -> Result<usize, Error> {
         let count = data.len();
 
         data.iter()
@@ -197,7 +201,8 @@ impl LpUart {
         Ok(count)
     }
 
-    fn flush_tx(&mut self) -> nb::Result<(), Error> {
+    /// Flush the UART's transmit buffer in a non-blocking manner.
+    pub fn flush_tx(&mut self) -> nb::Result<(), Error> {
         if self.is_tx_idle() {
             Ok(())
         } else {


### PR DESCRIPTION
- Add `Delay.delay_millis()`
- Make UART functions public, document them
- Deny missing documentation