### PR TITLE
Improve CP0-disabled error message

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Print a more helpful message in case of a `Cp0Disabled` exception (#2061)
 
 ### Fixed
 

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -100,7 +100,7 @@ unsafe fn __user_exception(cause: arch::ExceptionCause, context: arch::Context) 
 
     // Unfortunately, a different formatter string is used
     #[cfg(not(feature = "defmt"))]
-    esp_println::println!("\n\nException occurred '{:?}'", cause);
+    esp_println::println!("\n\nException occurred '{}'", cause);
 
     #[cfg(feature = "defmt")]
     defmt::error!("\n\nException occurred '{}'", cause);

--- a/esp-backtrace/src/xtensa.rs
+++ b/esp-backtrace/src/xtensa.rs
@@ -1,4 +1,4 @@
-use core::arch::asm;
+use core::{arch::asm, fmt::Display};
 
 use crate::MAX_BACKTRACE_ADDRESSES;
 
@@ -11,7 +11,7 @@ pub(super) const RA_OFFSET: usize = 3;
 
 /// Exception Cause
 #[doc(hidden)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C)]
 pub enum ExceptionCause {
@@ -97,6 +97,16 @@ pub enum ExceptionCause {
     Cp7Disabled                    = 39,
     /// None
     None                           = 255,
+}
+
+impl Display for ExceptionCause {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if *self == Self::Cp0Disabled {
+            write!(f, "Cp0Disabled (Access to the floating point coprocessor is not allowed. You may want to enable the `float-save-restore` feature of the `xtensa-lx-rt` crate.)")
+        } else {
+            write!(f, "{:?}", self)
+        }
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This shows the message from #2044 when using `esp-backtrace`

#### Testing
Change one of the interrupt examples to use floats inside the handler and see the error message. Should now look like this
```
Exception occurred 'Cp0Disabled (Access to the floating point coprocessor is not allowed. You may want to enable the `float-save-restore` feature of the `xtensa-lx-rt` crate.)'
Context
PC=0x42000cf6       PS=0x00060015
0x42000cf6 - timer_interrupt::__esp_hal_internal_tg0_t0_level::{{closure}}
...
```
