### PR TITLE
Update to latest release (`0.6.0`) for `embassy-executor` in `esp-embassy-hal` (fixes #1941)

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where the timeout was huge whenever the timestamp at the time of scheduling was already in the past (#1875)
 - Fixed interrupt executors looping endlessly when `integrated-timers` is used. (#1936)
-- Fixed reference to `OneShotTimer` which had a now unneeded lifetime annotation (#1942)
 
 ### Removed
 

--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where the timeout was huge whenever the timestamp at the time of scheduling was already in the past (#1875)
 - Fixed interrupt executors looping endlessly when `integrated-timers` is used. (#1936)
+- Fixed reference to `OneShotTimer` which had a now unneeded lifetime annotation (#1942)
 
 ### Removed
 

--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to latest release (`0.6.0`) for `embassy-executor` (#XXX)
+- Updated to latest release (`0.6.0`) for `embassy-executor` (#1942)
 
 ### Fixed
 

--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated to latest release (`0.6.0`) for `embassy-executor` (#XXX)
+
 ### Fixed
 
 - Fixed a bug where the timeout was huge whenever the timestamp at the time of scheduling was already in the past (#1875)

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -15,7 +15,7 @@ features       = ["esp32c6"]
 critical-section    = "1.1.2"
 defmt               = { version = "0.3.8", optional = true }
 document-features   = "0.2.10"
-embassy-executor    = { version = "0.5.0", optional = true }
+embassy-executor    = { version = "0.6.0", optional = true }
 embassy-time-driver = { version = "0.1.0", features = [ "tick-hz-1_000_000" ] }
 esp-hal             = { version = "0.19.0", path = "../esp-hal" }
 log                 = { version = "0.4.22", optional = true }

--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -12,7 +12,7 @@ use esp_hal::{
 
 pub const MAX_SUPPORTED_ALARM_COUNT: usize = 7;
 
-pub type Timer = OneShotTimer<ErasedTimer>;
+pub type Timer = OneShotTimer<'static, ErasedTimer>;
 
 static TIMERS: Mutex<RefCell<Option<&'static mut [Timer]>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -12,7 +12,7 @@ use esp_hal::{
 
 pub const MAX_SUPPORTED_ALARM_COUNT: usize = 7;
 
-pub type Timer = OneShotTimer<'static, ErasedTimer>;
+pub type Timer = OneShotTimer<ErasedTimer>;
 
 static TIMERS: Mutex<RefCell<Option<&'static mut [Timer]>>> = Mutex::new(RefCell::new(None));
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ cfg-if              = "1.0.0"
 critical-section    = "1.1.2"
 crypto-bigint       = { version = "0.5.5", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
-embassy-executor    = { version = "0.5.0", features = ["task-arena-size-40960"] }
+embassy-executor    = { version = "0.6.0", features = ["task-arena-size-40960"] }
 embassy-futures     = "0.1.1"
 embassy-net = { version = "0.4.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 embassy-sync        = "0.6.0"

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -145,7 +145,7 @@ static_cell        = { version = "2.1.0", features = ["nightly"] }
 [dev-dependencies]
 crypto-bigint       = { version = "0.5.5", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
-embassy-executor    = { version = "0.5.0", default-features = false }
+embassy-executor    = { version = "0.6.0", default-features = false }
 # Add the `embedded-test/defmt` feature for more verbose testing
 embedded-test       = { version = "0.4.0", default-features = false }
 hex-literal         = "0.4.1"


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Fixes #1941 by updating the embassy-executor crate to the latest version in the `esp-embassy-hal` crate, and the `hil-test` and `examples` crates.

#### Testing

I tested a number of examples (namely: wifi_access_point, wifi_embassy_access_point, embassy_hello_world) on an esp32c3, which all functioned as expected.

I also tested my own program which uses a variety of esp-hal projects, which led to me finding the `OneShotTimer` problem.