### PR TITLE
esp_hal: Try to fix espflash command not found in HIL CI

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -129,4 +129,6 @@ jobs:
 
       - name: Erase Flash on Failure
         if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}
-        run: espflash erase-flash
+        run: |
+          export PATH=$PATH:/home/espressif/.cargo/bin
+          espflash erase-flash


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Testing
`espflash` is installed on all runners.
No idea how to test, manual trigger doesn't pick my branch. 
This is fine and expected: https://github.com/esp-rs/esp-hal/actions/runs/10055905092/job/27793593075#step:3:21
However, this is weird https://github.com/esp-rs/esp-hal/actions/runs/10055905092/job/27793789788#step:2:20
I tried to explicitly point to my repo: https://github.com/esp-rs/esp-hal/compare/main...JurajSadel:esp-hal:ci/espflash#diff-3f888d600c3bcb11dd1c4600c03a6249d5741149bbcb7d04bf3e7b037f5cc693R124-R128
But I still can't see that export step here: https://github.com/esp-rs/esp-hal/actions/runs/10056365902/job/27795198164#step:5:1
So I'm not sure how to test if my "fix" is working or not other than adding it to the merge queue

NOTE: I was testing with other branch because it is a mess, main thing here is the `export PATH=$PATH:/home/espressif/.cargo/bin` before `espflash erase-flash`

closes #1842