### PR TITLE
Expose InputPin.is_interrupt_set in implementation of esp-hal::gpio::…

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Peripheral driver constructors don't take `InterruptHandler`s anymore. Use `set_interrupt_handler` to explicitly set the interrupt handler now. (#1819)
+- Add method to expose `InputPin::is_interrupt_set` in `Input<InputPin>` for use in interrupt handlers (#1829)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Peripheral driver constructors don't take `InterruptHandler`s anymore. Use `set_interrupt_handler` to explicitly set the interrupt handler now. (#1819)
-- Add method to expose `InputPin::is_interrupt_set` in `Input<InputPin>` for use in interrupt handlers (#1829)
 
 ### Fixed
 
@@ -41,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - uart: Make `rx_timeout` optional in Config struct (#1759)
 - Add interrupt related functions to `PeriodicTimer`/`OneShotTimer`, added `ErasedTimer` (#1753)
 - Added blocking `read_bytes` method to `Uart` and `UartRx` (#1784)
+- Add method to expose `InputPin::is_interrupt_set` in `Input<InputPin>` for use in interrupt handlers (#1829)
 
 ### Fixed
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1727,6 +1727,12 @@ where
         self.pin.clear_interrupt(private::Internal);
     }
 
+    /// Checks if the interrupt status bit for this Pin is set
+    #[inline]
+    pub fn is_interrupt_set(&self) -> bool {
+        self.pin.is_interrupt_set(private::Internal)
+    }
+
     /// Enable as a wake-up source.
     ///
     /// This will unlisten for interrupts

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -73,6 +73,18 @@ fn handler() {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
     esp_println::println!("GPIO Interrupt");
 
+    if critical_section::with(|cs| {
+        BUTTON
+            .borrow_ref_mut(cs)
+            .as_mut()
+            .unwrap()
+            .is_interrupt_set()
+    }) {
+        esp_println::println!("Button was the source of the interrupt");
+    } else {
+        esp_println::println!("Button was not the source of the interrupt");
+    }
+
     critical_section::with(|cs| {
         BUTTON
             .borrow_ref_mut(cs)


### PR DESCRIPTION
…Input

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
I'm unsure whether my modifications to the gpio_interrupt example are sufficient (perhaps adding a second button would help get the point across more clearly)

#### Description
As described in #1829 by ScreamsInJank, it is currently not possible to discern which from which gpio pin an interrupt originated when the `InputPin` is wrapped in `Input<>`.
Since `InputPin` already has a method for this I have just exposed that in the implementation of `Input<InputPin>`

#### Testing
I have not had a chance to test the change on any target other than the esp32 as all my c3s and s3s are currently tied up in other projects. Thusfar it works on my machine :)
