### PR TITLE
Only reserve the interrupt when executors are needed

### DIFF
--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -17,7 +17,7 @@ defmt               = { version = "0.3.8", optional = true }
 document-features   = "0.2.10"
 embassy-executor    = { version = "0.6.0", optional = true }
 embassy-time-driver = { version = "0.1.0", features = [ "tick-hz-1_000_000" ] }
-esp-hal             = { version = "0.19.0", path = "../esp-hal", features = ["__esp_hal_embassy"] }
+esp-hal             = { version = "0.19.0", path = "../esp-hal" }
 log                 = { version = "0.4.22", optional = true }
 macros              = { version = "0.12.0", features = ["embassy"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 portable-atomic     = "1.6.0"
@@ -44,7 +44,7 @@ defmt = ["dep:defmt", "embassy-executor?/defmt", "esp-hal/defmt"]
 ## Enable logging via the log crate
 log = ["dep:log"]
 ## Provide `Executor` and `InterruptExecutor`
-executors = ["dep:embassy-executor"]
+executors = ["dep:embassy-executor", "esp-hal/__esp_hal_embassy"]
 ## Use the executor-integrated `embassy-time` timer queue.
 integrated-timers = ["embassy-executor?/integrated-timers"]
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The esp-hal-embassy crate can be used just to create a time driver. In that case, it's not necessary to reserve one of the 4 precious software interrupts - as that is only used to signal the thread mode executors between cores.