### PR TITLE
Implemented queue_msg_waiting.

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implement `embedded_io::{ReadReady, WriteReady}` traits for `WifiStack` (#1882)
+- Implement `queue_msg_waiting` on the os_adapter (#1925)
 
 ### Changed
 

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -309,7 +309,7 @@ pub fn receive_queued(queue: *mut c_void, item: *mut c_void, block_time_tick: u3
     }
 }
 pub fn number_of_messages_in_queue(queue: *mut c_void) -> u32 {
-    trace!("queue_msg_waiting {queue:?}");
+    trace!("queue_msg_waiting {:?}", queue);
     if queue != unsafe { addr_of_mut!(REAL_WIFI_QUEUE).cast() } {
         warn!("queue_msg_waiting: Unknown queue.");
         return 0;

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -308,9 +308,9 @@ pub fn receive_queued(queue: *mut c_void, item: *mut c_void, block_time_tick: u3
         yield_task();
     }
 }
-pub fn number_of_messages_in_queue(queue: *mut c_void) -> u32 {
+pub fn number_of_messages_in_queue(queue: *const c_void) -> u32 {
     trace!("queue_msg_waiting {:?}", queue);
-    if queue != unsafe { addr_of_mut!(REAL_WIFI_QUEUE).cast() } {
+    if queue != unsafe { addr_of!(REAL_WIFI_QUEUE).cast() } {
         warn!("queue_msg_waiting: Unknown queue.");
         return 0;
     }

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -309,16 +309,12 @@ pub fn receive_queued(queue: *mut c_void, item: *mut c_void, block_time_tick: u3
     }
 }
 pub fn number_of_messages_in_queue(queue: *mut c_void) -> u32 {
-    trace!(
-        "queue_msg_waiting {queue:?}"
-    );
+    trace!("queue_msg_waiting {queue:?}");
     if queue != unsafe { addr_of_mut!(REAL_WIFI_QUEUE).cast() } {
         warn!("queue_msg_waiting: Unknown queue.");
         return 0;
     }
-    critical_section::with(|_| {
-        unsafe { REAL_WIFI_QUEUE.len() as u32 }
-    })
+    critical_section::with(|_| unsafe { REAL_WIFI_QUEUE.len() as u32 })
 }
 
 /// Implementation of sleep() from newlib in esp-idf.

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -308,6 +308,18 @@ pub fn receive_queued(queue: *mut c_void, item: *mut c_void, block_time_tick: u3
         yield_task();
     }
 }
+pub fn number_of_messages_in_queue(queue: *mut c_void) -> u32 {
+    trace!(
+        "queue_msg_waiting {queue:?}"
+    );
+    if queue != unsafe { addr_of_mut!(REAL_WIFI_QUEUE).cast() } {
+        warn!("queue_msg_waiting: Unknown queue.");
+        return 0;
+    }
+    critical_section::with(|_| {
+        unsafe { REAL_WIFI_QUEUE.len() as u32 }
+    })
+}
 
 /// Implementation of sleep() from newlib in esp-idf.
 /// components/newlib/time.c

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -17,7 +17,15 @@ use crate::{
     common_adapter::RADIO_CLOCKS,
     compat::{
         common::{
-            create_recursive_mutex, create_wifi_queue, lock_mutex, number_of_messages_in_queue, receive_queued, send_queued, str_from_c, thread_sem_get, unlock_mutex
+            create_recursive_mutex,
+            create_wifi_queue,
+            lock_mutex,
+            number_of_messages_in_queue,
+            receive_queued,
+            send_queued,
+            str_from_c,
+            thread_sem_get,
+            unlock_mutex,
         },
         malloc::calloc,
         task_runner::spawn_task,

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -17,14 +17,7 @@ use crate::{
     common_adapter::RADIO_CLOCKS,
     compat::{
         common::{
-            create_recursive_mutex,
-            create_wifi_queue,
-            lock_mutex,
-            receive_queued,
-            send_queued,
-            str_from_c,
-            thread_sem_get,
-            unlock_mutex,
+            create_recursive_mutex, create_wifi_queue, lock_mutex, number_of_messages_in_queue, receive_queued, send_queued, str_from_c, thread_sem_get, unlock_mutex
         },
         malloc::calloc,
         task_runner::spawn_task,
@@ -530,8 +523,8 @@ pub unsafe extern "C" fn queue_recv(
 ///   Message number
 ///
 /// *************************************************************************
-pub unsafe extern "C" fn queue_msg_waiting(_queue: *mut crate::binary::c_types::c_void) -> u32 {
-    todo!("queue_msg_waiting")
+pub unsafe extern "C" fn queue_msg_waiting(queue: *mut crate::binary::c_types::c_void) -> u32 {
+    number_of_messages_in_queue(queue)
 }
 
 /// **************************************************************************


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR implements the `queue_msg_waiting` function for the common os_adapter, which should allow #1879.

#### Testing
I tested this in a project of mine, which uses the `pp_post` function from the proprietary `libpp.a`, to kill the proprietary task. This usually led to a panic, due to `queue_msg_waiting not being implemented`, but now panics on `task_delete` not being implemented. 