### PR TITLE
Touch support for ESP32

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added new `Io::new_no_bind_interrupt` constructor (#1861)
+- Added touch pad support for esp32 (#1873)
 
 ### Changed
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -229,6 +229,8 @@ pub mod system;
 pub mod time;
 #[cfg(any(systimer, timg0, timg1))]
 pub mod timer;
+#[cfg(touch)]
+pub mod touch;
 #[cfg(trace0)]
 pub mod trace;
 #[cfg(any(twai0, twai1))]

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -871,11 +871,11 @@ pub(crate) fn errata36(pin_num: u8, pull_up: Option<bool>, pull_down: Option<boo
 }
 
 crate::gpio::gpio! {
-    (0, 0, InputOutputAnalog (5 => EMAC_TX_CLK) (1 => CLK_OUT1))
+    (0, 0, InputOutputAnalogTouch (5 => EMAC_TX_CLK) (1 => CLK_OUT1))
     (1, 0, InputOutput (5 => EMAC_RXD2) (0 => U0TXD 1 => CLK_OUT3))
-    (2, 0, InputOutputAnalog (1 => HSPIWP 3 => HS2_DATA0 4 => SD_DATA0) (3 => HS2_DATA0 4 => SD_DATA0))
+    (2, 0, InputOutputAnalogTouch (1 => HSPIWP 3 => HS2_DATA0 4 => SD_DATA0) (3 => HS2_DATA0 4 => SD_DATA0))
     (3, 0, InputOutput (0 => U0RXD) (1 => CLK_OUT2))
-    (4, 0, InputOutputAnalog (1 => HSPIHD 3 => HS2_DATA1 4 => SD_DATA1 5 => EMAC_TX_ER) (3 => HS2_DATA1 4 => SD_DATA1))
+    (4, 0, InputOutputAnalogTouch (1 => HSPIHD 3 => HS2_DATA1 4 => SD_DATA1 5 => EMAC_TX_ER) (3 => HS2_DATA1 4 => SD_DATA1))
     (5, 0, InputOutput (1 => VSPICS0 3 => HS1_DATA6 5 => EMAC_RX_CLK) (3 => HS1_DATA6))
     (6, 0, InputOutput (4 => U1CTS) (0 => SD_CLK 1 => SPICLK 3 => HS1_CLK))
     (7, 0, InputOutput (0 => SD_DATA0 1 => SPIQ 3 => HS1_DATA0) (0 => SD_DATA0 1 => SPIQ 3 => HS1_DATA0 4 => U2RTS))
@@ -883,10 +883,10 @@ crate::gpio::gpio! {
     (9, 0, InputOutput (0 => SD_DATA2 1 => SPIHD 3 => HS1_DATA2 4 => U1RXD) (0 => SD_DATA2 1 => SPIHD 3 => HS1_DATA2))
     (10, 0, InputOutput ( 0 => SD_DATA3 1 => SPIWP 3 => HS1_DATA3) (0 => SD_DATA3 1 => SPIWP 3 => HS1_DATA3 4 => U1TXD))
     (11, 0, InputOutput ( 1 => SPICS0) (0 => SD_CMD 1 => SPICS0 3 => HS1_CMD 4 => U1RTS))
-    (12, 0, InputOutputAnalog (0 => MTDI 1 => HSPIQ 3 => HS2_DATA2 4 => SD_DATA2) (1 => HSPIQ 3 => HS2_DATA2 4 => SD_DATA2 5 => EMAC_TXD3))
-    (13, 0, InputOutputAnalog (0 => MTCK 1 => HSPID 3 => HS2_DATA3 4 => SD_DATA3) (1 => HSPID 3 => HS2_DATA3 4 => SD_DATA3 5 => EMAC_RX_ER))
-    (14, 0, InputOutputAnalog (0 => MTMS 1 => HSPICLK) (1 => HSPICLK 3 => HS2_CLK 4 => SD_CLK 5 => EMAC_TXD2))
-    (15, 0, InputOutputAnalog (1 => HSPICS0 5 => EMAC_RXD3) (0 => MTDO 1 => HSPICS0 3 => HS2_CMD 4 => SD_CMD))
+    (12, 0, InputOutputAnalogTouch (0 => MTDI 1 => HSPIQ 3 => HS2_DATA2 4 => SD_DATA2) (1 => HSPIQ 3 => HS2_DATA2 4 => SD_DATA2 5 => EMAC_TXD3))
+    (13, 0, InputOutputAnalogTouch (0 => MTCK 1 => HSPID 3 => HS2_DATA3 4 => SD_DATA3) (1 => HSPID 3 => HS2_DATA3 4 => SD_DATA3 5 => EMAC_RX_ER))
+    (14, 0, InputOutputAnalogTouch (0 => MTMS 1 => HSPICLK) (1 => HSPICLK 3 => HS2_CLK 4 => SD_CLK 5 => EMAC_TXD2))
+    (15, 0, InputOutputAnalogTouch (1 => HSPICS0 5 => EMAC_RXD3) (0 => MTDO 1 => HSPICS0 3 => HS2_CMD 4 => SD_CMD))
     (16, 0, InputOutput (3 => HS1_DATA4 4 => U2RXD) (3 => HS1_DATA4 5 => EMAC_CLK_OUT))
     (17, 0, InputOutput (3 => HS1_DATA5) (3 => HS1_DATA5 4 => U2TXD 5 => EMAC_CLK_180))
     (18, 0, InputOutput (1 => VSPICLK 3 => HS1_DATA7) (1 => VSPICLK 3 => HS1_DATA7))
@@ -898,7 +898,7 @@ crate::gpio::gpio! {
     (24, 0, InputOutput)
     (25, 0, InputOutputAnalog (5 => EMAC_RXD0) ())
     (26, 0, InputOutputAnalog (5 => EMAC_RXD1) ())
-    (27, 0, InputOutputAnalog (5 => EMAC_RX_DV) ())
+    (27, 0, InputOutputAnalogTouch (5 => EMAC_RX_DV) ())
     (32, 1, InputOutputAnalog)
     (33, 1, InputOutputAnalog)
     (34, 1, InputOnlyAnalog)
@@ -949,6 +949,35 @@ crate::gpio::rtc_pins! {
         (12, 15, touch_pad5(),     "",      touch_pad5_hold_force, rue,       rde       )
         (14, 16, touch_pad6(),     "",      touch_pad6_hold_force, rue,       rde       )
         (27, 17, touch_pad7(),     "",      touch_pad7_hold_force, rue,       rde       )
+}
+
+crate::gpio::touch_into! {
+    // (touch_nr, pin_nr, rtc_pin, touch_comb_reg_nr, normal_pin)
+     (0, 4,  10, sar_touch_thres1, touch_out_th0, true )
+     (1, 0,  11, sar_touch_thres1, touch_out_th1, true )
+     (2, 2,  12, sar_touch_thres2, touch_out_th2, true )
+     (3, 15, 13, sar_touch_thres2, touch_out_th3, true )
+     (4, 13, 14, sar_touch_thres3, touch_out_th4, true )
+     (5, 12, 15, sar_touch_thres3, touch_out_th5, true )
+     (6, 14, 16, sar_touch_thres4, touch_out_th6, true )
+     (7, 27, 17, sar_touch_thres4, touch_out_th7, true )
+     ---
+     (8, 33, 8, sar_touch_thres5, touch_out_th8, false )
+     (9, 32, 9, sar_touch_thres5, touch_out_th9, false )
+}
+
+crate::gpio::touch_common! {
+    // (touch_nr, pin_nr, touch_out_reg, touch_thres_reg )
+     (0, 4,  sar_touch_out1, touch_meas_out0, sar_touch_thres1, touch_out_th0)
+     (1, 0,  sar_touch_out1, touch_meas_out1, sar_touch_thres1, touch_out_th1)
+     (2, 2,  sar_touch_out2, touch_meas_out2, sar_touch_thres2, touch_out_th2)
+     (3, 15, sar_touch_out2, touch_meas_out3, sar_touch_thres2, touch_out_th3)
+     (4, 13, sar_touch_out3, touch_meas_out4, sar_touch_thres3, touch_out_th4)
+     (5, 12, sar_touch_out3, touch_meas_out5, sar_touch_thres3, touch_out_th5)
+     (6, 14, sar_touch_out4, touch_meas_out6, sar_touch_thres4, touch_out_th6)
+     (7, 27, sar_touch_out4, touch_meas_out7, sar_touch_thres4, touch_out_th7)
+     (8, 33, sar_touch_out5, touch_meas_out8, sar_touch_thres5, touch_out_th8)
+     (9, 32, sar_touch_out5, touch_meas_out9, sar_touch_thres5, touch_out_th9)
 }
 
 impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {

--- a/esp-hal/src/soc/esp32/peripherals.rs
+++ b/esp-hal/src/soc/esp32/peripherals.rs
@@ -65,6 +65,7 @@ crate::peripherals! {
     SYSTEM <= DPORT,
     TIMG0 <= TIMG0,
     TIMG1 <= TIMG1,
+    TOUCH <= virtual,
     TWAI0 <= TWAI0,
     UART0 <= UART0,
     UART1 <= UART1,

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -1,0 +1,416 @@
+//! # Capacitive Touch Sensor
+//!
+//! ## Overview
+//!
+//! The touch sensor peripheral allows for cheap and robust user interfaces by
+//! e.g., dedicating a part of the pcb as touch button.
+//!
+//! ## Examples
+//!
+//! ```rust, no_run
+#![doc = crate::before_snippet!()]
+//! # use esp_hal::touch::{Touch, TouchPad};
+//! # use esp_hal::gpio::Io;
+//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let touch_pin0 = io.pins.gpio2;
+//! let touch = Touch::continous_mode(peripherals.TOUCH, None);
+//! let mut touchpad = TouchPad::new(touch_pin0, &touch);
+//! // ... give the peripheral some time for the measurement
+//! let touch_val = touchpad.read();
+//! # }
+//! ```
+//! 
+//! ## Implementation State:
+//!
+//! Mostly feature complete, missing:
+//!
+//! - Async support
+//! - Touch sensor slope control
+//! - Deep Sleep support (wakeup from Deep Sleep)
+
+#![deny(missing_docs)]
+
+use core::marker::PhantomData;
+
+use crate::{
+    gpio::TouchPin,
+    peripheral::{Peripheral, PeripheralRef},
+    peripherals::{RTC_CNTL, SENS, TOUCH},
+    private::{Internal, Sealed},
+};
+
+/// A marker trait describing the mode the touch pad is set to.
+pub trait TouchMode: Sealed {}
+
+/// Marker struct for the touch peripherals manual trigger mode. In the
+/// technical reference manual, this is referred to as "start FSM via software".
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct OneShot;
+
+/// Marker struct for the touch peripherals continous reading mode. In the
+/// technical reference manual, this is referred to as "start FSM via timer".
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Continous;
+
+impl TouchMode for OneShot {}
+impl TouchMode for Continous {}
+impl Sealed for OneShot {}
+impl Sealed for Continous {}
+
+/// Touchpad threshold type.
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ThresholdMode {
+    /// Pad is considered touched if value is greater than threshold.
+    GreaterThan,
+    /// Pad is considered touched if value is less than threshold.
+    LessThan,
+}
+
+/// Configurations for the touch pad driver
+#[derive(Debug, Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TouchConfig {
+    /// The [`ThresholdMode`] for the pads. Defaults to
+    /// `ThresholdMode::LessThan`
+    pub threshold_mode: Option<ThresholdMode>,
+    /// Duration of a single measurement (in cycles of the 8 MHz touch clock).
+    /// Defaults to `0x7fff`
+    pub measurement_duration: Option<u16>,
+    /// Sleep cycles for the touch timer in [`Continous`]-mode. Defaults to
+    /// `0x100`
+    pub sleep_cycles: Option<u16>,
+}
+
+/// This struct marks a successfully initialized touch peripheral
+pub struct Touch<'d, MODE: TouchMode> {
+    _inner: PeripheralRef<'d, TOUCH>,
+    phantom: PhantomData<MODE>,
+}
+impl<'d, MODE: TouchMode> Touch<'d, MODE> {
+    /// Common initialization of the touch peripheral.
+    fn initialize_common(config: Option<TouchConfig>) {
+        let rtccntl = unsafe { &*RTC_CNTL::ptr() };
+        let sens = unsafe { &*SENS::ptr() };
+
+        let mut threshold_mode = false;
+        let mut meas_dur = 0x7fff;
+
+        if let Some(config) = config {
+            threshold_mode = match config.threshold_mode {
+                Some(ThresholdMode::LessThan) => false,
+                Some(ThresholdMode::GreaterThan) => true,
+                None => false,
+            };
+            if let Some(dur) = config.measurement_duration {
+                meas_dur = dur;
+            }
+        }
+
+        // stop touch fsm
+        rtccntl
+            .state0()
+            .write(|w| w.touch_slp_timer_en().clear_bit());
+        // Disable touch interrupt
+        rtccntl.int_ena().write(|w| w.touch().clear_bit());
+        // Clear pending interrupts
+        rtccntl.int_clr().write(|w| w.touch().bit(true));
+
+        // Disable all interrupts and touch pads
+        sens.sar_touch_enable().write(|w| unsafe {
+            w.touch_pad_outen1()
+                .bits(0b0)
+                .touch_pad_outen2()
+                .bits(0b0)
+                .touch_pad_worken()
+                .bits(0b0)
+        });
+
+        sens.sar_touch_ctrl1().write(|w| unsafe {
+            w
+                // Default to trigger when touch is below threshold
+                .touch_out_sel()
+                .bit(threshold_mode)
+                // Interrupt only on set 1
+                .touch_out_1en()
+                .set_bit()
+                .touch_meas_delay()
+                .bits(meas_dur)
+                // TODO Chip Specific
+                .touch_xpd_wait()
+                .bits(0xff)
+        });
+    }
+}
+impl<'d> Touch<'d, OneShot> {
+    /// Initializes the touch peripheral and returns this marker struct.
+    /// Optionally accepts configuration options.
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    #[doc = crate::before_snippet!()]
+    /// # use esp_hal::touch::{Touch, TouchConfig};
+    /// let touch_cfg = Some(TouchConfig {
+    ///     measurement_duration: Some(0x2000),
+    ///     ..Default::default()
+    /// });
+    /// let touch = Touch::one_shot_mode(peripherals.TOUCH, touch_cfg);
+    /// # }
+    /// ```
+    pub fn one_shot_mode(
+        touch_peripheral: impl Peripheral<P = TOUCH> + 'd,
+        config: Option<TouchConfig>,
+    ) -> Self {
+        crate::into_ref!(touch_peripheral);
+        let rtccntl = unsafe { &*RTC_CNTL::ptr() };
+        let sens = unsafe { &*SENS::ptr() };
+
+        // Default nr of sleep cycles from IDF
+        let mut sleep_cyc = 0x1000;
+        if let Some(config) = config {
+            if let Some(slp) = config.sleep_cycles {
+                sleep_cyc = slp;
+            }
+        }
+
+        Self::initialize_common(config);
+
+        sens.sar_touch_ctrl2().write(|w| unsafe {
+            w
+                // Reset existing touch measurements
+                .touch_meas_en_clr()
+                .set_bit()
+                .touch_sleep_cycles()
+                .bits(sleep_cyc)
+                // Configure FSM for SW mode
+                .touch_start_fsm_en()
+                .set_bit()
+                .touch_start_en()
+                .clear_bit()
+                .touch_start_force()
+                .set_bit()
+        });
+
+        // start touch fsm
+        rtccntl.state0().write(|w| w.touch_slp_timer_en().set_bit());
+
+        Self {
+            _inner: touch_peripheral,
+            phantom: PhantomData,
+        }
+    }
+}
+impl<'d> Touch<'d, Continous> {
+    /// Initializes the touch peripheral in continous mode and returns this
+    /// marker struct. Optionally accepts configuration options.
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    #[doc = crate::before_snippet!()]
+    /// # use esp_hal::touch::{Touch, TouchConfig};
+    /// let touch_cfg = Some(TouchConfig {
+    ///     measurement_duration: Some(0x3000),
+    ///     ..Default::default()
+    /// });
+    /// let touch = Touch::continous_mode(peripherals.TOUCH, touch_cfg);
+    /// # }
+    /// ```
+    pub fn continous_mode(
+        touch_peripheral: impl Peripheral<P = TOUCH> + 'd,
+        config: Option<TouchConfig>,
+    ) -> Self {
+        crate::into_ref!(touch_peripheral);
+        let rtccntl = unsafe { &*RTC_CNTL::ptr() };
+        let sens = unsafe { &*SENS::ptr() };
+
+        // Default nr of sleep cycles from IDF
+        let mut sleep_cyc = 0x1000;
+        if let Some(config) = config {
+            if let Some(slp) = config.sleep_cycles {
+                sleep_cyc = slp;
+            }
+        }
+
+        Self::initialize_common(config);
+
+        sens.sar_touch_ctrl2().write(|w| unsafe {
+            w
+                // Reset existing touch measurements
+                .touch_meas_en_clr()
+                .set_bit()
+                .touch_sleep_cycles()
+                .bits(sleep_cyc)
+                // Configure FSM for timer mode
+                .touch_start_fsm_en()
+                .set_bit()
+                .touch_start_force()
+                .clear_bit()
+        });
+
+        // start touch fsm
+        rtccntl.state0().write(|w| w.touch_slp_timer_en().set_bit());
+
+        Self {
+            _inner: touch_peripheral,
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// A pin that is configured as a TouchPad.
+pub struct TouchPad<P, MODE: TouchMode>
+where
+    P: TouchPin,
+{
+    pin: P,
+    phantom: PhantomData<MODE>,
+}
+impl<P: TouchPin> TouchPad<P, OneShot> {
+    /// (Re-)Start a touch measurement on the pin. You can get the result by
+    /// calling [`read`](Self::read) once it is finished.
+    pub fn start_measurement(&mut self) {
+        unsafe { &*crate::peripherals::RTC_IO::ptr() }
+            .touch_pad2()
+            .write(|w| unsafe {
+                w.start()
+                    .set_bit()
+                    .xpd()
+                    .set_bit()
+                    // clear input_enable
+                    .fun_ie()
+                    .clear_bit()
+                    // Connect pin to analog / RTC module instead of standard GPIO
+                    .mux_sel()
+                    .set_bit()
+                    // Disable pull-up and pull-down resistors on the pin
+                    .rue()
+                    .clear_bit()
+                    .rde()
+                    .clear_bit()
+                    .tie_opt()
+                    .clear_bit()
+                    .to_gpio()
+                    .set_bit()
+                    // Select function "RTC function 1" (GPIO) for analog use
+                    .fun_sel()
+                    .bits(0b00)
+            });
+
+        unsafe { &*crate::peripherals::SENS::PTR }
+            .sar_touch_ctrl2()
+            .modify(|_, w| w.touch_start_en().clear_bit());
+        unsafe { &*crate::peripherals::SENS::PTR }
+            .sar_touch_ctrl2()
+            .modify(|_, w| w.touch_start_en().set_bit());
+    }
+}
+impl<P: TouchPin, MODE: TouchMode> TouchPad<P, MODE> {
+    /// Construct a new instance of [`TouchPad`].
+    ///
+    /// ## Parameters:
+    /// - `pin`: The pin that gets configured as touch pad
+    /// - `touch`: The [`Touch`] struct indicating that touch is configured.
+    pub fn new(pin: P, _touch: &Touch<MODE>) -> Self {
+        // TODO revert this on drop
+        pin.set_touch(Internal);
+
+        Self {
+            pin,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Read the current touch pad capacitance counter.
+    ///
+    /// Usually a lower value means higher capacitance, thus indicating touch
+    /// event.
+    ///
+    /// Returns `None` if the value is not yet ready. (Note: Measurement must be
+    /// started manually with [`start_measurement`](Self::start_measurement) if
+    /// the touch peripheral is in [`OneShot`] mode).
+    pub fn read(&mut self) -> Option<u16> {
+        if unsafe { &*crate::peripherals::SENS::ptr() }
+            .sar_touch_ctrl2()
+            .read()
+            .touch_meas_done()
+            .bit_is_set()
+        {
+            Some(self.pin.get_touch_measurement(Internal))
+        } else {
+            None
+        }
+    }
+
+    /// Enables the touch_pad interrupt.
+    ///
+    /// The raised interrupt is actually
+    /// [`RTC_CORE`](crate::peripherals::Interrupt::RTC_CORE). A handler can
+    /// be installed with [`Rtc::set_interrupt_handler()`][1].
+    ///
+    /// [1]: ../rtc_cntl/struct.Rtc.html#method.set_interrupt_handler
+    ///
+    /// ## Parameters:
+    /// - `threshold`: The threshold above/below which the pin is considered
+    ///   touched. Above/below depends on the configuration of `touch` in
+    ///   [`new`](Self::new) (defaults to below).
+    ///
+    /// ## Example
+    pub fn enable_interrupt(&mut self, threshold: u16) {
+        self.pin.set_threshold(threshold, Internal);
+
+        let rtccntl = unsafe { &*RTC_CNTL::ptr() };
+        // enable touch interrupts
+        rtccntl.int_ena().write(|w| w.touch().set_bit());
+
+        let sens = unsafe { &*SENS::ptr() };
+        sens.sar_touch_enable().modify(|r, w| unsafe {
+            w.touch_pad_outen1()
+                .bits(r.touch_pad_outen1().bits() | 1 << self.pin.get_touch_nr(Internal))
+        });
+    }
+
+    /// Disables the touch pad's interrupt.
+    ///
+    /// If no other touch pad interrupts are active, the touch interrupt is
+    /// disabled completely.
+    pub fn disable_interrupt(&mut self) {
+        let sens = unsafe { &*SENS::ptr() };
+        sens.sar_touch_enable().modify(|r, w| unsafe {
+            w.touch_pad_outen1()
+                .bits(r.touch_pad_outen1().bits() & !(1 << self.pin.get_touch_nr(Internal)))
+        });
+        if sens.sar_touch_enable().read().touch_pad_outen1().bits() == 0 {
+            let rtccntl = unsafe { &*RTC_CNTL::ptr() };
+            rtccntl.int_ena().write(|w| w.touch().clear_bit());
+        }
+    }
+
+    /// Clears a pending touch interrupt.
+    ///
+    /// ## Note on interrupt clearing behaviour:
+    ///
+    /// There is only a single interrupt for the touch pad.
+    /// [`is_interrupt_set`](Self::is_interrupt_set) can be used to check
+    /// which pins are touchted. However, this function clears the interrupt
+    /// status for all pins. So only call it when all pins are handled.
+    pub fn clear_interrupt(&mut self) {
+        let rtccntl = unsafe { &*RTC_CNTL::ptr() };
+        rtccntl.int_clr().write(|w| w.touch().clear_bit_by_one());
+        let sens = unsafe { &*SENS::ptr() };
+        sens.sar_touch_ctrl2()
+            .write(|w| w.touch_meas_en_clr().set_bit());
+    }
+
+    /// Checks if the pad is touched, based on the configured threshold value.
+    pub fn is_interrupt_set(&mut self) -> bool {
+        let sens = unsafe { &*SENS::ptr() };
+        let ctrl2 = sens.sar_touch_ctrl2().read();
+        // Only god knows, why the "interrupt flag" register is called "meas_en" on this
+        // chip...
+        ctrl2.touch_meas_en().bits() & (1 << self.pin.get_touch_nr(Internal)) != 0
+    }
+}

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -60,6 +60,7 @@ symbols = [
     "wifi",
     "psram",
     "timg_timer1",
+    "touch",
     "large_intr_status",
 
     # ROM capabilities

--- a/examples/src/bin/embassy_touch.rs
+++ b/examples/src/bin/embassy_touch.rs
@@ -1,0 +1,98 @@
+//! This example shows how to use the touch pad in an embassy context.
+//!
+//! The touch pad reading for GPIO pin 2 is manually read twice a second,
+//! whereas GPIO pin 4 is configured to raise an interrupt upon touch.
+//!
+//! GPIO pins 2 and 4 must be connected to a touch pad (usually a larger copper
+//! pad on a PCB).
+
+//% CHIPS: esp32
+//% FEATURES: async embassy esp-hal-embassy/integrated-timers
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::select::{select, Either};
+use embassy_time::{Duration, Timer};
+use esp_backtrace as _;
+use esp_hal::{
+    clock::ClockControl,
+    gpio::Io,
+    peripherals::Peripherals,
+    rtc_cntl::Rtc,
+    system::SystemControl,
+    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    touch::{Touch, TouchConfig, TouchPad},
+};
+use esp_println::println;
+
+// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
+macro_rules! mk_static {
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write(($val));
+        x
+    }};
+}
+
+#[esp_hal_embassy::main]
+async fn main(_spawner: Spawner) {
+    esp_println::logger::init_logger_from_env();
+
+    let peripherals = Peripherals::take();
+    let system = SystemControl::new(peripherals.SYSTEM);
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer0: ErasedTimer = timg0.timer0.into();
+    let timers = [OneShotTimer::new(timer0)];
+    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
+    esp_hal_embassy::init(&clocks, timers);
+
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let mut rtc = Rtc::new(peripherals.LPWR);
+
+    let touch_pin0 = io.pins.gpio2;
+    let touch_pin1 = io.pins.gpio4;
+
+    let touch_cfg = Some(TouchConfig {
+        measurement_duration: Some(0x2000),
+        ..Default::default()
+    });
+
+    let touch = Touch::async_mode(peripherals.TOUCH, &mut rtc, touch_cfg);
+    let mut touch0 = TouchPad::new(touch_pin0, &touch);
+    let mut touch1 = TouchPad::new(touch_pin1, &touch);
+
+    // The touch peripheral needs some time for the first measurement
+    Timer::after(Duration::from_millis(100)).await;
+    let mut touch0_baseline = touch0.try_read();
+    while touch0_baseline.is_none() {
+        Timer::after(Duration::from_millis(100)).await;
+        touch0_baseline = touch0.try_read();
+    }
+    let touch0_baseline = touch0.try_read().unwrap();
+    let touch1_baseline = touch1.try_read().unwrap();
+
+    println!("Waiting for touch pad interactions...");
+
+    loop {
+        match select(
+            touch0.wait_for_touch(touch0_baseline * 2 / 3),
+            touch1.wait_for_touch(touch1_baseline * 2 / 3),
+        )
+        .await
+        {
+            Either::First(_) => {
+                println!("Touchpad 0 touched!");
+            }
+            Either::Second(_) => {
+                println!("Touchpad 1 touched!");
+            }
+        }
+        // Add some "dead-timer" to avoid command line spamming
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}

--- a/examples/src/bin/touch.rs
+++ b/examples/src/bin/touch.rs
@@ -1,0 +1,105 @@
+//! This example shows how to configure a pin as a touch pad.
+//!
+//! The touch pad reading for GPIO pin 2 is manually read twice a second,
+//! whereas GPIO pin 4 is configured to raise an interrupt upon touch.
+//!
+//! GPIO pins 2 and 4 must be connected to a touch pad (usually a larger copper
+//! pad on a PCB).
+
+//% CHIPS: esp32
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use critical_section::Mutex;
+use esp_backtrace as _;
+use esp_hal::{
+    clock::ClockControl,
+    delay::Delay,
+    gpio,
+    gpio::Io,
+    macros::ram,
+    peripherals::Peripherals,
+    prelude::*,
+    rtc_cntl::Rtc,
+    system::SystemControl,
+    touch::{Continous, Touch, TouchConfig, TouchPad},
+};
+use esp_println::println;
+
+static TOUCH1: Mutex<RefCell<Option<TouchPad<gpio::Gpio4, Continous>>>> =
+    Mutex::new(RefCell::new(None));
+
+#[handler]
+#[ram]
+fn interrupt_handler() {
+    critical_section::with(|cs| {
+        let mut touch1 = TOUCH1.borrow_ref_mut(cs);
+        let touch1 = touch1.as_mut().unwrap();
+        if touch1.is_interrupt_set() {
+            println!("touch 1 pin interrupt");
+            touch1.clear_interrupt();
+            // We disable the interrupt until the next loop iteration to avoid massive retriggering.
+            touch1.disable_interrupt();
+        }
+    });
+}
+
+#[entry]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = Peripherals::take();
+    let system = SystemControl::new(peripherals.SYSTEM);
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let mut rtc = Rtc::new(peripherals.LPWR);
+    rtc.set_interrupt_handler(interrupt_handler);
+
+    let touch_pin0 = io.pins.gpio2;
+    let touch_pin1 = io.pins.gpio4;
+
+    let touch_cfg = Some(TouchConfig {
+        measurement_duration: Some(0x2000),
+        ..Default::default()
+    });
+
+    let touch = Touch::continous_mode(peripherals.TOUCH, touch_cfg);
+    let mut touch0 = TouchPad::new(touch_pin0, &touch);
+    let mut touch1 = TouchPad::new(touch_pin1, &touch);
+
+    let delay = Delay::new(&clocks);
+
+    let mut touch1_baseline = touch1.read();
+    while touch1_baseline.is_none() {
+        delay.delay_millis(1);
+        touch1_baseline = touch1.read();
+    }
+
+    critical_section::with(|cs| {
+        // A good threshold is 2/3 of the reading when the pad is not touched.
+        touch1.enable_interrupt(touch1_baseline.unwrap() * 2 / 3);
+        TOUCH1.borrow_ref_mut(cs).replace(touch1)
+    });
+
+    loop {
+        let mut touch_reading = touch0.read();
+        while touch_reading.is_none() {
+            delay.delay_millis(1);
+            touch_reading = touch0.read();
+        }
+        println!("touch pad measurement: {touch_reading:?}");
+        delay.delay_millis(500);
+
+        critical_section::with(|cs| {
+            TOUCH1
+                .borrow_ref_mut(cs)
+                .as_mut()
+                .unwrap()
+                .enable_interrupt(touch1_baseline.unwrap() * 2 / 3);
+        });
+    }
+}


### PR DESCRIPTION
## Touch Pad Support for ESP32

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR implements touch pad support for the ESP32. This fixes https://github.com/esp-rs/esp-hal/issues/644.

##### Status:

- [x] "Software mode" touch pad
- [x] "Timer mode" touch pad
- [x] Touch pad interrupts
- [x] Embassy support
- [x] Work around hardware quirks (`TOUCH_PAD8&9` registers work different)
- examples
  - [x] ~~Software mode example~~ I think this is an odd mode anyway, and it should not be too complicated to deduce it from the documentation.
  - [x] Timer mode example
  - [x] Interrupt example
  - [x] Embassy example
  - [x] Documentation examples
- ~~Implement for other chips than plain ESP32~~:
  -  `esp32c2`, `esp32c3`, `esp32c6`, `esp32h2` apparently don't have a touch peripheral
  - `esp32s3` apparently has a rather similar touch peripheral as the `esp32`. This one seems to have more advanced features. However, it looks like it is missing interrupts and other stuff, so this implementation can probably be adapted, but I don't have the time (and motivation) to tackle this. (My very first attempt can be found here: https://github.com/jounathaen/esp-hal/tree/touch-esp32s3 )
  - `esp32s2` has touch pad support, but seems to be programmed completely different.

##### Open questions:

- Is adding many public-internal functions to the _gpio_ module the right way?

#### Testing

This is tested on the ESP32 using the examples for TouchPad0 & 1. I don't have hardware here to test the other pads (especially not for touch 8 & 9 as these are the crystal pins).