### PR TITLE
Make additional memory available as `dram2_uninit`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Flex` now implements `Wait`. (#2075)
 - Added sleep and wakeup support for esp32c2 (#1922)
 - `Input`, `Output`, `OutputOpenDrain` and `Flex` now implement `Peripheral`. (#2094)
+- Previously unavailable memory is available via `.dram2_uninit` section (#2079)
 
 ### Changed
 

--- a/esp-hal/ld/esp32/esp32.x
+++ b/esp-hal/ld/esp32/esp32.x
@@ -26,14 +26,8 @@ INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"
 INCLUDE "stack.x"
+INCLUDE "dram2.x"
 /* End of Shared sections */
-
-/* an uninitialized section for use as the wifi-heap in esp-wifi */
-SECTIONS {
-    .dram2_uninit (NOLOAD) : ALIGN(4) {
-        *(.dram2_uninit)
-    } > dram2_seg
-}
 
 EXTERN(DefaultHandler);
 

--- a/esp-hal/ld/esp32c2/esp32c2.x
+++ b/esp-hal/ld/esp32c2/esp32c2.x
@@ -85,6 +85,7 @@ INCLUDE "rodata.x"
 INCLUDE "rwtext.x"
 INCLUDE "rwdata.x"
 INCLUDE "stack.x"
+INCLUDE "dram2.x"
 /* End of Shared sections */
 
 INCLUDE "debug.x"

--- a/esp-hal/ld/esp32c2/memory.x
+++ b/esp-hal/ld/esp32c2/memory.x
@@ -12,12 +12,14 @@ MEMORY
                       [0x4037C000, 0x403C0000, "IRAM"]]
     */
 
-    /* 272K of on soc RAM, 16K reserved for cache */
-    ICACHE : ORIGIN = 0x4037C000,  LENGTH = 16K
+    ICACHE : ORIGIN = 0x4037C000, LENGTH = 16K
     /* Instruction RAM */
-    IRAM : ORIGIN = 0x4037C000 + 16K, LENGTH = 272K - 16K
+    IRAM : ORIGIN = 0x4037C000 + LENGTH(ICACHE), LENGTH = 186k
     /* Data RAM */
-    DRAM : ORIGIN = 0x3FCA0000, LENGTH = 0x30000
+    DRAM : ORIGIN = 0x3FCA0000, LENGTH = 186k
+
+    /* memory available after the 2nd stage bootloader is finished */
+    dram2_seg ( RW )       : ORIGIN = ORIGIN(DRAM) + LENGTH(DRAM), len = 0x3fcdeb70 - (ORIGIN(DRAM) + LENGTH(DRAM))
 
     /* External flash */
     /* Instruction ROM */

--- a/esp-hal/ld/esp32c3/esp32c3.x
+++ b/esp-hal/ld/esp32c3/esp32c3.x
@@ -86,6 +86,7 @@ INCLUDE "rwtext.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
+INCLUDE "dram2.x"
 /* End of Shared sections */
 
 INCLUDE "debug.x"

--- a/esp-hal/ld/esp32c3/memory.x
+++ b/esp-hal/ld/esp32c3/memory.x
@@ -13,14 +13,15 @@ MEMORY
                   [0x50000000, 0x50002000, "RTC_IRAM"],
                   [0x50000000, 0x50002000, "RTC_DRAM"],
                   [0x600FE000, 0x60100000, "MEM_INTERNAL2"]]
-    */
-    /* 400K of on soc RAM, 16K reserved for cache */
+
     ICACHE : ORIGIN = 0x4037C000,  LENGTH = 0x4000
     /* Instruction RAM */
-    IRAM : ORIGIN = 0x4037C000 + 0x4000, LENGTH = 400K - 0x4000
+    IRAM : ORIGIN = 0x4037C000 + 0x4000, LENGTH = 313K - 0x4000
     /* Data RAM */
-    DRAM : ORIGIN = 0x3FC80000, LENGTH = 0x50000
+    DRAM : ORIGIN = 0x3FC80000, LENGTH = 313K
     
+    /* memory available after the 2nd stage bootloader is finished */
+    dram2_seg ( RW )       : ORIGIN = ORIGIN(DRAM) + LENGTH(DRAM), len = 0x3fcde710 - (ORIGIN(DRAM) + LENGTH(DRAM))
 
     /* External flash */
     /* Instruction ROM */

--- a/esp-hal/ld/esp32c6/esp32c6.x
+++ b/esp-hal/ld/esp32c6/esp32c6.x
@@ -78,6 +78,7 @@ INCLUDE "rodata.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
+INCLUDE "dram2.x"
 /* End of Shared sections */
 
 INCLUDE "debug.x"

--- a/esp-hal/ld/esp32c6/memory.x
+++ b/esp-hal/ld/esp32c6/memory.x
@@ -21,6 +21,9 @@ MEMORY
     */
     RAM : ORIGIN = 0x40800000 , LENGTH = 0x6E610
 
+    /* memory available after the 2nd stage bootloader is finished */
+    dram2_seg ( RW )       : ORIGIN = ORIGIN(RAM) + LENGTH(RAM), len = 0x4087e610 - (ORIGIN(RAM) + LENGTH(RAM))
+
     /* External flash */
     /* Instruction and Data ROM */
     ROM : ORIGIN =   0x42000000 + 0x20, LENGTH = 0x400000 - 0x20

--- a/esp-hal/ld/esp32h2/esp32h2.x
+++ b/esp-hal/ld/esp32h2/esp32h2.x
@@ -71,6 +71,7 @@ INCLUDE "rodata.x"
 INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
+INCLUDE "dram2.x"
 /* End of Shared sections */
 
 INCLUDE "debug.x"

--- a/esp-hal/ld/esp32h2/memory.x
+++ b/esp-hal/ld/esp32h2/memory.x
@@ -17,10 +17,13 @@ MEMORY
 
     /* 320K of on soc RAM, 16K reserved for cache */
     /* Instruction and Data RAM 
-    0x4086E610 = 2nd stage bootloader iram_loader_seg start address
+    0x4083EFD0 = 2nd stage bootloader iram_loader_seg start address
     see https://github.com/espressif/esp-idf/blob/03414a15508036c8fc0f51642aed7a264e9527df/components/esp_system/ld/esp32h2/memory.ld.in#L26
     */
     RAM : ORIGIN = 0x40800000, LENGTH = 0x3EFD0
+
+    /* memory available after the 2nd stage bootloader is finished */
+    dram2_seg ( RW )       : ORIGIN = ORIGIN(RAM) + LENGTH(RAM), len = 0x4084fee0 - (ORIGIN(RAM) + LENGTH(RAM))
 
     /* External flash */
     /* Instruction and Data ROM */

--- a/esp-hal/ld/esp32s2/esp32s2.x
+++ b/esp-hal/ld/esp32s2/esp32s2.x
@@ -34,6 +34,7 @@ INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"
 INCLUDE "stack.x"
+INCLUDE "dram2.x"
 /* End of Shared sections */
 
 EXTERN(DefaultHandler);

--- a/esp-hal/ld/esp32s2/memory.x
+++ b/esp-hal/ld/esp32s2/memory.x
@@ -15,10 +15,13 @@ VECTORS_SIZE = 0x400;
 /* Specify main memory areas */
 MEMORY
 {
-  vectors_seg ( RX )     : ORIGIN = 0x40020000 + RESERVE_CACHES, len = VECTORS_SIZE /* SRAM0 */
-  iram_seg ( RX )        : ORIGIN = 0x40020000 + RESERVE_CACHES + VECTORS_SIZE, len = 192k - RESERVE_CACHES - VECTORS_SIZE /* SRAM0 */
+  vectors_seg ( RX )     : ORIGIN = 0x40020000 + RESERVE_CACHES, len = VECTORS_SIZE
+  iram_seg ( RX )        : ORIGIN = 0x40020000 + RESERVE_CACHES + VECTORS_SIZE, len = 188k - RESERVE_CACHES - VECTORS_SIZE
 
   dram_seg ( RW )        : ORIGIN = 0x3FFB0000 + RESERVE_CACHES + VECTORS_SIZE, len = 188k - RESERVE_CACHES - VECTORS_SIZE
+
+  /* memory available after the 2nd stage bootloader is finished */
+  dram2_seg ( RW )       : ORIGIN = ORIGIN(dram_seg) + LENGTH(dram_seg), len = 0x3ffffa10 - (ORIGIN(dram_seg) + LENGTH(dram_seg))
 
   /* external flash 
      The 0x20 offset is a convenience for the app binary image generation.

--- a/esp-hal/ld/esp32s3/esp32s3.x
+++ b/esp-hal/ld/esp32s3/esp32s3.x
@@ -48,6 +48,7 @@ INCLUDE "rwdata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"
 INCLUDE "stack.x"
+INCLUDE "dram2.x"
 /* End of Shared sections */
 
 EXTERN(DefaultHandler);

--- a/esp-hal/ld/esp32s3/memory.x
+++ b/esp-hal/ld/esp32s3/memory.x
@@ -24,6 +24,9 @@ MEMORY
   iram_seg ( RX )        : ORIGIN = 0x40370000 + RESERVE_ICACHE + VECTORS_SIZE, len = 328k - VECTORS_SIZE - RESERVE_ICACHE
   dram_seg ( RW )        : ORIGIN = 0x3FC88000 , len = 345856 
 
+  /* memory available after the 2nd stage bootloader is finished */
+  dram2_seg ( RW )       : ORIGIN = ORIGIN(dram_seg) + LENGTH(dram_seg), len = 0x3fced710 - (ORIGIN(dram_seg) + LENGTH(dram_seg))
+
   /* external flash 
      The 0x20 offset is a convenience for the app binary image generation.
      Flash cache has 64KB pages. The .bin file which is flashed to the chip

--- a/esp-hal/ld/sections/dram2.x
+++ b/esp-hal/ld/sections/dram2.x
@@ -1,0 +1,6 @@
+/* an uninitialized section of RAM otherwise not useable */
+SECTIONS {
+    .dram2_uninit (NOLOAD) : ALIGN(4) {
+        *(.dram2_uninit)
+    } > dram2_seg
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This adds a way to make use of previously unavailable RAM occupied by the 2nd stage bootloader during boot (and RAM which was previously unavailable due to the placement of the bootloader). (Not ESP32 - but we already have a second memory region there)

The memory is available as `.dram2_uninit` - e.g. 
```rust
#[link_section = ".dram2_uninit"]
static mut HEAP_DATA: MaybeUninit<[u8; 1024 * 64]> = MaybeUninit::zeroed();
```

After this we might want to
- add a way to esp-alloc to use multiple memory regions
- use the global allocator in esp-wifi (#1609 - most probably we should remove the explicit wifi heap and only offer this)

I don't think this deserves an example

Closes #1084 
Closes #1071

#### Testing
Everything works as before and changing an example to make use of the additional RAM works
