### PR TITLE
Touch pin definition overhaul

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::now`. (#2091)
 - Renamed `touch::Continous` to `touch::Continuous`. (#2094)
 - The (previously undocumented) `ErasedPin` enum has been replaced with the `ErasedPin` struct. (#2094)
+- ESP32: Added support for touch sensing on GPIO32 and 33 (#2109)
 
 ### Fixed
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -177,15 +177,6 @@ pub enum Pull {
     Down,
 }
 
-/// RTC input pin mode
-pub struct RtcInput;
-
-/// RTC output pin mode
-pub struct RtcOutput;
-
-/// Analog mode
-pub struct Analog;
-
 /// Drive strength (values are approximates)
 pub enum DriveStrength {
     /// Drive strength of approximately 5mA.
@@ -259,11 +250,6 @@ pub trait RtcPinWithResistors: RtcPin {
     /// Enable/disable the internal pull-down resistor
     fn rtcio_pulldown(&mut self, enable: bool);
 }
-
-/// Marker for RTC pins which support input mode
-pub trait RtcInputPin: RtcPin {}
-/// Marker for RTC pins which support output mode
-pub trait RtcOutputPin: RtcPin {}
 
 /// Common trait implemented by pins
 pub trait Pin: private::Sealed {

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -793,8 +793,8 @@ crate::gpio::gpio! {
     (25, 0, InputOutputAnalog (5 => EMAC_RXD0) ())
     (26, 0, InputOutputAnalog (5 => EMAC_RXD1) ())
     (27, 0, InputOutputAnalogTouch (5 => EMAC_RX_DV) ())
-    (32, 1, InputOutputAnalog)
-    (33, 1, InputOutputAnalog)
+    (32, 1, InputOutputAnalogTouch)
+    (33, 1, InputOutputAnalogTouch)
     (34, 1, InputOnlyAnalog)
     (35, 1, InputOnlyAnalog)
     (36, 1, InputOnlyAnalog)
@@ -845,8 +845,8 @@ crate::gpio::rtc_pins! {
     (27, 17, touch_pad7(),     "",      touch_pad7_hold_force, rue,       rde       )
 }
 
-crate::gpio::touch_common! {
-    // (touch_nr, pin_nr, touch_out_reg, touch_thres_reg )
+crate::gpio::touch! {
+    // touch_nr, pin_nr, rtc_pin, touch_out_reg, meas_field, touch_thres_reg, touch_thres_field, normal_pin
     (0, 4,  10, sar_touch_out1, touch_meas_out0, sar_touch_thres1, touch_out_th0, true)
     (1, 0,  11, sar_touch_out1, touch_meas_out1, sar_touch_thres1, touch_out_th1, true)
     (2, 2,  12, sar_touch_out2, touch_meas_out2, sar_touch_thres2, touch_out_th2, true)

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -845,33 +845,19 @@ crate::gpio::rtc_pins! {
     (27, 17, touch_pad7(),     "",      touch_pad7_hold_force, rue,       rde       )
 }
 
-crate::gpio::touch_into! {
-    // (touch_nr, pin_nr, rtc_pin, touch_comb_reg_nr, normal_pin)
-    (0, 4,  10, sar_touch_thres1, touch_out_th0, true )
-    (1, 0,  11, sar_touch_thres1, touch_out_th1, true )
-    (2, 2,  12, sar_touch_thres2, touch_out_th2, true )
-    (3, 15, 13, sar_touch_thres2, touch_out_th3, true )
-    (4, 13, 14, sar_touch_thres3, touch_out_th4, true )
-    (5, 12, 15, sar_touch_thres3, touch_out_th5, true )
-    (6, 14, 16, sar_touch_thres4, touch_out_th6, true )
-    (7, 27, 17, sar_touch_thres4, touch_out_th7, true )
-    // ---
-    (8, 33, 8, sar_touch_thres5, touch_out_th8, false )
-    (9, 32, 9, sar_touch_thres5, touch_out_th9, false )
-}
-
 crate::gpio::touch_common! {
     // (touch_nr, pin_nr, touch_out_reg, touch_thres_reg )
-    (0, 4,  sar_touch_out1, touch_meas_out0, sar_touch_thres1, touch_out_th0)
-    (1, 0,  sar_touch_out1, touch_meas_out1, sar_touch_thres1, touch_out_th1)
-    (2, 2,  sar_touch_out2, touch_meas_out2, sar_touch_thres2, touch_out_th2)
-    (3, 15, sar_touch_out2, touch_meas_out3, sar_touch_thres2, touch_out_th3)
-    (4, 13, sar_touch_out3, touch_meas_out4, sar_touch_thres3, touch_out_th4)
-    (5, 12, sar_touch_out3, touch_meas_out5, sar_touch_thres3, touch_out_th5)
-    (6, 14, sar_touch_out4, touch_meas_out6, sar_touch_thres4, touch_out_th6)
-    (7, 27, sar_touch_out4, touch_meas_out7, sar_touch_thres4, touch_out_th7)
-    (8, 33, sar_touch_out5, touch_meas_out8, sar_touch_thres5, touch_out_th8)
-    (9, 32, sar_touch_out5, touch_meas_out9, sar_touch_thres5, touch_out_th9)
+    (0, 4,  10, sar_touch_out1, touch_meas_out0, sar_touch_thres1, touch_out_th0, true)
+    (1, 0,  11, sar_touch_out1, touch_meas_out1, sar_touch_thres1, touch_out_th1, true)
+    (2, 2,  12, sar_touch_out2, touch_meas_out2, sar_touch_thres2, touch_out_th2, true)
+    (3, 15, 13, sar_touch_out2, touch_meas_out3, sar_touch_thres2, touch_out_th3, true)
+    (4, 13, 14, sar_touch_out3, touch_meas_out4, sar_touch_thres3, touch_out_th4, true)
+    (5, 12, 15, sar_touch_out3, touch_meas_out5, sar_touch_thres3, touch_out_th5, true)
+    (6, 14, 16, sar_touch_out4, touch_meas_out6, sar_touch_thres4, touch_out_th6, true)
+    (7, 27, 17, sar_touch_out4, touch_meas_out7, sar_touch_thres4, touch_out_th7, true)
+    // ---
+    (8, 33, 8, sar_touch_out5, touch_meas_out8, sar_touch_thres5, touch_out_th8, false)
+    (9, 32, 9, sar_touch_out5, touch_meas_out9, sar_touch_thres5, touch_out_th9, false)
 }
 
 impl InterruptStatusRegisterAccess for InterruptStatusRegisterAccessBank0 {


### PR DESCRIPTION
This PR merges the different touch macros, which also enables implementing the Touch trait directly - uncovering two missing pins.