### PR TITLE
ESP32C6: Make `ADC` usable after `TRNG` deinitialization

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: Clear DMA interrupts before (not after) DMA starts (#1859)
 - SPI: disable and re-enable MISO and MOSI in `start_transfer_dma`, `start_read_bytes_dma` and `start_write_bytes_dma` accordingly (#1894)
 - TWAI: GPIO pins are not configured as input and output (#1906)
+- ESP32C6: Make ADC usable after TRNG deinicialization (#1945)
 
 ### Removed
 

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -152,7 +152,7 @@ impl rand_core::RngCore for Rng {
 /// let mut trng = Trng::new(peripherals.RNG, &mut peripherals.ADC1);
 /// trng.read(&mut buf);
 /// let mut true_rand = trng.random();
-#[cfg_attr(not(esp32c6), doc = "let mut rng = trng.downgrade();")]
+/// let mut rng = trng.downgrade();
 /// // ADC is available now
 #[cfg_attr(esp32, doc = "let analog_pin = io.pins.gpio32;")]
 #[cfg_attr(not(esp32), doc = "let analog_pin = io.pins.gpio3;")]
@@ -161,8 +161,8 @@ impl rand_core::RngCore for Rng {
 /// Attenuation::Attenuation11dB); let mut adc1 =
 /// Adc::<ADC1>::new(peripherals.ADC1, adc1_config); let pin_value: u16 =
 /// nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
-#[cfg_attr(not(esp32c6), doc = "rng.read(&mut buf);")]
-#[cfg_attr(not(esp32c6), doc = "true_rand = rng.random();")]
+/// rng.read(&mut buf);
+/// true_rand = rng.random();
 /// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
 /// # }
 /// ```
@@ -208,15 +208,11 @@ impl<'d> Trng<'d> {
 
     /// Downgrades the `Trng` instance to a `Rng` instance and releases the
     /// ADC1.
-    /// For esp32c6 - blocked on <https://github.com/espressif/esp-idf/issues/14124>
-    #[cfg(not(esp32c6))]
     pub fn downgrade(self) -> Rng {
         self.rng
     }
 }
 
-/// For esp32c6 - blocked on <https://github.com/espressif/esp-idf/issues/14124>
-#[cfg(not(esp32c6))]
 impl<'d> Drop for Trng<'d> {
     fn drop(&mut self) {
         crate::soc::trng::revert_trng();

--- a/esp-hal/src/soc/esp32c6/trng.rs
+++ b/esp-hal/src/soc/esp32c6/trng.rs
@@ -273,8 +273,6 @@ pub(crate) fn revert_trng() {
             0,
         );
 
-        pmu.rf_pwc().modify(|_, w| w.perif_i2c_rstb().clear_bit());
-
         pcr.saradc_clkm_conf().modify(|_, w| w.bits(0x00404000));
 
         pcr.saradc_conf().modify(|_, w| w.bits(0x5));


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
closes #1750
corresponding changes in `esp-idf` : https://github.com/espressif/esp-idf/commit/2babadab07854041459bbe4392fd84012c24d142

#### Testing
```rust
#![no_std]
#![no_main]

use esp_backtrace as _;
use esp_hal::{
    analog::adc::{Adc, AdcConfig, Attenuation},
    gpio::Io,
    peripherals::{Peripherals, ADC1},
    prelude::*,
    rng::Trng,
};
use esp_println::println;

#[entry]
fn main() -> ! {
    let mut peripherals = Peripherals::take();
    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);

    let mut buf = [0u8; 16];

    let mut trng = Trng::new(peripherals.RNG, &mut peripherals.ADC1);
    trng.read(&mut buf);
    let mut true_rand = trng.random();

    println!("Random u32:   {}", true_rand);
    println!("Random bytes: {:?}", buf);

    let mut rng = trng.downgrade();

    let analog_pin = io.pins.gpio3;

    let mut adc1_config = AdcConfig::new();
    let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::Attenuation11dB);
    let mut adc1 = Adc::<ADC1>::new(peripherals.ADC1, adc1_config);
    let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();

    true_rand = rng.random();
    rng.read(&mut buf);

    println!("Random u32:   {}", true_rand);
    println!("Random bytes: {:?}", buf);

    let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
    println!("ADC reading = {}", pin_value);

    loop {}
}
```
