### PR TITLE
Implement `embedded_hal_async::delay::DelayNs` for `TIMGx` timers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `RtcClock::get_xtal_freq` and `RtcClock::get_slow_freq` publically for all chips (#2183)
 - TWAI support for ESP32-H2 (#2199)
 - Added a way to configure watchdogs in `esp_hal::init` (#2180)
+- Implement `embedded_hal_async::delay::DelayNs` for `TIMGx` timers (#2084)
 
 ### Changed
 

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -1047,7 +1047,7 @@ mod asynch {
                 interrupt::enable(interrupt, handler.priority()).unwrap();
             }
 
-            alarm.set_interrupt_handler(target0_handler);
+            alarm.set_interrupt_handler(handler);
 
             alarm.enable_interrupt(true);
 

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -1121,10 +1121,6 @@ mod asynch {
                 .modify(|_, w| w.target0().clear_bit());
         });
 
-        // unsafe { &*crate::peripherals::SYSTIMER::PTR }
-        //     .int_clr()
-        //     .write(|w| w.target0().clear_bit_by_one());
-
         WAKERS[0].wake();
     }
 
@@ -1136,10 +1132,6 @@ mod asynch {
                 .modify(|_, w| w.target1().clear_bit());
         });
 
-        // unsafe { &*crate::peripherals::SYSTIMER::PTR }
-        //     .int_clr()
-        //     .write(|w| w.target1().clear_bit_by_one());
-
         WAKERS[1].wake();
     }
 
@@ -1150,10 +1142,6 @@ mod asynch {
                 .int_ena()
                 .modify(|_, w| w.target2().clear_bit());
         });
-
-        // unsafe { &*crate::peripherals::SYSTIMER::PTR }
-        //     .int_clr()
-        //     .write(|w| w.target2().clear_bit_by_one());
 
         WAKERS[2].wake();
     }

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -1098,10 +1098,10 @@ mod asynch {
     }
 
     impl<'d, COMP: Comparator, UNIT: Unit> embedded_hal_async::delay::DelayNs
-        for Alarm<'d, Target, crate::Async, COMP, UNIT> // TODO this changed
+        for Alarm<'d, Target, crate::Async, COMP, UNIT>
     {
         async fn delay_ns(&mut self, ns: u32) {
-            self.set_target(SystemTimer::now() + SystemTimer::ns_to_ticks(ns as u64 / 1000) as u64);
+            self.set_target(SystemTimer::now() + SystemTimer::ns_to_ticks(ns as u64 / 1000));
 
             AlarmFuture::new(self).await;
         }

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -1195,7 +1195,7 @@ mod asynch {
     // well.
     #[handler]
     pub(crate) fn timg0_timer0_handler() {
-        lock(&INT_ENA_LOCK, || {
+        lock(&INT_ENA_LOCK[0], || {
             unsafe { &*crate::peripherals::TIMG0::PTR }
                 .int_ena()
                 .modify(|_, w| w.t(0).clear_bit())
@@ -1211,7 +1211,7 @@ mod asynch {
     #[cfg(timg1)]
     #[handler]
     pub(crate) fn timg1_timer0_handler() {
-        lock(&INT_ENA_LOCK, || {
+        lock(&INT_ENA_LOCK[1], || {
             unsafe { &*crate::peripherals::TIMG1::PTR }
                 .int_ena()
                 .modify(|_, w| w.t(0).clear_bit())
@@ -1226,7 +1226,7 @@ mod asynch {
     #[cfg(timg_timer1)]
     #[handler]
     pub(crate) fn timg0_timer1_handler() {
-        lock(&INT_ENA_LOCK, || {
+        lock(&INT_ENA_LOCK[0], || {
             unsafe { &*crate::peripherals::TIMG0::PTR }
                 .int_ena()
                 .modify(|_, w| w.t(1).clear_bit())
@@ -1241,7 +1241,7 @@ mod asynch {
     #[cfg(all(timg1, timg_timer1))]
     #[handler]
     pub(crate) fn timg1_timer1_handler() {
-        lock(&INT_ENA_LOCK, || {
+        lock(&INT_ENA_LOCK[1], || {
             unsafe { &*crate::peripherals::TIMG1::PTR }
                 .int_ena()
                 .modify(|_, w| w.t(1).clear_bit())

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -304,12 +304,13 @@ where
 {
     /// Construct a new instance of [`TimerGroup`] in asynchronous mode
     pub fn new_async(_timer_group: impl Peripheral<P = T> + 'd) -> Self {
-        use crate::timer::timg::asynch::{
-            timg0_timer0_handler,
-            timg0_timer1_handler,
-            timg1_timer0_handler,
-            timg1_timer1_handler,
-        };
+        use crate::timer::timg::asynch::timg0_timer0_handler;
+        #[cfg(timg_timer1)]
+        use crate::timer::timg::asynch::timg0_timer1_handler;
+        #[cfg(timg1)]
+        use crate::timer::timg::asynch::timg1_timer0_handler;
+        #[cfg(all(timg1, timg_timer1))]
+        use crate::timer::timg::asynch::timg1_timer1_handler;
 
         match T::id() {
             0 => unsafe {
@@ -327,6 +328,7 @@ where
                         .unwrap();
                 }
             },
+            #[cfg(any(timg1, timg_timer1))]
             1 => unsafe {
                 #[cfg(timg1)]
                 {

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -1114,8 +1114,7 @@ mod asynch {
     }
 
     #[allow(clippy::declare_interior_mutable_const)]
-    const INIT: AtomicWaker = AtomicWaker::new();
-    static WAKERS: [AtomicWaker; NUM_WAKERS] = [INIT; NUM_WAKERS];
+    static WAKERS: [AtomicWaker; NUM_WAKERS] = [const { AtomicWaker::new() }; NUM_WAKERS];
 
     pub(crate) struct TimerFuture<'a, T>
     where

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -1164,6 +1164,15 @@ mod asynch {
         }
     }
 
+    impl<'a, T> Drop for TimerFuture<'a, T>
+    where
+        T: Instance,
+    {
+        fn drop(&mut self) {
+            self.timer.clear_interrupt();
+        }
+    }
+
     impl<T> embedded_hal_async::delay::DelayNs for Timer<T, crate::Async>
     where
         T: Instance,
@@ -1180,6 +1189,10 @@ mod asynch {
         }
     }
 
+    // INT_ENA means that when the interrupt occurs, it will show up in the INT_ST.
+    // Clearing INT_ENA that it won't show up on INT_ST but if interrupt is
+    // already there, it won't clear it - that's why we need to clear the INT_CLR as
+    // well.
     #[handler]
     pub(crate) fn timg0_timer0_handler() {
         lock(&INT_ENA_LOCK, || {

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -1113,7 +1113,6 @@ mod asynch {
         }
     }
 
-    #[allow(clippy::declare_interior_mutable_const)]
     static WAKERS: [AtomicWaker; NUM_WAKERS] = [const { AtomicWaker::new() }; NUM_WAKERS];
 
     pub(crate) struct TimerFuture<'a, T>

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -28,6 +28,10 @@ name    = "delay"
 harness = false
 
 [[test]]
+name    = "delay_async"
+harness = false
+
+[[test]]
 name    = "dma_macros"
 harness = false
 
@@ -161,12 +165,12 @@ harness = false
 
 [dependencies]
 cfg-if             = "1.0.0"
-critical-section   = "1.1.2"
+critical-section   = "1.1.3"
 defmt              = "0.3.8"
 defmt-rtt          = { version = "0.4.1", optional = true }
 embassy-futures    = "0.1.1"
 embassy-sync       = "0.6.0"
-embassy-time       = { version = "0.3.1" }
+embassy-time       = "0.3.2"
 embedded-hal       = "1.0.0"
 embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = ["unproven"] }
 embedded-hal-async = "1.0.0"
@@ -174,7 +178,7 @@ embedded-hal-nb    = { version = "1.0.0", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
 esp-hal            = { path = "../esp-hal", features = ["defmt", "digest"], optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
-portable-atomic    = "1.6.0"
+portable-atomic    = "1.7.0"
 static_cell        = { version = "2.1.0", features = ["nightly"] }
 
 [dev-dependencies]
@@ -193,8 +197,8 @@ sha1                = { version = "0.10.6", default-features = false }
 sha2                = { version = "0.10.8", default-features = false }
 
 [build-dependencies]
-esp-build    = { version = "0.1.0", path = "../esp-build" }
-esp-metadata = { version = "0.3.0", path = "../esp-metadata" }
+esp-build    = { path = "../esp-build" }
+esp-metadata = { path = "../esp-metadata" }
 
 [features]
 default = ["embassy"]

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -23,9 +23,9 @@ struct Context {
 }
 
 async fn test_async_delay_ns(mut timer: impl DelayNs, duration: u32) {
-    let t1 = esp_hal::time::current_time();
+    let t1 = esp_hal::time::now();
     timer.delay_ns(duration).await;
-    let t2 = esp_hal::time::current_time();
+    let t2 = esp_hal::time::now();
 
     assert!(t2 > t1);
     assert!(

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -1,0 +1,52 @@
+//! Async Delay Test
+//!
+//! Specifically tests the various implementations of the
+//! `embedded_hal_async::delay::DelayNs` trait.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use embedded_hal_async::delay::DelayNs as _;
+use esp_hal::{
+    peripherals::Peripherals,
+    timer::systimer::{Alarm, FrozenUnit, SystemTimer},
+};
+use hil_test as _;
+
+struct Context {
+    peripherals: Peripherals,
+}
+
+#[cfg(test)]
+#[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
+mod tests {
+    use super::*;
+
+    #[init]
+    fn init() -> Context {
+        Context {
+            peripherals: esp_hal::init(esp_hal::Config::default()),
+        }
+    }
+
+    #[test]
+    #[timeout(2)]
+    async fn test_systimer_async_delay_ns(ctx: Context) {
+        let mut alarms = SystemTimer::new(ctx.peripherals.SYSTIMER);
+        let unit = FrozenUnit::new(&mut alarms.unit0);
+        let mut alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
+
+        let t1 = esp_hal::time::current_time();
+        alarm0.delay_ns(600_000_000).await;
+        let t2 = esp_hal::time::current_time();
+
+        assert!(t2 > t1);
+        assert!(
+            (t2 - t1).to_nanos() >= 600_000_000u64,
+            "diff: {:?}",
+            (t2 - t1).to_nanos()
+        );
+    }
+}

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -9,13 +9,9 @@
 #![no_main]
 
 use embedded_hal_async::delay::DelayNs;
-use esp_hal::{
-    peripherals::Peripherals,
-    timer::{
-        systimer::{Alarm, FrozenUnit, SystemTimer},
-        timg::TimerGroup,
-    },
-};
+#[cfg(systimer)]
+use esp_hal::timer::systimer::{Alarm, FrozenUnit, SystemTimer};
+use esp_hal::{peripherals::Peripherals, timer::timg::TimerGroup};
 use hil_test as _;
 
 struct Context {
@@ -47,6 +43,7 @@ mod tests {
         }
     }
 
+    #[cfg(systimer)]
     #[test]
     #[timeout(2)]
     async fn test_systimer_async_delay_ns(ctx: Context) {

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -11,7 +11,10 @@
 use embedded_hal_async::delay::DelayNs as _;
 use esp_hal::{
     peripherals::Peripherals,
-    timer::systimer::{Alarm, FrozenUnit, SystemTimer},
+    timer::{
+        systimer::{Alarm, FrozenUnit, SystemTimer},
+        timg::TimerGroup,
+    },
 };
 use hil_test as _;
 
@@ -40,6 +43,24 @@ mod tests {
 
         let t1 = esp_hal::time::current_time();
         alarm0.delay_ns(600_000_000).await;
+        let t2 = esp_hal::time::current_time();
+
+        assert!(t2 > t1);
+        assert!(
+            (t2 - t1).to_nanos() >= 600_000_000u64,
+            "diff: {:?}",
+            (t2 - t1).to_nanos()
+        );
+    }
+
+    #[test]
+    #[timeout(2)]
+    async fn test_timg0_async_delay_ns(ctx: Context) {
+        let timg0 = TimerGroup::new_async(ctx.peripherals.TIMG0);
+        let mut timer0 = timg0.timer0;
+
+        let t1 = esp_hal::time::current_time();
+        timer0.delay_ns(600_000_000).await;
         let t2 = esp_hal::time::current_time();
 
         assert!(t2 > t1);

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -19,42 +19,48 @@ struct Context {
 }
 
 async fn test_async_delay_ns(mut timer: impl DelayNs, duration: u32) {
-    let t1 = esp_hal::time::now();
-    timer.delay_ns(duration).await;
-    let t2 = esp_hal::time::now();
+    for _ in 1..5 {
+        let t1 = esp_hal::time::now();
+        timer.delay_ns(duration).await;
+        let t2 = esp_hal::time::now();
 
-    assert!(t2 > t1);
-    assert!(
-        (t2 - t1).to_nanos() >= duration as u64,
-        "diff: {:?}",
-        (t2 - t1).to_nanos()
-    );
+        assert!(t2 > t1);
+        assert!(
+            (t2 - t1).to_nanos() >= duration as u64,
+            "diff: {:?}",
+            (t2 - t1).to_nanos()
+        );
+    }
 }
 
 async fn test_async_delay_us(mut timer: impl DelayNs, duration: u32) {
-    let t1 = esp_hal::time::now();
-    timer.delay_us(duration).await;
-    let t2 = esp_hal::time::now();
+    for _ in 1..5 {
+        let t1 = esp_hal::time::now();
+        timer.delay_us(duration).await;
+        let t2 = esp_hal::time::now();
 
-    assert!(t2 > t1);
-    assert!(
-        (t2 - t1).to_micros() >= duration as u64,
-        "diff: {:?}",
-        (t2 - t1).to_micros()
-    );
+        assert!(t2 > t1);
+        assert!(
+            (t2 - t1).to_nanos() >= duration as u64,
+            "diff: {:?}",
+            (t2 - t1).to_nanos()
+        );
+    }
 }
 
 async fn test_async_delay_ms(mut timer: impl DelayNs, duration: u32) {
-    let t1 = esp_hal::time::now();
-    timer.delay_ms(duration).await;
-    let t2 = esp_hal::time::now();
+    for _ in 1..5 {
+        let t1 = esp_hal::time::now();
+        timer.delay_ms(duration).await;
+        let t2 = esp_hal::time::now();
 
-    assert!(t2 > t1);
-    assert!(
-        (t2 - t1).to_millis() >= duration as u64,
-        "diff: {:?}",
-        (t2 - t1).to_millis()
-    );
+        assert!(t2 > t1);
+        assert!(
+            (t2 - t1).to_nanos() >= duration as u64,
+            "diff: {:?}",
+            (t2 - t1).to_nanos()
+        );
+    }
 }
 
 #[cfg(test)]
@@ -71,11 +77,11 @@ mod tests {
 
     #[cfg(systimer)]
     #[test]
-    #[timeout(2)]
+    #[timeout(20)]
     async fn test_systimer_async_delay_ns(ctx: Context) {
         let mut alarms = SystemTimer::new(ctx.peripherals.SYSTIMER);
         let unit = FrozenUnit::new(&mut alarms.unit0);
-        let alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
+        let alarm0 = Alarm::new_async(alarms.comparator0, &unit);
 
         test_async_delay_ns(alarm0, 10_000_000).await;
     }
@@ -107,7 +113,7 @@ mod tests {
     async fn test_systimer_async_delay_us(ctx: Context) {
         let mut alarms = SystemTimer::new(ctx.peripherals.SYSTIMER);
         let unit = FrozenUnit::new(&mut alarms.unit0);
-        let alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
+        let alarm0 = Alarm::new_async(alarms.comparator0, &unit);
 
         test_async_delay_us(alarm0, 10_000).await;
     }
@@ -139,7 +145,7 @@ mod tests {
     async fn test_systimer_async_delay_ms(ctx: Context) {
         let mut alarms = SystemTimer::new(ctx.peripherals.SYSTIMER);
         let unit = FrozenUnit::new(&mut alarms.unit0);
-        let alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
+        let alarm0 = Alarm::new_async(alarms.comparator0, &unit);
 
         test_async_delay_ms(alarm0, 10).await;
     }

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -77,7 +77,7 @@ mod tests {
 
     #[cfg(systimer)]
     #[test]
-    #[timeout(20)]
+    #[timeout(2)]
     async fn test_systimer_async_delay_ns(ctx: Context) {
         let mut alarms = SystemTimer::new(ctx.peripherals.SYSTIMER);
         let unit = FrozenUnit::new(&mut alarms.unit0);

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -3,7 +3,7 @@
 //! Specifically tests the various implementations of the
 //! `embedded_hal_async::delay::DelayNs` trait.
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -31,6 +31,32 @@ async fn test_async_delay_ns(mut timer: impl DelayNs, duration: u32) {
     );
 }
 
+async fn test_async_delay_us(mut timer: impl DelayNs, duration: u32) {
+    let t1 = esp_hal::time::now();
+    timer.delay_us(duration).await;
+    let t2 = esp_hal::time::now();
+
+    assert!(t2 > t1);
+    assert!(
+        (t2 - t1).to_micros() >= duration as u64,
+        "diff: {:?}",
+        (t2 - t1).to_micros()
+    );
+}
+
+async fn test_async_delay_ms(mut timer: impl DelayNs, duration: u32) {
+    let t1 = esp_hal::time::now();
+    timer.delay_ms(duration).await;
+    let t2 = esp_hal::time::now();
+
+    assert!(t2 > t1);
+    assert!(
+        (t2 - t1).to_millis() >= duration as u64,
+        "diff: {:?}",
+        (t2 - t1).to_millis()
+    );
+}
+
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
@@ -51,7 +77,7 @@ mod tests {
         let unit = FrozenUnit::new(&mut alarms.unit0);
         let alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
 
-        test_async_delay_ns(alarm0, 600_000_000).await;
+        test_async_delay_ns(alarm0, 10_000_000).await;
     }
 
     #[test]
@@ -59,9 +85,9 @@ mod tests {
     async fn test_timg0_async_delay_ns(ctx: Context) {
         let timg0 = TimerGroup::new_async(ctx.peripherals.TIMG0);
 
-        test_async_delay_ns(timg0.timer0, 600_000_000).await;
+        test_async_delay_ns(timg0.timer0, 10_000_000).await;
         #[cfg(timg_timer1)]
-        test_async_delay_ns(timg0.timer1, 600_000_000).await;
+        test_async_delay_ns(timg0.timer1, 10_000_000).await;
     }
 
     #[cfg(timg1)]
@@ -70,8 +96,72 @@ mod tests {
     async fn test_timg1_async_delay_ns(ctx: Context) {
         let timg1 = TimerGroup::new_async(ctx.peripherals.TIMG1);
 
-        test_async_delay_ns(timg1.timer0, 600_000_000).await;
+        test_async_delay_ns(timg1.timer0, 10_000_000).await;
         #[cfg(timg_timer1)]
-        test_async_delay_ns(timg1.timer1, 600_000_000).await;
+        test_async_delay_ns(timg1.timer1, 10_000_000).await;
+    }
+
+    #[cfg(systimer)]
+    #[test]
+    #[timeout(2)]
+    async fn test_systimer_async_delay_us(ctx: Context) {
+        let mut alarms = SystemTimer::new(ctx.peripherals.SYSTIMER);
+        let unit = FrozenUnit::new(&mut alarms.unit0);
+        let alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
+
+        test_async_delay_us(alarm0, 10_000).await;
+    }
+
+    #[test]
+    #[timeout(2)]
+    async fn test_timg0_async_delay_us(ctx: Context) {
+        let timg0 = TimerGroup::new_async(ctx.peripherals.TIMG0);
+
+        test_async_delay_us(timg0.timer0, 10_000).await;
+        #[cfg(timg_timer1)]
+        test_async_delay_us(timg0.timer1, 10_000).await;
+    }
+
+    #[cfg(timg1)]
+    #[test]
+    #[timeout(2)]
+    async fn test_timg1_async_delay_us(ctx: Context) {
+        let timg1 = TimerGroup::new_async(ctx.peripherals.TIMG1);
+
+        test_async_delay_us(timg1.timer0, 10_000).await;
+        #[cfg(timg_timer1)]
+        test_async_delay_us(timg1.timer1, 10_000).await;
+    }
+
+    #[cfg(systimer)]
+    #[test]
+    #[timeout(2)]
+    async fn test_systimer_async_delay_ms(ctx: Context) {
+        let mut alarms = SystemTimer::new(ctx.peripherals.SYSTIMER);
+        let unit = FrozenUnit::new(&mut alarms.unit0);
+        let alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
+
+        test_async_delay_ms(alarm0, 10).await;
+    }
+
+    #[test]
+    #[timeout(2)]
+    async fn test_timg0_async_delay_ms(ctx: Context) {
+        let timg0 = TimerGroup::new_async(ctx.peripherals.TIMG0);
+
+        test_async_delay_ms(timg0.timer0, 10).await;
+        #[cfg(timg_timer1)]
+        test_async_delay_ms(timg0.timer1, 10).await;
+    }
+
+    #[cfg(timg1)]
+    #[test]
+    #[timeout(2)]
+    async fn test_timg1_async_delay_ms(ctx: Context) {
+        let timg1 = TimerGroup::new_async(ctx.peripherals.TIMG1);
+
+        test_async_delay_ms(timg1.timer0, 10).await;
+        #[cfg(timg_timer1)]
+        test_async_delay_ms(timg1.timer1, 10).await;
     }
 }

--- a/hil-test/tests/delay_async.rs
+++ b/hil-test/tests/delay_async.rs
@@ -8,7 +8,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal_async::delay::DelayNs as _;
+use embedded_hal_async::delay::DelayNs;
 use esp_hal::{
     peripherals::Peripherals,
     timer::{
@@ -20,6 +20,19 @@ use hil_test as _;
 
 struct Context {
     peripherals: Peripherals,
+}
+
+async fn test_async_delay_ns(mut timer: impl DelayNs, duration: u32) {
+    let t1 = esp_hal::time::current_time();
+    timer.delay_ns(duration).await;
+    let t2 = esp_hal::time::current_time();
+
+    assert!(t2 > t1);
+    assert!(
+        (t2 - t1).to_nanos() >= duration as u64,
+        "diff: {:?}",
+        (t2 - t1).to_nanos()
+    );
 }
 
 #[cfg(test)]
@@ -39,35 +52,29 @@ mod tests {
     async fn test_systimer_async_delay_ns(ctx: Context) {
         let mut alarms = SystemTimer::new(ctx.peripherals.SYSTIMER);
         let unit = FrozenUnit::new(&mut alarms.unit0);
-        let mut alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
+        let alarm0 = Alarm::new_async(alarms.comparator0, &unit).into_periodic();
 
-        let t1 = esp_hal::time::current_time();
-        alarm0.delay_ns(600_000_000).await;
-        let t2 = esp_hal::time::current_time();
-
-        assert!(t2 > t1);
-        assert!(
-            (t2 - t1).to_nanos() >= 600_000_000u64,
-            "diff: {:?}",
-            (t2 - t1).to_nanos()
-        );
+        test_async_delay_ns(alarm0, 600_000_000).await;
     }
 
     #[test]
     #[timeout(2)]
     async fn test_timg0_async_delay_ns(ctx: Context) {
         let timg0 = TimerGroup::new_async(ctx.peripherals.TIMG0);
-        let mut timer0 = timg0.timer0;
 
-        let t1 = esp_hal::time::current_time();
-        timer0.delay_ns(600_000_000).await;
-        let t2 = esp_hal::time::current_time();
+        test_async_delay_ns(timg0.timer0, 600_000_000).await;
+        #[cfg(timg_timer1)]
+        test_async_delay_ns(timg0.timer1, 600_000_000).await;
+    }
 
-        assert!(t2 > t1);
-        assert!(
-            (t2 - t1).to_nanos() >= 600_000_000u64,
-            "diff: {:?}",
-            (t2 - t1).to_nanos()
-        );
+    #[cfg(timg1)]
+    #[test]
+    #[timeout(2)]
+    async fn test_timg1_async_delay_ns(ctx: Context) {
+        let timg1 = TimerGroup::new_async(ctx.peripherals.TIMG1);
+
+        test_async_delay_ns(timg1.timer0, 600_000_000).await;
+        #[cfg(timg_timer1)]
+        test_async_delay_ns(timg1.timer1, 600_000_000).await;
     }
 }


### PR DESCRIPTION
Both `SYSTIMER` alarms and `TIMGx` timers now implement this trait, and I've added some simple tests to cover the implementations.

I guess this closes #1864 because I am not sure there is a non-hacky and portable way to implement this trait for our `Delay` struct.