### PR TITLE
[esp-metadata] Make clap dependency optional

### DIFF
--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -9,7 +9,7 @@ license      = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow     = "1.0.86"
-clap       = { version = "4.5.16", features = ["derive"] }
+clap       = { version = "4.5.16", features = ["derive"], optional = true }
 basic-toml  = "0.1.9"
 lazy_static = "1.5.0"
 serde       = { version = "1.0.209", features = ["derive"] }

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -88,8 +88,8 @@ pub enum Cores {
     strum::EnumIter,
     strum::EnumString,
     strum::AsRefStr,
-    clap::ValueEnum,
 )]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub enum Chip {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,4 +17,4 @@ semver     = { version = "1.0.23",  features = ["serde"] }
 serde      = { version = "1.0.203", features = ["derive"] }
 strum      = { version = "0.26.2",  features = ["derive"] }
 toml_edit  = "0.22.13"
-esp-metadata = { path = "../esp-metadata" }
+esp-metadata = { path = "../esp-metadata", features = ["clap"] }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
I noticed that part of compiling my microcontroller app included compiling the clap command line library. I fixed that.

#### Testing
Used `cargo xtask fmt-packages` and `cargo xtask lint-packages`.
