### PR TITLE
Update probe-rs, prebuild xtask for HIL tests

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -18,6 +18,46 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  build-xtasks:
+    name: Build xtasks | ${{ matrix.host.arch }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - arch: armv7
+            rust-target: armv7-unknown-linux-gnueabihf
+          - arch: aarch64
+            rust-target: aarch64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch'
+      - uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rust-src
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Build xtasks
+        run: cross build --release --target ${{ matrix.host.rust-target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xtask-${{ matrix.host.arch }}
+          path: target/${{ matrix.host.rust-target }}/release/xtask
+
   build-tests:
     name: Build HIL Tests | ${{ matrix.target.soc }}
     runs-on: ubuntu-latest
@@ -93,7 +133,7 @@ jobs:
 
   hil:
     name: Run HIL Tests | ${{ matrix.target.soc }}
-    needs: build-tests
+    needs: [build-tests, build-xtasks]
     runs-on:
       labels: [self-hosted, "${{ matrix.target.runner }}"]
     strategy:
@@ -104,40 +144,41 @@ jobs:
           - soc: esp32c2
             runner: esp32c2-jtag
             usb: USB2
+            host: aarch64
           - soc: esp32c3
             runner: esp32c3-usb
             usb: ACM0
+            host: armv7
           - soc: esp32c6
             runner: esp32c6-usb
             usb: ACM0
+            host: armv7
           - soc: esp32h2
             runner: esp32h2-usb
             usb: USB0
+            host: armv7
           # Xtensa devices:
           - soc: esp32s2
             runner: esp32s2-jtag
             usb: USB1
+            host: armv7
           - soc: esp32s3
             runner: esp32s3-usb
             usb: USB0
+            host: armv7
     steps:
-      - uses: actions/checkout@v4
-        if: github.event_name != 'workflow_dispatch'
-      - uses: actions/checkout@v4
-        if: github.event_name == 'workflow_dispatch'
-        with:
-          repository: ${{ github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.branch }}
-
       - uses: actions/download-artifact@v4
         with:
           name: tests-${{ matrix.target.soc }}
           path: tests-${{ matrix.target.soc }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: xtask-${{ matrix.target.host }}
+
       - name: Run Tests
         id: run-tests
-        run: |
-          export PATH=$PATH:/home/espressif/.cargo/bin
-          cargo xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
+        run: ./xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
 
       - name: Erase Flash on Failure
         if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -178,7 +178,9 @@ jobs:
 
       - name: Run Tests
         id: run-tests
-        run: ./xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
+        run: |
+          export PATH=$PATH:/home/espressif/.cargo/bin
+          ./xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
 
       - name: Erase Flash on Failure
         if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -180,4 +180,5 @@ jobs:
         id: run-tests
         run: |
           export PATH=$PATH:/home/espressif/.cargo/bin
+          chmod +x xtask
           ./xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-tests:
-    name: HIL Test | ${{ matrix.target.soc }}
+    name: Build HIL Tests | ${{ matrix.target.soc }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -92,7 +92,7 @@ jobs:
           overwrite: true
 
   hil:
-    name: HIL Test | ${{ matrix.target.soc }}
+    name: Run HIL Tests | ${{ matrix.target.soc }}
     needs: build-tests
     runs-on:
       labels: [self-hosted, "${{ matrix.target.runner }}"]

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -181,11 +181,3 @@ jobs:
         run: |
           export PATH=$PATH:/home/espressif/.cargo/bin
           ./xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
-
-      - name: Erase Flash on Failure
-        if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}
-        env:
-          ESPFLASH_PORT: /dev/tty${{ matrix.target.usb }}
-        run: |
-          export PATH=$PATH:/home/espressif/.cargo/bin
-          espflash erase-flash

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -21,7 +21,7 @@ We use [probe-rs] for flashing and running the tests on a target device, however
 ```text
 cargo install probe-rs-tools \
   --git https://github.com/probe-rs/probe-rs \
-  --rev bba1bb5 --force --locked
+  --rev 9bde591 --force --locked
 ```
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
@@ -108,7 +108,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-t
 # Install dependencies
 sudo apt install -y pkg-config libudev-dev
 # Install probe-rs
-cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev bba1bb5 --force
+cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev 9bde591 --force
 # Add the udev rules
 wget -O - https://probe.rs/files/69-probe-rs.rules | sudo tee /etc/udev/rules.d/69-probe-rs.rules > /dev/null
 # Add the user to plugdev group

--- a/hil-test/tests/get_time.rs
+++ b/hil-test/tests/get_time.rs
@@ -37,6 +37,7 @@ mod tests {
     }
 
     #[test]
+    #[timeout(3)]
     fn test_current_time(ctx: Context) {
         let t1 = esp_hal::time::current_time();
         ctx.delay.delay_millis(500);

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -240,8 +240,6 @@ pub fn execute_app(
         .features(&features)
         .arg(bin);
 
-    // probe-rs cannot currently do auto detection, so we need to tell probe-rs run
-    // which chip we are testing
     if subcommand == "test" && chip == Chip::Esp32c2 {
         builder = builder.arg("--").arg("--speed").arg("15000");
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -683,17 +683,14 @@ fn run_elfs(args: RunElfArgs) -> Result<()> {
             command.arg("--speed").arg("15000");
         };
 
-        let command = command.output().context("Failed to execute probe-rs")?;
-
-        println!(
-            "{}\n{}",
-            String::from_utf8_lossy(&command.stderr),
-            String::from_utf8_lossy(&command.stdout)
-        );
+        let mut command = command.spawn().context("Failed to execute probe-rs")?;
+        let status = command
+            .wait()
+            .context("Error while waiting for probe-rs to exit")?;
 
         log::info!("'{elf_name}' done");
 
-        if !command.status.success() {
+        if !status.success() {
             failed.push(elf_name);
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -153,8 +153,7 @@ fn main() -> Result<()> {
         .filter_module("xtask", log::LevelFilter::Info)
         .init();
 
-    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace = workspace.parent().unwrap().canonicalize()?;
+    let workspace = std::env::current_dir()?;
 
     match Cli::parse() {
         Cli::BuildDocumentation(args) => build_documentation(&workspace, args),


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR updates mentions of probe-rs to the latest `main` ([9bde591](https://github.com/probe-rs/probe-rs/commit/9bde591c62eb0d9601c32c5dd34fd4f6c44fc1f4)). The changes include implementing system reset for Xtensa MCUs, which I hope will help with transient test runner failures.

#### Testing

~YOLO~

https://github.com/esp-rs/esp-hal/actions/runs/10370992061
