### PR TITLE
Make `C6` ADC calibration work properly again

### DIFF
--- a/examples/src/bin/adc_cal.rs
+++ b/examples/src/bin/adc_cal.rs
@@ -44,10 +44,10 @@ fn main() -> ! {
     // them. Note that only AdcCalLine returns readings in mV; the other two
     // return raw readings in some unspecified scale.
     //
-    //type AdcCal = ();
+    // type AdcCal = ();
     type AdcCal = esp_hal::analog::adc::AdcCalBasic<esp_hal::peripherals::ADC1>;
-    // type AdcCal = esp_hal::analog::adc::AdcCalLine<ADC1>;
-    // type AdcCal = esp_hal::analog::adc::AdcCalCurve<ADC1>;
+    // type AdcCal = esp_hal::analog::adc::AdcCalLine<esp_hal::peripherals::ADC1>;
+    // type AdcCal = esp_hal::analog::adc::AdcCalCurve<esp_hal::peripherals::ADC1>;
 
     let mut adc1_config = AdcConfig::new();
     let mut adc1_pin =


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
After bisecting, I managed to determine which change made calibration work incorrectly and fixed it. All the job was done in order to close https://github.com/esp-rs/esp-hal/issues/1796

IMPORTANT: For some reason, on devkit versions `v1.0` and `v1.1` (not the chip revision, devkit (!!!!)) after calibration, the peripheral still gives very strange values. At this point, it was decided not to invest even more time in trying to find the problem on an irrelevant devkit version than I already have. In case of emergency, I will of course try to dig deeper and find the cause, but for now I decided to fix the calibration at least for the current and most popular version of the devkit.

#### Testing
Tested on `adc_cal` example
