### PR TITLE
Clean up i2s_async test, add option to repeat

### DIFF
--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -2251,8 +2251,6 @@ pub mod asynch {
     }
 
     /// An in-progress async circular DMA write transfer.
-    #[non_exhaustive]
-
     pub struct I2sWriteDmaTransferAsync<'d, T, CH, BUFFER>
     where
         T: RegisterAccess,
@@ -2313,7 +2311,7 @@ pub mod asynch {
         /// One-shot read I2S.
         async fn read_dma_async(&mut self, words: &mut [u8]) -> Result<(), Error>;
 
-        /// Continuously read frm I2S. Returns [I2sReadDmaTransferAsync]
+        /// Continuously read from I2S. Returns [I2sReadDmaTransferAsync]
         fn read_dma_circular_async<RXBUF>(
             self,
             words: RXBUF,
@@ -2407,8 +2405,6 @@ pub mod asynch {
     }
 
     /// An in-progress async circular DMA read transfer.
-    #[non_exhaustive]
-
     pub struct I2sReadDmaTransferAsync<'d, T, CH, BUFFER>
     where
         T: RegisterAccess,

--- a/hil-test/.cargo/config.toml
+++ b/hil-test/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(target_arch = "riscv32")']
-runner    = "probe-rs run"
+runner    = "probe-rs run --preverify"
 rustflags = [
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Tembedded-test.x",
@@ -8,7 +8,7 @@ rustflags = [
 ]
 
 [target.'cfg(target_arch = "xtensa")']
-runner    = "probe-rs run"
+runner    = "probe-rs run --preverify"
 rustflags = [
     "-C", "link-arg=-nostartfiles",
     "-C", "link-arg=-Wl,-Tlinkall.x",

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -150,19 +150,13 @@ mod tests {
         let mut rcv = [0u8; BUFFER_SIZE];
         let mut sample_idx = 0;
         let mut samples = SampleSource::new();
-        let mut success = true;
         for _ in 0..30 {
             let len = rx_transfer.pop(&mut rcv).await.unwrap();
             for &b in &rcv[..len] {
                 let expected = samples.next().unwrap();
-                if b != expected {
-                    success = false;
-                    defmt::error!("Sample #{} does not match ({} != {})", sample_idx, b, expected);
-                }
+                assert_eq!(b, expected, "Sample #{} does not match ({} != {})", sample_idx, b, expected);
                 sample_idx += 1;
             }
         }
-
-        assert!(success);
     }
 }

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -16,34 +16,63 @@ use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaChannel0, DmaPriority},
     gpio::Io,
-    i2s::{asynch::*, DataFormat, I2s, Standard},
+    i2s::{asynch::*, DataFormat, I2s, I2sTx, Standard},
     peripheral::Peripheral,
-    peripherals::Peripherals,
+    peripherals::{I2S0, Peripherals},
     prelude::*,
     system::SystemControl,
+    Async,
 };
 
-// choose values which DON'T restart on every descriptor buffer's start
-const ADD: u8 = 5;
-const CUT_OFF: u8 = 113;
+const BUFFER_SIZE: usize = 2000;
+
+#[derive(Clone)]
+struct SampleSource {
+    i: u8,
+}
+
+impl SampleSource {
+    // choose values which DON'T restart on every descriptor buffer's start
+    const ADD: u8 = 5;
+    const CUT_OFF: u8 = 113;
+
+    fn new() -> Self {
+        Self { i: 0 }
+    }
+}
+
+impl Iterator for SampleSource {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let i = self.i;
+        self.i = (i + Self::ADD) % Self::CUT_OFF;
+        Some(i)
+    }
+}
 
 #[embassy_executor::task]
 async fn writer(
-    i: u8,
-    mut transfer: I2sWriteDmaTransferAsync<
+    tx_buffer: &'static mut [u8],
+    i2s_tx: I2sTx<
         'static,
-        esp_hal::peripherals::I2S0,
+        I2S0,
         DmaChannel0,
-        &'static mut [u8; 2000],
+        Async
     >,
 ) {
-    let mut i = i;
+    let mut samples = SampleSource::new();
+    for b in tx_buffer.iter_mut() {
+        *b = samples.next().unwrap();
+    }
+
+    let mut tx_transfer = i2s_tx.write_dma_circular_async(tx_buffer).unwrap();
+
     loop {
-        transfer
+        tx_transfer
             .push_with(|buffer| {
                 for b in buffer.iter_mut() {
-                    *b = i;
-                    i = (i + ADD) % CUT_OFF;
+                    *b = samples.next().unwrap();
                 }
                 buffer.len()
             })
@@ -73,9 +102,8 @@ mod tests {
         let dma = Dma::new(peripherals.DMA);
         let dma_channel = dma.channel0;
 
-        #[allow(non_upper_case_globals)]
         let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) =
-            esp_hal::dma_circular_buffers!(2000, 2000);
+            esp_hal::dma_circular_buffers!(BUFFER_SIZE, BUFFER_SIZE);
 
         let i2s = I2s::new(
             peripherals.I2S0,
@@ -92,7 +120,7 @@ mod tests {
             .i2s_tx
             .with_bclk(unsafe { io.pins.gpio0.clone_unchecked() })
             .with_ws(unsafe { io.pins.gpio1.clone_unchecked() })
-            .with_dout(unsafe { io.pins.gpio2.clone_unchecked() })
+            .with_dout(io.pins.gpio2)
             .build();
 
         let i2s_rx = i2s
@@ -116,38 +144,25 @@ mod tests {
             i2s.rx_conf().modify(|_, w| w.rx_update().set_bit());
         }
 
-        let mut iteration = 0;
-        let mut failed = false;
-        let mut check_i: u8 = 0;
-        let mut i = 0;
-        for b in tx_buffer.iter_mut() {
-            *b = i;
-            i = (i + ADD) % CUT_OFF;
-        }
-
-        let mut rcv = [0u8; 2000];
-
+        spawner.must_spawn(writer(tx_buffer, i2s_tx));
         let mut rx_transfer = i2s_rx.read_dma_circular_async(rx_buffer).unwrap();
-        let tx_transfer = i2s_tx.write_dma_circular_async(tx_buffer).unwrap();
 
-        spawner.must_spawn(writer(i, tx_transfer));
-
-        'outer: loop {
+        let mut rcv = [0u8; BUFFER_SIZE];
+        let mut sample_idx = 0;
+        let mut samples = SampleSource::new();
+        let mut success = true;
+        for _ in 0..30 {
             let len = rx_transfer.pop(&mut rcv).await.unwrap();
             for &b in &rcv[..len] {
-                if b != check_i {
-                    failed = true;
-                    break 'outer;
+                let expected = samples.next().unwrap();
+                if b != expected {
+                    success = false;
+                    defmt::error!("Sample #{} does not match ({} != {})", sample_idx, b, expected);
                 }
-                check_i = (check_i + ADD) % CUT_OFF;
-            }
-            iteration += 1;
-
-            if iteration > 30 {
-                break;
+                sample_idx += 1;
             }
         }
 
-        assert!(!failed);
+        assert!(success);
     }
 }

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Result};
 
 use crate::windows_safe_path;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CargoAction {
     Build,
     Run,

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -201,7 +201,8 @@ pub fn execute_app(
     chip: Chip,
     target: &str,
     app: &Metadata,
-    action: &CargoAction,
+    action: CargoAction,
+    mut repeat: usize,
 ) -> Result<()> {
     log::info!(
         "Building example '{}' for '{}'",
@@ -214,7 +215,8 @@ pub fn execute_app(
 
     let package = app.example_path().strip_prefix(package_path)?;
     log::info!("Package: {:?}", package);
-    let (bin, subcommand) = if action == &CargoAction::Build {
+    let (bin, subcommand) = if action == CargoAction::Build {
+        repeat = 1; // Do not repeat builds in a loop
         let bin = if package.starts_with("src/bin") {
             format!("--bin={}", app.name())
         } else if package.starts_with("tests") {
@@ -254,7 +256,11 @@ pub fn execute_app(
     let args = builder.build();
     log::debug!("{args:#?}");
 
-    cargo::run(&args, package_path)
+    for _ in 0..repeat {
+        cargo::run(&args, package_path)?;
+    }
+
+    Ok(())
 }
 
 /// Build the specified package, using the given toolchain/target/features if


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

I've been trying to figure out why this test fails with a low probability. While I don't yet know, this PR does some cleanup for the test and adds a new way to re-run tests multiple times with xtask.