### PR TITLE
Fix various SPI/DMA issues

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue with DMA transfers potentially not waking up the correct async task (#2065)
+
 ### Removed
 
 ## [0.20.1] - 2024-08-30

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -424,20 +424,21 @@ pub struct ChannelTxImpl<const N: u8> {}
 use embassy_sync::waitqueue::AtomicWaker;
 
 #[cfg(feature = "async")]
-const NEW_WAKER: AtomicWaker = AtomicWaker::new();
+#[allow(clippy::declare_interior_mutable_const)]
+const INIT: AtomicWaker = AtomicWaker::new();
 
 #[cfg(feature = "async")]
-static TX_WAKER: [AtomicWaker; CHANNEL_COUNT] = [NEW_WAKER; CHANNEL_COUNT];
+static TX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [INIT; CHANNEL_COUNT];
 
 #[cfg(feature = "async")]
-static RX_WAKER: [AtomicWaker; CHANNEL_COUNT] = [NEW_WAKER; CHANNEL_COUNT];
+static RX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [INIT; CHANNEL_COUNT];
 
 impl<const N: u8> crate::private::Sealed for ChannelTxImpl<N> {}
 
 impl<const N: u8> TxChannel<Channel<N>> for ChannelTxImpl<N> {
     #[cfg(feature = "async")]
     fn waker() -> &'static AtomicWaker {
-        &TX_WAKER[N as usize]
+        &TX_WAKERS[N as usize]
     }
 }
 
@@ -450,7 +451,7 @@ impl<const N: u8> crate::private::Sealed for ChannelRxImpl<N> {}
 impl<const N: u8> RxChannel<Channel<N>> for ChannelRxImpl<N> {
     #[cfg(feature = "async")]
     fn waker() -> &'static AtomicWaker {
-        &RX_WAKER[N as usize]
+        &RX_WAKERS[N as usize]
     }
 }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -3661,7 +3661,7 @@ impl Instance for crate::peripherals::SPI3 {
     #[inline(always)]
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         self.bind_spi3_interrupt(handler.handler());
-        crate::interrupt::enable(crate::peripherals::Interrupt::SPI2, handler.priority()).unwrap();
+        crate::interrupt::enable(crate::peripherals::Interrupt::SPI3, handler.priority()).unwrap();
     }
 
     #[inline(always)]
@@ -3792,7 +3792,7 @@ impl Instance for crate::peripherals::SPI3 {
     #[inline(always)]
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         self.bind_spi3_interrupt(handler.handler());
-        crate::interrupt::enable(crate::peripherals::Interrupt::SPI2, handler.priority()).unwrap();
+        crate::interrupt::enable(crate::peripherals::Interrupt::SPI3, handler.priority()).unwrap();
     }
 
     #[inline(always)]

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -159,6 +159,11 @@ harness           = false
 required-features = ["async", "embassy"]
 
 [[test]]
+name    = "embassy_interrupt_spi_dma"
+harness = false
+required-features = ["async", "embassy"]
+
+[[test]]
 name    = "twai"
 harness = false
 

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -1,6 +1,6 @@
 //! Reproduction and regression test for a sneaky issue.
 
-//% CHIPS: esp32s3
+//% CHIPS: esp32 esp32s2 esp32s3
 //% FEATURES: integrated-timers
 //% FEATURES: generic-queue
 
@@ -104,7 +104,7 @@ mod test {
             .with_buffers(dma_tx_buf, dma_rx_buf);
 
         let spi2 = Spi::new(peripherals.SPI3, 100.kHz(), SpiMode::Mode0, &clocks)
-            .with_dma(dma_channel2.configure_for_async(false, DmaPriority::Priority1));
+            .with_dma(dma_channel2.configure_for_async(false, DmaPriority::Priority0));
 
         let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -1,0 +1,130 @@
+//! Reproduction and regression test for a sneaky issue.
+
+//% CHIPS: esp32s3
+//% FEATURES: integrated-timers
+//% FEATURES: generic-queue
+
+#![no_std]
+#![no_main]
+
+use embassy_time::{Duration, Instant, Ticker};
+use esp_hal::{
+    dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma_buffers,
+    interrupt::{software::SoftwareInterruptControl, Priority},
+    peripherals::SPI3,
+    prelude::*,
+    spi::{
+        master::{Spi, SpiDma},
+        FullDuplexMode,
+        SpiMode,
+    },
+    timer::{timg::TimerGroup, ErasedTimer},
+    Async,
+};
+use esp_hal_embassy::InterruptExecutor;
+use hil_test as _;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(
+        feature = "esp32",
+        feature = "esp32s2",
+    ))] {
+        use esp_hal::dma::Spi3DmaChannel as DmaChannel1;
+    } else {
+        use esp_hal::dma::DmaChannel1;
+    }
+}
+
+macro_rules! mk_static {
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write(($val));
+        x
+    }};
+}
+
+#[embassy_executor::task]
+async fn interrupt_driven_task(spi: SpiDma<'static, SPI3, DmaChannel1, FullDuplexMode, Async>) {
+    let mut ticker = Ticker::every(Duration::from_millis(1));
+
+    let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(128);
+    let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+    let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+
+    let mut spi = spi.with_buffers(dma_tx_buf, dma_rx_buf);
+
+    loop {
+        let mut buffer: [u8; 8] = [0; 8];
+
+        spi.transfer_in_place_async(&mut buffer).await.unwrap();
+
+        ticker.next().await;
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
+mod test {
+    use super::*;
+
+    #[test]
+    #[timeout(3)]
+    async fn run_interrupt_executor_test() {
+        let (peripherals, clocks) = esp_hal::init(esp_hal::Config::default());
+
+        let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+        esp_hal_embassy::init(
+            &clocks,
+            [
+                ErasedTimer::from(timg0.timer0),
+                ErasedTimer::from(timg0.timer1),
+            ],
+        );
+
+        let dma = Dma::new(peripherals.DMA);
+
+        cfg_if::cfg_if! {
+            if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+                let dma_channel1 = dma.spi2channel;
+                let dma_channel2 = dma.spi3channel;
+            } else {
+                let dma_channel1 = dma.channel0;
+                let dma_channel2 = dma.channel1;
+            }
+        }
+
+        let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(1024);
+        let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+        let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+
+        let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_dma(dma_channel1.configure_for_async(false, DmaPriority::Priority0))
+            .with_buffers(dma_tx_buf, dma_rx_buf);
+
+        let spi2 = Spi::new(peripherals.SPI3, 100.kHz(), SpiMode::Mode0, &clocks)
+            .with_dma(dma_channel2.configure_for_async(false, DmaPriority::Priority1));
+
+        let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+
+        let interrupt_executor = mk_static!(
+            InterruptExecutor<1>,
+            InterruptExecutor::new(sw_ints.software_interrupt1)
+        );
+
+        let spawner = interrupt_executor.start(Priority::Priority3);
+
+        spawner.spawn(interrupt_driven_task(spi2)).unwrap();
+
+        let start = Instant::now();
+        let mut buffer: [u8; 1024] = [0; 1024];
+        loop {
+            spi.transfer_in_place_async(&mut buffer).await.unwrap();
+
+            if start.elapsed() > Duration::from_secs(1) {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

A static variable in a generic struct will not be instantiated separately for each generic param value. Thit meant that all DMA channels used the same waker. This meant that some tasks were not waken if multiple DMA-backed operations were ongoing at the same time.

Introduced in https://github.com/esp-rs/esp-hal/pull/1330

Includes gratis copy-paste bugfix regarding SPI interrupt handlers.