### PR TITLE
Remove redundant WithDmaSpi traits

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This package no longer re-exports the `esp_hal_procmacros::main` macro (#1828)
 - The `AesFlavour` trait no longer has the `ENCRYPT_MODE`/`DECRYPT_MODE` associated constants (#1849)
 - Removed `FlashSafeDma` (#1856)
+- Remove redundant WithDmaSpi traits (#1975)
 
 ## [0.19.0] - 2024-07-15
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -90,10 +90,7 @@ use crate::{
 
 /// Prelude for the SPI (Master) driver
 pub mod prelude {
-    #[cfg(spi3)]
-    pub use super::dma::WithDmaSpi3 as _esp_hal_spi_master_dma_WithDmaSpi3;
     pub use super::{
-        dma::WithDmaSpi2 as _esp_hal_spi_master_dma_WithDmaSpi2,
         Instance as _esp_hal_spi_master_Instance,
         InstanceDma as _esp_hal_spi_master_InstanceDma,
     };
@@ -867,44 +864,19 @@ pub mod dma {
         Mode,
     };
 
-    pub trait WithDmaSpi2<'d, C, M, DmaMode>
+    impl<'d, M> Spi<'d, crate::peripherals::SPI2, M>
     where
-        C: DmaChannel,
-        C::P: SpiPeripheral,
         M: DuplexMode,
-        DmaMode: Mode,
     {
-        fn with_dma(
-            self,
-            channel: Channel<'d, C, DmaMode>,
-        ) -> SpiDma<'d, crate::peripherals::SPI2, C, M, DmaMode>;
-    }
-
-    #[cfg(spi3)]
-    pub trait WithDmaSpi3<'d, C, M, DmaMode>
-    where
-        C: DmaChannel,
-        C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
-    {
-        fn with_dma(
-            self,
-            channel: Channel<'d, C, DmaMode>,
-        ) -> SpiDma<'d, crate::peripherals::SPI3, C, M, DmaMode>;
-    }
-
-    impl<'d, C, M, DmaMode> WithDmaSpi2<'d, C, M, DmaMode> for Spi<'d, crate::peripherals::SPI2, M>
-    where
-        C: DmaChannel,
-        C::P: SpiPeripheral + Spi2Peripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
-    {
-        fn with_dma(
+        pub fn with_dma<C, DmaMode>(
             self,
             mut channel: Channel<'d, C, DmaMode>,
-        ) -> SpiDma<'d, crate::peripherals::SPI2, C, M, DmaMode> {
+        ) -> SpiDma<'d, crate::peripherals::SPI2, C, M, DmaMode>
+        where
+            C: DmaChannel,
+            C::P: SpiPeripheral + Spi2Peripheral,
+            DmaMode: Mode,
+        {
             channel.tx.init_channel(); // no need to call this for both, TX and RX
 
             SpiDma {
@@ -916,17 +888,19 @@ pub mod dma {
     }
 
     #[cfg(spi3)]
-    impl<'d, C, M, DmaMode> WithDmaSpi3<'d, C, M, DmaMode> for Spi<'d, crate::peripherals::SPI3, M>
+    impl<'d, M> Spi<'d, crate::peripherals::SPI3, M>
     where
-        C: DmaChannel,
-        C::P: SpiPeripheral + Spi3Peripheral,
         M: DuplexMode,
-        DmaMode: Mode,
     {
-        fn with_dma(
+        pub fn with_dma<C, DmaMode>(
             self,
             mut channel: Channel<'d, C, DmaMode>,
-        ) -> SpiDma<'d, crate::peripherals::SPI3, C, M, DmaMode> {
+        ) -> SpiDma<'d, crate::peripherals::SPI3, C, M, DmaMode>
+        where
+            C: DmaChannel,
+            C::P: SpiPeripheral + Spi3Peripheral,
+            DmaMode: Mode,
+        {
             channel.tx.init_channel(); // no need to call this for both, TX and RX
 
             SpiDma {

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -28,10 +28,7 @@ use esp_hal::{
     gpio::Io,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     system::SystemControl,
     timer::timg::TimerGroup,
 };

--- a/examples/src/bin/qspi_flash.rs
+++ b/examples/src/bin/qspi_flash.rs
@@ -37,7 +37,7 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Address, Command, Spi},
+        master::{Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -27,10 +27,7 @@ use esp_hal::{
     gpio::Io,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     system::SystemControl,
 };
 use esp_println::println;

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -28,10 +28,7 @@ use esp_hal::{
     gpio::Io,
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     system::SystemControl,
 };
 use hil_test as _;

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -31,10 +31,7 @@ use esp_hal::{
     },
     peripherals::Peripherals,
     prelude::*,
-    spi::{
-        master::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{master::Spi, SpiMode},
     system::SystemControl,
 };
 use hil_test as _;

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -26,7 +26,7 @@ mod tests {
         peripherals::Peripherals,
         prelude::_fugit_RateExtU32,
         spi::{
-            master::{prelude::*, Address, Command, Spi},
+            master::{Address, Command, Spi},
             SpiDataMode,
             SpiMode,
         },

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -30,7 +30,7 @@ mod tests {
         peripherals::Peripherals,
         prelude::_fugit_RateExtU32,
         spi::{
-            master::{prelude::*, Address, Command, Spi},
+            master::{Address, Command, Spi},
             SpiDataMode,
             SpiMode,
         },


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Removed these redundant traits.
They weren't really being used for anything interesting and they tend to get in the way when refactoring.

#### Testing
CI
