### PR TITLE
Remove lazy_static in favor of OnceLock

### DIFF
--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name         = "esp-metadata"
 version      = "0.3.0"
 edition      = "2021"
-rust-version = "1.60.0"
+rust-version = "1.70.0"
 description  = "Metadata for Espressif devices"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
@@ -11,6 +11,5 @@ license      = "MIT OR Apache-2.0"
 anyhow     = "1.0.86"
 clap       = { version = "4.5.16", features = ["derive"] }
 basic-toml  = "0.1.9"
-lazy_static = "1.5.0"
 serde       = { version = "1.0.209", features = ["derive"] }
 strum       = { version = "0.26.3",  features = ["derive"] }

--- a/esp-metadata/README.md
+++ b/esp-metadata/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-metadata?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-metadata)
 [![docs.rs](https://img.shields.io/docsrs/esp-metadata?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-metadata)
-![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?labelColor=1C2C2E&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.70-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-metadata?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
@@ -14,7 +14,7 @@ Metadata for Espressif devices, intended for use in [build scripts].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.60 and up. It _might_
+This crate is guaranteed to compile on stable Rust 1.70 and up. It _might_
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -1,24 +1,15 @@
 //! Metadata for Espressif devices, primarily intended for use in build scripts.
 
+use std::sync::OnceLock;
+
 use anyhow::{bail, Result};
 use strum::IntoEnumIterator;
 
-const ESP32_TOML: &str = include_str!("../devices/esp32.toml");
-const ESP32C2_TOML: &str = include_str!("../devices/esp32c2.toml");
-const ESP32C3_TOML: &str = include_str!("../devices/esp32c3.toml");
-const ESP32C6_TOML: &str = include_str!("../devices/esp32c6.toml");
-const ESP32H2_TOML: &str = include_str!("../devices/esp32h2.toml");
-const ESP32S2_TOML: &str = include_str!("../devices/esp32s2.toml");
-const ESP32S3_TOML: &str = include_str!("../devices/esp32s3.toml");
-
-lazy_static::lazy_static! {
-    static ref ESP32_CFG: Config = basic_toml::from_str(ESP32_TOML).unwrap();
-    static ref ESP32C2_CFG: Config = basic_toml::from_str(ESP32C2_TOML).unwrap();
-    static ref ESP32C3_CFG: Config = basic_toml::from_str(ESP32C3_TOML).unwrap();
-    static ref ESP32C6_CFG: Config = basic_toml::from_str(ESP32C6_TOML).unwrap();
-    static ref ESP32H2_CFG: Config = basic_toml::from_str(ESP32H2_TOML).unwrap();
-    static ref ESP32S2_CFG: Config = basic_toml::from_str(ESP32S2_TOML).unwrap();
-    static ref ESP32S3_CFG: Config = basic_toml::from_str(ESP32S3_TOML).unwrap();
+macro_rules! include_toml {
+    ($type:ty, $file:expr) => {{
+        static LOADED_TOML: OnceLock<$type> = OnceLock::new();
+        LOADED_TOML.get_or_init(|| basic_toml::from_str(include_str!($file)).unwrap())
+    }};
 }
 
 /// Supported device architectures.
@@ -178,13 +169,13 @@ impl Config {
     /// The configuration for the specified chip.
     pub fn for_chip(chip: &Chip) -> &Self {
         match chip {
-            Chip::Esp32 => &ESP32_CFG,
-            Chip::Esp32c2 => &ESP32C2_CFG,
-            Chip::Esp32c3 => &ESP32C3_CFG,
-            Chip::Esp32c6 => &ESP32C6_CFG,
-            Chip::Esp32h2 => &ESP32H2_CFG,
-            Chip::Esp32s2 => &ESP32S2_CFG,
-            Chip::Esp32s3 => &ESP32S3_CFG,
+            Chip::Esp32 => include_toml!(Config, "../devices/esp32.toml"),
+            Chip::Esp32c2 => include_toml!(Config, "../devices/esp32c2.toml"),
+            Chip::Esp32c3 => include_toml!(Config, "../devices/esp32c3.toml"),
+            Chip::Esp32c6 => include_toml!(Config, "../devices/esp32c6.toml"),
+            Chip::Esp32h2 => include_toml!(Config, "../devices/esp32h2.toml"),
+            Chip::Esp32s2 => include_toml!(Config, "../devices/esp32s2.toml"),
+            Chip::Esp32s3 => include_toml!(Config, "../devices/esp32s3.toml"),
         }
     }
 

--- a/extras/esp-wifishark/Cargo.toml
+++ b/extras/esp-wifishark/Cargo.toml
@@ -8,4 +8,3 @@ r-extcap = "0.2.4"
 pcap-file = "2.0.0"
 serialport = "4.2.1"
 clap = { version = "4.3.5", features = ["derive"] }
-lazy_static = "1.4.0"

--- a/extras/ieee802154-sniffer/Cargo.toml
+++ b/extras/ieee802154-sniffer/Cargo.toml
@@ -8,4 +8,3 @@ r-extcap = "0.2.4"
 pcap-file = "2.0.0"
 serialport = "4.2.0"
 clap = { version = "4.1.7", features = ["derive"] }
-lazy_static = "1.4.0"

--- a/extras/ieee802154-sniffer/src/main.rs
+++ b/extras/ieee802154-sniffer/src/main.rs
@@ -28,6 +28,13 @@ pub struct AppArgs {
     channel: String,
 }
 
+fn config_option_value(value: &'static str) -> ConfigOptionValue {
+    ConfigOptionValue::builder()
+        .value(value)
+        .display(value)
+        .build()
+}
+
 lazy_static! {
     static ref METADATA: Metadata = Metadata {
         help_url: "http://github.com/esp-rs".into(),
@@ -62,66 +69,21 @@ lazy_static! {
                 .display("11")
                 .default(true)
                 .build(),
-            ConfigOptionValue::builder()
-                .value("12")
-                .display("12")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("13")
-                .display("13")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("14")
-                .display("14")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("15")
-                .display("15")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("16")
-                .display("16")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("17")
-                .display("17")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("18")
-                .display("18")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("19")
-                .display("19")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("20")
-                .display("20")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("21")
-                .display("21")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("22")
-                .display("22")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("23")
-                .display("23")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("24")
-                .display("24")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("25")
-                .display("25")
-                .build(),
-            ConfigOptionValue::builder()
-                .value("26")
-                .display("26")
-                .build(),
+            config_option_value("12"),
+            config_option_value("13"),
+            config_option_value("14"),
+            config_option_value("15"),
+            config_option_value("16"),
+            config_option_value("17"),
+            config_option_value("18"),
+            config_option_value("19"),
+            config_option_value("20"),
+            config_option_value("21"),
+            config_option_value("22"),
+            config_option_value("23"),
+            config_option_value("24"),
+            config_option_value("25"),
+            config_option_value("26"),
         ])
         .build();
 }

--- a/extras/ieee802154-sniffer/src/main.rs
+++ b/extras/ieee802154-sniffer/src/main.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use clap::Parser;
-use lazy_static::lazy_static;
 use pcap_file::{
     pcap::{PcapHeader, PcapPacket, PcapWriter},
     DataLink,
@@ -35,59 +34,6 @@ fn config_option_value(value: &'static str) -> ConfigOptionValue {
         .build()
 }
 
-lazy_static! {
-    static ref METADATA: Metadata = Metadata {
-        help_url: "http://github.com/esp-rs".into(),
-        display_description: "esp-ieee802154".into(),
-        ..r_extcap::cargo_metadata!()
-    };
-    static ref WIFI_CAPTURE_INTERFACE: Interface = Interface {
-        value: "802.15.4".into(),
-        display: "esp-ieee802154 Sniffer".into(),
-        dlt: Dlt {
-            data_link_type: DataLink::USER0,
-            name: "USER0".into(),
-            display: "IEEE802.15.4".into(),
-        },
-    };
-    static ref CONFIG_SERIALPORT: StringConfig = StringConfig::builder()
-        .config_number(1)
-        .call("serialport")
-        .display("Serialport")
-        .tooltip("Serialport to connect to")
-        .required(false)
-        .placeholder("")
-        .build();
-    static ref CONFIG_CHANNEL: SelectorConfig = SelectorConfig::builder()
-        .config_number(3)
-        .call("channel")
-        .display("Channel")
-        .tooltip("Channel Selector")
-        .default_options([
-            ConfigOptionValue::builder()
-                .value("11")
-                .display("11")
-                .default(true)
-                .build(),
-            config_option_value("12"),
-            config_option_value("13"),
-            config_option_value("14"),
-            config_option_value("15"),
-            config_option_value("16"),
-            config_option_value("17"),
-            config_option_value("18"),
-            config_option_value("19"),
-            config_option_value("20"),
-            config_option_value("21"),
-            config_option_value("22"),
-            config_option_value("23"),
-            config_option_value("24"),
-            config_option_value("25"),
-            config_option_value("26"),
-        ])
-        .build();
-}
-
 fn main() {
     let args = AppArgs::parse();
 
@@ -97,17 +43,71 @@ fn main() {
         }
     }
 
+    let wifi_capture_interface = Interface {
+        value: "802.15.4".into(),
+        display: "esp-ieee802154 Sniffer".into(),
+        dlt: Dlt {
+            data_link_type: DataLink::USER0,
+            name: "USER0".into(),
+            display: "IEEE802.15.4".into(),
+        },
+    };
+
     match args.extcap.run().unwrap() {
         ExtcapStep::Interfaces(interfaces_step) => {
-            interfaces_step.list_interfaces(&METADATA, &[&*WIFI_CAPTURE_INTERFACE], &[]);
+            let metadata = Metadata {
+                help_url: "http://github.com/esp-rs".into(),
+                display_description: "esp-ieee802154".into(),
+                ..r_extcap::cargo_metadata!()
+            };
+
+            interfaces_step.list_interfaces(&metadata, &[&wifi_capture_interface], &[]);
         }
         ExtcapStep::Dlts(dlts_step) => {
             dlts_step
-                .print_from_interfaces(&[&*WIFI_CAPTURE_INTERFACE])
+                .print_from_interfaces(&[&wifi_capture_interface])
                 .unwrap();
         }
         ExtcapStep::Config(config_step) => {
-            config_step.list_configs(&[&*CONFIG_SERIALPORT, &*CONFIG_CHANNEL])
+            let config_serialport = StringConfig::builder()
+                .config_number(1)
+                .call("serialport")
+                .display("Serialport")
+                .tooltip("Serialport to connect to")
+                .required(false)
+                .placeholder("")
+                .build();
+
+            let config_channel = SelectorConfig::builder()
+                .config_number(3)
+                .call("channel")
+                .display("Channel")
+                .tooltip("Channel Selector")
+                .default_options([
+                    ConfigOptionValue::builder()
+                        .value("11")
+                        .display("11")
+                        .default(true)
+                        .build(),
+                    config_option_value("12"),
+                    config_option_value("13"),
+                    config_option_value("14"),
+                    config_option_value("15"),
+                    config_option_value("16"),
+                    config_option_value("17"),
+                    config_option_value("18"),
+                    config_option_value("19"),
+                    config_option_value("20"),
+                    config_option_value("21"),
+                    config_option_value("22"),
+                    config_option_value("23"),
+                    config_option_value("24"),
+                    config_option_value("25"),
+                    config_option_value("26"),
+                ])
+                .build();
+
+            config_step.list_configs(&[&config_serialport, &config_channel])
         }
         ExtcapStep::ReloadConfig(_reload_config_step) => {
             panic!("Unsupported operation");


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
lazy_static is semi-deprecated ([source](https://github.com/rust-lang-nursery/lazy-static.rs/issues/214)) and there have been alternatives in the standard library for over a year now. Migration to `std::sync::LazyLock` would be the most similar, but requires an MSRV of 1.80 which is too soon, so this PR uses `std::sync::OnceLock` which was stabilized in 1.70 (over a year old).

I also cleaned up `ieee802154-sniffer` slightly, as the config initialization was killing me.

#### Testing
`cargo xtask fmt-packages` and `cargo xtask lint-packages`