### PR TITLE
make esp_println::Printer::write_bytes public again

### DIFF
--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- made `esp_println::Printer::write_bytes` public (#1812)
 
 ### Changed
 

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -8,6 +8,7 @@ pub mod defmt;
 #[cfg(feature = "log")]
 pub mod logger;
 
+/// Prints to the selected output, with a newline.
 #[cfg(not(feature = "no-op"))]
 #[macro_export]
 macro_rules! println {
@@ -19,6 +20,7 @@ macro_rules! println {
     }};
 }
 
+/// Prints to the selected output.
 #[cfg(not(feature = "no-op"))]
 #[macro_export]
 macro_rules! print {
@@ -30,18 +32,22 @@ macro_rules! print {
     }};
 }
 
+/// Prints to the configured output, with a newline.
 #[cfg(feature = "no-op")]
 #[macro_export]
 macro_rules! println {
     ($($arg:tt)*) => {{}};
 }
 
+/// Prints to the configured output.
 #[cfg(feature = "no-op")]
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {{}};
 }
 
+/// Prints and returns the value of a given expression for quick and dirty
+/// debugging.
 // implementation adapted from `std::dbg`
 #[macro_export]
 macro_rules! dbg {
@@ -68,6 +74,7 @@ macro_rules! dbg {
     };
 }
 
+/// The printer that is used by the `print!` and `println!` macros.
 pub struct Printer;
 
 impl core::fmt::Write for Printer {
@@ -78,7 +85,8 @@ impl core::fmt::Write for Printer {
 }
 
 impl Printer {
-    fn write_bytes(bytes: &[u8]) {
+    /// Writes a byte slice to the configured output.
+    pub fn write_bytes(bytes: &[u8]) {
         with(|| {
             PrinterImpl::write_bytes_assume_cs(bytes);
             PrinterImpl::flush();


### PR DESCRIPTION
### Pull Request Details 📖

#### Description
It's useful to be able to send raw bytes through the esp_println machinery.
Especially because `UsbSerialJtag` write implementation is blocking and this one isn't.
This was possible before #1687
Closes #1277 
