### PR TITLE
Fix defmt compatibility

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -444,8 +444,8 @@ macro_rules! dma_circular_buffers_chunk_size {
 macro_rules! dma_descriptors_chunk_size {
     ($tx_size:expr, $rx_size:expr, $chunk_size:expr) => {{
         // these will check for size at compile time
-        const _: () = assert!($chunk_size <= 4092, "chunk size must be <= 4092");
-        const _: () = assert!($chunk_size > 0, "chunk size must be > 0");
+        const _: () = ::core::assert!($chunk_size <= 4092, "chunk size must be <= 4092");
+        const _: () = ::core::assert!($chunk_size > 0, "chunk size must be > 0");
 
         static mut TX_DESCRIPTORS: [$crate::dma::DmaDescriptor;
             ($tx_size + $chunk_size - 1) / $chunk_size] =
@@ -473,8 +473,8 @@ macro_rules! dma_descriptors_chunk_size {
 macro_rules! dma_circular_descriptors_chunk_size {
     ($tx_size:expr, $rx_size:expr, $chunk_size:expr) => {{
         // these will check for size at compile time
-        const _: () = assert!($chunk_size <= 4092, "chunk size must be <= 4092");
-        const _: () = assert!($chunk_size > 0, "chunk size must be > 0");
+        const _: () = ::core::assert!($chunk_size <= 4092, "chunk size must be <= 4092");
+        const _: () = ::core::assert!($chunk_size > 0, "chunk size must be > 0");
 
         const tx_descriptor_len: usize = if $tx_size > $chunk_size * 2 {
             ($tx_size + $chunk_size - 1) / $chunk_size

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -76,6 +76,11 @@ async fn writer(tx_buffer: &'static mut [u8], i2s_tx: I2sTx<'static, I2S0, DmaCh
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
+    // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
+    // using defmt's non-const assert. Doing so would result in a compile error.
+    #[allow(unused_imports)]
+    use defmt::{assert_eq, *};
+
     use super::*;
 
     #[init]

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -56,7 +56,10 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
+    // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
+    // using defmt's non-const assert. Doing so would result in a compile error.
+    #[allow(unused_imports)]
+    use defmt::{assert_eq, *};
 
     use super::*;
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
When using `defmt`, rustc emits `error[E0015]: cannot call non-const fn `defmt::export::acquire` in constants`.

#### Testing
Modified tests that would now fail without this PR.