### PR TITLE
Additional fixes for array access panics in esp-ieee802154

### DIFF
--- a/esp-ieee802154/CHANGELOG.md
+++ b/esp-ieee802154/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added additional checks to prevent various array access panics while processing frames
 - Added range check to avoid panic when indexing into RX_BUFFER slice
 
 ### Changed

--- a/esp-ieee802154/src/frame.rs
+++ b/esp-ieee802154/src/frame.rs
@@ -37,9 +37,15 @@ pub struct ReceivedFrame {
 }
 
 pub(crate) fn frame_is_ack_required(frame: &[u8]) -> bool {
+    if frame.len() <= FRAME_AR_OFFSET {
+        return false;
+    }
     (frame[FRAME_AR_OFFSET] & FRAME_AR_BIT) != 0
 }
 
 pub(crate) fn frame_get_version(frame: &[u8]) -> u8 {
+    if frame.len() <= FRAME_VERSION_OFFSET {
+        return 0;
+    }
     frame[FRAME_VERSION_OFFSET] & FRAME_VERSION_MASK
 }

--- a/esp-ieee802154/src/lib.rs
+++ b/esp-ieee802154/src/lib.rs
@@ -159,12 +159,21 @@ impl<'a> Ieee802154<'a> {
     /// Get a received frame, if available
     pub fn get_received(&mut self) -> Option<Result<ReceivedFrame, Error>> {
         if let Some(raw) = ieee802154_poll() {
-            let maybe_decoded =
-                mac::Frame::try_read(&raw.data[1..][..raw.data[0] as usize], FooterMode::Explicit);
+            let maybe_decoded = if raw.data[0] as usize > raw.data.len() {
+                // try to decode up to data.len()
+                mac::Frame::try_read(&raw.data[1..][..raw.data.len()], FooterMode::Explicit)
+            } else {
+                mac::Frame::try_read(&raw.data[1..][..raw.data[0] as usize], FooterMode::Explicit)
+            };
 
             let result = match maybe_decoded {
                 Ok((decoded, _)) => {
-                    let rssi = raw.data[raw.data[0] as usize - 1] as i8; // crc is not written to rx buffer
+                    // crc is not written to rx buffer
+                    let rssi = if raw.data[0] as usize > raw.data.len() {
+                        raw.data[raw.data.len() - 1] as i8
+                    } else {
+                        raw.data[raw.data[0] as usize - 1] as i8
+                    };
 
                     Ok(ReceivedFrame {
                         frame: Frame {

--- a/esp-ieee802154/src/raw.rs
+++ b/esp-ieee802154/src/raw.rs
@@ -19,12 +19,16 @@ use esp_wifi_sys::include::{
 use heapless::spsc::Queue;
 
 use crate::{
-    frame::{frame_get_version, frame_is_ack_required, FRAME_VERSION_1, FRAME_VERSION_2},
+    frame::{
+        frame_get_version,
+        frame_is_ack_required,
+        FRAME_SIZE,
+        FRAME_VERSION_1,
+        FRAME_VERSION_2,
+    },
     hal::*,
     pib::*,
 };
-
-pub(crate) const FRAME_SIZE: usize = 129;
 
 const PHY_ENABLE_VERSION_PRINT: u32 = 1;
 
@@ -391,9 +395,9 @@ fn ZB_MAC() {
                     log::warn!("Receive queue full");
                 }
 
-                let frm = if RX_BUFFER[0] > FRAME_SIZE as u8 {
+                let frm = if RX_BUFFER[0] >= FRAME_SIZE as u8 {
                     log::warn!("RX_BUFFER[0] {:} is larger than frame size", RX_BUFFER[0]);
-                    &RX_BUFFER[1..][..FRAME_SIZE]
+                    &RX_BUFFER[1..][..FRAME_SIZE - 1]
                 } else {
                     &RX_BUFFER[1..][..RX_BUFFER[0] as usize]
                 };


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Adds additional array access checks to avoid panics in various frame processing methods.

#### Description

Adds some additional checks as a follow on to #1862, to resolve various array-access related panics I have seen (although worth noting these are very rare). Similar to #1862 I view these as just band-aids, I still need to dig in to determine root cause. But adding these checks will help with fault tolerance / recoverability either way.  Also fixes an off-by-one error introduced in fix from #1862

#### Testing

Have confirmed it builds and runs as expected using the `esp-openthread` crate's example binary, on both esp32-h2 and esp32-c6 targets. Currently running some longevity tests as these only seem to pop up after many days/weeks of continuous operation, so will follow up with any needed additions once longevity tests complete. 
