### PR TITLE
Update probe-rs version

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -122,6 +122,13 @@ jobs:
             usb: USB0
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch'
+      - uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.branch }}
+
       - uses: actions/download-artifact@v4
         with:
           name: tests-${{ matrix.target.soc }}

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -21,7 +21,7 @@ We use [probe-rs] for flashing and running the tests on a target device, however
 ```text
 cargo install probe-rs-tools \
   --git https://github.com/probe-rs/probe-rs \
-  --rev a6dd038 --force --locked
+  --rev bba1bb5 --force --locked
 ```
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
@@ -108,7 +108,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-t
 # Install dependencies
 sudo apt install -y pkg-config libudev-dev
 # Install probe-rs
-cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev a6dd038 --force
+cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev bba1bb5 --force
 # Add the udev rules
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -242,19 +242,8 @@ pub fn execute_app(
 
     // probe-rs cannot currently do auto detection, so we need to tell probe-rs run
     // which chip we are testing
-    if subcommand == "test" {
-        if chip == Chip::Esp32 {
-            builder = builder.arg("--").arg("--chip").arg("esp32-3.3v");
-        } else if chip == Chip::Esp32c2 {
-            builder = builder
-                .arg("--")
-                .arg("--chip")
-                .arg("esp32c2")
-                .arg("--speed")
-                .arg("15000");
-        } else {
-            builder = builder.arg("--").arg("--chip").arg(format!("{}", chip));
-        }
+    if subcommand == "test" && chip == Chip::Esp32c2 {
+        builder = builder.arg("--").arg("--speed").arg("15000");
     }
 
     // If targeting an Xtensa device, we must use the '+esp' toolchain modifier:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -676,29 +676,15 @@ fn run_elfs(args: RunElfArgs) -> Result<()> {
 
         log::info!("Running test '{}' for '{}'", elf_name, args.chip);
 
-        let command = if args.chip == Chip::Esp32 {
+        let command = if args.chip == Chip::Esp32c2 {
             Command::new("probe-rs")
                 .arg("run")
-                .arg("--chip")
-                .arg("esp32-3.3v")
-                .arg(elf_path)
-                .output()?
-        } else if args.chip == Chip::Esp32c2 {
-            Command::new("probe-rs")
-                .arg("run")
-                .arg("--chip")
-                .arg(args.chip.to_string())
                 .arg("--speed")
                 .arg("15000")
                 .arg(elf_path)
                 .output()?
         } else {
-            Command::new("probe-rs")
-                .arg("run")
-                .arg("--chip")
-                .arg(args.chip.to_string())
-                .arg(elf_path)
-                .output()?
+            Command::new("probe-rs").arg("run").arg(elf_path).output()?
         };
 
         println!(


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Update `probe-rs` version to current `main` (`bba1bb5`). There are a few PRs related to ESP32s, but since I'll be away for the next weeks, I'd rather test the new probe-rs version a few days while Im still around.

With the new probe-rs version, the noisy RTT errors are no longer present and we dont need the `--chip` argument.
#### Testing
HIL workflow runs: 
- https://github.com/esp-rs/esp-hal/actions/runs/10316550120/job/28559198329
- https://github.com/esp-rs/esp-hal/actions/runs/10317046082