### PR TITLE
Prettier panic message printing

### DIFF
--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -1,9 +1,5 @@
 #![allow(rustdoc::bare_urls, unused_macros)]
-#![cfg_attr(
-    target_arch = "xtensa",
-    feature(asm_experimental_arch),
-    feature(panic_info_message)
-)]
+#![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![no_std]
@@ -56,47 +52,13 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     set_color_code(RED);
 
     println!("");
-    println!("");
+    println!("====================== PANIC ======================");
 
-    if let Some(location) = info.location() {
-        let (file, line, column) = (location.file(), location.line(), location.column());
-        println!(
-            "!! A panic occured in '{}', at line {}, column {}:",
-            file, line, column
-        );
-    } else {
-        println!("!! A panic occured at an unknown location:");
-    }
+    #[cfg(not(feature = "defmt"))]
+    println!("{}", info);
 
-    #[cfg(not(any(nightly_before_2024_06_12, nightly_since_2024_06_12)))]
-    {
-        #[cfg(not(feature = "defmt"))]
-        println!("{:#?}", info);
-
-        #[cfg(feature = "defmt")]
-        println!("{:#?}", defmt::Display2Format(info));
-    }
-
-    #[cfg(nightly_before_2024_06_12)]
-    {
-        if let Some(message) = info.message() {
-            #[cfg(not(feature = "defmt"))]
-            println!("{}", message);
-
-            #[cfg(feature = "defmt")]
-            println!("{}", defmt::Display2Format(message));
-        }
-    }
-
-    #[cfg(nightly_since_2024_06_12)]
-    {
-        let message = info.message();
-        #[cfg(not(feature = "defmt"))]
-        println!("{}", message);
-
-        #[cfg(feature = "defmt")]
-        println!("{}", defmt::Display2Format(&message));
-    }
+    #[cfg(feature = "defmt")]
+    println!("{}", defmt::Display2Format(info));
 
     println!("");
     println!("Backtrace:");


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This improves the panic-message printing to look like this

![image](https://github.com/user-attachments/assets/5cae0a8b-5932-425b-89c6-a8a7f2b15012)


#### Testing
Change one of the examples to explicitly panic and see the result
