### PR TITLE
Cycle USB port power before each test run

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -153,29 +153,29 @@ jobs:
           # RISC-V devices:
           - soc: esp32c2
             runner: esp32c2-jtag
-            usb: USB2
             host: aarch64
+            hubs: "1 3"
           - soc: esp32c3
             runner: esp32c3-usb
-            usb: ACM0
             host: armv7
+            hubs: "1-1"
           - soc: esp32c6
             runner: esp32c6-usb
-            usb: ACM0
             host: armv7
+            hubs: "1-1"
           - soc: esp32h2
             runner: esp32h2-usb
-            usb: USB0
             host: armv7
+            hubs: "1-1"
           # Xtensa devices:
           - soc: esp32s2
             runner: esp32s2-jtag
-            usb: USB1
             host: armv7
+            hubs: "1-1"
           - soc: esp32s3
             runner: esp32s3-usb
-            usb: USB0
             host: armv7
+            hubs: "1-1"
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -185,6 +185,27 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: xtask-${{ matrix.target.host }}
+
+      - name: Cycle USB ports
+        run: |
+          export PATH=$PATH:/home/espressif/.cargo/bin
+          for i in {1..10}; do
+            # Disable all used hubs
+            for hub in ${{ matrix.target.hubs }}; do
+              sudo uhubctl -a off -l $hub
+            done
+
+            # Enable all used hubs
+            for hub in ${{ matrix.target.hubs }}; do
+              sudo uhubctl -a on -l $hub
+            done
+
+            sleep 0.5
+
+            if probe-rs list | grep -q "\[0\]:"; then
+              break
+            fi
+          done
 
       - name: Run Tests
         id: run-tests

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -112,7 +112,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-t
 # Source the current shell:
 . "$HOME/.cargo/env"
 # Install dependencies
-sudo apt install -y pkg-config libudev-dev
+sudo apt install -y pkg-config libudev-dev uhubctl
 # Install probe-rs
 cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --rev 9bde591 --force
 # Add the udev rules


### PR DESCRIPTION
Unfortunately, it seems that some devices can't be left sitting for an extended period of time. C2 after a successful run may decide at a random point it time that it will no longer accept anything via JTAG and needs to be reset somehow.

I've tried resetting devices by `espflash flash`, which should hard reset after flashing. Unfortunately, this meant the devices were stuck in download mode (that, or some other fishy state, can't really tell) and weren't able to run tests.

The solution I ended up with is to forcefully switch off, then on the USB ports. This can be done by `uhubctl`, but needs two different commands:

- On older Raspberries, there is only a single USB hub for all 4 ports. Normally limiting, this is the simpler case: we can just `uhubctl -a cycle -l 1-1` to toggle power of all 4 port.
- Unfortunately, on newer Raspberries, the ports are independent and we have, for the C2, two USB cables. This means we need to manually turn off, then on, all affected hubs - cycling one after the other doesn't actually take the power away from the device.