### PR TITLE
Add dynamic output gpio example to demonstrate how to use AnyPin and Flex

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the dynamic_output_gpio example
 - Added new `Io::new_no_bind_interrupt` constructor (#1861)
 
 ### Changed

--- a/examples/src/bin/dynamic_output_gpio.rs
+++ b/examples/src/bin/dynamic_output_gpio.rs
@@ -10,18 +10,17 @@
 #![no_std]
 #![no_main]
 
+use core::primitive::u32;
+
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,
-    gpio::Io,
+    gpio::{any_pin::AnyPin, Flex, Io},
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    gpio::any_pin::AnyPin,
-    gpio::Flex,
 };
-use core::primitive::u32;
 
 pub struct FlexIo<'a> {
     pub gpio0: Flex<'a, AnyPin<'a>>,
@@ -55,9 +54,9 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
     let delay = Delay::new(&clocks);
-    
+
     let mut flexIo = FlexIo::new(io);
-    // You can also use set_as_input() to use those GPIOs easily as input too 
+    // You can also use set_as_input() to use those GPIOs easily as input too
     flexIo.gpio0.set_as_output();
     flexIo.gpio1.set_as_output();
     flexIo.gpio2.set_as_output();

--- a/examples/src/bin/dynamic_output_gpio.rs
+++ b/examples/src/bin/dynamic_output_gpio.rs
@@ -10,8 +10,6 @@
 #![no_std]
 #![no_main]
 
-use core::primitive::u32;
-
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,

--- a/examples/src/bin/dynamic_output_gpio.rs
+++ b/examples/src/bin/dynamic_output_gpio.rs
@@ -1,0 +1,71 @@
+//! Iterates over an array of LEDs, demonstrating how to use AnyPin and FlexPins to drive GPIOs.
+//!
+//! The following wiring is assumed:
+//! - LED => GPIO0
+//! - LED => GPIO1
+//! - LED => GPIO2
+
+//% CHIPS: esp32c6
+
+#![no_std]
+#![no_main]
+
+use esp_backtrace as _;
+use esp_hal::{
+    clock::ClockControl,
+    delay::Delay,
+    gpio::Io,
+    peripherals::Peripherals,
+    prelude::*,
+    system::SystemControl,
+    gpio::any_pin::AnyPin,
+    gpio::Flex,
+};
+use core::primitive::u32;
+
+pub struct FlexIo<'a> {
+    pub gpio0: Flex<'a, AnyPin<'a>>,
+    pub gpio1: Flex<'a, AnyPin<'a>>,
+    pub gpio2: Flex<'a, AnyPin<'a>>,
+}
+
+impl<'a> FlexIo<'a> {
+    pub fn new(io: Io) -> Self {
+        FlexIo {
+            gpio0: Flex::new(AnyPin::new(io.pins.gpio0)),
+            gpio1: Flex::new(AnyPin::new(io.pins.gpio1)),
+            gpio2: Flex::new(AnyPin::new(io.pins.gpio2)),
+        }
+    }
+    pub fn get_pin(&mut self, index: u32) -> &mut Flex<'a, AnyPin<'a>> {
+        match index {
+            0 => &mut self.gpio0,
+            1 => &mut self.gpio1,
+            2 => &mut self.gpio2,
+            _ => panic!("No such pin"),
+        }
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let system = SystemControl::new(peripherals.SYSTEM);
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let delay = Delay::new(&clocks);
+    
+    let mut flexIo = FlexIo::new(io);
+    // You can also use set_as_input() to use those GPIOs easily as input too 
+    flexIo.gpio0.set_as_output();
+    flexIo.gpio1.set_as_output();
+    flexIo.gpio2.set_as_output();
+
+    loop {
+        for n in 0..3 {
+            flexIo.get_pin(n).toggle();
+            delay.delay_millis(250);
+        }
+    }
+}

--- a/examples/src/bin/dynamic_output_gpio.rs
+++ b/examples/src/bin/dynamic_output_gpio.rs
@@ -1,4 +1,4 @@
-//! Iterates over an array of LEDs, demonstrating how to use AnyPin and FlexPins to drive GPIOs.
+//! Iterates over an array of LEDs, demonstrating how to use AnyPin and Flex to drive GPIOs.
 //!
 //! The following wiring is assumed:
 //! - LED => GPIO0


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
I added an example which shows how to use the AnyPin and Flex, because it took me too much time to figure out myself and I don't want for anyone else to waste time on this.

#### Testing
Measured the GPIOs states on the ESP32-C6-DevKitM-1 using an oscilloscope. 
