### PR TITLE
Disable RTT polling in HIL tests by default

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+name = "hil_test"
+
 [[test]]
 name    = "aes"
 harness = false
@@ -117,7 +120,6 @@ required-features = ["async", "embassy"]
 name    = "uart_tx_rx"
 harness = false
 
-
 [[test]]
 name    = "uart_tx_rx_async"
 harness = false
@@ -140,7 +142,7 @@ harness = false
 cfg-if             = "1.0.0"
 critical-section   = "1.1.2"
 defmt              = "0.3.8"
-defmt-rtt          = "0.4.1"
+defmt-rtt          = { version = "0.4.1", optional = true }
 embassy-futures    = "0.1.1"
 embassy-sync       = "0.6.0"
 embassy-time       = { version = "0.3.1", features = ["generic-queue-64"] }
@@ -167,6 +169,8 @@ p256                = { version = "0.13.2", default-features = false, features =
 
 [features]
 default = ["async", "embassy"]
+
+defmt = ["dep:defmt-rtt"]
 
 # Device support (required!):
 esp32 = [

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -9,14 +9,13 @@ For assistance with this package please [open an issue] or [start a discussion].
 
 ## Quickstart
 
-We use [embedded-test] as our testing framework, which relies on [defmt] internally. This allows us to write unit and integration tests much in the same way you would for a normal Rust project, when the standard library is available, and to execute them using Cargo's built-in test runner.
+We use [embedded-test] as our testing framework. This allows us to write unit and integration tests much in the same way you would for a normal Rust project, when the standard library is available, and to execute them using Cargo's built-in test runner.
 
 [embedded-test]: https://github.com/probe-rs/embedded-test
-[defmt]: https://github.com/knurling-rs/defmt
 
 ### Running Tests Locally
 
-We use [probe-rs] for flashing and running the tests on a target device, however, this **MUST** be installed from the correct revision, and with the correct features enabled:
+We use [probe-rs] for flashing and running the tests on a target device, however, this **MUST** be installed from the correct revision:
 
 ```text
 cargo install probe-rs-tools \
@@ -37,6 +36,13 @@ For running a single test on a target, from the `xtask` folder run:
 ```shell
 # Run GPIO tests for ESP32-C6
 cargo xtask run-tests esp32c6 --test gpio
+```
+
+If you want to run a test multiple times:
+
+```shell
+# Run GPIO tests for ESP32-C6
+cargo xtask run-tests esp32c6 --test gpio --repeat 10
 ```
 
 Another alternative way of running a single test is, from the `hil-tests` folder:
@@ -138,3 +144,23 @@ sudo reboot
 If the test is supported by all the targets, you can omit the header.
 
 6. Write some documentation at the top of the `tests/$PERIPHERAL.rs` file with the pins being used and the required connections, if applicable.
+
+## Logging in tests
+
+The tests can use [defmt] to print logs. To enable log output, add the `defmt` feature to the test
+you want to run. Eg:
+
+```rust
+//! AES Test
+
+//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: defmt
+```
+
+Make sure to remove this addition before you commit any modifications.
+
+> NOTE: log output is disabled by default. Enabling it can introduce some timing issues, which
+makes some tests fail randomly. This issue affects all Xtensa devices, as well as ESP32-C2 and
+ESP32-C3 currently.
+
+[defmt]: https://github.com/knurling-rs/defmt

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+
+// By default, we don't want probe-rs to interfere with test timings by halting
+// cores and polling RTT. The tests don't produce output most of the time
+// anyway. The only cases where output can be interesting are: during
+// development, and when a test fails. In these cases, you can enable
+// the `defmt` feature to get the output.
+
+#[cfg(not(feature = "defmt"))]
+#[defmt::global_logger]
+struct Logger;
+
+#[cfg(not(feature = "defmt"))]
+unsafe impl defmt::Logger for Logger {
+    fn acquire() {}
+    unsafe fn flush() {}
+    unsafe fn release() {}
+    unsafe fn write(_bytes: &[u8]) {}
+}
+
+#[cfg(feature = "defmt")]
+use defmt_rtt as _;
+// Make sure esp_backtrace is not removed.
+use esp_backtrace as _;

--- a/hil-test/tests/aes.rs
+++ b/hil-test/tests/aes.rs
@@ -5,12 +5,11 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     aes::{Aes, Mode},
     peripherals::Peripherals,
 };
+use hil_test as _;
 
 struct Context<'a> {
     aes: Aes<'a>,

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -5,8 +5,6 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     aes::{
         dma::{CipherMode, WithDmaAes},
@@ -17,6 +15,7 @@ use esp_hal::{
     dma_buffers,
     peripherals::Peripherals,
 };
+use hil_test as _;
 
 const DMA_BUFFER_SIZE: usize = 16;
 

--- a/hil-test/tests/clock_monitor.rs
+++ b/hil-test/tests/clock_monitor.rs
@@ -5,14 +5,13 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     peripherals::Peripherals,
     rtc_cntl::Rtc,
     system::SystemControl,
 };
+use hil_test as _;
 
 struct Context<'a> {
     rtc: Rtc<'a>,

--- a/hil-test/tests/crc.rs
+++ b/hil-test/tests/crc.rs
@@ -7,9 +7,8 @@
 
 use core::ops::Deref;
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::rom::{crc, md5};
+use hil_test as _;
 
 #[cfg(test)]
 #[embedded_test::tests]

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -6,10 +6,9 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
 use embedded_hal::delay::DelayNs;
-use esp_backtrace as _;
 use esp_hal::{clock::ClockControl, delay::Delay, peripherals::Peripherals, system::SystemControl};
+use hil_test as _;
 
 struct Context {
     delay: Delay,

--- a/hil-test/tests/dma_macros.rs
+++ b/hil-test/tests/dma_macros.rs
@@ -5,8 +5,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
+use hil_test as _;
 
 const DATA_SIZE: usize = 1024 * 10;
 

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -5,8 +5,6 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaError, DmaPriority, Mem2Mem},
@@ -16,6 +14,7 @@ use esp_hal::{
     peripherals::Peripherals,
     system::SystemControl,
 };
+use hil_test as _;
 
 const DATA_SIZE: usize = 1024 * 10;
 

--- a/hil-test/tests/ecc.rs
+++ b/hil-test/tests/ecc.rs
@@ -13,9 +13,7 @@ use crypto_bigint::{
     U192,
     U256,
 };
-use defmt_rtt as _;
 use elliptic_curve::sec1::ToEncodedPoint;
-use esp_backtrace as _;
 #[cfg(feature = "esp32h2")]
 use esp_hal::ecc::WorkMode;
 use esp_hal::{
@@ -25,6 +23,7 @@ use esp_hal::{
     Blocking,
 };
 use hex_literal::hex;
+use hil_test as _;
 
 struct TestParams<'a> {
     prime_fields: &'a [&'a [u8]],

--- a/hil-test/tests/embassy_interrupt_executor.rs
+++ b/hil-test/tests/embassy_interrupt_executor.rs
@@ -28,7 +28,6 @@ async fn interrupt_driven_task(signal: &'static Signal<CriticalSectionRawMutex, 
 #[cfg(test)]
 #[embedded_test::tests]
 mod test {
-    use hil_test as _;
     use esp_hal::{
         clock::ClockControl,
         interrupt::Priority,
@@ -36,6 +35,7 @@ mod test {
         system::{SoftwareInterrupt, SystemControl},
     };
     use esp_hal_embassy::InterruptExecutor;
+    use hil_test as _;
 
     use super::*;
 

--- a/hil-test/tests/embassy_interrupt_executor.rs
+++ b/hil-test/tests/embassy_interrupt_executor.rs
@@ -22,15 +22,13 @@ macro_rules! mk_static {
 async fn interrupt_driven_task(signal: &'static Signal<CriticalSectionRawMutex, ()>) {
     loop {
         signal.wait().await;
-        defmt::info!("Received");
     }
 }
 
 #[cfg(test)]
 #[embedded_test::tests]
 mod test {
-    use defmt_rtt as _;
-    use esp_backtrace as _;
+    use hil_test as _;
     use esp_hal::{
         clock::ClockControl,
         interrupt::Priority,
@@ -61,6 +59,5 @@ mod test {
         spawner.spawn(interrupt_driven_task(signal)).unwrap();
 
         signal.signal(());
-        defmt::info!("Returned");
     }
 }

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -6,7 +6,6 @@
 #![no_std]
 #![no_main]
 
-use hil_test as _;
 use embassy_time::{Duration, Ticker, Timer};
 use esp_hal::{
     clock::{ClockControl, Clocks},
@@ -22,6 +21,7 @@ use esp_hal::{
 };
 #[cfg(not(feature = "esp32"))]
 use esp_hal_embassy::InterruptExecutor;
+use hil_test as _;
 
 macro_rules! mk_static {
     ($t:ty,$val:expr) => {{

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -6,9 +6,8 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
+use hil_test as _;
 use embassy_time::{Duration, Ticker, Timer};
-use esp_backtrace as _;
 use esp_hal::{
     clock::{ClockControl, Clocks},
     peripherals::Peripherals,

--- a/hil-test/tests/get_time.rs
+++ b/hil-test/tests/get_time.rs
@@ -6,9 +6,8 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{clock::ClockControl, delay::Delay, peripherals::Peripherals, system::SystemControl};
+use hil_test as _;
 
 struct Context {
     delay: Delay,

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -12,7 +12,6 @@
 use core::cell::RefCell;
 
 use critical_section::Mutex;
-use hil_test as _;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,
@@ -23,6 +22,7 @@ use esp_hal::{
     timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
     InterruptConfigurable,
 };
+use hil_test as _;
 
 macro_rules! mk_static {
     ($t:ty,$val:expr) => {{

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -12,8 +12,7 @@
 use core::cell::RefCell;
 
 use critical_section::Mutex;
-use defmt_rtt as _;
-use esp_backtrace as _;
+use hil_test as _;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -10,8 +10,6 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,
@@ -24,6 +22,7 @@ use esp_hal::{
     prelude::*,
     system::SystemControl,
 };
+use hil_test as _;
 
 // choose values which DON'T restart on every descriptor buffer's start
 const ADD: u8 = 5;

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -24,9 +24,30 @@ use esp_hal::{
 };
 use hil_test as _;
 
-// choose values which DON'T restart on every descriptor buffer's start
-const ADD: u8 = 5;
-const CUT_OFF: u8 = 113;
+#[derive(Clone)]
+struct SampleSource {
+    i: u8,
+}
+
+impl SampleSource {
+    // choose values which DON'T restart on every descriptor buffer's start
+    const ADD: u8 = 5;
+    const CUT_OFF: u8 = 113;
+
+    fn new() -> Self {
+        Self { i: 0 }
+    }
+}
+
+impl Iterator for SampleSource {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let i = self.i;
+        self.i = (i + Self::ADD) % Self::CUT_OFF;
+        Some(i)
+    }
+}
 
 #[cfg(test)]
 #[embedded_test::tests]
@@ -91,13 +112,9 @@ mod tests {
             i2s.rx_conf().modify(|_, w| w.rx_update().set_bit());
         }
 
-        let mut iteration = 0;
-        let mut failed = false;
-        let mut check_i: u8 = 0;
-        let mut i = 0;
+        let mut samples = SampleSource::new();
         for b in tx_buffer.iter_mut() {
-            *b = i;
-            i = (i + ADD) % CUT_OFF;
+            *b = samples.next().unwrap();
         }
 
         let mut rcv = [0u8; 11000];
@@ -112,14 +129,16 @@ mod tests {
 
         let mut tx_transfer = i2s_tx.write_dma_circular(&tx_buffer).unwrap();
 
-        'outer: loop {
+        let mut iteration = 0;
+        let mut sample_idx = 0;
+        let mut check_samples = SampleSource::new();
+        loop {
             let tx_avail = tx_transfer.available();
 
             // make sure there are more than one descriptor buffers ready to push
             if tx_avail > 5000 {
                 for b in &mut filler[0..tx_avail].iter_mut() {
-                    *b = i;
-                    i = (i + ADD) % CUT_OFF;
+                    *b = samples.next().unwrap();
                 }
                 tx_transfer.push(&filler[0..tx_avail]).unwrap();
             }
@@ -146,11 +165,13 @@ mod tests {
                 assert!(len > 0);
 
                 for &b in &rcv[..len] {
-                    if b != check_i {
-                        failed = true;
-                        break 'outer;
-                    }
-                    check_i = (check_i + ADD) % CUT_OFF;
+                    let expected = check_samples.next().unwrap();
+                    assert_eq!(
+                        b, expected,
+                        "Sample #{} does not match ({} != {})",
+                        sample_idx, b, expected
+                    );
+                    sample_idx += 1;
                 }
 
                 iteration += 1;
@@ -166,7 +187,5 @@ mod tests {
                 break;
             }
         }
-
-        assert!(!failed);
     }
 }

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -10,7 +10,6 @@
 #![no_std]
 #![no_main]
 
-use hil_test as _;
 use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaChannel0, DmaPriority},
@@ -22,6 +21,7 @@ use esp_hal::{
     system::SystemControl,
     Async,
 };
+use hil_test as _;
 
 const BUFFER_SIZE: usize = 2000;
 

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -10,8 +10,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
+use hil_test as _;
 use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaChannel0, DmaPriority},

--- a/hil-test/tests/interrupt.rs
+++ b/hil-test/tests/interrupt.rs
@@ -10,15 +10,13 @@
 use core::{arch::asm, cell::RefCell};
 
 use critical_section::Mutex;
-use defmt::info;
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     interrupt::{self, *},
     peripherals::{Interrupt, Peripherals},
     system::{SoftwareInterrupt, SystemControl},
 };
+use hil_test as _;
 
 static SWINT0: Mutex<RefCell<Option<SoftwareInterrupt<0>>>> = Mutex::new(RefCell::new(None));
 
@@ -79,7 +77,7 @@ fn interrupt20() {
             x = inout(reg) perf_counter,
         )
     };
-    info!("Performance counter:{}", perf_counter);
+    defmt::info!("Performance counter:{}", perf_counter);
     // TODO these values should be adjusted to catch smaller regressions
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32c3", feature = "esp32c2"))] {

--- a/hil-test/tests/lcd_cam_i8080.rs
+++ b/hil-test/tests/lcd_cam_i8080.rs
@@ -5,8 +5,6 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     clock::{ClockControl, Clocks},
     dma::{Dma, DmaDescriptor, DmaPriority},
@@ -23,6 +21,7 @@ use esp_hal::{
     prelude::*,
     system::SystemControl,
 };
+use hil_test as _;
 
 const DATA_SIZE: usize = 1024 * 10;
 

--- a/hil-test/tests/lcd_cam_i8080_async.rs
+++ b/hil-test/tests/lcd_cam_i8080_async.rs
@@ -5,7 +5,6 @@
 #![no_std]
 #![no_main]
 
-use hil_test as _;
 use esp_hal::{
     clock::{ClockControl, Clocks},
     dma::{Dma, DmaDescriptor, DmaPriority},
@@ -22,6 +21,7 @@ use esp_hal::{
     prelude::*,
     system::SystemControl,
 };
+use hil_test as _;
 
 const DATA_SIZE: usize = 1024 * 10;
 

--- a/hil-test/tests/lcd_cam_i8080_async.rs
+++ b/hil-test/tests/lcd_cam_i8080_async.rs
@@ -5,8 +5,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
+use hil_test as _;
 use esp_hal::{
     clock::{ClockControl, Clocks},
     dma::{Dma, DmaDescriptor, DmaPriority},

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -7,9 +7,8 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{delay::Delay, gpio::GpioPin, pcnt::Pcnt};
+use hil_test as _;
 
 struct Context<'d> {
     pcnt: Pcnt<'d>,

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -7,8 +7,6 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     gpio::Io,
@@ -17,6 +15,7 @@ use esp_hal::{
     rmt::{PulseCode, Rmt, RxChannel, RxChannelConfig, TxChannel, TxChannelConfig},
     system::SystemControl,
 };
+use hil_test as _;
 
 #[cfg(test)]
 #[embedded_test::tests]

--- a/hil-test/tests/rsa.rs
+++ b/hil-test/tests/rsa.rs
@@ -6,8 +6,6 @@
 #![no_main]
 
 use crypto_bigint::{Uint, U1024, U512};
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
@@ -20,6 +18,8 @@ use esp_hal::{
     },
     Blocking,
 };
+use hil_test as _;
+
 const BIGNUM_1: U512 = Uint::from_be_hex(
     "c7f61058f96db3bd87dbab08ab03b4f7f2f864eac249144adea6a65f97803b719d8ca980b7b3c0389c1c7c6\
     7dc353c5e0ec11f5fc8ce7f6073796cc8f73fa878",

--- a/hil-test/tests/sha.rs
+++ b/hil-test/tests/sha.rs
@@ -5,13 +5,12 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     sha::{Sha, ShaMode},
 };
+use hil_test as _;
 use nb::block;
 
 #[cfg(test)]

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -13,9 +13,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
 use embedded_hal::spi::SpiBus;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     gpio::Io,
@@ -24,6 +22,7 @@ use esp_hal::{
     spi::{master::Spi, FullDuplexMode, SpiMode},
     system::SystemControl,
 };
+use hil_test as _;
 
 struct Context {
     spi: Spi<'static, esp_hal::peripherals::SPI2, FullDuplexMode>,

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -21,8 +21,6 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaPriority},
@@ -36,6 +34,7 @@ use esp_hal::{
     },
     system::SystemControl,
 };
+use hil_test as _;
 
 #[cfg(test)]
 #[embedded_test::tests]

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -19,9 +19,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
 use embedded_hal_async::spi::SpiBus;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     dma::{Dma, DmaPriority},
@@ -39,6 +37,7 @@ use esp_hal::{
     },
     system::SystemControl,
 };
+use hil_test as _;
 
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -13,8 +13,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
+use hil_test as _;
 
 #[cfg(test)]
 #[embedded_test::tests]

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -13,8 +13,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
+use hil_test as _;
 
 #[cfg(test)]
 #[embedded_test::tests]

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -11,9 +11,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
 use embedded_hal_02::can::Frame;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     gpio::Io,
@@ -23,6 +21,7 @@ use esp_hal::{
     twai::{self, filter::SingleStandardFilter, EspTwaiFrame, StandardId, TwaiMode},
     Blocking,
 };
+use hil_test as _;
 use nb::block;
 
 struct Context {

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -11,9 +11,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
 use embedded_hal_02::serial::{Read, Write};
-use esp_backtrace as _;
 use esp_hal::{
     clock::{ClockControl, Clocks},
     gpio::Io,
@@ -23,6 +21,7 @@ use esp_hal::{
     uart::{ClockSource, Uart},
     Blocking,
 };
+use hil_test as _;
 use nb::block;
 
 struct Context {

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -11,7 +11,6 @@
 #![no_std]
 #![no_main]
 
-use hil_test as _;
 use esp_hal::{
     clock::ClockControl,
     gpio::Io,
@@ -20,6 +19,7 @@ use esp_hal::{
     uart::Uart,
     Async,
 };
+use hil_test as _;
 
 struct Context {
     uart: Uart<'static, UART0, Async>,

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -11,8 +11,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
+use hil_test as _;
 use esp_hal::{
     clock::ClockControl,
     gpio::Io,

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -11,8 +11,6 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     gpio::Io,
@@ -22,6 +20,7 @@ use esp_hal::{
     uart::{UartRx, UartTx},
     Blocking,
 };
+use hil_test as _;
 use nb::block;
 
 struct Context {

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -11,7 +11,6 @@
 #![no_std]
 #![no_main]
 
-use hil_test as _;
 use esp_hal::{
     clock::ClockControl,
     gpio::Io,
@@ -20,6 +19,7 @@ use esp_hal::{
     uart::{UartRx, UartTx},
     Async,
 };
+use hil_test as _;
 
 struct Context {
     tx: UartTx<'static, UART0, Async>,

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -11,8 +11,7 @@
 #![no_std]
 #![no_main]
 
-use defmt_rtt as _;
-use esp_backtrace as _;
+use hil_test as _;
 use esp_hal::{
     clock::ClockControl,
     gpio::Io,

--- a/hil-test/tests/usb_serial_jtag.rs
+++ b/hil-test/tests/usb_serial_jtag.rs
@@ -8,8 +8,6 @@
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt_rtt as _;
-    use esp_backtrace as _;
     use esp_hal::{
         clock::ClockControl,
         peripherals::Peripherals,
@@ -17,6 +15,7 @@ mod tests {
         timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
         usb_serial_jtag::UsbSerialJtag,
     };
+    use hil_test as _;
 
     // When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
     macro_rules! mk_static {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Polling RTT periodically (1 or 100ms) stops the core to read a few bits of memory. In some of our tests this seem to be causing problems, so let's disable for HIL tests.

Why we might not want to do this?

Our users might be hitting similar rare, random issues. Maybe we should try and make esp-hal more resilient to random interruptions?

#### Testing

Ran a problematic test 1000 times in a loop.