### PR TITLE
Provide ehal impls for DummyPin

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implement `embedded-hal` output pin traits for `DummyPin` (#2019)
+
 ### Changed
 
 ### Fixed

--- a/esp-hal/src/gpio/dummy_pin.rs
+++ b/esp-hal/src/gpio/dummy_pin.rs
@@ -132,3 +132,55 @@ impl InputPin for DummyPin {
 
     fn disconnect_input_from_peripheral(&mut self, _signal: InputSignal, _: private::Internal) {}
 }
+
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_02::digital::v2::OutputPin for DummyPin {
+    type Error = core::convert::Infallible;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_output_high(true, private::Internal);
+        Ok(())
+    }
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_output_high(false, private::Internal);
+        Ok(())
+    }
+}
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_02::digital::v2::StatefulOutputPin for DummyPin {
+    fn is_set_high(&self) -> Result<bool, Self::Error> {
+        Ok(OutputPin::is_set_high(self, private::Internal))
+    }
+    fn is_set_low(&self) -> Result<bool, Self::Error> {
+        Ok(!OutputPin::is_set_high(self, private::Internal))
+    }
+}
+
+#[cfg(feature = "embedded-hal")]
+impl embedded_hal::digital::ErrorType for DummyPin {
+    type Error = core::convert::Infallible;
+}
+
+#[cfg(feature = "embedded-hal")]
+impl embedded_hal::digital::OutputPin for DummyPin {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_output_high(true, private::Internal);
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_output_high(false, private::Internal);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "embedded-hal")]
+impl embedded_hal::digital::StatefulOutputPin for DummyPin {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(OutputPin::is_set_high(self, private::Internal))
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(!OutputPin::is_set_high(self, private::Internal))
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable). (does card-io count here? :D )
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

We are missing the embedded-hal impls, making the DummyPin somewhat limited. Since I don't know if InputPin makes sense on something like this, I've omitted implementing that.
