### PR TITLE
Remove AnyInputOnlyPin

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `NoPinType` in favour of `DummyPin`. (#2068)
 - Removed the `async`, `embedded-hal-02`, `embedded-hal`, `embedded-io`, `embedded-io-async`, and `ufmt` features (#2070)
 - Removed the `GpioN` type aliasses. Use `GpioPin<N>` instead. (#2073)
+- Removed `AnyInputOnlyPin` in favour of `AnyPin`. (#2071)
 
 ## [0.20.1] - 2024-08-30
 

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -38,4 +38,6 @@ Instead of manually grabbing peripherals and setting up clocks, you should now c
 
 ## GPIO changes
 
-The `GpioN` type aliasses are no longer available. You can use `GpioPin<N>` instead.
+ - The `GpioN` type aliasses are no longer available. You can use `GpioPin<N>` instead.
+ - The `AnyInputOnlyPin` has been removed. Replace any use with `AnyPin`.
+ - The `NoPinType` has been removed. You can use `DummyPin` in its place.

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -25,8 +25,7 @@
 //! - [Input] pins can be used as digital inputs.
 //! - [Output] and [OutputOpenDrain] pins can be used as digital outputs.
 //! - [Flex] pin is a pin that can be used as an input and output pin.
-//! - [AnyPin] and [AnyInputOnlyPin] are type-erased GPIO pins with support for
-//!   inverted signalling.
+//! - [AnyPin] is a type-erased GPIO pin with support for inverted signalling.
 //! - [DummyPin] is a useful for cases where peripheral driver requires a pin,
 //!   but real pin cannot be used.
 //!
@@ -77,7 +76,7 @@ pub(crate) use crate::{touch_common, touch_into};
 mod any_pin;
 mod dummy_pin;
 
-pub use any_pin::{AnyInputOnlyPin, AnyPin};
+pub use any_pin::AnyPin;
 pub use dummy_pin::DummyPin;
 
 #[cfg(soc_etm)]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

I believe only the ESP32 has input-only GPIOs. I don't feel justified to keep the type around just for them. While compile time errors are nice, we can probably tolerate panicking here instead.
