### PR TITLE
Disable object's unnecessary features in proc macro that loads LP code

### DIFF
--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 darling           = "0.20.10"
 document-features = "0.2.10"
 litrs             = "0.4.1"
-object            = { version = "0.36.3", optional = true, default-features = false, features = ["read"] }
+object            = { version = "0.36.4", optional = true, default-features = false, features = ["read_core", "elf"] }
 proc-macro-crate  = "3.2.0"
 proc-macro-error  = "1.0.4"
 proc-macro2       = "1.0.86"

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 darling           = "0.20.10"
 document-features = "0.2.10"
 litrs             = "0.4.1"
-object            = { version = "0.36.3", optional = true }
+object            = { version = "0.36.3", optional = true, default-features = false, features = ["read"] }
 proc-macro-crate  = "3.2.0"
 proc-macro-error  = "1.0.4"
 proc-macro2       = "1.0.86"


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The idea is to avoid compiling flate2 in CI for no good reason, hopefully saving a few seconds.
