### PR TITLE
Remove `free(self)` in HMAC which goes against esp-hal API guidelines

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DMA buffers now don't require a static lifetime. Make sure to never `mem::forget` an in-progress DMA transfer (consider using `#[deny(clippy::mem_forget)]`) (#1837)
 - Peripherals (where possible) are now explicitly reset and enabled in their constructors (#1893)
 - Reset peripherals in driver constructors where missing (#1893, #1961)
+- Remove `fn free(self)` in HMAC which goes against esp-hal API guidelines (#1972)
 
 ### Fixed
 

--- a/esp-hal/src/hmac.rs
+++ b/esp-hal/src/hmac.rs
@@ -109,10 +109,6 @@ impl<'d> Hmac<'d> {
         }
     }
 
-    pub fn free(self) -> PeripheralRef<'d, HMAC> {
-        self.hmac
-    }
-
     /// Step 1. Enable HMAC module.
     ///
     /// Before these steps, the user shall set the peripheral clocks bits for


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

