### PR TITLE
storage: Clean up ROM function declarations

### DIFF
--- a/esp-storage/src/common.rs
+++ b/esp-storage/src/common.rs
@@ -117,7 +117,7 @@ impl FlashStorage {
         offset: u32,
         bytes: &mut [u8],
     ) -> Result<(), FlashStorageError> {
-        check_rc(chip_specific::esp_rom_spiflash_read(
+        check_rc(chip_specific::spiflash_read(
             offset,
             bytes.as_ptr() as *mut u32,
             bytes.len() as u32,
@@ -127,7 +127,7 @@ impl FlashStorage {
     #[inline(always)]
     fn unlock_once(&mut self) -> Result<(), FlashStorageError> {
         if !self.unlocked {
-            if chip_specific::esp_rom_spiflash_unlock() != 0 {
+            if chip_specific::spiflash_unlock() != 0 {
                 return Err(FlashStorageError::CantUnlock);
             }
             self.unlocked = true;
@@ -140,7 +140,7 @@ impl FlashStorage {
     pub(crate) fn internal_erase(&mut self, sector: u32) -> Result<(), FlashStorageError> {
         self.unlock_once()?;
 
-        check_rc(chip_specific::esp_rom_spiflash_erase_sector(sector))
+        check_rc(chip_specific::spiflash_erase_sector(sector))
     }
 
     #[inline(never)]
@@ -152,7 +152,7 @@ impl FlashStorage {
     ) -> Result<(), FlashStorageError> {
         self.unlock_once()?;
 
-        check_rc(chip_specific::esp_rom_spiflash_write(
+        check_rc(chip_specific::spiflash_write(
             offset,
             bytes.as_ptr() as *const u32,
             bytes.len() as u32,

--- a/esp-storage/src/esp32.rs
+++ b/esp-storage/src/esp32.rs
@@ -1,14 +1,5 @@
 use crate::maybe_with_critical_section;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x40062ed8;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40062ccc;
-const SPI_READ_STATUS_HIGH: u32 = 0x40062448;
-const SPI_READ_STATUS: u32 = 0x4006226c;
-const SPI_WRITE_STATUS: u32 = 0x400622f0;
-
-const CACHE_FLUSH_ROM: u32 = 0x40009a14;
-const CACHE_READ_ENABLE_ROM: u32 = 0x40009a84;
-
 const SPI_BASE_REG: u32 = 0x3ff42000; // SPI peripheral 1, used for SPI flash
 const SPI0_BASE_REG: u32 = 0x3ff43000; // SPI peripheral 0, inner state machine
 const SPI_EXT2_REG: u32 = SPI_BASE_REG + 0xF8;
@@ -34,23 +25,17 @@ const SPI_WRSR_2B: u32 = 1 << 22;
 const FLASH_CHIP_ADDR: u32 = 0x3ffae270;
 const FLASH_DUMMY_LEN_PLUS_ADDR: u32 = 0x3ffae290;
 
-#[inline(always)]
-#[link_section = ".rwtext"]
-pub(crate) fn cache_flush_rom(cpu_num: u32) {
-    unsafe {
-        let cache_flush_rom: unsafe extern "C" fn(u32) = core::mem::transmute(CACHE_FLUSH_ROM);
-        cache_flush_rom(cpu_num)
-    }
-}
-
-#[inline(always)]
-#[link_section = ".rwtext"]
-pub(crate) fn cache_read_enable_rom(cpu_num: u32) {
-    unsafe {
-        let cache_read_enable_rom: unsafe extern "C" fn(u32) =
-            core::mem::transmute(CACHE_READ_ENABLE_ROM);
-        cache_read_enable_rom(cpu_num)
-    }
+crate::rom_fn! {
+    fn esp_rom_cache_flush(cpu_num: u32) = 0x40009a14,
+    fn esp_rom_cache_read_enable(cpu_num: u32) = 0x40009a84,
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40062ed8,
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40062ccc,
+    fn esp_rom_spi_read_status_high(
+        flash_chip: *const EspRomSpiflashChipT,
+        status: *mut u32
+    ) -> i32 = 0x40062448,
+    fn esp_rom_spi_read_status(flash_chip: *const EspRomSpiflashChipT, status: *mut u32) -> i32 = 0x4006226c,
+    fn esp_rom_spi_write_status(flash_chip: *const EspRomSpiflashChipT, status_value: u32) -> i32 = 0x400622f0,
 }
 
 #[inline(always)]
@@ -59,33 +44,19 @@ pub(crate) fn spi_read_status_high(
     flash_chip: *const EspRomSpiflashChipT,
     status: &mut u32,
 ) -> i32 {
-    unsafe {
-        let spi_read_status_high: unsafe extern "C" fn(
-            *const EspRomSpiflashChipT,
-            *mut u32,
-        ) -> i32 = core::mem::transmute(SPI_READ_STATUS_HIGH);
-        spi_read_status_high(flash_chip, status as *mut u32)
-    }
+    esp_rom_spi_read_status_high(flash_chip, status as *mut u32)
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn spi_read_status(flash_chip: *const EspRomSpiflashChipT, status: &mut u32) -> i32 {
-    unsafe {
-        let spi_read_status: unsafe extern "C" fn(*const EspRomSpiflashChipT, *mut u32) -> i32 =
-            core::mem::transmute(SPI_READ_STATUS);
-        spi_read_status(flash_chip, status as *mut u32)
-    }
+    esp_rom_spi_read_status(flash_chip, status as *mut u32)
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn spi_write_status(flash_chip: *const EspRomSpiflashChipT, status_value: u32) -> i32 {
-    unsafe {
-        let spi_write_status: unsafe extern "C" fn(*const EspRomSpiflashChipT, u32) -> i32 =
-            core::mem::transmute(SPI_WRITE_STATUS);
-        spi_write_status(flash_chip, status_value)
-    }
+    esp_rom_spi_write_status(flash_chip, status_value)
 }
 
 #[inline(always)]
@@ -98,10 +69,10 @@ fn begin() {
 #[inline(always)]
 #[link_section = ".rwtext"]
 fn end() {
-    cache_flush_rom(0);
-    cache_flush_rom(1);
-    cache_read_enable_rom(0);
-    cache_read_enable_rom(1);
+    esp_rom_cache_flush(0);
+    esp_rom_cache_flush(1);
+    esp_rom_cache_read_enable(0);
+    esp_rom_cache_read_enable(1);
 }
 
 #[derive(Debug)]
@@ -117,26 +88,18 @@ pub struct EspRomSpiflashChipT {
 
 #[inline(never)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
     maybe_with_critical_section(|| {
         spiflash_wait_for_ready();
-        unsafe {
-            let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-                core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-            esp_rom_spiflash_read(src_addr, data, len)
-        }
+        esp_rom_spiflash_read(src_addr, data, len)
     })
 }
 
 #[inline(never)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
+pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
     maybe_with_critical_section(|| {
-        let res = unsafe {
-            let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-                core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-            esp_rom_spiflash_erase_sector(sector_number)
-        };
+        let res = esp_rom_spiflash_erase_sector(sector_number);
         spiflash_wait_for_ready();
         res
     })
@@ -154,7 +117,7 @@ fn spi_write_enable() {
 
 #[inline(never)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
     maybe_with_critical_section(|| {
         begin();
 
@@ -250,7 +213,7 @@ fn spiflash_wait_for_ready() {
 
 #[inline(never)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
+pub(crate) fn spiflash_unlock() -> i32 {
     let flashchip = FLASH_CHIP_ADDR as *const EspRomSpiflashChipT;
     if unsafe { (*flashchip).device_id } >> 16 & 0xff == 0x9D {
         panic!("ISSI flash is not supported");

--- a/esp-storage/src/esp32.rs
+++ b/esp-storage/src/esp32.rs
@@ -26,16 +26,16 @@ const FLASH_CHIP_ADDR: u32 = 0x3ffae270;
 const FLASH_DUMMY_LEN_PLUS_ADDR: u32 = 0x3ffae290;
 
 crate::rom_fn! {
-    fn esp_rom_cache_flush(cpu_num: u32) = 0x40009a14,
-    fn esp_rom_cache_read_enable(cpu_num: u32) = 0x40009a84,
-    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40062ed8,
-    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40062ccc,
+    fn esp_rom_cache_flush(cpu_num: u32) = 0x40009a14;
+    fn esp_rom_cache_read_enable(cpu_num: u32) = 0x40009a84;
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40062ed8;
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40062ccc;
     fn esp_rom_spi_read_status_high(
         flash_chip: *const EspRomSpiflashChipT,
         status: *mut u32
-    ) -> i32 = 0x40062448,
-    fn esp_rom_spi_read_status(flash_chip: *const EspRomSpiflashChipT, status: *mut u32) -> i32 = 0x4006226c,
-    fn esp_rom_spi_write_status(flash_chip: *const EspRomSpiflashChipT, status_value: u32) -> i32 = 0x400622f0,
+    ) -> i32 = 0x40062448;
+    fn esp_rom_spi_read_status(flash_chip: *const EspRomSpiflashChipT, status: *mut u32) -> i32 = 0x4006226c;
+    fn esp_rom_spi_write_status(flash_chip: *const EspRomSpiflashChipT, status_value: u32) -> i32 = 0x400622f0;
 }
 
 #[inline(always)]

--- a/esp-storage/src/esp32c2.rs
+++ b/esp-storage/src/esp32c2.rs
@@ -1,10 +1,10 @@
 use crate::maybe_with_critical_section;
 
 crate::rom_fn! {
-    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000013c,
-    fn esp_rom_spiflash_unlock() -> i32 = 0x40000140,
-    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000130,
-    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000138,
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000013c;
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000140;
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000130;
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000138;
 }
 
 pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {

--- a/esp-storage/src/esp32c2.rs
+++ b/esp-storage/src/esp32c2.rs
@@ -1,38 +1,24 @@
 use crate::maybe_with_critical_section;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x4000013c;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000140;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000130;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000138;
-
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+crate::rom_fn! {
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000013c,
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000140,
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000130,
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000138,
 }
 
-pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_read(src_addr, data, len))
 }
 
-pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+pub(crate) fn spiflash_unlock() -> i32 {
+    maybe_with_critical_section(esp_rom_spiflash_unlock)
 }
 
-pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_erase_sector(sector_number))
+}
+
+pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_write(dest_addr, data, len))
 }

--- a/esp-storage/src/esp32c3.rs
+++ b/esp-storage/src/esp32c3.rs
@@ -1,10 +1,10 @@
 use crate::maybe_with_critical_section;
 
 crate::rom_fn! {
-    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000130,
-    fn esp_rom_spiflash_unlock() -> i32 = 0x40000140,
-    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000128,
-    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000012c,
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000130;
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000140;
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000128;
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000012c;
 }
 
 pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {

--- a/esp-storage/src/esp32c3.rs
+++ b/esp-storage/src/esp32c3.rs
@@ -1,38 +1,24 @@
 use crate::maybe_with_critical_section;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x40000130;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000140;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000128;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x4000012c;
-
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+crate::rom_fn! {
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000130,
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000140,
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000128,
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000012c,
 }
 
-pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_read(src_addr, data, len))
 }
 
-pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+pub(crate) fn spiflash_unlock() -> i32 {
+    maybe_with_critical_section(esp_rom_spiflash_unlock)
 }
 
-pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_erase_sector(sector_number))
+}
+
+pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_write(dest_addr, data, len))
 }

--- a/esp-storage/src/esp32c6.rs
+++ b/esp-storage/src/esp32c6.rs
@@ -1,10 +1,10 @@
 use crate::maybe_with_critical_section;
 
 crate::rom_fn! {
-    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000150,
-    fn esp_rom_spiflash_unlock() -> i32 = 0x40000154,
-    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000144,
-    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000014c,
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000150;
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000154;
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000144;
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000014c;
 }
 
 pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {

--- a/esp-storage/src/esp32c6.rs
+++ b/esp-storage/src/esp32c6.rs
@@ -1,38 +1,24 @@
 use crate::maybe_with_critical_section;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x40000150;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000154;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000144;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x4000014c;
-
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+crate::rom_fn! {
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000150,
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000154,
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000144,
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000014c,
 }
 
-pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_read(src_addr, data, len))
 }
 
-pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+pub(crate) fn spiflash_unlock() -> i32 {
+    maybe_with_critical_section(esp_rom_spiflash_unlock)
 }
 
-pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_erase_sector(sector_number))
+}
+
+pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_write(dest_addr, data, len))
 }

--- a/esp-storage/src/esp32h2.rs
+++ b/esp-storage/src/esp32h2.rs
@@ -1,38 +1,24 @@
 use crate::maybe_with_critical_section;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x4000012c;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000130;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000120;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000128;
-
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+crate::rom_fn! {
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000012c,
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000130,
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000120,
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000128,
 }
 
-pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_read(src_addr, data, len))
 }
 
-pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+pub(crate) fn spiflash_unlock() -> i32 {
+    maybe_with_critical_section(esp_rom_spiflash_unlock)
 }
 
-pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_erase_sector(sector_number))
+}
+
+pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_write(dest_addr, data, len))
 }

--- a/esp-storage/src/esp32h2.rs
+++ b/esp-storage/src/esp32h2.rs
@@ -1,10 +1,10 @@
 use crate::maybe_with_critical_section;
 
 crate::rom_fn! {
-    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000012c,
-    fn esp_rom_spiflash_unlock() -> i32 = 0x40000130,
-    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000120,
-    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000128,
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4000012c;
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000130;
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x40000120;
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000128;
 }
 
 pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {

--- a/esp-storage/src/esp32s2.rs
+++ b/esp-storage/src/esp32s2.rs
@@ -1,38 +1,24 @@
 use crate::maybe_with_critical_section;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x4001728c;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40016e88;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x4001716c;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x400171cc;
-
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+crate::rom_fn! {
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4001728c,
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40016e88,
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x4001716c,
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x400171cc,
 }
 
-pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_read(src_addr, data, len))
 }
 
-pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+pub(crate) fn spiflash_unlock() -> i32 {
+    maybe_with_critical_section(esp_rom_spiflash_unlock)
 }
 
-pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_erase_sector(sector_number))
+}
+
+pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_write(dest_addr, data, len))
 }

--- a/esp-storage/src/esp32s2.rs
+++ b/esp-storage/src/esp32s2.rs
@@ -1,10 +1,10 @@
 use crate::maybe_with_critical_section;
 
 crate::rom_fn! {
-    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4001728c,
-    fn esp_rom_spiflash_unlock() -> i32 = 0x40016e88,
-    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x4001716c,
-    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x400171cc,
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x4001728c;
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40016e88;
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x4001716c;
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x400171cc;
 }
 
 pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {

--- a/esp-storage/src/esp32s3.rs
+++ b/esp-storage/src/esp32s3.rs
@@ -1,46 +1,32 @@
 use crate::maybe_with_critical_section;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x40000a20;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000a2c;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x400009fc;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000a14;
-
-#[inline(always)]
-#[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+crate::rom_fn! {
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000a20,
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000a2c,
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x400009fc,
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000a14,
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_read(src_addr, data, len))
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+pub(crate) fn spiflash_unlock() -> i32 {
+    maybe_with_critical_section(esp_rom_spiflash_unlock)
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
-pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_erase_sector(sector_number))
+}
+
+#[inline(always)]
+#[link_section = ".rwtext"]
+pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+    maybe_with_critical_section(|| esp_rom_spiflash_write(dest_addr, data, len))
 }

--- a/esp-storage/src/esp32s3.rs
+++ b/esp-storage/src/esp32s3.rs
@@ -1,10 +1,10 @@
 use crate::maybe_with_critical_section;
 
 crate::rom_fn! {
-    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000a20,
-    fn esp_rom_spiflash_unlock() -> i32 = 0x40000a2c,
-    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x400009fc,
-    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000a14,
+    fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000a20;
+    fn esp_rom_spiflash_unlock() -> i32 = 0x40000a2c;
+    fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 = 0x400009fc;
+    fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 = 0x40000a14;
 }
 
 #[inline(always)]

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -76,7 +76,7 @@ macro_rules! rom_fn {
         }
     };
 
-    ($($(#[$attrs:meta])* fn $name:ident($($arg:tt: $ty:ty),*) $(-> $retval:ty)? = $addr:expr),+ $(,)?) => {
+    ($($(#[$attrs:meta])* fn $name:ident($($arg:tt: $ty:ty),*) $(-> $retval:ty)? = $addr:expr;)+) => {
         $(
             $crate::rom_fn!(fn $name($($arg: $ty),*) $(-> $retval)? = $addr);
         )+

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -58,3 +58,27 @@ fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
 fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
     f()
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! rom_fn {
+    ($(#[$attrs:meta])* fn $name:ident($($arg:tt: $ty:ty),*) $(-> $retval:ty)? = $addr:expr) => {
+        $(#[$attrs])*
+        #[allow(unused)]
+        #[inline(always)]
+        #[link_section = ".rwtext"]
+        fn $name($($arg:$ty),*) $(-> $retval)? {
+            unsafe {
+                let rom_fn: unsafe extern "C" fn($($arg: $ty),*) $(-> $retval)? =
+                    core::mem::transmute($addr as usize);
+                rom_fn($($arg),*)
+            }
+        }
+    };
+
+    ($($(#[$attrs:meta])* fn $name:ident($($arg:tt: $ty:ty),*) $(-> $retval:ty)? = $addr:expr),+ $(,)?) => {
+        $(
+            $crate::rom_fn!(fn $name($($arg: $ty),*) $(-> $retval)? = $addr);
+        )+
+    };
+}

--- a/esp-storage/src/ll.rs
+++ b/esp-storage/src/ll.rs
@@ -13,7 +13,7 @@ use crate::chip_specific;
 /// The `data` expected to points to word-aligned pre-allocated buffer with size
 /// greater or equals to `len`.
 pub unsafe fn spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> Result<(), i32> {
-    match chip_specific::esp_rom_spiflash_read(src_addr, data, len) {
+    match chip_specific::spiflash_read(src_addr, data, len) {
         0 => Ok(()),
         value => Err(value),
     }
@@ -23,7 +23,7 @@ pub unsafe fn spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> Result<(
 ///
 /// # Safety
 pub unsafe fn spiflash_unlock() -> Result<(), i32> {
-    match chip_specific::esp_rom_spiflash_unlock() {
+    match chip_specific::spiflash_unlock() {
         0 => Ok(()),
         value => Err(value),
     }
@@ -35,7 +35,7 @@ pub unsafe fn spiflash_unlock() -> Result<(), i32> {
 ///
 /// The `sector_number` * sector_size should not exceeds the size of flash.
 pub unsafe fn spiflash_erase_sector(sector_number: u32) -> Result<(), i32> {
-    match chip_specific::esp_rom_spiflash_erase_sector(sector_number) {
+    match chip_specific::spiflash_erase_sector(sector_number) {
         0 => Ok(()),
         value => Err(value),
     }
@@ -49,7 +49,7 @@ pub unsafe fn spiflash_erase_sector(sector_number: u32) -> Result<(), i32> {
 /// The `data` expected to points to word-aligned buffer with size greater or
 /// equals to `len`.
 pub unsafe fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> Result<(), i32> {
-    match chip_specific::esp_rom_spiflash_write(dest_addr, data, len) {
+    match chip_specific::spiflash_write(dest_addr, data, len) {
         0 => Ok(()),
         value => Err(value),
     }

--- a/esp-storage/src/stub.rs
+++ b/esp-storage/src/stub.rs
@@ -57,7 +57,7 @@ fn check<const ALIGN: u32, const SIZE: u32, const MAX_LEN: u32>(
     true
 }
 
-pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
+pub(crate) fn spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
     if check::<WORD_SIZE, FLASH_SIZE, SECTOR_SIZE>(src_addr, len, data) {
         maybe_with_critical_section(|| {
             let src = unsafe { slice::from_raw_parts_mut(data as *mut u8, len as _) };
@@ -69,14 +69,14 @@ pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> 
     }
 }
 
-pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
+pub(crate) fn spiflash_unlock() -> i32 {
     maybe_with_critical_section(|| {
         unsafe { FLASH_LOCK = false };
     });
     SUCCESS_CODE
 }
 
-pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
+pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
     if check::<1, NUM_SECTORS, 1>(sector_number, 1, ptr::null()) {
         maybe_with_critical_section(|| {
             let dst_addr = sector_number * SECTOR_SIZE;
@@ -89,7 +89,7 @@ pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
     }
 }
 
-pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
     if check::<WORD_SIZE, FLASH_SIZE, SECTOR_SIZE>(dest_addr, len, data) {
         maybe_with_critical_section(|| {
             let dst = unsafe { slice::from_raw_parts(data as *const u8, len as _) };


### PR DESCRIPTION
The amount of explicitly spelled out transmutes has been bugging me for a while - I'm sweeping some of them under a macro here. This solution is similar enough to what I've been using with [norfs](https://github.com/card-io-ecg/norfs/blob/main/norfs-esp32s3/src/lib.rs#L30).

I've also removed the `esp_rom_` prefix from chip-specific functions as not everything there is actually rom code :)

Skipping changelog because this is internal only.