### PR TITLE
Update esp-println version in usage section

### DIFF
--- a/esp-println/README.md
+++ b/esp-println/README.md
@@ -19,7 +19,7 @@ logging capabilities for Espressif devices.
 # Usage
 
 ```toml
-esp-println = { version = "0.9.1", features = ["esp32c2"] }
+esp-println = { version = "0.11.0", features = ["esp32c2"] }
 ```
 
 or `cargo add esp-println --features esp32c2`


### PR DESCRIPTION
Makes a mess with features

Do I need to add this to the changelog? I hope not