### PR TITLE
Automatically apply status:needs-attention to new esp-hal issues

### DIFF
--- a/.github/workflows/issue_handler.yml
+++ b/.github/workflows/issue_handler.yml
@@ -14,3 +14,4 @@ jobs:
         with:
           project-url: https://github.com/orgs/esp-rs/projects/2
           github-token: ${{ secrets.PAT }}
+          labeled: status:needs-attention


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

I'm not sure if we came to a concrete answer on whether we want to do this, but I think it could be a good idea, and will definitely help keeping track of new issues for the issue guard.

We could also add a new label `needs-triage` if we prefer.
