### PR TITLE
i2c: fix embedded-hal transactions

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ESP32-S2 systimer interrupts (#1979)
 - Software interrupt 3 is no longer available when it is required by `esp-hal-embassy`. (#2011)
 - ESP32: Fixed async RSA (#2002)
+- Fix i2c embedded-hal transaction (#2028)
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A build issue when including doc comment prelude (#2040)
+- Fix i2c embedded-hal transaction (#2028)
 
 ## [0.20.0] - 2024-08-29
 
@@ -81,7 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ESP32-S2 systimer interrupts (#1979)
 - Software interrupt 3 is no longer available when it is required by `esp-hal-embassy`. (#2011)
 - ESP32: Fixed async RSA (#2002)
-- Fix i2c embedded-hal transaction (#2028)
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue with DMA transfers potentially not waking up the correct async task (#2065)
 - Fixed an issue with LCD_CAM i8080 where it would send double the clocks in 16bit mode (#2085)
+- Fix i2c embedded-hal transaction (#2028)
 
 ### Removed
 - Removed `digest::Digest` implementation from SHA (#2049)
@@ -38,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A build issue when including doc comment prelude (#2040)
-- Fix i2c embedded-hal transaction (#2028)
 
 ## [0.20.0] - 2024-08-29
 

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -281,7 +281,7 @@ where
                         address,
                         bytes,
                         last_op != Op::Write,
-                        op_iter.peek().is_none(),
+                        next_op == Op::None,
                         cmd_iterator,
                     )?;
                     last_op = Op::Write;
@@ -295,7 +295,7 @@ where
                         address,
                         buffer,
                         last_op != Op::Read,
-                        op_iter.peek().is_none(),
+                        next_op == Op::None,
                         next_op == Op::Read,
                         cmd_iterator,
                     )?;
@@ -740,6 +740,14 @@ mod asynch {
             Ok(())
         }
 
+        /// Executes an async I2C write operation.
+        /// - `addr` is the address of the slave device.
+        /// - `bytes` is the data two be sent.
+        /// - `start` indicates whether the operation should start by a START
+        ///   condition and sending the address.
+        /// - `stop` indicates whether the operation should end with a STOP
+        ///   condition.
+        /// - `cmd_iterator` is an iterator over the command registers.
         async fn write_operation<'a, I>(
             &self,
             address: u8,
@@ -772,6 +780,16 @@ mod asynch {
             Ok(())
         }
 
+        /// Executes an async I2C read operation.
+        /// - `addr` is the address of the slave device.
+        /// - `buffer` is the buffer to store the read data.
+        /// - `start` indicates whether the operation should start by a START
+        ///   condition and sending the address.
+        /// - `stop` indicates whether the operation should end with a STOP
+        ///   condition.
+        /// - `will_continue` indicates whether there is another read operation
+        ///   following this one and we should not nack the last byte.
+        /// - `cmd_iterator` is an iterator over the command registers.
         async fn read_operation<'a, I>(
             &self,
             address: u8,
@@ -929,7 +947,7 @@ mod asynch {
                             address,
                             bytes,
                             last_op != Op::Write,
-                            op_iter.peek().is_none(),
+                            next_op == Op::None,
                             cmd_iterator,
                         )
                         .await?;
@@ -943,7 +961,7 @@ mod asynch {
                             address,
                             buffer,
                             last_op != Op::Read,
-                            op_iter.peek().is_none(),
+                            next_op == Op::None,
                             next_op == Op::Read,
                             cmd_iterator,
                         )
@@ -1463,6 +1481,11 @@ pub trait Instance: crate::private::Sealed {
     }
 
     /// Configures the I2C peripheral for a write operation.
+    /// - `addr` is the address of the slave device.
+    /// - `bytes` is the data two be sent.
+    /// - `start` indicates whether the operation should start by a START
+    ///   condition and sending the address.
+    /// - `cmd_iterator` is an iterator over the command registers.
     fn setup_write<'a, I>(
         &self,
         addr: u8,
@@ -1503,12 +1526,13 @@ pub trait Instance: crate::private::Sealed {
     }
 
     /// Configures the I2C peripheral for a read operation.
-    /// `addr` is the address of the slave device.
-    /// `buffer` is the buffer to store the read data.
-    /// `start` indicates whether the operation should start by writing the
-    /// address `will_continue` indicates whether there is another read
-    /// operation following this one and we should not nack the last byte.
-    /// The `cmd_iterator` parameter is an iterator over the command registers.
+    /// - `addr` is the address of the slave device.
+    /// - `buffer` is the buffer to store the read data.
+    /// - `start` indicates whether the operation should start by a START
+    ///   condition and sending the address.
+    /// - `will_continue` indicates whether there is another read operation
+    ///   following this one and we should not nack the last byte.
+    /// - `cmd_iterator` is an iterator over the command registers.
     fn setup_read<'a, I>(
         &self,
         addr: u8,
@@ -1915,6 +1939,13 @@ pub trait Instance: crate::private::Sealed {
     }
 
     /// Executes an I2C write operation.
+    /// - `addr` is the address of the slave device.
+    /// - `bytes` is the data two be sent.
+    /// - `start` indicates whether the operation should start by a START
+    ///   condition and sending the address.
+    /// - `stop` indicates whether the operation should end with a STOP
+    ///   condition.
+    /// - `cmd_iterator` is an iterator over the command registers.
     fn write_operation<'a, I>(
         &self,
         address: u8,
@@ -1948,6 +1979,15 @@ pub trait Instance: crate::private::Sealed {
     }
 
     /// Executes an I2C read operation.
+    /// - `addr` is the address of the slave device.
+    /// - `buffer` is the buffer to store the read data.
+    /// - `start` indicates whether the operation should start by a START
+    ///   condition and sending the address.
+    /// - `stop` indicates whether the operation should end with a STOP
+    ///   condition.
+    /// - `will_continue` indicates whether there is another read operation
+    ///   following this one and we should not nack the last byte.
+    /// - `cmd_iterator` is an iterator over the command registers.
     fn read_operation<'a, I>(
         &self,
         address: u8,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -769,6 +769,12 @@ mod asynch {
         where
             I: Iterator<Item = &'a COMD>,
         {
+            // Short circuit for zero length writes without start as that would be an
+            // invalid operation write lengths in the TRM (at least for ESP32-S3) are 1-255
+            if bytes.is_empty() && !start {
+                return Ok(());
+            }
+
             // Reset FIFO and command list
             self.peripheral.reset_fifo();
             self.peripheral.reset_command_list();
@@ -812,6 +818,12 @@ mod asynch {
         where
             I: Iterator<Item = &'a COMD>,
         {
+            // Short circuit for zero length reads as that would be an invalid operation
+            // read lengths in the TRM (at least for ESP32-S3) are 1-255
+            if buffer.is_empty() {
+                return Ok(());
+            }
+
             // Reset FIFO and command list
             self.peripheral.reset_fifo();
             self.peripheral.reset_command_list();
@@ -1507,7 +1519,9 @@ pub trait Instance: crate::private::Sealed {
         if bytes.is_empty() && !start {
             return Err(Error::InvalidZeroLength);
         }
-        // if start we can only send 254 additional bytes, the address would be the first
+
+        // if start is true we can only send 254 additional bytes with the address as
+        // the first
         let max_len = if start { 254usize } else { 255usize };
         if bytes.len() > max_len {
             // we could support more by adding multiple write operations
@@ -1972,6 +1986,12 @@ pub trait Instance: crate::private::Sealed {
     where
         I: Iterator<Item = &'a COMD>,
     {
+        // Short circuit for zero length writes without start as that would be an
+        // invalid operation write lengths in the TRM (at least for ESP32-S3) are 1-255
+        if bytes.is_empty() && !start {
+            return Ok(());
+        }
+
         // Reset FIFO and command list
         self.reset_fifo();
         self.reset_command_list();
@@ -2015,6 +2035,12 @@ pub trait Instance: crate::private::Sealed {
     where
         I: Iterator<Item = &'a COMD>,
     {
+        // Short circuit for zero length reads as that would be an invalid operation
+        // read lengths in the TRM (at least for ESP32-S3) are 1-255
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
         // Reset FIFO and command list
         self.reset_fifo();
         self.reset_command_list();

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -1477,7 +1477,7 @@ pub trait Instance: crate::private::Sealed {
             return Err(Error::ExceedingFifo);
         }
 
-        let extra_len = if start {1} else {0};
+        let extra_len = if start { 1 } else { 0 };
         // WRITE command
         add_cmd(
             cmd_iterator,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -92,6 +92,8 @@ pub enum Error {
     ExecIncomplete,
     /// The number of commands issued exceeded the limit.
     CommandNrExceeded,
+    /// Zero length read or write operation.
+    InvalidZeroLength,
 }
 
 #[derive(PartialEq)]
@@ -1489,6 +1491,9 @@ pub trait Instance: crate::private::Sealed {
     where
         I: Iterator<Item = &'a COMD>,
     {
+        if bytes.is_empty() && !start {
+            return Err(Error::InvalidZeroLength);
+        }
         let max_len = if start { 254usize } else { 255usize };
         if bytes.len() > max_len {
             // we could support more by adding multiple write operations
@@ -1537,15 +1542,13 @@ pub trait Instance: crate::private::Sealed {
     where
         I: Iterator<Item = &'a COMD>,
     {
+        if buffer.is_empty() {
+            return Err(Error::InvalidZeroLength);
+        }
         let (max_len, initial_len) = if will_continue {
             (255usize, buffer.len())
         } else {
-            let len = if buffer.is_empty() {
-                0
-            } else {
-                buffer.len() - 1
-            };
-            (254usize, len)
+            (254usize, buffer.len() - 1)
         };
         if buffer.len() > max_len {
             // we could support more by adding multiple read operations
@@ -1575,9 +1578,7 @@ pub trait Instance: crate::private::Sealed {
             )?;
         }
 
-        // If we are not continuing the read in the next operation we need to nack the
-        // last byte. But don't issue the read command if the buffer is empty!
-        if !will_continue && !buffer.is_empty() {
+        if !will_continue {
             // this is the last read so we need to nack the last byte
             // READ w/o ACK
             add_cmd(

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -96,9 +96,10 @@ pub enum Error {
 
 #[derive(PartialEq)]
 // This enum is used to keep track of the last/next operation that was/will be
-// performed in an embedded-hal(-async) I2C::transaction. It used to determine
-// whether a START condition should be issued at the start of the current
-// operation and whether a read needs an ack or a nack for the final byte.
+// performed in an embedded-hal(-async) I2C::transaction. It is used to
+// determine whether a START condition should be issued at the start of the
+// current operation and whether a read needs an ack or a nack for the final
+// byte.
 enum Op {
     Write,
     Read,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -895,11 +895,13 @@ mod asynch {
                 addr,
                 bytes,
                 true,
-                false,
+                buffer.is_empty(), // if the read buffer is empty, then issue a stop
                 &mut self.peripheral.register_block().comd_iter(),
             )
             .await?;
             self.peripheral.clear_all_interrupts();
+            // this will be a no-op if the buffer is empty, in that case we issued the stop
+            // with the write
             self.read_operation(
                 addr,
                 buffer,
@@ -2111,10 +2113,12 @@ pub trait Instance: crate::private::Sealed {
             addr,
             bytes,
             true,
-            false,
+            buffer.is_empty(), // if the read buffer is empty, then issue a stop
             &mut self.register_block().comd_iter(),
         )?;
         self.clear_all_interrupts();
+        // this will be a no-op if the buffer is empty, in that case we issued the stop
+        // with the write
         self.read_operation(
             addr,
             buffer,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -1494,6 +1494,7 @@ pub trait Instance: crate::private::Sealed {
         if bytes.is_empty() && !start {
             return Err(Error::InvalidZeroLength);
         }
+        // if start we can only send 254 additional bytes, the address would be the first
         let max_len = if start { 254usize } else { 255usize };
         if bytes.len() > max_len {
             // we could support more by adding multiple write operations

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -1540,14 +1540,17 @@ pub trait Instance: crate::private::Sealed {
                 },
             )?;
         }
-        // there is another read so we need to ack all
-        add_cmd(
-            cmd_iterator,
-            Command::Read {
-                ack_value: Ack::Ack,
-                length: initial_len as u8,
-            },
-        )?;
+
+        if initial_len > 0 {
+            // READ command
+            add_cmd(
+                cmd_iterator,
+                Command::Read {
+                    ack_value: Ack::Ack,
+                    length: initial_len as u8,
+                },
+            )?;
+        }
 
         if !will_continue {
             // this is the last read so we need to nack the last byte


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Original implementation would not skip the start for the second of two operations of the same type.  This PR fixes that
Fixes #1998

#### Testing
[Read and Write to registers on a DS3231](https://gist.github.com/liebman/4db2358c59b5147af009d699fc4cc520) and observed signals on logic analyzer.
Sample with "double" read (one byte followed by 6 bytes):
```rust
    const REG: u8 = 0; // seconds register
    let write = [REG];
    let mut buf1 = [0u8; 1];
    let mut buf2 = [0u8; 6];
    i2c.transaction(
        0x68,
        &mut [
            Operation::Write(&write),
            Operation::Read(&mut buf1),
            Operation::Read(&mut buf2),
        ],
    );
```
![image](https://github.com/user-attachments/assets/8646e8c1-cabe-40ea-b380-dc49798bed66)
