### PR TITLE
esp-hal: remove warnings in PCNT example and HIL test

### DIFF
--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -41,14 +41,14 @@ fn main() -> ! {
     // Set up a pulse counter:
     println!("setup pulse counter unit 0");
     let pcnt = Pcnt::new(peripherals.PCNT, Some(interrupt_handler));
-    let mut u0 = pcnt.unit1;
+    let u0 = pcnt.unit1;
     u0.set_low_limit(Some(-100)).unwrap();
     u0.set_high_limit(Some(100)).unwrap();
     u0.set_filter(Some(min(10u16 * 80, 1023u16))).unwrap();
     u0.clear();
 
     println!("setup channel 0");
-    let mut ch0 = &u0.channel0;
+    let ch0 = &u0.channel0;
     let mut pin_a = io.pins.gpio4;
     let mut pin_b = io.pins.gpio5;
 
@@ -64,7 +64,7 @@ fn main() -> ! {
     ch0.set_input_mode(channel::EdgeMode::Increment, channel::EdgeMode::Decrement);
 
     println!("setup channel 1");
-    let mut ch1 = &u0.channel1;
+    let ch1 = &u0.channel1;
     ch1.set_ctrl_signal(PcntSource::from_pin(
         &mut pin_b,
         PcntInputConfig { pull: Pull::Up },

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -25,11 +25,7 @@ mod tests {
         clock::ClockControl,
         delay::Delay,
         gpio::{Io, Level, Output, Pull},
-        pcnt::{
-            channel,
-            channel::{CtrlMode, EdgeMode, PcntInputConfig, PcntSource},
-            unit,
-        },
+        pcnt::channel::{EdgeMode, PcntInputConfig, PcntSource},
         peripherals::Peripherals,
         system::SystemControl,
     };


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Warnings cleanup in `pcnt_encoder` example and `pcnt` HIL test.

#### Testing
Builds should be without warnings
