### PR TITLE
Update channels being used in CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
   esp-hal:
     name: esp-hal (${{ matrix.device.soc }})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.device.toolchain == 'nightly' }}
     env:
       SSID: SSID
       PASSWORD: PASSWORD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           target: ${{ matrix.target.rust-target }}
-          toolchain: nightly
+          toolchain: stable
           components: rust-src
       # Install the Rust toolchain for Xtensa devices:
       - if: contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.target.soc)

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -128,7 +128,6 @@ pub fn build_documentation(
 
     // Build up an array of command-line arguments to pass to `cargo`:
     let builder = CargoArgsBuilder::default()
-        .toolchain(if chip.is_xtensa() { "esp" } else { "nightly" })
         .subcommand("doc")
         .target(target)
         .features(&features)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Today, several jobs failed with the same nightly error:
- https://github.com/esp-rs/esp-hal/actions/runs/10297472494/job/28500673750
- https://github.com/esp-rs/no_std-training/actions/runs/10298194840/job/28502829419
- https://github.com/esp-rs/esp-idf-template/actions/runs/10298128530/job/28502620377

I noticed that the `ci/hil` job still uses `nightly` and the for the documentation check, we also use `nigthly` for RISC-V devices. I changed it to `esp` in the CI workflow (it still uses `nightly` in the nightly CI)

Also removed one line that forgot to delete in https://github.com/esp-rs/esp-hal/pull/1896
#### Testing
CI Run: https://github.com/SergioGasquez/esp-hal/actions/runs/10298028653