### PR TITLE
dma: allow choices of CHUNK_SIZE

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use the peripheral ref pattern for `OneShotTimer` and `PeriodicTimer` (#1855)
 
 - Allow DMA to/from psram for esp32s3 (#1827)
+- Allow DMA default chunk size choices. This allows DMA to peripherals to/from psram as drivers don't allow specifying chunk size with DMA descriptors (#1889)
 - DMA buffers now don't require a static lifetime. Make sure to never `mem::forget` an in-progress DMA transfer (consider using `#[deny(clippy::mem_forget)]`) (#1837)
 
 ### Fixed

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -180,6 +180,12 @@ opsram-8m = []
 ## Use externally connected Octal RAM (16MB).
 opsram-16m = []
 
+#! ### DMA Feature Flags
+## Use a DMA chunk size that is a multiple of 32 bytes.
+dma4064 = []
+## Use a DMA chunk size that is a multiple of 64 bytes.
+dma4032 = []
+
 # This feature is intended for testing; you probably don't want to enable it:
 ci = ["async", "embedded-hal-02", "embedded-io", "ufmt", "defmt", "bluetooth", "place-spi-driver-in-ram"]
 

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -7,7 +7,7 @@ use std::{
     str::FromStr,
 };
 
-use esp_build::assert_unique_used_features;
+use esp_build::{assert_unique_features, assert_unique_used_features};
 use esp_metadata::{Chip, Config};
 
 #[cfg(debug_assertions)]
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Ensure at most one dma chunk size feature is specified.
-    assert_unique_used_features!("dma4032", "dma4064");
+    assert_unique_features!("dma4032", "dma4064");
 
     #[cfg(all(
         feature = "flip-link",

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -26,6 +26,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"
     );
 
+    // Ensure at most one dma chunk size feature is specified.
+    assert_unique_used_features!("dma4032", "dma4064");
+
     #[cfg(all(
         feature = "flip-link",
         not(any(feature = "esp32c6", feature = "esp32h2"))

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -281,8 +281,18 @@ pub enum DmaInterrupt {
     RxDone,
 }
 
-/// The default CHUNK_SIZE used for DMA transfers
-pub const CHUNK_SIZE: usize = 4092;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "dma4064")] {
+        /// The default CHUNK_SIZE used for DMA transfers
+        pub const CHUNK_SIZE: usize = 4064;
+    } else if #[cfg(feature = "dma4032")] {
+        /// The default CHUNK_SIZE used for DMA transfers
+        pub const CHUNK_SIZE: usize = 4032;
+    } else {
+        /// The default CHUNK_SIZE used for DMA transfers
+        pub const CHUNK_SIZE: usize = 4092;
+    }
+}
 
 /// Convenience macro to create DMA buffers and descriptors
 ///


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
If you need to DMA to/from PSRAM the descriptor buffer size (CHUNK_SIZE) needs to be a multiple of the cache block size. The default value 4092 is 4 byte aligned and not 32 (a common cache block size) or 64 (an allowable cache size). This PR adds features that change the default CHUNK_SIZE to 4064 (32 byte multiple) or 4032 (64 byte multiple).

- dma4064
- dma4032

I'm not sure that this is the best approach, it is the easiest.  An alternative would be to make the `DmaDescriptor` or a `DmaDescriptorList`  be  CHUNK_SIZE aware.

#### Testing
DMA from PSRAM to hub75 panel via LCD peripheral in i8080 mode.