### PR TITLE
Fix an infinite loop in interrupt executors

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug where the timeout was huge whenever the timestamp at the time of scheduling was already in the past (#1875)
+- Fixed interrupt executors looping endlessly when `integrated-timers` is used. (#1936)
 
 ### Removed
 

--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -156,10 +156,11 @@ impl Driver for EmbassyTimer {
     }
 
     fn set_alarm(&self, alarm: AlarmHandle, timestamp: u64) -> bool {
-        // we sometimes get called with `u64::MAX` for apparently not yet initialized
-        // timers which would fail later on
+        // If `embassy-executor/integrated-timers` is enabled and there are no pending
+        // timers, embassy still calls `set_alarm` with `u64::MAX`. By returning
+        // `true` we signal that no re-polling is necessary.
         if timestamp == u64::MAX {
-            return false;
+            return true;
         }
 
         // The hardware fires the alarm even if timestamp is lower than the current

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: Clear DMA interrupts before (not after) DMA starts (#1859)
 - SPI: disable and re-enable MISO and MOSI in `start_transfer_dma`, `start_read_bytes_dma` and `start_write_bytes_dma` accordingly (#1894)
 - TWAI: GPIO pins are not configured as input and output (#1906)
-- Embassy: fix infinite looping in interrupt executors when `integrated-timers` is used. (#1936)
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: Clear DMA interrupts before (not after) DMA starts (#1859)
 - SPI: disable and re-enable MISO and MOSI in `start_transfer_dma`, `start_read_bytes_dma` and `start_write_bytes_dma` accordingly (#1894)
 - TWAI: GPIO pins are not configured as input and output (#1906)
-- Embassy: fix infinite looping in interrupt executors when `integrated-timers` is used. (#???)
+- Embassy: fix infinite looping in interrupt executors when `integrated-timers` is used. (#1936)
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: Clear DMA interrupts before (not after) DMA starts (#1859)
 - SPI: disable and re-enable MISO and MOSI in `start_transfer_dma`, `start_read_bytes_dma` and `start_write_bytes_dma` accordingly (#1894)
 - TWAI: GPIO pins are not configured as input and output (#1906)
+- Embassy: fix infinite looping in interrupt executors when `integrated-timers` is used. (#???)
 
 ### Removed
 

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -119,12 +119,18 @@ name              = "embassy_timers_executors"
 harness           = false
 required-features = ["async", "embassy"]
 
+[[test]]
+name              = "embassy_interrupt_executor"
+harness           = false
+required-features = ["async", "embassy", "integrated-timers"]
+
 [dependencies]
 cfg-if             = "1.0.0"
 critical-section   = "1.1.2"
 defmt              = "0.3.8"
 defmt-rtt          = "0.4.1"
 embassy-futures    = "0.1.1"
+embassy-sync       = "0.6.0"
 embassy-time       = { version = "0.3.1", features = ["generic-queue-64"] }
 embedded-hal       = "1.0.0"
 embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = ["unproven"] }
@@ -179,6 +185,9 @@ embassy = [
     "embedded-test/embassy",
     "embedded-test/external-executor",
     "dep:esp-hal-embassy",
+]
+integrated-timers = [
+    "embassy-executor/integrated-timers",
 ]
 
 # https://doc.rust-lang.org/cargo/reference/profiles.html#test

--- a/hil-test/tests/embassy_interrupt_executor.rs
+++ b/hil-test/tests/embassy_interrupt_executor.rs
@@ -7,8 +7,7 @@
 #![no_std]
 #![no_main]
 
-use embassy_sync::signal::Signal;
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 
 macro_rules! mk_static {
     ($t:ty,$val:expr) => {{
@@ -38,9 +37,9 @@ mod test {
     use esp_backtrace as _;
     use esp_hal::{
         clock::ClockControl,
+        interrupt::Priority,
         peripherals::Peripherals,
         system::{SoftwareInterrupt, SystemControl},
-        interrupt::Priority,
     };
     use esp_hal_embassy::InterruptExecutor;
 

--- a/hil-test/tests/embassy_interrupt_executor.rs
+++ b/hil-test/tests/embassy_interrupt_executor.rs
@@ -18,10 +18,6 @@ macro_rules! mk_static {
     }};
 }
 
-unsafe fn __make_static<T>(t: &mut T) -> &'static mut T {
-    ::core::mem::transmute(t)
-}
-
 #[embassy_executor::task]
 async fn interrupt_driven_task(signal: &'static Signal<CriticalSectionRawMutex, ()>) {
     loop {

--- a/hil-test/tests/embassy_interrupt_executor.rs
+++ b/hil-test/tests/embassy_interrupt_executor.rs
@@ -1,0 +1,71 @@
+//! Test that the interrupt executor correctly gives back control to thread mode
+//! code.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: integrated-timers
+
+#![no_std]
+#![no_main]
+
+use embassy_sync::signal::Signal;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+
+macro_rules! mk_static {
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write(($val));
+        x
+    }};
+}
+
+unsafe fn __make_static<T>(t: &mut T) -> &'static mut T {
+    ::core::mem::transmute(t)
+}
+
+#[embassy_executor::task]
+async fn interrupt_driven_task(signal: &'static Signal<CriticalSectionRawMutex, ()>) {
+    loop {
+        signal.wait().await;
+        defmt::info!("Received");
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod test {
+    use defmt_rtt as _;
+    use esp_backtrace as _;
+    use esp_hal::{
+        clock::ClockControl,
+        peripherals::Peripherals,
+        system::{SoftwareInterrupt, SystemControl},
+        interrupt::Priority,
+    };
+    use esp_hal_embassy::InterruptExecutor;
+
+    use super::*;
+
+    #[init]
+    fn init() -> SoftwareInterrupt<1> {
+        let peripherals = Peripherals::take();
+        let system = SystemControl::new(peripherals.SYSTEM);
+        let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+        system.software_interrupt_control.software_interrupt1
+    }
+
+    #[test]
+    #[timeout(3)]
+    fn run_interrupt_executor_test(interrupt: SoftwareInterrupt<1>) {
+        let interrupt_executor =
+            mk_static!(InterruptExecutor<1>, InterruptExecutor::new(interrupt));
+        let signal = mk_static!(Signal<CriticalSectionRawMutex, ()>, Signal::new());
+
+        let spawner = interrupt_executor.start(Priority::Priority3);
+
+        spawner.spawn(interrupt_driven_task(signal)).unwrap();
+
+        signal.signal(());
+        defmt::info!("Returned");
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

When the interrupt executor has no pending timers in the timer queue, it will still call `set_alarm`. By returning `false` we previously signalled a request for a re-poll, which lead to an infinite loop.

#### Testing

I added a new HIL test, observed it failing on an ESP32-S3. Then I fixed the bug and observed that the test now passes. The failure mode is a test timeout.