### PR TITLE
Simplify initialization APIs

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated to latest release (`0.6.0`) for `embassy-executor` (#1942)
+- Changed `init` to accept timers of multiple types (#1957)
 
 ### Fixed
 

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -21,6 +21,7 @@ esp-hal             = { version = "0.19.0", path = "../esp-hal" }
 log                 = { version = "0.4.22", optional = true }
 macros              = { version = "0.12.0", features = ["embassy"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 portable-atomic     = "1.6.0"
+static_cell         = "2.1.0"
 
 [build-dependencies]
 cfg-if       = "1.0.0"

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -127,12 +127,25 @@ impl<const N: usize> TimerCollection for &'static mut [Timer; N] {
 ///
 /// The time driver can be one of a number of different options:
 ///
-/// - A [Timg] timer instance
-/// - An [Alarm] instance
-/// - An [ErasedTimer] instance
-/// - A [OneShotTimer] instance
-/// - A mutable static slice of [OneShotTimer] instances
-/// - A mutable static array of [OneShotTimer] instances
+/// - A timg `Timer` instance
+/// - A systimer `Alarm` instance
+/// - An `ErasedTimer` instance
+/// - A `OneShotTimer` instance
+/// - A mutable static slice of `OneShotTimer` instances
+/// - A mutable static array of `OneShotTimer` instances
+///
+/// # Examples
+///
+/// ```rust, no_run
+#[doc = esp_hal::before_snippet!()]
+/// use esp_hal::timg::TimerGroup;
+///
+/// let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+/// esp_hal_embassy::init(&clocks, timg0.timer0);
+///
+/// // ... now you can spawn embassy tasks or use `Timer::after` etc.
+/// # }
+/// ```
 pub fn init(clocks: &Clocks, time_driver: impl TimerCollection) {
     EmbassyTimer::init(clocks, time_driver.timers())
 }

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -36,7 +36,17 @@
 // MUST be the first module
 mod fmt;
 
-use esp_hal::clock::Clocks;
+#[cfg(not(feature = "esp32"))]
+use esp_hal::timer::systimer::Alarm;
+#[cfg(timg_timer1)]
+use esp_hal::timer::timg::Timer1;
+use esp_hal::{
+    clock::Clocks,
+    timer::{
+        timg::{Timer as Timg, Timer0, TimerGroupInstance},
+        ErasedTimer,
+    },
+};
 pub use macros::main;
 
 #[cfg(feature = "executors")]
@@ -47,7 +57,83 @@ use self::time_driver::{EmbassyTimer, Timer};
 mod executor;
 mod time_driver;
 
-/// Initialize embassy
-pub fn init(clocks: &Clocks, time_driver: &'static mut [Timer]) {
-    EmbassyTimer::init(clocks, time_driver)
+macro_rules! mk_static {
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write(($val));
+        x
+    }};
+}
+
+/// A trait to allow better UX for initializing the timers.
+pub trait TimerCollection {
+    /// Returns the timers as a slice.
+    fn timers(self) -> &'static mut [Timer];
+}
+
+impl TimerCollection for Timer {
+    fn timers(self) -> &'static mut [Timer] {
+        let timers = mk_static!([Timer; 1], [self]);
+        timers.timers()
+    }
+}
+
+impl<T, DM> TimerCollection for Timg<Timer0<T>, DM>
+where
+    DM: esp_hal::Mode,
+    T: TimerGroupInstance,
+    ErasedTimer: From<Timg<Timer0<T>, DM>>,
+{
+    fn timers(self) -> &'static mut [Timer] {
+        Timer::new(ErasedTimer::from(self)).timers()
+    }
+}
+
+#[cfg(timg_timer1)]
+impl<T, DM> TimerCollection for Timg<Timer1<T>, DM>
+where
+    DM: esp_hal::Mode,
+    T: TimerGroupInstance,
+    ErasedTimer: From<Timg<Timer1<T>, DM>>,
+{
+    fn timers(self) -> &'static mut [Timer] {
+        Timer::new(ErasedTimer::from(self)).timers()
+    }
+}
+
+#[cfg(not(feature = "esp32"))]
+impl<T, DM, const N: u8> TimerCollection for Alarm<T, DM, N>
+where
+    DM: esp_hal::Mode,
+    ErasedTimer: From<Alarm<T, DM, N>>,
+{
+    fn timers(self) -> &'static mut [Timer] {
+        Timer::new(ErasedTimer::from(self)).timers()
+    }
+}
+
+impl TimerCollection for &'static mut [Timer] {
+    fn timers(self) -> &'static mut [Timer] {
+        self
+    }
+}
+
+impl<const N: usize> TimerCollection for &'static mut [Timer; N] {
+    fn timers(self) -> &'static mut [Timer] {
+        self.as_mut()
+    }
+}
+
+/// Initialize embassy.
+///
+/// Call this as soon as possible, before the first timer-related operation.
+///
+/// The time driver can be one of a number of different options:
+///
+/// - A single timer unit, such as a TIMG timer or a SYSTIMER alarm.
+/// - A slice (or array reference) of multiple `[OneShotTimer<ErasedTimer>]`
+///   objects.
+pub fn init(clocks: &Clocks, time_driver: impl TimerCollection) {
+    EmbassyTimer::init(clocks, time_driver.timers())
 }

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -86,7 +86,7 @@ where
 }
 
 #[cfg(not(feature = "esp32"))]
-impl<T, DM, const N: u8> IntoErasedTimer for Alarm<T, DM, N>
+impl<T, DM, COMP, UNIT> IntoErasedTimer for Alarm<'_, T, DM, COMP, UNIT>
 where
     DM: esp_hal::Mode,
     Self: Into<ErasedTimer>,

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -680,7 +680,10 @@ unsafe extern "C" fn stack_chk_fail() {
 #[macro_export]
 macro_rules! before_snippet {
     () => {
-        core::include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/doc-helper/before"))
+        core::include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../esp-hal/doc-helper/before"
+        ))
     };
 }
 
@@ -690,6 +693,9 @@ macro_rules! before_snippet {
 #[macro_export]
 macro_rules! before_snippet {
     () => {
-        core::include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "\\doc-helper\\before"))
+        core::include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "\\..\\esp-hal\\doc-helper\\before"
+        ))
     };
 }

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -369,7 +369,7 @@ where
         }
     }
 
-    /// Block until the timer has elasped.
+    /// Block until the timer has elapsed.
     pub fn wait(&mut self) {
         while !self.has_elapsed() {}
     }

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed `init` to accept timers of multiple types (#1957)
+
 ### Fixed
 
 - Increased NPL event queue size to prevent overflow (#1891)

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -53,8 +53,9 @@ atomic-waker = { version = "1.1.2", default-features = false, features = [
 ] }
 
 [build-dependencies]
-toml-cfg = "0.2.0"
-esp-build = { version = "0.1.0", path = "../esp-build" }
+toml-cfg     = "0.2.0"
+esp-build    = { version = "0.1.0", path = "../esp-build" }
+esp-metadata = { version = "0.2.0", path = "../esp-metadata" }
 
 [features]
 default = ["log"]

--- a/esp-wifi/README.md
+++ b/esp-wifi/README.md
@@ -28,7 +28,7 @@ Minimum supported Rust compiler version: 1.72.0.0
 
 ### Importing
 
-Ensure that the right features are enabled for your chip. See [Examples] for more examples.
+Ensure that the right features are enabled for your chip. See [Examples](https://github.com/esp-rs/esp-hal/tree/main/examples#examples) for more examples.
 
 ```toml
 [dependencies.esp-wifi]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -275,10 +275,29 @@ impl EspWifiTimerSource for TimeBase {
 /// The `timer` argument is a timer source that is used by the WiFi driver to
 /// schedule internal tasks. The timer source can be any of the following:
 ///
-/// - A [Timg] timer instance
-/// - An [Alarm] instance
-/// - An [ErasedTimer] instance
-/// - A [PeriodicTimer] instance
+/// - A timg `Timer` instance
+/// - A systimer `Alarm` instance
+/// - An `ErasedTimer` instance
+/// - A `OneShotTimer` instance
+///
+/// # Examples
+///
+/// ```rust, no_run
+#[doc = esp_hal::before_snippet!()]
+/// use esp_hal::{rng::Rng, timg::TimerGroup};
+/// use esp_wifi::EspWifiInitFor;
+///
+/// let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+/// let init = esp_wifi::initialize(
+///     EspWifiInitFor::Wifi,
+///     timg0.timer0,
+///     Rng::new(peripherals.RNG),
+///     peripherals.RADIO_CLK,
+///     &clocks,
+/// )
+/// .unwrap();
+/// # }
+/// ```
 pub fn initialize(
     init_for: EspWifiInitFor,
     timer: impl EspWifiTimerSource,

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -244,7 +244,7 @@ where
 }
 
 #[cfg(not(feature = "esp32"))]
-impl<T, DM, const N: u8> IntoErasedTimer for Alarm<T, DM, N>
+impl<T, DM, COMP, UNIT> IntoErasedTimer for Alarm<'_, T, DM, COMP, UNIT>
 where
     DM: esp_hal::Mode,
     Self: Into<ErasedTimer>,

--- a/esp-wifi/src/timer/mod.rs
+++ b/esp-wifi/src/timer/mod.rs
@@ -14,6 +14,8 @@ mod arch_specific;
 pub use arch_specific::*;
 pub use chip_specific::*;
 
+use crate::TimeBase;
+
 pub fn setup_timer_isr(timebase: TimeBase) -> Result<(), esp_hal::timer::Error> {
     setup_radio_isr();
 

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -1,10 +1,7 @@
 use core::cell::RefCell;
 
 use critical_section::Mutex;
-use esp_hal::{
-    interrupt::InterruptHandler,
-    timer::{ErasedTimer, PeriodicTimer},
-};
+use esp_hal::interrupt::InterruptHandler;
 #[cfg(any(feature = "esp32c6", feature = "esp32h2"))]
 use peripherals::INTPRI as SystemPeripheral;
 #[cfg(not(any(feature = "esp32c6", feature = "esp32h2")))]

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -17,10 +17,10 @@ use crate::{
         riscv,
     },
     preempt::preempt::task_switch,
+    TimeBase,
 };
 
 /// The timer responsible for time slicing.
-pub type TimeBase = PeriodicTimer<'static, ErasedTimer>;
 static ALARM0: Mutex<RefCell<Option<TimeBase>>> = Mutex::new(RefCell::new(None));
 const TIMESLICE_FREQUENCY: fugit::HertzU64 =
     fugit::HertzU64::from_raw(crate::CONFIG.tick_rate_hz as u64);

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -1,18 +1,15 @@
 use core::cell::RefCell;
 
 use critical_section::Mutex;
-use esp_hal::{
-    interrupt::InterruptHandler,
-    timer::{ErasedTimer, PeriodicTimer},
-};
+use esp_hal::interrupt::InterruptHandler;
 
 use crate::{
     hal::{interrupt, trapframe::TrapFrame, xtensa_lx, xtensa_lx_rt},
     preempt::preempt::task_switch,
+    TimeBase,
 };
 
 /// The timer responsible for time slicing.
-pub type TimeBase = PeriodicTimer<'static, ErasedTimer>;
 static TIMER1: Mutex<RefCell<Option<TimeBase>>> = Mutex::new(RefCell::new(None));
 const TIMESLICE_FREQUENCY: fugit::HertzU64 =
     fugit::HertzU64::from_raw(crate::CONFIG.tick_rate_hz as u64);

--- a/examples/src/bin/embassy_hello_world.rs
+++ b/examples/src/bin/embassy_hello_world.rs
@@ -16,7 +16,7 @@ use esp_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
 };
 
 #[embassy_executor::task]

--- a/examples/src/bin/embassy_hello_world.rs
+++ b/examples/src/bin/embassy_hello_world.rs
@@ -16,18 +16,8 @@ use esp_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
 };
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[embassy_executor::task]
 async fn run() {
@@ -47,10 +37,7 @@ async fn main(spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     spawner.spawn(run()).ok();
 

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -26,19 +26,9 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup,},
 };
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -47,10 +37,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -26,7 +26,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{timg::TimerGroup,},
+    timer::timg::TimerGroup,
 };
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
 

--- a/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -27,7 +27,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
 };
 
 #[esp_hal_embassy::main]

--- a/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -27,18 +27,8 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
 };
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -47,10 +37,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -28,19 +28,9 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
 };
 use esp_println::println;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -50,10 +40,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -28,7 +28,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -42,7 +42,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 
@@ -54,16 +54,6 @@ const SINE: [i16; 64] = [
     -28897, -27244, -25329, -23169, -20787, -18204, -15446, -12539, -9511, -6392, -3211,
 ];
 
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
-
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
     println!("Init!");
@@ -72,10 +62,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -105,8 +105,7 @@ async fn main(low_prio_spawner: Spawner) {
         OneShotTimer::new(alarm0)
     };
 
-    let timers = [timer0, timer1];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 2], timers);
+    let timers = mk_static!([OneShotTimer<ErasedTimer>; 2], [timer0, timer1]);
     esp_hal_embassy::init(&clocks, timers);
 
     static EXECUTOR: StaticCell<InterruptExecutor<2>> = StaticCell::new();

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -22,9 +22,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{
-        systimer::{SystemTimer, Target},
-    },
+    timer::systimer::{SystemTimer, Target},
 };
 use esp_println::println;
 

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -24,21 +24,9 @@ use esp_hal::{
     system::SystemControl,
     timer::{
         systimer::{SystemTimer, Target},
-        ErasedTimer,
-        OneShotTimer,
     },
 };
 use esp_println::println;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -48,10 +36,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
-    let alarm0: ErasedTimer = systimer.alarm0.into();
-    let timers = [OneShotTimer::new(alarm0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, systimer.alarm0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -33,23 +33,9 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{
-        systimer::{SystemTimer, Target},
-        ErasedTimer,
-        OneShotTimer,
-    },
+    timer::systimer::{SystemTimer, Target},
 };
 use esp_println::println;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -59,10 +59,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
-    let alarm0: ErasedTimer = systimer.alarm0.into();
-    let timers = [OneShotTimer::new(alarm0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, systimer.alarm0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     prelude::*,
     rmt::{asynch::RxChannelAsync, PulseCode, Rmt, RxChannelConfig, RxChannelCreatorAsync},
     system::SystemControl,
-    timer::{timg::TimerGroup},
+    timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
 

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     prelude::*,
     rmt::{asynch::RxChannelAsync, PulseCode, Rmt, RxChannelConfig, RxChannelCreatorAsync},
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup},
 };
 use esp_println::{print, println};
 
@@ -27,16 +27,6 @@ const WIDTH: usize = 80;
 
 #[cfg(debug_assertions)]
 compile_error!("Run this example in release mode");
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[embassy_executor::task]
 async fn signal_task(mut pin: Output<'static, Gpio5>) {
@@ -57,10 +47,7 @@ async fn main(spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -21,19 +21,9 @@ use esp_hal::{
     prelude::*,
     rmt::{asynch::TxChannelAsync, PulseCode, Rmt, TxChannelConfig, TxChannelCreatorAsync},
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
 };
 use esp_println::println;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -43,10 +33,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -21,7 +21,7 @@ use esp_hal::{
     prelude::*,
     rmt::{asynch::TxChannelAsync, PulseCode, Rmt, TxChannelConfig, TxChannelCreatorAsync},
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -17,7 +17,7 @@ use esp_hal::{
     gpio::Io,
     peripherals::{Peripherals, UART0},
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
     uart::{
         config::{AtCmdConfig, Config},
         Uart,

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -17,7 +17,7 @@ use esp_hal::{
     gpio::Io,
     peripherals::{Peripherals, UART0},
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
     uart::{
         config::{AtCmdConfig, Config},
         Uart,
@@ -32,16 +32,6 @@ use static_cell::StaticCell;
 const READ_BUF_SIZE: usize = 64;
 // EOT (CTRL-D)
 const AT_CMD: u8 = 0x04;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[embassy_executor::task]
 async fn writer(
@@ -95,10 +85,7 @@ async fn main(spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -33,18 +33,8 @@ use esp_hal::{
         SpiMode,
     },
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
 };
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -54,10 +44,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio0;

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -33,7 +33,7 @@ use esp_hal::{
         SpiMode,
     },
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
 };
 
 #[esp_hal_embassy::main]

--- a/examples/src/bin/embassy_touch.rs
+++ b/examples/src/bin/embassy_touch.rs
@@ -22,20 +22,10 @@ use esp_hal::{
     peripherals::Peripherals,
     rtc_cntl::Rtc,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::timg::TimerGroup,
     touch::{Touch, TouchConfig, TouchPad},
 };
 use esp_println::println;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {

--- a/examples/src/bin/embassy_touch.rs
+++ b/examples/src/bin/embassy_touch.rs
@@ -46,10 +46,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut rtc = Rtc::new(peripherals.LPWR);

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -30,23 +30,13 @@ use esp_hal::{
     interrupt,
     peripherals::{self, Peripherals, TWAI0},
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup,},
     twai::{self, EspTwaiFrame, TwaiMode, TwaiRx, TwaiTx},
 };
 use esp_println::println;
 use static_cell::StaticCell;
 
 type TwaiOutbox = Channel<NoopRawMutex, EspTwaiFrame, 16>;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[embassy_executor::task]
 async fn receiver(
@@ -99,10 +89,7 @@ async fn main(spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -30,7 +30,7 @@ use esp_hal::{
     interrupt,
     peripherals::{self, Peripherals, TWAI0},
     system::SystemControl,
-    timer::{timg::TimerGroup,},
+    timer::timg::TimerGroup,
     twai::{self, EspTwaiFrame, TwaiMode, TwaiRx, TwaiTx},
 };
 use esp_println::println;

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -29,7 +29,7 @@ use esp_hal::{
     },
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
 };
 
 #[esp_hal_embassy::main]

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -29,18 +29,8 @@ use esp_hal::{
     },
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
 };
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) -> () {
@@ -50,10 +40,7 @@ async fn main(_spawner: Spawner) -> () {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/examples/src/bin/embassy_usb_serial_jtag.rs
+++ b/examples/src/bin/embassy_usb_serial_jtag.rs
@@ -15,7 +15,7 @@ use esp_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
     usb_serial_jtag::{UsbSerialJtag, UsbSerialJtagRx, UsbSerialJtagTx},
     Async,
 };

--- a/examples/src/bin/embassy_usb_serial_jtag.rs
+++ b/examples/src/bin/embassy_usb_serial_jtag.rs
@@ -15,23 +15,13 @@ use esp_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
     usb_serial_jtag::{UsbSerialJtag, UsbSerialJtagRx, UsbSerialJtagTx},
     Async,
 };
 use static_cell::StaticCell;
 
 const MAX_BUFFER_SIZE: usize = 512;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[embassy_executor::task]
 async fn writer(
@@ -80,10 +70,7 @@ async fn main(spawner: Spawner) -> () {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let (tx, rx) = UsbSerialJtag::new_async(peripherals.USB_DEVICE).split();
 

--- a/examples/src/bin/embassy_wait.rs
+++ b/examples/src/bin/embassy_wait.rs
@@ -16,7 +16,7 @@ use esp_hal::{
     gpio::{Input, Io, Pull},
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, },
+    timer::timg::TimerGroup,
 };
 
 #[esp_hal_embassy::main]

--- a/examples/src/bin/embassy_wait.rs
+++ b/examples/src/bin/embassy_wait.rs
@@ -16,18 +16,8 @@ use esp_hal::{
     gpio::{Input, Io, Pull},
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, },
 };
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -37,10 +27,7 @@ async fn main(_spawner: Spawner) {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timers = [OneShotTimer::new(timer0)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
     #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]

--- a/examples/src/bin/wifi_access_point.rs
+++ b/examples/src/bin/wifi_access_point.rs
@@ -21,7 +21,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -48,12 +48,10 @@ fn main() -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_access_point_with_sta.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -55,12 +55,10 @@ fn main() -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_bench.rs
+++ b/examples/src/bin/wifi_bench.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 use esp_wifi::{
@@ -68,12 +68,10 @@ fn main() -> ! {
     let server_address: Ipv4Address = HOST_IP.parse().expect("Invalid HOST_IP address");
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_ble.rs
+++ b/examples/src/bin/wifi_ble.rs
@@ -30,7 +30,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 use esp_wifi::{ble::controller::BleConnector, initialize, EspWifiInitFor};
@@ -45,12 +45,10 @@ fn main() -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Ble,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_coex.rs
+++ b/examples/src/bin/wifi_coex.rs
@@ -32,7 +32,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -61,12 +61,10 @@ fn main() -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::WifiBle,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_dhcp.rs
+++ b/examples/src/bin/wifi_dhcp.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -54,12 +54,10 @@ fn main() -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -32,7 +32,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -69,12 +69,10 @@ async fn main(spawner: Spawner) -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -32,7 +32,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -88,20 +88,14 @@ async fn main(spawner: Spawner) -> ! {
     #[cfg(feature = "esp32")]
     {
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-        let timer0: ErasedTimer = timg1.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg1.timer0);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
             .split::<esp_hal::timer::systimer::Target>();
-        let alarm0: ErasedTimer = systimer.alarm0.into();
-        let timers = [OneShotTimer::new(alarm0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, systimer.alarm0);
     }
 
     let config = Config::ipv4_static(StaticConfigV4 {

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -35,7 +35,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -77,12 +77,10 @@ async fn main(spawner: Spawner) -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -35,7 +35,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -96,20 +96,14 @@ async fn main(spawner: Spawner) -> ! {
     #[cfg(feature = "esp32")]
     {
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-        let timer0: ErasedTimer = timg1.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg1.timer0);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
             .split::<esp_hal::timer::systimer::Target>();
-        let alarm0: ErasedTimer = systimer.alarm0.into();
-        let timers = [OneShotTimer::new(alarm0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, systimer.alarm0);
     }
 
     let ap_config = Config::ipv4_static(StaticConfigV4 {

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -26,7 +26,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 use esp_wifi::{
@@ -81,12 +81,10 @@ async fn main(spawner: Spawner) -> ! {
     let server_address: Ipv4Address = HOST_IP.parse().expect("Invalid HOST_IP address");
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -26,7 +26,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -100,20 +100,14 @@ async fn main(spawner: Spawner) -> ! {
     #[cfg(feature = "esp32")]
     {
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-        let timer0: ErasedTimer = timg1.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg1.timer0);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
             .split::<esp_hal::timer::systimer::Target>();
-        let alarm0: ErasedTimer = systimer.alarm0.into();
-        let timers = [OneShotTimer::new(alarm0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, systimer.alarm0);
     }
 
     let config = Config::dhcpv4(Default::default());

--- a/examples/src/bin/wifi_embassy_ble.rs
+++ b/examples/src/bin/wifi_embassy_ble.rs
@@ -32,20 +32,10 @@ use esp_hal::{
     peripherals::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{ble::controller::asynch::BleConnector, initialize, EspWifiInitFor};
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) -> ! {
@@ -83,20 +73,14 @@ async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "esp32")]
     {
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-        let timer0: ErasedTimer = timg1.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg1.timer0);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
             .split::<esp_hal::timer::systimer::Target>();
-        let alarm0: ErasedTimer = systimer.alarm0.into();
-        let timers = [OneShotTimer::new(alarm0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, systimer.alarm0);
     }
 
     let mut bluetooth = peripherals.BT;

--- a/examples/src/bin/wifi_embassy_ble.rs
+++ b/examples/src/bin/wifi_embassy_ble.rs
@@ -32,7 +32,7 @@ use esp_hal::{
     peripherals::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 use esp_wifi::{ble::controller::asynch::BleConnector, initialize, EspWifiInitFor};
@@ -47,12 +47,10 @@ async fn main(_spawner: Spawner) -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Ble,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 use esp_wifi::{
@@ -62,12 +62,10 @@ async fn main(spawner: Spawner) -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -81,20 +81,14 @@ async fn main(spawner: Spawner) -> ! {
     #[cfg(feature = "esp32")]
     {
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-        let timer0: ErasedTimer = timg1.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg1.timer0);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
             .split::<esp_hal::timer::systimer::Target>();
-        let alarm0: ErasedTimer = systimer.alarm0.into();
-        let timers = [OneShotTimer::new(alarm0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, systimer.alarm0);
     }
 
     let config = Config::dhcpv4(Default::default());

--- a/examples/src/bin/wifi_embassy_esp_now.rs
+++ b/examples/src/bin/wifi_embassy_esp_now.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 use esp_wifi::{
@@ -38,12 +38,10 @@ async fn main(_spawner: Spawner) -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_embassy_esp_now.rs
+++ b/examples/src/bin/wifi_embassy_esp_now.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -27,16 +27,6 @@ use esp_wifi::{
     initialize,
     EspWifiInitFor,
 };
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) -> ! {
@@ -67,20 +57,14 @@ async fn main(_spawner: Spawner) -> ! {
     #[cfg(feature = "esp32")]
     {
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-        let timer0: ErasedTimer = timg1.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg1.timer0);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
             .split::<esp_hal::timer::systimer::Target>();
-        let alarm0: ErasedTimer = systimer.alarm0.into();
-        let timers = [OneShotTimer::new(alarm0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, systimer.alarm0);
     }
 
     let mut ticker = Ticker::every(Duration::from_secs(5));

--- a/examples/src/bin/wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/wifi_embassy_esp_now_duplex.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 use esp_wifi::{

--- a/examples/src/bin/wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/wifi_embassy_esp_now_duplex.rs
@@ -48,12 +48,10 @@ async fn main(spawner: Spawner) -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/wifi_embassy_esp_now_duplex.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     peripherals::Peripherals,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
 };
 use esp_println::println;
 use esp_wifi::{
@@ -67,20 +67,14 @@ async fn main(spawner: Spawner) -> ! {
     #[cfg(feature = "esp32")]
     {
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-        let timer0: ErasedTimer = timg1.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg1.timer0);
     }
 
     #[cfg(not(feature = "esp32"))]
     {
         let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
             .split::<esp_hal::timer::systimer::Target>();
-        let alarm0: ErasedTimer = systimer.alarm0.into();
-        let timers = [OneShotTimer::new(alarm0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, systimer.alarm0);
     }
 
     let (manager, sender, receiver) = esp_now.split();

--- a/examples/src/bin/wifi_esp_now.rs
+++ b/examples/src/bin/wifi_esp_now.rs
@@ -15,7 +15,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::println;
 use esp_wifi::{
@@ -35,12 +35,10 @@ fn main() -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/src/bin/wifi_static_ip.rs
+++ b/examples/src/bin/wifi_static_ip.rs
@@ -20,7 +20,7 @@ use esp_hal::{
     prelude::*,
     rng::Rng,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, PeriodicTimer},
+    timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
 use esp_wifi::{
@@ -54,12 +54,10 @@ fn main() -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let timer0: ErasedTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
 
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -120,17 +120,13 @@ struct Resources {
 impl Resources {
     fn set_up_embassy_with_timg0(self) {
         let timg0 = TimerGroup::new(self.timg0, &self.clocks);
-        let timer0: ErasedTimer = timg0.timer0.into();
-        let timers = mk_static!(OneShotTimer<ErasedTimer>, OneShotTimer::new(timer0));
-        esp_hal_embassy::init(&self.clocks, core::slice::from_mut(timers));
+        esp_hal_embassy::init(&self.clocks, timg0.timer0);
     }
 
     #[cfg(not(feature = "esp32"))]
     fn set_up_embassy_with_systimer(self) {
         let systimer = SystemTimer::new(self.systimer).split::<Target>();
-        let alarm0: ErasedTimer = systimer.alarm0.into();
-        let timers = mk_static!(OneShotTimer<ErasedTimer>, OneShotTimer::new(alarm0));
-        esp_hal_embassy::init(&self.clocks, core::slice::from_mut(timers));
+        esp_hal_embassy::init(&self.clocks, systimer.alarm0);
     }
 }
 

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -55,10 +55,7 @@ impl<'d> Context<'d> {
         let delay = Delay::new(&clocks);
 
         let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-        let timer0: ErasedTimer = timg0.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg0.timer0);
 
         Context {
             io2: Input::new(io.pins.gpio2, Pull::Down),


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR reduces the boilerplate necessary to call esp_hal_embassy::init and esp_wifi::initialize (not touching the inconsistent naming) by introducing conversion traits and implementing it for the most commonly used types.

(skip-changelog) added because the typo fix in esp-hal doesn't deserve any.

#### Testing

Compiled the examples, no additional testing done yet.
