### PR TITLE
GPIO user interrupt tweaks

### DIFF
--- a/esp-hal/src/gpio/dummy_pin.rs
+++ b/esp-hal/src/gpio/dummy_pin.rs
@@ -61,8 +61,6 @@ impl Pin for DummyPin {
     }
 
     fn clear_interrupt(&mut self, _: private::Internal) {}
-
-    fn wakeup_enable(&mut self, _enable: bool, _event: WakeEvent, _: private::Internal) {}
 }
 
 impl OutputPin for DummyPin {

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -110,12 +110,6 @@ impl InterruptHandler {
     pub fn priority(&self) -> Priority {
         self.prio
     }
-
-    /// Call the function
-    #[inline]
-    pub(crate) extern "C" fn call(&self) {
-        (self.f)()
-    }
 }
 
 #[cfg(large_intr_status)]

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -5,6 +5,7 @@
 //!
 //! The following wiring is assumed:
 //! - LED => GPIO2
+//! - BUTTON => GPIO0 (ESP32, ESP32-S2, ESP32-S3) / GPIO9
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR originally intended to introduce per-pin interrupt handlers. Unfortunately that implementation wasn't viable, but the PR and the discussion around it created some (I believe) valuable results.

- There's no need to hold a critical section just to load the user handler
- Moved the actual async interrupt handling into a callback
  This hopefully makes it easier to modify in the future, should we want to. Also, while only two lines, this change deduplicates logic that has some subtleties.
- Removed some unnecessary stuff
- Updated the `set_interrupt_handler` documentation to better highlight what the user should expect, and how it interferes with `async`