### PR TITLE
Build examples in debug mode

### DIFF
--- a/.github/actions/check-esp-hal/action.yml
+++ b/.github/actions/check-esp-hal/action.yml
@@ -58,4 +58,4 @@ runs:
         	esp-hal
     - name: Build (examples)
       shell: bash
-      run: cargo +${{ inputs.toolchain }} xtask build-examples esp-hal ${{ inputs.device }}
+      run: cargo +${{ inputs.toolchain }} xtask build-examples esp-hal ${{ inputs.device }} --debug

--- a/.github/actions/check-esp-hal/action.yml
+++ b/.github/actions/check-esp-hal/action.yml
@@ -57,5 +57,7 @@ runs:
         	--target=${{ inputs.target }} \
         	esp-hal
     - name: Build (examples)
+      env:
+        CI: 1
       shell: bash
       run: cargo +${{ inputs.toolchain }} xtask build-examples esp-hal ${{ inputs.device }} --debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           cargo xtask build-package --features=esp32c3,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
           cargo xtask build-package --features=esp32c6,wifi,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
           cargo xtask build-package --features=esp32h2,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
-      
+
         # Verify the MSRV for all Xtensa chips:
       - name: msrv Xtensa (esp-hal)
         run: |

--- a/esp-storage/build.rs
+++ b/esp-storage/build.rs
@@ -6,14 +6,14 @@ fn main() -> Result<(), String> {
 
     if cfg!(feature = "esp32") {
         match std::env::var("OPT_LEVEL") {
-            Ok(level) => {
+            Ok(level) if std::env::var("CI").is_err() => {
                 if level != "2" && level != "3" {
                     Err(format!("Building esp-storage for ESP32 needs optimization level 2 or 3 - yours is {}. See https://github.com/esp-rs/esp-storage", level))
                 } else {
                     Ok(())
                 }
             }
-            Err(_err) => Ok(()),
+            _ => Ok(()),
         }
     } else {
         Ok(())

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -8,4 +8,12 @@ fn main() {
     if cfg!(feature = "esp-wifi") {
         println!("cargo::rustc-link-arg=-Trom_functions.x");
     }
+
+    // Allow building examples in CI in debug mode
+    println!("cargo:rustc-check-cfg=cfg(is_not_release)");
+    println!("cargo:rerun-if-env-changed=CI");
+    #[cfg(debug_assertions)]
+    if std::env::var("CI").is_err() {
+        println!("cargo::rustc-cfg=is_not_release");
+    }
 }

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -22,7 +22,7 @@ use esp_println::{print, println};
 
 const WIDTH: usize = 80;
 
-#[cfg(debug_assertions)]
+#[cfg(is_not_release)]
 compile_error!("Run this example in release mode");
 
 #[embassy_executor::task]

--- a/examples/src/bin/psram_octal.rs
+++ b/examples/src/bin/psram_octal.rs
@@ -25,11 +25,11 @@ fn init_psram_heap() {
     }
 }
 
+#[cfg(is_not_release)]
+compile_error!("PSRAM example must be built in release mode!");
+
 #[entry]
 fn main() -> ! {
-    #[cfg(debug_assertions)]
-    compile_error!("This example MUST be built in release mode!");
-
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     psram::init_psram(peripherals.PSRAM);

--- a/examples/src/bin/psram_quad.rs
+++ b/examples/src/bin/psram_quad.rs
@@ -1,6 +1,6 @@
 //! This shows how to use PSRAM as heap-memory via esp-alloc
 //!
-//! You need an ESP32, ESP32-S2, or ESP32-S3 with at least 2 MB of PSRAM memory.
+//! You need an ESP32, ESP32-S2 or ESP32-S3 with at least 2 MB of PSRAM memory.
 
 //% CHIPS: esp32 esp32s2 esp32s3
 //% FEATURES: psram-2m
@@ -25,11 +25,11 @@ fn init_psram_heap() {
     }
 }
 
+#[cfg(is_not_release)]
+compile_error!("PSRAM example must be built in release mode!");
+
 #[entry]
 fn main() -> ! {
-    #[cfg(debug_assertions)]
-    compile_error!("PSRAM example must be built in release mode!");
-
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     psram::init_psram(peripherals.PSRAM);

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -113,6 +113,14 @@ impl CargoArgsBuilder {
         self
     }
 
+    pub fn add_arg<S>(&mut self, arg: S) -> &mut Self
+    where
+        S: Into<String>,
+    {
+        self.args.push(arg.into());
+        self
+    }
+
     #[must_use]
     pub fn build(self) -> Vec<String> {
         let mut args = vec![];

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -57,11 +57,11 @@ pub enum Package {
 pub struct Metadata {
     example_path: PathBuf,
     chips: Vec<Chip>,
-    feature_sets: Vec<Vec<String>>,
+    feature_set: Vec<String>,
 }
 
 impl Metadata {
-    pub fn new(example_path: &Path, chips: Vec<Chip>, feature_sets: Vec<Vec<String>>) -> Self {
+    pub fn new(example_path: &Path, chips: Vec<Chip>, feature_set: Vec<String>) -> Self {
         let chips = if chips.is_empty() {
             Chip::iter().collect()
         } else {
@@ -71,7 +71,7 @@ impl Metadata {
         Self {
             example_path: example_path.to_path_buf(),
             chips,
-            feature_sets,
+            feature_set,
         }
     }
 
@@ -89,9 +89,9 @@ impl Metadata {
             .replace(".rs", "")
     }
 
-    /// A list of all features required for building a given examples.
-    pub fn feature_sets(&self) -> &[Vec<String>] {
-        &self.feature_sets
+    /// A list of all features required for building a given example.
+    pub fn feature_set(&self) -> &[String] {
+        &self.feature_set
     }
 
     /// If the specified chip is in the list of chips, then it is supported.
@@ -154,7 +154,7 @@ pub fn build_documentation(
 }
 
 /// Load all examples at the given path, and parse their metadata.
-pub fn load_examples(path: &Path) -> Result<Vec<Metadata>> {
+pub fn load_examples(path: &Path, action: CargoAction) -> Result<Vec<Metadata>> {
     let mut examples = Vec::new();
 
     for entry in fs::read_dir(path)? {
@@ -172,7 +172,7 @@ pub fn load_examples(path: &Path) -> Result<Vec<Metadata>> {
                 .trim()
                 .split_ascii_whitespace()
                 .map(|s| s.to_string())
-                .collect::<VecDeque<_>>();
+                .collect::<Vec<_>>();
 
             if split.len() < 2 {
                 bail!(
@@ -182,7 +182,7 @@ pub fn load_examples(path: &Path) -> Result<Vec<Metadata>> {
             }
 
             // The trailing ':' on metadata keys is optional :)
-            let key = split.pop_front().unwrap();
+            let key = split.swap_remove(0);
             let key = key.trim_end_matches(':');
 
             if key == "CHIPS" {
@@ -191,14 +191,30 @@ pub fn load_examples(path: &Path) -> Result<Vec<Metadata>> {
                     .map(|s| Chip::from_str(s, false).unwrap())
                     .collect::<Vec<_>>();
             } else if key == "FEATURES" {
-                feature_sets.push(split.into());
+                // Sort the features so they are in a deterministic order:
+                split.sort();
+                feature_sets.push(split);
             } else {
                 log::warn!("Unrecognized metadata key '{key}', ignoring");
             }
         }
 
-        examples.push(Metadata::new(&path, chips, feature_sets));
+        if feature_sets.is_empty() {
+            feature_sets.push(Vec::new());
+        }
+        if action == CargoAction::Build {
+            // Only build the first feature set for each example.
+            // Rebuilding with a different feature set just wastes time because the latter
+            // one will overwrite the former one(s).
+            feature_sets.truncate(1);
+        }
+        for feature_set in feature_sets {
+            examples.push(Metadata::new(&path, chips.clone(), feature_set));
+        }
     }
+
+    // Sort by feature set, to prevent rebuilding packages if not necessary.
+    examples.sort_by_key(|e| e.feature_set().join(","));
 
     Ok(examples)
 }
@@ -210,7 +226,7 @@ pub fn execute_app(
     target: &str,
     app: &Metadata,
     action: CargoAction,
-    repeat: usize,
+    mut repeat: usize,
     debug: bool,
 ) -> Result<()> {
     log::info!(
@@ -219,40 +235,7 @@ pub fn execute_app(
         chip
     );
 
-    let feature_sets = if app.feature_sets().is_empty() {
-        vec![vec![]]
-    } else {
-        app.feature_sets().to_vec()
-    };
-
-    for features in feature_sets {
-        execute_app_with_features(
-            package_path,
-            chip,
-            target,
-            app,
-            action,
-            repeat,
-            features,
-            debug,
-        )?;
-    }
-
-    Ok(())
-}
-
-/// Run or build the specified test or example for the specified chip, with the
-/// specified features enabled.
-pub fn execute_app_with_features(
-    package_path: &Path,
-    chip: Chip,
-    target: &str,
-    app: &Metadata,
-    action: CargoAction,
-    mut repeat: usize,
-    mut features: Vec<String>,
-    debug: bool,
-) -> Result<()> {
+    let mut features = app.feature_set().to_vec();
     if !features.is_empty() {
         log::info!("Features: {}", features.join(","));
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -58,6 +58,9 @@ struct ExampleArgs {
     chip: Chip,
     /// Optional example to act on (all examples used if omitted)
     example: Option<String>,
+    /// Build examples in debug mode only
+    #[arg(long)]
+    debug: bool,
 }
 
 #[derive(Debug, Args)]
@@ -236,6 +239,7 @@ fn build_examples(args: ExampleArgs, examples: Vec<Metadata>, package_path: &Pat
             example,
             CargoAction::Build,
             1,
+            args.debug,
         )
     } else if args.example.is_some() {
         // An invalid argument was provided:
@@ -250,6 +254,7 @@ fn build_examples(args: ExampleArgs, examples: Vec<Metadata>, package_path: &Pat
                 example,
                 CargoAction::Build,
                 1,
+                args.debug,
             )
         })
     }
@@ -269,6 +274,7 @@ fn run_example(args: ExampleArgs, examples: Vec<Metadata>, package_path: &Path) 
             example,
             CargoAction::Run,
             1,
+            args.debug,
         )
     } else {
         bail!("Example not found or unsupported for the given chip")
@@ -300,6 +306,7 @@ fn tests(workspace: &Path, args: TestArgs, action: CargoAction) -> Result<()> {
             test,
             action,
             args.repeat.unwrap_or(1),
+            false,
         )
     } else if args.test.is_some() {
         bail!("Test not found or unsupported for the given chip")
@@ -313,6 +320,7 @@ fn tests(workspace: &Path, args: TestArgs, action: CargoAction) -> Result<()> {
                 &test,
                 action,
                 args.repeat.unwrap_or(1),
+                false,
             )
             .is_err()
             {


### PR DESCRIPTION
- Don't spend time optimising examples in CI runs.
- We collect build artifacts after the fact, so building tests with multiple feature sets is a waste of time at this moment
- We're wasting a few seconds on rebuilding dependencies if features change. Some of it is unavoidable, but the rest might be saved by sorting examples by feature set.