### PR TITLE
Add self-testing mode for `TWAI` peripheral.

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new `Io::new_no_bind_interrupt` constructor (#1861)
 - Added touch pad support for esp32 (#1873)
 - Allow configuration of period updating method for MCPWM timers (#1898)
+- Add self-testing mode for TWAI peripheral. (#1929)
 
 ### Changed
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -28,6 +28,7 @@
 //! # use esp_hal::twai::filter;
 //! # use esp_hal::twai::TwaiConfiguration;
 //! # use esp_hal::twai::BaudRate;
+//! # use esp_hal::twai::TwaiMode;
 //! # use esp_hal::gpio::Io;
 //! # use embedded_can::Frame;
 //! # use core::option::Option::None;
@@ -49,6 +50,7 @@
 //!     can_rx_pin,
 //!     &clocks,
 //!     CAN_BAUDRATE,
+//!     TwaiMode::Normal
 //! );
 //!
 //! // Partially filter the incoming messages to reduce overhead of receiving
@@ -69,6 +71,61 @@
 //!     // Transmit the frame back.
 //!     let _result = block!(can.transmit(&frame)).unwrap();
 //! }
+//! # }
+//! ```
+//! ### Self-testing (self reception of transmitted messages)
+//! ```rust, no_run
+#![doc = crate::before_snippet!()]
+//! # use esp_hal::twai;
+//! # use embedded_can::Id;
+//! # use esp_hal::twai::filter::SingleStandardFilter;
+//! # use esp_hal::twai::filter;
+//! # use esp_hal::twai::TwaiConfiguration;
+//! # use esp_hal::twai::BaudRate;
+//! # use esp_hal::twai::TwaiMode;
+//! # use esp_hal::gpio::Io;
+//! # use embedded_can::Frame;
+//! # use core::option::Option::None;
+//! # use nb::block;
+//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! // Use GPIO pins 2 and 3 to connect to the respective pins on the CAN
+//! // transceiver.
+//! let can_tx_pin = io.pins.gpio2;
+//! let can_rx_pin = io.pins.gpio3;
+//!
+//! // The speed of the CAN bus.
+//! const CAN_BAUDRATE: twai::BaudRate = BaudRate::B1000K;
+//!
+//! // Begin configuring the TWAI peripheral.
+//! let mut can_config = twai::TwaiConfiguration::new(
+//!     peripherals.TWAI0,
+//!     can_tx_pin,
+//!     can_rx_pin,
+//!     &clocks,
+//!     CAN_BAUDRATE,
+//!     TwaiMode::NoAck
+//! );
+//!
+//! // Partially filter the incoming messages to reduce overhead of receiving
+//! // undesired messages
+//! const FILTER: twai::filter::SingleStandardFilter =
+//!     SingleStandardFilter::new_self_reception(b"xxxxxxxxxx0", b"x",
+//!         [b"xxxxxxxx", b"xxxxxxxx"]);
+//! can_config.set_filter(FILTER);
+//!
+//! // Start the peripheral. This locks the configuration settings of the
+//! // peripheral and puts it into operation mode, allowing packets to be sent
+//! // and received.
+//! let mut can = can_config.start();
+//!
+//! let frame = EspTwaiFrame::new_self_reception(StandardId::ZERO.into(),
+//!     &[1, 2, 3]).unwrap();
+//! println!("Sent a frame");
+//! // Wait for a frame to be received.
+//! let frame = block!(can.receive()).unwrap();
+//! println!("Received a frame: {frame:?}");
+//!
+//! loop {}
 //! # }
 //! ```
 
@@ -184,6 +241,17 @@ impl embedded_can::Error for ErrorKind {
     fn kind(&self) -> embedded_can::ErrorKind {
         (*self).into()
     }
+}
+
+/// Specifies in which mode the TWAI controller will operate.
+pub enum TwaiMode {
+    /// Normal operating mode
+    Normal,
+    /// Self-test mode (no acknowledgement required for a successful message
+    /// transmission)
+    NoAck,
+    /// Listen only operating mode
+    ListenOnly,
 }
 
 /// Standard 11-bit CAN Identifier (`0..=0x7FF`).
@@ -400,6 +468,7 @@ pub struct EspTwaiFrame {
     dlc: usize,
     data: [u8; 8],
     is_remote: bool,
+    self_reception: bool,
 }
 
 impl EspTwaiFrame {
@@ -418,6 +487,7 @@ impl EspTwaiFrame {
             data: d,
             dlc: data.len(),
             is_remote: false,
+            self_reception: false,
         })
     }
 
@@ -432,6 +502,25 @@ impl EspTwaiFrame {
             data: [0; 8],
             dlc,
             is_remote: true,
+            self_reception: false,
+        })
+    }
+
+    pub fn new_self_reception(id: Id, data: &[u8]) -> Option<Self> {
+        if data.len() > 8 {
+            return None;
+        }
+
+        let mut d: [u8; 8] = [0; 8];
+        let (left, _unused) = d.split_at_mut(data.len());
+        left.clone_from_slice(data);
+
+        Some(EspTwaiFrame {
+            id,
+            data: d,
+            dlc: data.len(),
+            is_remote: false,
+            self_reception: true,
         })
     }
 
@@ -455,6 +544,7 @@ impl EspTwaiFrame {
             data,
             dlc,
             is_remote: false,
+            self_reception: true,
         }
     }
 }
@@ -643,6 +733,7 @@ where
         clocks: &Clocks<'d>,
         baud_rate: BaudRate,
         no_transceiver: bool,
+        mode: TwaiMode,
     ) -> Self {
         // Enable the peripheral clock for the TWAI peripheral.
         T::enable_peripheral();
@@ -662,10 +753,24 @@ where
         rx_pin.set_to_input(crate::private::Internal);
         rx_pin.connect_input_to_peripheral(T::INPUT_SIGNAL, crate::private::Internal);
 
-        // Set mod to listen only first
-        T::register_block()
-            .mode()
-            .modify(|_, w| w.listen_only_mode().set_bit());
+        // Set the operating mode based on provided option
+        match mode {
+            TwaiMode::Normal => {
+                // Do nothing special, the default state is Normal mode.
+            }
+            TwaiMode::NoAck => {
+                // Set the self-test mode (no acknowledgement required)
+                T::register_block()
+                    .mode()
+                    .modify(|_, w| w.self_test_mode().set_bit());
+            }
+            TwaiMode::ListenOnly => {
+                // Set listen-only mode
+                T::register_block()
+                    .mode()
+                    .modify(|_, w| w.listen_only_mode().set_bit());
+            }
+        }
 
         // Set TEC to 0
         T::register_block()
@@ -810,8 +915,9 @@ where
         rx_pin: impl Peripheral<P = RX> + 'd,
         clocks: &Clocks<'d>,
         baud_rate: BaudRate,
+        mode: TwaiMode,
     ) -> Self {
-        Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, false)
+        Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, false, mode)
     }
 
     /// Create a new instance of [TwaiConfiguration] meant to connect two ESP32s
@@ -825,8 +931,9 @@ where
         rx_pin: impl Peripheral<P = RX> + 'd,
         clocks: &Clocks<'d>,
         baud_rate: BaudRate,
+        mode: TwaiMode,
     ) -> Self {
-        Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, true)
+        Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, true, mode)
     }
 }
 
@@ -855,8 +962,10 @@ where
         rx_pin: impl Peripheral<P = RX> + 'd,
         clocks: &Clocks<'d>,
         baud_rate: BaudRate,
+        mode: TwaiMode,
     ) -> Self {
-        let mut this = Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, false);
+        let mut this =
+            Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, false, mode);
         this.internal_set_interrupt_handler(T::async_handler());
         this
     }
@@ -872,8 +981,10 @@ where
         rx_pin: impl Peripheral<P = RX> + 'd,
         clocks: &Clocks<'d>,
         baud_rate: BaudRate,
+        mode: TwaiMode,
     ) -> Self {
-        let mut this = Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, true);
+        let mut this =
+            Self::new_internal(peripheral, tx_pin, rx_pin, clocks, baud_rate, true, mode);
         this.internal_set_interrupt_handler(T::async_handler());
         this
     }
@@ -1264,9 +1375,19 @@ pub trait OperationInstance: Instance {
             // Is RTR frame, so no data is included.
         }
 
-        // Set the transmit request command, this will lock the transmit buffer until
-        // the transmission is complete or aborted.
-        register_block.cmd().write(|w| w.tx_req().set_bit());
+        // Trigger the appropriate transmission request based on self_reception flag
+        if frame.self_reception {
+            #[cfg(any(esp32, esp32c3, esp32s2, esp32s3))]
+            register_block.cmd().write(|w| w.self_rx_req().set_bit());
+            #[cfg(not(any(esp32, esp32c3, esp32s2, esp32s3)))]
+            register_block
+                .cmd()
+                .write(|w| w.self_rx_request().set_bit());
+        } else {
+            // Set the transmit request command, this will lock the transmit buffer until
+            // the transmission is complete or aborted.
+            register_block.cmd().write(|w| w.tx_req().set_bit());
+        }
     }
 
     /// Read a frame from the peripheral.

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -82,6 +82,8 @@
 //! # use esp_hal::twai::filter;
 //! # use esp_hal::twai::TwaiConfiguration;
 //! # use esp_hal::twai::BaudRate;
+//! # use esp_hal::twai::EspTwaiFrame;
+//! # use esp_hal::twai::StandardId;
 //! # use esp_hal::twai::TwaiMode;
 //! # use esp_hal::gpio::Io;
 //! # use embedded_can::Frame;
@@ -109,7 +111,7 @@
 //! // Partially filter the incoming messages to reduce overhead of receiving
 //! // undesired messages
 //! const FILTER: twai::filter::SingleStandardFilter =
-//!     SingleStandardFilter::new_self_reception(b"xxxxxxxxxx0", b"x",
+//!     SingleStandardFilter::new(b"xxxxxxxxxx0", b"x",
 //!         [b"xxxxxxxx", b"xxxxxxxx"]);
 //! can_config.set_filter(FILTER);
 //!
@@ -120,10 +122,8 @@
 //!
 //! let frame = EspTwaiFrame::new_self_reception(StandardId::ZERO.into(),
 //!     &[1, 2, 3]).unwrap();
-//! println!("Sent a frame");
 //! // Wait for a frame to be received.
 //! let frame = block!(can.receive()).unwrap();
-//! println!("Received a frame: {frame:?}");
 //!
 //! loop {}
 //! # }

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -105,7 +105,7 @@
 //!     can_rx_pin,
 //!     &clocks,
 //!     CAN_BAUDRATE,
-//!     TwaiMode::NoAck
+//!     TwaiMode::SelfTest
 //! );
 //!
 //! // Partially filter the incoming messages to reduce overhead of receiving
@@ -249,7 +249,7 @@ pub enum TwaiMode {
     Normal,
     /// Self-test mode (no acknowledgement required for a successful message
     /// transmission)
-    NoAck,
+    SelfTest,
     /// Listen only operating mode
     ListenOnly,
 }
@@ -758,7 +758,7 @@ where
             TwaiMode::Normal => {
                 // Do nothing special, the default state is Normal mode.
             }
-            TwaiMode::NoAck => {
+            TwaiMode::SelfTest => {
                 // Set the self-test mode (no acknowledgement required)
                 T::register_block()
                     .mode()

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -31,7 +31,7 @@ use esp_hal::{
     peripherals::{self, Peripherals, TWAI0},
     system::SystemControl,
     timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
-    twai::{self, EspTwaiFrame, TwaiRx, TwaiTx},
+    twai::{self, EspTwaiFrame, TwaiMode, TwaiRx, TwaiTx},
 };
 use esp_println::println;
 use static_cell::StaticCell;
@@ -122,6 +122,7 @@ async fn main(spawner: Spawner) {
         can_rx_pin,
         &clocks,
         CAN_BAUDRATE,
+        TwaiMode::Normal,
     );
 
     // Partially filter the incoming messages to reduce overhead of receiving

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
 
     // Begin configuring the TWAI peripheral. The peripheral is in a reset like
     // state that prevents transmission but allows configuration.
-    // For self-testing use `NoAck` mode of the TWAI peripheral.
+    // For self-testing use `SelfTest` mode of the TWAI peripheral.
     let mut can_config = twai::TwaiConfiguration::new_no_transceiver(
         peripherals.TWAI0,
         can_tx_pin,

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -14,7 +14,7 @@
 //!
 //! `IS_FIRST_SENDER` below must be set to false on one of the ESP's
 //!
-//! In case you want to use `self-testing``, get rid of everything related to the aforementioned `IS_FIRST_SENDER`
+//! In case you want to use `self-testing`, get rid of everything related to the aforementioned `IS_FIRST_SENDER`
 //! and follow the advice in the comments related to this mode.
 
 //% CHIPS: esp32c3 esp32c6 esp32s2 esp32s3
@@ -62,7 +62,7 @@ fn main() -> ! {
         can_rx_pin,
         &clocks,
         CAN_BAUDRATE,
-        TwaiMode::NoAck,
+        TwaiMode::Normal,
     );
 
     // Partially filter the incoming messages to reduce overhead of receiving
@@ -83,7 +83,7 @@ fn main() -> ! {
     if IS_FIRST_SENDER {
         // Send a frame to the other ESP
         // Use `new_self_reception` if you want to use self-testing.
-        let frame = EspTwaiFrame::new_self_reception(StandardId::ZERO.into(), &[1, 2, 3]).unwrap();
+        let frame = EspTwaiFrame::new(StandardId::ZERO.into(), &[1, 2, 3]).unwrap();
         block!(can.transmit(&frame)).unwrap();
         println!("Sent a frame");
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
closes https://github.com/esp-rs/esp-hal/issues/1907. 
Adds a new enum `TwaiMode`, one of its values should now be passed to the new function to instantiate the `Twai` peripheral. Also adds a new function for creating a message (aka. `TWAI` frame), since the related registers also need some customization for `self-testing` mode.

#### Testing
I reworked the existing example a bit and checked to see if the mechanism works where the TWAI peripheral itself receives and serves the sent message. I have specified all the necessary changes in the updated documentation of both the peripheral and in the example comments
