### PR TITLE
[esp-hal-procmacros] Update to proc-macro-error2

### DIFF
--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -19,7 +19,7 @@ document-features = "0.2.10"
 litrs             = "0.4.1"
 object            = { version = "0.36.4", optional = true, default-features = false, features = ["read_core", "elf"] }
 proc-macro-crate  = "3.2.0"
-proc-macro-error  = "1.0.4"
+proc-macro-error2 = "2.0.0"
 proc-macro2       = "1.0.86"
 quote             = "1.0.37"
 syn               = { version = "2.0.76", features = ["extra-traits", "full"] }

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -128,11 +128,11 @@ struct RamArgs {
 /// [`bytemuck::Zeroable`]: https://docs.rs/bytemuck/1.9.0/bytemuck/trait.Zeroable.html
 #[cfg(feature = "ram")]
 #[proc_macro_attribute]
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
     use darling::{ast::NestedMeta, Error, FromMeta};
     use proc_macro::Span;
-    use proc_macro_error::abort;
+    use proc_macro_error2::abort;
     use syn::{parse, Item};
 
     let attr_args = match NestedMeta::parse_meta_list(args.into()) {
@@ -241,7 +241,7 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// If no priority is given, `Priority::min()` is assumed
 #[cfg(feature = "interrupt")]
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
     use darling::{ast::NestedMeta, FromMeta};
@@ -352,7 +352,7 @@ pub fn load_lp_code(input: TokenStream) -> TokenStream {
 
 /// Marks the entry function of a LP core / ULP program.
 #[cfg(any(feature = "is-lp-core", feature = "is-ulp-core"))]
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     lp_core::entry(args, input)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
`proc-macro-error` is unmaintained (see https://github.com/rustsec/advisory-db/pull/2057) and pulls in `syn 1.x` leading to longer build times, it also has a ton of warnings firing due to not being touched for 4 years. Therefore, I have made a fork that fixes all that and filed the above rustsec PR.

This PR just swaps over the dependency, which should make no difference to users of this crate except from improved build times and not getting hit by the rustsec warning when merged.

#### Testing
`cargo xtask fmt-packages` and `cargo xtask lint-packages`