### PR TITLE
try to fix espflash command not found in HIL CI

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -129,4 +129,6 @@ jobs:
 
       - name: Erase Flash on Failure
         if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}
-        run: espflash erase-flash
+        run: |
+          export PATH=$PATH:/home/espressif/.cargo/bin
+          espflash erase-flash

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -103,24 +103,29 @@ jobs:
           # RISC-V devices:
           - soc: esp32c2
             runner: esp32c2-jtag
+            usb: ACM0
           - soc: esp32c3
             runner: esp32c3-usb
+            usb: ACM0
           - soc: esp32c6
             runner: esp32c6-usb
+            usb: ACM0
           - soc: esp32h2
             runner: esp32h2-usb
+            usb: ACM0
           # Xtensa devices:
           - soc: esp32s2
             runner: esp32s2-jtag
+            usb: USB0
           - soc: esp32s3
             runner: esp32s3-usb
+            usb: USB0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: tests-${{ matrix.target.soc }}
           path: tests-${{ matrix.target.soc }}
-
       - name: Run Tests
         id: run-tests
         run: |
@@ -129,6 +134,8 @@ jobs:
 
       - name: Erase Flash on Failure
         if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}
+        env:
+          ESPFLASH_PORT: /dev/tty${{ matrix.target.usb }}
         run: |
           export PATH=$PATH:/home/espressif/.cargo/bin
           espflash erase-flash


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Adds espflash to the path, and sets the ESPFLASH_PORT env
