### PR TITLE
Adding `I2C` HIL test

### DIFF
--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -2318,11 +2318,6 @@ impl<'d> AnyInput<'d> {
         self.pin.listen(event, private::Internal);
     }
 
-    /// Stop listening for interrupts
-    pub fn unlisten(&mut self) {
-        self.pin.unlisten(private::Internal);
-    }
-
     /// Clear the interrupt status bit for this Pin
     #[inline]
     pub fn clear_interrupt(&mut self) {

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -2318,6 +2318,11 @@ impl<'d> AnyInput<'d> {
         self.pin.listen(event, private::Internal);
     }
 
+    /// Stop listening for interrupts
+    pub fn unlisten(&mut self) {
+        self.pin.unlisten(private::Internal);
+    }
+
     /// Clear the interrupt status bit for this Pin
     #[inline]
     pub fn clear_interrupt(&mut self) {

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -52,6 +52,10 @@ name    = "interrupt"
 harness = false
 
 [[test]]
+name    = "i2c"
+harness = false
+
+[[test]]
 name    = "i2s"
 harness = false
 

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -74,9 +74,8 @@ Our self-hosted runners have the following setup:
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-C3 (`rustboard`):
   - Devkit: `ESP32-C3-DevKit-RUST-1` connected via USB-Serial-JTAG.
-    - `GPIO4` and `GPIO7` are I2C pins.
+    - `GPIO4` and `GPIO5` are I2C pins.
     - `GPIO2` and `GPIO3` are connected.
-    - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-C6 (`esp32c6-usb`):
   - Devkit: `ESP32-C6-DevKitC-1 V1.2` connected via USB-Serial-JTAG (`USB` port).

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -68,7 +68,7 @@ The [`hil.yml`] workflow builds the test suite for all our available targets and
 Our self-hosted runners have the following setup:
 - ESP32-C2 (`esp32c2-jtag`):
   - Devkit: `ESP8684-DevKitM-1` connected via UART.
-    - `GPIO18` and `GPIO19` are I2C pins.
+    - `GPIO18` and `GPIO9` are I2C pins.
     - `GPIO2` and `GPIO3` are connected.
   - Probe: `ESP-Prog` connected with the [following connections][connection_c2]
   - RPi: Raspbian 12 configured with the following [setup]
@@ -85,15 +85,14 @@ Our self-hosted runners have the following setup:
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-H2 (`esp32h2-usb`):
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).
-    - `GPIO4` and `GPIO22` are I2C pins.
+    - `GPIO12` and `GPIO22` are I2C pins.
     - `GPIO2` and `GPIO3` are connected.
-    - `GPIO5` and `GPIO8` are connected.
+    - `GPIO4` and `GPIO5` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-S2 (`esp32s2-jtag`):
   - Devkit: `ESP32-S2-Saola-1` connected via UART.
     - `GPIO2` and `GPIO3` are I2C pins.
     - `GPIO9` and `GPIO10` are connected.
-    - `GPIO5` and `GPIO6` are connected.
   - Probe: `ESP-Prog` connected with the [following connections][connection_s2]
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-S3 (`esp32s3-usb`):

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -95,7 +95,7 @@ Our self-hosted runners have the following setup:
 - ESP32-S3 (`esp32s3-usb`):
   - Devkit: `ESP32-S3-DevKitC-1` connected via USB-Serial-JTAG.
     - `GPIO2` and `GPIO3` are connected.
-    - `GPIO5` and `GPIO6` are connected.
+    - `GPIO4` and `GPIO5` are connected.
     - `GPIO1` and `GPIO21` are connected.
     - `GPIO43 (TX)` and `GPIO45` are connected.
   - RPi: Raspbian 12 configured with the following [setup]

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -79,7 +79,7 @@ Our self-hosted runners have the following setup:
 - ESP32-C6 (`esp32c6-usb`):
   - Devkit: `ESP32-C6-DevKitC-1 V1.2` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO3` are connected.
-    - `GPIO5` and `GPIO6` are connected.
+    - `GPIO4` and `GPIO5` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-H2 (`esp32h2-usb`):
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -68,35 +68,41 @@ The [`hil.yml`] workflow builds the test suite for all our available targets and
 Our self-hosted runners have the following setup:
 - ESP32-C2 (`esp32c2-jtag`):
   - Devkit: `ESP8684-DevKitM-1` connected via UART.
+    - `GPIO18` and `GPIO19` are I2C pins.
     - `GPIO2` and `GPIO3` are connected.
   - Probe: `ESP-Prog` connected with the [following connections][connection_c2]
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-C3 (`rustboard`):
   - Devkit: `ESP32-C3-DevKit-RUST-1` connected via USB-Serial-JTAG.
+    - `GPIO4` and `GPIO7` are I2C pins.
     - `GPIO2` and `GPIO3` are connected.
     - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-C6 (`esp32c6-usb`):
   - Devkit: `ESP32-C6-DevKitC-1 V1.2` connected via USB-Serial-JTAG (`USB` port).
+    - `GPIO6` and `GPIO7` are I2C pins.
     - `GPIO2` and `GPIO3` are connected.
     - `GPIO4` and `GPIO5` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-H2 (`esp32h2-usb`):
   - Devkit: `ESP32-H2-DevKitM-1` connected via USB-Serial-JTAG (`USB` port).
+    - `GPIO4` and `GPIO22` are I2C pins.
     - `GPIO2` and `GPIO3` are connected.
     - `GPIO5` and `GPIO8` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-S2 (`esp32s2-jtag`):
   - Devkit: `ESP32-S2-Saola-1` connected via UART.
-    - `GPIO2` and `GPIO3` are connected.
+    - `GPIO2` and `GPIO3` are I2C pins.
+    - `GPIO9` and `GPIO10` are connected.
     - `GPIO5` and `GPIO6` are connected.
   - Probe: `ESP-Prog` connected with the [following connections][connection_s2]
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-S3 (`esp32s3-usb`):
   - Devkit: `ESP32-S3-DevKitC-1` connected via USB-Serial-JTAG.
-    - `GPIO2` and `GPIO3` are connected.
+    - `GPIO2` and `GPIO3` are I2C pins.
     - `GPIO4` and `GPIO5` are connected.
     - `GPIO1` and `GPIO21` are connected.
+    - `GPIO9` and `GPIO10` are connected.
     - `GPIO43 (TX)` and `GPIO45` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -22,3 +22,45 @@ unsafe impl defmt::Logger for Logger {
 use defmt_rtt as _;
 // Make sure esp_backtrace is not removed.
 use esp_backtrace as _;
+
+use cfg_if::cfg_if;
+// Define type aliases and macros for conditional pin assignments
+cfg_if! {
+    if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
+        // Type alias for I2C pin configuration on S2 and S3 using GPIOs 2 and 3
+        pub type I2C_SCL_Pin = esp_hal::gpio::Gpio2;
+        pub type I2C_SDA_Pin = esp_hal::gpio::Gpio3;
+
+        // SPI pin aliases for avoiding conflicts with I2C on S2 and S3
+        pub type MFU_Pin1 = esp_hal::gpio::Gpio9;
+        pub type MFU_Pin2 = esp_hal::gpio::Gpio10;
+    } else if #[cfg(any(feature = "esp32c6"))] {
+        // Type alias for I2C pin configuration on C6 using GPIOs 6 and 7
+        pub type I2C_SCL_Pin = esp_hal::gpio::Gpio7;
+        pub type I2C_SDA_Pin = esp_hal::gpio::Gpio6;
+
+        /// SPI_MISO pin alias for avoiding conflicts with I2C on C6
+        pub type SPI_MISO_Pin = esp_hal::gpio::Gpio4;
+        /// SPI_MOSI pin alias for avoiding conflicts with I2C on C6
+        pub type SPI_MOSI_Pin = esp_hal::gpio::Gpio5;
+
+        /// Most
+        pub type MFU_Pin1 = esp_hal::gpio::Gpio2;
+        pub type MFU_Pin2 = esp_hal::gpio::Gpio3;
+    } else if #[cfg(any(feature = "esp32h2"))] {
+        // Type alias for I2C pin configuration on H2 using GPIOs 6 and 7
+        pub type I2C_SCL_Pin = esp_hal::gpio::Gpio6;
+        pub type I2C_SDA_Pin = esp_hal::gpio::Gpio7;
+
+        pub type MFU_Pin1 = esp_hal::gpio::Gpio2;
+        pub type MFU_Pin2 = esp_hal::gpio::Gpio3;
+        // No special pin assignments needed for SPI on H2
+    } else {
+        // Default case for other chips
+        pub type I2C_SCL_Pin = esp_hal::gpio::Gpio4;
+        pub type I2C_SDA_Pin = esp_hal::gpio::Gpio5;
+        
+        pub type MFU_Pin1 = esp_hal::gpio::Gpio2;
+        pub type MFU_Pin2 = esp_hal::gpio::Gpio3;
+    }
+}

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -35,9 +35,9 @@ macro_rules! i2c_pins {
             } else if #[cfg(esp32h2)] {
                 ($io.pins.gpio12, $io.pins.gpio22)
             } else if #[cfg(esp32c2)] {
-                ($io.pins.gpio18, $io.pins.gpio19)
+                ($io.pins.gpio18, $io.pins.gpio9)
             } else {
-                ($io.pins.gpio18, $io.pins.gpio7)
+                ($io.pins.gpio4, $io.pins.gpio5)
             }
         }
     }};

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -33,11 +33,11 @@ macro_rules! i2c_pins {
             } else if #[cfg(esp32c6)] {
                 ($io.pins.gpio6, $io.pins.gpio7)
             } else if #[cfg(esp32h2)] {
-                ($io.pins.gpio4, $io.pins.gpio22)
+                ($io.pins.gpio12, $io.pins.gpio22)
             } else if #[cfg(esp32c2)] {
                 ($io.pins.gpio18, $io.pins.gpio19)
             } else {
-                ($io.pins.gpio4, $io.pins.gpio7)
+                ($io.pins.gpio18, $io.pins.gpio7)
             }
         }
     }};

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -23,25 +23,19 @@ use defmt_rtt as _;
 // Make sure esp_backtrace is not removed.
 use esp_backtrace as _;
 
-// Define type aliases and macros for conditional pin assignments
 #[macro_export]
 macro_rules! i2c_pins {
     ($io:expr) => {{
         cfg_if::cfg_if! {
             if #[cfg(any(esp32s2, esp32s3))] {
-                // For ESP32-S2 and ESP32-S3, use GPIO 2(SDA) and 3(SCL) for I2C
                 ($io.pins.gpio2, $io.pins.gpio3)
             } else if #[cfg(esp32c6)] {
-                // For ESP32-C6, use GPIO 6(SDA) and 7(SCL) for I2C
                 ($io.pins.gpio6, $io.pins.gpio7)
             } else if #[cfg(esp32h2)] {
-                // For ESP32-H2, use GPIO 4(SDA) and 22(SCL) for I2C
                 ($io.pins.gpio4, $io.pins.gpio22)
             } else if #[cfg(esp32c2)] {
-                // For ESP32-C2, use GPIO 18(SDA) and 19(SCL) for I2C
                 ($io.pins.gpio18, $io.pins.gpio19)
             } else {
-                // ESP32 and ESP32C3, use GPIO 4(SDA) and 7(SCL)
                 ($io.pins.gpio4, $io.pins.gpio7)
             }
         }
@@ -53,10 +47,8 @@ macro_rules! common_test_pins {
     ($io:expr) => {{
         cfg_if::cfg_if! {
             if #[cfg(not(any(esp32s2, esp32s3)))] {
-                // For other targets, use GPIO 2 and 3 for common tests
                 ($io.pins.gpio2, $io.pins.gpio3)
             } else if #[cfg(any(esp32s2, esp32s3))] {
-                // For ESP32-S2 and ESP32-S3, use GPIO 9 and 10 for common tests
                 ($io.pins.gpio9, $io.pins.gpio10)
             }
         }

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -29,19 +29,19 @@ macro_rules! i2c_pins {
     ($io:expr) => {{
         cfg_if::cfg_if! {
             if #[cfg(any(esp32s2, esp32s3))] {
-                // For ESP32-S2 and ESP32-S3, use GPIO 2 and 3 for I2C
+                // For ESP32-S2 and ESP32-S3, use GPIO 2(SDA) and 3(SCL) for I2C
                 ($io.pins.gpio2, $io.pins.gpio3)
             } else if #[cfg(esp32c6)] {
-                // For ESP32-C6, use GPIO 6 and 7 for I2C
+                // For ESP32-C6, use GPIO 6(SDA) and 7(SCL) for I2C
                 ($io.pins.gpio6, $io.pins.gpio7)
             } else if #[cfg(esp32h2)] {
-                // For ESP32-H2, use GPIO 6 and 7 for I2C
-                ($io.pins.gpio4, $io.pins.gpio7)
-            } else if #[cfg(any(esp32c2, esp32c3))] {
-                // For ESP32-C2 and ESP32-C3, use GPIO 4 and 7 for I2C
-                ($io.pins.gpio4, $io.pins.gpio7)
+                // For ESP32-H2, use GPIO 4(SDA) and 22(SCL) for I2C
+                ($io.pins.gpio4, $io.pins.gpio22)
+            } else if #[cfg(esp32c2)] {
+                // For ESP32-C2, use GPIO 18(SDA) and 19(SCL) for I2C
+                ($io.pins.gpio18, $io.pins.gpio19)
             } else {
-                // Default case: fallback if needed
+                // ESP32 and ESP32C3, use GPIO 4(SDA) and 7(SCL)
                 ($io.pins.gpio4, $io.pins.gpio7)
             }
         }
@@ -53,13 +53,12 @@ macro_rules! common_test_pins {
     ($io:expr) => {{
         cfg_if::cfg_if! {
             if #[cfg(not(any(esp32s2, esp32s3)))] {
-                // For ESP32-S2 and ESP32-S3, use GPIO 2 and 3 for I2C
+                // For other targets, use GPIO 2 and 3 for common tests
                 ($io.pins.gpio2, $io.pins.gpio3)
             } else if #[cfg(any(esp32s2, esp32s3))] {
-                // For ESP32-C6, use GPIO 6 and 7 for I2C
+                // For ESP32-S2 and ESP32-S3, use GPIO 9 and 10 for common tests
                 ($io.pins.gpio9, $io.pins.gpio10)
             }
         }
     }};
 }
-

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -26,6 +26,7 @@ use esp_backtrace as _;
 #[macro_export]
 macro_rules! i2c_pins {
     ($io:expr) => {{
+        // Order: (SDA, SCL)
         cfg_if::cfg_if! {
             if #[cfg(any(esp32s2, esp32s3))] {
                 ($io.pins.gpio2, $io.pins.gpio3)

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -23,44 +23,43 @@ use defmt_rtt as _;
 // Make sure esp_backtrace is not removed.
 use esp_backtrace as _;
 
-use cfg_if::cfg_if;
 // Define type aliases and macros for conditional pin assignments
-cfg_if! {
-    if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
-        // Type alias for I2C pin configuration on S2 and S3 using GPIOs 2 and 3
-        pub type I2C_SCL_Pin = esp_hal::gpio::Gpio2;
-        pub type I2C_SDA_Pin = esp_hal::gpio::Gpio3;
-
-        // SPI pin aliases for avoiding conflicts with I2C on S2 and S3
-        pub type MFU_Pin1 = esp_hal::gpio::Gpio9;
-        pub type MFU_Pin2 = esp_hal::gpio::Gpio10;
-    } else if #[cfg(any(feature = "esp32c6"))] {
-        // Type alias for I2C pin configuration on C6 using GPIOs 6 and 7
-        pub type I2C_SCL_Pin = esp_hal::gpio::Gpio7;
-        pub type I2C_SDA_Pin = esp_hal::gpio::Gpio6;
-
-        /// SPI_MISO pin alias for avoiding conflicts with I2C on C6
-        pub type SPI_MISO_Pin = esp_hal::gpio::Gpio4;
-        /// SPI_MOSI pin alias for avoiding conflicts with I2C on C6
-        pub type SPI_MOSI_Pin = esp_hal::gpio::Gpio5;
-
-        /// Most
-        pub type MFU_Pin1 = esp_hal::gpio::Gpio2;
-        pub type MFU_Pin2 = esp_hal::gpio::Gpio3;
-    } else if #[cfg(any(feature = "esp32h2"))] {
-        // Type alias for I2C pin configuration on H2 using GPIOs 6 and 7
-        pub type I2C_SCL_Pin = esp_hal::gpio::Gpio6;
-        pub type I2C_SDA_Pin = esp_hal::gpio::Gpio7;
-
-        pub type MFU_Pin1 = esp_hal::gpio::Gpio2;
-        pub type MFU_Pin2 = esp_hal::gpio::Gpio3;
-        // No special pin assignments needed for SPI on H2
-    } else {
-        // Default case for other chips
-        pub type I2C_SCL_Pin = esp_hal::gpio::Gpio4;
-        pub type I2C_SDA_Pin = esp_hal::gpio::Gpio5;
-        
-        pub type MFU_Pin1 = esp_hal::gpio::Gpio2;
-        pub type MFU_Pin2 = esp_hal::gpio::Gpio3;
-    }
+#[macro_export]
+macro_rules! i2c_pins {
+    ($io:expr) => {{
+        cfg_if::cfg_if! {
+            if #[cfg(any(esp32s2, esp32s3))] {
+                // For ESP32-S2 and ESP32-S3, use GPIO 2 and 3 for I2C
+                ($io.pins.gpio2, $io.pins.gpio3)
+            } else if #[cfg(esp32c6)] {
+                // For ESP32-C6, use GPIO 6 and 7 for I2C
+                ($io.pins.gpio6, $io.pins.gpio7)
+            } else if #[cfg(esp32h2)] {
+                // For ESP32-H2, use GPIO 6 and 7 for I2C
+                ($io.pins.gpio4, $io.pins.gpio7)
+            } else if #[cfg(any(esp32c2, esp32c3))] {
+                // For ESP32-C2 and ESP32-C3, use GPIO 4 and 7 for I2C
+                ($io.pins.gpio4, $io.pins.gpio7)
+            } else {
+                // Default case: fallback if needed
+                ($io.pins.gpio4, $io.pins.gpio7)
+            }
+        }
+    }};
 }
+
+#[macro_export]
+macro_rules! common_test_pins {
+    ($io:expr) => {{
+        cfg_if::cfg_if! {
+            if #[cfg(not(any(esp32s2, esp32s3)))] {
+                // For ESP32-S2 and ESP32-S3, use GPIO 2 and 3 for I2C
+                ($io.pins.gpio2, $io.pins.gpio3)
+            } else if #[cfg(any(esp32s2, esp32s3))] {
+                // For ESP32-C6, use GPIO 6 and 7 for I2C
+                ($io.pins.gpio9, $io.pins.gpio10)
+            }
+        }
+    }};
+}
+

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -47,10 +47,11 @@ macro_rules! i2c_pins {
 macro_rules! common_test_pins {
     ($io:expr) => {{
         cfg_if::cfg_if! {
-            if #[cfg(not(any(esp32s2, esp32s3)))] {
-                ($io.pins.gpio2, $io.pins.gpio3)
-            } else if #[cfg(any(esp32s2, esp32s3))] {
+            if #[cfg(any(esp32s2, esp32s3))] {
                 ($io.pins.gpio9, $io.pins.gpio10)
+            }
+            else {
+                ($io.pins.gpio2, $io.pins.gpio3)
             }
         }
     }};

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -1,8 +1,8 @@
 //! GPIO Test
 //!
 //! Folowing pins are used:
-//! GPIO2
-//! GPIO3
+//! GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! GPIO3 / GPIO10 (esp32s2 and esp32s3)
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -16,13 +16,7 @@
 #![no_std]
 #![no_main]
 
-use esp_hal::{
-    gpio::Io,
-    i2c::I2C,
-    peripherals::I2C0,
-    prelude::*,
-    Blocking,
-};
+use esp_hal::{gpio::Io, i2c::I2C, peripherals::I2C0, prelude::*, Blocking};
 use hil_test as _;
 
 struct Context {

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -4,7 +4,7 @@
 //! SCL    GPIO4
 //! SDA    GPIO7
 
-//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]
@@ -19,7 +19,6 @@ use esp_hal::{
     Blocking,
 };
 use hil_test as _;
-use nb::block;
 
 struct Context {
     i2c: I2C<'static, I2C0, Blocking>,
@@ -38,13 +37,12 @@ mod tests {
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-
-        let scl = unsafe { hil_test::I2C_SCL_Pin::steal() };
-        let sda = unsafe { hil_test::I2C_SDA_Pin::steal() };
+        
+        let (sda, scl) = hil_test::i2c_pins!(io);
 
         // Create a new peripheral object with the described wiring and standard
         // I2C clock speed:
-        let mut i2c = I2C::new(
+        let i2c = I2C::new(
             peripherals.I2C0,
             sda,
             scl,

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -1,8 +1,8 @@
 //! TWAI test
 //!
 //! Folowing pins are used:
-//! SCL    GPIO2
-//! SDA    GPIO3
+//! SCL    GPIO4
+//! SDA    GPIO7
 
 //% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -38,7 +38,7 @@ impl Context {
         let mut i2c = I2C::new(
             peripherals.I2C0,
             io.pins.gpio4,
-            io.pins.gpio5,
+            io.pins.gpio7,
             100.kHz(),
             &clocks,
         );    

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -37,18 +37,12 @@ mod tests {
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        
+
         let (sda, scl) = hil_test::i2c_pins!(io);
 
         // Create a new peripheral object with the described wiring and standard
         // I2C clock speed:
-        let i2c = I2C::new(
-            peripherals.I2C0,
-            sda,
-            scl,
-            100.kHz(),
-            &clocks,
-        );
+        let i2c = I2C::new(peripherals.I2C0, sda, scl, 100.kHz(), &clocks);
 
         Context { i2c }
     }

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -4,8 +4,8 @@
 //! SDA     GPIO2   (esp32s2 and esp32s3)
 //!         GPIO6   (esp32c6)
 //!         GPIO18  (esp32c2)
-//!         GPIO4   (esp32, esp32h2 and esp32c3) 
-//! 
+//!         GPIO4   (esp32, esp32h2 and esp32c3)
+//!
 //! SCL     GPIO3   (esp32s2 and esp32s3)
 //!         GPIO7   (esp32c6, esp32 and esp32c3)
 //!         GPIO22  (esp32h2)
@@ -22,7 +22,6 @@ use esp_hal::{
     i2c::I2C,
     peripherals::{Peripherals, I2C0},
     prelude::*,
-    system::SystemControl,
     Blocking,
 };
 use hil_test as _;
@@ -39,10 +38,7 @@ mod tests {
 
     #[init]
     fn init() -> Context {
-        let peripherals = Peripherals::take();
-        let system = SystemControl::new(peripherals.SYSTEM);
-        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-
+        let (peripherals, clocks) = esp_hal::init(esp_hal::Config::default());
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
         let (sda, scl) = hil_test::i2c_pins!(io);

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -16,7 +16,7 @@ use esp_hal::{
     peripherals::{Peripherals, I2C0},
     prelude::*,
     system::SystemControl,
-    Blocking
+    Blocking,
 };
 use hil_test as _;
 use nb::block;
@@ -30,9 +30,9 @@ impl Context {
         let peripherals = Peripherals::take();
         let system = SystemControl::new(peripherals.SYSTEM);
         let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
-    
+
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    
+
         // Create a new peripheral object with the described wiring and standard
         // I2C clock speed:
         let mut i2c = I2C::new(
@@ -41,7 +41,7 @@ impl Context {
             io.pins.gpio7,
             100.kHz(),
             &clocks,
-        );    
+        );
 
         Context { i2c }
     }

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -1,0 +1,71 @@
+//! TWAI test
+//!
+//! Folowing pins are used:
+//! SCL    GPIO2
+//! SDA    GPIO3
+
+//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use esp_hal::{
+    clock::ClockControl,
+    gpio::Io,
+    i2c::I2C,
+    peripherals::{Peripherals, I2C0},
+    prelude::*,
+    system::SystemControl,
+    Blocking
+};
+use hil_test as _;
+use nb::block;
+
+struct Context {
+    i2c: I2C<'static, I2C0, Blocking>,
+}
+
+impl Context {
+    pub fn init() -> Self {
+        let peripherals = Peripherals::take();
+        let system = SystemControl::new(peripherals.SYSTEM);
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    
+        // Create a new peripheral object with the described wiring and standard
+        // I2C clock speed:
+        let mut i2c = I2C::new(
+            peripherals.I2C0,
+            io.pins.gpio4,
+            io.pins.gpio5,
+            100.kHz(),
+            &clocks,
+        );    
+
+        Context { i2c }
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use defmt::assert_ne;
+
+    use super::*;
+
+    #[init]
+    fn init() -> Context {
+        Context::init()
+    }
+
+    #[test]
+    #[timeout(3)]
+    fn test_measures(mut ctx: Context) {
+        let mut read_data = [0u8; 22];
+
+        ctx.i2c.write_read(0x77, &[0xaa], &mut read_data).ok();
+
+        assert_ne!(read_data, [0u8; 22])
+    }
+}

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -1,8 +1,15 @@
 //! I2C test
 //!
 //! Folowing pins are used:
-//! SCL    GPIO4
-//! SDA    GPIO7
+//! SDA     GPIO2   (esp32s2 and esp32s3)
+//!         GPIO6   (esp32c6)
+//!         GPIO18  (esp32c2)
+//!         GPIO4   (esp32, esp32h2 and esp32c3) 
+//! 
+//! SCL     GPIO3   (esp32s2 and esp32s3)
+//!         GPIO7   (esp32c6, esp32 and esp32c3)
+//!         GPIO22  (esp32h2)
+//!         GPIO19  (esp32c2)
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -17,10 +17,9 @@
 #![no_main]
 
 use esp_hal::{
-    clock::ClockControl,
     gpio::Io,
     i2c::I2C,
-    peripherals::{Peripherals, I2C0},
+    peripherals::I2C0,
     prelude::*,
     Blocking,
 };

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -78,18 +78,20 @@ mod tests {
             &clocks,
         );
 
+        let (dout, din) = hil_test::common_test_pins!(io);
+
         let mut i2s_tx = i2s
             .i2s_tx
             .with_bclk(unsafe { io.pins.gpio0.clone_unchecked() })
             .with_ws(unsafe { io.pins.gpio1.clone_unchecked() })
-            .with_dout(unsafe { io.pins.gpio2.clone_unchecked() })
+            .with_dout(dout)
             .build();
 
         let mut i2s_rx = i2s
             .i2s_rx
             .with_bclk(io.pins.gpio0)
             .with_ws(io.pins.gpio1)
-            .with_din(io.pins.gpio3)
+            .with_din(din)
             .build();
 
         // enable loopback testing

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -1,6 +1,7 @@
 //! I2S Loopback Test
 //!
 //! It's assumed GPIO2 is connected to GPIO3
+//! (GPIO9 and GPIO10 for esp32s3)
 //!
 //! This test uses I2S TX to transmit known data to I2S RX (forced to slave mode
 //! with loopback mode enabled). It's using circular DMA mode

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -1,6 +1,7 @@
 //! I2S Loopback Test (Async)
 //!
 //! It's assumed GPIO2 is connected to GPIO3
+//! (GPIO9 and GPIO10 for esp32s3)
 //!
 //! This test uses I2S TX to transmit known data to I2S RX (forced to slave mode
 //! with loopback mode enabled). It's using circular DMA mode

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -109,18 +109,20 @@ mod tests {
             &clocks,
         );
 
+        let (dout, din) = hil_test::common_test_pins!(io);
+
         let i2s_tx = i2s
             .i2s_tx
             .with_bclk(unsafe { io.pins.gpio0.clone_unchecked() })
             .with_ws(unsafe { io.pins.gpio1.clone_unchecked() })
-            .with_dout(io.pins.gpio2)
+            .with_dout(dout)
             .build();
 
         let i2s_rx = i2s
             .i2s_rx
             .with_bclk(io.pins.gpio0)
             .with_ws(io.pins.gpio1)
-            .with_din(io.pins.gpio3)
+            .with_din(din)
             .build();
 
         // enable loopback testing

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -1,6 +1,7 @@
 //! PCNT tests
 //!
 //! It's assumed GPIO2 is connected to GPIO3
+//! (GPIO9 and GPIO10 for esp32s3)
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -1,7 +1,7 @@
 //! PCNT tests
 //!
 //! It's assumed GPIO2 is connected to GPIO3
-//! (GPIO9 and GPIO10 for esp32s3)
+//! (GPIO9 and GPIO10 for esp32s2 and esp32s3)
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -10,7 +10,7 @@
 
 use esp_hal::{
     delay::Delay,
-    gpio::{GpioPin, AnyPin, Io, Level, Output, Pull},
+    gpio::{AnyPin, Io, Level, Output, Pull},
     pcnt::{
         channel::{EdgeMode, PcntInputConfig, PcntSource},
         Pcnt,

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -9,7 +9,7 @@
 
 use esp_hal::{
     delay::Delay,
-    gpio::{GpioPin, Io, Level, Output, Pull},
+    gpio::{GpioPin, AnyPin, Io, Level, Output, Pull},
     pcnt::{
         channel::{EdgeMode, PcntInputConfig, PcntSource},
         Pcnt,
@@ -19,8 +19,8 @@ use hil_test as _;
 
 struct Context<'d> {
     pcnt: Pcnt<'d>,
-    gpio2: GpioPin<2>,
-    gpio3: GpioPin<3>,
+    input: AnyPin<'d>,
+    output: AnyPin<'d>,
     delay: Delay,
 }
 
@@ -35,10 +35,15 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
+        let (din, dout) = hil_test::common_test_pins!(io);
+
+        let din = AnyPin::new(din);
+        let dout = AnyPin::new(dout);
+
         Context {
             pcnt: Pcnt::new(peripherals.PCNT),
-            gpio2: io.pins.gpio2,
-            gpio3: io.pins.gpio3,
+            input: din,
+            output: dout,
             delay: Delay::new(&clocks),
         }
     }
@@ -49,13 +54,13 @@ mod tests {
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
         unit.channel0.set_edge_signal(PcntSource::from_pin(
-            ctx.gpio2,
+            ctx.input,
             PcntInputConfig { pull: Pull::Down },
         ));
         unit.channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        let mut output = Output::new(ctx.gpio3, Level::Low);
+        let mut output = Output::new(ctx.output, Level::Low);
 
         unit.resume();
 
@@ -88,13 +93,13 @@ mod tests {
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
         unit.channel0.set_edge_signal(PcntSource::from_pin(
-            ctx.gpio2,
+            ctx.input,
             PcntInputConfig { pull: Pull::Up },
         ));
         unit.channel0
             .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
 
-        let mut output = Output::new(ctx.gpio3, Level::High);
+        let mut output = Output::new(ctx.output, Level::High);
 
         unit.resume();
 
@@ -129,13 +134,13 @@ mod tests {
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
         unit.channel0.set_edge_signal(PcntSource::from_pin(
-            ctx.gpio2,
+            ctx.input,
             PcntInputConfig { pull: Pull::Up },
         ));
         unit.channel0
             .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
 
-        let mut output = Output::new(ctx.gpio3, Level::High);
+        let mut output = Output::new(ctx.output, Level::High);
 
         unit.resume();
 
@@ -192,13 +197,13 @@ mod tests {
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
         unit.channel0.set_edge_signal(PcntSource::from_pin(
-            ctx.gpio2,
+            ctx.input,
             PcntInputConfig { pull: Pull::Up },
         ));
         unit.channel0
             .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
 
-        let mut output = Output::new(ctx.gpio3, Level::High);
+        let mut output = Output::new(ctx.output, Level::High);
 
         unit.resume();
 
@@ -259,13 +264,13 @@ mod tests {
 
         // Setup channel 0 to decrement the count when gpio2 does LOW -> HIGH
         unit.channel0.set_edge_signal(PcntSource::from_pin(
-            ctx.gpio2,
+            ctx.input,
             PcntInputConfig { pull: Pull::Up },
         ));
         unit.channel0
             .set_input_mode(EdgeMode::Decrement, EdgeMode::Hold);
 
-        let mut output = Output::new(ctx.gpio3, Level::High);
+        let mut output = Output::new(ctx.output, Level::High);
 
         unit.resume();
 
@@ -317,13 +322,13 @@ mod tests {
 
         // Setup channel 1 to increment the count when gpio2 does LOW -> HIGH
         unit.channel1.set_edge_signal(PcntSource::from_pin(
-            ctx.gpio2,
+            ctx.input,
             PcntInputConfig { pull: Pull::Up },
         ));
         unit.channel1
             .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
 
-        let mut output = Output::new(ctx.gpio3, Level::High);
+        let mut output = Output::new(ctx.output, Level::High);
 
         unit.resume();
 

--- a/hil-test/tests/qspi_write.rs
+++ b/hil-test/tests/qspi_write.rs
@@ -3,11 +3,11 @@
 //! This uses PCNT to count the edges of the MOSI signal
 //!
 //! Following pins are used:
-//! MOSI    GPIO2
+//! MOSI    GPIO2 / GPIO9 (esp32s2 and esp32s3)
 //!
-//! PCNT    GPIO3
+//! PCNT    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! Connect MOSI (GPIO2) and PCNT (GPIO3) pins.
+//! Connect MOSI and PCNT pins.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -18,7 +18,7 @@ use esp_hal::{
     clock::Clocks,
     dma::{Channel, Dma, DmaPriority, DmaTxBuf},
     dma_buffers,
-    gpio::{Io, Pull},
+    gpio::{AnyPin, Io, Pull},
     pcnt::{
         channel::{EdgeMode, PcntInputConfig, PcntSource},
         unit::Unit,
@@ -50,8 +50,8 @@ struct Context {
     spi: esp_hal::peripherals::SPI2,
     pcnt: esp_hal::peripherals::PCNT,
     dma_channel: Channel<'static, DmaChannel0, Blocking>,
-    mosi: esp_hal::gpio::GpioPin<2>,
-    mosi_mirror: esp_hal::gpio::GpioPin<3>,
+    mosi: AnyPin<'static>,
+    mosi_mirror: AnyPin<'static>,
     clocks: Clocks<'static>,
 }
 
@@ -113,8 +113,11 @@ mod tests {
         let (peripherals, clocks) = esp_hal::init(esp_hal::Config::default());
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let mosi = io.pins.gpio2;
-        let mosi_mirror = io.pins.gpio3;
+
+        let (mosi, mosi_mirror) = hil_test::common_test_pins!(io);
+
+        let mosi = AnyPin::new(mosi);
+        let mosi_mirror = AnyPin::new(mosi_mirror);
 
         let dma = Dma::new(peripherals.DMA);
 

--- a/hil-test/tests/qspi_write_read.rs
+++ b/hil-test/tests/qspi_write_read.rs
@@ -3,11 +3,11 @@
 //! Make sure issue #1860 doesn't affect us
 //!
 //! Following pins are used:
-//! MOSI/MISO    GPIO2
+//! MOSI/MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
 //!
-//! GPIO         GPIO3
+//! GPIO         GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! Connect MOSI/MISO (GPIO2) and GPIO (GPIO3) pins.
+//! Connect MOSI/MISO and GPIO pins.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -18,7 +18,7 @@ use esp_hal::{
     clock::Clocks,
     dma::{Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{GpioPin, Io, Level, Output},
+    gpio::{AnyOutput, AnyPin, Io, Level},
     prelude::*,
     spi::{
         master::{Address, Command, Spi, SpiDma},
@@ -44,14 +44,14 @@ cfg_if::cfg_if! {
 struct Context {
     spi: esp_hal::peripherals::SPI2,
     dma_channel: Channel<'static, DmaChannel0, Blocking>,
-    mosi: esp_hal::gpio::GpioPin<2>,
-    mosi_mirror: Output<'static, GpioPin<3>>,
+    mosi: AnyPin<'static>,
+    mosi_mirror: AnyOutput<'static>,
     clocks: Clocks<'static>,
 }
 
 fn execute(
     mut spi: SpiDma<'static, esp_hal::peripherals::SPI2, DmaChannel0, HalfDuplexMode, Blocking>,
-    mut mosi_mirror: Output<'static, GpioPin<3>>,
+    mut mosi_mirror: AnyOutput<'static>,
     wanted: u8,
 ) {
     const DMA_BUFFER_SIZE: usize = 4;
@@ -104,8 +104,11 @@ mod tests {
         let (peripherals, clocks) = esp_hal::init(esp_hal::Config::default());
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let mosi = io.pins.gpio2;
-        let mosi_mirror = Output::new(io.pins.gpio3, Level::High);
+
+        let (mosi, mosi_mirror) = hil_test::common_test_pins!(io);
+
+        let mosi = AnyPin::new(mosi);
+        let mosi_mirror = AnyOutput::new(mosi_mirror, Level::High);
 
         let dma = Dma::new(peripherals.DMA);
 

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -1,7 +1,7 @@
 //! RMT Loopback Test
 //!
 //! It's assumed GPIO2 is connected to GPIO3
-//! (GPIO9 and GPIO10 for esp32s3)
+//! (GPIO9 and GPIO10 for esp32s2 and esp32s3)
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -39,6 +39,8 @@ mod tests {
 
         let rmt = Rmt::new(peripherals.RMT, freq, &clocks).unwrap();
 
+        let (tx, rx) = hil_test::common_test_pins!(io);
+
         let tx_config = TxChannelConfig {
             clk_divider: 255,
             ..TxChannelConfig::default()
@@ -46,7 +48,7 @@ mod tests {
 
         let tx_channel = {
             use esp_hal::rmt::TxChannelCreator;
-            rmt.channel0.configure(io.pins.gpio2, tx_config).unwrap()
+            rmt.channel0.configure(tx, tx_config).unwrap()
         };
 
         let rx_config = RxChannelConfig {
@@ -59,17 +61,17 @@ mod tests {
             if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel1.configure(io.pins.gpio3, rx_config).unwrap()
+                    rmt.channel1.configure(rx, rx_config).unwrap()
                 };
             } else if #[cfg(feature = "esp32s3")] {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel7.configure(io.pins.gpio3, rx_config).unwrap()
+                    rmt.channel7.configure(rx, rx_config).unwrap()
                 };
             } else {
                 let  rx_channel = {
                     use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel2.configure(io.pins.gpio3, rx_config).unwrap()
+                    rmt.channel2.configure(rx, rx_config).unwrap()
                 };
             }
         }

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -1,6 +1,7 @@
 //! RMT Loopback Test
 //!
 //! It's assumed GPIO2 is connected to GPIO3
+//! (GPIO9 and GPIO10 for esp32s3)
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -38,8 +38,7 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
-        let miso = io.pins.gpio2;
-        let mosi = io.pins.gpio3;
+        let (miso, mosi) = hil_test::common_test_pins!(io);
         let cs = io.pins.gpio8;
 
         let spi = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0, &clocks).with_pins(

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -2,11 +2,11 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2
-//! MOSI    GPIO3
+//! MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! MOSI    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //! CS      GPIO8
 //!
-//! Connect MISO (GPIO2) and MOSI (GPIO3) pins.
+//! Connect MISO and MOSI pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -56,8 +56,7 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
-        let mosi = io.pins.gpio3;
-        let miso = io.pins.gpio2;
+        let (miso, mosi) = hil_test::common_test_pins!(io);
         let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -2,11 +2,11 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2
-//! MOSI    GPIO3
+//! MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! MOSI    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //! CS      GPIO8
 //!
-//! Connect MISO (GPIO2) and MOSI (GPIO3) pins.
+//! Connect MISO and MOSI pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -2,17 +2,17 @@
 //!
 //! Following pins are used:
 //! SCLK    GPIO0
-//! MOSI    GPIO3
+//! MOSI    GPIO3 / GPIO10 (esp32s3)
 //! MISO    GPIO4
 //! CS      GPIO8
 //!
-//! PCNT    GPIO2
+//! PCNT    GPIO2 / GPIO9 (esp32s3)
 //! OUTPUT  GPIO5 (helper to keep MISO LOW)
 //!
 //! The idea of using PCNT (input) here is to connect MOSI to it and count the
 //! edges of whatever SPI writes (in this test case 3 pos edges).
 //!
-//! Connect PCNT (GPIO2) and MOSI (GPIO3) and MISO (GPIO4) and GPIO5 pins.
+//! Connect PCNT and MOSI, MISO and GPIO5 pins.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s3
 //% FEATURES: generic-queue

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -24,7 +24,7 @@ use embedded_hal_async::spi::SpiBus;
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{GpioPin, Io, Level, Output, Pull},
+    gpio::{AnyPin, GpioPin, Io, Level, Output, Pull},
     pcnt::{
         channel::{EdgeMode, PcntInputConfig, PcntSource},
         unit::Unit,
@@ -58,7 +58,7 @@ struct Context {
     spi: SpiDmaBus<'static, SPI2, DmaChannel0, FullDuplexMode, Async>,
     pcnt_unit: Unit<'static, 0>,
     out_pin: Output<'static, GpioPin<5>>,
-    mosi_mirror: GpioPin<2>,
+    mosi_mirror: AnyPin<'static>,
 }
 
 #[cfg(test)]
@@ -75,10 +75,11 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let pcnt = Pcnt::new(peripherals.PCNT);
         let sclk = io.pins.gpio0;
-        let mosi_mirror = io.pins.gpio2;
-        let mosi = io.pins.gpio3;
-        let miso = io.pins.gpio6;
+
+        let (mosi_mirror, mosi) = hil_test::common_test_pins!(io);
+        let miso = io.pins.gpio4;
         let cs = io.pins.gpio8;
+        let mosi_mirror = AnyPin::new(mosi_mirror);
 
         let mut out_pin = Output::new(io.pins.gpio5, Level::Low);
         out_pin.set_low();

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -3,7 +3,7 @@
 //! Following pins are used:
 //! SCLK    GPIO0
 //! MOSI    GPIO3
-//! MISO    GPIO6
+//! MISO    GPIO4
 //! CS      GPIO8
 //!
 //! PCNT    GPIO2
@@ -12,7 +12,7 @@
 //! The idea of using PCNT (input) here is to connect MOSI to it and count the
 //! edges of whatever SPI writes (in this test case 3 pos edges).
 //!
-//! Connect PCNT (GPIO2) and MOSI (GPIO3) and MISO (GPIO6) and GPIO5 pins.
+//! Connect PCNT (GPIO2) and MOSI (GPIO3) and MISO (GPIO4) and GPIO5 pins.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s3
 //% FEATURES: generic-queue

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -77,7 +77,7 @@ mod tests {
         let sclk = io.pins.gpio0;
         let mosi_mirror = io.pins.gpio2;
         let mosi = io.pins.gpio3;
-        let miso = unsafe { hil_test::SPI_MISO_Pin::steal() };
+        let miso = io.pins.gpio6;
         let cs = io.pins.gpio8;
 
         let mut out_pin = Output::new(io.pins.gpio5, Level::Low);

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -77,7 +77,7 @@ mod tests {
         let sclk = io.pins.gpio0;
         let mosi_mirror = io.pins.gpio2;
         let mosi = io.pins.gpio3;
-        let miso = io.pins.gpio6;
+        let miso = unsafe { hil_test::SPI_MISO_Pin::steal() };
         let cs = io.pins.gpio8;
 
         let mut out_pin = Output::new(io.pins.gpio5, Level::Low);

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -2,15 +2,15 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MOSI    GPIO3
+//! MOSI    GPIO3 / GPIO10 (esp32s3)
 //! CS      GPIO8
-//! PCNT    GPIO2
+//! PCNT    GPIO2 / GPIO9 (esp32s3)
 //! OUTPUT  GPIO5 (helper to keep MISO LOW)
 //!
 //! The idea of using PCNT (input) here is to connect MOSI to it and count the
 //! edges of whatever SPI writes (in this test case 3 pos edges).
 //!
-//! Connect MISO (GPIO2) and MOSI (GPIO3) pins.
+//! Connect MISO and MOSI pins.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s3
 

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -69,7 +69,7 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let mosi = io.pins.gpio3;
-        let miso = unsafe { hil_test::SPI_MISO_Pin::steal() };
+        let miso = io.pins.gpio6;
         let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -68,8 +68,8 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
-        let mosi = io.pins.gpio3;
-        let miso = io.pins.gpio6;
+        let (_, mosi) = hil_test::common_test_pins!(io);
+        let miso = io.pins.gpio4;
         let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -69,7 +69,7 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let mosi = io.pins.gpio3;
-        let miso = io.pins.gpio6;
+        let miso = unsafe { hil_test::SPI_MISO_Pin::steal() };
         let cs = io.pins.gpio8;
 
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -20,7 +20,7 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{GpioPin, Io, Level, Output, Pull},
+    gpio::{AnyPin, GpioPin, Io, Level, Output, Pull},
     pcnt::{
         channel::{EdgeMode, PcntInputConfig, PcntSource},
         unit::Unit,
@@ -52,7 +52,7 @@ struct Context {
     spi: SpiDma<'static, SPI2, DmaChannel0, FullDuplexMode, Blocking>,
     pcnt_unit: Unit<'static, 0>,
     out_pin: Output<'static, GpioPin<5>>,
-    mosi_mirror: GpioPin<2>,
+    mosi_mirror: AnyPin<'static>,
 }
 
 #[cfg(test)]
@@ -68,7 +68,7 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
-        let (_, mosi) = hil_test::common_test_pins!(io);
+        let (mosi_mirror, mosi) = hil_test::common_test_pins!(io);
         let miso = io.pins.gpio4;
         let cs = io.pins.gpio8;
 
@@ -91,7 +91,7 @@ mod tests {
         let mut out_pin = Output::new(io.pins.gpio5, Level::Low);
         out_pin.set_low();
         assert_eq!(out_pin.is_set_low(), true);
-        let mosi_mirror = io.pins.gpio2;
+        let mosi_mirror = AnyPin::new(mosi_mirror);
 
         Context {
             spi,

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -3,7 +3,7 @@
 //! Folowing pins are used:
 //! SCLK    GPIO0
 //! MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! 
+//!
 //! GPIO    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
 //! Connect MISO and GPIO pins.
@@ -16,7 +16,7 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{AnyOutput, Io, Level, Output},
+    gpio::{AnyOutput, Io, Level},
     peripherals::SPI2,
     prelude::*,
     spi::{

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -2,11 +2,11 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO2
+//! MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! 
+//! GPIO    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! GPIO    GPIO3
-//!
-//! Connect MISO (GPIO2) and GPIO (GPIO3) pins.
+//! Connect MISO and GPIO pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -16,7 +16,7 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{GpioPin, Io, Level, Output},
+    gpio::{AnyOutput, Io, Level, Output},
     peripherals::SPI2,
     prelude::*,
     spi::{
@@ -42,7 +42,7 @@ cfg_if::cfg_if! {
 
 struct Context {
     spi: SpiDma<'static, SPI2, DmaChannel0, HalfDuplexMode, Blocking>,
-    miso_mirror: Output<'static, GpioPin<3>>,
+    miso_mirror: AnyOutput<'static>,
 }
 
 #[cfg(test)]
@@ -58,9 +58,9 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
-        let miso = io.pins.gpio2;
+        let (miso, miso_mirror) = hil_test::common_test_pins!(io);
 
-        let miso_mirror = Output::new(io.pins.gpio3, Level::High);
+        let miso_mirror = AnyOutput::new(miso_mirror, Level::High);
 
         let dma = Dma::new(peripherals.DMA);
 

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -2,11 +2,11 @@
 //!
 //! Following pins are used:
 //! SCLK    GPIO0
-//! MOSI    GPIO2
+//! MOSI    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! 
+//! PCNT    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! PCNT    GPIO3
-//!
-//! Connect MOSI (GPIO2) and PCNT (GPIO3) pins.
+//! Connect MOSI and PCNT pins.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -16,7 +16,7 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{GpioPin, Io, Pull},
+    gpio::{AnyPin, Io, Pull},
     pcnt::{
         channel::{EdgeMode, PcntInputConfig, PcntSource},
         unit::Unit,
@@ -48,7 +48,7 @@ cfg_if::cfg_if! {
 struct Context {
     spi: SpiDma<'static, SPI2, DmaChannel0, HalfDuplexMode, Blocking>,
     pcnt_unit: Unit<'static, 0>,
-    mosi_mirror: GpioPin<3>,
+    mosi_mirror: AnyPin<'static>,
 }
 
 #[cfg(test)]
@@ -67,8 +67,9 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
-        let mosi = io.pins.gpio2;
-        let mosi_mirror = io.pins.gpio3;
+        let (mosi, mosi_mirror) = hil_test::common_test_pins!(io);
+
+        let mosi_mirror = AnyPin::new(mosi_mirror);
 
         let pcnt = Pcnt::new(peripherals.PCNT);
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -3,7 +3,7 @@
 //! Following pins are used:
 //! SCLK    GPIO0
 //! MOSI    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//! 
+//!
 //! PCNT    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
 //! Connect MOSI and PCNT pins.

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -39,8 +39,7 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let can_tx_pin = io.pins.gpio2;
-        let can_rx_pin = io.pins.gpio3;
+        let (can_tx_pin, can_rx_pin) = hil_test::common_test_pins!(io);
 
         let mut config = twai::TwaiConfiguration::new(
             peripherals.TWAI0,

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -1,10 +1,10 @@
 //! TWAI test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2
-//! RX    GPIO3
+//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! Connect TX (GPIO2) and RX (GPIO3) pins.
+//! Connect TX and RX pins.
 
 //% CHIPS: esp32c3 esp32c6 esp32s2 esp32s3
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -1,10 +1,10 @@
 //! UART Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2
-//! RX    GPIO3
+//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! Connect TX (GPIO2) and RX (GPIO3) pins.
+//! Connect TX and RX pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -1,7 +1,7 @@
 //! UART Test
 //!
 //! Folowing pins are used:
-//! TX    GPIP2
+//! TX    GPIO2
 //! RX    GPIO3
 //!
 //! Connect TX (GPIO2) and RX (GPIO3) pins.

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -41,7 +41,9 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let uart = Uart::new(peripherals.UART1, &clocks, io.pins.gpio2, io.pins.gpio3).unwrap();
+        let (tx, rx) = hil_test::common_test_pins!(io);
+
+        let uart = Uart::new(peripherals.UART1, &clocks, tx, rx).unwrap();
 
         Context { clocks, uart }
     }

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -1,7 +1,7 @@
 //! UART Test
 //!
 //! Folowing pins are used:
-//! TX    GPIP2
+//! TX    GPIO2
 //! RX    GPIO3
 //!
 //! Connect TX (GPIO2) and RX (GPIO3) pins.
@@ -32,8 +32,10 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
+        let (tx, rx) = hil_test::common_test_pins!(io);
+    
         let uart =
-            Uart::new_async(peripherals.UART0, &clocks, io.pins.gpio2, io.pins.gpio3).unwrap();
+            Uart::new_async(peripherals.UART0, &clocks, tx, rx).unwrap();
 
         Context { uart }
     }

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -1,10 +1,10 @@
 //! UART Test
 //!
 //! Folowing pins are used:
-//! TX    GPIO2
-//! RX    GPIO3
+//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! Connect TX (GPIO2) and RX (GPIO3) pins.
+//! Connect TX and RX pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -33,9 +33,8 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
         let (tx, rx) = hil_test::common_test_pins!(io);
-    
-        let uart =
-            Uart::new_async(peripherals.UART0, &clocks, tx, rx).unwrap();
+
+        let uart = Uart::new_async(peripherals.UART0, &clocks, tx, rx).unwrap();
 
         Context { uart }
     }

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -1,10 +1,10 @@
 //! UART TX/RX Test
 //!
 //! Folowing pins are used:
-//! TX    GPIP2
-//! RX    GPIO3
+//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! Connect TX (GPIO2) and RX (GPIO3) pins.
+//! Connect TX and RX pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -39,8 +39,10 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let tx = UartTx::new(peripherals.UART0, &clocks, io.pins.gpio2).unwrap();
-        let rx = UartRx::new(peripherals.UART1, &clocks, io.pins.gpio3).unwrap();
+        let (tx, rx) = hil_test::common_test_pins!(io);
+
+        let tx = UartTx::new(peripherals.UART0, &clocks, tx).unwrap();
+        let rx = UartRx::new(peripherals.UART1, &clocks, rx).unwrap();
 
         Context { tx, rx }
     }

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -38,8 +38,10 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let tx = UartTx::new_async(peripherals.UART0, &clocks, io.pins.gpio2).unwrap();
-        let rx = UartRx::new_async(peripherals.UART1, &clocks, io.pins.gpio3).unwrap();
+        let (tx, rx) = hil_test::common_test_pins!(io);
+
+        let tx = UartTx::new_async(peripherals.UART0, &clocks, tx).unwrap();
+        let rx = UartRx::new_async(peripherals.UART1, &clocks, rx).unwrap();
 
         Context { tx, rx }
     }

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -1,10 +1,10 @@
 //! UART TX/RX Async Test
 //!
 //! Folowing pins are used:
-//! TX    GPIP2
-//! RX    GPIO3
+//! TX    GPIO2 / GPIO9 (esp32s2 and esp32s3)
+//! RX    GPIO3 / GPIO10 (esp32s2 and esp32s3)
 //!
-//! Connect TX (GPIO2) and RX (GPIO3) pins.
+//! Connect TX and RX pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adding basic `I2C` HIL test with `BMP180` sensor.
There are also large changes in the physical configuration of the HIL infrastructure in order to select appropriate and as versatile pins as possible. As you can understand, the last 2 days all the problems with HIL are related to this very thing.
All the changes can be seen in the code and hil-test README 

#### Testing
Ran tests locally. 
