### PR TITLE
make panic_handler and user_exception public

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- make panic_handler, user_exception and exception_handler public (#1814)
 
 ### Changed
 


### PR DESCRIPTION
### Pull Request Details 📖

#### Description
It would be nice to be able to run some custom code before entering the provided exception handlers.
By making these functions public users can write their own handlers and call the provided ones whenever they're ready.

Also fix clippy::manual_flatten lint
