### PR TITLE
esp-wifi/ble/npl: increase event queue size

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Increased NPL event queue size to prevent overflow (#1891)
+
 ### Removed
 
 ## 0.7.1 - 2024-07-17

--- a/esp-wifi/src/ble/npl.rs
+++ b/esp-wifi/src/ble/npl.rs
@@ -61,7 +61,7 @@ struct Event {
 
 static mut EVENTS: [Option<Event>; 95] = [None; 95];
 
-static mut EVENT_QUEUE: SimpleQueue<usize, 10> = SimpleQueue::new();
+static mut EVENT_QUEUE: SimpleQueue<usize, 16> = SimpleQueue::new();
 
 static BT_RECEIVE_QUEUE: Mutex<RefCell<SimpleQueue<ReceivedPacket, 10>>> =
     Mutex::new(RefCell::new(SimpleQueue::new()));


### PR DESCRIPTION

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

With my ESP32-C6 device, I saw the following panic when scanning was enabled and there were many BLE devices in vicinity:

    unwrap of `EVENT_QUEUE.enqueue((*event).dummy as usize)` failed: 14,

This occurs because the NPL event queue has overflowed. I increased the queue size from 10 to 16, and the panic went away. I also did some testing and discovered that there were at most 13 elements on the queue at any given time, so a queue size of 16 (which allows for 15 elements) should give us some margin. This also gives a slight overhead reduction as the heapless crate recommends the queue size to be a power of two.

#### Testing

Scanning no longer causes a panic.
