### PR TITLE
Use peripheral ref pattern for `OneShotTimer and `PeriodicTimer`

### DIFF
--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -12,7 +12,7 @@ use esp_hal::{
 
 pub const MAX_SUPPORTED_ALARM_COUNT: usize = 7;
 
-pub type Timer = OneShotTimer<ErasedTimer>;
+pub type Timer = OneShotTimer<'static, ErasedTimer>;
 
 static TIMERS: Mutex<RefCell<Option<&'static mut [Timer]>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Peripheral driver constructors don't take `InterruptHandler`s anymore. Use `set_interrupt_handler` to explicitly set the interrupt handler now. (#1819)
+- Use the peripheral ref pattern for `OneShotTimer` and `PeriodicTimer` (#1855)
 
 ### Fixed
-- Improve error detection in the I2C driver (#1847)
 
+- Improve error detection in the I2C driver (#1847)
 - Fix I2S async-tx (#1833)
 - Fix PARL_IO async-rx (#1851)
 

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -586,6 +586,18 @@ where
     }
 }
 
+impl<T, DM, const CHANNEL: u8> Peripheral for Alarm<T, DM, CHANNEL>
+where
+    DM: Mode,
+{
+    type P = Self;
+
+    #[inline]
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        core::ptr::read(self as *const _)
+    }
+}
+
 // Async functionality of the system timer.
 #[cfg(feature = "async")]
 mod asynch {

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -522,6 +522,19 @@ where
     }
 }
 
+impl<T, DM> Peripheral for Timer<T, DM>
+where
+    T: Instance,
+    DM: Mode,
+{
+    type P = Self;
+
+    #[inline]
+    unsafe fn clone_unchecked(&mut self) -> Self::P {
+        core::ptr::read(self as *const _)
+    }
+}
+
 #[doc(hidden)]
 pub trait Instance: Sealed + Enable {
     fn register_block(&self) -> &RegisterBlock;

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// The timer responsible for time slicing.
-pub type TimeBase = PeriodicTimer<ErasedTimer>;
+pub type TimeBase = PeriodicTimer<'static, ErasedTimer>;
 static ALARM0: Mutex<RefCell<Option<TimeBase>>> = Mutex::new(RefCell::new(None));
 const TIMESLICE_FREQUENCY: fugit::HertzU64 =
     fugit::HertzU64::from_raw(crate::CONFIG.tick_rate_hz as u64);

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// The timer responsible for time slicing.
-pub type TimeBase = PeriodicTimer<ErasedTimer>;
+pub type TimeBase = PeriodicTimer<'static, ErasedTimer>;
 static TIMER1: Mutex<RefCell<Option<TimeBase>>> = Mutex::new(RefCell::new(None));
 const TIMESLICE_FREQUENCY: fugit::HertzU64 =
     fugit::HertzU64::from_raw(crate::CONFIG.tick_rate_hz as u64);

--- a/examples/src/bin/embassy_hello_world.rs
+++ b/examples/src/bin/embassy_hello_world.rs
@@ -47,8 +47,8 @@ async fn main(spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timers = [timer0];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -47,8 +47,8 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timers = [timer0];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -47,8 +47,8 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timers = [timer0];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -50,8 +50,8 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timers = [timer0];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -72,8 +72,8 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timers = [timer0];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -71,9 +71,9 @@ async fn main(_spawner: Spawner) {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timer1 = OneShotTimer::new(timg0.timer1.into());
-    let timers = [timer0, timer1];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer1: ErasedTimer = timg0.timer1.into();
+    let timers = [OneShotTimer::new(timer0), OneShotTimer::new(timer1)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 2], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -91,9 +91,9 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timer1 = OneShotTimer::new(timg0.timer1.into());
-    let timers = [timer0, timer1];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer1: ErasedTimer = timg0.timer1.into();
+    let timers = [OneShotTimer::new(timer0), OneShotTimer::new(timer1)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 2], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -88,17 +88,22 @@ async fn main(low_prio_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer0 = OneShotTimer::new(timer0);
+
     #[cfg(not(feature = "esp32c2"))]
     let timer1 = {
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-        OneShotTimer::new(timg1.timer0.into())
+        let timer0: ErasedTimer = timg1.timer0.into();
+        OneShotTimer::new(timer0)
     };
     #[cfg(feature = "esp32c2")]
     let timer1 = {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER);
-        OneShotTimer::new(systimer.alarm0.into())
+        let alarm0: ErasedTimer = systimer.alarm0.into();
+        OneShotTimer::new(alarm0)
     };
+
     let timers = [timer0, timer1];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 2], timers);
     esp_hal_embassy::init(&clocks, timers);

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -44,7 +44,8 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let systimer = SystemTimer::new(peripherals.SYSTIMER);
-    let timers = [OneShotTimer::new(systimer.alarm0.into())];
+    let alarm0: ErasedTimer = systimer.alarm0.into();
+    let timers = [OneShotTimer::new(alarm0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -55,7 +55,8 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let systimer = SystemTimer::new(peripherals.SYSTIMER);
-    let timers = [OneShotTimer::new(systimer.alarm0.into())];
+    let alarm0: ErasedTimer = systimer.alarm0.into();
+    let timers = [OneShotTimer::new(alarm0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -57,8 +57,8 @@ async fn main(spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timers = [timer0];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -43,8 +43,8 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timers = [timer0];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -95,8 +95,8 @@ async fn main(spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0 = OneShotTimer::new(timg0.timer0.into());
-    let timers = [timer0];
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
     let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -54,10 +54,9 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timers = mk_static!(
-        [OneShotTimer<ErasedTimer>; 1],
-        [OneShotTimer::new(timg0.timer0.into())]
-    );
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
+    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -99,10 +99,9 @@ async fn main(spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timers = mk_static!(
-        [OneShotTimer<ErasedTimer>; 1],
-        [OneShotTimer::new(timg0.timer0.into())]
-    );
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
+    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
     esp_hal_embassy::init(&clocks, timers);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -50,13 +50,10 @@ async fn main(_spawner: Spawner) -> () {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    esp_hal_embassy::init(
-        &clocks,
-        mk_static!(
-            [OneShotTimer<ErasedTimer>; 1],
-            [OneShotTimer::new(timg0.timer0.into())]
-        ),
-    );
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
+    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+    esp_hal_embassy::init(&clocks, timers);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_usb_serial_jtag.rs
+++ b/examples/src/bin/embassy_usb_serial_jtag.rs
@@ -80,13 +80,10 @@ async fn main(spawner: Spawner) -> () {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    esp_hal_embassy::init(
-        &clocks,
-        mk_static!(
-            [OneShotTimer<ErasedTimer>; 1],
-            [OneShotTimer::new(timg0.timer0.into())]
-        ),
-    );
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
+    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+    esp_hal_embassy::init(&clocks, timers);
 
     let (tx, rx) = UsbSerialJtag::new_async(peripherals.USB_DEVICE).split();
 

--- a/examples/src/bin/embassy_wait.rs
+++ b/examples/src/bin/embassy_wait.rs
@@ -37,13 +37,10 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    esp_hal_embassy::init(
-        &clocks,
-        mk_static!(
-            [OneShotTimer<ErasedTimer>; 1],
-            [OneShotTimer::new(timg0.timer0.into())]
-        ),
-    );
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
+    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+    esp_hal_embassy::init(&clocks, timers);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
     #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]

--- a/examples/src/bin/wifi_access_point.rs
+++ b/examples/src/bin/wifi_access_point.rs
@@ -21,7 +21,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::PeriodicTimer,
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -47,11 +47,9 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,

--- a/examples/src/bin/wifi_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_access_point_with_sta.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::PeriodicTimer,
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -54,11 +54,9 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,

--- a/examples/src/bin/wifi_bench.rs
+++ b/examples/src/bin/wifi_bench.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::PeriodicTimer,
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -67,11 +67,9 @@ fn main() -> ! {
 
     let server_address: Ipv4Address = HOST_IP.parse().expect("Invalid HOST_IP address");
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,

--- a/examples/src/bin/wifi_ble.rs
+++ b/examples/src/bin/wifi_ble.rs
@@ -30,7 +30,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::PeriodicTimer,
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{ble::controller::BleConnector, initialize, EspWifiInitFor};
@@ -44,11 +44,9 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Ble,

--- a/examples/src/bin/wifi_coex.rs
+++ b/examples/src/bin/wifi_coex.rs
@@ -32,7 +32,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::PeriodicTimer,
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -60,11 +60,9 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::WifiBle,

--- a/examples/src/bin/wifi_dhcp.rs
+++ b/examples/src/bin/wifi_dhcp.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::PeriodicTimer,
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -53,11 +53,9 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -32,7 +32,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -68,11 +68,9 @@ async fn main(spawner: Spawner) -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
@@ -89,26 +87,20 @@ async fn main(spawner: Spawner) -> ! {
 
     #[cfg(feature = "esp32")]
     {
-        let timg1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(timg1.timer0.into())]
-            ),
-        );
+        let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        let timer0: ErasedTimer = timg1.timer0.into();
+        let timers = [OneShotTimer::new(timer0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(systimer.alarm0.into())]
-            ),
-        );
+        let alarm0: ErasedTimer = systimer.alarm0.into();
+        let timers = [OneShotTimer::new(alarm0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     let config = Config::ipv4_static(StaticConfigV4 {

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -35,7 +35,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -76,11 +76,9 @@ async fn main(spawner: Spawner) -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
@@ -97,26 +95,20 @@ async fn main(spawner: Spawner) -> ! {
 
     #[cfg(feature = "esp32")]
     {
-        let timg1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(timg1.timer0.into())]
-            ),
-        );
+        let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        let timer0: ErasedTimer = timg1.timer0.into();
+        let timers = [OneShotTimer::new(timer0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(systimer.alarm0.into())]
-            ),
-        );
+        let alarm0: ErasedTimer = systimer.alarm0.into();
+        let timers = [OneShotTimer::new(alarm0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     let ap_config = Config::ipv4_static(StaticConfigV4 {

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -26,7 +26,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -80,11 +80,9 @@ async fn main(spawner: Spawner) -> ! {
 
     let server_address: Ipv4Address = HOST_IP.parse().expect("Invalid HOST_IP address");
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
@@ -101,26 +99,20 @@ async fn main(spawner: Spawner) -> ! {
 
     #[cfg(feature = "esp32")]
     {
-        let timg1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(timg1.timer0.into())]
-            ),
-        );
+        let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        let timer0: ErasedTimer = timg1.timer0.into();
+        let timers = [OneShotTimer::new(timer0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(systimer.alarm0.into())]
-            ),
-        );
+        let alarm0: ErasedTimer = systimer.alarm0.into();
+        let timers = [OneShotTimer::new(alarm0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     let config = Config::dhcpv4(Default::default());

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -61,11 +61,9 @@ async fn main(spawner: Spawner) -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
@@ -82,26 +80,20 @@ async fn main(spawner: Spawner) -> ! {
 
     #[cfg(feature = "esp32")]
     {
-        let timg1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(timg1.timer0.into())]
-            ),
-        );
+        let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        let timer0: ErasedTimer = timg1.timer0.into();
+        let timers = [OneShotTimer::new(timer0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(systimer.alarm0.into())]
-            ),
-        );
+        let alarm0: ErasedTimer = systimer.alarm0.into();
+        let timers = [OneShotTimer::new(alarm0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     let config = Config::dhcpv4(Default::default());

--- a/examples/src/bin/wifi_embassy_esp_now.rs
+++ b/examples/src/bin/wifi_embassy_esp_now.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -47,11 +47,9 @@ async fn main(_spawner: Spawner) -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
@@ -68,26 +66,20 @@ async fn main(_spawner: Spawner) -> ! {
 
     #[cfg(feature = "esp32")]
     {
-        let timg1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(timg1.timer0.into())]
-            ),
-        );
+        let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        let timer0: ErasedTimer = timg1.timer0.into();
+        let timers = [OneShotTimer::new(timer0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(systimer.alarm0.into())]
-            ),
-        );
+        let alarm0: ErasedTimer = systimer.alarm0.into();
+        let timers = [OneShotTimer::new(alarm0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     let mut ticker = Ticker::every(Duration::from_secs(5));

--- a/examples/src/bin/wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/wifi_embassy_esp_now_duplex.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -47,11 +47,9 @@ async fn main(spawner: Spawner) -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
@@ -68,26 +66,20 @@ async fn main(spawner: Spawner) -> ! {
 
     #[cfg(feature = "esp32")]
     {
-        let timg1 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(timg1.timer0.into())]
-            ),
-        );
+        let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        let timer0: ErasedTimer = timg1.timer0.into();
+        let timers = [OneShotTimer::new(timer0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(systimer.alarm0.into())]
-            ),
-        );
+        let alarm0: ErasedTimer = systimer.alarm0.into();
+        let timers = [OneShotTimer::new(alarm0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
     }
 
     let (manager, sender, receiver) = esp_now.split();

--- a/examples/src/bin/wifi_esp_now.rs
+++ b/examples/src/bin/wifi_esp_now.rs
@@ -15,7 +15,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::PeriodicTimer,
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -34,11 +34,9 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,

--- a/examples/src/bin/wifi_static_ip.rs
+++ b/examples/src/bin/wifi_static_ip.rs
@@ -20,7 +20,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::PeriodicTimer,
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -53,11 +53,9 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    let timer = PeriodicTimer::new(
-        esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0, &clocks)
-            .timer0
-            .into(),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -55,13 +55,10 @@ impl<'d> Context<'d> {
         let delay = Delay::new(&clocks);
 
         let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-        esp_hal_embassy::init(
-            &clocks,
-            mk_static!(
-                [OneShotTimer<ErasedTimer>; 1],
-                [OneShotTimer::new(timg0.timer0.into())]
-            ),
-        );
+        let timer0: ErasedTimer = timg0.timer0.into();
+        let timers = [OneShotTimer::new(timer0)];
+        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+        esp_hal_embassy::init(&clocks, timers);
 
         Context {
             io2: Input::new(io.pins.gpio2, Pull::Down),


### PR DESCRIPTION
Changes should be pretty self-explanatory I think, but I did a lot of copy-pasting so please keep an eye out for silly mistakes.

Closes #1741