### PR TITLE
Introduce traits for the DMA buffer objects

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Introduce DMA buffer objects (#1856)
+- Introduce traits for the DMA buffer objects (#1976)
 - Added new `Io::new_no_bind_interrupt` constructor (#1861)
 - Added touch pad support for esp32 (#1873, #1956)
 - Allow configuration of period updating method for MCPWM timers (#1898)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Introduces `DmaTxBuffer` and `DmaRxBuffer`. These are implemented by `DmaTxBuf`, `DmaRxBuf` and `DmaTxRxBuf`.
This also opens the door to other buffer types like ones that live in PSRAM, flash (ESP32-P4), IRAM, etc. with different alignments and burst modes/sizes. (I won't be implementing these enhancements anytime soon, I'm just opening the door)

Naming is hard, I'm happy to rename things to something else. :slightly_smiling_face: 

#### Testing
Ran the SPI examples.
(I couldn't run the HIL tests myself, my probe-rs setup seems to be broken.... CI should check now though)