### PR TITLE
esp-hal: Add (where missing) used GPIOs to example descriptions

### DIFF
--- a/examples/src/bin/adc.rs
+++ b/examples/src/bin/adc.rs
@@ -3,6 +3,13 @@
 //!
 //! Alternatively, you could also connect the IO pin to GND or 3V3 to see the
 //! maximum and minimum raw values read.
+//!
+//! The following wiring is assumed for ESP32:
+//! - Analog pin => GPIO32
+//! The following wiring is assumed for ESP32S2/S3:
+//! - Analog pin => GPIO3
+//! The following wiring is assumed for others:
+//! - Analog pin => GPIO2
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/adc_cal.rs
+++ b/examples/src/bin/adc_cal.rs
@@ -1,6 +1,11 @@
-//! Connect a potentiometer to PIN2 and see the read values change when
+//! Connect a potentiometer to GPIO and see the read values change when
 //! rotating the shaft. Alternatively you could also connect the PIN to GND or
 //! 3V3 to see the maximum and minimum raw values read.
+//!
+//! The following wiring is assumed for ESP32S3:
+//! - Analog pin => GPIO3
+//! The following wiring is assumed for others:
+//! - Analog pin => GPIO2
 
 //% CHIPS: esp32c2 esp32c3 esp32c6 esp32s3
 

--- a/examples/src/bin/blinky.rs
+++ b/examples/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 //! Blinks an LED
 //!
-//! This assumes that a LED is connected to the pin assigned to `led`. (GPIO0)
+//! The following wiring is assumed:
+//! - LED => GPIO0
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/blinky_erased_pins.rs
+++ b/examples/src/bin/blinky_erased_pins.rs
@@ -1,9 +1,10 @@
 //! Blinks 3 LEDs
 //!
-//! This assumes that LEDs are connected to GPIO2, 4 and 5.
+//! The boot button is treated as an input, and will print a message when pressed.
+//! This additionally demonstrates passing GPIO to a function in a generic way.
 //!
-//! GPIO1 is treated as an input, and will print a message when pressed. This
-//! Additionally demonstrates passing GPIO to a function in a generic way.
+//! The following wiring is assumed:
+//! - LEDs => GPIO2, GPIO4, GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/dac.rs
+++ b/examples/src/bin/dac.rs
@@ -5,6 +5,13 @@
 //!
 //! When targeting the ESP32, the pins for `DAC1` and `DAC2` are GPIO25 and
 //! GPIO26 respectively; for the ESP32-S2, they are GPIO17 and GPIO18.
+//!
+//! The following wiring is assumed for ESP32:
+//! - DAC1 => GPIO25
+//! - DAC2 => GPIO26
+//! The following wiring is assumed for ESP32S2:
+//! - DAC1 => GPIO17
+//! - DAC2 => GPIO18
 
 //% CHIPS: esp32 esp32s2
 

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -1,14 +1,14 @@
 //! Embassy I2C
 //!
-//! Folowing pins are used:
-//! SDA    GPIO4
-//! SCL    GPIO5
-//!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
 //!
 //! This is an example of running the embassy executor with IC2. It uses an
 //! LIS3DH to get accelerometer data.
+//!
+//! Folowing pins are used:
+//! - SDA => GPIO4
+//! - SCL => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -3,9 +3,9 @@
 //! This example dumps the calibration data from a BMP180 sensor by reading by reading
 //! with the direct I2C API and the embedded-hal-async I2C API.
 //!
-//! //! Folowing pins are used:
-//! SDA    GPIO4
-//! SCL    GPIO5
+//! Folowing pins are used:
+//! - SDA => GPIO4
+//! - SCL => GPIO5
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -1,15 +1,15 @@
 //! This shows how to continously receive data via I2S.
 //!
-//! Pins used:
-//! MCLK    GPIO0 (not ESP32)
-//! BCLK    GPIO2
-//! WS      GPIO4
-//! DIN     GPIO5
-//!
 //! Without an additional I2S source device you can connect 3V3 or GND to DIN
 //! to read 0 or 0xFF or connect DIN to WS to read two different values.
 //!
 //! You can also inspect the MCLK, BCLK and WS with a logic analyzer.
+//!
+//! The following wiring is assumed:
+//! - MCLK =>  GPIO0 (not supported on ESP32)
+//! - BCLK =>  GPIO2
+//! - WS   =>  GPIO4
+//! - DIN  =>  GPIO5
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -1,18 +1,17 @@
 //! This shows how to transmit data continously via I2S.
 //!
-//! Pins used:
-//! BCLK    GPIO2
-//! WS      GPIO4
-//! DOUT    GPIO5
-//!
 //! Without an additional I2S sink device you can inspect the BCLK, WS
 //! and DOUT with a logic analyzer.
 //!
 //! You can also connect e.g. a PCM510x to hear an annoying loud sine tone (full
 //! scale), so turn down the volume before running this example.
 //!
-//! Wiring is like this:
+//! The following wiring is assumed:
+//! - BCLK => GPIO2
+//! - WS   => GPIO4
+//! - DOUT => GPIO5
 //!
+//! PCM510x:
 //! | Pin   | Connected to    |
 //! |-------|-----------------|
 //! | BCK   | GPIO1           |

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -2,6 +2,9 @@
 //!
 //! The second core runs a simple LED blinking task, that is controlled by a
 //! signal set by the task running on the other core.
+//!
+//! The following wiring is assumed:
+//! - LED => GPIO0
 
 //% CHIPS: esp32 esp32s3
 //% FEATURES: embassy embassy-generic-timers

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -2,6 +2,9 @@
 //!
 //! The second core runs a simple LED blinking task, that is controlled by a
 //! signal set by the task running on the other core.
+//!
+//! The following wiring is assumed:
+//! - LED => GPIO0
 
 //% CHIPS: esp32 esp32s3
 //% FEATURES: embassy embassy-generic-timers

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -1,7 +1,8 @@
 //! This shows using Parallel IO to input 4 bit parallel data at 1MHz clock
 //! rate.
 //!
-//! Uses GPIO 1, 2, 3 and 4 as the data pins.
+//! The following wiring is assumed:
+//! - Data pins => GPIO1, GPIO2, GPIO3, and GPIO4.
 
 //% CHIPS: esp32c6 esp32h2
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -1,9 +1,10 @@
 //! This shows using Parallel IO to output 4 bit parallel data at 1MHz clock
 //! rate.
 //!
-//! Uses GPIO 1, 2, 3 and 4 as the data pins.
-//! GPIO 5 as the "valid pin" (driven high during an active transfer) and GPIO
-//! 8 as the clock signal output.
+//! The following wiring is assumed:
+//! - Data pins => GPIO1, GPIO2, GPIO3, and GPIO4
+//! - Valid pin => GPIO5 (driven high during an active transfer)
+//! - Clock output pin => GPIO8
 //!
 //! You can use a logic analyzer to see how the pins are used.
 

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -1,5 +1,7 @@
 //! Demonstrates decoding pulse sequences with RMT
-//! Connect GPIO5 to GPIO4
+//!
+//! The following wiring is assumed:
+//! - Connect GPIO4 and GPIO5
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -1,6 +1,9 @@
 //! Demonstrates generating pulse sequences with RMT
 //!
 //! Connect a logic analyzer to GPIO4 to see the generated pulses.
+//!
+//! The following wiring is assumed:
+//! - generated pulses => GPIO4
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -3,11 +3,11 @@
 //! This is an example of running the embassy executor and asynchronously
 //! writing to and reading from uart
 
-#![no_std]
-#![no_main]
-
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers
+
+#![no_std]
+#![no_main]
 
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -1,18 +1,16 @@
 //! Embassy SPI
 //!
-//! Folowing pins are used:
-//! SCLK    GPIO0
-//! MISO    GPIO2
-//! MOSI    GPIO4
-//! CS      GPIO5
-//!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
 //!
 //! Connect MISO and MOSI pins to see the outgoing data is read as incoming
 //! data.
 //!
-//! This is an example of running the embassy executor with SPI.
+//! The following wiring is assumed:
+//! SCLK => GPIO0
+//! MISO => GPIO2
+//! MOSI => GPIO4
+//! CS   => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -9,6 +9,10 @@
 //!
 //! This example should work with another ESP board running the `twai` example
 //! with `IS_SENDER` set to `true`.
+//!
+//! The following wiring is assumed:
+//! - TX => GPIO0
+//! - RX => GPIO2
 
 //% CHIPS: esp32c3 esp32c6 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -1,6 +1,10 @@
 //! CDC-ACM serial port example using embassy.
 //!
 //! This example should be built in release mode.
+//!
+//! The following wiring is assumed:
+//! - DP => GPIO20
+//! - DM => GPIO19
 
 //% CHIPS: esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/embassy_wait.rs
+++ b/examples/src/bin/embassy_wait.rs
@@ -1,6 +1,6 @@
 //! embassy wait
 //!
-//! This is an example of asynchronously `Wait`ing for a pin state to change.
+//! This is an example of asynchronously `Wait`ing for a pin state (boot button) to change.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-generic-timers

--- a/examples/src/bin/etm_blinky_systimer.rs
+++ b/examples/src/bin/etm_blinky_systimer.rs
@@ -1,4 +1,7 @@
-//! Control LED on GPIO1 by the systimer via ETM
+//! Control LED by the systimer via ETM without involving the CPU.
+
+//! The following wiring is assumed:
+//! - LED => GPIO1
 
 //% CHIPS: esp32c6 esp32h2
 

--- a/examples/src/bin/etm_gpio.rs
+++ b/examples/src/bin/etm_gpio.rs
@@ -1,4 +1,7 @@
-//! Control LED on GPIO1 by the BOOT-BUTTON via ETM
+//! Control LED by the boot button via ETM without involving the CPU.
+
+//! The following wiring is assumed:
+//! - LED => GPIO1
 
 //% CHIPS: esp32c6 esp32h2
 

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -2,6 +2,9 @@
 //!
 //! This prints "Interrupt" when the boot button is pressed.
 //! It also blinks an LED like the blinky example.
+//!
+//! The following wiring is assumed:
+//! - LED => GPIO2
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/hello_rgb.rs
+++ b/examples/src/bin/hello_rgb.rs
@@ -7,6 +7,17 @@
 //! crate functionality to circle through the HSV hue color space (with
 //! saturation and value both at 255). Additionally, we apply a gamma correction
 //! and limit the brightness to 10 (out of 255).
+//!
+//! The following wiring is assumed for ESP32:
+//! - LED => GPIO33
+//! The following wiring is assumed for ESP32C3:
+//! - LED => GPIO8
+//! The following wiring is assumed for ESP32C6, ESP32H2:
+//! - LED => GPIO8
+//! The following wiring is assumed for ESP32S2:
+//! - LED => GPIO18
+//! The following wiring is assumed for ESP32S3:
+//! - LED => GPIO48
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/i2s_read.rs
+++ b/examples/src/bin/i2s_read.rs
@@ -1,15 +1,15 @@
 //! This shows how to continously receive data via I2S.
 //!
-//! Pins used:
-//! MCLK    GPIO0 (not ESP32)
-//! BCLK    GPIO2
-//! WS      GPIO4
-//! DIN     GPIO5
-//!
 //! Without an additional I2S source device you can connect 3V3 or GND to DIN
 //! to read 0 or 0xFF or connect DIN to WS to read two different values.
 //!
 //! You can also inspect the MCLK, BCLK and WS with a logic analyzer.
+//!
+//! The following wiring is assumed:
+//! - MCLK =>  GPIO0 (not supported on ESP32)
+//! - BCLK =>  GPIO2
+//! - WS   =>  GPIO4
+//! - DIN  =>  GPIO5
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/i2s_sound.rs
+++ b/examples/src/bin/i2s_sound.rs
@@ -1,18 +1,17 @@
 //! This shows how to transmit data continously via I2S.
 //!
-//! Pins used:
-//! BCLK    GPIO2
-//! WS      GPIO4
-//! DOUT    GPIO5
-//!
 //! Without an additional I2S sink device you can inspect the MCLK, BCLK, WS
 //!  andDOUT with a logic analyzer.
 //!
 //! You can also connect e.g. a PCM510x to hear an annoying loud sine tone (full
 //! scale), so turn down the volume before running this example.
 //!
-//! Wiring is like this:
+//! The following wiring is assumed:
+//! - BCLK => GPIO2
+//! - WS   => GPIO4
+//! - DOUT => GPIO5
 //!
+//! PCM510x:
 //! | Pin   | Connected to    |
 //! |-------|-----------------|
 //! | BCK   | GPIO0           |

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -3,20 +3,20 @@
 //! This example reads a JPEG from an OV2640 and writes it to the console as hex.
 //!
 //! The following wiring is assumed:
-//! SIOD  => GPIO4
-//! SIOC  => GPIO5
-//! XCLK  => GPIO15
-//! VSYNC => GPIO6
-//! HREF  => GPIO7
-//! PCLK  => GPIO13
-//! D2    => GPIO11
-//! D3    => GPIO9
-//! D4    => GPIO8
-//! D5    => GPIO10
-//! D6    => GPIO12
-//! D7    => GPIO18
-//! D8    => GPIO17
-//! D9    => GPIO16
+//! - SIOD  => GPIO4
+//! - SIOC  => GPIO5
+//! - XCLK  => GPIO15
+//! - VSYNC => GPIO6
+//! - HREF  => GPIO7
+//! - PCLK  => GPIO13
+//! - D2    => GPIO11
+//! - D3    => GPIO9
+//! - D4    => GPIO8
+//! - D5    => GPIO10
+//! - D6    => GPIO12
+//! - D7    => GPIO18
+//! - D8    => GPIO17
+//! - D9    => GPIO16
 
 //% CHIPS: esp32s3
 

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -2,21 +2,21 @@
 //!
 //! This example reads a JPEG from an OV2640 and writes it to the console as hex.
 //!
-//! Pins used:
-//! SIOD      GPIO4
-//! SIOC      GPIO5
-//! XCLK      GPIO15
-//! VSYNC     GPIO6
-//! HREF      GPIO7
-//! PCLK      GPIO13
-//! D2        GPIO11
-//! D3        GPIO9
-//! D4        GPIO8
-//! D5        GPIO10
-//! D6        GPIO12
-//! D7        GPIO18
-//! D8        GPIO17
-//! D9        GPIO16
+//! The following wiring is assumed:
+//! SIOD  => GPIO4
+//! SIOC  => GPIO5
+//! XCLK  => GPIO15
+//! VSYNC => GPIO6
+//! HREF  => GPIO7
+//! PCLK  => GPIO13
+//! D2    => GPIO11
+//! D3    => GPIO9
+//! D4    => GPIO8
+//! D5    => GPIO10
+//! D6    => GPIO12
+//! D7    => GPIO18
+//! D8    => GPIO17
+//! D9    => GPIO16
 
 //% CHIPS: esp32s3
 

--- a/examples/src/bin/lcd_i8080.rs
+++ b/examples/src/bin/lcd_i8080.rs
@@ -3,18 +3,18 @@
 //! This example clears the screen with red and then blue every second.
 //!
 //! The following wiring is assumed:
-//! Backlight => GPIO45
-//! Reset     => GPIO4
-//! CD        => GPIO0
-//! WR        => GPIO47
-//! D0        => GPIO9
-//! D1        => GPIO46
-//! D2        => GPIO3
-//! D3        => GPIO8
-//! D4        => GPIO18
-//! D5        => GPIO17
-//! D6        => GPIO16
-//! D7        => GPIO15
+//! - Backlight => GPIO45
+//! - Reset     => GPIO4
+//! - CD        => GPIO0
+//! - WR        => GPIO47
+//! - D0        => GPIO9
+//! - D1        => GPIO46
+//! - D2        => GPIO3
+//! - D3        => GPIO8
+//! - D4        => GPIO18
+//! - D5        => GPIO17
+//! - D6        => GPIO16
+//! - D7        => GPIO15
 
 //% CHIPS: esp32s3
 

--- a/examples/src/bin/lcd_i8080.rs
+++ b/examples/src/bin/lcd_i8080.rs
@@ -2,20 +2,19 @@
 //!
 //! This example clears the screen with red and then blue every second.
 //!
-//! Pins used:
-//!
-//! Backlight GPIO45
-//! Reset     GPIO4
-//! CD        GPIO0
-//! WR        GPIO47
-//! D0        GPIO9
-//! D1        GPIO46
-//! D2        GPIO3
-//! D3        GPIO8
-//! D4        GPIO18
-//! D5        GPIO17
-//! D6        GPIO16
-//! D7        GPIO15
+//! The following wiring is assumed:
+//! Backlight => GPIO45
+//! Reset     => GPIO4
+//! CD        => GPIO0
+//! WR        => GPIO47
+//! D0        => GPIO9
+//! D1        => GPIO46
+//! D2        => GPIO3
+//! D3        => GPIO8
+//! D4        => GPIO18
+//! D5        => GPIO17
+//! D6        => GPIO16
+//! D7        => GPIO15
 
 //% CHIPS: esp32s3
 

--- a/examples/src/bin/ledc.rs
+++ b/examples/src/bin/ledc.rs
@@ -1,7 +1,8 @@
 //! Turns on LED with the option to change LED intensity depending on `duty`
 //! value. Possible values (`u32`) are in range 0..100.
 //!
-//! This assumes that a LED is connected to the pin assigned to `led`. (GPIO0)
+//! The following wiring is assumed:
+//! - LED => GPIO0
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/lp_core_basic.rs
+++ b/examples/src/bin/lp_core_basic.rs
@@ -1,9 +1,12 @@
 //! This shows a very basic example of running code on the LP core.
 //!
-//! Code on LP core increments a counter and continuously toggles GPIO1. The
+//! Code on LP core increments a counter and continuously toggles LED. The
 //! current value is printed by the HP core.
 //!
 //! Make sure to first compile the `esp-lp-hal/examples/blinky.rs` example
+//!
+//! The following wiring is assumed:
+//! - LED => GPIO1
 
 //% CHIPS: esp32c6
 

--- a/examples/src/bin/lp_core_i2c.rs
+++ b/examples/src/bin/lp_core_i2c.rs
@@ -4,6 +4,10 @@
 //! check `lp_core_i2c` example in the `esp-lp-hal`.
 //!
 //! Make sure to first compile the `esp-lp-hal/examples/i2c.rs` example
+//!
+//! The following wiring is assumed:
+//! - SDA => GPIO6
+//! - SCL => GPIO7
 
 //% CHIPS: esp32c6
 

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -4,6 +4,10 @@
 //! check `lp_core_uart` example in the `esp-lp-hal.
 //!
 //! Make sure to first compile the `esp-lp-hal/examples/uart.rs` example
+//!
+//! The following wiring is assumed:
+//! - TX => GPIO5
+//! - RX => GPIO4
 
 //% CHIPS: esp32c6
 

--- a/examples/src/bin/mcpwm.rs
+++ b/examples/src/bin/mcpwm.rs
@@ -1,7 +1,8 @@
 //! Uses timer0 and operator0 of the MCPWM0 peripheral to output a 50% duty
 //! signal at 20 kHz.
 //!
-//! The signal will be output to the pin assigned to `pin`. (GPIO0)
+//! The following wiring is assumed:
+//! - Output pin => GPIO0
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s3
 

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -1,7 +1,8 @@
 //! This shows using Parallel IO to input 4 bit parallel data at 1MHz clock
 //! rate.
 //!
-//! Uses GPIO 1, 2, 3 and 4 as the data pins.
+//! The following wiring is assumed:
+//! - Data pins => GPIO1, GPIO2, GPIO3, and GPIO4.
 
 //% CHIPS: esp32c6 esp32h2
 

--- a/examples/src/bin/parl_io_tx.rs
+++ b/examples/src/bin/parl_io_tx.rs
@@ -1,9 +1,10 @@
 //! This shows using Parallel IO to output 4 bit parallel data at 1MHz clock
 //! rate.
 //!
-//! Uses GPIO 1, 2, 3 and 4 as the data pins.
-//! GPIO 5 as the "valid pin" (driven high during an active transfer) and GPIO
-//! 6 as the clock signal output.
+//! The following wiring is assumed:
+//! - Data pins => GPIO1, GPIO2, GPIO3, and GPIO4
+//! - Valid pin => GPIO5 (driven high during an active transfer)
+//! - Clock output pin => GPIO6
 //!
 //! You can use a logic analyzer to see how the pins are used.
 

--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -5,6 +5,10 @@
 //! Since the PCNT units reset to zero when they reach their limits
 //! we enable an interrupt on the upper and lower limits and
 //! track the overflow in an AtomicI32
+//!
+//! The following wiring is assumed:
+//! - Control signal => GPIO4
+//! - Edge signal    => GPIO5
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/qspi_flash.rs
+++ b/examples/src/bin/qspi_flash.rs
@@ -1,20 +1,20 @@
 //! SPI write and read a flash chip
 //!
-//! Folowing pins are used:
-//! SCLK            GPIO0
-//! MISO/IO0        GPIO1
-//! MOSI/IO1        GPIO2
-//! IO2             GPIO3
-//! IO3             GPIO4
-//! CS              GPIO5
+//! The following wiring is assumed:
+//! - SCLK => GPIO0
+//! - MISO => GPIO1
+//! - MOSI => GPIO2
+//! - IO2  => GPIO3
+//! - IO3  => GPIO4
+//! - CS   => GPIO5
 //!
-//! Folowing pins are used for ESP32:
-//! SCLK            GPIO0
-//! MISO/IO0        GPIO2
-//! MOSI/IO1        GPIO4
-//! IO2             GPIO5
-//! IO3             GPIO13
-//! CS              GPIO14
+//! The following wiring is assumed for ESP32:
+//! - SCLK => GPIO0
+//! - MISO => GPIO2
+//! - MOSI => GPIO4
+//! - IO2  => GPIO5
+//! - IO3  => GPIO13
+//! - CS   => GPIO14
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.

--- a/examples/src/bin/rmt_rx.rs
+++ b/examples/src/bin/rmt_rx.rs
@@ -1,4 +1,9 @@
 //! Demonstrates decoding pulse sequences with RMT
+//!
+//! The following wiring is assumed:
+//! - Input pin  => GPIO4
+//! - Output pin => GPIO5
+//!
 //! Connect GPIO5 to GPIO4
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3

--- a/examples/src/bin/rmt_tx.rs
+++ b/examples/src/bin/rmt_tx.rs
@@ -1,6 +1,9 @@
 //! Demonstrates generating pulse sequences with RMT
 //!
 //! Connect a logic analyzer to GPIO4 to see the generated pulses.
+//!
+//! The following wiring is assumed:
+//! - generated pulses => GPIO4
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/examples/src/bin/sleep_timer_ext0.rs
+++ b/examples/src/bin/sleep_timer_ext0.rs
@@ -1,4 +1,7 @@
-//! Demonstrates deep sleep with timer and ext0 (using gpio4) wakeup
+//! Demonstrates deep sleep with timer and ext0 wakeup
+//!
+//! The following wiring is assumed:
+//! - ext0 wakeup pin => GPIO4
 
 //% CHIPS: esp32 esp32s3
 

--- a/examples/src/bin/sleep_timer_ext1.rs
+++ b/examples/src/bin/sleep_timer_ext1.rs
@@ -1,4 +1,7 @@
-//! Demonstrates deep sleep with timer and ext1 (using gpio4 & gpio2) wakeup
+//! Demonstrates deep sleep with timer and ext1 wakeup
+//!
+//! The following wiring is assumed:
+//! - ext1 wakeup pins => GPIO2, GPIO4
 
 //% CHIPS: esp32 esp32s3
 

--- a/examples/src/bin/sleep_timer_lpio.rs
+++ b/examples/src/bin/sleep_timer_lpio.rs
@@ -1,4 +1,8 @@
-//! Demonstrates deep sleep with timer, using gpio2 (low) and gpio3 (high) as wakeup sources.
+//! Demonstrates deep sleep with timer, using low and high level pins as wakeup sources.
+//!
+//! The following wiring is assumed:
+//! - ext1 wakeup pin => GPIO2 (low level)
+//!                   => GPIO3 (high level)
 
 //% CHIPS: esp32c6
 

--- a/examples/src/bin/sleep_timer_rtcio.rs
+++ b/examples/src/bin/sleep_timer_rtcio.rs
@@ -1,5 +1,11 @@
-//! Demonstrates deep sleep with timer, using GPIO2 (low) and GPIO3 (high) as
+//! Demonstrates deep sleep with timer, using RTC pins as
 //! wakeup.
+//!
+//! The following wiring is assumed for ESP32C3:
+//! - RTC wakeup pin => GPIO2 (low level)
+//! - RTC wakeup pin => GPIO3 (high level)
+//! The following wiring is assumed for ESP32S3:
+//! - RTC wakeup pin => GPIO18 (low level)
 
 //% CHIPS: esp32c3 esp32s3
 

--- a/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -1,20 +1,20 @@
 //! SPI read manufacturer id from flash chip
 //!
-//! Folowing pins are used:
-//! SCLK            GPIO0
-//! MISO/IO0        GPIO1
-//! MOSI/IO1        GPIO2
-//! IO2             GPIO3
-//! IO3             GPIO4
-//! CS              GPIO5
+//! The following wiring is assumed:
+//! - SCLK        =>  GPIO0
+//! - MISO/IO0    =>  GPIO1
+//! - MOSI/IO1    =>  GPIO2
+//! - IO2         =>  GPIO3
+//! - IO3         =>  GPIO4
+//! - CS          =>  GPIO5
 //!
-//! Folowing pins are used for ESP32:
-//! SCLK            GPIO0
-//! MISO/IO0        GPIO2
-//! MOSI/IO1        GPIO4
-//! IO2             GPIO5
-//! IO3             GPIO13
-//! CS              GPIO14
+//! The following wiring is assumed for ESP32:
+//! - SCLK        =>  GPIO0
+//! - MISO/IO0    =>  GPIO2
+//! - MOSI/IO1    =>  GPIO4
+//! - IO2         =>  GPIO5
+//! - IO3         =>  GPIO13
+//! - CS          =>  GPIO14
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -1,10 +1,10 @@
 //! SPI loopback test
 //!
-//! Folowing pins are used:
-//! SCLK    GPIO0
-//! MISO    GPIO2
-//! MOSI    GPIO4
-//! CS      GPIO5
+//! The following wiring is assumed:
+//! - SCLK => GPIO0
+//! - MISO => GPIO2
+//! - MOSI => GPIO4
+//! - CS   => GPIO5
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -1,10 +1,10 @@
 //! SPI loopback test using DMA
 //!
-//! Folowing pins are used:
-//! SCLK    GPIO0
-//! MISO    GPIO2
-//! MOSI    GPIO4
-//! CS      GPIO5
+//! The following wiring is assumed:
+//! - SCLK => GPIO0
+//! - MISO => GPIO2
+//! - MOSI => GPIO4
+//! - CS   => GPIO5
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -1,17 +1,17 @@
 //! SPI slave loopback test using DMA
 //!
-//! Following pins are used for the (bitbang) slave:
+//! The following wiring is assumed for the (bitbang) slave:
 //!
-//! SCLK    GPIO0
-//! MISO    GPIO1
-//! MOSI    GPIO2
-//! CS      GPIO3
+//! - SCLK => GPIO0
+//! - MISO => GPIO1
+//! - MOSI => GPIO2
+//! - CS   => GPIO3
 //!
-//! Following pins are used for the (bitbang) master:
-//! SCLK    GPIO4
-//! MISO    GPIO5
-//! MOSI    GPIO8
-//! CS      GPIO9
+//! The following wiring is assumed for the (bitbang) master:
+//! - SCLK => GPIO4
+//! - MISO => GPIO5
+//! - MOSI => GPIO8
+//! - CS   => GPIO9
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -1,13 +1,16 @@
 //! This example sends a CAN message to another ESP and receives it back.
 //!
-//! Wiring:
 //! This example works without CAN Transceivers by:
 //! * setting the tx pins to open drain
 //! * connecting all rx and tx pins together
 //! * adding a pull-up to the signal pins
 //!
+//! The following wiring is assumed:
+//! - TX => GPIO0
+//! - RX => GPIO2
+//!
 //! ESP1/GND --- ESP2/GND
-//! ESP1/IO0 --- ESP1/IO2 --- ESP2/IO0 --- ESP2/IO2 --- 4.8kOhm --- ESP1/5V
+//! ESP1/GPIO0 --- ESP1/GPIO2 --- ESP2/GPIO0 --- ESP2/GPIO2 --- 4.8kOhm --- ESP1/5V
 //!
 //! `IS_FIRST_SENDER` below must be set to false on one of the ESP's
 

--- a/examples/src/bin/ulp_riscv_core_basic.rs
+++ b/examples/src/bin/ulp_riscv_core_basic.rs
@@ -1,7 +1,10 @@
 //! This shows a very basic example of running code on the ULP RISCV core.
 //!
-//! Code on ULP core just increments a counter and blinks GPIO 1. The current
+//! Code on ULP core just increments a counter and blinks with LED. The current
 //! value is printed by the HP core.
+//!
+//! The following wiring is assumed:
+//! - LED => GPIO1
 
 //% CHIPS: esp32s2 esp32s3
 

--- a/examples/src/bin/usb_serial.rs
+++ b/examples/src/bin/usb_serial.rs
@@ -1,6 +1,10 @@
 //! CDC-ACM serial port example using polling in a busy loop.
 //!
 //! This example should be built in release mode.
+//!
+//! The following wiring is assumed:
+//! - DP => GPIO20
+//! - DM => GPIO19
 
 //% CHIPS: esp32s2 esp32s3
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The goal of this PR is to add GPIOs being used in the examples (where missing) and made the example descriptions more consistent and hopefully easier to follow.

#### Testing
All examples should build.
