### PR TITLE
Adds check to guard against rcv frame panic issue

### DIFF
--- a/esp-ieee802154/CHANGELOG.md
+++ b/esp-ieee802154/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added range check to avoid panic when indexing into RX_BUFFER slice
+
 ### Changed
 
 ### Fixed

--- a/esp-ieee802154/src/raw.rs
+++ b/esp-ieee802154/src/raw.rs
@@ -391,7 +391,12 @@ fn ZB_MAC() {
                     log::warn!("Receive queue full");
                 }
 
-                let frm = &RX_BUFFER[1..][..RX_BUFFER[0] as usize];
+                let frm = if RX_BUFFER[0] > FRAME_SIZE as u8 {
+                    log::warn!("RX_BUFFER[0] {:} is larger than frame size", RX_BUFFER[0]);
+                    &RX_BUFFER[1..][..FRAME_SIZE]
+                } else {
+                    &RX_BUFFER[1..][..RX_BUFFER[0] as usize]
+                };
                 if will_auto_send_ack(frm) {
                     *STATE.borrow_ref_mut(cs) = Ieee802154State::TxAck;
                 } else if should_send_enhanced_ack(frm) {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Adds a length check to avoid out-of-bounds access panic in the `RX_BUFFER` slice during `Event::RxDone` event processing. 

#### Description
I have seen a rare bug pop up a two times now after leaving multiple esp32c6 devices running openthread (via the `esp-openthread` crate) for long periods of time :

```
WARN - timer interrupt triggered at 73875446
INFO - trigger_tx_done


====================== PANIC ======================
panicked at /home/nerdlet/.cargo/git/checkouts/esp-hal-42ec44e8c6943228/1424f2a/esp-ieee802154/src/raw.rs:394:42:
range end index 138 out of range for slice of length 128
```

I view this PR addition as a temporary hold over. A more comprehensive fix is likely needed here or elsewhere (this crate, the `esp-openthread` crate, etc). Unfortunately I had no backtrace when the bug popped up the two times I saw it nor had anything else set up to assist in debugging. So need to work on reliable repro before digging in further. This bug only popped up twice over many days/hours of constant operation so will continue to monitor. 

#### Testing
Applied the fix and confirmed it builds and runs as expected using the `esp-openthread` crate. Have also verified the ieee802154 example bins still run as well. 