### PR TITLE
bump esp-backtrace to 0.13.0

### DIFF
--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-backtrace"
-version      = "0.12.2"
+version      = "0.13.0"
 edition      = "2021"
 rust-version = "1.76.0"
 description  = "Bare-metal backtrace support for Espressif devices"

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -8,7 +8,7 @@
 //!
 //! Connect MOSI (GPIO2) and PCNT (GPIO3) pins.
 
-//% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c6 esp32h2 esp32s3
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

We after merging this, we should

* Yank 0.12.2
* Publish 0.13.0

because of the bump of esp-println, and the fact it has a `links` key now users can end up with two versions of esp-println in their program _without_ choosing to upgrade esp-backtrace (i.e cargo will auto update users to 0.12.2)