### PR TITLE
Change semantics of DMA futures

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2154,8 +2154,6 @@ pub(crate) mod asynch {
         TX: Tx,
     {
         pub fn new(tx: &'a mut TX) -> Self {
-            tx.listen_eof();
-            tx.listen_out_descriptor_error();
             Self { tx, _a: () }
         }
 
@@ -2182,6 +2180,8 @@ pub(crate) mod asynch {
                 self.tx.clear_interrupts();
                 Poll::Ready(Err(DmaError::DescriptorError))
             } else {
+                self.tx.listen_eof();
+                self.tx.listen_out_descriptor_error();
                 Poll::Pending
             }
         }
@@ -2210,10 +2210,6 @@ pub(crate) mod asynch {
         RX: Rx,
     {
         pub fn new(rx: &'a mut RX) -> Self {
-            rx.listen_eof();
-            rx.listen_in_descriptor_error();
-            rx.listen_in_descriptor_error_dscr_empty();
-            rx.listen_in_descriptor_error_err_eof();
             Self { rx, _a: () }
         }
 
@@ -2243,6 +2239,10 @@ pub(crate) mod asynch {
                 self.rx.clear_interrupts();
                 Poll::Ready(Err(DmaError::DescriptorError))
             } else {
+                self.rx.listen_eof();
+                self.rx.listen_in_descriptor_error();
+                self.rx.listen_in_descriptor_error_dscr_empty();
+                self.rx.listen_in_descriptor_error_err_eof();
                 Poll::Pending
             }
         }
@@ -2275,8 +2275,6 @@ pub(crate) mod asynch {
         TX: Tx,
     {
         pub fn new(tx: &'a mut TX) -> Self {
-            tx.listen_ch_out_done();
-            tx.listen_out_descriptor_error();
             Self { tx, _a: () }
         }
     }
@@ -2300,6 +2298,8 @@ pub(crate) mod asynch {
                 self.tx.clear_interrupts();
                 Poll::Ready(Err(DmaError::DescriptorError))
             } else {
+                self.tx.listen_ch_out_done();
+                self.tx.listen_out_descriptor_error();
                 Poll::Pending
             }
         }
@@ -2331,10 +2331,6 @@ pub(crate) mod asynch {
         RX: Rx,
     {
         pub fn new(rx: &'a mut RX) -> Self {
-            rx.listen_ch_in_done();
-            rx.listen_in_descriptor_error();
-            rx.listen_in_descriptor_error_dscr_empty();
-            rx.listen_in_descriptor_error_err_eof();
             Self { rx, _a: () }
         }
     }
@@ -2361,6 +2357,10 @@ pub(crate) mod asynch {
                 self.rx.clear_interrupts();
                 Poll::Ready(Err(DmaError::DescriptorError))
             } else {
+                self.rx.listen_ch_in_done();
+                self.rx.listen_in_descriptor_error();
+                self.rx.listen_in_descriptor_error_dscr_empty();
+                self.rx.listen_in_descriptor_error_err_eof();
                 Poll::Pending
             }
         }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2294,7 +2294,7 @@ pub(crate) mod asynch {
         ) -> Poll<Self::Output> {
             TX::waker().register(cx.waker());
             if self.tx.is_ch_out_done_set() {
-                self.tx.clear_interrupts();
+                self.tx.clear_ch_out_done();
                 Poll::Ready(Ok(()))
             } else if self.tx.has_error() {
                 self.tx.clear_interrupts();
@@ -2352,7 +2352,7 @@ pub(crate) mod asynch {
         ) -> Poll<Self::Output> {
             RX::waker().register(cx.waker());
             if self.rx.is_ch_in_done_set() {
-                self.rx.clear_interrupts();
+                self.rx.clear_ch_in_done();
                 Poll::Ready(Ok(()))
             } else if self.rx.has_error()
                 || self.rx.has_dscr_empty_error()

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1758,8 +1758,9 @@ pub mod asynch {
                 }
             }
 
-            Self::start_receive_bytes_dma(&mut self.rx_channel, &mut self.rx_chain, ptr, len)?;
-            DmaRxDoneChFuture::new(&mut self.rx_channel).await?;
+            let future = DmaRxDoneChFuture::new(&mut self.rx_channel);
+            Self::start_receive_bytes_dma(future.rx, &mut self.rx_chain, ptr, len)?;
+            future.await?;
 
             Ok(())
         }

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1758,9 +1758,8 @@ pub mod asynch {
                 }
             }
 
-            let future = DmaRxDoneChFuture::new(&mut self.rx_channel);
-            Self::start_receive_bytes_dma(future.rx, &mut self.rx_chain, ptr, len)?;
-            future.await?;
+            Self::start_receive_bytes_dma(&mut self.rx_channel, &mut self.rx_chain, ptr, len)?;
+            DmaRxDoneChFuture::new(&mut self.rx_channel).await?;
 
             Ok(())
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR is part of #1785, a small part that can be reviewed before the big PR comes in.
I've skipped changelog since this is an internal refactor.

The new semantics in this PR is also a proposal for how most (a handful are a little messy) interrupt based futures should work in the hal, so review this PR with that in mind as well.

The existing semantics of the DMA futures are:
- Set INT_ENA in the constructor.
- Interrupt fires and unsets INT_ENA, clears INT_CLR and wakes waker.
- Poll checks for the unset INT_ENA then returns some result.

The new semantics are:
- Do nothing in constructor. (Rust `Future`s do nothing unless polled)
- Poll checks for INT_RAW...
- If !=0, clear INT_CLR and returns a result based on what was in INT_RAW. 
- Otherwise set INT_ENA and return `Poll::Pending`.
- Interrupt fires and unsets INT_ENA and wakes waker.
- Poll checks for INT_RAW, clear INT_CLR and returns a result based on what was in INT_RAW. 
- Clear INT_ENA in the Drop. (No-op if interrupt fired)

The new semantics are meant to achieve two things.
- Cancel safety
- Eliminate any race conditions

Cancel safety is achieved by the fact that that the interrupt bits are not cleared unless `poll` returns `Poll::Ready(...)`. So if the future is dropped before (or even after) the interrupt fires, the interrupt bits are still there and can be consumed by some other part of the application if needed. The future can also be re-created if the application wants to try waiting again.

Race conditions are eliminated by not using INT_ENA to check that the interrupt has fired but by instead checking INT_RAW. The existing semantics required you to create the future *before* starting the DMA, which ran the risk of bugs like #1728 . The new semantics in this PR let you create the future at any point, even after the transfer has started or even after it had finished.

Future enhancements include:
- Marking the futures as `!Send`. Bad things can happen (before and after this PR) if the interrupt is executed on a different core to where the future is polled.

#### Testing
I've tested this alongside other changes but not in isolation, I'll need to test this in isolation but it can still be reviewed before that.
