### PR TITLE
Rename `esp_hal::time::current_time` to `esp_hal::time::now`

### DIFF
--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -5,7 +5,7 @@ use embassy_time_driver::{AlarmHandle, Driver};
 use esp_hal::{
     interrupt::{InterruptHandler, Priority},
     prelude::*,
-    time::current_time,
+    time::uptime,
     timer::{ErasedTimer, OneShotTimer},
 };
 
@@ -119,7 +119,7 @@ impl EmbassyTimer {
     }
 
     fn arm(timer: &mut Timer, timestamp: u64) {
-        let now = current_time().duration_since_epoch();
+        let now = uptime().duration_since_epoch();
         let ts = timestamp.micros();
         // if the TS is already in the past make the timer fire immediately
         let timeout = if ts > now { ts - now } else { 0.micros() };
@@ -130,7 +130,7 @@ impl EmbassyTimer {
 
 impl Driver for EmbassyTimer {
     fn now(&self) -> u64 {
-        current_time().ticks()
+        uptime().ticks()
     }
 
     unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {

--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -5,7 +5,7 @@ use embassy_time_driver::{AlarmHandle, Driver};
 use esp_hal::{
     interrupt::{InterruptHandler, Priority},
     prelude::*,
-    time::uptime,
+    time::now,
     timer::{ErasedTimer, OneShotTimer},
 };
 
@@ -119,7 +119,7 @@ impl EmbassyTimer {
     }
 
     fn arm(timer: &mut Timer, timestamp: u64) {
-        let now = uptime().duration_since_epoch();
+        let now = now().duration_since_epoch();
         let ts = timestamp.micros();
         // if the TS is already in the past make the timer fire immediately
         let timeout = if ts > now { ts - now } else { 0.micros() };
@@ -130,7 +130,7 @@ impl EmbassyTimer {
 
 impl Driver for EmbassyTimer {
     fn now(&self) -> u64 {
-        uptime().ticks()
+        now().ticks()
     }
 
     unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Delay::new()` is now a `const` function (#1999)
 - You can now create an `AnyPin` out of an `ErasedPin`. (#2072)
 - `Input`, `Output`, `OutputOpenDrain` and `Flex` are now type-erased by default. Use the new `new_typed` constructor to keep using the ZST pin types. (#2075)
-- To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::uptime()`. (#2091)
+- To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::now`. (#2091)
 
 ### Fixed
 - SHA driver can now be safely used in multiple contexts concurrently (#2049)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Delay::new()` is now a `const` function (#1999)
 - You can now create an `AnyPin` out of an `ErasedPin`. (#2072)
 - `Input`, `Output`, `OutputOpenDrain` and `Flex` are now type-erased by default. Use the new `new_typed` constructor to keep using the ZST pin types. (#2075)
+- To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::uptime()`. (#2091)
 
 ### Fixed
 - SHA driver can now be safely used in multiple contexts concurrently (#2049)

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -53,9 +53,9 @@ let pin = Input::new_typed(io.gpio0); // pin will have the type `Input<'some, Gp
 
 ## `esp_hal::time::current_time` rename
 
-To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::uptime()`.
+To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::now()`.
 
 ```diff
 - use esp_hal::time::current_time;
-+ use esp_hal::time::uptime;
++ use esp_hal::time::now;
 ```

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -50,4 +50,12 @@ However, if you want to, you can keep using their typed form!
 ```rust
 let pin = Input::new(io.gpio0); // pin will have the type `Input<'some>` (or `Input<'some, ErasedPin>` if you want to be explicit about it)
 let pin = Input::new_typed(io.gpio0); // pin will have the type `Input<'some, GpioPin<0>>`
+
+## `esp_hal::time::current_time` rename
+
+To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::uptime()`.
+
+```diff
+- use esp_hal::time::current_time;
++ use esp_hal::time::uptime;
 ```

--- a/esp-hal/src/delay.rs
+++ b/esp-hal/src/delay.rs
@@ -31,7 +31,7 @@
 //! [DelayMs]: embedded_hal_02::blocking::delay::DelayMs
 //! [DelayUs]: embedded_hal_02::blocking::delay::DelayUs
 //! [embedded-hal]: https://docs.rs/embedded-hal/1.0.0/embedded_hal/delay/index.html
-//! [current_time]: crate::time::current_time
+//! [current_time]: crate::time::uptime
 
 pub use fugit::MicrosDurationU64;
 
@@ -75,7 +75,7 @@ impl Delay {
 
     /// Delay for the specified time
     pub fn delay(&self, delay: MicrosDurationU64) {
-        let start = crate::time::current_time();
+        let start = crate::time::uptime();
 
         while elapsed_since(start) < delay {}
     }
@@ -101,7 +101,7 @@ impl Delay {
 }
 
 fn elapsed_since(start: fugit::Instant<u64, 1, 1_000_000>) -> MicrosDurationU64 {
-    let now = crate::time::current_time();
+    let now = crate::time::uptime();
 
     if start.ticks() <= now.ticks() {
         now - start

--- a/esp-hal/src/delay.rs
+++ b/esp-hal/src/delay.rs
@@ -3,7 +3,7 @@
 //! ## Overview
 //!
 //! The Delay driver provides blocking delay functionalities using the
-//! [current_time] function.
+//! [now] function.
 //!
 //! ## Configuration
 //!
@@ -31,7 +31,7 @@
 //! [DelayMs]: embedded_hal_02::blocking::delay::DelayMs
 //! [DelayUs]: embedded_hal_02::blocking::delay::DelayUs
 //! [embedded-hal]: https://docs.rs/embedded-hal/1.0.0/embedded_hal/delay/index.html
-//! [current_time]: crate::time::uptime
+//! [now]: crate::time::now
 
 pub use fugit::MicrosDurationU64;
 
@@ -75,7 +75,7 @@ impl Delay {
 
     /// Delay for the specified time
     pub fn delay(&self, delay: MicrosDurationU64) {
-        let start = crate::time::uptime();
+        let start = crate::time::now();
 
         while elapsed_since(start) < delay {}
     }
@@ -101,12 +101,12 @@ impl Delay {
 }
 
 fn elapsed_since(start: fugit::Instant<u64, 1, 1_000_000>) -> MicrosDurationU64 {
-    let now = crate::time::uptime();
+    let now = crate::time::now();
 
     if start.ticks() <= now.ticks() {
         now - start
     } else {
-        // current_time specifies at least 7 happy years, let's ignore this issue for
+        // now specifies at least 7 happy years, let's ignore this issue for
         // now.
         panic!("Time has wrapped around, which we currently don't handle");
     }

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -734,8 +734,7 @@ pub struct Config {
 ///
 /// This function sets up the CPU clock and returns the peripherals and clocks.
 pub fn init(config: Config) -> Peripherals {
-    use self::peripherals::*;
-    let peripherals = Peripherals::take();
+    let mut peripherals = Peripherals::take();
 
     Clocks::init(config.cpu_clock);
 
@@ -745,15 +744,15 @@ pub fn init(config: Config) -> Peripherals {
     crate::time::time_init();
 
     // RTC domain must be enabled before we try to disable
-    let mut rtc = crate::rtc_cntl::Rtc::new(unsafe { LPWR::steal() });
+    let mut rtc = crate::rtc_cntl::Rtc::new(&mut peripherals.LPWR);
     #[cfg(not(any(esp32, esp32s2)))]
     rtc.swd.disable();
     rtc.rwdt.disable();
 
     unsafe {
-        crate::timer::timg::Wdt::<TIMG0, crate::Blocking>::set_wdt_enabled(false);
+        crate::timer::timg::Wdt::<self::peripherals::TIMG0, Blocking>::set_wdt_enabled(false);
         #[cfg(timg1)]
-        crate::timer::timg::Wdt::<TIMG1, crate::Blocking>::set_wdt_enabled(false);
+        crate::timer::timg::Wdt::<self::peripherals::TIMG1, Blocking>::set_wdt_enabled(false);
     }
 
     peripherals

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -7,11 +7,7 @@
 
 use core::ptr::addr_of_mut;
 
-use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{
-    rtc_cntl::{Rtc, SocResetReason},
-    timer::timg::Wdt,
-};
+use crate::rtc_cntl::SocResetReason;
 
 pub mod cpu_control;
 pub mod efuse;
@@ -111,9 +107,6 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         stack_chk_guard.write_volatile(0xdeadbabe);
     }
 
-    crate::interrupt::setup_interrupts();
-    crate::time::time_init();
-
     // continue with default reset handler
     xtensa_lx_rt::Reset();
 }
@@ -125,14 +118,4 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 #[rustfmt::skip]
 pub extern "Rust" fn __init_data() -> bool {
     false
-}
-
-#[export_name = "__post_init"]
-unsafe fn post_init() {
-    // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LPWR::steal());
-    rtc.rwdt.disable();
-
-    Wdt::<TIMG0, crate::Blocking>::set_wdt_enabled(false);
-    Wdt::<TIMG1, crate::Blocking>::set_wdt_enabled(false);
 }

--- a/esp-hal/src/soc/esp32c2/mod.rs
+++ b/esp-hal/src/soc/esp32c2/mod.rs
@@ -5,9 +5,6 @@
 //! The `SOC` module provides access, functions and structures that are useful
 //! for interacting with various system-related peripherals on `ESP32-C2` chip.
 
-use self::peripherals::{LPWR, TIMG0};
-use crate::{rtc_cntl::Rtc, timer::timg::Wdt};
-
 pub mod efuse;
 pub mod gpio;
 pub mod peripherals;
@@ -37,14 +34,4 @@ pub(crate) mod constants {
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);
-}
-
-#[export_name = "__post_init"]
-unsafe fn post_init() {
-    // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LPWR::steal());
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
-    Wdt::<TIMG0, crate::Blocking>::set_wdt_enabled(false);
 }

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -9,9 +9,6 @@
 //!    * I2S_SCLK: 160_000_000 - I2S clock frequency
 //!    * I2S_DEFAULT_CLK_SRC: 2 - I2S clock source
 
-use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{rtc_cntl::Rtc, timer::timg::Wdt};
-
 pub mod efuse;
 pub mod gpio;
 pub mod peripherals;
@@ -55,15 +52,4 @@ pub(crate) mod constants {
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);
-}
-
-#[export_name = "__post_init"]
-unsafe fn post_init() {
-    // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LPWR::steal());
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
-    Wdt::<TIMG0, crate::Blocking>::set_wdt_enabled(false);
-    Wdt::<TIMG1, crate::Blocking>::set_wdt_enabled(false);
 }

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -10,9 +10,6 @@
 //!    * I2S_DEFAULT_CLK_SRC: 2 - I2S clock source
 //!    * I2S_SCLK: 160_000_000 - I2S clock frequency
 
-use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{rtc_cntl::Rtc, timer::timg::Wdt};
-
 pub mod efuse;
 pub mod gpio;
 pub mod lp_core;
@@ -63,15 +60,4 @@ pub(crate) mod constants {
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17_500);
-}
-
-#[export_name = "__post_init"]
-unsafe fn post_init() {
-    // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LPWR::steal());
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
-    Wdt::<TIMG0, crate::Blocking>::set_wdt_enabled(false);
-    Wdt::<TIMG1, crate::Blocking>::set_wdt_enabled(false);
 }

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -10,9 +10,6 @@
 //!    * I2S_DEFAULT_CLK_SRC: 1 - I2S clock source
 //!    * I2S_SCLK: 96_000_000 - I2S clock frequency
 
-use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{rtc_cntl::Rtc, timer::timg::Wdt};
-
 pub mod efuse;
 pub mod gpio;
 pub mod peripherals;
@@ -63,15 +60,4 @@ pub(crate) mod constants {
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);
-}
-
-#[export_name = "__post_init"]
-unsafe fn post_init() {
-    // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LPWR::steal());
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-
-    Wdt::<TIMG0, crate::Blocking>::set_wdt_enabled(false);
-    Wdt::<TIMG1, crate::Blocking>::set_wdt_enabled(false);
 }

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -11,11 +11,7 @@
 
 use core::ptr::addr_of_mut;
 
-use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{
-    rtc_cntl::{Rtc, SocResetReason},
-    timer::timg::Wdt,
-};
+use crate::rtc_cntl::SocResetReason;
 
 pub mod efuse;
 pub mod gpio;
@@ -116,8 +112,6 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         stack_chk_guard.write_volatile(0xdeadbabe);
     }
 
-    crate::interrupt::setup_interrupts();
-
     // continue with default reset handler
     xtensa_lx_rt::Reset();
 }
@@ -129,14 +123,4 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 #[rustfmt::skip]
 pub extern "Rust" fn __init_data() -> bool {
     false
-}
-
-#[export_name = "__post_init"]
-unsafe fn post_init() {
-    // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LPWR::steal());
-    rtc.rwdt.disable();
-
-    Wdt::<TIMG0, crate::Blocking>::set_wdt_enabled(false);
-    Wdt::<TIMG1, crate::Blocking>::set_wdt_enabled(false);
 }

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -11,11 +11,7 @@
 
 use core::ptr::addr_of_mut;
 
-use self::peripherals::{LPWR, TIMG0, TIMG1};
-use crate::{
-    rtc_cntl::{Rtc, SocResetReason},
-    timer::timg::Wdt,
-};
+use crate::rtc_cntl::SocResetReason;
 
 pub mod cpu_control;
 pub mod efuse;
@@ -155,8 +151,6 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         stack_chk_guard.write_volatile(0xdeadbabe);
     }
 
-    crate::interrupt::setup_interrupts();
-
     // continue with default reset handler
     xtensa_lx_rt::Reset();
 }
@@ -168,16 +162,6 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 #[rustfmt::skip]
 pub extern "Rust" fn __init_data() -> bool {
     false
-}
-
-#[export_name = "__post_init"]
-unsafe fn post_init() {
-    // RTC domain must be enabled before we try to disable
-    let mut rtc = Rtc::new(LPWR::steal());
-    rtc.rwdt.disable();
-
-    Wdt::<TIMG0, crate::Blocking>::set_wdt_enabled(false);
-    Wdt::<TIMG1, crate::Blocking>::set_wdt_enabled(false);
 }
 
 /// Write back a specific range of data in the cache.

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -1,6 +1,6 @@
 //! # Time
 //!
-//! The `time` module offers a way to get the system uptime.
+//! The `time` module offers a way to get the system now.
 
 /// Provides time since system start in microseconds precision.
 ///
@@ -10,7 +10,7 @@
 #[cfg_attr(esp32, doc = "36_558 years")]
 #[cfg_attr(esp32s2, doc = "7_311 years")]
 #[cfg_attr(not(any(esp32, esp32s2)), doc = "more than 7 years")]
-pub fn uptime() -> fugit::Instant<u64, 1, 1_000_000> {
+pub fn now() -> fugit::Instant<u64, 1, 1_000_000> {
     #[cfg(esp32)]
     let (ticks, div) = {
         // on ESP32 use LACT

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -50,10 +50,10 @@ pub fn uptime() -> fugit::Instant<u64, 1, 1_000_000> {
 
 #[cfg(esp32)]
 pub(crate) fn time_init() {
-    let apb = Clocks::get().apb_clock.to_Hz();
+    let apb = crate::Clocks::get().apb_clock.to_Hz();
     // we assume 80MHz APB clock source - there is no way to configure it in a
     // different way currently
-    assert!(apb, 80_000_000u32);
+    assert_eq!(apb, 80_000_000u32);
 
     let tg0 = unsafe { crate::peripherals::TIMG0::steal() };
 

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -148,7 +148,7 @@ impl<'d> SystemTimer<'d> {
 
     /// Create a new instance.
     pub fn new(_systimer: impl Peripheral<P = SYSTIMER> + 'd) -> Self {
-        // Don't reset Systimer as it will break `current_time`, only enable it
+        // Don't reset Systimer as it will break `time::now`, only enable it
         PeripheralClockControl::enable(PeripheralEnable::Systimer);
 
         #[cfg(soc_etm)]

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -159,7 +159,7 @@ impl TimerGroupInstance for TIMG0 {
     }
 
     fn reset_peripheral() {
-        // for TIMG0 do nothing for now because the reset breaks `current_time`
+        // for TIMG0 do nothing for now because the reset breaks `time::now`
     }
 
     #[inline(always)]

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -89,7 +89,7 @@ pub fn yield_task() {
 /// Current systimer count value
 /// A tick is 1 / 1_000_000 seconds
 pub fn get_systimer_count() -> u64 {
-    esp_hal::time::current_time().ticks()
+    esp_hal::time::uptime().ticks()
 }
 
 // TODO: use an Instance type instead...

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -89,7 +89,7 @@ pub fn yield_task() {
 /// Current systimer count value
 /// A tick is 1 / 1_000_000 seconds
 pub fn get_systimer_count() -> u64 {
-    esp_hal::time::uptime().ticks()
+    esp_hal::time::now().ticks()
 }
 
 // TODO: use an Instance type instead...

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -20,7 +20,7 @@ pub const TICKS_PER_SECOND: u64 = 1_000_000;
 /// This function must not be called in a critical section. Doing so may return
 /// an incorrect value.
 pub fn get_systimer_count() -> u64 {
-    esp_hal::time::uptime().ticks()
+    esp_hal::time::now().ticks()
 }
 
 pub fn setup_timer(mut timer1: TimeBase) -> Result<(), esp_hal::timer::Error> {

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -20,7 +20,7 @@ pub const TICKS_PER_SECOND: u64 = 1_000_000;
 /// This function must not be called in a critical section. Doing so may return
 /// an incorrect value.
 pub fn get_systimer_count() -> u64 {
-    esp_hal::time::current_time().ticks()
+    esp_hal::time::uptime().ticks()
 }
 
 pub fn setup_timer(mut timer1: TimeBase) -> Result<(), esp_hal::timer::Error> {

--- a/examples/src/bin/timer_interrupt.rs
+++ b/examples/src/bin/timer_interrupt.rs
@@ -46,9 +46,7 @@ fn tg0_t0_level() {
     critical_section::with(|cs| {
         esp_println::println!(
             "Interrupt at {} ms",
-            esp_hal::time::current_time()
-                .duration_since_epoch()
-                .to_millis()
+            esp_hal::time::uptime().duration_since_epoch().to_millis()
         );
 
         let mut timer0 = TIMER0.borrow_ref_mut(cs);

--- a/examples/src/bin/timer_interrupt.rs
+++ b/examples/src/bin/timer_interrupt.rs
@@ -46,7 +46,7 @@ fn tg0_t0_level() {
     critical_section::with(|cs| {
         esp_println::println!(
             "Interrupt at {} ms",
-            esp_hal::time::uptime().duration_since_epoch().to_millis()
+            esp_hal::time::now().duration_since_epoch().to_millis()
         );
 
         let mut timer0 = TIMER0.borrow_ref_mut(cs);

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -29,9 +29,9 @@ mod tests {
     #[test]
     #[timeout(2)]
     fn delay_ns(mut ctx: Context) {
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         ctx.delay.delay_ns(600_000_000);
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1);
         assert!(
@@ -44,9 +44,9 @@ mod tests {
     #[test]
     #[timeout(2)]
     fn delay_700millis(ctx: Context) {
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         ctx.delay.delay_millis(700);
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1);
         assert!(
@@ -59,9 +59,9 @@ mod tests {
     #[test]
     #[timeout(2)]
     fn delay_1_500_000us(mut ctx: Context) {
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         ctx.delay.delay_us(1_500_000);
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1);
         assert!(
@@ -74,9 +74,9 @@ mod tests {
     #[test]
     #[timeout(5)]
     fn delay_3_000ms(mut ctx: Context) {
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         ctx.delay.delay_ms(3000);
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1);
         assert!(

--- a/hil-test/tests/delay.rs
+++ b/hil-test/tests/delay.rs
@@ -29,9 +29,9 @@ mod tests {
     #[test]
     #[timeout(2)]
     fn delay_ns(mut ctx: Context) {
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         ctx.delay.delay_ns(600_000_000);
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1);
         assert!(
@@ -44,9 +44,9 @@ mod tests {
     #[test]
     #[timeout(2)]
     fn delay_700millis(ctx: Context) {
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         ctx.delay.delay_millis(700);
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1);
         assert!(
@@ -59,9 +59,9 @@ mod tests {
     #[test]
     #[timeout(2)]
     fn delay_1_500_000us(mut ctx: Context) {
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         ctx.delay.delay_us(1_500_000);
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1);
         assert!(
@@ -74,9 +74,9 @@ mod tests {
     #[test]
     #[timeout(5)]
     fn delay_3_000ms(mut ctx: Context) {
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         ctx.delay.delay_ms(3000);
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1);
         assert!(

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -48,10 +48,10 @@ mod test_cases {
     use super::*;
 
     pub async fn run_test_one_shot_async() {
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         Timer::after_millis(50).await;
         Timer::after_millis(30).await;
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
         assert!(
@@ -64,11 +64,11 @@ mod test_cases {
     pub fn run_test_periodic_timer<T: esp_hal::timer::Timer>(timer: impl Peripheral<P = T>) {
         let mut periodic = PeriodicTimer::new(timer);
 
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         periodic.start(100.millis()).unwrap();
 
         nb::block!(periodic.wait()).unwrap();
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
         assert!(
@@ -81,9 +81,9 @@ mod test_cases {
     pub fn run_test_oneshot_timer<T: esp_hal::timer::Timer>(timer: impl Peripheral<P = T>) {
         let timer = OneShotTimer::new(timer);
 
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         timer.delay_millis(50);
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
         assert!(
@@ -94,10 +94,10 @@ mod test_cases {
     }
 
     pub async fn run_join_test() {
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         embassy_futures::join::join(Timer::after_millis(50), Timer::after_millis(30)).await;
         Timer::after_millis(50).await;
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
         assert!(
@@ -232,11 +232,11 @@ mod test {
             let outcome = async {
                 let mut ticker = Ticker::every(Duration::from_millis(30));
 
-                let t1 = esp_hal::time::current_time();
+                let t1 = esp_hal::time::uptime();
                 ticker.next().await;
                 ticker.next().await;
                 ticker.next().await;
-                let t2 = esp_hal::time::current_time();
+                let t2 = esp_hal::time::uptime();
 
                 assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
                 assert!(
@@ -268,13 +268,13 @@ mod test {
         // We are retrying 5 times because probe-rs polling RTT may introduce some
         // jitter.
         for _ in 0..5 {
-            let t1 = esp_hal::time::current_time();
+            let t1 = esp_hal::time::uptime();
 
             let mut ticker = Ticker::every(Duration::from_hz(100_000));
             for _ in 0..2000 {
                 ticker.next().await;
             }
-            let t2 = esp_hal::time::current_time();
+            let t2 = esp_hal::time::uptime();
 
             assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
             let duration = (t2 - t1).to_micros();

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -48,10 +48,10 @@ mod test_cases {
     use super::*;
 
     pub async fn run_test_one_shot_async() {
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         Timer::after_millis(50).await;
         Timer::after_millis(30).await;
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
         assert!(
@@ -64,11 +64,11 @@ mod test_cases {
     pub fn run_test_periodic_timer<T: esp_hal::timer::Timer>(timer: impl Peripheral<P = T>) {
         let mut periodic = PeriodicTimer::new(timer);
 
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         periodic.start(100.millis()).unwrap();
 
         nb::block!(periodic.wait()).unwrap();
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
         assert!(
@@ -81,9 +81,9 @@ mod test_cases {
     pub fn run_test_oneshot_timer<T: esp_hal::timer::Timer>(timer: impl Peripheral<P = T>) {
         let timer = OneShotTimer::new(timer);
 
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         timer.delay_millis(50);
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
         assert!(
@@ -94,10 +94,10 @@ mod test_cases {
     }
 
     pub async fn run_join_test() {
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         embassy_futures::join::join(Timer::after_millis(50), Timer::after_millis(30)).await;
         Timer::after_millis(50).await;
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
         assert!(
@@ -232,11 +232,11 @@ mod test {
             let outcome = async {
                 let mut ticker = Ticker::every(Duration::from_millis(30));
 
-                let t1 = esp_hal::time::uptime();
+                let t1 = esp_hal::time::now();
                 ticker.next().await;
                 ticker.next().await;
                 ticker.next().await;
-                let t2 = esp_hal::time::uptime();
+                let t2 = esp_hal::time::now();
 
                 assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
                 assert!(
@@ -268,13 +268,13 @@ mod test {
         // We are retrying 5 times because probe-rs polling RTT may introduce some
         // jitter.
         for _ in 0..5 {
-            let t1 = esp_hal::time::uptime();
+            let t1 = esp_hal::time::now();
 
             let mut ticker = Ticker::every(Duration::from_hz(100_000));
             for _ in 0..2000 {
                 ticker.next().await;
             }
-            let t2 = esp_hal::time::uptime();
+            let t2 = esp_hal::time::now();
 
             assert!(t2 > t1, "t2: {:?}, t1: {:?}", t2, t1);
             let duration = (t2 - t1).to_micros();

--- a/hil-test/tests/get_time.rs
+++ b/hil-test/tests/get_time.rs
@@ -13,9 +13,9 @@ struct Context {
 }
 
 fn time_moves_forward_during<F: FnOnce(Context)>(ctx: Context, f: F) {
-    let t1 = esp_hal::time::current_time();
+    let t1 = esp_hal::time::uptime();
     f(ctx);
-    let t2 = esp_hal::time::current_time();
+    let t2 = esp_hal::time::uptime();
 
     assert!(t2 > t1);
 }
@@ -37,9 +37,9 @@ mod tests {
     #[test]
     #[timeout(3)]
     fn test_current_time(ctx: Context) {
-        let t1 = esp_hal::time::current_time();
+        let t1 = esp_hal::time::uptime();
         ctx.delay.delay_millis(500);
-        let t2 = esp_hal::time::current_time();
+        let t2 = esp_hal::time::uptime();
 
         assert!(t2 > t1);
         assert!((t2 - t1).to_millis() >= 500u64);

--- a/hil-test/tests/get_time.rs
+++ b/hil-test/tests/get_time.rs
@@ -1,4 +1,4 @@
-//! current_time Test
+//! time::now Test
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -13,9 +13,9 @@ struct Context {
 }
 
 fn time_moves_forward_during<F: FnOnce(Context)>(ctx: Context, f: F) {
-    let t1 = esp_hal::time::uptime();
+    let t1 = esp_hal::time::now();
     f(ctx);
-    let t2 = esp_hal::time::uptime();
+    let t2 = esp_hal::time::now();
 
     assert!(t2 > t1);
 }
@@ -37,9 +37,9 @@ mod tests {
     #[test]
     #[timeout(3)]
     fn test_current_time(ctx: Context) {
-        let t1 = esp_hal::time::uptime();
+        let t1 = esp_hal::time::now();
         ctx.delay.delay_millis(500);
-        let t2 = esp_hal::time::uptime();
+        let t2 = esp_hal::time::now();
 
         assert!(t2 > t1);
         assert!((t2 - t1).to_millis() >= 500u64);


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::now()`.