### PR TITLE
Adding `TWAI` HIL test

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -124,6 +124,10 @@ name              = "embassy_interrupt_executor"
 harness           = false
 required-features = ["async", "embassy", "integrated-timers"]
 
+[[test]]
+name    = "twai"
+harness = false
+
 [dependencies]
 cfg-if             = "1.0.0"
 critical-section   = "1.1.2"

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -55,7 +55,7 @@ impl Context {
             SingleStandardFilter::new(b"00000000000", b"x", [b"xxxxxxxx", b"xxxxxxxx"]);
         config.set_filter(FILTER);
 
-        let mut twai = config.start();
+        let twai = config.start();
 
         Context { twai }
     }

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -12,6 +12,7 @@
 #![no_main]
 
 use defmt_rtt as _;
+use embedded_hal_02::can::Frame;
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
@@ -22,7 +23,6 @@ use esp_hal::{
     twai::{self, filter::SingleStandardFilter, EspTwaiFrame, StandardId, TwaiMode},
     Blocking,
 };
-use embedded_hal_02::can::Frame;
 use nb::block;
 
 struct Context {
@@ -81,6 +81,6 @@ mod tests {
 
         let frame = block!(ctx.twai.receive()).unwrap();
 
-        assert_eq!(frame.data(),  &[1, 2, 3])
+        assert_eq!(frame.data(), &[1, 2, 3])
     }
 }

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -1,0 +1,86 @@
+//! TWAI test
+//!
+//! Folowing pins are used:
+//! TX    GPIO2
+//! RX    GPIO3
+//!
+//! Connect TX (GPIO2) and RX (GPIO3) pins.
+
+//% CHIPS: esp32c3 esp32c6 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use esp_backtrace as _;
+use esp_hal::{
+    clock::ClockControl,
+    gpio::Io,
+    peripherals::{Peripherals, TWAI0},
+    prelude::*,
+    system::SystemControl,
+    twai::{self, filter::SingleStandardFilter, EspTwaiFrame, StandardId, TwaiMode},
+    Blocking,
+};
+use embedded_hal_02::can::Frame;
+use nb::block;
+
+struct Context {
+    twai: twai::Twai<'static, TWAI0, Blocking>,
+}
+
+impl Context {
+    pub fn init() -> Self {
+        let peripherals = Peripherals::take();
+        let system = SystemControl::new(peripherals.SYSTEM);
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+        let can_tx_pin = io.pins.gpio2;
+        let can_rx_pin = io.pins.gpio3;
+
+        const CAN_BAUDRATE: twai::BaudRate = twai::BaudRate::B1000K;
+
+        let mut config = twai::TwaiConfiguration::new(
+            peripherals.TWAI0,
+            can_tx_pin,
+            can_rx_pin,
+            &clocks,
+            CAN_BAUDRATE,
+            TwaiMode::SelfTest,
+        );
+
+        const FILTER: SingleStandardFilter =
+            SingleStandardFilter::new(b"00000000000", b"x", [b"xxxxxxxx", b"xxxxxxxx"]);
+        config.set_filter(FILTER);
+
+        let mut twai = config.start();
+
+        Context { twai }
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use defmt::assert_eq;
+
+    use super::*;
+
+    #[init]
+    fn init() -> Context {
+        Context::init()
+    }
+
+    #[test]
+    #[timeout(3)]
+    fn test_send_receive(mut ctx: Context) {
+        let frame = EspTwaiFrame::new_self_reception(StandardId::ZERO.into(), &[1, 2, 3]).unwrap();
+        block!(ctx.twai.transmit(&frame)).unwrap();
+
+        let frame = block!(ctx.twai.receive()).unwrap();
+
+        assert_eq!(frame.data(),  &[1, 2, 3])
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
closes https://github.com/esp-rs/esp-hal/issues/1912
Uses recently implemented self-testing mode (#1907)

#### Testing
Ran tests locally, HIL test CI action fails on multiple chips currently, but `TWAI` test completed successfully on `S3` (which apparently works fine 😄 ). I guess this should wait until `HIL` feels fine again
