### PR TITLE
SPI DMA: use `State` for both blocking and async operations

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Introduce DMA buffer objects (#1856)
+- Introduce DMA buffer objects (#1856, #1985)
 - Added new `Io::new_no_bind_interrupt` constructor (#1861)
 - Added touch pad support for esp32 (#1873, #1956)
 - Allow configuration of period updating method for MCPWM timers (#1898)
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Peripheral driver constructors don't take `InterruptHandler`s anymore. Use `set_interrupt_handler` to explicitly set the interrupt handler now. (#1819)
-- Migrate SPI driver to use DMA buffer objects (#1856)
+- Migrate SPI driver to use DMA buffer objects (#1856, #1985)
 - Use the peripheral ref pattern for `OneShotTimer` and `PeriodicTimer` (#1855)
 - Improve SYSTIMER API (#1871)
 - DMA buffers now don't require a static lifetime. Make sure to never `mem::forget` an in-progress DMA transfer (consider using `#[deny(clippy::mem_forget)]`) (#1837)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `AesFlavour` trait no longer has the `ENCRYPT_MODE`/`DECRYPT_MODE` associated constants (#1849)
 - Removed `FlashSafeDma` (#1856)
 - Remove redundant WithDmaSpi traits (#1975)
+- `IsFullDuplex` and `IsHalfDuplex` traits (#1985)
 
 ## [0.19.0] - 2024-07-15
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -16,7 +16,7 @@
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::dma_buffers;
 //! # use esp_hal::gpio::Io;
-//! # use esp_hal::spi::{master::{Spi, prelude::*}, SpiMode};
+//! # use esp_hal::spi::{master::Spi, SpiMode};
 //! # use esp_hal::dma::{Dma, DmaPriority};
 //! # use crate::esp_hal::prelude::_fugit_RateExtU32;
 //! let dma = Dma::new(peripherals.DMA);

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1947,6 +1947,16 @@ impl DmaTxBuf {
         Ok(buf)
     }
 
+    /// Create an empty DmaTxBuf.
+    ///
+    /// This has no ability to transmit data.
+    pub fn empty() -> Self {
+        Self {
+            descriptors: &mut [],
+            buffer: &mut [],
+        }
+    }
+
     /// Consume the buf, returning the descriptors and buffer.
     pub fn split(self) -> (&'static mut [DmaDescriptor], &'static mut [u8]) {
         (self.descriptors, self.buffer)
@@ -2080,6 +2090,16 @@ impl DmaRxBuf {
         buf.set_length(buf.capacity());
 
         Ok(buf)
+    }
+
+    /// Create an empty DmaRxBuf.
+    ///
+    /// This has no ability to recieve data.
+    pub fn empty() -> Self {
+        Self {
+            descriptors: &mut [],
+            buffer: &mut [],
+        }
     }
 
     /// Consume the buf, returning the descriptors and buffer.

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1947,16 +1947,6 @@ impl DmaTxBuf {
         Ok(buf)
     }
 
-    /// Create an empty DmaTxBuf.
-    ///
-    /// This has no ability to transmit data.
-    pub fn empty() -> Self {
-        Self {
-            descriptors: &mut [],
-            buffer: &mut [],
-        }
-    }
-
     /// Consume the buf, returning the descriptors and buffer.
     pub fn split(self) -> (&'static mut [DmaDescriptor], &'static mut [u8]) {
         (self.descriptors, self.buffer)
@@ -2090,16 +2080,6 @@ impl DmaRxBuf {
         buf.set_length(buf.capacity());
 
         Ok(buf)
-    }
-
-    /// Create an empty DmaRxBuf.
-    ///
-    /// This has no ability to recieve data.
-    pub fn empty() -> Self {
-        Self {
-            descriptors: &mut [],
-            buffer: &mut [],
-        }
     }
 
     /// Consume the buf, returning the descriptors and buffer.

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -67,6 +67,7 @@ use fugit::HertzU32;
 use procmacros::ram;
 
 use super::{
+    DmaError,
     DuplexMode,
     Error,
     FullDuplexMode,
@@ -1754,22 +1755,23 @@ pub mod dma {
             buffer: &mut [u8],
         ) -> Result<(), Self::Error> {
             let (mut spi_dma, mut tx_buf, mut rx_buf) = self.wait_for_idle();
-
-            for chunk in buffer.chunks_mut(rx_buf.capacity()) {
-                rx_buf.set_length(chunk.len());
-
-                match spi_dma.read(data_mode, cmd, address, dummy, rx_buf) {
-                    Ok(transfer) => self.state = State::Reading(transfer, tx_buf),
-                    Err((e, spi, rx)) => {
-                        self.state = State::Idle(spi, tx_buf, rx);
-                        return Err(e);
-                    }
-                }
-                (spi_dma, tx_buf, rx_buf) = self.wait_for_idle();
-
-                let bytes_read = rx_buf.read_received_data(chunk);
-                debug_assert_eq!(bytes_read, chunk.len());
+            if buffer.len() > rx_buf.capacity() {
+                return Err(super::Error::DmaError(DmaError::Overflow));
             }
+
+            rx_buf.set_length(buffer.len());
+
+            match spi_dma.read(data_mode, cmd, address, dummy, rx_buf) {
+                Ok(transfer) => self.state = State::Reading(transfer, tx_buf),
+                Err((e, spi, rx)) => {
+                    self.state = State::Idle(spi, tx_buf, rx);
+                    return Err(e);
+                }
+            }
+            (spi_dma, tx_buf, rx_buf) = self.wait_for_idle();
+
+            let bytes_read = rx_buf.read_received_data(buffer);
+            debug_assert_eq!(bytes_read, buffer.len());
 
             self.state = State::Idle(spi_dma, tx_buf, rx_buf);
 
@@ -1786,19 +1788,20 @@ pub mod dma {
             buffer: &[u8],
         ) -> Result<(), Self::Error> {
             let (mut spi_dma, mut tx_buf, mut rx_buf) = self.wait_for_idle();
-
-            for chunk in buffer.chunks(tx_buf.capacity()) {
-                tx_buf.fill(chunk);
-
-                match spi_dma.write(data_mode, cmd, address, dummy, tx_buf) {
-                    Ok(transfer) => self.state = State::Writing(transfer, rx_buf),
-                    Err((e, spi, tx)) => {
-                        self.state = State::Idle(spi, tx, rx_buf);
-                        return Err(e);
-                    }
-                }
-                (spi_dma, tx_buf, rx_buf) = self.wait_for_idle();
+            if buffer.len() > tx_buf.capacity() {
+                return Err(super::Error::DmaError(DmaError::Overflow));
             }
+
+            tx_buf.fill(buffer);
+
+            match spi_dma.write(data_mode, cmd, address, dummy, tx_buf) {
+                Ok(transfer) => self.state = State::Writing(transfer, rx_buf),
+                Err((e, spi, tx)) => {
+                    self.state = State::Idle(spi, tx, rx_buf);
+                    return Err(e);
+                }
+            }
+            (spi_dma, tx_buf, rx_buf) = self.wait_for_idle();
 
             self.state = State::Idle(spi_dma, tx_buf, rx_buf);
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -72,8 +72,6 @@ use super::{
     Error,
     FullDuplexMode,
     HalfDuplexMode,
-    IsFullDuplex,
-    IsHalfDuplex,
     SpiBitOrder,
     SpiDataMode,
     SpiMode,
@@ -464,10 +462,9 @@ pub struct Spi<'d, T, M> {
     _mode: PhantomData<M>,
 }
 
-impl<'d, T, M> Spi<'d, T, M>
+impl<'d, T> Spi<'d, T, FullDuplexMode>
 where
     T: Instance,
-    M: IsFullDuplex,
 {
     /// Read bytes from SPI.
     ///
@@ -860,10 +857,9 @@ where
     }
 }
 
-impl<T, M> HalfDuplexReadWrite for Spi<'_, T, M>
+impl<T> HalfDuplexReadWrite for Spi<'_, T, HalfDuplexMode>
 where
     T: Instance,
-    M: IsHalfDuplex,
 {
     type Error = Error;
 
@@ -908,10 +904,9 @@ where
 }
 
 #[cfg(feature = "embedded-hal-02")]
-impl<T, M> embedded_hal_02::spi::FullDuplex<u8> for Spi<'_, T, M>
+impl<T> embedded_hal_02::spi::FullDuplex<u8> for Spi<'_, T, FullDuplexMode>
 where
     T: Instance,
-    M: IsFullDuplex,
 {
     type Error = Error;
 
@@ -925,10 +920,9 @@ where
 }
 
 #[cfg(feature = "embedded-hal-02")]
-impl<T, M> embedded_hal_02::blocking::spi::Transfer<u8> for Spi<'_, T, M>
+impl<T> embedded_hal_02::blocking::spi::Transfer<u8> for Spi<'_, T, FullDuplexMode>
 where
     T: Instance,
-    M: IsFullDuplex,
 {
     type Error = Error;
 
@@ -938,10 +932,9 @@ where
 }
 
 #[cfg(feature = "embedded-hal-02")]
-impl<T, M> embedded_hal_02::blocking::spi::Write<u8> for Spi<'_, T, M>
+impl<T> embedded_hal_02::blocking::spi::Write<u8> for Spi<'_, T, FullDuplexMode>
 where
     T: Instance,
-    M: IsFullDuplex,
 {
     type Error = Error;
 
@@ -1274,12 +1267,11 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, D, M> SpiDma<'d, T, C, D, M>
+    impl<'d, T, C, M> SpiDma<'d, T, C, FullDuplexMode, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        D: IsFullDuplex,
         M: Mode,
     {
         /// Perform a DMA write.
@@ -1292,7 +1284,8 @@ pub mod dma {
         pub fn dma_write(
             mut self,
             buffer: DmaTxBuf,
-        ) -> Result<SpiDmaTransfer<'d, T, C, D, M, DmaTxBuf>, (Error, Self, DmaTxBuf)> {
+        ) -> Result<SpiDmaTransfer<'d, T, C, FullDuplexMode, M, DmaTxBuf>, (Error, Self, DmaTxBuf)>
+        {
             let bytes_to_write = buffer.len();
             if bytes_to_write > MAX_DMA_SIZE {
                 return Err((Error::MaxDmaTransferSizeExceeded, self, buffer));
@@ -1319,7 +1312,8 @@ pub mod dma {
         pub fn dma_read(
             mut self,
             buffer: DmaRxBuf,
-        ) -> Result<SpiDmaTransfer<'d, T, C, D, M, DmaRxBuf>, (Error, Self, DmaRxBuf)> {
+        ) -> Result<SpiDmaTransfer<'d, T, C, FullDuplexMode, M, DmaRxBuf>, (Error, Self, DmaRxBuf)>
+        {
             let bytes_to_read = buffer.len();
             if bytes_to_read > MAX_DMA_SIZE {
                 return Err((Error::MaxDmaTransferSizeExceeded, self, buffer));
@@ -1347,7 +1341,7 @@ pub mod dma {
             tx_buffer: DmaTxBuf,
             rx_buffer: DmaRxBuf,
         ) -> Result<
-            SpiDmaTransfer<'d, T, C, D, M, (DmaTxBuf, DmaRxBuf)>,
+            SpiDmaTransfer<'d, T, C, FullDuplexMode, M, (DmaTxBuf, DmaRxBuf)>,
             (Error, Self, DmaTxBuf, DmaRxBuf),
         > {
             let bytes_to_write = tx_buffer.len();
@@ -1385,12 +1379,11 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, D, M> SpiDma<'d, T, C, D, M>
+    impl<'d, T, C, M> SpiDma<'d, T, C, HalfDuplexMode, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        D: IsHalfDuplex,
         M: Mode,
     {
         /// Perform a half-duplex read operation using DMA.
@@ -1403,7 +1396,8 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: DmaRxBuf,
-        ) -> Result<SpiDmaTransfer<'d, T, C, D, M, DmaRxBuf>, (Error, Self, DmaRxBuf)> {
+        ) -> Result<SpiDmaTransfer<'d, T, C, HalfDuplexMode, M, DmaRxBuf>, (Error, Self, DmaRxBuf)>
+        {
             let bytes_to_read = buffer.len();
             if bytes_to_read > MAX_DMA_SIZE {
                 return Err((Error::MaxDmaTransferSizeExceeded, self, buffer));
@@ -1480,7 +1474,8 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: DmaTxBuf,
-        ) -> Result<SpiDmaTransfer<'d, T, C, D, M, DmaTxBuf>, (Error, Self, DmaTxBuf)> {
+        ) -> Result<SpiDmaTransfer<'d, T, C, HalfDuplexMode, M, DmaTxBuf>, (Error, Self, DmaTxBuf)>
+        {
             let bytes_to_write = buffer.len();
             if bytes_to_write > MAX_DMA_SIZE {
                 return Err((Error::MaxDmaTransferSizeExceeded, self, buffer));
@@ -1620,12 +1615,11 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, D, M> SpiDmaBus<'d, T, C, D, M>
+    impl<'d, T, C, M> SpiDmaBus<'d, T, C, FullDuplexMode, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        D: IsFullDuplex,
         M: Mode,
     {
         /// Reads data from the SPI bus using DMA.
@@ -1744,12 +1738,11 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, D, M> HalfDuplexReadWrite for SpiDmaBus<'d, T, C, D, M>
+    impl<'d, T, C, M> HalfDuplexReadWrite for SpiDmaBus<'d, T, C, HalfDuplexMode, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        D: IsHalfDuplex,
         M: Mode,
     {
         type Error = super::Error;
@@ -2140,10 +2133,9 @@ mod ehal1 {
         type Error = super::Error;
     }
 
-    impl<T, M> FullDuplex for Spi<'_, T, M>
+    impl<T> FullDuplex for Spi<'_, T, FullDuplexMode>
     where
         T: Instance,
-        M: IsFullDuplex,
     {
         fn read(&mut self) -> nb::Result<u8, Self::Error> {
             self.spi.read_byte()
@@ -2154,10 +2146,9 @@ mod ehal1 {
         }
     }
 
-    impl<T, M> SpiBus for Spi<'_, T, M>
+    impl<T> SpiBus for Spi<'_, T, FullDuplexMode>
     where
         T: Instance,
-        M: IsFullDuplex,
     {
         fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
             self.spi.read_bytes(words)

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -58,6 +58,7 @@
 
 use core::marker::PhantomData;
 
+pub use dma::*;
 #[cfg(not(any(esp32, esp32s2)))]
 use enumset::EnumSet;
 #[cfg(not(any(esp32, esp32s2)))]
@@ -86,14 +87,6 @@ use crate::{
     private,
     system::PeripheralClockControl,
 };
-
-/// Prelude for the SPI (Master) driver
-pub mod prelude {
-    pub use super::{
-        Instance as _esp_hal_spi_master_Instance,
-        InstanceDma as _esp_hal_spi_master_InstanceDma,
-    };
-}
 
 /// Enumeration of possible SPI interrupt events.
 #[cfg(not(any(esp32, esp32s2)))]
@@ -944,8 +937,7 @@ where
     }
 }
 
-/// DMA (Direct Memory Access) funtionality (Master).
-pub mod dma {
+mod dma {
     use core::{
         cmp::min,
         sync::atomic::{fence, Ordering},
@@ -1845,7 +1837,7 @@ pub mod dma {
 
     /// Async functionality
     #[cfg(feature = "async")]
-    pub mod asynch {
+    mod asynch {
         use core::{cmp::min, mem::take};
 
         use super::*;

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1030,24 +1030,24 @@ pub mod dma {
     }
 
     /// A DMA capable SPI instance.
-    pub struct SpiDma<'d, T, C, M, DmaMode>
+    pub struct SpiDma<'d, T, C, D, M>
     where
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
+        D: DuplexMode,
+        M: Mode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
-        pub(crate) channel: Channel<'d, C, DmaMode>,
-        _mode: PhantomData<M>,
+        pub(crate) channel: Channel<'d, C, M>,
+        _mode: PhantomData<D>,
     }
 
-    impl<'d, T, C, M, DmaMode> core::fmt::Debug for SpiDma<'d, T, C, M, DmaMode>
+    impl<'d, T, C, D, M> core::fmt::Debug for SpiDma<'d, T, C, D, M>
     where
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
+        D: DuplexMode,
+        M: Mode,
     {
         /// Formats the `SpiDma` instance for debugging purposes.
         ///
@@ -1058,13 +1058,13 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, M, DmaMode> SpiDma<'d, T, C, M, DmaMode>
+    impl<'d, T, C, D, M> SpiDma<'d, T, C, D, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
+        D: DuplexMode,
+        M: Mode,
     {
         /// Sets the interrupt handler
         ///
@@ -1098,23 +1098,23 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, M, DmaMode> crate::private::Sealed for SpiDma<'d, T, C, M, DmaMode>
+    impl<'d, T, C, D, M> crate::private::Sealed for SpiDma<'d, T, C, D, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
+        D: DuplexMode,
+        M: Mode,
     {
     }
 
-    impl<'d, T, C, M, DmaMode> InterruptConfigurable for SpiDma<'d, T, C, M, DmaMode>
+    impl<'d, T, C, D, M> InterruptConfigurable for SpiDma<'d, T, C, D, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
+        D: DuplexMode,
+        M: Mode,
     {
         /// Configures the interrupt handler for the DMA-enabled SPI instance.
         fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
@@ -1122,13 +1122,13 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, M, DmaMode> SpiDma<'d, T, C, M, DmaMode>
+    impl<'d, T, C, D, M> SpiDma<'d, T, C, D, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
+        D: DuplexMode,
+        M: Mode,
     {
         /// Changes the SPI bus frequency for the DMA-enabled SPI instance.
         pub fn change_bus_frequency(&mut self, frequency: HertzU32, clocks: &Clocks<'d>) {
@@ -1161,14 +1161,14 @@ pub mod dma {
     ///
     /// This structure holds references to the SPI instance, DMA buffers, and
     /// transfer status.
-    pub struct SpiDmaTransfer<'d, T, C, M, DmaMode, Buf>
+    pub struct SpiDmaTransfer<'d, T, C, D, M, Buf>
     where
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
+        D: DuplexMode,
+        M: Mode,
     {
-        spi_dma: SpiDma<'d, T, C, M, DmaMode>,
+        spi_dma: SpiDma<'d, T, C, D, M>,
         dma_buf: Buf,
         is_rx: bool,
         is_tx: bool,
@@ -1177,16 +1177,16 @@ pub mod dma {
         tx_future_awaited: bool,
     }
 
-    impl<'d, T, C, M, DmaMode, Buf> SpiDmaTransfer<'d, T, C, M, DmaMode, Buf>
+    impl<'d, T, C, D, M, Buf> SpiDmaTransfer<'d, T, C, D, M, Buf>
     where
         T: Instance,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
-        DmaMode: Mode,
+        D: DuplexMode,
+        M: Mode,
     {
         fn new(
-            spi_dma: SpiDma<'d, T, C, M, DmaMode>,
+            spi_dma: SpiDma<'d, T, C, D, M>,
             dma_buf: Buf,
             is_rx: bool,
             is_tx: bool,
@@ -1233,7 +1233,7 @@ pub mod dma {
         ///
         /// This method blocks until the transfer is finished and returns the
         /// `SpiDma` instance and the associated buffer.
-        pub fn wait(mut self) -> (SpiDma<'d, T, C, M, DmaMode>, Buf) {
+        pub fn wait(mut self) -> (SpiDma<'d, T, C, D, M>, Buf) {
             self.spi_dma.spi.flush().ok();
             fence(Ordering::Acquire);
             (self.spi_dma, self.dma_buf)
@@ -1241,12 +1241,12 @@ pub mod dma {
     }
 
     #[cfg(feature = "async")]
-    impl<'d, T, C, M, Buf> SpiDmaTransfer<'d, T, C, M, crate::Async, Buf>
+    impl<'d, T, C, D, Buf> SpiDmaTransfer<'d, T, C, D, crate::Async, Buf>
     where
         T: Instance,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: DuplexMode,
+        D: DuplexMode,
     {
         /// Waits for the DMA transfer to complete asynchronously.
         ///
@@ -1266,13 +1266,13 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, M, DmaMode> SpiDma<'d, T, C, M, DmaMode>
+    impl<'d, T, C, D, M> SpiDma<'d, T, C, D, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: IsFullDuplex,
-        DmaMode: Mode,
+        D: IsFullDuplex,
+        M: Mode,
     {
         /// Perform a DMA write.
         ///
@@ -1284,7 +1284,7 @@ pub mod dma {
         pub fn dma_write(
             mut self,
             buffer: DmaTxBuf,
-        ) -> Result<SpiDmaTransfer<'d, T, C, M, DmaMode, DmaTxBuf>, (Error, Self, DmaTxBuf)>
+        ) -> Result<SpiDmaTransfer<'d, T, C, D, M, DmaTxBuf>, (Error, Self, DmaTxBuf)>
         {
             let bytes_to_write = buffer.len();
             if bytes_to_write > MAX_DMA_SIZE {
@@ -1312,7 +1312,7 @@ pub mod dma {
         pub fn dma_read(
             mut self,
             buffer: DmaRxBuf,
-        ) -> Result<SpiDmaTransfer<'d, T, C, M, DmaMode, DmaRxBuf>, (Error, Self, DmaRxBuf)>
+        ) -> Result<SpiDmaTransfer<'d, T, C, D, M, DmaRxBuf>, (Error, Self, DmaRxBuf)>
         {
             let bytes_to_read = buffer.len();
             if bytes_to_read > MAX_DMA_SIZE {
@@ -1341,7 +1341,7 @@ pub mod dma {
             tx_buffer: DmaTxBuf,
             rx_buffer: DmaRxBuf,
         ) -> Result<
-            SpiDmaTransfer<'d, T, C, M, DmaMode, (DmaTxBuf, DmaRxBuf)>,
+            SpiDmaTransfer<'d, T, C, D, M, (DmaTxBuf, DmaRxBuf)>,
             (Error, Self, DmaTxBuf, DmaRxBuf),
         > {
             let bytes_to_write = tx_buffer.len();
@@ -1379,13 +1379,13 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, C, M, DmaMode> SpiDma<'d, T, C, M, DmaMode>
+    impl<'d, T, C, D, M> SpiDma<'d, T, C, D, M>
     where
         T: InstanceDma,
         C: DmaChannel,
         C::P: SpiPeripheral,
-        M: IsHalfDuplex,
-        DmaMode: Mode,
+        D: IsHalfDuplex,
+        M: Mode,
     {
         /// Perform a half-duplex read operation using DMA.
         #[allow(clippy::type_complexity)]
@@ -1397,7 +1397,7 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: DmaRxBuf,
-        ) -> Result<SpiDmaTransfer<'d, T, C, M, DmaMode, DmaRxBuf>, (Error, Self, DmaRxBuf)>
+        ) -> Result<SpiDmaTransfer<'d, T, C, D, M, DmaRxBuf>, (Error, Self, DmaRxBuf)>
         {
             let bytes_to_read = buffer.len();
             if bytes_to_read > MAX_DMA_SIZE {
@@ -1475,7 +1475,7 @@ pub mod dma {
             address: Address,
             dummy: u8,
             buffer: DmaTxBuf,
-        ) -> Result<SpiDmaTransfer<'d, T, C, M, DmaMode, DmaTxBuf>, (Error, Self, DmaTxBuf)>
+        ) -> Result<SpiDmaTransfer<'d, T, C, D, M, DmaTxBuf>, (Error, Self, DmaTxBuf)>
         {
             let bytes_to_write = buffer.len();
             if bytes_to_write > MAX_DMA_SIZE {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1883,7 +1883,8 @@ pub mod dma {
                 }
             }
 
-            async fn read_async(&mut self, words: &mut [u8]) -> Result<(), super::Error> {
+            /// Fill the given buffer with data from the bus.
+            pub async fn read_async(&mut self, words: &mut [u8]) -> Result<(), super::Error> {
                 // Get previous transfer.
                 let (mut spi_dma, mut tx_buf, mut rx_buf) = self.wait_for_idle_async().await;
 
@@ -1911,7 +1912,8 @@ pub mod dma {
                 Ok(())
             }
 
-            async fn write_async(&mut self, words: &[u8]) -> Result<(), super::Error> {
+            /// Transmit the given buffer to the bus.
+            pub async fn write_async(&mut self, words: &[u8]) -> Result<(), super::Error> {
                 // Get previous transfer.
                 let (mut spi_dma, mut tx_buf, mut rx_buf) = self.wait_for_idle_async().await;
 
@@ -1936,7 +1938,9 @@ pub mod dma {
                 Ok(())
             }
 
-            async fn transfer_async(
+            /// Transfer by writing out a buffer and reading the response from
+            /// the bus into another buffer.
+            pub async fn transfer_async(
                 &mut self,
                 read: &mut [u8],
                 write: &[u8],
@@ -1984,7 +1988,9 @@ pub mod dma {
                 }
             }
 
-            async fn transfer_in_place_async(
+            /// Transfer by writing out a buffer and reading the response from
+            /// the bus into the same buffer.
+            pub async fn transfer_in_place_async(
                 &mut self,
                 words: &mut [u8],
             ) -> Result<(), super::Error> {
@@ -2027,7 +2033,8 @@ pub mod dma {
                 Ok(())
             }
 
-            async fn flush_async(&mut self) -> Result<(), super::Error> {
+            /// Flush any pending data in the SPI peripheral.
+            pub async fn flush_async(&mut self) -> Result<(), super::Error> {
                 // Get previous transfer.
                 let (spi_dma, tx_buf, rx_buf) = self.wait_for_idle_async().await;
                 self.state = State::Idle(spi_dma, tx_buf, rx_buf);

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1033,6 +1033,12 @@ pub mod dma {
     }
 
     /// A DMA capable SPI instance.
+    ///
+    /// Using `SpiDma` is not recommended unless you wish
+    /// to manage buffers yourself. It's recommended to use
+    /// [`SpiDmaBus`] via `with_buffers` to get access
+    /// to a DMA capable SPI bus that implements the
+    /// embedded-hal traits.
     pub struct SpiDma<'d, T, C, D, M>
     where
         C: DmaChannel,
@@ -1559,7 +1565,7 @@ pub mod dma {
     /// A DMA-capable SPI bus.
     ///
     /// This structure is responsible for managing SPI transfers using DMA
-    /// buffers.
+    /// buffers. Implements the embedded-hal traits.
     pub struct SpiDmaBus<'d, T, C, D, M>
     where
         T: InstanceDma,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1549,7 +1549,7 @@ mod dma {
         Writing(SpiDmaTransfer<'d, T, C, D, M, DmaTxBuf>, DmaRxBuf),
         Transferring(SpiDmaTransfer<'d, T, C, D, M, (DmaTxBuf, DmaRxBuf)>),
         #[default]
-        InUse,
+        TemporarilyRemoved,
     }
 
     /// A DMA-capable SPI bus.
@@ -1602,7 +1602,7 @@ mod dma {
                     let (spi, (tx_buf, rx_buf)) = transfer.wait();
                     (spi, tx_buf, rx_buf)
                 }
-                State::InUse => unreachable!(),
+                State::TemporarilyRemoved => unreachable!(),
             }
         }
     }
@@ -1860,7 +1860,7 @@ mod dma {
                     State::Reading(transfer, _) => transfer.wait_for_done().await,
                     State::Writing(transfer, _) => transfer.wait_for_done().await,
                     State::Transferring(transfer) => transfer.wait_for_done().await,
-                    State::InUse => unreachable!(),
+                    State::TemporarilyRemoved => unreachable!(),
                 }
                 match take(&mut self.state) {
                     State::Idle(spi, tx_buf, rx_buf) => (spi, tx_buf, rx_buf),
@@ -1876,7 +1876,7 @@ mod dma {
                         let (spi, (tx_buf, rx_buf)) = transfer.wait();
                         (spi, tx_buf, rx_buf)
                     }
-                    State::InUse => unreachable!(),
+                    State::TemporarilyRemoved => unreachable!(),
                 }
             }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -100,6 +100,7 @@ pub mod prelude {
 /// Enumeration of possible SPI interrupt events.
 #[cfg(not(any(esp32, esp32s2)))]
 #[derive(EnumSetType)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SpiInterrupt {
     /// Indicates that the SPI transaction has completed successfully.
     ///
@@ -125,6 +126,7 @@ const MAX_DMA_SIZE: usize = 32736;
 /// Used to define specific commands sent over the SPI bus.
 /// Can be [Command::None] if command phase should be suppressed.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Command {
     /// No command is sent.
     None,
@@ -239,6 +241,7 @@ impl Command {
 /// This can be used to specify the address phase of SPI transactions.
 /// Can be [Address::None] if address phase should be suppressed.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Address {
     /// No address phase.
     None,
@@ -1565,7 +1568,7 @@ pub mod dma {
     /// A DMA-capable SPI bus.
     ///
     /// This structure is responsible for managing SPI transfers using DMA
-    /// buffers. Implements the embedded-hal traits.
+    /// buffers.
     pub struct SpiDmaBus<'d, T, C, D, M>
     where
         T: InstanceDma,

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -79,11 +79,7 @@ pub enum SpiBitOrder {
 }
 
 /// Trait marker for defining SPI duplex modes.
-pub trait DuplexMode {}
-/// Trait marker for SPI full-duplex mode.
-pub trait IsFullDuplex: DuplexMode {}
-/// Trait marker for SPI half-duplex mode.
-pub trait IsHalfDuplex: DuplexMode {}
+pub trait DuplexMode: crate::private::Sealed {}
 
 /// SPI data mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -100,9 +96,9 @@ pub enum SpiDataMode {
 /// Full-duplex operation
 pub struct FullDuplexMode {}
 impl DuplexMode for FullDuplexMode {}
-impl IsFullDuplex for FullDuplexMode {}
+impl crate::private::Sealed for FullDuplexMode {}
 
 /// Half-duplex operation
 pub struct HalfDuplexMode {}
 impl DuplexMode for HalfDuplexMode {}
-impl IsHalfDuplex for HalfDuplexMode {}
+impl crate::private::Sealed for HalfDuplexMode {}

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -86,7 +86,7 @@ pub trait IsFullDuplex: DuplexMode {}
 pub trait IsHalfDuplex: DuplexMode {}
 
 /// SPI data mode
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SpiDataMode {
     /// `Single` Data Mode - 1 bit, 2 wires.

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -21,7 +21,7 @@ use esp_hal::{
     peripherals::{Peripherals, SPI2},
     prelude::*,
     spi::{
-        master::{dma::SpiDma, Spi},
+        master::{Spi, SpiDma},
         FullDuplexMode,
         SpiMode,
     },

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -49,6 +49,7 @@ struct Context {
 #[embedded_test::tests]
 mod tests {
     use defmt::assert_eq;
+    use esp_hal::dma::{DmaRxBuf, DmaTxBuf};
 
     use super::*;
 

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -34,10 +34,12 @@ use esp_hal::{
     peripherals::{Peripherals, SPI2},
     prelude::*,
     spi::{
-        master::{dma::asynch::SpiDmaAsyncBus, Spi},
+        master::{dma::SpiDmaBus, Spi},
+        FullDuplexMode,
         SpiMode,
     },
     system::SystemControl,
+    Async,
 };
 use hil_test as _;
 
@@ -55,7 +57,7 @@ cfg_if::cfg_if! {
 const DMA_BUFFER_SIZE: usize = 5;
 
 struct Context {
-    spi: SpiDmaAsyncBus<'static, SPI2, DmaChannel0>,
+    spi: SpiDmaBus<'static, SPI2, DmaChannel0, FullDuplexMode, Async>,
     pcnt_unit: Unit<'static, 0>,
     out_pin: Output<'static, GpioPin<5>>,
     mosi_mirror: GpioPin<2>,

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -34,7 +34,7 @@ use esp_hal::{
     peripherals::{Peripherals, SPI2},
     prelude::*,
     spi::{
-        master::{dma::SpiDmaBus, Spi},
+        master::{Spi, SpiDmaBus},
         FullDuplexMode,
         SpiMode,
     },

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -30,7 +30,7 @@ use esp_hal::{
     peripherals::{Peripherals, SPI2},
     prelude::*,
     spi::{
-        master::{dma::SpiDma, Spi},
+        master::{Spi, SpiDma},
         FullDuplexMode,
         SpiMode,
     },

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -129,4 +129,65 @@ mod tests {
 
         assert_eq!(dma_rx_buf.as_slice(), &[0xFF; DMA_BUFFER_SIZE]);
     }
+
+    #[test]
+    #[timeout(3)]
+    fn test_spidmabus_reads_correctly_from_gpio_pin() {
+        const DMA_BUFFER_SIZE: usize = 4;
+
+        let peripherals = Peripherals::take();
+        let system = SystemControl::new(peripherals.SYSTEM);
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let sclk = io.pins.gpio0;
+        let miso = io.pins.gpio2;
+
+        let mut miso_mirror = Output::new(io.pins.gpio3, Level::High);
+
+        let dma = Dma::new(peripherals.DMA);
+
+        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        let dma_channel = dma.spi2channel;
+        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        let dma_channel = dma.channel0;
+
+        let (buffer, descriptors, _, _) = dma_buffers!(DMA_BUFFER_SIZE, 0);
+        let dma_rx_buf = DmaRxBuf::new(descriptors, buffer).unwrap();
+
+        let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_sck(sclk)
+            .with_miso(miso)
+            .with_dma(dma_channel.configure(false, DmaPriority::Priority0))
+            .with_buffers(DmaTxBuf::empty(), dma_rx_buf);
+
+        // SPI should read '0's from the MISO pin
+        miso_mirror.set_low();
+
+        let mut buffer = [0xAA; DMA_BUFFER_SIZE];
+        spi.read(
+            SpiDataMode::Single,
+            Command::None,
+            Address::None,
+            0,
+            &mut buffer,
+        )
+        .unwrap();
+
+        assert_eq!(buffer.as_slice(), &[0x00; DMA_BUFFER_SIZE]);
+
+        // SPI should read '1's from the MISO pin
+        miso_mirror.set_high();
+
+        spi.read(
+            SpiDataMode::Single,
+            Command::None,
+            Address::None,
+            0,
+            &mut buffer,
+        )
+        .unwrap();
+
+        assert_eq!(buffer.as_slice(), &[0xFF; DMA_BUFFER_SIZE]);
+    }
 }

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -152,14 +152,15 @@ mod tests {
         #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
-        let (buffer, descriptors, _, _) = dma_buffers!(DMA_BUFFER_SIZE, 0);
+        let (buffer, descriptors, tx, txd) = dma_buffers!(DMA_BUFFER_SIZE, 1);
         let dma_rx_buf = DmaRxBuf::new(descriptors, buffer).unwrap();
+        let dma_tx_buf = DmaTxBuf::new(txd, tx).unwrap();
 
         let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
             .with_sck(sclk)
             .with_miso(miso)
             .with_dma(dma_channel.configure(false, DmaPriority::Priority0))
-            .with_buffers(DmaTxBuf::empty(), dma_rx_buf);
+            .with_buffers(dma_tx_buf, dma_rx_buf);
 
         // SPI should read '0's from the MISO pin
         miso_mirror.set_low();

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -21,7 +21,7 @@ use esp_hal::{
     peripherals::{Peripherals, SPI2},
     prelude::*,
     spi::{
-        master::{dma::SpiDma, Address, Command, HalfDuplexReadWrite, Spi},
+        master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDma},
         HalfDuplexMode,
         SpiDataMode,
         SpiMode,

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -166,14 +166,15 @@ mod tests {
         #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
         let dma_channel = dma.channel0;
 
-        let (buffer, descriptors, _, _) = dma_buffers!(DMA_BUFFER_SIZE, 0);
+        let (buffer, descriptors, rx, rxd) = dma_buffers!(DMA_BUFFER_SIZE, 1);
         let dma_tx_buf = DmaTxBuf::new(descriptors, buffer).unwrap();
+        let dma_rx_buf = DmaRxBuf::new(rxd, rx).unwrap();
 
         let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
             .with_sck(sclk)
             .with_mosi(mosi)
             .with_dma(dma_channel.configure(false, DmaPriority::Priority0))
-            .with_buffers(dma_tx_buf, DmaRxBuf::empty());
+            .with_buffers(dma_tx_buf, dma_rx_buf);
 
         let unit = pcnt.unit0;
         unit.channel0.set_edge_signal(PcntSource::from_pin(

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -26,7 +26,7 @@ use esp_hal::{
     peripherals::{Peripherals, SPI2},
     prelude::*,
     spi::{
-        master::{dma::SpiDma, Address, Command, HalfDuplexReadWrite, Spi},
+        master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDma},
         HalfDuplexMode,
         SpiDataMode,
         SpiMode,


### PR DESCRIPTION
Also removes the async version of SpiDmaBus in favour of being generic over the mode

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

I found the `State` enum much easier to understand the flow of the `SpiDmaBusAsync` instead of the option based impl on the blocking `SpiDmaBus`. Therefore I started looking at sharing the state enum for both, before quickly realizing we can actually remove the `Async` variant in favour of being generic over the mode (not sure how I missed that in my review :sweat_smile:).

I think using `State` everywhere possible is a good idea, especially if we want to add more wrappers, for things like double buffering.

#### Testing

I ran the HIL suite locally.

## TODO

- [x] Document the new public methods
- [x] Add Half duplex support to `SpiDmaBus`


cc: @Dominaezzz (I hope I didn't step on your toes with your ongoing work :sweat_smile:)
