### PR TITLE
esp_hal_embassy: Implement timer conversion for some arrays

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated to latest release (`0.6.0`) for `embassy-executor` (#1942)
-- Changed `init` to accept timers of multiple types (#1957)
+- Changed `init` to accept timers of multiple types (#1957, #2012)
 
 ### Fixed
 

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -121,6 +121,23 @@ impl<const N: usize> TimerCollection for &'static mut [Timer; N] {
     }
 }
 
+macro_rules! impl_array {
+    ($n:literal) => {
+        impl<T> TimerCollection for [T; $n]
+        where
+            T: IntoErasedTimer,
+        {
+            fn timers(self) -> &'static mut [Timer] {
+                mk_static!([Timer; $n], self.map(|t| Timer::new(t.into())))
+            }
+        }
+    };
+}
+
+impl_array!(2);
+impl_array!(3);
+impl_array!(4);
+
 /// Initialize embassy.
 ///
 /// Call this as soon as possible, before the first timer-related operation.
@@ -133,6 +150,7 @@ impl<const N: usize> TimerCollection for &'static mut [Timer; N] {
 /// - A `OneShotTimer` instance
 /// - A mutable static slice of `OneShotTimer` instances
 /// - A mutable static array of `OneShotTimer` instances
+/// - A 2, 3, 4 element array of `ErasedTimer` instances
 ///
 /// # Examples
 ///

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -25,23 +25,13 @@ use esp_hal::{
     gpio::{AnyOutput, Io, Level},
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, ErasedTimer},
 };
 use esp_hal_embassy::Executor;
 use esp_println::println;
 use static_cell::StaticCell;
 
 static mut APP_CORE_STACK: Stack<8192> = Stack::new();
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 /// Waits for a message that contains a duration, then flashes a led for that
 /// duration of time.
@@ -73,9 +63,7 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let timer0: ErasedTimer = timg0.timer0.into();
     let timer1: ErasedTimer = timg0.timer1.into();
-    let timers = [OneShotTimer::new(timer0), OneShotTimer::new(timer1)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 2], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, [timer0, timer1]);
 
     let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -26,23 +26,13 @@ use esp_hal::{
     peripherals::Peripherals,
     prelude::*,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, ErasedTimer},
 };
 use esp_hal_embassy::InterruptExecutor;
 use esp_println::println;
 use static_cell::StaticCell;
 
 static mut APP_CORE_STACK: Stack<8192> = Stack::new();
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 /// Waits for a message that contains a duration, then flashes a led for that
 /// duration of time.
@@ -93,9 +83,7 @@ fn main() -> ! {
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let timer0: ErasedTimer = timg0.timer0.into();
     let timer1: ErasedTimer = timg0.timer1.into();
-    let timers = [OneShotTimer::new(timer0), OneShotTimer::new(timer1)];
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 2], timers);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, [timer0, timer1]);
 
     let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -28,21 +28,11 @@ use esp_hal::{
     interrupt::Priority,
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::{timg::TimerGroup, ErasedTimer},
 };
 use esp_hal_embassy::InterruptExecutor;
 use esp_println::println;
 use static_cell::StaticCell;
-
-// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 /// Periodically print something.
 #[embassy_executor::task]
@@ -89,23 +79,19 @@ async fn main(low_prio_spawner: Spawner) {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     let timer0: ErasedTimer = timg0.timer0.into();
-    let timer0 = OneShotTimer::new(timer0);
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32c2")] {
             use esp_hal::timer::systimer::{SystemTimer, Target};
             let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
-            let alarm0: ErasedTimer = systimer.alarm0.into();
-            let timer1 = OneShotTimer::new(alarm0);
+            let timer1: ErasedTimer = systimer.alarm0.into();
         } else {
             let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
             let timer1: ErasedTimer = timg1.timer0.into();
-            let timer1 = OneShotTimer::new(timer1);
         }
     }
 
-    let timers = mk_static!([OneShotTimer<ErasedTimer>; 2], [timer0, timer1]);
-    esp_hal_embassy::init(&clocks, timers);
+    esp_hal_embassy::init(&clocks, [timer0, timer1]);
 
     static EXECUTOR: StaticCell<InterruptExecutor<2>> = StaticCell::new();
     let executor = InterruptExecutor::new(system.software_interrupt_control.software_interrupt2);

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -20,7 +20,7 @@ use esp_hal::{
     macros::handler,
     peripherals::Peripherals,
     system::SystemControl,
-    timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+    timer::timg::TimerGroup,
     InterruptConfigurable,
 };
 use hil_test as _;

--- a/hil-test/tests/usb_serial_jtag.rs
+++ b/hil-test/tests/usb_serial_jtag.rs
@@ -12,20 +12,10 @@ mod tests {
         clock::ClockControl,
         peripherals::Peripherals,
         system::SystemControl,
-        timer::{timg::TimerGroup, ErasedTimer, OneShotTimer},
+        timer::timg::TimerGroup,
         usb_serial_jtag::UsbSerialJtag,
     };
     use hil_test as _;
-
-    // When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
-    macro_rules! mk_static {
-        ($t:ty,$val:expr) => {{
-            static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-            #[deny(unused_attributes)]
-            let x = STATIC_CELL.uninit().write(($val));
-            x
-        }};
-    }
 
     #[test]
     fn creating_peripheral_does_not_break_debug_connection() {
@@ -34,10 +24,7 @@ mod tests {
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
         let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-        let timer0: ErasedTimer = timg0.timer0.into();
-        let timers = [OneShotTimer::new(timer0)];
-        let timers = mk_static!([OneShotTimer<ErasedTimer>; 1], timers);
-        esp_hal_embassy::init(&clocks, timers);
+        esp_hal_embassy::init(&clocks, timg0.timer0);
 
         _ = UsbSerialJtag::new_async(peripherals.USB_DEVICE).split();
     }


### PR DESCRIPTION
Further simplify the timer setup. Because array elements need to be the same type, we still need to erase the timer type. To circumvent that, we can implement conversions for tuples, but `esp_hal_embassy::init((timer1, timer2));` just looks weird.