### PR TITLE
Disable TWAI CLKOUT when initializing peripheral

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: disable and re-enable MISO and MOSI in `start_transfer_dma`, `start_read_bytes_dma` and `start_write_bytes_dma` accordingly (#1894)
 - TWAI: GPIO pins are not configured as input and output (#1906)
 - ESP32C6: Make ADC usable after TRNG deinicialization (#1945)
+- TWAI: CLKOUT is not disabled on initialization (#1949)
 
 ### Removed
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -791,6 +791,11 @@ where
             .err_warning_limit()
             .write(|w| unsafe { w.err_warning_limit().bits(96) });
 
+        // Disable CLKOUT
+        T::register_block()
+            .clock_divider()
+            .write(|w| unsafe { w.cd().bits(0).clock_off().set_bit() });
+
         let mut cfg = TwaiConfiguration {
             peripheral: PhantomData,
             phantom: PhantomData,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This change set the `TWAI_CLOCK_OFF` bit in the `TWAI_CLOCK_DIVIDER_REG` on initialization of the TWAI peripheral. This fixes the issues with the ESP32-C3 being unable to receive on GPIO1 (#1207). Additionally it sets `TWAI_CD` to zero to be sure, although it should already be zero after reset. 

#### Testing
I have tested sending and receiving messages using GPIO1 as RX and GPIO2 as TX on an ESP32-C3. 
