### PR TITLE
Fix hil-test xtask instruction

### DIFF
--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -31,7 +31,7 @@ You can run all tests for a given device by running the following command from t
 cargo xtask run-tests $CHIP
 ```
 
-For running a single test on a target, from the `xtask` folder run:
+To run a single test on a target, run the following command from the workspace root:
 
 ```shell
 # Run GPIO tests for ESP32-C6

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -25,7 +25,7 @@ cargo install probe-rs-tools \
 
 Target device **MUST** connected via its USB-Serial-JTAG port, or if unavailable (eg. ESP32, ESP32-C2, ESP32-S2) then you must connect a compatible debug probe such as an [ESP-Prog].
 
-You can run all tests for a given device by running the following command from the `xtask` folder:
+You can run all tests for a given device by running the following command from the workspace root:
 
 ```shell
 cargo xtask run-tests $CHIP


### PR DESCRIPTION
We've made changes to the xtask to be able to precompile. One of those changes is related to CWD (https://github.com/esp-rs/esp-hal/pull/1939/files#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35R156). This means we have to run xtask from the workspace root now.

As I'm not sure what everyone's workflow looks like, maybe we could conditionally re-add the old "where is the workspace" code - I myself usually only open the workspace and do my thing there, so I didn't run into issues previously.