### PR TITLE
esp-storage: Fix incorrect usage of MaybeUninit

### DIFF
--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix incorrect usage of MaybeUninit (#1902)
+
 ### Removed
 
 ## 0.3.0 - 2023-08-16

--- a/esp-storage/src/buffer.rs
+++ b/esp-storage/src/buffer.rs
@@ -1,0 +1,61 @@
+use core::{mem::MaybeUninit, slice};
+
+#[cfg(feature = "nor-flash")]
+pub fn uninit_slice(bytes: &[u8]) -> &[MaybeUninit<u8>] {
+    unsafe { core::mem::transmute(bytes) }
+}
+
+#[cfg(feature = "nor-flash")]
+pub fn uninit_slice_mut(bytes: &mut [u8]) -> &mut [MaybeUninit<u8>] {
+    unsafe { core::mem::transmute(bytes) }
+}
+
+pub type FlashWordBuffer = FlashBuffer<4, 1>;
+pub type FlashSectorBuffer = FlashBuffer<4096, 1024>;
+
+#[repr(C)]
+pub union FlashBuffer<const N: usize, const M: usize> {
+    bytes: [MaybeUninit<u8>; M],
+    words: [MaybeUninit<u32>; N],
+}
+
+impl<const N: usize, const M: usize> FlashBuffer<N, M> {
+    pub const fn uninit() -> Self {
+        debug_assert!(N * 4 == M);
+        Self {
+            words: [MaybeUninit::uninit(); N],
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[MaybeUninit<u8>] {
+        unsafe { self.bytes.as_ref() }
+    }
+
+    pub fn as_bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        unsafe { self.bytes.as_mut() }
+    }
+
+    pub fn as_words(&self) -> &[MaybeUninit<u32>] {
+        unsafe { self.words.as_ref() }
+    }
+
+    pub fn as_words_mut(&mut self) -> &mut [MaybeUninit<u32>] {
+        unsafe { self.words.as_mut() }
+    }
+
+    pub unsafe fn assume_init_bytes(&self) -> &[u8] {
+        slice::from_raw_parts(self.bytes.as_ptr() as *const u8, self.bytes.len())
+    }
+
+    pub unsafe fn assume_init_bytes_mut(&mut self) -> &mut [u8] {
+        slice::from_raw_parts_mut(self.bytes.as_mut_ptr() as *mut u8, self.bytes.len())
+    }
+
+    pub unsafe fn assume_init_words(&self) -> &[u32] {
+        slice::from_raw_parts(self.words.as_ptr() as *const u32, self.words.len())
+    }
+
+    pub unsafe fn assume_init_words_mut(&mut self) -> &mut [u32] {
+        slice::from_raw_parts_mut(self.words.as_mut_ptr() as *mut u32, self.words.len())
+    }
+}

--- a/esp-storage/src/buffer.rs
+++ b/esp-storage/src/buffer.rs
@@ -15,15 +15,15 @@ pub type FlashSectorBuffer = FlashBuffer<4096, 1024>;
 
 #[repr(C)]
 pub union FlashBuffer<const N: usize, const M: usize> {
-    bytes: [MaybeUninit<u8>; M],
-    words: [MaybeUninit<u32>; N],
+    bytes: [MaybeUninit<u8>; N],
+    words: [MaybeUninit<u32>; M],
 }
 
 impl<const N: usize, const M: usize> FlashBuffer<N, M> {
     pub const fn uninit() -> Self {
-        debug_assert!(N * 4 == M);
+        assert!(N == M * 4);
         Self {
-            words: [MaybeUninit::uninit(); N],
+            words: [MaybeUninit::uninit(); M],
         }
     }
 

--- a/esp-storage/src/buffer.rs
+++ b/esp-storage/src/buffer.rs
@@ -20,8 +20,12 @@ pub union FlashBuffer<const N: usize, const M: usize> {
 }
 
 impl<const N: usize, const M: usize> FlashBuffer<N, M> {
-    pub const fn uninit() -> Self {
+    const _CHECK: () = {
         assert!(N == M * 4);
+    };
+
+    pub const fn uninit() -> Self {
+        let _ = Self::_CHECK;
         Self {
             words: [MaybeUninit::uninit(); M],
         }

--- a/esp-storage/src/esp32.rs
+++ b/esp-storage/src/esp32.rs
@@ -117,11 +117,11 @@ pub struct EspRomSpiflashChipT {
 
 #[inline(never)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
     maybe_with_critical_section(|| {
         spiflash_wait_for_ready();
         unsafe {
-            let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+            let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *mut u32, u32) -> i32 =
                 core::mem::transmute(ESP_ROM_SPIFLASH_READ);
             esp_rom_spiflash_read(src_addr, data, len)
         }

--- a/esp-storage/src/esp32c2.rs
+++ b/esp-storage/src/esp32c2.rs
@@ -5,9 +5,9 @@ const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000140;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000130;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000138;
 
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *mut u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
     })

--- a/esp-storage/src/esp32c3.rs
+++ b/esp-storage/src/esp32c3.rs
@@ -5,9 +5,9 @@ const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000140;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000128;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x4000012c;
 
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *mut u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
     })

--- a/esp-storage/src/esp32c6.rs
+++ b/esp-storage/src/esp32c6.rs
@@ -5,9 +5,9 @@ const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000154;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000144;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x4000014c;
 
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *mut u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
     })

--- a/esp-storage/src/esp32h2.rs
+++ b/esp-storage/src/esp32h2.rs
@@ -5,9 +5,9 @@ const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000130;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000120;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000128;
 
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *mut u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
     })

--- a/esp-storage/src/esp32s2.rs
+++ b/esp-storage/src/esp32s2.rs
@@ -5,9 +5,9 @@ const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40016e88;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x4001716c;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x400171cc;
 
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *mut u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
     })

--- a/esp-storage/src/esp32s3.rs
+++ b/esp-storage/src/esp32s3.rs
@@ -7,9 +7,9 @@ const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000a14;
 
 #[inline(always)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *mut u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
     })

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -30,7 +30,7 @@ mod chip_specific;
 mod common;
 
 #[cfg(any(feature = "storage", feature = "nor-flash"))]
-use common::FlashSectorBuffer;
+mod buffer;
 #[cfg(any(feature = "storage", feature = "nor-flash"))]
 pub use common::{FlashStorage, FlashStorageError};
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
I found incorrect usage of `MaybeUninit` while browsing the source that might cause UB. Specifically, calling `assume_init_mut` on a `MaybeUninit` that has not been initialized [ref](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.assume_init_mut). 

#### Testing
WIP
