### PR TITLE
esp_hal: Warnings in examples cleanup

### DIFF
--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -24,7 +24,6 @@ use esp_hal::{
     get_core,
     gpio::{AnyOutput, Io, Level},
     peripherals::Peripherals,
-    prelude::*,
     system::SystemControl,
     timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
 };

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -28,7 +28,7 @@ use esp_hal::{
     interrupt::Priority,
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{/*systimer::SystemTimer,*/ timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
 };
 use esp_hal_embassy::InterruptExecutor;
 use esp_println::println;

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -28,7 +28,6 @@ use esp_hal::{
         Usb,
     },
     peripherals::Peripherals,
-    prelude::*,
     system::SystemControl,
     timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
 };


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

There are two more warnings left regarding new `nightly` and unnecessary unsafe blocks - I will keep them for now.
[first in DA example](https://github.com/JurajSadel/esp-hal/actions/runs/10073828018/job/27848673521#step:9:372) and second in [esp-wifi](https://github.com/JurajSadel/esp-hal/actions/runs/10073828018/job/27848673521#step:9:734).
