### PR TITLE
Add missing #[doc(hidden)] in xtensa-lx-rt-proc-macros

### DIFF
--- a/xtensa-lx-rt/procmacros/src/lib.rs
+++ b/xtensa-lx-rt/procmacros/src/lib.rs
@@ -128,6 +128,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
             )
         }
 
+        #[doc(hidden)]
         #[allow(clippy::inline_always)]
         #[inline(always)]
         #f
@@ -398,6 +399,7 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
                 )
             }
 
+            #[doc(hidden)]
             #[allow(clippy::inline_always)]
             #[inline(always)]
             #f


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
An oversight from https://github.com/esp-rs/xtensa-lx/pull/37.
I missed a few spots where public macros were exposed, without a `#[doc(hidden)]` attribute.

I don't think the changes necessitate a new entry in `CHANGELOG.md`

#### Testing
CI should pass. The changes should not break anything.
