### PR TITLE
Improve Xtensa backtraces

### DIFF
--- a/esp-backtrace/src/xtensa.rs
+++ b/esp-backtrace/src/xtensa.rs
@@ -307,7 +307,8 @@ pub(crate) fn backtrace_internal(
 
             old_address = address;
 
-            if address == 0 {
+            // the address is 0 but we sanitized the address - then 0 becomes 0x40000000
+            if address == 0x40000000 {
                 break;
             }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Before the backtrace didn't stop when it should for Xtensa. This fixes it. I don't think this deserves a changelog entry (but not sure)

#### Testing
Modify one of the examples to panic or cause an exception and see the backtrace with and without the fix