### PR TITLE
TWAI: GPIO pins are not configured as input and output

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix I2S async-tx (#1833)
 - Fix PARL_IO async-rx (#1851)
 - SPI: Clear DMA interrupts before (not after) DMA starts (#1859)
+- TWAI: GPIO pins are not configured as input and output (#1906)
 
 ### Removed
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Fixes #1895, this should also fix the same problem for other chips (ESP32/C3/etc).
Also updated the initialization procedure to closely follow the IDF version.

#### Testing

Run the TWAI example with a live CAN bus.
