### PR TITLE
Add a new constructor to `gpio::Io` which does not bind an interrupt handler

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added new `Io::new_no_bind_interrupt` constructor (#1861)
+
 ### Changed
 
 - Peripheral driver constructors don't take `InterruptHandler`s anymore. Use `set_interrupt_handler` to explicitly set the interrupt handler now. (#1819)

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1213,6 +1213,21 @@ impl Io {
             pins,
         }
     }
+
+    /// Initialize the I/O driver without enabling the GPIO interrupt or
+    /// binding an interrupt handler to it.
+    ///
+    /// *Note:* You probably don't want to use this, it is intended to be used
+    /// in very specific use cases. Async GPIO functionality will not work
+    /// when instantiating `Io` using this constructor.
+    pub fn new_no_bind_interrupt(gpio: GPIO, io_mux: IO_MUX) -> Self {
+        let pins = gpio.pins();
+
+        Io {
+            _io_mux: io_mux,
+            pins,
+        }
+    }
 }
 
 impl crate::private::Sealed for Io {}


### PR DESCRIPTION
Wasn't sure what to call it (as usual), but I think this is a reasonable enough name. Happy to change it if anybody has any better suggestions.

I think the comment should hopefully suffice, but again let me know if I should make it more scary and/or mention anything else.

Closes #1858