### PR TITLE
Add basic GPIO HIL test for `AnyPin` and touch pin

### DIFF
--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -17,7 +17,7 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     delay::Delay,
-    gpio::{Gpio2, Gpio3, GpioPin, Input, Io, Level, Output, Pull},
+    gpio::{any_pin::AnyPin, Gpio2, Gpio3, GpioPin, Input, Io, Level, Output, Pull},
     macros::handler,
     peripherals::Peripherals,
     system::SystemControl,
@@ -275,5 +275,33 @@ mod tests {
 
         assert_eq!(io2.is_low(), true);
         assert_eq!(io3.is_set_low(), true);
+    }
+
+    // Tests touch pin (GPIO2) as AnyPin and Output
+    // https://github.com/esp-rs/esp-hal/issues/1943
+    #[test]
+    fn test_gpio_touch_anypin_output() {
+        let any_pin2 = AnyPin::new(unsafe { GpioPin::<2>::steal() });
+        let any_pin3 = AnyPin::new(unsafe { GpioPin::<3>::steal() });
+
+        let out_pin = Output::new(any_pin2, Level::High);
+        let in_pin = Input::new(any_pin3, Pull::Down);
+
+        assert_eq!(out_pin.is_set_high(), true);
+        assert_eq!(in_pin.is_high(), true);
+    }
+
+    // Tests touch pin (GPIO2) as AnyPin and Input
+    // https://github.com/esp-rs/esp-hal/issues/1943
+    #[test]
+    fn test_gpio_touch_anypin_input() {
+        let any_pin2 = AnyPin::new(unsafe { GpioPin::<2>::steal() });
+        let any_pin3 = AnyPin::new(unsafe { GpioPin::<3>::steal() });
+
+        let out_pin = Output::new(any_pin3, Level::Low);
+        let in_pin = Input::new(any_pin2, Pull::Down);
+
+        assert_eq!(out_pin.is_set_high(), false);
+        assert_eq!(in_pin.is_high(), false);
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Related to https://github.com/esp-rs/esp-hal/issues/1943

#### Testing
From https://github.com/esp-rs/esp-hal/issues/1943#issue-2464114412
```rust
let blue_led = io.pins.gpio2;
spawner.spawn(led_blinker(AnyPin::new(blue_led))).ok();


async fn led_blinker(pin: AnyPin<'static>) {
    let mut led = Output::new(pin, Level::High);
}
```

is the key part that panics on ESP32 without https://github.com/esp-rs/esp-hal/pull/1956. Now it should work fine.