### PR TITLE
Ensure that clock init happens after Rtc domain is initialized

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -736,13 +736,6 @@ pub struct Config {
 pub fn init(config: Config) -> Peripherals {
     let mut peripherals = Peripherals::take();
 
-    Clocks::init(config.cpu_clock);
-
-    #[cfg(xtensa)]
-    crate::interrupt::setup_interrupts();
-    #[cfg(esp32)]
-    crate::time::time_init();
-
     // RTC domain must be enabled before we try to disable
     let mut rtc = crate::rtc_cntl::Rtc::new(&mut peripherals.LPWR);
     #[cfg(not(any(esp32, esp32s2)))]
@@ -754,6 +747,13 @@ pub fn init(config: Config) -> Peripherals {
         #[cfg(timg1)]
         crate::timer::timg::Wdt::<self::peripherals::TIMG1, Blocking>::set_wdt_enabled(false);
     }
+
+    Clocks::init(config.cpu_clock);
+
+    #[cfg(xtensa)]
+    crate::interrupt::setup_interrupts();
+    #[cfg(esp32)]
+    crate::time::time_init();
 
     peripherals
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Still unsure why this is required, I'll try to investigate the TRMs a bit further, but this should put everything back into working order.

Closes #2101 
