### PR TITLE
Enable ESP32 HIL

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -86,6 +86,8 @@ jobs:
           - soc: esp32h2
             rust-target: riscv32imac-unknown-none-elf
           # # Xtensa devices:
+          - soc: esp32
+            rust-target: xtensa-esp32-none-elf
           - soc: esp32s2
             rust-target: xtensa-esp32s2-none-elf
           - soc: esp32s3
@@ -168,6 +170,10 @@ jobs:
             host: armv7
             hubs: "1-1"
           # Xtensa devices:
+          - soc: esp32
+            runner: esp32-jtag
+            usb: USB1 # ESP32 HIL TODO
+            host: aarch64
           - soc: esp32s2
             runner: esp32s2-jtag
             host: armv7

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -172,8 +172,8 @@ jobs:
           # Xtensa devices:
           - soc: esp32
             runner: esp32-jtag
-            usb: USB1 # ESP32 HIL TODO
             host: aarch64
+            hubs: "1 3"
           - soc: esp32s2
             runner: esp32s2-jtag
             host: armv7

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -103,9 +103,17 @@ Our self-hosted runners have the following setup:
     - `GPIO9` and `GPIO10` are connected.
     - `GPIO43 (TX)` and `GPIO45` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
+- ESP32 (`esp32-jtag`):
+  - Devkit: `ESP32-DevKitC-V4` connected via UART.
+    - `GPIO32` and `GPIO33` are I2C pins.
+    - `GPIO4` and `GPIO5` are connected.
+    - `GPIO26` and `GPIO27` are connected.
+  - Probe: `ESP-Prog` connected with the [following connections][connection_esp32]
+  - RPi: Raspbian 12 configured with the following [setup]
 
 [connection_c2]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32c2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware
 [connection_s2]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware
+[connection_esp32]: https://docs.espressif.com/projects/esp-idf/en/v5.3.1/esp32/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml
 [setup]: #rpi-setup
 

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -113,7 +113,7 @@ Our self-hosted runners have the following setup:
 
 [connection_c2]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32c2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware
 [connection_s2]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s2/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware
-[connection_esp32]: https://docs.espressif.com/projects/esp-idf/en/v5.3.1/esp32/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware
+[connection_esp32]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/jtag-debugging/configure-other-jtag.html#configure-hardware.html#configure-hardware
 [`hil.yml`]: https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/hil.yml
 [setup]: #rpi-setup
 

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -30,6 +30,8 @@ macro_rules! i2c_pins {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32s2, esp32s3))] {
                 ($io.pins.gpio2, $io.pins.gpio3)
+            } else if #[cfg(esp32)] {
+                ($io.pins.gpio32, $io.pins.gpio33)
             } else if #[cfg(esp32c6)] {
                 ($io.pins.gpio6, $io.pins.gpio7)
             } else if #[cfg(esp32h2)] {
@@ -49,7 +51,11 @@ macro_rules! common_test_pins {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32s2, esp32s3))] {
                 ($io.pins.gpio9, $io.pins.gpio10)
-            } else {
+            }
+            else if #[cfg(esp32)] {
+                ($io.pins.gpio26, $io.pins.gpio27)
+            }
+            else {
                 ($io.pins.gpio2, $io.pins.gpio3)
             }
         }

--- a/hil-test/tests/ecc.rs
+++ b/hil-test/tests/ecc.rs
@@ -1,6 +1,6 @@
 //! ECC Test
 
-//% CHIPS: esp32c2 esp32c6 esp32h2
+//% CHIPS: esp32 esp32c2 esp32c6 esp32h2
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/ecc.rs
+++ b/hil-test/tests/ecc.rs
@@ -1,6 +1,6 @@
 //! ECC Test
 
-//% CHIPS: esp32 esp32c2 esp32c6 esp32h2
+//% CHIPS: esp32c2 esp32c6 esp32h2
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -8,18 +8,17 @@
 #![no_main]
 
 use embassy_time::{Duration, Ticker, Timer};
-use esp_hal::{
-    interrupt::software::SoftwareInterruptControl,
-    peripherals::Peripherals,
-    prelude::*,
-    timer::{timg::TimerGroup, OneShotTimer, PeriodicTimer},
-};
 #[cfg(not(feature = "esp32"))]
 use esp_hal::{
     interrupt::software::SoftwareInterruptControl,
     interrupt::Priority,
     timer::systimer::{Alarm, FrozenUnit, Periodic, SystemTimer, Target},
     timer::ErasedTimer,
+};
+use esp_hal::{
+    peripherals::Peripherals,
+    prelude::*,
+    timer::{timg::TimerGroup, OneShotTimer, PeriodicTimer},
 };
 #[cfg(not(feature = "esp32"))]
 use esp_hal_embassy::InterruptExecutor;

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -12,17 +12,20 @@ use esp_hal::{
     interrupt::software::SoftwareInterruptControl,
     peripherals::Peripherals,
     prelude::*,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer, PeriodicTimer},
+    timer::{timg::TimerGroup, OneShotTimer, PeriodicTimer},
 };
 #[cfg(not(feature = "esp32"))]
 use esp_hal::{
+    interrupt::software::SoftwareInterruptControl,
     interrupt::Priority,
     timer::systimer::{Alarm, FrozenUnit, Periodic, SystemTimer, Target},
+    timer::ErasedTimer,
 };
 #[cfg(not(feature = "esp32"))]
 use esp_hal_embassy::InterruptExecutor;
 use hil_test as _;
 
+#[cfg(not(feature = "esp32"))]
 macro_rules! mk_static {
     ($t:ty,$val:expr) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
@@ -123,7 +126,9 @@ fn set_up_embassy_with_systimer(peripherals: Peripherals) {
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod test {
     use super::*;
-    use crate::{test_cases::*, test_helpers::*};
+    use crate::test_cases::*;
+    #[cfg(not(feature = "esp32"))]
+    use crate::test_helpers::*;
 
     #[init]
     fn init() -> Peripherals {

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -13,6 +13,10 @@
 use core::cell::RefCell;
 
 use critical_section::Mutex;
+#[cfg(feature = "esp32")]
+use esp_hal::gpio::Gpio0;
+#[cfg(not(feature = "esp32"))]
+use esp_hal::gpio::Gpio3;
 use esp_hal::{
     delay::Delay,
     gpio::{AnyPin, ErasedPin, Input, Io, Level, Output, Pin, Pull},

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -14,7 +14,7 @@ use core::cell::RefCell;
 
 use critical_section::Mutex;
 #[cfg(feature = "esp32")]
-use esp_hal::gpio::Gpio0;
+use esp_hal::gpio::Gpio4;
 #[cfg(not(feature = "esp32"))]
 use esp_hal::gpio::Gpio3;
 use esp_hal::{

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -1,8 +1,8 @@
 //! GPIO Test
 //!
 //! Folowing pins are used:
-//! GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! GPIO3 / GPIO10 (esp32s2 and esp32s3)
+//! GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! GPIO3 / GPIO10 / GPIO26 (esp32s2 / esp32s3 / esp32)
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue
@@ -13,10 +13,6 @@
 use core::cell::RefCell;
 
 use critical_section::Mutex;
-#[cfg(feature = "esp32")]
-use esp_hal::gpio::Gpio4;
-#[cfg(not(feature = "esp32"))]
-use esp_hal::gpio::Gpio3;
 use esp_hal::{
     delay::Delay,
     gpio::{AnyPin, ErasedPin, Input, Io, Level, Output, Pin, Pull},

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -1,8 +1,8 @@
 //! GPIO Test
 //!
 //! Folowing pins are used:
-//! GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
-//! GPIO3 / GPIO10 / GPIO26 (esp32s2 / esp32s3 / esp32)
+//! GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -4,12 +4,14 @@
 //! SDA     GPIO2   (esp32s2 and esp32s3)
 //!         GPIO6   (esp32c6)
 //!         GPIO18  (esp32c2)
-//!         GPIO4   (esp32, esp32h2 and esp32c3)
+//!         GPIO4   (esp32h2 and esp32c3)
+//!         GPIO32  (esp32)
 //!
 //! SCL     GPIO3   (esp32s2 and esp32s3)
-//!         GPIO7   (esp32c6, esp32 and esp32c3)
+//!         GPIO7   (esp32c6 and esp32c3)
 //!         GPIO22  (esp32h2)
 //!         GPIO19  (esp32c2)
+//!         GPIO33  (esp32)
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -13,7 +13,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{Dma, DmaChannel0, DmaPriority},
+    dma::{Dma, DmaPriority},
     gpio::Io,
     i2s::{asynch::*, DataFormat, I2s, I2sTx, Standard},
     peripheral::Peripheral,
@@ -22,6 +22,17 @@ use esp_hal::{
     Async,
 };
 use hil_test as _;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(
+        feature = "esp32",
+        feature = "esp32s2",
+    ))] {
+        use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
+    } else {
+        use esp_hal::dma::DmaChannel0;
+    }
+}
 
 const BUFFER_SIZE: usize = 2000;
 
@@ -91,10 +102,14 @@ mod tests {
         let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
         let dma = Dma::new(peripherals.DMA);
-        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
-        let dma_channel = dma.i2s0channel;
-        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
-        let dma_channel = dma.channel0;
+
+        cfg_if::cfg_if! {
+            if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+                let dma_channel = dma.spi2channel;
+            } else {
+                let dma_channel = dma.channel0;
+            }
+        }
 
         let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) =
             esp_hal::dma_circular_buffers!(BUFFER_SIZE, BUFFER_SIZE);

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -91,6 +91,9 @@ mod tests {
         let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
         let dma = Dma::new(peripherals.DMA);
+        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        let dma_channel = dma.i2s0channel;
+        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
         let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) =

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -2,6 +2,7 @@
 //!
 //! It's assumed GPIO2 is connected to GPIO3
 //! (GPIO9 and GPIO10 for esp32s2 and esp32s3)
+//! (GPIO26 and GPIO27 for esp32)
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/qspi_read.rs
+++ b/hil-test/tests/qspi_read.rs
@@ -7,7 +7,7 @@
 //!
 //! Connect MISO and GPIO pins.
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/qspi_write.rs
+++ b/hil-test/tests/qspi_write.rs
@@ -9,7 +9,7 @@
 //!
 //! Connect MOSI and PCNT pins.
 
-//% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/qspi_write_read.rs
+++ b/hil-test/tests/qspi_write_read.rs
@@ -9,7 +9,7 @@
 //!
 //! Connect MOSI/MISO and GPIO pins.
 
-//% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -106,12 +106,12 @@ mod tests {
 
         let rx_transaction = rx_channel.receive(&mut rcv_data).unwrap();
         let tx_transaction = tx_channel.transmit(&tx_data);
+
+        rx_transaction.wait().unwrap();
         tx_transaction.wait().unwrap();
 
-        rx_transaction.wait().unwrap(); // HERE ESP32 hangs
-
-        // the last two pulse-codes are the ones which wait for the timeout so they
-        // can't be equal
+        // the last two pulse-codes are the ones which wait for the timeout so
+        // they can't be equal
         assert_eq!(&tx_data[..18], &rcv_data[..18]);
     }
 }

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -2,6 +2,7 @@
 //!
 //! It's assumed GPIO2 is connected to GPIO3
 //! (GPIO9 and GPIO10 for esp32s2 and esp32s3)
+//! (GPIO26 and GPIO27 for esp32)
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -68,7 +68,7 @@ mod tests {
             } else if #[cfg(feature = "esp32s2")] {
                     let  rx_channel = {
                         use esp_hal::rmt::RxChannelCreator;
-                        rmt.channel1.configure(io.pins.gpio3, rx_config).unwrap()
+                        rmt.channel1.configure(rx, rx_config).unwrap()
                     };
             } else if #[cfg(feature = "esp32s3")] {
                 let  rx_channel = {

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -66,10 +66,10 @@ mod tests {
                     rmt.channel1.configure(rx, rx_config).unwrap()
                 };
             } else if #[cfg(feature = "esp32s2")] {
-                    let  rx_channel = {
-                        use esp_hal::rmt::RxChannelCreator;
-                        rmt.channel1.configure(rx, rx_config).unwrap()
-                    };
+                let rx_channel = {
+                    use esp_hal::rmt::RxChannelCreator;
+                    rmt.channel1.configure(rx, rx_config).unwrap()
+                };
             } else if #[cfg(feature = "esp32s3")] {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -59,11 +59,16 @@ mod tests {
         };
 
         cfg_if::cfg_if! {
-            if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+            if #[cfg(feature = "esp32")] {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;
                     rmt.channel1.configure(rx, rx_config).unwrap()
                 };
+            } else if #[cfg(feature = "esp32s2")] {
+                    let  rx_channel = {
+                        use esp_hal::rmt::RxChannelCreator;
+                        rmt.channel1.configure(io.pins.gpio3, rx_config).unwrap()
+                    };
             } else if #[cfg(feature = "esp32s3")] {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;
@@ -102,7 +107,8 @@ mod tests {
         let rx_transaction = rx_channel.receive(&mut rcv_data).unwrap();
         let tx_transaction = tx_channel.transmit(&tx_data);
         tx_transaction.wait().unwrap();
-        rx_transaction.wait().unwrap();
+
+        rx_transaction.wait().unwrap(); // HERE ESP32 hangs
 
         // the last two pulse-codes are the ones which wait for the timeout so they
         // can't be equal

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -37,6 +37,7 @@ mod tests {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
         let sclk = io.pins.gpio0;
         let (miso, mosi) = hil_test::common_test_pins!(io);
         let cs = io.pins.gpio8;

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -2,7 +2,7 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! MISO    GPIO2(esp32s2) / GPIO9(esp32s3) / GPIO26(esp32)
 //! MOSI    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect MISO and MOSI pins.

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -2,9 +2,8 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! MOSI    GPIO3 / GPIO10 (esp32s2 and esp32s3)
-//! CS      GPIO8
+//! MISO    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! MOSI    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect MISO and MOSI pins.
 
@@ -40,14 +39,11 @@ mod tests {
 
         let sclk = io.pins.gpio0;
         let (miso, mosi) = hil_test::common_test_pins!(io);
-        let cs = io.pins.gpio8;
 
-        let spi = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0).with_pins(
-            Some(sclk),
-            Some(mosi),
-            Some(miso),
-            Some(cs),
-        );
+        let spi = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0, &clocks)
+            .with_sck(sclk)
+            .with_mosi(mosi)
+            .with_miso(miso);
 
         Context { spi }
     }

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -40,7 +40,7 @@ mod tests {
         let sclk = io.pins.gpio0;
         let (miso, mosi) = hil_test::common_test_pins!(io);
 
-        let spi = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0, &clocks)
+        let spi = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0)
             .with_sck(sclk)
             .with_mosi(mosi)
             .with_miso(miso);

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -2,8 +2,8 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2(esp32s2) / GPIO9(esp32s3) / GPIO26(esp32)
-//! MOSI    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
+//! MISO    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! MOSI    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect MISO and MOSI pins.
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -56,7 +56,6 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let (miso, mosi) = hil_test::common_test_pins!(io);
-        // let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -2,8 +2,8 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
-//! MOSI    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
+//! MISO    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! MOSI    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect MISO and MOSI pins.
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -67,7 +67,7 @@ mod tests {
             }
         }
 
-        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
             .with_sck(sclk)
             .with_mosi(mosi)
             .with_miso(miso)

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -2,15 +2,12 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! MOSI    GPIO3 / GPIO10 (esp32s2 and esp32s3)
-//! CS      GPIO8
+//! MISO    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! MOSI    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect MISO and MOSI pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-
-//% FEATURES: defmt
 
 #![no_std]
 #![no_main]
@@ -59,7 +56,7 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let (miso, mosi) = hil_test::common_test_pins!(io);
-        let cs = io.pins.gpio8;
+        // let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 
@@ -71,8 +68,10 @@ mod tests {
             }
         }
 
-        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
-            .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_sck(sclk)
+            .with_mosi(mosi)
+            .with_miso(miso)
             .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
 
         Context { spi }

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -10,6 +10,8 @@
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
+//% FEATURES: defmt
+
 #![no_std]
 #![no_main]
 

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -4,7 +4,6 @@
 //! SCLK    GPIO0
 //! MOSI    GPIO3 / GPIO10 (esp32s3)
 //! MISO    GPIO4
-//! CS      GPIO8
 //!
 //! PCNT    GPIO2 / GPIO9 (esp32s3)
 //! OUTPUT  GPIO5 (helper to keep MISO LOW)
@@ -99,8 +98,10 @@ mod tests {
         let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
         let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
 
-        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
-            .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_sck(sclk)
+            .with_mosi(mosi)
+            .with_miso(miso)
             .with_dma(dma_channel.configure_for_async(false, DmaPriority::Priority0))
             .with_buffers(dma_tx_buf, dma_rx_buf);
 

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -14,7 +14,7 @@
 //!
 //! Connect PCNT and MOSI, MISO and GPIO5 pins.
 
-//% CHIPS: esp32 esp32c6 esp32h2 esp32s3
+//% CHIPS: esp32c6 esp32h2 esp32s3
 //% FEATURES: generic-queue
 
 #![no_std]

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -77,7 +77,6 @@ mod tests {
 
         let (mosi_mirror, mosi) = hil_test::common_test_pins!(io);
         let miso = io.pins.gpio4;
-        let cs = io.pins.gpio8;
         let mosi_mirror = mosi_mirror.degrade();
 
         let mut out_pin = Output::new(io.pins.gpio5, Level::Low);

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -98,7 +98,7 @@ mod tests {
         let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
         let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
 
-        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
             .with_sck(sclk)
             .with_mosi(mosi)
             .with_miso(miso)

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -3,7 +3,6 @@
 //! Folowing pins are used:
 //! SCLK    GPIO0
 //! MOSI    GPIO3 / GPIO10 (esp32s3)
-//! CS      GPIO8
 //! PCNT    GPIO2 / GPIO9 (esp32s3)
 //! OUTPUT  GPIO5 (helper to keep MISO LOW)
 //!
@@ -70,7 +69,6 @@ mod tests {
         let sclk = io.pins.gpio0;
         let (mosi_mirror, mosi) = hil_test::common_test_pins!(io);
         let miso = io.pins.gpio4;
-        let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);
 
@@ -82,8 +80,10 @@ mod tests {
             }
         }
 
-        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
-            .with_pins(Some(sclk), Some(mosi), Some(miso), Some(cs))
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_sck(sclk)
+            .with_mosi(mosi)
+            .with_miso(miso)
             .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
 
         let pcnt = Pcnt::new(peripherals.PCNT);

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -80,7 +80,7 @@ mod tests {
             }
         }
 
-        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
             .with_sck(sclk)
             .with_mosi(mosi)
             .with_miso(miso)

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -12,7 +12,7 @@
 //!
 //! Connect MISO and MOSI pins.
 
-//% CHIPS: esp32 esp32c6 esp32h2 esp32s3
+//% CHIPS: esp32c6 esp32h2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! MISO    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
 //!
-//! GPIO    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 /esp32)
+//! GPIO    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect MISO and GPIO pins.
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! MISO    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
 //!
-//! GPIO    GPIO3 / GPIO10 (esp32s2 and esp32s3)
+//! GPIO    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 /esp32)
 //!
 //! Connect MISO and GPIO pins.
 

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -2,9 +2,9 @@
 //!
 //! Following pins are used:
 //! SCLK    GPIO0
-//! MOSI    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! MOSI    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
 //!
-//! PCNT    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
+//! PCNT    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect MOSI and PCNT pins.
 

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -2,9 +2,9 @@
 //!
 //! Following pins are used:
 //! SCLK    GPIO0
-//! MOSI    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! MOSI    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
 //!
-//! PCNT    GPIO3 / GPIO10 (esp32s2 and esp32s3)
+//! PCNT    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect MOSI and PCNT pins.
 

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -1,8 +1,8 @@
 //! TWAI test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
+//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -1,8 +1,8 @@
 //! TWAI test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
-//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
+//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -1,8 +1,8 @@
 //! UART Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
+//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -1,8 +1,8 @@
 //! UART Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
-//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
+//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -1,8 +1,8 @@
 //! UART Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
+//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -1,8 +1,8 @@
 //! UART Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
-//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
+//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -1,8 +1,8 @@
 //! UART TX/RX Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
-//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
+//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -1,8 +1,8 @@
 //! UART TX/RX Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
+//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -1,8 +1,8 @@
 //! UART TX/RX Async Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
+//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
+//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
 //!
 //! Connect TX and RX pins.
 

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -1,8 +1,8 @@
 //! UART TX/RX Async Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2 / GPIO9 / GPIO26  (esp32s2 / esp32s3 / esp32)
-//! RX    GPIO3 / GPIO10 / GPIO27 (esp32s2 / esp32s3 / esp32)
+//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 //!
 //! Connect TX and RX pins.
 


### PR DESCRIPTION
For now, the following tests are not working:
- [ ] `i2s`, `i2s_async` -> register names used in test doesn't match on ESP32 (?), choosing correct GPIOs
- [x] `rmt`  -> `rx_transaction.wait().unwrap()` hangs and timeouts
- [x] `sha` -> `test_sha_1`, `test_sha_rolling` and `test_for_digest_rolling` fail 
- [x] Basic`SPI_DMA` -> hopefully just matter of using correct GPIOs
- [ ] SPI DMA with PCNT
- [ ] QSPI -> `qspi_write` test is not possible to run on ESP32, `qspi_read` reads all 0
 
 Other TODOs
 - [ ] update CI files
 - [ ] update README and test description GPIOs usage
 - [ ] I'm testing with `probe-rs` rev `0ea505566e139a7dbf3b33d21cde555ea5258443` (cc @bugadani)
 
 Note: RPi is setted up and ready (SW-wise), HW is not yet connected, need to figure out which GPIOs can be used first.

 closes https://github.com/esp-rs/esp-hal/issues/1969
 