### PR TITLE
ci: Use stable channel for RISCV devices

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -55,7 +55,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           target: ${{ matrix.target.rust-target }}
-          toolchain: nightly
+          toolchain: stable
           components: rust-src
       # Install the Rust toolchain for Xtensa devices:
       - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.target.soc)
@@ -103,7 +103,7 @@ jobs:
           # RISC-V devices:
           - soc: esp32c2
             runner: esp32c2-jtag
-            usb: ACM0
+            usb: USB2
           - soc: esp32c3
             runner: esp32c3-usb
             usb: ACM0
@@ -112,7 +112,7 @@ jobs:
             usb: ACM0
           - soc: esp32h2
             runner: esp32h2-usb
-            usb: ACM0
+            usb: USB0
           # Xtensa devices:
           - soc: esp32s2
             runner: esp32s2-jtag


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Some targets were failing in the `ecc` test as, for some reason, it fails if you build it with nightly. Also fixed the serial port of some targets.

#### Testing
Manually triggered the HIL workflow with this branch: https://github.com/esp-rs/esp-hal/actions/runs/10200511269/job/28220450420