### PR TITLE
Make esp-wifi build on stable, again. Bump to 0.9.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       - name: msrv Xtensa (esp-wifi)
         run: |
           cargo xtask build-package --toolchain=esp --features=esp32,wifi,ble,async   --target=xtensa-esp32-none-elf   esp-wifi
-          cargo xtask build-package --toolchain=esp --features=esp32s2,wifi,ble,async --target=xtensa-esp32s2-none-elf esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32s2,wifi,async --target=xtensa-esp32s2-none-elf esp-wifi
           cargo xtask build-package --toolchain=esp --features=esp32s3,wifi,ble,async --target=xtensa-esp32s3-none-elf esp-wifi
 
       - name: msrv (esp-lp-hal)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,25 @@ jobs:
           cargo xtask build-package --features=esp32c6,ci --target=riscv32imac-unknown-none-elf  esp-hal
           cargo xtask build-package --features=esp32h2,ci --target=riscv32imac-unknown-none-elf  esp-hal
 
-      # Verify the MSRV for all Xtensa chips:
+      - name: msrv RISCV (esp-wifi)
+        run: |
+          cargo xtask build-package --features=esp32c2,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
+          cargo xtask build-package --features=esp32c3,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
+          cargo xtask build-package --features=esp32c6,wifi,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
+          cargo xtask build-package --features=esp32h2,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
+      
+        # Verify the MSRV for all Xtensa chips:
       - name: msrv Xtensa (esp-hal)
         run: |
           cargo xtask build-package --toolchain=esp --features=esp32,ci   --target=xtensa-esp32-none-elf   esp-hal
           cargo xtask build-package --toolchain=esp --features=esp32s2,ci --target=xtensa-esp32s2-none-elf esp-hal
           cargo xtask build-package --toolchain=esp --features=esp32s3,ci --target=xtensa-esp32s3-none-elf esp-hal
+
+      - name: msrv Xtensa (esp-wifi)
+        run: |
+          cargo xtask build-package --toolchain=esp --features=esp32,wifi,ble,async   --target=xtensa-esp32-none-elf   esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32s2,wifi,ble,async --target=xtensa-esp32s2-none-elf esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32s3,wifi,ble,async --target=xtensa-esp32s3-none-elf esp-wifi
 
       - name: msrv (esp-lp-hal)
         run: |

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## 0.9.1 - 2024-09-03
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Builds on stable, again
+
+### Removed
+
 ## 0.9.0 - 2024-09-03
 
 ### Added

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Builds on stable, again
+- Builds on stable, again (#2067)
 
 ### Removed
 

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-wifi"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["The ESP-RS team"]
 description = "A WiFi, Bluetooth and ESP-NOW driver for use with Espressif chips and bare-metal Rust"

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -2,6 +2,7 @@
 
 use core::{
     fmt::Write,
+    mem::size_of_val,
     ptr::{addr_of, addr_of_mut},
 };
 

--- a/esp-wifi/src/preempt/mod.rs
+++ b/esp-wifi/src/preempt/mod.rs
@@ -2,7 +2,7 @@
 #[cfg_attr(target_arch = "xtensa", path = "preempt_xtensa.rs")]
 pub mod arch_specific;
 
-use core::cell::RefCell;
+use core::{cell::RefCell, mem::size_of};
 
 use arch_specific::*;
 use critical_section::Mutex;


### PR DESCRIPTION
While 0.9.0 builds just fine on nightly it failed to build on stable (before 1.80)