### PR TITLE
Implement `embedded_io::{ReadReady, WriteReady}` traits for `WifiStack`

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implement `embedded_io::{ReadReady, WriteReady}` traits for `WifiStack` (#1882)
+
 ### Changed
 
 ### Fixed
@@ -17,8 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.7.1 - 2024-07-17
 
-### Added
-
 ### Changed
 
 - Check no password is set when using `AuthMethod::None`(#1806)
@@ -26,8 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Downgrade `embedded-svc` to 0.27.1 (#1820)
-
-### Removed
 
 ## 0.7.0 - 2024-07-15
 

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -30,7 +30,7 @@ const LOCAL_PORT_MAX: u16 = 65535;
 ///
 /// Mostly a convenience wrapper for `smoltcp`
 pub struct WifiStack<'a, MODE: WifiDeviceMode> {
-    device: RefCell<WifiDevice<'static, MODE>>, // TODO allow non static lifetime
+    device: RefCell<WifiDevice<'a, MODE>>,
     network_interface: RefCell<Interface>,
     sockets: RefCell<SocketSet<'a>>,
     current_millis_fn: fn() -> u64,
@@ -49,7 +49,7 @@ pub struct WifiStack<'a, MODE: WifiDeviceMode> {
 impl<'a, MODE: WifiDeviceMode> WifiStack<'a, MODE> {
     pub fn new(
         network_interface: Interface,
-        device: WifiDevice<'static, MODE>, // TODO relax this lifetime requirement
+        device: WifiDevice<'a, MODE>,
         #[allow(unused_mut)] mut sockets: SocketSet<'a>,
         current_millis_fn: fn() -> u64,
     ) -> WifiStack<'a, MODE> {

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -740,7 +740,7 @@ impl<'s, 'n: 's, MODE: WifiDeviceMode> embedded_io::ReadReady for Socket<'s, 'n,
             let socket = sockets.get_mut::<TcpSocket>(self.socket_handle);
 
             match socket.peek(1) {
-                Ok(s) => Ok(s.len() > 0),
+                Ok(s) => Ok(!s.is_empty()),
                 Err(RecvError::Finished) => Err(IoError::SocketClosed),
                 Err(RecvError::InvalidState) => Err(IoError::TcpRecvError),
             }


### PR DESCRIPTION
I'm not certain these implementations are correct, but at least as far as I understand they should be fine. Happy to make any changes as needed of course.

I also noticed the comments regarding that `'static` lifetimes while I was in here, and have updated those. Not additional changes required.

Closes #1620