### PR TITLE
HIL: Don't skip cleanup

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -195,6 +195,8 @@ jobs:
               sudo uhubctl -a off -l $hub
             done
 
+            sleep 0.5
+
             # Enable all used hubs
             for hub in ${{ matrix.target.hubs }}; do
               sudo uhubctl -a on -l $hub

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -215,6 +215,7 @@ jobs:
           ./xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
 
       - name: Clean up
+        if: always()
         run: |
           rm -rf tests-${{ matrix.target.soc }}
           rm -f xtask


### PR DESCRIPTION
Adding a new (failing) test can break the whole pipeline if the cleanup doesn't remove the file. Let's fix this.

Also make sure the USB ports are actually off for a short while - hoping this will make C2 just a bit more reliable.