### PR TITLE
Fix async PARL_IO RX

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix I2S async-tx (#1833)
+- Fix PARL_IO async-rx (#1851)
 
 ### Removed
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1664,7 +1664,7 @@ pub mod asynch {
 
     use super::{private::Instance, Error, ParlIoRx, ParlIoTx, MAX_DMA_SIZE};
     use crate::{
-        dma::{asynch::DmaRxDoneChFuture, DmaChannel, ParlIoPeripheral},
+        dma::{asynch::DmaRxFuture, DmaChannel, ParlIoPeripheral},
         peripherals::Interrupt,
     };
 
@@ -1756,7 +1756,7 @@ pub mod asynch {
                 return Err(Error::MaxDmaTransferSizeExceeded);
             }
 
-            let future = DmaRxDoneChFuture::new(&mut self.rx_channel);
+            let future = DmaRxFuture::new(&mut self.rx_channel);
             Self::start_receive_bytes_dma(future.rx, &mut self.rx_chain, ptr, len)?;
             future.await?;
 

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -74,7 +74,11 @@ async fn main(_spawner: Spawner) {
     let buffer = rx_buffer;
     loop {
         parl_io_rx.read_dma_async(buffer).await.unwrap();
-        println!("Received: {:02x?} ...", &buffer[..30]);
+        println!(
+            "Received: {:02x?} ... {:02x?}",
+            &buffer[..30],
+            &buffer[(buffer.len() - 30)..]
+        );
 
         Timer::after(Duration::from_millis(500)).await;
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1841 

While reviewing the "Change Semantics of DMA Futures" it was found that PARL_IO was using the wrong DMA future - this is a fix for it.

#### Testing
Run the modified example (connect 3V3 to one of the input pins) without the fix and see that the DMA buffer isn't completely filled in the first iteration. Run the same example with the fix and see how the DMA buffer is correctly filled now
