### PR TITLE
Disable test_asymmetric_dma_transfer for S3

### DIFF
--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -81,6 +81,8 @@ mod tests {
 
     #[test]
     #[timeout(3)]
+    // S3 is disabled due to https://github.com/esp-rs/esp-hal/issues/1524#issuecomment-2255306292
+    #[cfg(not(feature = "esp32s3"))]
     fn test_asymmetric_dma_transfer() {
         let peripherals = Peripherals::take();
         let system = SystemControl::new(peripherals.SYSTEM);


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Disables the failing test for S3, so we get the workflow back to green and we can reenable the required check. 

#### Testing
https://github.com/esp-rs/esp-hal/actions/runs/10182650638