### PR TITLE
Check all features and targets in CI when linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,26 +64,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Install the Rust toolchain for Xtensa devices:
+      - uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          default: true
+          ldproxy: false
       # Install the Rust stable and nightly toolchains for RISC-V devices:
-      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
-        uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
           toolchain: stable
           components: rust-src
-      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
-        uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
           toolchain: nightly
           components: rust-src
-      # Install the Rust toolchain for Xtensa devices:
-      - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc)
-        uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          buildtargets: ${{ matrix.device.soc }}
-          default: true
-          ldproxy: false
 
       - uses: Swatinem/rust-cache@v2
 
@@ -109,9 +105,14 @@ jobs:
         run: cargo xtask build-examples esp-hal ${{ matrix.device.soc }}
       # Check doc-tests
       - name: Check doc-tests
-        run: cargo xtask run-doc-test esp-hal ${{ matrix.device.soc }}
+        run: cargo +esp xtask run-doc-test esp-hal ${{ matrix.device.soc }}
       - name: Check documentation
         run: RUSTDOCFLAGS="-D warnings" cargo xtask build-documentation --packages esp-hal --chips ${{ matrix.device.soc }}
+      # Run clippy
+      - name: Clippy
+        # We use the 'esp' toolchain for *all* targets, in order to get a
+        # semi-stable and consistent set of lints for all targets:
+        run: cargo +esp xtask lint-packages --chips ${{ matrix.device.soc }}
 
   extras:
     runs-on: ubuntu-latest
@@ -165,7 +166,7 @@ jobs:
           cargo xtask build-package --features=esp32h2,ci --target=riscv32imac-unknown-none-elf  esp-hal
 
       # Verify the MSRV for all Xtensa chips:
-      - name: msrv RISCV (esp-hal)
+      - name: msrv Xtensa (esp-hal)
         run: |
           cargo xtask build-package --toolchain=esp --features=esp32,ci   --target=xtensa-esp32-none-elf   esp-hal
           cargo xtask build-package --toolchain=esp --features=esp32s2,ci --target=xtensa-esp32s2-none-elf esp-hal
@@ -178,23 +179,7 @@ jobs:
           cargo xtask build-package --features=esp32s3 --target=riscv32imc-unknown-none-elf  esp-lp-hal
 
   # --------------------------------------------------------------------------
-  # Lint & Format
-
-  clippy:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      # We use the 'esp' toolchain for *all* targets, in order to get a
-      # semi-stable and consistent set of lints for all targets:
-      - uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          default: true
-          ldproxy: false
-      - uses: Swatinem/rust-cache@v2
-
-      # Lint all packages:
-      - run: cargo xtask lint-packages
+  # Format
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,11 @@ jobs:
 
       # Build all supported examples for the low-power core first (if present):
       - if: contains(fromJson('["esp32c6", "esp32s2", "esp32s3"]'), matrix.device.soc)
-        name: Build prerequisites (esp-lp-hal)
+        name: Build prerequisite examples (esp-lp-hal)
         run: cargo xtask build-examples esp-lp-hal ${{ matrix.device.soc }}
+      - if: contains(fromJson('["esp32c6", "esp32s2", "esp32s3"]'), matrix.device.soc)
+        name: Check esp-lp-hal documentation
+        run: RUSTDOCFLAGS="-D warnings" cargo xtask build-documentation --packages esp-lp-hal --chips ${{ matrix.device.soc }}
 
       # Make sure we're able to build the HAL without the default features
       # enabled:
@@ -108,132 +111,8 @@ jobs:
       - name: Check doc-tests
         run: cargo xtask run-doc-test esp-hal ${{ matrix.device.soc }}
       - name: Check documentation
-        run:  RUSTDOCFLAGS="-D warnings" cargo xtask build-documentation --packages esp-hal --chips ${{ matrix.device.soc }}
+        run: RUSTDOCFLAGS="-D warnings" cargo xtask build-documentation --packages esp-hal --chips ${{ matrix.device.soc }}
 
-  esp-lp-hal:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        soc: ["esp32c6", "esp32s2", "esp32s3"]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # Install the Rust stable and nightly toolchains for RISC-V devices:
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          toolchain: stable
-          components: rust-src
-      - uses: dtolnay/rust-toolchain@v1
-        if: ${{ !contains(fromJson('["esp32s2", "esp32s3"]'), matrix.soc) }}
-        with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          toolchain: nightly
-          components: rust-src
-      # Install the Rust toolchain for Xtensa devices:
-      - if: contains(fromJson('["esp32s2", "esp32s3"]'), matrix.soc)
-        uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          buildtargets: ${{ matrix.soc }}
-          default: true
-          ldproxy: false
-
-
-      - uses: Swatinem/rust-cache@v2
-
-      # Build all supported examples for the specified device:
-      - name: Build examples
-        run: cargo xtask build-examples esp-lp-hal ${{ matrix.soc }}
-      - name: Check documentation
-        run:  RUSTDOCFLAGS="-D warnings" cargo xtask build-documentation --packages esp-lp-hal --chips ${{ matrix.soc }}
-  esp-riscv-rt:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          toolchain: stable
-          components: rust-src
-      - uses: Swatinem/rust-cache@v2
-
-      # Build for all RISC-V targets (no features):
-      - name: Build esp-riscv-rt (riscv32imc, no features)
-        run: cd esp-riscv-rt/ && cargo build --target=riscv32imc-unknown-none-elf
-      - name: Build esp-riscv-rt (riscv32imac, no features)
-        run: cd esp-riscv-rt/ && cargo build --target=riscv32imac-unknown-none-elf
-      # Build for all RISC-V targets (all features):
-      - name: Build esp-riscv-rt (riscv32imc, all features)
-        run: cd esp-riscv-rt/ && cargo build --target=riscv32imc-unknown-none-elf --features=ci
-      - name: Build esp-riscv-rt (riscv32imac, all features)
-        run: cd esp-riscv-rt/ && cargo build --target=riscv32imac-unknown-none-elf --features=ci
-
-  esp-println:
-    name: esp-println (${{ matrix.device.soc }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        device: [
-            # RISC-V devices:
-            { soc: "esp32c2", target: "riscv32imc-unknown-none-elf" },
-            { soc: "esp32c3", target: "riscv32imc-unknown-none-elf" },
-            { soc: "esp32c6", target: "riscv32imac-unknown-none-elf" },
-            { soc: "esp32h2", target: "riscv32imac-unknown-none-elf" },
-            # Xtensa devices:
-            { soc: "esp32", target: "xtensa-esp32-none-elf" },
-            { soc: "esp32s2", target: "xtensa-esp32s2-none-elf" },
-            { soc: "esp32s3", target: "xtensa-esp32s3-none-elf" },
-          ]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # Install the Rust stable and nightly toolchains for RISC-V devices:
-      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          toolchain: stable
-          components: rust-src
-      - if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          toolchain: nightly
-          components: rust-src
-      # Install the Rust toolchain for Xtensa devices:
-      - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc)
-        uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          buildtargets: ${{ matrix.device.soc }}
-          default: true
-          ldproxy: false
-
-      - uses: Swatinem/rust-cache@v2
-
-      # Make sure we're able to build with the default features and most common features enabled
-      - name: Build (no features)
-        run: |
-          cargo xtask build-package \
-            --features=${{ matrix.device.soc }},log \
-            --target=${{ matrix.device.target }} \
-            esp-println
-
-      # So #1678 doesn't reoccur ('defmt-espflash,auto')
-      - name: Build (with feature 'defmt-espflash')
-        run: |
-          cargo xtask build-package \
-            --features=${{ matrix.device.soc }},log,defmt-espflash \
-            --target=${{ matrix.device.target }} \
-            esp-println
-      - name: Check documentation
-        run:  RUSTDOCFLAGS="-D warnings" cargo xtask build-documentation --packages esp-println --chips ${{ matrix.device.soc }}
   extras:
     runs-on: ubuntu-latest
 
@@ -257,13 +136,19 @@ jobs:
   # --------------------------------------------------------------------------
   # MSRV
 
-  msrv-riscv:
+  msrv:
     runs-on: ubuntu-latest
     env:
       RUSTC_BOOTSTRAP: 1
 
     steps:
       - uses: actions/checkout@v4
+      # install esp toolchain first so it isn't set as the default
+      - uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          default: true
+          ldproxy: false
+          version: ${{ env.MSRV }}
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
@@ -272,37 +157,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       # Verify the MSRV for all RISC-V chips.
-      - name: msrv (esp-hal)
+      - name: msrv RISCV (esp-hal)
         run: |
           cargo xtask build-package --features=esp32c2,ci --target=riscv32imc-unknown-none-elf   esp-hal
           cargo xtask build-package --features=esp32c3,ci --target=riscv32imc-unknown-none-elf   esp-hal
           cargo xtask build-package --features=esp32c6,ci --target=riscv32imac-unknown-none-elf  esp-hal
           cargo xtask build-package --features=esp32h2,ci --target=riscv32imac-unknown-none-elf  esp-hal
+
+      # Verify the MSRV for all Xtensa chips:
+      - name: msrv RISCV (esp-hal)
+        run: |
+          cargo xtask build-package --toolchain=esp --features=esp32,ci   --target=xtensa-esp32-none-elf   esp-hal
+          cargo xtask build-package --toolchain=esp --features=esp32s2,ci --target=xtensa-esp32s2-none-elf esp-hal
+          cargo xtask build-package --toolchain=esp --features=esp32s3,ci --target=xtensa-esp32s3-none-elf esp-hal
+
       - name: msrv (esp-lp-hal)
         run: |
           cargo xtask build-package --features=esp32c6 --target=riscv32imac-unknown-none-elf esp-lp-hal
           cargo xtask build-package --features=esp32s2 --target=riscv32imc-unknown-none-elf  esp-lp-hal
           cargo xtask build-package --features=esp32s3 --target=riscv32imc-unknown-none-elf  esp-lp-hal
-
-  msrv-xtensa:
-    runs-on: ubuntu-latest
-    env:
-      RUSTC_BOOTSTRAP: 1
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          ldproxy: false
-          version: ${{ env.MSRV }}
-      - uses: Swatinem/rust-cache@v2
-
-      # Verify the MSRV for all Xtensa chips:
-      - name: msrv (esp-hal)
-        run: |
-          cargo xtask build-package --toolchain=esp --features=esp32,ci   --target=xtensa-esp32-none-elf   esp-hal
-          cargo xtask build-package --toolchain=esp --features=esp32s2,ci --target=xtensa-esp32s2-none-elf esp-hal
-          cargo xtask build-package --toolchain=esp --features=esp32s3,ci --target=xtensa-esp32s3-none-elf esp-hal
 
   # --------------------------------------------------------------------------
   # Lint & Format

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -7,7 +7,7 @@ use crate::MAX_BACKTRACE_ADDRESSES;
 // we get better results (especially if the caller was the last function in the
 // calling function) if we report the address of the JALR itself
 // even if it was a C.JALR we should get good results using RA - 4
-#[allow(unused)]
+#[cfg(feature = "panic-handler")]
 pub(super) const RA_OFFSET: usize = 4;
 
 /// Registers saved in trap handler

--- a/esp-backtrace/src/xtensa.rs
+++ b/esp-backtrace/src/xtensa.rs
@@ -6,6 +6,7 @@ use crate::MAX_BACKTRACE_ADDRESSES;
 // the return address is the address following the callxN
 // we get better results (especially if the caller was the last function in the
 // calling function) if we report the address of callxN itself
+#[cfg(feature = "panic-handler")]
 pub(super) const RA_OFFSET: usize = 3;
 
 #[doc(hidden)]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -182,7 +182,7 @@ opsram-8m = []
 opsram-16m = []
 
 # This feature is intended for testing; you probably don't want to enable it:
-ci = ["async", "embedded-hal-02", "embedded-io", "ufmt"]
+ci = ["async", "embedded-hal-02", "embedded-io", "ufmt", "defmt", "bluetooth", "place-spi-driver-in-ram"]
 
 [lints.clippy]
 mixed_attributes_style = "allow"

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2174,13 +2174,11 @@ pub(crate) mod asynch {
             TX::waker().register(cx.waker());
             if self.tx.is_listening_eof() {
                 Poll::Pending
+            } else if self.tx.has_error() {
+                self.tx.clear_interrupts();
+                Poll::Ready(Err(DmaError::DescriptorError))
             } else {
-                if self.tx.has_error() {
-                    self.tx.clear_interrupts();
-                    Poll::Ready(Err(DmaError::DescriptorError))
-                } else {
-                    Poll::Ready(Ok(()))
-                }
+                Poll::Ready(Ok(()))
             }
         }
     }
@@ -2220,14 +2218,14 @@ pub(crate) mod asynch {
             RX::waker().register(cx.waker());
             if self.rx.is_listening_eof() {
                 Poll::Pending
+            } else if self.rx.has_error()
+                || self.rx.has_dscr_empty_error()
+                || self.rx.has_eof_error()
+            {
+                self.rx.clear_interrupts();
+                Poll::Ready(Err(DmaError::DescriptorError))
             } else {
-                if self.rx.has_error() || self.rx.has_dscr_empty_error() || self.rx.has_eof_error()
-                {
-                    self.rx.clear_interrupts();
-                    Poll::Ready(Err(DmaError::DescriptorError))
-                } else {
-                    Poll::Ready(Ok(()))
-                }
+                Poll::Ready(Ok(()))
             }
         }
     }
@@ -2264,13 +2262,11 @@ pub(crate) mod asynch {
             TX::waker().register(cx.waker());
             if self.tx.is_listening_ch_out_done() {
                 Poll::Pending
+            } else if self.tx.has_error() {
+                self.tx.clear_interrupts();
+                Poll::Ready(Err(DmaError::DescriptorError))
             } else {
-                if self.tx.has_error() {
-                    self.tx.clear_interrupts();
-                    Poll::Ready(Err(DmaError::DescriptorError))
-                } else {
-                    Poll::Ready(Ok(()))
-                }
+                Poll::Ready(Ok(()))
             }
         }
     }
@@ -2309,14 +2305,14 @@ pub(crate) mod asynch {
             RX::waker().register(cx.waker());
             if self.rx.is_listening_ch_in_done() {
                 Poll::Pending
+            } else if self.rx.has_error()
+                || self.rx.has_dscr_empty_error()
+                || self.rx.has_eof_error()
+            {
+                self.rx.clear_interrupts();
+                Poll::Ready(Err(DmaError::DescriptorError))
             } else {
-                if self.rx.has_error() || self.rx.has_dscr_empty_error() || self.rx.has_eof_error()
-                {
-                    self.rx.clear_interrupts();
-                    Poll::Ready(Err(DmaError::DescriptorError))
-                } else {
-                    Poll::Ready(Ok(()))
-                }
+                Poll::Ready(Ok(()))
             }
         }
     }

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -619,7 +619,7 @@ mod asynch {
             const NUM_I2C: usize = 1;
         }
     }
-
+    #[allow(clippy::declare_interior_mutable_const)]
     const INIT: AtomicWaker = AtomicWaker::new();
     static WAKERS: [AtomicWaker; NUM_I2C] = [INIT; NUM_I2C];
 

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -2268,7 +2268,7 @@ pub mod asynch {
         /// Will wait for more than 0 bytes available.
         pub async fn available(&mut self) -> Result<usize, Error> {
             loop {
-                self.state.update(&mut self.i2s_tx.tx_channel);
+                self.state.update(&self.i2s_tx.tx_channel);
                 let res = self.state.available;
 
                 if res != 0 {

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1752,10 +1752,8 @@ pub mod asynch {
         pub async fn read_dma_async(&mut self, words: &mut [u8]) -> Result<(), Error> {
             let (ptr, len) = (words.as_mut_ptr(), words.len());
 
-            if !Instance::is_suc_eof_generated_externally() {
-                if len > MAX_DMA_SIZE {
-                    return Err(Error::MaxDmaTransferSizeExceeded);
-                }
+            if !Instance::is_suc_eof_generated_externally() && len > MAX_DMA_SIZE {
+                return Err(Error::MaxDmaTransferSizeExceeded);
             }
 
             let future = DmaRxDoneChFuture::new(&mut self.rx_channel);

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1123,6 +1123,7 @@ pub mod asynch {
     #[cfg(not(any(esp32, esp32s3)))]
     const NUM_CHANNELS: usize = 4;
 
+    #[allow(clippy::declare_interior_mutable_const)]
     const INIT: AtomicWaker = AtomicWaker::new();
     static WAKER: [AtomicWaker; NUM_CHANNELS] = [INIT; NUM_CHANNELS];
 

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -363,7 +363,7 @@ pub(crate) mod asynch {
             r: &T::InputType,
             outbuf: &mut T::InputType,
         ) {
-            self.start_exponentiation(&base, &r);
+            self.start_exponentiation(base, r);
             RsaFuture::new(&self.rsa.rsa).await;
             self.read_results(outbuf);
         }

--- a/esp-hal/src/soc/esp32/psram.rs
+++ b/esp-hal/src/soc/esp32/psram.rs
@@ -1121,8 +1121,6 @@ pub(crate) mod utils {
 
         let spi_cache_dummy;
         let rd_mode_reg = read_peri_reg(SPI0_CTRL_REG);
-        #[allow(clippy::if_same_then_else)]
-        // TODO/FIXME: https://github.com/esp-rs/esp-hal/issues/1825
         if (rd_mode_reg & SPI_FREAD_QIO_M) != 0 {
             spi_cache_dummy = SPI0_R_QIO_DUMMY_CYCLELEN;
         } else if (rd_mode_reg & SPI_FREAD_DIO_M) != 0 {

--- a/esp-hal/src/soc/esp32s2/psram.rs
+++ b/esp-hal/src/soc/esp32s2/psram.rs
@@ -41,11 +41,11 @@ pub const PSRAM_VADDR_START: usize = PSRAM_VADDR as usize;
 pub fn init_psram(_peripheral: impl crate::peripheral::Peripheral<P = crate::peripherals::PSRAM>) {
     #[allow(unused)]
     enum CacheLayout {
-        CacheMemoryInvalid    = 0,
-        CacheMemoryICacheLow  = 1 << 0,
-        CacheMemoryICacheHigh = 1 << 1,
-        CacheMemoryDCacheLow  = 1 << 2,
-        CacheMemoryDCacheHigh = 1 << 3,
+        Invalid    = 0,
+        ICacheLow  = 1 << 0,
+        ICacheHigh = 1 << 1,
+        DCacheLow  = 1 << 2,
+        DCacheHigh = 1 << 3,
     }
 
     const MMU_ACCESS_SPIRAM: u32 = 1 << 16;
@@ -102,10 +102,10 @@ pub fn init_psram(_peripheral: impl crate::peripheral::Peripheral<P = crate::per
 
     unsafe {
         Cache_Allocate_SRAM(
-            CacheLayout::CacheMemoryICacheLow as u32,
-            CacheLayout::CacheMemoryDCacheLow as u32,
-            CacheLayout::CacheMemoryInvalid as u32,
-            CacheLayout::CacheMemoryInvalid as u32,
+            CacheLayout::ICacheLow as u32,
+            CacheLayout::DCacheLow as u32,
+            CacheLayout::Invalid as u32,
+            CacheLayout::Invalid as u32,
         );
         Cache_Set_DCache_Mode(CACHE_SIZE_8KB, CACHE_4WAYS_ASSOC, CACHE_LINE_SIZE_16B);
         Cache_Invalidate_DCache_All();
@@ -149,10 +149,7 @@ pub(crate) mod utils {
         psram_reset_mode();
         psram_enable_qio_mode();
 
-        psram_cache_init(
-            PsramCacheSpeed::PsramCacheMax,
-            PsramVaddrMode::PsramVaddrModeNormal,
-        );
+        psram_cache_init(PsramCacheSpeed::PsramCacheMax, PsramVaddrMode::Normal);
     }
 
     // send reset command to psram, in spi mode
@@ -220,6 +217,7 @@ pub(crate) mod utils {
         PsramCmdSpi = 1,
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn psram_exec_cmd(
         mode: CommandMode,
         cmd: u16,
@@ -284,6 +282,7 @@ pub(crate) mod utils {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn _psram_exec_cmd(
         cmd: u16,
         cmd_bit_len: u16,
@@ -443,13 +442,13 @@ pub(crate) mod utils {
     #[allow(unused)]
     enum PsramVaddrMode {
         /// App and pro CPU use their own flash cache for external RAM access
-        PsramVaddrModeNormal = 0,
+        Normal = 0,
         /// App and pro CPU share external RAM caches: pro CPU has low2M, app
         /// CPU has high 2M
-        PsramVaddrModeLowhigh,
+        Lowhigh,
         /// App and pro CPU share external RAM caches: pro CPU does even 32yte
         /// ranges, app does odd ones.
-        PsramVaddrModeEvenodd,
+        Evenodd,
     }
 
     const PSRAM_IO_MATRIX_DUMMY_20M: u32 = 0;

--- a/esp-hal/src/soc/esp32s3/psram.rs
+++ b/esp-hal/src/soc/esp32s3/psram.rs
@@ -539,6 +539,7 @@ pub(crate) mod utils {
         PsramCmdSpi = 1,
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[ram]
     fn psram_exec_cmd(
         mode: CommandMode,
@@ -604,6 +605,7 @@ pub(crate) mod utils {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[ram]
     fn _psram_exec_cmd(
         cmd: u16,

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -601,6 +601,7 @@ mod asynch {
 
     const NUM_ALARMS: usize = 3;
 
+    #[allow(clippy::declare_interior_mutable_const)]
     const INIT: AtomicWaker = AtomicWaker::new();
     static WAKERS: [AtomicWaker; NUM_ALARMS] = [INIT; NUM_ALARMS];
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1461,6 +1461,12 @@ mod asynch {
         pub rx_queue: Channel<CriticalSectionRawMutex, Result<EspTwaiFrame, EspTwaiError>, 32>,
     }
 
+    impl Default for TwaiAsyncState {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl TwaiAsyncState {
         pub const fn new() -> Self {
             Self {
@@ -1472,6 +1478,7 @@ mod asynch {
     }
 
     const NUM_TWAI: usize = 2;
+    #[allow(clippy::declare_interior_mutable_const)]
     const NEW_STATE: TwaiAsyncState = TwaiAsyncState::new();
     pub(crate) static TWAI_STATE: [TwaiAsyncState; NUM_TWAI] = [NEW_STATE; NUM_TWAI];
 
@@ -1511,7 +1518,7 @@ mod asynch {
 
                 T::write_frame(frame);
 
-                return Poll::Ready(Ok(()));
+                Poll::Ready(Ok(()))
             })
             .await
         }

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -805,7 +805,7 @@ mod asynch {
 
     impl UsbSerialJtagRx<'_, Async> {
         async fn read_bytes_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
-            if buf.len() == 0 {
+            if buf.is_empty() {
                 return Ok(0);
             }
 

--- a/esp-lp-hal/src/uart.rs
+++ b/esp-lp-hal/src/uart.rs
@@ -284,7 +284,7 @@ impl embedded_io::ErrorType for LpUart {
 #[cfg(feature = "embedded-io")]
 impl embedded_io::Read for LpUart {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        if buf.len() == 0 {
+        if buf.is_empty() {
             return Ok(0);
         }
 

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -9,7 +9,7 @@ license      = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow     = "1.0.86"
-clap       = { version = "4.5.4",  features = ["derive"] } # TODO remove this dep here
+clap       = { version = "4.5.4",  features = ["derive"] }
 basic-toml  = "0.1.9"
 lazy_static = "1.5.0"
 serde       = { version = "1.0.204", features = ["derive"] }

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -8,6 +8,8 @@ repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 
 [dependencies]
+anyhow     = "1.0.86"
+clap       = { version = "4.5.4",  features = ["derive"] } # TODO remove this dep here
 basic-toml  = "0.1.9"
 lazy_static = "1.5.0"
 serde       = { version = "1.0.204", features = ["derive"] }

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -7,7 +7,6 @@ const ESP32C2_TOML: &str = include_str!("../devices/esp32c2.toml");
 const ESP32C3_TOML: &str = include_str!("../devices/esp32c3.toml");
 const ESP32C6_TOML: &str = include_str!("../devices/esp32c6.toml");
 const ESP32H2_TOML: &str = include_str!("../devices/esp32h2.toml");
-const ESP32P4_TOML: &str = include_str!("../devices/esp32p4.toml");
 const ESP32S2_TOML: &str = include_str!("../devices/esp32s2.toml");
 const ESP32S3_TOML: &str = include_str!("../devices/esp32s3.toml");
 
@@ -17,7 +16,6 @@ lazy_static::lazy_static! {
     static ref ESP32C3_CFG: Config = basic_toml::from_str(ESP32C3_TOML).unwrap();
     static ref ESP32C6_CFG: Config = basic_toml::from_str(ESP32C6_TOML).unwrap();
     static ref ESP32H2_CFG: Config = basic_toml::from_str(ESP32H2_TOML).unwrap();
-    static ref ESP32P4_CFG: Config = basic_toml::from_str(ESP32P4_TOML).unwrap();
     static ref ESP32S2_CFG: Config = basic_toml::from_str(ESP32S2_TOML).unwrap();
     static ref ESP32S3_CFG: Config = basic_toml::from_str(ESP32S3_TOML).unwrap();
 }

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -1,5 +1,7 @@
 //! Metadata for Espressif devices, primarily intended for use in build scripts.
 
+use anyhow::{bail, Result};
+
 const ESP32_TOML: &str = include_str!("../devices/esp32.toml");
 const ESP32C2_TOML: &str = include_str!("../devices/esp32c2.toml");
 const ESP32C3_TOML: &str = include_str!("../devices/esp32c3.toml");
@@ -84,9 +86,10 @@ pub enum Cores {
     strum::Display,
     strum::EnumIter,
     strum::EnumString,
+    clap::ValueEnum,
 )]
-#[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
 pub enum Chip {
     /// ESP32
     Esp32,
@@ -98,12 +101,60 @@ pub enum Chip {
     Esp32c6,
     /// ESP32-H2
     Esp32h2,
-    /// ESP32-P4
-    Esp32p4,
     /// ESP32-S2
     Esp32s2,
     /// ESP32-S3
     Esp32s3,
+}
+
+impl Chip {
+    pub fn target(&self) -> &str {
+        use Chip::*;
+
+        match self {
+            Esp32 => "xtensa-esp32-none-elf",
+            Esp32c2 | Esp32c3 => "riscv32imc-unknown-none-elf",
+            Esp32c6 | Esp32h2 => "riscv32imac-unknown-none-elf",
+            Esp32s2 => "xtensa-esp32s2-none-elf",
+            Esp32s3 => "xtensa-esp32s3-none-elf",
+        }
+    }
+
+    pub fn has_lp_core(&self) -> bool {
+        use Chip::*;
+
+        matches!(self, Esp32c6 | Esp32s2 | Esp32s3)
+    }
+
+    pub fn lp_target(&self) -> Result<&str> {
+        use Chip::*;
+
+        match self {
+            Esp32c6 => Ok("riscv32imac-unknown-none-elf"),
+            Esp32s2 | Esp32s3 => Ok("riscv32imc-unknown-none-elf"),
+            _ => bail!("Chip does not contain an LP core: '{}'", self),
+        }
+    }
+
+    pub fn pretty_name(&self) -> &str {
+        match self {
+            Chip::Esp32 => "ESP32",
+            Chip::Esp32c2 => "ESP32-C2",
+            Chip::Esp32c3 => "ESP32-C3",
+            Chip::Esp32c6 => "ESP32-C6",
+            Chip::Esp32h2 => "ESP32-H2",
+            Chip::Esp32s2 => "ESP32-S2",
+            Chip::Esp32s3 => "ESP32-S3",
+        }
+    }
+
+    pub fn is_xtensa(&self) -> bool {
+        matches!(self, Chip::Esp32 | Chip::Esp32s2 | Chip::Esp32s3)
+    }
+
+    pub fn is_riscv(&self) -> bool {
+        !self.is_xtensa()
+    }
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
@@ -130,7 +181,6 @@ impl Config {
             Chip::Esp32c3 => ESP32C3_CFG.clone(),
             Chip::Esp32c6 => ESP32C6_CFG.clone(),
             Chip::Esp32h2 => ESP32H2_CFG.clone(),
-            Chip::Esp32p4 => ESP32P4_CFG.clone(),
             Chip::Esp32s2 => ESP32S2_CFG.clone(),
             Chip::Esp32s3 => ESP32S3_CFG.clone(),
         }

--- a/esp-storage/src/nor_flash.rs
+++ b/esp-storage/src/nor_flash.rs
@@ -1,7 +1,4 @@
-use core::{
-    mem::MaybeUninit,
-    ops::{Deref, DerefMut},
-};
+use core::mem::MaybeUninit;
 
 use embedded_storage::nor_flash::{
     ErrorType,
@@ -13,6 +10,7 @@ use embedded_storage::nor_flash::{
 
 use crate::{FlashSectorBuffer, FlashStorage, FlashStorageError};
 
+#[cfg(feature = "bytewise-read")]
 #[repr(C, align(4))]
 struct FlashWordBuffer {
     // NOTE: Ensure that no unaligned fields are added above `data` to maintain its required
@@ -20,7 +18,8 @@ struct FlashWordBuffer {
     data: [u8; FlashStorage::WORD_SIZE as usize],
 }
 
-impl Deref for FlashWordBuffer {
+#[cfg(feature = "bytewise-read")]
+impl core::ops::Deref for FlashWordBuffer {
     type Target = [u8; FlashStorage::WORD_SIZE as usize];
 
     fn deref(&self) -> &Self::Target {
@@ -28,7 +27,8 @@ impl Deref for FlashWordBuffer {
     }
 }
 
-impl DerefMut for FlashWordBuffer {
+#[cfg(feature = "bytewise-read")]
+impl core::ops::DerefMut for FlashWordBuffer {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.data
     }

--- a/esp-wifi/src/ble/os_adapter_esp32.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32.rs
@@ -475,7 +475,7 @@ pub(crate) unsafe extern "C" fn coex_schm_curr_period_get() -> u8 {
     debug!("coex_schm_curr_period_get");
 
     #[cfg(coex)]
-    return crate::binary::include::coex_schm_curr_period_get() as u8;
+    return crate::binary::include::coex_schm_curr_period_get();
 
     #[cfg(not(coex))]
     0
@@ -571,14 +571,13 @@ const BTDM_ASYNC_WAKEUP_REQ_COEX: i32 = 1;
 
 #[cfg(coex)]
 fn async_wakeup_request(event: i32) -> bool {
-    let request_lock: bool;
     let mut do_wakeup_request = false;
 
-    match event {
-        e if e == BTDM_ASYNC_WAKEUP_REQ_HCI => request_lock = true,
-        e if e == BTDM_ASYNC_WAKEUP_REQ_COEX => request_lock = false,
+    let request_lock = match event {
+        e if e == BTDM_ASYNC_WAKEUP_REQ_HCI => true,
+        e if e == BTDM_ASYNC_WAKEUP_REQ_COEX => false,
         _ => return false,
-    }
+    };
 
     extern "C" {
         fn btdm_power_state_active() -> bool;
@@ -590,7 +589,7 @@ fn async_wakeup_request(event: i32) -> bool {
         unsafe { btdm_wakeup_request(request_lock) };
     }
 
-    return do_wakeup_request;
+    do_wakeup_request
 }
 
 /// **************************************************************************
@@ -609,13 +608,11 @@ fn async_wakeup_request(event: i32) -> bool {
 
 #[cfg(coex)]
 fn async_wakeup_request_end(event: i32) {
-    let request_lock: bool;
-
-    match event {
-        e if e == BTDM_ASYNC_WAKEUP_REQ_HCI => request_lock = true,
-        e if e == BTDM_ASYNC_WAKEUP_REQ_COEX => request_lock = false,
+    let request_lock = match event {
+        e if e == BTDM_ASYNC_WAKEUP_REQ_HCI => true,
+        e if e == BTDM_ASYNC_WAKEUP_REQ_COEX => false,
         _ => return,
-    }
+    };
 
     extern "C" {
         // this isn't found anywhere ... not a ROM function
@@ -626,6 +623,4 @@ fn async_wakeup_request_end(event: i32) {
     if request_lock {
         // unsafe { btdm_wakeup_request_end() };
     }
-
-    return;
 }

--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -201,7 +201,9 @@ unsafe extern "C" fn phy_enter_critical() -> u32 {
 unsafe extern "C" fn phy_exit_critical(level: u32) {
     trace!("phy_exit_critical {}", level);
 
-    critical_section::release(core::mem::transmute(level));
+    critical_section::release(core::mem::transmute::<u32, critical_section::RestoreState>(
+        level,
+    ));
 }
 
 #[ram]

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
@@ -196,7 +196,9 @@ unsafe extern "C" fn phy_enter_critical() -> u32 {
 unsafe extern "C" fn phy_exit_critical(level: u32) {
     trace!("phy_exit_critical {}", level);
 
-    critical_section::release(core::mem::transmute(level));
+    critical_section::release(core::mem::transmute::<u32, critical_section::RestoreState>(
+        level,
+    ));
 }
 
 #[no_mangle]

--- a/esp-wifi/src/fmt.rs
+++ b/esp-wifi/src/fmt.rs
@@ -201,6 +201,7 @@ pub struct NoneError;
 pub trait Try {
     type Ok;
     type Error;
+    #[allow(unused)]
     fn into_result(self) -> Result<Self::Ok, Self::Error>;
 }
 

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -28,7 +28,7 @@ pub fn get_systimer_count() -> u64 {
 
 pub fn setup_timer(mut timer1: TimeBase) -> Result<(), esp_hal::timer::Error> {
     timer1.set_interrupt_handler(InterruptHandler::new(
-        unsafe { core::mem::transmute(handler as *const ()) },
+        unsafe { core::mem::transmute::<*const (), extern "C" fn()>(handler as *const ()) },
         interrupt::Priority::Priority2,
     ));
     timer1.start(TIMESLICE_FREQUENCY.into_duration())?;

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -2688,10 +2688,9 @@ impl Drop for FreeApListOnDrop {
 mod embedded_svc_compat {
     use super::*;
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::wifi::Capability> for Capability {
-        fn into(self) -> embedded_svc::wifi::Capability {
-            match self {
+    impl From<Capability> for embedded_svc::wifi::Capability {
+        fn from(s: Capability) -> embedded_svc::wifi::Capability {
+            match s {
                 Capability::Client => embedded_svc::wifi::Capability::Client,
                 Capability::AccessPoint => embedded_svc::wifi::Capability::AccessPoint,
                 Capability::Mixed => embedded_svc::wifi::Capability::Mixed,
@@ -2699,10 +2698,9 @@ mod embedded_svc_compat {
         }
     }
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::wifi::AuthMethod> for AuthMethod {
-        fn into(self) -> embedded_svc::wifi::AuthMethod {
-            match self {
+    impl From<AuthMethod> for embedded_svc::wifi::AuthMethod {
+        fn from(s: AuthMethod) -> embedded_svc::wifi::AuthMethod {
+            match s {
                 AuthMethod::None => embedded_svc::wifi::AuthMethod::None,
                 AuthMethod::WEP => embedded_svc::wifi::AuthMethod::WEP,
                 AuthMethod::WPA => embedded_svc::wifi::AuthMethod::WPA,
@@ -2732,10 +2730,9 @@ mod embedded_svc_compat {
         }
     }
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::wifi::Protocol> for Protocol {
-        fn into(self) -> embedded_svc::wifi::Protocol {
-            match self {
+    impl From<Protocol> for embedded_svc::wifi::Protocol {
+        fn from(s: Protocol) -> embedded_svc::wifi::Protocol {
+            match s {
                 Protocol::P802D11B => embedded_svc::wifi::Protocol::P802D11B,
                 Protocol::P802D11BG => embedded_svc::wifi::Protocol::P802D11BG,
                 Protocol::P802D11BGN => embedded_svc::wifi::Protocol::P802D11BGN,
@@ -2759,10 +2756,9 @@ mod embedded_svc_compat {
         }
     }
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::wifi::Configuration> for Configuration {
-        fn into(self) -> embedded_svc::wifi::Configuration {
-            match self {
+    impl From<Configuration> for embedded_svc::wifi::Configuration {
+        fn from(s: Configuration) -> embedded_svc::wifi::Configuration {
+            match s {
                 Configuration::None => embedded_svc::wifi::Configuration::None,
                 Configuration::Client(conf) => embedded_svc::wifi::Configuration::Client(
                     embedded_svc::wifi::ClientConfiguration {
@@ -2881,31 +2877,29 @@ mod embedded_svc_compat {
         }
     }
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::wifi::AccessPointInfo> for AccessPointInfo {
-        fn into(self) -> embedded_svc::wifi::AccessPointInfo {
+    impl From<AccessPointInfo> for embedded_svc::wifi::AccessPointInfo {
+        fn from(s: AccessPointInfo) -> embedded_svc::wifi::AccessPointInfo {
             embedded_svc::wifi::AccessPointInfo {
-                ssid: self.ssid.clone(),
-                bssid: self.bssid,
-                channel: self.channel,
-                secondary_channel: self.secondary_channel.into(),
-                signal_strength: self.signal_strength,
+                ssid: s.ssid.clone(),
+                bssid: s.bssid,
+                channel: s.channel,
+                secondary_channel: s.secondary_channel.into(),
+                signal_strength: s.signal_strength,
                 protocols: {
                     let mut res = EnumSet::<embedded_svc::wifi::Protocol>::new();
-                    self.protocols.into_iter().for_each(|v| {
+                    s.protocols.into_iter().for_each(|v| {
                         res.insert(v.into());
                     });
                     res
                 },
-                auth_method: self.auth_method.map(|v| v.into()),
+                auth_method: s.auth_method.map(|v| v.into()),
             }
         }
     }
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::wifi::SecondaryChannel> for SecondaryChannel {
-        fn into(self) -> embedded_svc::wifi::SecondaryChannel {
-            match self {
+    impl From<SecondaryChannel> for embedded_svc::wifi::SecondaryChannel {
+        fn from(s: SecondaryChannel) -> embedded_svc::wifi::SecondaryChannel {
+            match s {
                 SecondaryChannel::None => embedded_svc::wifi::SecondaryChannel::None,
                 SecondaryChannel::Above => embedded_svc::wifi::SecondaryChannel::Above,
                 SecondaryChannel::Below => embedded_svc::wifi::SecondaryChannel::Below,
@@ -2913,12 +2907,11 @@ mod embedded_svc_compat {
         }
     }
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::ipv4::Subnet> for crate::wifi::ipv4::Subnet {
-        fn into(self) -> embedded_svc::ipv4::Subnet {
+    impl From<crate::wifi::ipv4::Subnet> for embedded_svc::ipv4::Subnet {
+        fn from(s: crate::wifi::ipv4::Subnet) -> embedded_svc::ipv4::Subnet {
             embedded_svc::ipv4::Subnet {
-                gateway: embedded_svc::ipv4::Ipv4Addr::from(self.gateway.octets()),
-                mask: embedded_svc::ipv4::Mask(self.mask.0),
+                gateway: embedded_svc::ipv4::Ipv4Addr::from(s.gateway.octets()),
+                mask: embedded_svc::ipv4::Mask(s.mask.0),
             }
         }
     }
@@ -2932,16 +2925,15 @@ mod embedded_svc_compat {
         }
     }
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::ipv4::IpInfo> for super::ipv4::IpInfo {
-        fn into(self) -> embedded_svc::ipv4::IpInfo {
+    impl From<super::ipv4::IpInfo> for embedded_svc::ipv4::IpInfo {
+        fn from(s: super::ipv4::IpInfo) -> embedded_svc::ipv4::IpInfo {
             embedded_svc::ipv4::IpInfo {
-                ip: embedded_svc::ipv4::Ipv4Addr::from(self.ip.octets()),
-                subnet: self.subnet.into(),
-                dns: self
+                ip: embedded_svc::ipv4::Ipv4Addr::from(s.ip.octets()),
+                subnet: s.subnet.into(),
+                dns: s
                     .dns
                     .map(|v| embedded_svc::ipv4::Ipv4Addr::from(v.octets())),
-                secondary_dns: self
+                secondary_dns: s
                     .secondary_dns
                     .map(|v| embedded_svc::ipv4::Ipv4Addr::from(v.octets())),
             }
@@ -2988,10 +2980,9 @@ mod embedded_svc_compat {
         }
     }
 
-    #[allow(clippy::from_over_into)]
-    impl Into<embedded_svc::ipv4::Configuration> for super::ipv4::Configuration {
-        fn into(self) -> embedded_svc::ipv4::Configuration {
-            match self {
+    impl From<super::ipv4::Configuration> for embedded_svc::ipv4::Configuration {
+        fn from(s: super::ipv4::Configuration) -> embedded_svc::ipv4::Configuration {
+            match s {
                 super::ipv4::Configuration::Client(client) => {
                     let config = match client {
                         super::ipv4::ClientConfiguration::DHCP(dhcp) => {

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -861,6 +861,7 @@ pub(crate) unsafe extern "C" fn coex_init() -> i32 {
     #[cfg(coex)]
     {
         debug!("coex-init");
+        #[allow(clippy::needless_return)]
         return include::coex_init();
     }
 
@@ -2687,6 +2688,7 @@ impl Drop for FreeApListOnDrop {
 mod embedded_svc_compat {
     use super::*;
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::wifi::Capability> for Capability {
         fn into(self) -> embedded_svc::wifi::Capability {
             match self {
@@ -2697,6 +2699,7 @@ mod embedded_svc_compat {
         }
     }
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::wifi::AuthMethod> for AuthMethod {
         fn into(self) -> embedded_svc::wifi::AuthMethod {
             match self {
@@ -2729,6 +2732,7 @@ mod embedded_svc_compat {
         }
     }
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::wifi::Protocol> for Protocol {
         fn into(self) -> embedded_svc::wifi::Protocol {
             match self {
@@ -2755,6 +2759,7 @@ mod embedded_svc_compat {
         }
     }
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::wifi::Configuration> for Configuration {
         fn into(self) -> embedded_svc::wifi::Configuration {
             match self {
@@ -2823,10 +2828,10 @@ mod embedded_svc_compat {
                 embedded_svc::wifi::Configuration::Client(conf) => {
                     Configuration::Client(ClientConfiguration {
                         ssid: conf.ssid.clone(),
-                        bssid: conf.bssid.clone(),
+                        bssid: conf.bssid,
                         auth_method: conf.auth_method.into(),
                         password: conf.password.clone(),
-                        channel: conf.channel.clone(),
+                        channel: conf.channel,
                     })
                 }
                 embedded_svc::wifi::Configuration::AccessPoint(conf) => {
@@ -2850,14 +2855,14 @@ mod embedded_svc_compat {
                 embedded_svc::wifi::Configuration::Mixed(client, ap) => Configuration::Mixed(
                     ClientConfiguration {
                         ssid: client.ssid.clone(),
-                        bssid: client.bssid.clone(),
+                        bssid: client.bssid,
                         auth_method: client.auth_method.into(),
                         password: client.password.clone(),
                         channel: client.channel,
                     },
                     AccessPointConfiguration {
                         ssid: ap.ssid.clone(),
-                        ssid_hidden: ap.ssid_hidden.clone(),
+                        ssid_hidden: ap.ssid_hidden,
                         channel: ap.channel,
                         secondary_channel: ap.secondary_channel,
                         protocols: {
@@ -2876,11 +2881,12 @@ mod embedded_svc_compat {
         }
     }
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::wifi::AccessPointInfo> for AccessPointInfo {
         fn into(self) -> embedded_svc::wifi::AccessPointInfo {
             embedded_svc::wifi::AccessPointInfo {
                 ssid: self.ssid.clone(),
-                bssid: self.bssid.clone(),
+                bssid: self.bssid,
                 channel: self.channel,
                 secondary_channel: self.secondary_channel.into(),
                 signal_strength: self.signal_strength,
@@ -2896,6 +2902,7 @@ mod embedded_svc_compat {
         }
     }
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::wifi::SecondaryChannel> for SecondaryChannel {
         fn into(self) -> embedded_svc::wifi::SecondaryChannel {
             match self {
@@ -2906,6 +2913,7 @@ mod embedded_svc_compat {
         }
     }
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::ipv4::Subnet> for crate::wifi::ipv4::Subnet {
         fn into(self) -> embedded_svc::ipv4::Subnet {
             embedded_svc::ipv4::Subnet {
@@ -2924,6 +2932,7 @@ mod embedded_svc_compat {
         }
     }
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::ipv4::IpInfo> for super::ipv4::IpInfo {
         fn into(self) -> embedded_svc::ipv4::IpInfo {
             embedded_svc::ipv4::IpInfo {
@@ -2979,6 +2988,7 @@ mod embedded_svc_compat {
         }
     }
 
+    #[allow(clippy::from_over_into)]
     impl Into<embedded_svc::ipv4::Configuration> for super::ipv4::Configuration {
         fn into(self) -> embedded_svc::ipv4::Configuration {
             match self {

--- a/esp-wifi/src/wifi/os_adapter_esp32.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32.rs
@@ -29,7 +29,9 @@ pub(crate) unsafe extern "C" fn wifi_int_restore(
     wifi_int_mux: *mut crate::binary::c_types::c_void,
     tmp: u32,
 ) {
-    critical_section::release(core::mem::transmute(tmp))
+    critical_section::release(core::mem::transmute::<u32, critical_section::RestoreState>(
+        tmp,
+    ))
 }
 
 pub(crate) unsafe extern "C" fn phy_common_clock_disable() {

--- a/esp-wifi/src/wifi/os_adapter_esp32s2.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32s2.rs
@@ -22,7 +22,9 @@ pub(crate) unsafe extern "C" fn wifi_int_restore(
     wifi_int_mux: *mut crate::binary::c_types::c_void,
     tmp: u32,
 ) {
-    critical_section::release(core::mem::transmute(tmp))
+    critical_section::release(core::mem::transmute::<u32, critical_section::RestoreState>(
+        tmp,
+    ))
 }
 
 pub(crate) unsafe extern "C" fn set_intr(

--- a/esp-wifi/src/wifi/os_adapter_esp32s3.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32s3.rs
@@ -22,7 +22,9 @@ pub(crate) unsafe extern "C" fn wifi_int_restore(
     wifi_int_mux: *mut crate::binary::c_types::c_void,
     tmp: u32,
 ) {
-    critical_section::release(core::mem::transmute(tmp))
+    critical_section::release(core::mem::transmute::<u32, critical_section::RestoreState>(
+        tmp,
+    ))
 }
 
 pub(crate) unsafe extern "C" fn set_intr(

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,3 +17,4 @@ semver     = { version = "1.0.23",  features = ["serde"] }
 serde      = { version = "1.0.203", features = ["derive"] }
 strum      = { version = "0.26.2",  features = ["derive"] }
 toml_edit  = "0.22.13"
+esp-metadata = { path = "../esp-metadata" }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::{bail, Result};
 use cargo::CargoAction;
 use clap::ValueEnum;
+use esp_metadata::Chip;
 use strum::{Display, EnumIter, IntoEnumIterator as _};
 
 use self::cargo::CargoArgsBuilder;
@@ -50,69 +51,6 @@ pub enum Package {
     HilTest,
     XtensaLx,
     XtensaLxRt,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter, ValueEnum, serde::Serialize)]
-#[serde(rename_all = "kebab-case")]
-#[strum(serialize_all = "kebab-case")]
-pub enum Chip {
-    Esp32,
-    Esp32c2,
-    Esp32c3,
-    Esp32c6,
-    Esp32h2,
-    Esp32s2,
-    Esp32s3,
-}
-
-impl Chip {
-    pub fn target(&self) -> &str {
-        use Chip::*;
-
-        match self {
-            Esp32 => "xtensa-esp32-none-elf",
-            Esp32c2 | Esp32c3 => "riscv32imc-unknown-none-elf",
-            Esp32c6 | Esp32h2 => "riscv32imac-unknown-none-elf",
-            Esp32s2 => "xtensa-esp32s2-none-elf",
-            Esp32s3 => "xtensa-esp32s3-none-elf",
-        }
-    }
-
-    pub fn has_lp_core(&self) -> bool {
-        use Chip::*;
-
-        matches!(self, Esp32c6 | Esp32s2 | Esp32s3)
-    }
-
-    pub fn lp_target(&self) -> Result<&str> {
-        use Chip::*;
-
-        match self {
-            Esp32c6 => Ok("riscv32imac-unknown-none-elf"),
-            Esp32s2 | Esp32s3 => Ok("riscv32imc-unknown-none-elf"),
-            _ => bail!("Chip does not contain an LP core: '{}'", self),
-        }
-    }
-
-    pub fn pretty_name(&self) -> &str {
-        match self {
-            Chip::Esp32 => "ESP32",
-            Chip::Esp32c2 => "ESP32-C2",
-            Chip::Esp32c3 => "ESP32-C3",
-            Chip::Esp32c6 => "ESP32-C6",
-            Chip::Esp32h2 => "ESP32-H2",
-            Chip::Esp32s2 => "ESP32-S2",
-            Chip::Esp32s3 => "ESP32-S3",
-        }
-    }
-
-    pub fn is_xtensa(&self) -> bool {
-        matches!(self, Chip::Esp32 | Chip::Esp32s2 | Chip::Esp32s3)
-    }
-
-    pub fn is_riscv(&self) -> bool {
-        !self.is_xtensa()
-    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,7 +12,9 @@ use minijinja::Value;
 use strum::IntoEnumIterator;
 use xtask::{
     cargo::{CargoAction, CargoArgsBuilder},
-    Metadata, Package, Version,
+    Metadata,
+    Package,
+    Version,
 };
 
 // ----------------------------------------------------------------------------
@@ -588,7 +590,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                             "-Zbuild-std=core",
                             &format!("--target={}", chip.target()),
                             &format!(
-                                "--features={chip},wifi-default,ble,esp-now,async,embassy-net,embedded-svc,coex,ps-min-modem,defmt,dump-packets"
+                                "--features={chip},wifi-default,ble,esp-now,async,embassy-net,embedded-svc,coex,ps-min-modem,dump-packets"
                             ),
                         ],
                     )?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -565,23 +565,32 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                 ],
             )?,
 
-            Package::EspPrintln => lint_package(
-                &path,
-                &[
-                    "-Zbuild-std=core",
-                    "--target=riscv32imc-unknown-none-elf",
-                    "--features=esp32c6",
-                ],
-            )?,
+            Package::EspPrintln => {
+                for chip in Chip::iter() {
+                    lint_package(
+                        &path,
+                        &[
+                            "-Zbuild-std=core",
+                            &format!("--target={}", chip.target()),
+                            &format!("--features={chip},defmt-espflash"),
+                        ],
+                    )?;
+                }
+            }
 
-            Package::EspStorage => lint_package(
-                &path,
-                &[
-                    "-Zbuild-std=core",
-                    "--target=riscv32imc-unknown-none-elf",
-                    "--features=esp32c6",
-                ],
-            )?,
+            Package::EspStorage => {
+                for chip in Chip::iter() {
+                    lint_package(
+                        &path,
+                        &[
+                            "-Zbuild-std=core",
+                            &format!("--target={}", chip.target()),
+                            &format!("--features={chip},storage,nor-flash,low-level"),
+                            "--release",
+                        ],
+                    )?;
+                }
+            }
 
             Package::EspWifi => {
                 // Since different files/modules can be included/excluded

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -639,7 +639,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
 }
 
 fn lint_package(path: &Path, args: &[&str]) -> Result<()> {
-    log::info!("Linting package: {} with args: {:?}", path.display(), args);
+    log::info!("Linting package: {}", path.display());
 
     let mut builder = CargoArgsBuilder::default()
         .toolchain("esp")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -589,7 +589,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                 }
 
                 Package::EspWifi => {
-                    let mut features = format!("--features={chip},async,ps-min-modem");
+                    let mut features = format!("--features={chip},async,ps-min-modem,defmt");
 
                     if device.contains(&"wifi".to_owned()) {
                         features
@@ -606,6 +606,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                         &[
                             "-Zbuild-std=core",
                             &format!("--target={}", chip.target()),
+                            "--no-default-features",
                             &features,
                         ],
                     )?;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

What this doesn't solve just yet:

* log/defmt, checking, I've gone with defmt for now, but ideally I'd like to check both but this would require double the CI time.
* ~all the packages, this _mostly_ tackles esp-hal and esp-wifi, but I'd like 100% coverage~ I think this covers everything now, at the very least each package is built for each target.


Closes #1644
Closes #1693
