### PR TITLE
esp-wifi: Check no password given for AuthMethod::None

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Check no password is set when using `AuthMethod::None`
 
 ### Fixed
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -2074,6 +2074,12 @@ fn apply_ap_config(config: &AccessPointConfiguration) -> Result<(), WifiError> {
         },
     };
 
+    if config.auth_method == AuthMethod::None && !config.password.is_empty() {
+        return Err(WifiError::InternalError(
+            InternalWifiError::EspErrInvalidArg,
+        ));
+    }
+
     unsafe {
         cfg.ap.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
         cfg.ap.ssid_len = config.ssid.len() as u8;
@@ -2112,6 +2118,12 @@ fn apply_sta_config(config: &ClientConfiguration) -> Result<(), WifiError> {
             sae_h2e_identifier: [0; 32],
         },
     };
+
+    if config.auth_method == AuthMethod::None && !config.password.is_empty() {
+        return Err(WifiError::InternalError(
+            InternalWifiError::EspErrInvalidArg,
+        ));
+    }
 
     unsafe {
         cfg.sta.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1621 


#### Testing
Using one of the wifi examples in the repo - change the auth_method to None and see it returns an error now
