### PR TITLE
esp-wifi: other crates also provide `strchr` (littlefs2-sys)

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `have-strchr` feature to disable including `strchr` (#2096)
+
 ### Changed
 
 ### Fixed

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -133,6 +133,7 @@ wifi-default = ["ipv4", "tcp", "udp", "icmp", "igmp", "dns", "dhcpv4"]
 defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt"]
 log = ["dep:log", "esp-hal/log"]
 sniffer = ["wifi"]
+have-strchr = []
 
 [package.metadata.docs.rs]
 features = [

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -46,7 +46,6 @@ unsafe extern "C" fn strcmp(str1: *const i8, str2: *const i8) -> i32 {
     }
 }
 
-
 #[cfg(feature = "have-strchr")]
 extern "C" {
     fn strchr(str: *const i8, c: i32) -> *const i8;

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -46,6 +46,13 @@ unsafe extern "C" fn strcmp(str1: *const i8, str2: *const i8) -> i32 {
     }
 }
 
+
+#[cfg(feature = "have-strchr")]
+extern "C" {
+    fn strchr(str: *const i8, c: i32) -> *const i8;
+}
+
+#[cfg(not(feature = "have-strchr"))]
 #[no_mangle]
 unsafe extern "C" fn strchr(str: *const i8, c: i32) -> *const i8 {
     trace!("strchr {:?} {}", str, c);


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
With the WPA2 ENTERPRISE (#2004) PR came an implementation of `strchr` - is someone is using littlefs2 this causes link failures with this symbol being multiply defined.

This PR make that optional with a `have-strchr` feature.  Not sure this is the best solution - ideally there would be some common crate of these `C` functions that could be used.

#### Testing
Compiled unit that includes littlefs with `have-strchr` feature enabled.
