### PR TITLE
Protect SYSTIMER/TIMG shared registers

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -575,16 +575,17 @@ mod critical_section_impl {
 // The state of a re-entrant lock
 pub(crate) struct LockState {
     #[cfg(multi_core)]
-    core: core::sync::atomic::AtomicUsize,
+    core: portable_atomic::AtomicUsize,
 }
 
 impl LockState {
+    #[cfg(multi_core)]
     const UNLOCKED: usize = usize::MAX;
 
     pub const fn new() -> Self {
         Self {
             #[cfg(multi_core)]
-            core: core::sync::atomic::AtomicUsize::new(Self::UNLOCKED),
+            core: portable_atomic::AtomicUsize::new(Self::UNLOCKED),
         }
     }
 }
@@ -610,7 +611,7 @@ pub(crate) fn lock<T>(state: &LockState, f: impl FnOnce() -> T) -> T {
 
     #[cfg(multi_core)]
     {
-        use core::sync::atomic::Ordering;
+        use portable_atomic::Ordering;
 
         let current_core = get_core() as usize;
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1874 (though it's closed now).
These registers were previously unprotected, which meant you could get garbage in them if the methods modifying them were called in different contexts.
The `INT_ENA` register (of both peripherals) is shared amongst three different handlers, each of which could be assigned to any core.
`critical_section` would work but I see it as a giant sledge hammer of a tool. I've introduced a more granular alternative in this PR which would allow for less contention between cores. (I go into more detail in the linked issue)

I skipped the changelog since this is an internal change and most users won't notice.

#### Testing
Ran the HIL tests
