### PR TITLE
Fix nightly warnings

### DIFF
--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -417,7 +417,7 @@ pub mod dma {
             mode: Mode,
             cipher_mode: CipherMode,
             key: K,
-        ) -> Result<DmaTransferTxRx<'_, Self>, crate::dma::DmaError>
+        ) -> Result<DmaTransferTxRx<'t, Self>, crate::dma::DmaError>
         where
             K: Into<Key>,
             TXBUF: ReadBuffer,

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -272,7 +272,7 @@ where
     /// Write I2S.
     /// Returns [DmaTransferTx] which represents the in-progress DMA
     /// transfer
-    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<'_, Self>, Error>
+    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<'t, Self>, Error>
     where
         TXBUF: ReadBuffer;
 
@@ -281,7 +281,7 @@ where
     fn write_dma_circular<'t>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTxCircular<'_, Self>, Error>
+    ) -> Result<DmaTransferTxCircular<'t, Self>, Error>
     where
         TXBUF: ReadBuffer;
 }
@@ -304,7 +304,7 @@ where
     /// Read I2S.
     /// Returns [DmaTransferRx] which represents the in-progress DMA
     /// transfer
-    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<'_, Self>, Error>
+    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<'t, Self>, Error>
     where
         RXBUF: WriteBuffer;
 
@@ -314,7 +314,7 @@ where
     fn read_dma_circular<'t>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircular<'_, Self>, Error>
+    ) -> Result<DmaTransferRxCircular<'t, Self>, Error>
     where
         RXBUF: WriteBuffer;
 }
@@ -663,7 +663,7 @@ where
     CH: DmaChannel,
     DmaMode: Mode,
 {
-    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<'_, Self>, Error>
+    fn write_dma<'t>(&'t mut self, words: &'t TXBUF) -> Result<DmaTransferTx<'t, Self>, Error>
     where
         TXBUF: ReadBuffer,
     {
@@ -674,7 +674,7 @@ where
     fn write_dma_circular<'t>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTxCircular<'_, Self>, Error>
+    ) -> Result<DmaTransferTxCircular<'t, Self>, Error>
     where
         TXBUF: ReadBuffer,
     {
@@ -844,7 +844,7 @@ where
     DmaMode: Mode,
     Self: DmaSupportRx + Sized,
 {
-    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<'_, Self>, Error>
+    fn read_dma<'t>(&'t mut self, words: &'t mut RXBUF) -> Result<DmaTransferRx<'t, Self>, Error>
     where
         RXBUF: WriteBuffer,
     {
@@ -855,7 +855,7 @@ where
     fn read_dma_circular<'t>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircular<'_, Self>, Error>
+    ) -> Result<DmaTransferRxCircular<'t, Self>, Error>
     where
         RXBUF: WriteBuffer,
     {

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1430,7 +1430,7 @@ where
     pub fn write_dma<'t, TXBUF>(
         &'t mut self,
         words: &'t TXBUF,
-    ) -> Result<DmaTransferTx<'_, Self>, Error>
+    ) -> Result<DmaTransferTx<'t, Self>, Error>
     where
         TXBUF: ReadBuffer,
     {
@@ -1526,7 +1526,7 @@ where
     pub fn read_dma<'t, RXBUF>(
         &'t mut self,
         words: &'t mut RXBUF,
-    ) -> Result<DmaTransferRx<'_, Self>, Error>
+    ) -> Result<DmaTransferRx<'t, Self>, Error>
     where
         RXBUF: WriteBuffer,
     {

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -356,7 +356,7 @@ pub mod dma {
         pub fn dma_write<'t, TXBUF>(
             &'t mut self,
             words: &'t TXBUF,
-        ) -> Result<DmaTransferTx<'_, Self>, Error>
+        ) -> Result<DmaTransferTx<'t, Self>, Error>
         where
             TXBUF: ReadBuffer,
         {
@@ -382,7 +382,7 @@ pub mod dma {
         pub fn dma_read<'t, RXBUF>(
             &'t mut self,
             words: &'t mut RXBUF,
-        ) -> Result<DmaTransferRx<'_, Self>, Error>
+        ) -> Result<DmaTransferRx<'t, Self>, Error>
         where
             RXBUF: WriteBuffer,
         {
@@ -410,7 +410,7 @@ pub mod dma {
             &'t mut self,
             words: &'t TXBUF,
             read_buffer: &'t mut RXBUF,
-        ) -> Result<DmaTransferTxRx<'_, Self>, Error>
+        ) -> Result<DmaTransferTxRx<'t, Self>, Error>
         where
             TXBUF: ReadBuffer,
             RXBUF: WriteBuffer,


### PR DESCRIPTION
```
warning: elided lifetime has a name
   --> C:\_Espressif\esp-hal\esp-hal\src\spi\slave.rs:385:35
    |
382 |         pub fn dma_read<'t, RXBUF>(
    |                         -- lifetime `'t` declared here
...
385 |         ) -> Result<DmaTransferRx<'_, Self>, Error>
    |                                   ^^ this elided lifetime gets resolved as `'t`
```