### PR TITLE
Deny Rust 2018 idioms in `esp-hal`

### DIFF
--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -406,7 +406,7 @@ pub mod dma {
             mode: Mode,
             cipher_mode: CipherMode,
             key: K,
-        ) -> Result<DmaTransferTxRx<Self>, crate::dma::DmaError>
+        ) -> Result<DmaTransferTxRx<'_, Self>, crate::dma::DmaError>
         where
             K: Into<Key>,
             TXBUF: ReadBuffer,

--- a/esp-hal/src/delay.rs
+++ b/esp-hal/src/delay.rs
@@ -87,7 +87,7 @@ mod implementation {
 
     impl Delay {
         /// Create a new `Delay` instance
-        pub fn new(clocks: &Clocks) -> Self {
+        pub fn new(clocks: &Clocks<'_>) -> Self {
             // The counters and comparators are driven using `XTAL_CLK`.
             // The average clock frequency is fXTAL_CLK/2.5, which is 16 MHz.
             // The timer counting is incremented by 1/16 μs on each `CNT_CLK` cycle.
@@ -134,7 +134,7 @@ mod implementation {
 
     impl Delay {
         /// Create a new `Delay` instance
-        pub fn new(clocks: &Clocks) -> Self {
+        pub fn new(clocks: &Clocks<'_>) -> Self {
             Self {
                 freq: clocks.cpu_clock.into(),
             }

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -749,7 +749,7 @@ mod m2m {
             &mut self,
             tx_buffer: &'t TXBUF,
             rx_buffer: &'t mut RXBUF,
-        ) -> Result<DmaTransferRx<Self>, DmaError>
+        ) -> Result<DmaTransferRx<'_, Self>, DmaError>
         where
             TXBUF: ReadBuffer,
             RXBUF: WriteBuffer,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -453,7 +453,7 @@ where
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
         frequency: HertzU32,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         timeout: Option<u32>,
     ) -> Self {
         crate::into_ref!(i2c, sda, scl);
@@ -529,7 +529,7 @@ where
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
         frequency: HertzU32,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Self {
         Self::new_with_timeout(i2c, sda, scl, frequency, clocks, None)
     }
@@ -542,7 +542,7 @@ where
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
         frequency: HertzU32,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         timeout: Option<u32>,
     ) -> Self {
         Self::new_internal(i2c, sda, scl, frequency, clocks, timeout)
@@ -573,7 +573,7 @@ where
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
         frequency: HertzU32,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Self {
         Self::new_with_timeout_async(i2c, sda, scl, frequency, clocks, None)
     }
@@ -586,7 +586,7 @@ where
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
         frequency: HertzU32,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         timeout: Option<u32>,
     ) -> Self {
         let mut this = Self::new_internal(i2c, sda, scl, frequency, clocks, timeout);
@@ -1153,7 +1153,7 @@ pub trait Instance: crate::private::Sealed {
 
     fn i2c_number(&self) -> usize;
 
-    fn setup(&mut self, frequency: HertzU32, clocks: &Clocks, timeout: Option<u32>) {
+    fn setup(&mut self, frequency: HertzU32, clocks: &Clocks<'_>, timeout: Option<u32>) {
         self.register_block().ctr().modify(|_, w| unsafe {
             // Clear register
             w.bits(0)
@@ -2426,8 +2426,8 @@ pub mod lp_i2c {
     impl LpI2c {
         pub fn new(
             i2c: LP_I2C0,
-            _sda: LowPowerOutputOpenDrain<6>,
-            _scl: LowPowerOutputOpenDrain<7>,
+            _sda: LowPowerOutputOpenDrain<'_, 6>,
+            _scl: LowPowerOutputOpenDrain<'_, 7>,
             frequency: HertzU32,
         ) -> Self {
             let me = Self { i2c };

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -251,7 +251,7 @@ where
     /// Write I2S.
     /// Returns [DmaTransferTx] which represents the in-progress DMA
     /// transfer
-    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<Self>, Error>
+    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<'_, Self>, Error>
     where
         TXBUF: ReadBuffer;
 
@@ -260,7 +260,7 @@ where
     fn write_dma_circular<'t>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTxCircular<Self>, Error>
+    ) -> Result<DmaTransferTxCircular<'_, Self>, Error>
     where
         TXBUF: ReadBuffer;
 }
@@ -281,7 +281,7 @@ where
     /// Read I2S.
     /// Returns [DmaTransferRx] which represents the in-progress DMA
     /// transfer
-    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<Self>, Error>
+    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<'_, Self>, Error>
     where
         RXBUF: WriteBuffer;
 
@@ -291,7 +291,7 @@ where
     fn read_dma_circular<'t>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircular<Self>, Error>
+    ) -> Result<DmaTransferRxCircular<'_, Self>, Error>
     where
         RXBUF: WriteBuffer;
 }
@@ -323,7 +323,7 @@ where
         mut channel: Channel<'d, CH, DmaMode>,
         tx_descriptors: &'static mut [DmaDescriptor],
         rx_descriptors: &'static mut [DmaDescriptor],
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Self {
         // on ESP32-C3 / ESP32-S3 and later RX and TX are independent and
         // could be configured totally independently but for now handle all
@@ -429,7 +429,7 @@ where
         channel: Channel<'d, CH, DmaMode>,
         tx_descriptors: &'static mut [DmaDescriptor],
         rx_descriptors: &'static mut [DmaDescriptor],
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Self
     where
         I: I2s0Instance,
@@ -460,7 +460,7 @@ where
         channel: Channel<'d, CH, DmaMode>,
         tx_descriptors: &'static mut [DmaDescriptor],
         rx_descriptors: &'static mut [DmaDescriptor],
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Self
     where
         I: I2s1Instance,
@@ -646,7 +646,7 @@ where
     CH: DmaChannel,
     DmaMode: Mode,
 {
-    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<Self>, Error>
+    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<'_, Self>, Error>
     where
         TXBUF: ReadBuffer,
     {
@@ -657,7 +657,7 @@ where
     fn write_dma_circular<'t>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTxCircular<Self>, Error>
+    ) -> Result<DmaTransferTxCircular<'_, Self>, Error>
     where
         TXBUF: ReadBuffer,
     {
@@ -827,7 +827,7 @@ where
     DmaMode: Mode,
     Self: DmaSupportRx + Sized,
 {
-    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<Self>, Error>
+    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<'_, Self>, Error>
     where
         RXBUF: WriteBuffer,
     {
@@ -838,7 +838,7 @@ where
     fn read_dma_circular<'t>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircular<Self>, Error>
+    ) -> Result<DmaTransferRxCircular<'_, Self>, Error>
     where
         RXBUF: WriteBuffer,
     {
@@ -2084,7 +2084,7 @@ mod private {
         sample_rate: impl Into<fugit::HertzU32>,
         channels: u8,
         data_bits: u8,
-        _clocks: &Clocks,
+        _clocks: &Clocks<'_>,
     ) -> I2sClockDividers {
         // this loosely corresponds to `i2s_std_calculate_clock` and
         // `i2s_ll_tx_set_mclk` in esp-idf

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -134,7 +134,7 @@ where
         descriptors: &'static mut [DmaDescriptor],
         _pins: P,
         frequency: HertzU32,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Self {
         let lcd_cam = cam.lcd_cam;
 
@@ -391,7 +391,7 @@ impl<'d, CH: DmaChannel> Camera<'d, CH> {
     pub fn read_dma<'t, RXBUF: WriteBuffer>(
         &'t mut self,
         buf: &'t mut RXBUF,
-    ) -> Result<DmaTransferRx<Self>, DmaError> {
+    ) -> Result<DmaTransferRx<'_, Self>, DmaError> {
         self.reset_unit_and_fifo();
         // Start DMA to receive incoming transfer.
         self.start_dma(false, buf)?;
@@ -403,7 +403,7 @@ impl<'d, CH: DmaChannel> Camera<'d, CH> {
     pub fn read_dma_circular<'t, RXBUF: WriteBuffer>(
         &'t mut self,
         buf: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircular<Self>, DmaError> {
+    ) -> Result<DmaTransferRxCircular<'_, Self>, DmaError> {
         self.reset_unit_and_fifo();
         // Start DMA to receive incoming transfer.
         self.start_dma(true, buf)?;

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -111,7 +111,7 @@ where
         mut pins: P,
         frequency: HertzU32,
         config: Config,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Self {
         let is_2byte_mode = size_of::<P::Word>() == 2;
 
@@ -355,7 +355,7 @@ where
         cmd: impl Into<Command<P::Word>>,
         dummy: u8,
         data: &'t TXBUF,
-    ) -> Result<DmaTransferTx<Self>, DmaError>
+    ) -> Result<DmaTransferTx<'_, Self>, DmaError>
     where
         TXBUF: ReadBuffer,
     {

--- a/esp-hal/src/ledc/mod.rs
+++ b/esp-hal/src/ledc/mod.rs
@@ -111,7 +111,7 @@ impl<'d> Ledc<'d> {
     /// Return a new LEDC
     pub fn new(
         _instance: impl Peripheral<P = crate::peripherals::LEDC> + 'd,
-        clock_control_config: &'d Clocks,
+        clock_control_config: &'d Clocks<'d>,
     ) -> Self {
         crate::into_ref!(_instance);
         PeripheralClockControl::enable(PeripheralEnable::Ledc);
@@ -164,7 +164,7 @@ impl<'d> Ledc<'d> {
     }
 
     /// Return a new timer
-    pub fn get_timer<S: TimerSpeed>(&self, number: timer::Number) -> Timer<S> {
+    pub fn get_timer<S: TimerSpeed>(&self, number: timer::Number) -> Timer<'d, S> {
         Timer::new(self.ledc, self.clock_control_config, number)
     }
 
@@ -173,7 +173,7 @@ impl<'d> Ledc<'d> {
         &self,
         number: channel::Number,
         output_pin: impl Peripheral<P = O> + 'd,
-    ) -> Channel<S, O> {
+    ) -> Channel<'d, S, O> {
         Channel::new(number, output_pin)
     }
 }

--- a/esp-hal/src/ledc/timer.rs
+++ b/esp-hal/src/ledc/timer.rs
@@ -227,7 +227,7 @@ impl<'a, S: TimerSpeed> Timer<'a, S> {
     /// Create a new intance of a timer
     pub fn new(
         ledc: &'a ledc::RegisterBlock,
-        clock_control_config: &'a Clocks,
+        clock_control_config: &'a Clocks<'a>,
         number: Number,
     ) -> Self {
         Timer {

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -142,6 +142,7 @@
 #![allow(asm_sub_register)]
 #![cfg_attr(feature = "async", allow(stable_features, async_fn_in_trait))]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]
+#![deny(rust_2018_idioms)]
 #![no_std]
 
 // MUST be the first module

--- a/esp-hal/src/mcpwm/mod.rs
+++ b/esp-hal/src/mcpwm/mod.rs
@@ -128,7 +128,7 @@ impl<'d, PWM: PwmPeripheral> McPwm<'d, PWM> {
     // clocks.crypto_pwm_clock normally is 160 MHz
     pub fn new(
         peripheral: impl Peripheral<P = PWM> + 'd,
-        peripheral_clock: PeripheralClockConfig,
+        peripheral_clock: PeripheralClockConfig<'d>,
     ) -> Self {
         crate::into_ref!(peripheral);
 
@@ -201,7 +201,7 @@ impl<'a> PeripheralClockConfig<'a> {
     ///
     /// The peripheral clock frequency is calculated as:
     /// `peripheral_clock = input_clock / (prescaler + 1)`
-    pub fn with_prescaler(clocks: &'a Clocks, prescaler: u8) -> Self {
+    pub fn with_prescaler(clocks: &'a Clocks<'a>, prescaler: u8) -> Self {
         #[cfg(esp32)]
         let source_clock = clocks.pwm_clock;
         #[cfg(esp32c6)]
@@ -233,7 +233,7 @@ impl<'a> PeripheralClockConfig<'a> {
     /// `160 Mhz / 256`) are representable exactly. Other target frequencies
     /// will be rounded up to the next divisor.
     pub fn with_frequency(
-        clocks: &'a Clocks,
+        clocks: &'a Clocks<'a>,
         target_freq: HertzU32,
     ) -> Result<Self, FrequencyError> {
         #[cfg(esp32)]

--- a/esp-hal/src/mcpwm/timer.rs
+++ b/esp-hal/src/mcpwm/timer.rs
@@ -41,7 +41,7 @@ impl<const TIM: u8, PWM: PwmPeripheral> Timer<TIM, PWM> {
     ///
     /// The hardware supports writing these settings in sync with certain timer
     /// events but this HAL does not expose these for now.
-    pub fn start(&mut self, timer_config: TimerClockConfig) {
+    pub fn start(&mut self, timer_config: TimerClockConfig<'_>) {
         // write prescaler and period with immediate update method
         self.cfg0().write(|w| unsafe {
             w.prescale().bits(timer_config.prescaler);

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1122,7 +1122,7 @@ where
         tx_descriptors: &'static mut [DmaDescriptor],
         rx_descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
-        _clocks: &Clocks,
+        _clocks: &Clocks<'d>,
     ) -> Result<Self, Error> {
         internal_init(&mut dma_channel, frequency)?;
 
@@ -1215,7 +1215,7 @@ where
         mut dma_channel: Channel<'d, CH, DM>,
         descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
-        _clocks: &Clocks,
+        _clocks: &Clocks<'d>,
     ) -> Result<Self, Error> {
         internal_init(&mut dma_channel, frequency)?;
 
@@ -1303,7 +1303,7 @@ where
         mut dma_channel: Channel<'d, CH, DM>,
         descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
-        _clocks: &Clocks,
+        _clocks: &Clocks<'d>,
     ) -> Result<Self, Error> {
         internal_init(&mut dma_channel, frequency)?;
 
@@ -1430,7 +1430,7 @@ where
     pub fn write_dma<'t, TXBUF>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTx<Self>, Error>
+    ) -> Result<DmaTransferTx<'_, Self>, Error>
     where
         TXBUF: ReadBuffer,
     {
@@ -1526,7 +1526,7 @@ where
     pub fn read_dma<'t, RXBUF>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRx<Self>, Error>
+    ) -> Result<DmaTransferRx<'_, Self>, Error>
     where
         RXBUF: WriteBuffer,
     {

--- a/esp-hal/src/pcnt/unit.rs
+++ b/esp-hal/src/pcnt/unit.rs
@@ -263,7 +263,7 @@ impl<'d, const NUM: usize> Unit<'d, NUM> {
     }
 
     /// Disable interrupts for this unit.
-    pub fn unlisten(&self, _cs: CriticalSection) {
+    pub fn unlisten(&self, _cs: CriticalSection<'_>) {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         critical_section::with(|_cs| {
             pcnt.int_ena()

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -218,7 +218,7 @@ where
     pub(crate) fn new_internal(
         peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
         frequency: HertzU32,
-        _clocks: &Clocks,
+        _clocks: &Clocks<'d>,
     ) -> Result<Self, Error> {
         let me = Rmt::create(peripheral);
 
@@ -247,7 +247,7 @@ where
     }
 
     #[cfg(not(any(esp32, esp32s2)))]
-    fn configure_clock(&self, frequency: HertzU32, _clocks: &Clocks) -> Result<(), Error> {
+    fn configure_clock(&self, frequency: HertzU32, _clocks: &Clocks<'d>) -> Result<(), Error> {
         let src_clock = crate::soc::constants::RMT_CLOCK_SRC_FREQ;
 
         if frequency > src_clock {
@@ -271,7 +271,7 @@ impl<'d> Rmt<'d, crate::Blocking> {
     pub fn new(
         peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
         frequency: HertzU32,
-        _clocks: &Clocks,
+        _clocks: &Clocks<'d>,
     ) -> Result<Self, Error> {
         Self::new_internal(peripheral, frequency, _clocks)
     }
@@ -291,7 +291,7 @@ impl<'d> Rmt<'d, crate::Async> {
     pub fn new_async(
         peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
         frequency: HertzU32,
-        _clocks: &Clocks,
+        _clocks: &Clocks<'d>,
     ) -> Result<Self, Error> {
         let mut this = Self::new_internal(peripheral, frequency, _clocks)?;
         this.internal_set_interrupt_handler(asynch::async_interrupt_handler);
@@ -995,7 +995,7 @@ pub trait TxChannel: private::TxChannelInternal<crate::Blocking> {
     /// This returns a [`SingleShotTxTransaction`] which can be used to wait for
     /// the transaction to complete and get back the channel for further
     /// use.
-    fn transmit<T: Into<u32> + Copy>(self, data: &[T]) -> SingleShotTxTransaction<Self, T>
+    fn transmit<T: Into<u32> + Copy>(self, data: &[T]) -> SingleShotTxTransaction<'_, Self, T>
     where
         Self: Sized,
     {
@@ -1088,7 +1088,10 @@ pub trait RxChannel: private::RxChannelInternal<crate::Blocking> {
     /// This returns a [RxTransaction] which can be used to wait for receive to
     /// complete and get back the channel for further use.
     /// The length of the received data cannot exceed the allocated RMT RAM.
-    fn receive<T: From<u32> + Copy>(self, data: &mut [T]) -> Result<RxTransaction<Self, T>, Error>
+    fn receive<T: From<u32> + Copy>(
+        self,
+        data: &mut [T],
+    ) -> Result<RxTransaction<'_, Self, T>, Error>
     where
         Self: Sized,
     {

--- a/esp-hal/src/rsa/esp32.rs
+++ b/esp-hal/src/rsa/esp32.rs
@@ -101,7 +101,7 @@ where
         }
     }
 
-    fn set_mode(rsa: &mut Rsa<DM>) {
+    fn set_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_multi_mode((N / 16 - 1) as u32)
     }
 
@@ -165,7 +165,7 @@ where
         }
     }
 
-    pub(super) fn set_mode(rsa: &mut Rsa<DM>) {
+    pub(super) fn set_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_modexp_mode((N / 16 - 1) as u32)
     }
 
@@ -196,7 +196,7 @@ where
         self.set_start();
     }
 
-    pub(super) fn set_mode(rsa: &mut Rsa<DM>) {
+    pub(super) fn set_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_multi_mode(((N * 2) / 16 + 7) as u32)
     }
 

--- a/esp-hal/src/rsa/esp32cX.rs
+++ b/esp-hal/src/rsa/esp32cX.rs
@@ -255,7 +255,7 @@ where
         0
     }
 
-    pub(super) fn set_mode(rsa: &mut Rsa<DM>) {
+    pub(super) fn set_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_mode((N - 1) as u32)
     }
 
@@ -268,7 +268,7 @@ impl<'a, 'd, T: RsaMode, DM: crate::Mode, const N: usize> RsaModularMultiplicati
 where
     T: RsaMode<InputType = [u32; N]>,
 {
-    fn write_mode(rsa: &mut Rsa<DM>) {
+    fn write_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_mode((N - 1) as u32)
     }
 
@@ -335,7 +335,7 @@ where
         self.set_start();
     }
 
-    pub(super) fn set_mode(rsa: &mut Rsa<DM>) {
+    pub(super) fn set_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_mode((N * 2 - 1) as u32)
     }
 

--- a/esp-hal/src/rsa/esp32sX.rs
+++ b/esp-hal/src/rsa/esp32sX.rs
@@ -296,7 +296,7 @@ where
         0
     }
 
-    pub(super) fn set_mode(rsa: &mut Rsa<DM>) {
+    pub(super) fn set_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_mode((N - 1) as u32)
     }
 
@@ -333,7 +333,7 @@ where
         }
     }
 
-    fn write_mode(rsa: &mut Rsa<DM>) {
+    fn write_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_mode((N - 1) as u32)
     }
 
@@ -376,7 +376,7 @@ where
         self.set_start();
     }
 
-    pub(super) fn set_mode(rsa: &mut Rsa<DM>) {
+    pub(super) fn set_mode(rsa: &mut Rsa<'d, DM>) {
         rsa.write_mode((N * 2 - 1) as u32)
     }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32.rs
@@ -40,7 +40,12 @@ pub const RTC_CNTL_CK8M_WAIT_DEFAULT: u8 = 20;
 pub const RTC_CK8M_ENABLE_WAIT_DEFAULT: u8 = 5;
 
 impl WakeSource for TimerWakeupSource {
-    fn apply(&self, rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        _sleep_config: &mut RtcSleepConfig,
+    ) {
         triggers.set_timer(true);
         let rtc_cntl = unsafe { &*esp32::RTC_CNTL::ptr() };
         let clock_freq = RtcClock::get_slow_freq();
@@ -67,7 +72,12 @@ impl WakeSource for TimerWakeupSource {
 }
 
 impl<P: RtcPin> WakeSource for Ext0WakeupSource<'_, P> {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        sleep_config: &mut RtcSleepConfig,
+    ) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
         triggers.set_ext0(true);
@@ -104,7 +114,12 @@ impl<P: RtcPin> Drop for Ext0WakeupSource<'_, P> {
 }
 
 impl WakeSource for Ext1WakeupSource<'_, '_> {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        sleep_config: &mut RtcSleepConfig,
+    ) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
         triggers.set_ext1(true);
@@ -222,7 +237,7 @@ impl RtcSleepConfig {
         cfg
     }
 
-    pub(crate) fn base_settings(_rtc: &Rtc) {
+    pub(crate) fn base_settings(_rtc: &Rtc<'_>) {
         // settings derived from esp-idf after basic boot
         unsafe {
             let rtc_cntl = &*esp32::RTC_CNTL::ptr();

--- a/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
@@ -85,7 +85,12 @@ pub const SIG_GPIO_OUT_IDX: u32 = 128;
 pub const GPIO_NUM_MAX: usize = 22;
 
 impl WakeSource for TimerWakeupSource {
-    fn apply(&self, rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        _sleep_config: &mut RtcSleepConfig,
+    ) {
         triggers.set_timer(true);
         let rtc_cntl = unsafe { &*esp32c3::RTC_CNTL::ptr() };
         let clock_freq = RtcClock::get_slow_freq();
@@ -178,7 +183,12 @@ fn isolate_digital_gpio() {
 }
 
 impl WakeSource for RtcioWakeupSource<'_, '_> {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        sleep_config: &mut RtcSleepConfig,
+    ) {
         let mut pins = self.pins.borrow_mut();
 
         if pins.is_empty() {
@@ -486,7 +496,7 @@ impl RtcSleepConfig {
         cfg
     }
 
-    pub(crate) fn base_settings(_rtc: &Rtc) {
+    pub(crate) fn base_settings(_rtc: &Rtc<'_>) {
         let cfg = RtcConfig::default();
 
         // settings derived from esp_clk_init -> rtc_init

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -31,7 +31,12 @@ use crate::{
 };
 
 impl WakeSource for TimerWakeupSource {
-    fn apply(&self, rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        _sleep_config: &mut RtcSleepConfig,
+    ) {
         triggers.set_timer(true);
 
         let lp_timer = unsafe { &*esp32c6::LP_TIMER::ptr() };
@@ -91,7 +96,12 @@ impl Ext1WakeupSource<'_, '_> {
 }
 
 impl WakeSource for Ext1WakeupSource<'_, '_> {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        _sleep_config: &mut RtcSleepConfig,
+    ) {
         // We don't have to keep the LP domain powered if we hold the wakeup pin states.
         triggers.set_ext1(true);
 
@@ -140,7 +150,12 @@ impl Drop for Ext1WakeupSource<'_, '_> {
 }
 
 impl WakeSource for WakeFromLpCoreWakeupSource {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        _sleep_config: &mut RtcSleepConfig,
+    ) {
         triggers.set_lp_core(true);
     }
 }
@@ -823,7 +838,7 @@ impl RtcSleepConfig {
         }
     }
 
-    pub(crate) fn base_settings(_rtc: &Rtc) {
+    pub(crate) fn base_settings(_rtc: &Rtc<'_>) {
         Self::wake_io_reset();
     }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
@@ -80,7 +80,12 @@ pub const RTC_MEM_POWERUP_CYCLES: u8 = OTHER_BLOCKS_POWERUP;
 pub const RTC_MEM_WAIT_CYCLES: u16 = OTHER_BLOCKS_WAIT;
 
 impl WakeSource for TimerWakeupSource {
-    fn apply(&self, rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        _sleep_config: &mut RtcSleepConfig,
+    ) {
         triggers.set_timer(true);
         let rtc_cntl = unsafe { &*esp32s3::RTC_CNTL::ptr() };
         let clock_freq = RtcClock::get_slow_freq();
@@ -111,7 +116,12 @@ impl WakeSource for TimerWakeupSource {
 }
 
 impl<P: RtcPin> WakeSource for Ext0WakeupSource<'_, P> {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        sleep_config: &mut RtcSleepConfig,
+    ) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
         triggers.set_ext0(true);
@@ -148,7 +158,12 @@ impl<P: RtcPin> Drop for Ext0WakeupSource<'_, P> {
 }
 
 impl WakeSource for Ext1WakeupSource<'_, '_> {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        sleep_config: &mut RtcSleepConfig,
+    ) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
         triggers.set_ext1(true);
@@ -209,7 +224,12 @@ impl<'a, 'b> RtcioWakeupSource<'a, 'b> {
 }
 
 impl WakeSource for RtcioWakeupSource<'_, '_> {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        sleep_config: &mut RtcSleepConfig,
+    ) {
         let mut pins = self.pins.borrow_mut();
 
         if pins.is_empty() {
@@ -421,7 +441,7 @@ impl RtcSleepConfig {
         cfg
     }
 
-    pub(crate) fn base_settings(_rtc: &Rtc) {
+    pub(crate) fn base_settings(_rtc: &Rtc<'_>) {
         // settings derived from esp_clk_init -> rtc_init
         unsafe {
             let rtc_cntl = &*esp32s3::RTC_CNTL::ptr();

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -170,7 +170,12 @@ impl Default for GpioWakeupSource {
 }
 
 impl WakeSource for GpioWakeupSource {
-    fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+    fn apply(
+        &self,
+        _rtc: &Rtc<'_>,
+        triggers: &mut WakeTriggers,
+        _sleep_config: &mut RtcSleepConfig,
+    ) {
         triggers.set_gpio(true);
     }
 }
@@ -216,7 +221,7 @@ macro_rules! uart_wakeup_impl {
             }
 
             impl WakeSource for [< Uart $num WakeupSource >] {
-                fn apply(&self, _rtc: &Rtc, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
+                fn apply(&self, _rtc: &Rtc<'_>, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
                     triggers.[< set_uart $num >](true);
                     let uart = unsafe { crate::peripherals::[< UART $num >]::steal() };
 
@@ -302,5 +307,5 @@ bitfield::bitfield! {
 }
 
 pub trait WakeSource {
-    fn apply(&self, rtc: &Rtc, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig);
+    fn apply(&self, rtc: &Rtc<'_>, triggers: &mut WakeTriggers, sleep_config: &mut RtcSleepConfig);
 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -454,7 +454,7 @@ where
         spi: impl Peripheral<P = T> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Spi<'d, T, FullDuplexMode> {
         crate::into_ref!(spi);
         Self::new_internal(spi, frequency, mode, clocks)
@@ -542,7 +542,7 @@ where
         spi: PeripheralRef<'d, T>,
         frequency: HertzU32,
         mode: SpiMode,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Spi<'d, T, FullDuplexMode> {
         spi.enable_peripheral();
 
@@ -557,7 +557,7 @@ where
         spi
     }
 
-    pub fn change_bus_frequency(&mut self, frequency: HertzU32, clocks: &Clocks) {
+    pub fn change_bus_frequency(&mut self, frequency: HertzU32, clocks: &Clocks<'d>) {
         self.spi.ch_bus_freq(frequency, clocks);
     }
 }
@@ -574,7 +574,7 @@ where
         spi: impl Peripheral<P = T> + 'd,
         frequency: HertzU32,
         mode: SpiMode,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Spi<'d, T, HalfDuplexMode> {
         crate::into_ref!(spi);
         Self::new_internal(spi, frequency, mode, clocks)
@@ -719,7 +719,7 @@ where
         spi: PeripheralRef<'d, T>,
         frequency: HertzU32,
         mode: SpiMode,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Spi<'d, T, HalfDuplexMode> {
         spi.enable_peripheral();
 
@@ -734,7 +734,7 @@ where
         spi
     }
 
-    pub fn change_bus_frequency(&mut self, frequency: HertzU32, clocks: &Clocks) {
+    pub fn change_bus_frequency(&mut self, frequency: HertzU32, clocks: &Clocks<'d>) {
         self.spi.ch_bus_freq(frequency, clocks);
     }
 
@@ -1047,7 +1047,7 @@ pub mod dma {
         M: DuplexMode,
         DmaMode: Mode,
     {
-        pub fn change_bus_frequency(&mut self, frequency: HertzU32, clocks: &Clocks) {
+        pub fn change_bus_frequency(&mut self, frequency: HertzU32, clocks: &Clocks<'d>) {
             self.spi.ch_bus_freq(frequency, clocks);
         }
     }
@@ -1123,7 +1123,7 @@ pub mod dma {
         pub fn dma_write<'t, TXBUF>(
             &'t mut self,
             words: &'t TXBUF,
-        ) -> Result<DmaTransferTx<Self>, super::Error>
+        ) -> Result<DmaTransferTx<'_, Self>, super::Error>
         where
             TXBUF: ReadBuffer,
         {
@@ -1178,7 +1178,7 @@ pub mod dma {
         pub fn dma_read<'t, RXBUF>(
             &'t mut self,
             words: &'t mut RXBUF,
-        ) -> Result<DmaTransferRx<Self>, super::Error>
+        ) -> Result<DmaTransferRx<'_, Self>, super::Error>
         where
             RXBUF: WriteBuffer,
         {
@@ -1234,7 +1234,7 @@ pub mod dma {
             &'t mut self,
             words: &'t TXBUF,
             read_buffer: &'t mut RXBUF,
-        ) -> Result<DmaTransferTxRx<Self>, super::Error>
+        ) -> Result<DmaTransferTxRx<'_, Self>, super::Error>
         where
             TXBUF: ReadBuffer,
             RXBUF: WriteBuffer,
@@ -1310,7 +1310,7 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: &'t mut RXBUF,
-        ) -> Result<DmaTransferRx<Self>, super::Error>
+        ) -> Result<DmaTransferRx<'_, Self>, super::Error>
         where
             RXBUF: WriteBuffer,
         {
@@ -1389,7 +1389,7 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: &'t TXBUF,
-        ) -> Result<DmaTransferTx<Self>, super::Error>
+        ) -> Result<DmaTransferTx<'_, Self>, super::Error>
         where
             TXBUF: ReadBuffer,
         {
@@ -2554,7 +2554,7 @@ pub trait Instance: private::Sealed {
     }
 
     // taken from https://github.com/apache/incubator-nuttx/blob/8267a7618629838231256edfa666e44b5313348e/arch/risc-v/src/esp32c3/esp32c3_spi.c#L496
-    fn setup(&mut self, frequency: HertzU32, clocks: &Clocks) {
+    fn setup(&mut self, frequency: HertzU32, clocks: &Clocks<'_>) {
         #[cfg(not(esp32h2))]
         let apb_clk_freq: HertzU32 = HertzU32::Hz(clocks.apb_clock.to_Hz());
         // ESP32-H2 is using PLL_48M_CLK source instead of APB_CLK
@@ -2753,7 +2753,7 @@ pub trait Instance: private::Sealed {
         self
     }
 
-    fn ch_bus_freq(&mut self, frequency: HertzU32, clocks: &Clocks) {
+    fn ch_bus_freq(&mut self, frequency: HertzU32, clocks: &Clocks<'_>) {
         // Disable clock source
         #[cfg(not(any(esp32, esp32s2)))]
         self.register_block().clk_gate().modify(|_, w| {

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -344,7 +344,7 @@ pub mod dma {
         pub fn dma_write<'t, TXBUF>(
             &'t mut self,
             words: &'t TXBUF,
-        ) -> Result<DmaTransferTx<Self>, Error>
+        ) -> Result<DmaTransferTx<'_, Self>, Error>
         where
             TXBUF: ReadBuffer,
         {
@@ -370,7 +370,7 @@ pub mod dma {
         pub fn dma_read<'t, RXBUF>(
             &'t mut self,
             words: &'t mut RXBUF,
-        ) -> Result<DmaTransferRx<Self>, Error>
+        ) -> Result<DmaTransferRx<'_, Self>, Error>
         where
             RXBUF: WriteBuffer,
         {
@@ -398,7 +398,7 @@ pub mod dma {
             &'t mut self,
             words: &'t TXBUF,
             read_buffer: &'t mut RXBUF,
-        ) -> Result<DmaTransferTxRx<Self>, Error>
+        ) -> Result<DmaTransferTxRx<'_, Self>, Error>
         where
             TXBUF: ReadBuffer,
             RXBUF: WriteBuffer,

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -227,7 +227,7 @@ where
     T: TimerGroupInstance,
 {
     /// Construct a new instance of [`TimerGroup`] in blocking mode
-    pub fn new(_timer_group: impl Peripheral<P = T> + 'd, clocks: &Clocks) -> Self {
+    pub fn new(_timer_group: impl Peripheral<P = T> + 'd, clocks: &Clocks<'d>) -> Self {
         crate::into_ref!(_timer_group);
 
         T::configure_src_clk();
@@ -266,7 +266,7 @@ where
     T: TimerGroupInstance,
 {
     /// Construct a new instance of [`TimerGroup`] in asynchronous mode
-    pub fn new_async(_timer_group: impl Peripheral<P = T> + 'd, clocks: &Clocks) -> Self {
+    pub fn new_async(_timer_group: impl Peripheral<P = T> + 'd, clocks: &Clocks<'d>) -> Self {
         crate::into_ref!(_timer_group);
 
         T::configure_src_clk();

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -303,7 +303,7 @@ impl<'d> Touch<'d, Continous, Async> {
     /// ```
     pub fn async_mode(
         touch_peripheral: impl Peripheral<P = TOUCH> + 'd,
-        rtc: &mut Rtc,
+        rtc: &mut Rtc<'_>,
         config: Option<TouchConfig>,
     ) -> Self {
         crate::into_ref!(touch_peripheral);
@@ -371,7 +371,7 @@ impl<P: TouchPin, TOUCHMODE: TouchMode, MODE: Mode> TouchPad<P, TOUCHMODE, MODE>
     /// ## Parameters:
     /// - `pin`: The pin that gets configured as touch pad
     /// - `touch`: The [`Touch`] struct indicating that touch is configured.
-    pub fn new(pin: P, _touch: &Touch<TOUCHMODE, MODE>) -> Self {
+    pub fn new(pin: P, _touch: &Touch<'_, TOUCHMODE, MODE>) -> Self {
         // TODO revert this on drop
         pin.set_touch(Internal);
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -640,7 +640,7 @@ where
         _peripheral: impl Peripheral<P = T> + 'd,
         tx_pin: impl Peripheral<P = TX> + 'd,
         rx_pin: impl Peripheral<P = RX> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         baud_rate: BaudRate,
         no_transceiver: bool,
     ) -> Self {
@@ -674,7 +674,7 @@ where
     /// Set the bitrate of the bus.
     ///
     /// Note: The timings currently assume a APB_CLK of 80MHz.
-    fn set_baud_rate(&mut self, baud_rate: BaudRate, _clocks: &Clocks) {
+    fn set_baud_rate(&mut self, baud_rate: BaudRate, _clocks: &Clocks<'d>) {
         // TWAI is clocked from the APB_CLK according to Table 6-4 [ESP32C3 Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf)
         // Included timings are all for 80MHz so assert that we are running at 80MHz.
         #[cfg(not(esp32c6))]
@@ -781,7 +781,7 @@ where
         peripheral: impl Peripheral<P = T> + 'd,
         tx_pin: impl Peripheral<P = TX> + 'd,
         rx_pin: impl Peripheral<P = RX> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         baud_rate: BaudRate,
     ) -> Self {
         Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, false)
@@ -796,7 +796,7 @@ where
         peripheral: impl Peripheral<P = T> + 'd,
         tx_pin: impl Peripheral<P = TX> + 'd,
         rx_pin: impl Peripheral<P = RX> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         baud_rate: BaudRate,
     ) -> Self {
         Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, true)
@@ -826,7 +826,7 @@ where
         peripheral: impl Peripheral<P = T> + 'd,
         tx_pin: impl Peripheral<P = TX> + 'd,
         rx_pin: impl Peripheral<P = RX> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         baud_rate: BaudRate,
     ) -> Self {
         let mut this = Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, false);
@@ -843,7 +843,7 @@ where
         peripheral: impl Peripheral<P = T> + 'd,
         tx_pin: impl Peripheral<P = TX> + 'd,
         rx_pin: impl Peripheral<P = RX> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         baud_rate: BaudRate,
     ) -> Self {
         let mut this = Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, true);

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -464,7 +464,7 @@ where
     /// Create a new UART TX instance in [`Blocking`] mode.
     pub fn new<TX: OutputPin>(
         uart: impl Peripheral<P = T> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         tx: impl Peripheral<P = TX> + 'd,
     ) -> Result<Self, Error> {
         Self::new_with_config(uart, Default::default(), clocks, tx)
@@ -475,7 +475,7 @@ where
     pub fn new_with_config<TX: OutputPin>(
         uart: impl Peripheral<P = T> + 'd,
         config: Config,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         tx: impl Peripheral<P = TX> + 'd,
     ) -> Result<Self, Error> {
         crate::into_ref!(tx);
@@ -672,7 +672,7 @@ where
     /// Create a new UART RX instance in [`Blocking`] mode.
     pub fn new<RX: InputPin>(
         uart: impl Peripheral<P = T> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         rx: impl Peripheral<P = RX> + 'd,
     ) -> Result<Self, Error> {
         Self::new_with_config(uart, Default::default(), clocks, rx)
@@ -683,7 +683,7 @@ where
     pub fn new_with_config<RX: InputPin>(
         uart: impl Peripheral<P = T> + 'd,
         config: Config,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         rx: impl Peripheral<P = RX> + 'd,
     ) -> Result<Self, Error> {
         crate::into_ref!(rx);
@@ -706,7 +706,7 @@ where
     pub fn new_with_config<TX: OutputPin, RX: InputPin>(
         uart: impl Peripheral<P = T> + 'd,
         config: Config,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         tx: impl Peripheral<P = TX> + 'd,
         rx: impl Peripheral<P = RX> + 'd,
     ) -> Result<Self, Error> {
@@ -723,7 +723,7 @@ where
     /// Create a new UART instance with defaults in [`Blocking`] mode.
     pub fn new<TX: OutputPin, RX: InputPin>(
         uart: impl Peripheral<P = T> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         tx: impl Peripheral<P = TX> + 'd,
         rx: impl Peripheral<P = RX> + 'd,
     ) -> Result<Self, Error> {
@@ -741,7 +741,7 @@ where
     /// Verify that the default pins (DefaultTxPin and DefaultRxPin) are used.
     pub fn new_with_default_pins(
         uart: impl Peripheral<P = T> + 'd,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
         tx: &mut DefaultTxPin,
         rx: &mut DefaultRxPin,
     ) -> Result<Self, Error> {
@@ -762,7 +762,7 @@ where
     pub(crate) fn new_with_config_inner(
         _uart: impl Peripheral<P = T> + 'd,
         config: Config,
-        clocks: &Clocks,
+        clocks: &Clocks<'d>,
     ) -> Result<Self, Error> {
         Self::init();
 
@@ -810,7 +810,7 @@ where
         }
     }
 
-    fn new_inner(uart: impl Peripheral<P = T> + 'd, clocks: &Clocks) -> Result<Self, Error> {
+    fn new_inner(uart: impl Peripheral<P = T> + 'd, clocks: &Clocks<'d>) -> Result<Self, Error> {
         Self::new_with_config_inner(uart, Default::default(), clocks)
     }
 
@@ -1042,7 +1042,7 @@ where
     }
 
     #[cfg(any(esp32c2, esp32c3, esp32s3))]
-    fn change_baud_internal(&self, baudrate: u32, clock_source: ClockSource, clocks: &Clocks) {
+    fn change_baud_internal(&self, baudrate: u32, clock_source: ClockSource, clocks: &Clocks<'d>) {
         let clk = match clock_source {
             ClockSource::Apb => clocks.apb_clock.to_Hz(),
             ClockSource::Xtal => clocks.xtal_clock.to_Hz(),
@@ -1079,7 +1079,7 @@ where
     }
 
     #[cfg(any(esp32c6, esp32h2))]
-    fn change_baud_internal(&self, baudrate: u32, clock_source: ClockSource, clocks: &Clocks) {
+    fn change_baud_internal(&self, baudrate: u32, clock_source: ClockSource, clocks: &Clocks<'d>) {
         let clk = match clock_source {
             ClockSource::Apb => clocks.apb_clock.to_Hz(),
             ClockSource::Xtal => clocks.xtal_clock.to_Hz(),
@@ -1150,7 +1150,7 @@ where
     }
 
     #[cfg(any(esp32, esp32s2))]
-    fn change_baud_internal(&self, baudrate: u32, clock_source: ClockSource, clocks: &Clocks) {
+    fn change_baud_internal(&self, baudrate: u32, clock_source: ClockSource, clocks: &Clocks<'d>) {
         let clk = match clock_source {
             ClockSource::Apb => clocks.apb_clock.to_Hz(),
             ClockSource::RefTick => REF_TICK.to_Hz(), /* ESP32(/-S2) TRM, section 3.2.4.2
@@ -1189,7 +1189,7 @@ where
     }
 
     /// Modify UART baud rate and reset TX/RX fifo.
-    pub fn change_baud(&mut self, baudrate: u32, clock_source: ClockSource, clocks: &Clocks) {
+    pub fn change_baud(&mut self, baudrate: u32, clock_source: ClockSource, clocks: &Clocks<'d>) {
         self.change_baud_internal(baudrate, clock_source, clocks);
         self.txfifo_reset();
         self.rxfifo_reset();
@@ -2003,7 +2003,7 @@ mod asynch {
         pub fn new_async_with_config<TX: OutputPin, RX: InputPin>(
             uart: impl Peripheral<P = T> + 'd,
             config: Config,
-            clocks: &Clocks,
+            clocks: &Clocks<'d>,
             tx: impl Peripheral<P = TX> + 'd,
             rx: impl Peripheral<P = RX> + 'd,
         ) -> Result<Self, Error> {
@@ -2032,7 +2032,7 @@ mod asynch {
         /// Create a new UART instance with defaults in [`Async`] mode.
         pub fn new_async<TX: OutputPin, RX: InputPin>(
             uart: impl Peripheral<P = T> + 'd,
-            clocks: &Clocks,
+            clocks: &Clocks<'d>,
             tx: impl Peripheral<P = TX> + 'd,
             rx: impl Peripheral<P = RX> + 'd,
         ) -> Result<Self, Error> {
@@ -2042,7 +2042,7 @@ mod asynch {
         /// Create a new UART instance with defaults in [`Async`] mode.
         pub fn new_async_with_default_pins(
             uart: impl Peripheral<P = T> + 'd,
-            clocks: &Clocks,
+            clocks: &Clocks<'d>,
             tx: DefaultTxPin,
             rx: DefaultRxPin,
         ) -> Result<Self, Error> {
@@ -2075,7 +2075,7 @@ mod asynch {
         /// Create a new UART TX instance in [`Async`] mode.
         pub fn new_async<TX: OutputPin>(
             uart: impl Peripheral<P = T> + 'd,
-            clocks: &Clocks,
+            clocks: &Clocks<'d>,
             tx: impl Peripheral<P = TX> + 'd,
         ) -> Result<Self, Error> {
             Self::new_async_with_config(uart, Default::default(), clocks, tx)
@@ -2086,7 +2086,7 @@ mod asynch {
         pub fn new_async_with_config<TX: OutputPin>(
             uart: impl Peripheral<P = T> + 'd,
             config: Config,
-            clocks: &Clocks,
+            clocks: &Clocks<'d>,
             tx: impl Peripheral<P = TX> + 'd,
         ) -> Result<Self, Error> {
             crate::into_ref!(tx);
@@ -2151,7 +2151,7 @@ mod asynch {
         /// Create a new UART RX instance in [`Async`] mode.
         pub fn new_async<RX: InputPin>(
             uart: impl Peripheral<P = T> + 'd,
-            clocks: &Clocks,
+            clocks: &Clocks<'d>,
             rx: impl Peripheral<P = RX> + 'd,
         ) -> Result<Self, Error> {
             Self::new_async_with_config(uart, Default::default(), clocks, rx)
@@ -2162,7 +2162,7 @@ mod asynch {
         pub fn new_async_with_config<RX: InputPin>(
             uart: impl Peripheral<P = T> + 'd,
             config: Config,
-            clocks: &Clocks,
+            clocks: &Clocks<'d>,
             rx: impl Peripheral<P = RX> + 'd,
         ) -> Result<Self, Error> {
             crate::into_ref!(rx);
@@ -2387,7 +2387,7 @@ pub mod lp_uart {
     impl LpUart {
         /// Initialize the UART driver using the default configuration
         // TODO: CTS and RTS pins
-        pub fn new(uart: LP_UART, _tx: LowPowerOutput<5>, _rx: LowPowerInput<4>) -> Self {
+        pub fn new(uart: LP_UART, _tx: LowPowerOutput<'_, 5>, _rx: LowPowerInput<'_, 4>) -> Self {
             let lp_io = unsafe { &*crate::peripherals::LP_IO::PTR };
             let lp_aon = unsafe { &*crate::peripherals::LP_AON::PTR };
 


### PR DESCRIPTION
Just minor styling nitpicks, but I figure with Rust 2024 around the corner, we should at least keep up with Rust 2021 😁 