### PR TITLE
HIL: Multiple featuresets & conditionally enable generic-queue feature

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -136,7 +136,7 @@ required-features = ["async", "embassy"]
 [[test]]
 name              = "embassy_interrupt_executor"
 harness           = false
-required-features = ["async", "embassy", "integrated-timers"]
+required-features = ["async", "embassy"]
 
 [[test]]
 name    = "twai"
@@ -166,7 +166,7 @@ digest              = { version = "0.10.7", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
 embassy-executor    = { version = "0.6.0", default-features = false }
 # Add the `embedded-test/defmt` feature for more verbose testing
-embedded-test       = { version = "0.4.0", default-features = false, git = "https://github.com/probe-rs/embedded-test.git", branch = "embassy" }
+embedded-test       = { version = "0.4.0", default-features = false }
 fugit               = "0.3.7"
 hex-literal         = "0.4.1"
 nb                  = "1.1.0"

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -149,7 +149,7 @@ defmt              = "0.3.8"
 defmt-rtt          = { version = "0.4.1", optional = true }
 embassy-futures    = "0.1.1"
 embassy-sync       = "0.6.0"
-embassy-time       = { version = "0.3.1", features = ["generic-queue-64"] }
+embassy-time       = { version = "0.3.1" }
 embedded-hal       = "1.0.0"
 embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = ["unproven"] }
 embedded-hal-async = { version = "1.0.0", optional = true }
@@ -166,7 +166,7 @@ digest              = { version = "0.10.7", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
 embassy-executor    = { version = "0.6.0", default-features = false }
 # Add the `embedded-test/defmt` feature for more verbose testing
-embedded-test       = { version = "0.4.0", default-features = false }
+embedded-test       = { version = "0.4.0", default-features = false, git = "https://github.com/probe-rs/embedded-test.git", branch = "embassy" }
 fugit               = "0.3.7"
 hex-literal         = "0.4.1"
 nb                  = "1.1.0"
@@ -214,8 +214,11 @@ embassy = [
     "embedded-test/external-executor",
     "dep:esp-hal-embassy",
 ]
+generic-queue = [
+    "embassy-time/generic-queue-64"
+]
 integrated-timers = [
-    "embassy-executor/integrated-timers",
+    "esp-hal-embassy/integrated-timers",
 ]
 
 # https://doc.rust-lang.org/cargo/reference/profiles.html#test

--- a/hil-test/tests/embassy_interrupt_executor.rs
+++ b/hil-test/tests/embassy_interrupt_executor.rs
@@ -3,6 +3,7 @@
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: integrated-timers
+//% FEATURES: generic-queue
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -2,6 +2,7 @@
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: integrated-timers
+//% FEATURES: generic-queue
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -1,6 +1,7 @@
 //! Embassy timer and executor Test
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: integrated-timers
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -5,6 +5,7 @@
 //! GPIO3
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: generic-queue
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -6,6 +6,7 @@
 //! with loopback mode enabled). It's using circular DMA mode
 
 //% CHIPS: esp32c3 esp32c6 esp32s3 esp32h2
+//% FEATURES: generic-queue
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/lcd_cam_i8080_async.rs
+++ b/hil-test/tests/lcd_cam_i8080_async.rs
@@ -1,6 +1,7 @@
 //! lcd_cam i8080 tests
 
 //% CHIPS: esp32s3
+//% FEATURES: generic-queue
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -15,6 +15,7 @@
 //! Connect PCNT (GPIO2) and MOSI (GPIO3) and MISO (GPIO6) and GPIO5 pins.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s3
+//% FEATURES: generic-queue
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -7,6 +7,7 @@
 //! Connect TX (GPIO2) and RX (GPIO3) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: generic-queue
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -7,6 +7,7 @@
 //! Connect TX (GPIO2) and RX (GPIO3) pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: generic-queue
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
Previously, enabling `integrated-queue` could fail to link because we enabled generic queues, too.