### PR TITLE
Remove most trait implementation features from `esp-hal`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed `NoPinType` in favour of `DummyPin`. (#2068)
+- Removed the `async`, `embedded-hal-02`, `embedded-hal`, `embedded-io`, `embedded-io-async`, and `ufmt` features (#2070)
 
 ## [0.20.1] - 2024-08-30
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -11,7 +11,7 @@ links         = "esp-hal"
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
-features       = ["embedded-hal", "esp32c6"]
+features       = ["esp32c6"]
 rustdoc-args   = ["--cfg", "docsrs"]
 
 [dependencies]
@@ -28,11 +28,11 @@ embassy-futures          = { version = "0.1.1", optional = true }
 embassy-sync             = { version = "0.6.0", optional = true }
 embassy-usb-driver       = { version = "0.1.0", optional = true }
 embassy-usb-synopsys-otg = { version = "0.1.0", optional = true }
-embedded-can             = { version = "0.4.1", optional = true }
+embedded-can             = "0.4.1"
 embedded-hal-02          = { version = "0.2.7", features = ["unproven"], package = "embedded-hal" }
-embedded-hal             = { version = "1.0.0", optional = true }
+embedded-hal             = "1.0.0"
 embedded-hal-async       = { version = "1.0.0", optional = true }
-embedded-hal-nb          = { version = "1.0.0", optional = true }
+embedded-hal-nb          = "1.0.0"
 embedded-io              = { version = "0.6.1", optional = true }
 embedded-io-async        = { version = "0.6.1", optional = true }
 enumset                  = "1.1.5"
@@ -76,7 +76,7 @@ esp-metadata = { version = "0.3.0", path = "../esp-metadata" }
 serde        = { version = "1.0.209", features = ["derive"] }
 
 [features]
-default = ["embedded-hal"]
+default = []
 
 riscv  = ["dep:riscv",     "critical-section/restore-state-u8"]
 xtensa = ["dep:xtensa-lx", "critical-section/restore-state-u32"]
@@ -128,7 +128,6 @@ flip-link = ["esp-riscv-rt/fix-sp"]
 ## `embedded-hal-async` and `embedded-io-async`.
 ## Also enables `embassy-usb` support for ESP32-S2 and ESP32-S3.
 async = [
-    "embedded-hal",
     "embedded-hal-async",
     "embedded-io",
     "embedded-io-async",
@@ -142,7 +141,7 @@ defmt = [
     "dep:defmt",
     "embassy-futures?/defmt",
     "embassy-sync?/defmt",
-    "embedded-hal?/defmt-03",
+    "embedded-hal/defmt-03",
     "embedded-io/defmt-03",
     "embedded-io-async?/defmt-03",
     "esp32?/defmt",
@@ -153,9 +152,6 @@ defmt = [
     "esp32s2?/defmt",
     "esp32s3?/defmt",
 ]
-## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
-## `embedded-hal-nb` for the relevant peripherals.
-embedded-hal = ["dep:embedded-hal", "dep:embedded-hal-nb", "dep:embedded-can"]
 ## Implement the traits defined in `embedded-io` for certain peripherals.
 embedded-io = ["dep:embedded-io"]
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -24,17 +24,17 @@ defmt                    = { version = "0.3.8", optional = true }
 delegate                 = "0.12.0"
 digest                   = { version = "0.10.7", default-features = false, optional = true }
 document-features        = "0.2.10"
-embassy-futures          = { version = "0.1.1", optional = true }
-embassy-sync             = { version = "0.6.0", optional = true }
+embassy-futures          = "0.1.1"
+embassy-sync             = "0.6.0"
 embassy-usb-driver       = { version = "0.1.0", optional = true }
 embassy-usb-synopsys-otg = { version = "0.1.0", optional = true }
 embedded-can             = "0.4.1"
 embedded-hal-02          = { version = "0.2.7", features = ["unproven"], package = "embedded-hal" }
 embedded-hal             = "1.0.0"
-embedded-hal-async       = { version = "1.0.0", optional = true }
+embedded-hal-async       = "1.0.0"
 embedded-hal-nb          = "1.0.0"
 embedded-io              = "0.6.1"
-embedded-io-async        = { version = "0.6.1", optional = true }
+embedded-io-async        = "0.6.1"
 enumset                  = "1.1.5"
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                    = "0.3.7"
@@ -83,7 +83,7 @@ xtensa = ["dep:xtensa-lx", "critical-section/restore-state-u32"]
 
 bluetooth = []
 
-usb-otg = ["esp-synopsys-usb-otg", "usb-device"]
+usb-otg = ["dep:embassy-usb-driver", "dep:embassy-usb-synopsys-otg", "dep:esp-synopsys-usb-otg", "dep:usb-device"]
 
 __esp_hal_embassy = []
 
@@ -124,25 +124,14 @@ esp32s3 = ["dep:esp32s3", "xtensa", "procmacros/has-ulp-core", "xtensa-lx/spin",
 flip-link = ["esp-riscv-rt/fix-sp"]
 
 #! ### Trait Implementation Feature Flags
-## Enable support for asynchronous operation, with interfaces provided by
-## `embedded-hal-async` and `embedded-io-async`.
-## Also enables `embassy-usb` support for ESP32-S2 and ESP32-S3.
-async = [
-    "embedded-hal-async",
-    "embedded-io-async",
-    "embassy-sync",
-    "embassy-futures",
-    "embassy-usb-driver",
-    "embassy-usb-synopsys-otg"
-]
 ## Implement `defmt::Format` on certain types.
 defmt = [
     "dep:defmt",
-    "embassy-futures?/defmt",
-    "embassy-sync?/defmt",
+    "embassy-futures/defmt",
+    "embassy-sync/defmt",
     "embedded-hal/defmt-03",
     "embedded-io/defmt-03",
-    "embedded-io-async?/defmt-03",
+    "embedded-io-async/defmt-03",
     "esp32?/defmt",
     "esp32c2?/defmt",
     "esp32c3?/defmt",
@@ -173,7 +162,7 @@ opsram-8m = []
 opsram-16m = []
 
 # This feature is intended for testing; you probably don't want to enable it:
-ci = ["async", "defmt", "bluetooth", "place-spi-driver-in-ram"]
+ci = ["defmt", "bluetooth", "place-spi-driver-in-ram"]
 
 [lints.clippy]
 mixed_attributes_style = "allow"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -33,7 +33,7 @@ embedded-hal-02          = { version = "0.2.7", features = ["unproven"], package
 embedded-hal             = "1.0.0"
 embedded-hal-async       = { version = "1.0.0", optional = true }
 embedded-hal-nb          = "1.0.0"
-embedded-io              = { version = "0.6.1", optional = true }
+embedded-io              = "0.6.1"
 embedded-io-async        = { version = "0.6.1", optional = true }
 enumset                  = "1.1.5"
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
@@ -129,7 +129,6 @@ flip-link = ["esp-riscv-rt/fix-sp"]
 ## Also enables `embassy-usb` support for ESP32-S2 and ESP32-S3.
 async = [
     "embedded-hal-async",
-    "embedded-io",
     "embedded-io-async",
     "embassy-sync",
     "embassy-futures",
@@ -152,8 +151,6 @@ defmt = [
     "esp32s2?/defmt",
     "esp32s3?/defmt",
 ]
-## Implement the traits defined in `embedded-io` for certain peripherals.
-embedded-io = ["dep:embedded-io"]
 
 #! ### PSRAM Feature Flags
 ## Use externally connected PSRAM (2MB).
@@ -176,7 +173,7 @@ opsram-8m = []
 opsram-16m = []
 
 # This feature is intended for testing; you probably don't want to enable it:
-ci = ["async", "embedded-io", "defmt", "bluetooth", "place-spi-driver-in-ram"]
+ci = ["async", "defmt", "bluetooth", "place-spi-driver-in-ram"]
 
 [lints.clippy]
 mixed_attributes_style = "allow"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -29,7 +29,7 @@ embassy-sync             = { version = "0.6.0", optional = true }
 embassy-usb-driver       = { version = "0.1.0", optional = true }
 embassy-usb-synopsys-otg = { version = "0.1.0", optional = true }
 embedded-can             = { version = "0.4.1", optional = true }
-embedded-hal-02          = { version = "0.2.7", optional = true, features = ["unproven"], package = "embedded-hal" }
+embedded-hal-02          = { version = "0.2.7", features = ["unproven"], package = "embedded-hal" }
 embedded-hal             = { version = "1.0.0", optional = true }
 embedded-hal-async       = { version = "1.0.0", optional = true }
 embedded-hal-nb          = { version = "1.0.0", optional = true }
@@ -156,8 +156,6 @@ defmt = [
 ## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
 ## `embedded-hal-nb` for the relevant peripherals.
 embedded-hal = ["dep:embedded-hal", "dep:embedded-hal-nb", "dep:embedded-can"]
-## Implement the traits defined in the `0.2.x` release of `embedded-hal`.
-embedded-hal-02 = ["dep:embedded-hal-02"]
 ## Implement the traits defined in `embedded-io` for certain peripherals.
 embedded-io = ["dep:embedded-io"]
 
@@ -182,7 +180,7 @@ opsram-8m = []
 opsram-16m = []
 
 # This feature is intended for testing; you probably don't want to enable it:
-ci = ["async", "embedded-hal-02", "embedded-io", "defmt", "bluetooth", "place-spi-driver-in-ram"]
+ci = ["async", "embedded-io", "defmt", "bluetooth", "place-spi-driver-in-ram"]
 
 [lints.clippy]
 mixed_attributes_style = "allow"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -48,7 +48,7 @@ strum                    = { version = "0.26.3", default-features = false, featu
 void                     = { version = "1.0.2", default-features = false }
 usb-device               = { version = "0.3.2", optional = true }
 rand_core                = "0.6.4"
-ufmt-write               = { version = "0.1.0", optional = true }
+ufmt-write               = "0.1.0"
 xtensa-lx                = { version = "0.9.0", optional = true }
 
 # IMPORTANT:
@@ -160,8 +160,6 @@ embedded-hal = ["dep:embedded-hal", "dep:embedded-hal-nb", "dep:embedded-can"]
 embedded-hal-02 = ["dep:embedded-hal-02"]
 ## Implement the traits defined in `embedded-io` for certain peripherals.
 embedded-io = ["dep:embedded-io"]
-## Implement the `ufmt_write::uWrite` trait for certain peripherals.
-ufmt = ["dep:ufmt-write"]
 
 #! ### PSRAM Feature Flags
 ## Use externally connected PSRAM (2MB).
@@ -184,7 +182,7 @@ opsram-8m = []
 opsram-16m = []
 
 # This feature is intended for testing; you probably don't want to enable it:
-ci = ["async", "embedded-hal-02", "embedded-io", "ufmt", "defmt", "bluetooth", "place-spi-driver-in-ram"]
+ci = ["async", "embedded-hal-02", "embedded-io", "defmt", "bluetooth", "place-spi-driver-in-ram"]
 
 [lints.clippy]
 mixed_attributes_style = "allow"

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -1,8 +1,19 @@
-Migration Guide from 0.20.x to vNext
-====================================
+# Migration Guide from 0.20.x to vNext
 
-HAL initialsation
------------------
+## Cargo Features
+
+A number of trait implementations which were previously feature-gated are now implemented by default. The following Cargo features have been removed:
+
+- `async`
+- `embedded-hal-02`
+- `embedded-hal`
+- `embedded-io`
+- `embedded-io-async`
+- `ufmt`
+
+If your project enables any of these features, simply remove them from your Cargo manifest and things should continue to work as expected.
+
+## HAL Initialisation
 
 Instead of manually grabbing peripherals and setting up clocks, you should now call `esp_hal::init`.
 
@@ -13,7 +24,7 @@ Instead of manually grabbing peripherals and setting up clocks, you should now c
      prelude::*,
 -    system::SystemControl,
  };
- 
+
  #[entry]
  fn main() -> ! {
 -    let peripherals = Peripherals::take();

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -343,7 +343,6 @@ impl<'d, ADC1> Adc<'d, ADC1> {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, ADCI, PIN> embedded_hal_02::adc::OneShot<ADCI, u16, super::AdcPin<PIN, ADCI>>
     for Adc<'d, ADCI>
 where

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -110,7 +110,6 @@ pub struct AdcPin<PIN, ADCI, CS = ()> {
     _phantom: PhantomData<ADCI>,
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<PIN, ADCI, CS> embedded_hal_02::adc::Channel<ADCI> for AdcPin<PIN, ADCI, CS>
 where
     PIN: embedded_hal_02::adc::Channel<ADCI, ID = u8>,
@@ -260,7 +259,6 @@ macro_rules! impl_adc_interface {
                 const CHANNEL: u8 = $channel;
             }
 
-            #[cfg(feature = "embedded-hal-02")]
             impl embedded_hal_02::adc::Channel<crate::peripherals::$adc> for crate::gpio::$pin {
                 type ID = u8;
 

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -530,7 +530,6 @@ impl super::AdcCalEfuse for crate::peripherals::ADC2 {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, ADCI, PIN, CS> embedded_hal_02::adc::OneShot<ADCI, u16, super::AdcPin<PIN, ADCI, CS>>
     for Adc<'d, ADCI>
 where

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -590,7 +590,6 @@ impl super::AdcCalEfuse for crate::peripherals::ADC2 {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, ADCI, PIN, CS> embedded_hal_02::adc::OneShot<ADCI, u16, AdcPin<PIN, ADCI, CS>>
     for Adc<'d, ADCI>
 where

--- a/esp-hal/src/delay.rs
+++ b/esp-hal/src/delay.rs
@@ -45,7 +45,6 @@ use crate::clock::Clocks;
 #[non_exhaustive]
 pub struct Delay;
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::delay::DelayMs<T> for Delay
 where
     T: Into<u32>,
@@ -55,7 +54,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::delay::DelayUs<T> for Delay
 where
     T: Into<u32>,

--- a/esp-hal/src/delay.rs
+++ b/esp-hal/src/delay.rs
@@ -63,7 +63,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_hal::delay::DelayNs for Delay {
     fn delay_ns(&mut self, ns: u32) {
         self.delay_nanos(ns);

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -420,23 +420,18 @@ impl<const N: u8> RegisterAccess for Channel<N> {
 #[doc(hidden)]
 pub struct ChannelTxImpl<const N: u8> {}
 
-#[cfg(feature = "async")]
 use embassy_sync::waitqueue::AtomicWaker;
 
-#[cfg(feature = "async")]
 #[allow(clippy::declare_interior_mutable_const)]
 const INIT: AtomicWaker = AtomicWaker::new();
 
-#[cfg(feature = "async")]
 static TX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [INIT; CHANNEL_COUNT];
 
-#[cfg(feature = "async")]
 static RX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [INIT; CHANNEL_COUNT];
 
 impl<const N: u8> crate::private::Sealed for ChannelTxImpl<N> {}
 
 impl<const N: u8> TxChannel<Channel<N>> for ChannelTxImpl<N> {
-    #[cfg(feature = "async")]
     fn waker() -> &'static AtomicWaker {
         &TX_WAKERS[N as usize]
     }
@@ -449,7 +444,6 @@ pub struct ChannelRxImpl<const N: u8> {}
 impl<const N: u8> crate::private::Sealed for ChannelRxImpl<N> {}
 
 impl<const N: u8> RxChannel<Channel<N>> for ChannelRxImpl<N> {
-    #[cfg(feature = "async")]
     fn waker() -> &'static AtomicWaker {
         &RX_WAKERS[N as usize]
     }
@@ -551,7 +545,6 @@ macro_rules! impl_channel {
                 ///
                 /// Descriptors should be sized as `(CHUNK_SIZE + 4091) / 4092`. I.e., to
                 /// transfer buffers of size `1..=4092`, you need 1 descriptor.
-                #[cfg(feature = "async")]
                 pub fn configure_for_async<'a>(
                     self,
                     burst_mode: bool,
@@ -578,23 +571,19 @@ macro_rules! impl_channel {
 
 cfg_if::cfg_if! {
     if #[cfg(esp32c2)] {
-        #[cfg(feature = "async")]
         const CHANNEL_COUNT: usize = 1;
         impl_channel!(0, super::asynch::interrupt::interrupt_handler_ch0, DMA_CH0);
     } else if #[cfg(esp32c3)] {
-        #[cfg(feature = "async")]
         const CHANNEL_COUNT: usize = 3;
         impl_channel!(0, super::asynch::interrupt::interrupt_handler_ch0, DMA_CH0);
         impl_channel!(1, super::asynch::interrupt::interrupt_handler_ch1, DMA_CH1);
         impl_channel!(2, super::asynch::interrupt::interrupt_handler_ch2, DMA_CH2);
     } else if #[cfg(any(esp32c6, esp32h2))] {
-        #[cfg(feature = "async")]
         const CHANNEL_COUNT: usize = 3;
         impl_channel!(0, super::asynch::interrupt::interrupt_handler_ch0, DMA_IN_CH0, DMA_OUT_CH0);
         impl_channel!(1, super::asynch::interrupt::interrupt_handler_ch1, DMA_IN_CH1, DMA_OUT_CH1);
         impl_channel!(2, super::asynch::interrupt::interrupt_handler_ch2, DMA_IN_CH2, DMA_OUT_CH2);
     } else if #[cfg(esp32s3)] {
-        #[cfg(feature = "async")]
         const CHANNEL_COUNT: usize = 5;
         impl_channel!(0, super::asynch::interrupt::interrupt_handler_ch0, DMA_IN_CH0, DMA_OUT_CH0);
         impl_channel!(1, super::asynch::interrupt::interrupt_handler_ch1, DMA_IN_CH1, DMA_OUT_CH1);

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1249,7 +1249,6 @@ pub trait RxPrivate: crate::private::Sealed {
 
     fn clear_interrupts(&self);
 
-    #[cfg(feature = "async")]
     fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker;
 }
 
@@ -1296,7 +1295,6 @@ where
         R::is_in_done()
     }
 
-    #[cfg(feature = "async")]
     fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker;
 }
 
@@ -1494,7 +1492,6 @@ where
         CH::Channel::clear_in_interrupts();
     }
 
-    #[cfg(feature = "async")]
     fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker {
         CH::Rx::waker()
     }
@@ -1552,7 +1549,6 @@ pub trait TxPrivate: crate::private::Sealed {
 
     fn clear_interrupts(&self);
 
-    #[cfg(feature = "async")]
     fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker;
 
     fn descriptors_handled(&self) -> bool;
@@ -1633,7 +1629,6 @@ where
         R::last_out_dscr_address()
     }
 
-    #[cfg(feature = "async")]
     fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker;
 }
 
@@ -1759,7 +1754,6 @@ where
         CH::Channel::has_out_descriptor_error()
     }
 
-    #[cfg(feature = "async")]
     fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker {
         CH::Tx::waker()
     }
@@ -2762,7 +2756,6 @@ where
     }
 }
 
-#[cfg(feature = "async")]
 pub(crate) mod asynch {
     use core::task::Poll;
 

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -356,7 +356,6 @@ macro_rules! ImplSpiChannel {
             impl $crate::private::Sealed for [<Spi $num DmaChannelTxImpl>] {}
 
             impl<'a> TxChannel<[<Spi $num DmaChannel>]> for [<Spi $num DmaChannelTxImpl>] {
-                #[cfg(feature = "async")]
                 fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker {
                     static WAKER: embassy_sync::waitqueue::AtomicWaker = embassy_sync::waitqueue::AtomicWaker::new();
                     &WAKER
@@ -370,7 +369,6 @@ macro_rules! ImplSpiChannel {
             impl $crate::private::Sealed for [<Spi $num DmaChannelRxImpl>] {}
 
             impl<'a> RxChannel<[<Spi $num DmaChannel>]> for [<Spi $num DmaChannelRxImpl>] {
-                #[cfg(feature = "async")]
                 fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker {
                     static WAKER: embassy_sync::waitqueue::AtomicWaker = embassy_sync::waitqueue::AtomicWaker::new();
                     &WAKER
@@ -408,7 +406,6 @@ macro_rules! ImplSpiChannel {
                 ///
                 /// Descriptors should be sized as `(CHUNK_SIZE + 4091) / 4092`. I.e., to
                 /// transfer buffers of size `1..=4092`, you need 1 descriptor.
-                #[cfg(feature = "async")]
                 pub fn configure_for_async<'a>(
                     self,
                     burst_mode: bool,
@@ -752,7 +749,6 @@ macro_rules! ImplI2sChannel {
             impl $crate::private::Sealed for [<I2s $num DmaChannelTxImpl>] {}
 
             impl<'a> TxChannel<[<I2s $num DmaChannel>]> for [<I2s $num DmaChannelTxImpl>] {
-                #[cfg(feature = "async")]
                 fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker {
                     static WAKER: embassy_sync::waitqueue::AtomicWaker = embassy_sync::waitqueue::AtomicWaker::new();
                     &WAKER
@@ -765,7 +761,6 @@ macro_rules! ImplI2sChannel {
             impl $crate::private::Sealed for [<I2s $num DmaChannelRxImpl>] {}
 
             impl<'a> RxChannel<[<I2s $num DmaChannel>]> for [<I2s $num DmaChannelRxImpl>] {
-                #[cfg(feature = "async")]
                 fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker {
                     static WAKER: embassy_sync::waitqueue::AtomicWaker = embassy_sync::waitqueue::AtomicWaker::new();
                     &WAKER
@@ -802,7 +797,6 @@ macro_rules! ImplI2sChannel {
                 ///
                 /// Descriptors should be sized as `(CHUNK_SIZE + 4091) / 4092`. I.e., to
                 /// transfer buffers of size `1..=4092`, you need 1 descriptor.
-                #[cfg(feature = "async")]
                 pub fn configure_for_async<'a>(
                     self,
                     burst_mode: bool,

--- a/esp-hal/src/gpio/dummy_pin.rs
+++ b/esp-hal/src/gpio/dummy_pin.rs
@@ -133,7 +133,6 @@ impl InputPin for DummyPin {
     fn disconnect_input_from_peripheral(&mut self, _signal: InputSignal, _: private::Internal) {}
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::OutputPin for DummyPin {
     type Error = core::convert::Infallible;
 
@@ -146,7 +145,6 @@ impl embedded_hal_02::digital::v2::OutputPin for DummyPin {
         Ok(())
     }
 }
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::StatefulOutputPin for DummyPin {
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         Ok(OutputPin::is_set_high(self, private::Internal))

--- a/esp-hal/src/gpio/dummy_pin.rs
+++ b/esp-hal/src/gpio/dummy_pin.rs
@@ -154,12 +154,10 @@ impl embedded_hal_02::digital::v2::StatefulOutputPin for DummyPin {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_hal::digital::ErrorType for DummyPin {
     type Error = core::convert::Infallible;
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_hal::digital::OutputPin for DummyPin {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         self.set_output_high(true, private::Internal);
@@ -172,7 +170,6 @@ impl embedded_hal::digital::OutputPin for DummyPin {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_hal::digital::StatefulOutputPin for DummyPin {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
         Ok(OutputPin::is_set_high(self, private::Internal))

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -3248,7 +3248,6 @@ mod embedded_hal_02_impls {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 mod embedded_hal_impls {
     use embedded_hal::digital;
 
@@ -3498,7 +3497,6 @@ mod embedded_hal_impls {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 #[cfg(feature = "async")]
 mod embedded_hal_async_impls {
     use embedded_hal_async::digital::Wait;

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1328,7 +1328,6 @@ extern "C" fn gpio_interrupt_handler() {
         user_handler.call();
     }
 
-    #[cfg(feature = "async")]
     asynch::handle_gpio_interrupt();
 }
 
@@ -2786,7 +2785,6 @@ pub(crate) mod internal {
     }
 }
 
-#[cfg(feature = "async")]
 mod asynch {
     use core::task::{Context, Poll};
 
@@ -3497,7 +3495,6 @@ mod embedded_hal_impls {
     }
 }
 
-#[cfg(feature = "async")]
 mod embedded_hal_async_impls {
     use embedded_hal_async::digital::Wait;
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -2954,7 +2954,6 @@ mod asynch {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 mod embedded_hal_02_impls {
     use embedded_hal_02::digital::v2 as digital;
 

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -203,7 +203,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::Read for I2C<'_, T, crate::Blocking>
 where
     T: Instance,
@@ -215,7 +214,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::Write for I2C<'_, T, crate::Blocking>
 where
     T: Instance,
@@ -227,7 +225,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::WriteRead for I2C<'_, T, crate::Blocking>
 where
     T: Instance,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -410,7 +410,6 @@ where
     }
 }
 
-#[cfg(feature = "async")]
 impl<'d, T> I2C<'d, T, crate::Async>
 where
     T: Instance,
@@ -457,7 +456,6 @@ where
     }
 }
 
-#[cfg(feature = "async")]
 mod asynch {
     #[cfg(not(esp32))]
     use core::{

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -95,7 +95,6 @@ pub enum Error {
     CommandNrExceeded,
 }
 
-#[cfg(any(feature = "embedded-hal", feature = "async"))]
 #[derive(PartialEq)]
 // This enum is used to keep track of the last operation that was performed
 // in an embedded-hal(-async) I2C::transaction. It used to determine whether
@@ -106,7 +105,6 @@ enum LastOpWas {
     None,
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_hal::i2c::Error for Error {
     fn kind(&self) -> embedded_hal::i2c::ErrorKind {
         use embedded_hal::i2c::{ErrorKind, NoAcknowledgeSource};
@@ -241,12 +239,10 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, DM: crate::Mode> embedded_hal::i2c::ErrorType for I2C<'_, T, DM> {
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, DM: crate::Mode> embedded_hal::i2c::I2c for I2C<'_, T, DM>
 where
     T: Instance,
@@ -890,7 +886,6 @@ mod asynch {
         }
     }
 
-    #[cfg(feature = "embedded-hal")]
     impl<'d, T> embedded_hal_async::i2c::I2c for I2C<'d, T, crate::Async>
     where
         T: Instance,

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -2181,7 +2181,6 @@ mod private {
 }
 
 /// Async functionality
-#[cfg(feature = "async")]
 pub mod asynch {
     use super::{Error, I2sRx, I2sTx, RegisterAccess};
     use crate::{

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -62,8 +62,6 @@ use core::{fmt::Formatter, marker::PhantomData, mem::size_of};
 
 use fugit::HertzU32;
 
-#[cfg(feature = "async")]
-use crate::lcd_cam::asynch::LcdDoneFuture;
 use crate::{
     clock::Clocks,
     dma::{
@@ -81,6 +79,7 @@ use crate::{
     },
     gpio::{OutputPin, OutputSignal},
     lcd_cam::{
+        asynch::LcdDoneFuture,
         lcd::{i8080::private::TxPins, ClockMode, DelayMode, Phase, Polarity},
         private::calculate_clkm,
         BitOrder,
@@ -378,7 +377,6 @@ where
     }
 }
 
-#[cfg(feature = "async")]
 impl<'d, CH: DmaChannel, P: TxPins> I8080<'d, CH, P, crate::Async>
 where
     P::Word: Into<u16>,

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -63,7 +63,6 @@ impl<'d> InterruptConfigurable for LcdCam<'d, crate::Blocking> {
     }
 }
 
-#[cfg(feature = "async")]
 impl<'d> LcdCam<'d, crate::Async> {
     /// Creates a new `LcdCam` instance for asynchronous operation.
     pub fn new_async(lcd_cam: impl Peripheral<P = LCD_CAM> + 'd) -> Self {
@@ -118,7 +117,6 @@ pub enum ByteOrder {
 }
 
 #[doc(hidden)]
-#[cfg(feature = "async")]
 pub mod asynch {
     use core::task::Poll;
 
@@ -173,13 +171,11 @@ pub mod asynch {
 }
 
 mod private {
-    #[cfg(feature = "async")]
     pub(crate) struct Instance;
 
     // NOTE: the LCD_CAM interrupt registers are shared between LCD and Camera and
     // this is only implemented for the LCD side, when the Camera is implemented a
     // CriticalSection will be needed to protect these shared registers.
-    #[cfg(feature = "async")]
     impl Instance {
         pub(crate) fn listen_lcd_done() {
             let lcd_cam = unsafe { crate::peripherals::LCD_CAM::steal() };

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -294,7 +294,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 mod ehal1 {
     use embedded_hal::pwm::{self, ErrorKind, ErrorType, SetDutyCycle};
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -130,8 +130,7 @@
 //! ## Feature Flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
-#![allow(asm_sub_register)]
-#![cfg_attr(feature = "async", allow(stable_features, async_fn_in_trait))]
+#![allow(asm_sub_register, async_fn_in_trait, stable_features)]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]
 #![deny(missing_docs, rust_2018_idioms)]
 #![no_std]

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -414,7 +414,6 @@ impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> embedded_hal_02::PwmPin
     for PwmPin<'d, Pin, PWM, OP, IS_A>
 {

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -448,7 +448,6 @@ impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> emb
 }
 
 /// Implement no error type for the PwmPin because the method are infallible
-#[cfg(feature = "embedded-hal")]
 impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
     embedded_hal::pwm::ErrorType for PwmPin<'d, Pin, PWM, OP, IS_A>
 {
@@ -456,7 +455,6 @@ impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
 }
 
 /// Implement the trait SetDutyCycle for PwmPin
-#[cfg(feature = "embedded-hal")]
 impl<'d, Pin: OutputPin, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
     embedded_hal::pwm::SetDutyCycle for PwmPin<'d, Pin, PWM, OP, IS_A>
 {

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -132,7 +132,6 @@ unsafe impl<'d> UsbPeripheral for Usb<'d> {
     }
 }
 /// Async functionality
-#[cfg(feature = "async")]
 pub mod asynch {
     use embassy_usb_driver::{
         EndpointAddress,

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1660,7 +1660,6 @@ where
 }
 
 #[doc(hidden)]
-#[cfg(feature = "async")]
 pub mod asynch {
     use core::task::Poll;
 
@@ -2045,7 +2044,6 @@ mod private {
             reg_block.rx_cfg0().read().rx_eof_gen_sel().bit_is_set()
         }
 
-        #[cfg(feature = "async")]
         pub fn listen_tx_done() {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2053,7 +2051,6 @@ mod private {
             reg_block.int_ena().modify(|_, w| w.tx_eof().set_bit());
         }
 
-        #[cfg(feature = "async")]
         pub fn unlisten_tx_done() {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2061,7 +2058,6 @@ mod private {
             reg_block.int_ena().modify(|_, w| w.tx_eof().clear_bit());
         }
 
-        #[cfg(feature = "async")]
         pub fn is_listening_tx_done() -> bool {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2069,7 +2065,6 @@ mod private {
             reg_block.int_ena().read().tx_eof().bit()
         }
 
-        #[cfg(feature = "async")]
         pub fn is_tx_done_set() -> bool {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2077,7 +2072,6 @@ mod private {
             reg_block.int_raw().read().tx_eof().bit()
         }
 
-        #[cfg(feature = "async")]
         pub fn clear_is_tx_done() {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2312,7 +2306,6 @@ mod private {
                 .bit_is_set()
         }
 
-        #[cfg(feature = "async")]
         pub fn listen_tx_done() {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2320,7 +2313,6 @@ mod private {
             reg_block.int_ena().modify(|_, w| w.tx_eof().set_bit());
         }
 
-        #[cfg(feature = "async")]
         pub fn unlisten_tx_done() {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2328,7 +2320,6 @@ mod private {
             reg_block.int_ena().modify(|_, w| w.tx_eof().clear_bit());
         }
 
-        #[cfg(feature = "async")]
         pub fn is_listening_tx_done() -> bool {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2336,7 +2327,6 @@ mod private {
             reg_block.int_ena().read().tx_eof().bit()
         }
 
-        #[cfg(feature = "async")]
         pub fn is_tx_done_set() -> bool {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };
@@ -2344,7 +2334,6 @@ mod private {
             reg_block.int_raw().read().tx_eof().bit()
         }
 
-        #[cfg(feature = "async")]
         pub fn clear_is_tx_done() {
             let reg_block: crate::peripherals::PARL_IO =
                 unsafe { crate::peripherals::PARL_IO::steal() };

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -208,7 +208,6 @@ pub struct RxChannelConfig {
 
 pub use impl_for_chip::{ChannelCreator, Rmt};
 
-#[cfg(feature = "async")]
 use self::asynch::{RxChannelAsync, TxChannelAsync};
 
 impl<'d, M> Rmt<'d, M>
@@ -288,7 +287,6 @@ impl<'d> InterruptConfigurable for Rmt<'d, crate::Blocking> {
     }
 }
 
-#[cfg(feature = "async")]
 impl<'d> Rmt<'d, crate::Async> {
     /// Create a new RMT instance
     pub fn new_async(
@@ -334,7 +332,6 @@ where
 }
 
 /// Creates a TX channel in async mode
-#[cfg(feature = "async")]
 pub trait TxChannelCreatorAsync<'d, T, P>
 where
     P: OutputPin,
@@ -412,7 +409,6 @@ where
 }
 
 /// Creates a RX channel in async mode
-#[cfg(feature = "async")]
 pub trait RxChannelCreatorAsync<'d, T, P>
 where
     P: InputPin,
@@ -601,7 +597,6 @@ macro_rules! impl_tx_channel_creator {
 
         impl $crate::rmt::TxChannel for $crate::rmt::Channel<$crate::Blocking, $channel> {}
 
-        #[cfg(feature = "async")]
         impl<'d, P> $crate::rmt::TxChannelCreatorAsync<'d, $crate::rmt::Channel<$crate::Async, $channel>, P>
             for ChannelCreator<$crate::Async, $channel>
         where
@@ -609,7 +604,6 @@ macro_rules! impl_tx_channel_creator {
         {
         }
 
-        #[cfg(feature = "async")]
         impl $crate::rmt::asynch::TxChannelAsync for $crate::rmt::Channel<$crate::Async, $channel> {}
     };
 }
@@ -625,7 +619,6 @@ macro_rules! impl_rx_channel_creator {
 
         impl $crate::rmt::RxChannel for $crate::rmt::Channel<$crate::Blocking, $channel> {}
 
-        #[cfg(feature = "async")]
         impl<'d, P> $crate::rmt::RxChannelCreatorAsync<'d, $crate::rmt::Channel<$crate::Async, $channel>, P>
         for ChannelCreator<$crate::Async, $channel>
         where
@@ -633,7 +626,6 @@ macro_rules! impl_rx_channel_creator {
         {
         }
 
-        #[cfg(feature = "async")]
         impl $crate::rmt::asynch::RxChannelAsync for $crate::rmt::Channel<$crate::Async, $channel> {}
     };
 }
@@ -1132,7 +1124,6 @@ pub trait RxChannel: private::RxChannelInternal<crate::Blocking> {
 }
 
 /// Async functionality
-#[cfg(feature = "async")]
 pub mod asynch {
     use core::{
         pin::Pin,

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -93,7 +93,6 @@ impl Rng {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::rng::Read for Rng {
     type Error = core::convert::Infallible;
 
@@ -219,7 +218,6 @@ impl<'d> Drop for Trng<'d> {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::rng::Read for Trng<'_> {
     type Error = core::convert::Infallible;
     /// Fills the provided buffer with random bytes.

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -64,7 +64,6 @@ impl<'d> InterruptConfigurable for Rsa<'d, crate::Blocking> {
     }
 }
 
-#[cfg(feature = "async")]
 impl<'d> Rsa<'d, crate::Async> {
     /// Create a new instance in [crate::Blocking] mode.
     pub fn new_async(rsa: impl Peripheral<P = RSA> + 'd) -> Self {
@@ -365,7 +364,6 @@ where
 }
 
 /// Async functionality
-#[cfg(feature = "async")]
 pub(crate) mod asynch {
     use core::task::Poll;
 

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -854,14 +854,12 @@ impl Rwdt {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::watchdog::WatchdogDisable for Rwdt {
     fn disable(&mut self) {
         self.disable();
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::watchdog::WatchdogEnable for Rwdt {
     type Time = MicrosDurationU64;
 
@@ -873,7 +871,6 @@ impl embedded_hal_02::watchdog::WatchdogEnable for Rwdt {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::watchdog::Watchdog for Rwdt {
     fn feed(&mut self) {
         self.feed();
@@ -935,10 +932,7 @@ impl Default for Swd {
     }
 }
 
-#[cfg(all(
-    any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3),
-    feature = "embedded-hal-02"
-))]
+#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
 impl embedded_hal_02::watchdog::WatchdogDisable for Swd {
     fn disable(&mut self) {
         self.disable();

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -900,7 +900,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::spi::FullDuplex<u8> for Spi<'_, T, FullDuplexMode>
 where
     T: Instance,
@@ -916,7 +915,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::spi::Transfer<u8> for Spi<'_, T, FullDuplexMode>
 where
     T: Instance,
@@ -928,7 +926,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::spi::Write<u8> for Spi<'_, T, FullDuplexMode>
 where
     T: Instance,
@@ -1899,7 +1896,6 @@ mod dma {
         }
     }
 
-    #[cfg(feature = "embedded-hal-02")]
     impl<'d, T, C> embedded_hal_02::blocking::spi::Transfer<u8>
         for SpiDmaBus<'d, T, C, FullDuplexMode, crate::Blocking>
     where
@@ -1915,7 +1911,6 @@ mod dma {
         }
     }
 
-    #[cfg(feature = "embedded-hal-02")]
     impl<'d, T, C> embedded_hal_02::blocking::spi::Write<u8>
         for SpiDmaBus<'d, T, C, FullDuplexMode, crate::Blocking>
     where

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -16,9 +16,8 @@
 //!
 //! - Use the [`FullDuplex`](embedded_hal_02::spi::FullDuplex) trait to
 //!   read/write single bytes at a time,
-//! - Use the [`SpiBus`](embedded_hal::spi::SpiBus) trait (requires the
-//!   "embedded-hal" feature) and its associated functions to initiate
-//!   transactions with simultaneous reads and writes, or
+//! - Use the [`SpiBus`](embedded_hal::spi::SpiBus) trait and its associated
+//!   functions to initiate transactions with simultaneous reads and writes, or
 //! - Use the `ExclusiveDevice` struct from [`embedded-hal-bus`] or `SpiDevice`
 //!   from [`embassy-embedded-hal`].
 //!
@@ -2158,7 +2157,6 @@ mod dma {
         }
     }
 
-    #[cfg(feature = "embedded-hal")]
     mod ehal1 {
         use embedded_hal::spi::{ErrorType, SpiBus};
 
@@ -2205,7 +2203,6 @@ mod dma {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 mod ehal1 {
     use embedded_hal::spi::SpiBus;
     use embedded_hal_nb::spi::FullDuplex;

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -944,12 +944,11 @@ mod dma {
     };
 
     use super::*;
-    #[cfg(feature = "async")]
-    use crate::dma::asynch::{DmaRxFuture, DmaTxFuture};
     #[cfg(spi3)]
     use crate::dma::Spi3Peripheral;
     use crate::{
         dma::{
+            asynch::{DmaRxFuture, DmaTxFuture},
             Channel,
             DmaChannel,
             DmaRxBuf,
@@ -1233,7 +1232,6 @@ mod dma {
         }
     }
 
-    #[cfg(feature = "async")]
     impl<'d, T, C, D, Buf> SpiDmaTransfer<'d, T, C, D, crate::Async, Buf>
     where
         T: Instance,
@@ -1926,7 +1924,6 @@ mod dma {
     }
 
     /// Async functionality
-    #[cfg(feature = "async")]
     mod asynch {
         use core::{cmp::min, mem::take};
 

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -39,7 +39,6 @@ impl From<DmaError> for Error {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_hal::spi::Error for Error {
     fn kind(&self) -> embedded_hal::spi::ErrorKind {
         embedded_hal::spi::ErrorKind::Other

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -232,7 +232,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<'d, T> embedded_hal::delay::DelayNs for OneShotTimer<'d, T>
 where
     T: Timer,

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -212,7 +212,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, T, UXX> embedded_hal_02::blocking::delay::DelayMs<UXX> for OneShotTimer<'d, T>
 where
     T: Timer,
@@ -223,7 +222,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, T, UXX> embedded_hal_02::blocking::delay::DelayUs<UXX> for OneShotTimer<'d, T>
 where
     T: Timer,
@@ -329,7 +327,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, T> embedded_hal_02::timer::CountDown for PeriodicTimer<'d, T>
 where
     T: Timer,
@@ -348,7 +345,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, T> embedded_hal_02::timer::Cancel for PeriodicTimer<'d, T>
 where
     T: Timer,
@@ -360,7 +356,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, T> embedded_hal_02::timer::Periodic for PeriodicTimer<'d, T> where T: Timer {}
 
 /// A type-erased timer

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -1013,7 +1013,6 @@ static CONF_LOCK: LockState = LockState::new();
 static INT_ENA_LOCK: LockState = LockState::new();
 
 // Async functionality of the system timer.
-#[cfg(feature = "async")]
 mod asynch {
     use core::{
         pin::Pin,

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -820,7 +820,6 @@ where
     (1_000_000 * micros / period as u64) as u64
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T, DM> embedded_hal_02::timer::CountDown for Timer<T, DM>
 where
     T: Instance + super::Timer,
@@ -845,7 +844,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T, DM> embedded_hal_02::timer::Cancel for Timer<T, DM>
 where
     T: Instance + super::Timer,
@@ -866,7 +864,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T, DM> embedded_hal_02::timer::Periodic for Timer<T, DM>
 where
     T: Instance + super::Timer,
@@ -1033,7 +1030,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<TG, DM> embedded_hal_02::watchdog::WatchdogDisable for Wdt<TG, DM>
 where
     TG: TimerGroupInstance,
@@ -1044,7 +1040,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<TG, DM> embedded_hal_02::watchdog::WatchdogEnable for Wdt<TG, DM>
 where
     TG: TimerGroupInstance,
@@ -1061,7 +1056,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<TG, DM> embedded_hal_02::watchdog::Watchdog for Wdt<TG, DM>
 where
     TG: TimerGroupInstance,

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -34,11 +34,12 @@ use crate::{
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{RTC_CNTL, SENS, TOUCH},
     private::{Internal, Sealed},
+    rtc_cntl::Rtc,
+    Async,
     Blocking,
+    InterruptConfigurable,
     Mode,
 };
-#[cfg(feature = "async")]
-use crate::{rtc_cntl::Rtc, Async, InterruptConfigurable};
 
 /// A marker trait describing the mode the touch pad is set to.
 pub trait TouchMode: Sealed {}
@@ -271,7 +272,6 @@ impl<'d> Touch<'d, Continous, Blocking> {
         }
     }
 }
-#[cfg(feature = "async")]
 impl<'d> Touch<'d, Continous, Async> {
     /// Initializes the touch peripheral in continous async mode and returns
     /// this marker struct.
@@ -294,6 +294,7 @@ impl<'d> Touch<'d, Continous, Async> {
     ///
     /// ```rust, no_run
     #[doc = crate::before_snippet!()]
+    /// # use esp_hal::rtc_cntl::Rtc;
     /// # use esp_hal::touch::{Touch, TouchConfig};
     /// let mut rtc = Rtc::new(peripherals.LPWR);
     /// let touch = Touch::async_mode(peripherals.TOUCH, &mut rtc, None);
@@ -493,7 +494,6 @@ fn internal_disable_interrupt(touch_nr: u8) {
     }
 }
 
-#[cfg(feature = "async")]
 fn internal_disable_interrupts() {
     let sens = unsafe { &*SENS::ptr() };
     sens.sar_touch_enable()
@@ -523,7 +523,6 @@ fn internal_is_interrupt_set(touch_nr: u8) -> bool {
     internal_pins_touched() & (1 << touch_nr) != 0
 }
 
-#[cfg(feature = "async")]
 mod asynch {
     use core::{
         sync::atomic::{AtomicU16, Ordering},

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -201,7 +201,6 @@ impl core::fmt::Display for ErrorKind {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl From<ErrorKind> for embedded_hal_02::can::ErrorKind {
     fn from(value: ErrorKind) -> Self {
         match value {
@@ -216,7 +215,6 @@ impl From<ErrorKind> for embedded_hal_02::can::ErrorKind {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::can::Error for ErrorKind {
     fn kind(&self) -> embedded_hal_02::can::ErrorKind {
         (*self).into()
@@ -297,14 +295,12 @@ impl StandardId {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl From<StandardId> for embedded_hal_02::can::StandardId {
     fn from(value: StandardId) -> Self {
         embedded_hal_02::can::StandardId::new(value.as_raw()).unwrap()
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl From<embedded_hal_02::can::StandardId> for StandardId {
     fn from(value: embedded_hal_02::can::StandardId) -> Self {
         StandardId::new(value.as_raw()).unwrap()
@@ -372,14 +368,12 @@ impl ExtendedId {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl From<ExtendedId> for embedded_hal_02::can::ExtendedId {
     fn from(value: ExtendedId) -> Self {
         embedded_hal_02::can::ExtendedId::new(value.0).unwrap()
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl From<embedded_hal_02::can::ExtendedId> for ExtendedId {
     fn from(value: embedded_hal_02::can::ExtendedId) -> Self {
         ExtendedId::new(value.as_raw()).unwrap()
@@ -423,7 +417,6 @@ impl From<ExtendedId> for Id {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl From<Id> for embedded_hal_02::can::Id {
     fn from(value: Id) -> Self {
         match value {
@@ -433,7 +426,6 @@ impl From<Id> for embedded_hal_02::can::Id {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl From<embedded_hal_02::can::Id> for Id {
     fn from(value: embedded_hal_02::can::Id) -> Self {
         match value {
@@ -556,7 +548,6 @@ impl EspTwaiFrame {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::can::Frame for EspTwaiFrame {
     fn new(id: impl Into<embedded_hal_02::can::Id>, data: &[u8]) -> Option<Self> {
         let id: embedded_hal_02::can::Id = id.into();
@@ -1190,7 +1181,6 @@ pub enum EspTwaiError {
     EmbeddedHAL(ErrorKind),
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::can::Error for EspTwaiError {
     fn kind(&self) -> embedded_hal_02::can::ErrorKind {
         match self {
@@ -1242,7 +1232,6 @@ unsafe fn copy_to_data_register(dest: *mut u32, src: &[u8]) {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<'d, T, DM> embedded_hal_02::can::Can for Twai<'d, T, DM>
 where
     T: OperationInstance,

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -943,7 +943,6 @@ where
     }
 }
 
-#[cfg(feature = "async")]
 impl<'d, T> TwaiConfiguration<'d, T, crate::Async>
 where
     T: Instance,
@@ -1283,7 +1282,7 @@ pub trait Instance: crate::private::Sealed {
     const OUTPUT_SIGNAL: OutputSignal;
     /// The interrupt associated with this TWAI instance.
     const INTERRUPT: crate::peripherals::Interrupt;
-    #[cfg(feature = "async")]
+
     /// Provides an asynchronous interrupt handler for TWAI instance.
     fn async_handler() -> InterruptHandler;
 
@@ -1303,7 +1302,6 @@ pub trait Instance: crate::private::Sealed {
 /// An extension of the `Instance` trait that provides additional operations
 /// for managing and interacting with the TWAI peripheral.
 pub trait OperationInstance: Instance {
-    #[cfg(feature = "async")]
     /// Returns a reference to the asynchronous state for this TWAI instance.
     fn async_state() -> &'static asynch::TwaiAsyncState {
         &asynch::TWAI_STATE[Self::NUMBER]
@@ -1480,7 +1478,6 @@ impl Instance for crate::peripherals::TWAI0 {
 
     const INTERRUPT: crate::peripherals::Interrupt = crate::peripherals::Interrupt::TWAI0;
 
-    #[cfg(feature = "async")]
     fn async_handler() -> InterruptHandler {
         asynch::twai0
     }
@@ -1528,7 +1525,6 @@ impl Instance for crate::peripherals::TWAI0 {
 
     const INTERRUPT: crate::peripherals::Interrupt = crate::peripherals::Interrupt::TWAI0;
 
-    #[cfg(feature = "async")]
     fn async_handler() -> InterruptHandler {
         asynch::twai0
     }
@@ -1576,7 +1572,6 @@ impl Instance for crate::peripherals::TWAI1 {
 
     const INTERRUPT: crate::peripherals::Interrupt = crate::peripherals::Interrupt::TWAI1;
 
-    #[cfg(feature = "async")]
     fn async_handler() -> InterruptHandler {
         asynch::twai1
     }
@@ -1614,7 +1609,6 @@ impl Instance for crate::peripherals::TWAI1 {
 #[cfg(esp32c6)]
 impl OperationInstance for crate::peripherals::TWAI1 {}
 
-#[cfg(feature = "async")]
 mod asynch {
     use core::{future::poll_fn, task::Poll};
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -221,7 +221,6 @@ impl embedded_hal_02::can::Error for ErrorKind {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl From<ErrorKind> for embedded_can::ErrorKind {
     fn from(value: ErrorKind) -> Self {
         match value {
@@ -236,7 +235,6 @@ impl From<ErrorKind> for embedded_can::ErrorKind {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_can::Error for ErrorKind {
     fn kind(&self) -> embedded_can::ErrorKind {
         (*self).into()
@@ -307,14 +305,12 @@ impl From<embedded_hal_02::can::StandardId> for StandardId {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl From<StandardId> for embedded_can::StandardId {
     fn from(value: StandardId) -> Self {
         embedded_can::StandardId::new(value.as_raw()).unwrap()
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl From<embedded_can::StandardId> for StandardId {
     fn from(value: embedded_can::StandardId) -> Self {
         StandardId::new(value.as_raw()).unwrap()
@@ -380,14 +376,12 @@ impl From<embedded_hal_02::can::ExtendedId> for ExtendedId {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl From<ExtendedId> for embedded_can::ExtendedId {
     fn from(value: ExtendedId) -> Self {
         embedded_can::ExtendedId::new(value.0).unwrap()
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl From<embedded_can::ExtendedId> for ExtendedId {
     fn from(value: embedded_can::ExtendedId) -> Self {
         ExtendedId::new(value.as_raw()).unwrap()
@@ -435,7 +429,6 @@ impl From<embedded_hal_02::can::Id> for Id {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl From<Id> for embedded_can::Id {
     fn from(value: Id) -> Self {
         match value {
@@ -445,7 +438,6 @@ impl From<Id> for embedded_can::Id {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl From<embedded_can::Id> for Id {
     fn from(value: embedded_can::Id) -> Self {
         match value {
@@ -588,7 +580,6 @@ impl embedded_hal_02::can::Frame for EspTwaiFrame {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_can::Frame for EspTwaiFrame {
     fn new(id: impl Into<embedded_can::Id>, data: &[u8]) -> Option<Self> {
         let id: embedded_can::Id = id.into();
@@ -1190,7 +1181,6 @@ impl embedded_hal_02::can::Error for EspTwaiError {
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_can::Error for EspTwaiError {
     fn kind(&self) -> embedded_can::ErrorKind {
         match self {
@@ -1256,7 +1246,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<'d, T, DM> embedded_can::nb::Can for Twai<'d, T, DM>
 where
     T: OperationInstance,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1662,7 +1662,6 @@ impl_instance!(UART1, 1, U1TXD, U1RXD, U1CTS, U1RTS, Uart1);
 #[cfg(uart2)]
 impl_instance!(UART2, 2, U2TXD, U2RXD, U2CTS, U2RTS, Uart2);
 
-#[cfg(feature = "ufmt")]
 impl<T, M> ufmt_write::uWrite for Uart<'_, T, M>
 where
     T: Instance,
@@ -1681,7 +1680,6 @@ where
     }
 }
 
-#[cfg(feature = "ufmt")]
 impl<T, M> ufmt_write::uWrite for UartTx<'_, T, M>
 where
     T: Instance,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -261,7 +261,6 @@ impl embedded_hal_nb::serial::Error for Error {
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl embedded_io::Error for Error {
     fn kind(&self) -> embedded_io::ErrorKind {
         embedded_io::ErrorKind::Other
@@ -1833,22 +1832,18 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::ErrorType for Uart<'_, T, M> {
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::ErrorType for UartTx<'_, T, M> {
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::ErrorType for UartRx<'_, T, M> {
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::Read for Uart<'_, T, M>
 where
     T: Instance,
@@ -1859,7 +1854,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::Read for UartRx<'_, T, M>
 where
     T: Instance,
@@ -1878,7 +1872,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::ReadReady for Uart<'_, T, M>
 where
     T: Instance,
@@ -1889,7 +1882,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::ReadReady for UartRx<'_, T, M>
 where
     T: Instance,
@@ -1900,7 +1892,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::Write for Uart<'_, T, M>
 where
     T: Instance,
@@ -1915,7 +1906,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<T, M> embedded_io::Write for UartTx<'_, T, M>
 where
     T: Instance,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -228,7 +228,6 @@ pub enum Error {
     InvalidArgument,
 
     /// The RX FIFO overflowed.
-    #[cfg(feature = "async")]
     RxFifoOvf,
 
     /// A glitch was detected on the RX line.
@@ -236,14 +235,12 @@ pub enum Error {
     /// This error occurs when an unexpected or erroneous signal (glitch) is
     /// detected on the UART RX line, which could lead to incorrect data
     /// reception.
-    #[cfg(feature = "async")]
     RxGlitchDetected,
 
     /// A framing error was detected on the RX line.
     ///
     /// This error occurs when the received data does not conform to the
     /// expected UART frame format.
-    #[cfg(feature = "async")]
     RxFrameError,
 
     /// A parity error was detected on the RX line.
@@ -251,7 +248,6 @@ pub enum Error {
     /// This error occurs when the parity bit in the received data does not
     /// match the expected parity configuration.
     /// with the `async` feature.
-    #[cfg(feature = "async")]
     RxParityError,
 }
 
@@ -1928,7 +1924,6 @@ where
     }
 }
 
-#[cfg(feature = "async")]
 mod asynch {
     use core::task::Poll;
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1718,7 +1718,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T, M> embedded_hal_02::serial::Write<u8> for Uart<'_, T, M>
 where
     T: Instance,
@@ -1735,7 +1734,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T, M> embedded_hal_02::serial::Write<u8> for UartTx<'_, T, M>
 where
     T: Instance,
@@ -1752,7 +1750,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T, M> embedded_hal_02::serial::Read<u8> for Uart<'_, T, M>
 where
     T: Instance,
@@ -1765,7 +1762,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<T, M> embedded_hal_02::serial::Read<u8> for UartRx<'_, T, M>
 where
     T: Instance,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -255,7 +255,6 @@ pub enum Error {
     RxParityError,
 }
 
-#[cfg(feature = "embedded-hal")]
 impl embedded_hal_nb::serial::Error for Error {
     fn kind(&self) -> embedded_hal_nb::serial::ErrorKind {
         embedded_hal_nb::serial::ErrorKind::Other
@@ -1774,22 +1773,18 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, M> embedded_hal_nb::serial::ErrorType for Uart<'_, T, M> {
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, M> embedded_hal_nb::serial::ErrorType for UartTx<'_, T, M> {
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, M> embedded_hal_nb::serial::ErrorType for UartRx<'_, T, M> {
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, M> embedded_hal_nb::serial::Read for Uart<'_, T, M>
 where
     T: Instance,
@@ -1800,7 +1795,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, M> embedded_hal_nb::serial::Read for UartRx<'_, T, M>
 where
     T: Instance,
@@ -1811,7 +1805,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, M> embedded_hal_nb::serial::Write for Uart<'_, T, M>
 where
     T: Instance,
@@ -1826,7 +1819,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<T, M> embedded_hal_nb::serial::Write for UartTx<'_, T, M>
 where
     T: Instance,

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -652,7 +652,6 @@ where
     }
 }
 
-#[cfg(feature = "async")]
 mod asynch {
     use core::{marker::PhantomData, task::Poll};
 

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -463,7 +463,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<M> embedded_hal_02::serial::Read<u8> for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -475,7 +474,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<M> embedded_hal_02::serial::Read<u8> for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -487,7 +485,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<M> embedded_hal_02::serial::Write<u8> for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -503,7 +500,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
 impl<M> embedded_hal_02::serial::Write<u8> for UsbSerialJtagTx<'_, M>
 where
     M: Mode,

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -515,7 +515,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<M> embedded_hal_nb::serial::ErrorType for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -523,7 +522,6 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<M> embedded_hal_nb::serial::ErrorType for UsbSerialJtagTx<'_, M>
 where
     M: Mode,
@@ -531,7 +529,6 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<M> embedded_hal_nb::serial::ErrorType for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -539,7 +536,6 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<M> embedded_hal_nb::serial::Read for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -549,7 +545,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<M> embedded_hal_nb::serial::Read for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -559,7 +554,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<M> embedded_hal_nb::serial::Write for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -573,7 +567,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-hal")]
 impl<M> embedded_hal_nb::serial::Write for UsbSerialJtagTx<'_, M>
 where
     M: Mode,

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -580,7 +580,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<M> embedded_io::ErrorType for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -588,7 +587,6 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-io")]
 impl<M> embedded_io::ErrorType for UsbSerialJtagTx<'_, M>
 where
     M: Mode,
@@ -596,7 +594,6 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-io")]
 impl<M> embedded_io::ErrorType for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -604,7 +601,6 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "embedded-io")]
 impl<M> embedded_io::Read for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -614,7 +610,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<M> embedded_io::Read for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -629,7 +624,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<M> embedded_io::Write for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -643,7 +637,6 @@ where
     }
 }
 
-#[cfg(feature = "embedded-io")]
 impl<M> embedded_io::Write for UsbSerialJtagTx<'_, M>
 where
     M: Mode,

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -425,7 +425,6 @@ where
     }
 }
 
-#[cfg(feature = "ufmt")]
 impl<M> ufmt_write::uWrite for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -443,7 +442,6 @@ where
     }
 }
 
-#[cfg(feature = "ufmt")]
 impl<M> ufmt_write::uWrite for UsbSerialJtagTx<'_, M>
 where
     M: Mode,

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -103,7 +103,6 @@ async = [
   "dep:embassy-futures",
   "dep:embedded-io-async",
   "dep:esp-hal-embassy",
-  "esp-hal/async",
 ]
 
 embassy-net = ["dep:embassy-net-driver", "async"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,7 @@ embassy-net = { version = "0.4.0", features = [ "tcp", "udp", "dhcpv4", "medium-
 embassy-sync        = "0.6.0"
 embassy-time        = "0.3.1"
 embassy-time-driver = { version = "0.1.0", optional = true }
-embassy-usb         = { version = "0.2.0", default-features = false, optional = true }
+embassy-usb         = { version = "0.2.0", default-features = false }
 embedded-can        = "0.4.1"
 embedded-graphics   = "0.8.1"
 embedded-hal        = "1.0.0"
@@ -68,8 +68,6 @@ esp32s2 = ["esp-hal/esp32s2", "esp-backtrace/esp32s2", "esp-hal-embassy?/esp32s2
 esp32s3 = ["esp-hal/esp32s3", "esp-backtrace/esp32s3", "esp-hal-embassy?/esp32s3", "esp-println/esp32s3", "esp-storage?/esp32s3", "esp-wifi?/esp32s3", "esp-hal-smartled/esp32s3"]
 
 esp-wifi = ["dep:esp-wifi"]
-
-async = ["esp-hal/async", "embassy-usb"]
 
 embassy                = ["dep:esp-hal-embassy"]
 embassy-generic-timers = ["embassy-time/generic-queue-8"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -71,10 +71,7 @@ esp-wifi = ["dep:esp-wifi"]
 
 async = ["esp-hal/async", "embassy-usb"]
 
-embedded-hal = ["esp-hal/embedded-hal"]
-
-embassy = ["dep:esp-hal-embassy"]
-
+embassy                = ["dep:esp-hal-embassy"]
 embassy-generic-timers = ["embassy-time/generic-queue-8"]
 
 opsram-2m = ["esp-hal/opsram-2m"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -71,7 +71,6 @@ esp-wifi = ["dep:esp-wifi"]
 
 async = ["esp-hal/async", "embassy-usb"]
 
-embedded-hal-02 = ["esp-hal/embedded-hal-02"]
 embedded-hal = ["esp-hal/embedded-hal"]
 
 embassy = ["dep:esp-hal-embassy"]

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -11,7 +11,7 @@
 //! - SCL => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -12,7 +12,7 @@
 //!
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -12,7 +12,7 @@
 //! - DIN  =>  GPIO5
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -26,7 +26,7 @@
 //! | XSMT  | +3V3            |
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -5,7 +5,7 @@
 //! - Data pins => GPIO1, GPIO2, GPIO3, and GPIO4.
 
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -9,7 +9,7 @@
 //! You can use a logic analyzer to see how the pins are used.
 
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -4,7 +4,7 @@
 //! - Connect GPIO4 and GPIO5
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -6,7 +6,7 @@
 //! - generated pulses => GPIO4
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -4,7 +4,7 @@
 //! writing to and reading from UART.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -13,7 +13,7 @@
 //! CS   => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_touch.rs
+++ b/examples/src/bin/embassy_touch.rs
@@ -7,7 +7,7 @@
 //! pad on a PCB).
 
 //% CHIPS: esp32
-//% FEATURES: async embassy esp-hal-embassy/integrated-timers
+//% FEATURES: embassy esp-hal-embassy/integrated-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -15,7 +15,7 @@
 //! - RX => GPIO2
 
 //% CHIPS: esp32c3 esp32c6 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -7,7 +7,7 @@
 //! - DM => GPIO19
 
 //% CHIPS: esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_usb_serial_jtag.rs
+++ b/examples/src/bin/embassy_usb_serial_jtag.rs
@@ -3,7 +3,7 @@
 //! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
 
 //% CHIPS: esp32c3 esp32c6 esp32h2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_wait.rs
+++ b/examples/src/bin/embassy_wait.rs
@@ -3,7 +3,7 @@
 //! This is an example of asynchronously `Wait`ing for a pin state (boot button) to change.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/i2c_display.rs
+++ b/examples/src/bin/i2c_display.rs
@@ -8,7 +8,6 @@
 //! - SCL => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -8,7 +8,7 @@
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 
-//% FEATURES: async embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -11,7 +11,7 @@
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 
-//% FEATURES: async embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -10,7 +10,7 @@
 //! Because of the huge task-arena size configured this won't work on ESP32-S2 and ESP32-C2
 //!
 
-//% FEATURES: async embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s3 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_ble.rs
+++ b/examples/src/bin/wifi_embassy_ble.rs
@@ -4,7 +4,7 @@
 //! - offers one service with three characteristics (one is read/write, one is write only, one is read/write/notify)
 //! - pressing the boot-button on a dev-board will send a notification if it is subscribed
 
-//% FEATURES: async embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/ble
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/ble
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -7,7 +7,7 @@
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 
-//% FEATURES: async embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_esp_now.rs
+++ b/examples/src/bin/wifi_embassy_esp_now.rs
@@ -4,7 +4,7 @@
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 
-//% FEATURES: async embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/wifi_embassy_esp_now_duplex.rs
@@ -4,7 +4,7 @@
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 
-//% FEATURES: async embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -180,7 +180,7 @@ embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = [
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-hal-nb    = { version = "1.0.0", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
-esp-hal            = { path = "../esp-hal", features = ["defmt", "digest", "embedded-hal", "embedded-hal-02"], optional = true }
+esp-hal            = { path = "../esp-hal", features = ["defmt", "digest", "embedded-hal"], optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 portable-atomic    = "1.6.0"
 static_cell        = { version = "2.1.0", features = ["nightly"] }

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -177,7 +177,7 @@ embassy-sync       = "0.6.0"
 embassy-time       = { version = "0.3.1" }
 embedded-hal       = "1.0.0"
 embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = ["unproven"] }
-embedded-hal-async = { version = "1.0.0", optional = true }
+embedded-hal-async = "1.0.0"
 embedded-hal-nb    = { version = "1.0.0", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
 esp-hal            = { path = "../esp-hal", features = ["defmt", "digest"], optional = true }
@@ -205,7 +205,7 @@ esp-build    = { version = "0.1.0", path = "../esp-build" }
 esp-metadata = { version = "0.3.0", path = "../esp-metadata" }
 
 [features]
-default = ["async", "embassy"]
+default = ["embassy"]
 
 defmt = ["dep:defmt-rtt"]
 
@@ -233,7 +233,6 @@ esp32s3 = [
     "esp-hal-embassy/esp32s3",
 ]
 # Async & Embassy:
-async = ["dep:embedded-hal-async", "esp-hal?/async"]
 embassy = [
     "embedded-test/embassy",
     "embedded-test/external-executor",

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -138,7 +138,7 @@ harness = false
 [[test]]
 name              = "uart_async"
 harness           = false
-required-features = ["async", "embassy"]
+required-features = ["embassy"]
 
 [[test]]
 name    = "uart_tx_rx"
@@ -151,17 +151,17 @@ harness = false
 [[test]]
 name              = "embassy_timers_executors"
 harness           = false
-required-features = ["async", "embassy"]
+required-features = ["embassy"]
 
 [[test]]
 name              = "embassy_interrupt_executor"
 harness           = false
-required-features = ["async", "embassy"]
+required-features = ["embassy"]
 
 [[test]]
 name    = "embassy_interrupt_spi_dma"
 harness = false
-required-features = ["async", "embassy"]
+required-features = ["embassy"]
 
 [[test]]
 name    = "twai"

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -180,7 +180,7 @@ embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = [
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-hal-nb    = { version = "1.0.0", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
-esp-hal            = { path = "../esp-hal", features = ["defmt", "digest", "embedded-hal"], optional = true }
+esp-hal            = { path = "../esp-hal", features = ["defmt", "digest"], optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 portable-atomic    = "1.6.0"
 static_cell        = { version = "2.1.0", features = ["nightly"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -572,7 +572,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                             &[
                                 "-Zbuild-std=core",
                                 &format!("--target={}", chip.lp_target().unwrap()),
-                                &format!("--features={chip},embedded-io,embedded-hal-02"),
+                                &format!("--features={chip},embedded-io"),
                             ],
                         )?;
                     }


### PR DESCRIPTION
I accidentally nuked my branch and had to close #2047, but I believe this should now be in a good state again. See the previous PR for conversation, I believe the review comments have been addressed.

Adding `skip-changelog` again to silence the other packages, but `esp-hal` will have its `CHANGELOG.md` updated still.

Closes #2007