### PR TITLE
DMA: Don't require implementors of Read/WriteBuffer to be Sealed

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Peripheral driver constructors don't take `InterruptHandler`s anymore. Use `set_interrupt_handler` to explicitly set the interrupt handler now. (#1819)
 - Use the peripheral ref pattern for `OneShotTimer` and `PeriodicTimer` (#1855)
-
+- DMA: don't require `Sealed` to implement `ReadBuffer` and `WriteBuffer` (#1921)
 - Allow DMA to/from psram for esp32s3 (#1827)
 - DMA buffers now don't require a static lifetime. Make sure to never `mem::forget` an in-progress DMA transfer (consider using `#[deny(clippy::mem_forget)]`) (#1837)
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -79,7 +79,13 @@ impl<W> crate::private::Sealed for &[W] where W: Word {}
 impl<W> crate::private::Sealed for &mut [W] where W: Word {}
 
 /// Trait for buffers that can be given to DMA for reading.
-pub trait ReadBuffer {
+///
+/// # Safety
+///
+/// Once the `read_buffer` method has been called, it is unsafe to call any
+/// `&mut self` methods on this object as long as the returned value is in use
+/// (by DMA).
+pub unsafe trait ReadBuffer {
     /// Provide a buffer usable for DMA reads.
     ///
     /// The return value is:
@@ -94,7 +100,7 @@ pub trait ReadBuffer {
     unsafe fn read_buffer(&self) -> (*const u8, usize);
 }
 
-impl<W, const S: usize> ReadBuffer for [W; S]
+unsafe impl<W, const S: usize> ReadBuffer for [W; S]
 where
     W: Word,
 {
@@ -103,7 +109,7 @@ where
     }
 }
 
-impl<W, const S: usize> ReadBuffer for &[W; S]
+unsafe impl<W, const S: usize> ReadBuffer for &[W; S]
 where
     W: Word,
 {
@@ -112,7 +118,7 @@ where
     }
 }
 
-impl<W, const S: usize> ReadBuffer for &mut [W; S]
+unsafe impl<W, const S: usize> ReadBuffer for &mut [W; S]
 where
     W: Word,
 {
@@ -121,7 +127,7 @@ where
     }
 }
 
-impl<W> ReadBuffer for &[W]
+unsafe impl<W> ReadBuffer for &[W]
 where
     W: Word,
 {
@@ -130,7 +136,7 @@ where
     }
 }
 
-impl<W> ReadBuffer for &mut [W]
+unsafe impl<W> ReadBuffer for &mut [W]
 where
     W: Word,
 {
@@ -140,7 +146,13 @@ where
 }
 
 /// Trait for buffers that can be given to DMA for writing.
-pub trait WriteBuffer {
+///
+/// # Safety
+///
+/// Once the `write_buffer` method has been called, it is unsafe to call any
+/// `&mut self` methods, except for `write_buffer`, on this object as long as
+/// the returned value is in use (by DMA).
+pub unsafe trait WriteBuffer {
     /// Provide a buffer usable for DMA writes.
     ///
     /// The return value is:
@@ -156,7 +168,7 @@ pub trait WriteBuffer {
     unsafe fn write_buffer(&mut self) -> (*mut u8, usize);
 }
 
-impl<W, const S: usize> WriteBuffer for [W; S]
+unsafe impl<W, const S: usize> WriteBuffer for [W; S]
 where
     W: Word,
 {
@@ -165,7 +177,7 @@ where
     }
 }
 
-impl<W, const S: usize> WriteBuffer for &mut [W; S]
+unsafe impl<W, const S: usize> WriteBuffer for &mut [W; S]
 where
     W: Word,
 {
@@ -174,7 +186,7 @@ where
     }
 }
 
-impl<W> WriteBuffer for &mut [W]
+unsafe impl<W> WriteBuffer for &mut [W]
 where
     W: Word,
 {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -79,7 +79,7 @@ impl<W> crate::private::Sealed for &[W] where W: Word {}
 impl<W> crate::private::Sealed for &mut [W] where W: Word {}
 
 /// Trait for buffers that can be given to DMA for reading.
-pub trait ReadBuffer: crate::private::Sealed {
+pub trait ReadBuffer {
     /// Provide a buffer usable for DMA reads.
     ///
     /// The return value is:
@@ -140,7 +140,7 @@ where
 }
 
 /// Trait for buffers that can be given to DMA for writing.
-pub trait WriteBuffer: crate::private::Sealed {
+pub trait WriteBuffer {
     /// Provide a buffer usable for DMA writes.
     ///
     /// The return value is:


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR remove the `Sealed` requirement from `dma::ReadBuffer` and `dma::WriteBuffer`.

By having `dma::ReadBuffer` and `dma::WriteBuffer` require implementations to be Sealed prevents users of `esp-hal` from implementing them.

For instance I've implemented `embedded-graphics` traits on a DMA buffer that will render to a HUB75 display in [BCM](https://www.batsocks.co.uk/readme/art_bcm_5.htm) but I'm required to transmute it to pass it to dma because I can't implement `dma::ReadBuffer`.

#### Testing
- local hub75 project (esp32s3)
