### PR TITLE
gpio: Make AnyPin and AnyInputOnlyPin available from gpio module

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SHA driver now use specific structs for the hashing algorithm instead of a parameter. (#1908)
 - Remove `fn free(self)` in HMAC which goes against esp-hal API guidelines (#1972)
 - PARL_IO use ReadBuffer and WriteBuffer for Async DMA (#1996)
+- `AnyPin`, `AnyInputOnyPin` and `DummyPin` are now accessible from `gpio` module (#1918)
 
 ### Fixed
 

--- a/esp-hal/src/gpio/any_pin.rs
+++ b/esp-hal/src/gpio/any_pin.rs
@@ -1,9 +1,3 @@
-//! Type-erased wrappers for GPIO pins.
-//! These are useful to pass them into peripheral drivers.
-//!
-//! If you want a generic pin for GPIO input/output look into
-//! [Output],[OutputOpenDrain], [Input] and [Flex].
-
 use super::*;
 
 #[derive(Clone, Copy)]

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -21,10 +21,10 @@
 //! - [Input] pins can be used as digital inputs.
 //! - [Output] and [OutputOpenDrain] pins can be used as digital outputs.
 //! - [Flex] pin is a pin that can be used as an input and output pin.
-//! - [any_pin::AnyPin] pin is type-erased that can be used for peripherals
-//!   signals.
-//!    - It supports inverting the pin, so the peripheral signal can be
-//!      inverted.
+//! - [AnyPin] and [AnyInputOnlyPin] are type-erased GPIO pins with support for
+//!   inverted signalling.
+//! - [DummyPin] is a useful for cases where peripheral driver requires a pin,
+//!   but real pin cannot be used.
 //!
 //! ## Examples
 //! ### Set up a GPIO as an Output
@@ -67,8 +67,11 @@ use crate::{
 #[cfg(touch)]
 pub(crate) use crate::{touch_common, touch_into};
 
-pub mod any_pin;
-pub mod dummy_pin;
+mod any_pin;
+mod dummy_pin;
+
+pub use any_pin::{AnyInputOnlyPin, AnyPin};
+pub use dummy_pin::DummyPin;
 
 #[cfg(soc_etm)]
 pub mod etm;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -90,7 +90,7 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::uart::{config::Config, Uart};
-//! use esp_hal::gpio::{Io, any_pin::AnyPin};
+//! use esp_hal::gpio::{AnyPin, Io};
 //! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 //!
 //! let tx = AnyPin::new_inverted(io.pins.gpio1);
@@ -103,7 +103,7 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::uart::{config::Config, UartTx, UartRx};
-//! use esp_hal::gpio::{Io, any_pin::AnyPin};
+//! use esp_hal::gpio::{AnyPin, Io};
 //! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 //!
 //! let tx = UartTx::new(peripherals.UART0, &clocks,

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -22,7 +22,7 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,
-    gpio::{any_pin::AnyPin, Io},
+    gpio::{AnyPin, Io},
     peripherals::Peripherals,
     prelude::*,
     spi::{master::Spi, SpiMode},

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -16,7 +16,7 @@ use critical_section::Mutex;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,
-    gpio::{any_pin::AnyPin, Gpio2, Gpio3, GpioPin, Input, Io, Level, Output, Pull},
+    gpio::{AnyPin, Gpio2, Gpio3, GpioPin, Input, Io, Level, Output, Pull},
     macros::handler,
     peripherals::Peripherals,
     system::SystemControl,

--- a/hil-test/tests/lcd_cam_i8080.rs
+++ b/hil-test/tests/lcd_cam_i8080.rs
@@ -9,7 +9,7 @@ use esp_hal::{
     clock::{ClockControl, Clocks},
     dma::{Dma, DmaDescriptor, DmaPriority},
     dma_buffers,
-    gpio::dummy_pin::DummyPin,
+    gpio::DummyPin,
     lcd_cam::{
         lcd::{
             i8080,

--- a/hil-test/tests/lcd_cam_i8080_async.rs
+++ b/hil-test/tests/lcd_cam_i8080_async.rs
@@ -10,7 +10,7 @@ use esp_hal::{
     clock::{ClockControl, Clocks},
     dma::{Dma, DmaDescriptor, DmaPriority},
     dma_buffers,
-    gpio::dummy_pin::DummyPin,
+    gpio::DummyPin,
     lcd_cam::{
         lcd::{
             i8080,


### PR DESCRIPTION
We can now use `use esp32::gpio::AnyPin` as it is done on embassy nrf and stm32. Supplement for #1917 

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.
