### PR TITLE
Fix asymmetric SPI transfers on the chips that support it

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SHA driver can now be safely used in multiple contexts concurrently (#2049)
 - Fixed an issue with DMA transfers potentially not waking up the correct async task (#2065)
 - Fixed an issue with LCD_CAM i8080 where it would send double the clocks in 16bit mode (#2085)
+- Fix asymmetric SPI transfers on the chips that support it (#2113)
 - Fix i2c embedded-hal transaction (#2028)
 
 ### Removed

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -109,8 +109,27 @@ mod tests {
             .dma_transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
-        let (_, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
+        let (_spi, (dma_rx_buf, mut dma_tx_buf)) = transfer.wait();
         assert_eq!(dma_tx_buf.as_slice()[0..1], dma_rx_buf.as_slice()[0..1]);
+
+        // Try transfer again to make sure DMA isn't in a broken state.
+
+        dma_tx_buf.fill(&[0xad, 0xde, 0xef, 0xbe]);
+
+        // TODO: The following transfer doesn't work correctly as the previous transfer
+        // leaves the  DMA in a broken state. Work/investigation needs to be
+        // done to figure out what the  hardware wants from the driver to work
+        // correctly.
+
+        #[cfg(any(feature = "esp32"))]
+        {
+            let transfer = _spi
+                .dma_transfer(dma_rx_buf, dma_tx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            let (_, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
+            assert_eq!(dma_tx_buf.as_slice()[0..1], dma_rx_buf.as_slice()[0..1]);
+        }
     }
 
     #[test]

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -121,7 +121,7 @@ mod tests {
         // done to figure out what the  hardware wants from the driver to work
         // correctly.
 
-        #[cfg(any(feature = "esp32"))]
+        #[cfg(feature = "esp32")]
         {
             let transfer = _spi
                 .dma_transfer(dma_rx_buf, dma_tx_buf)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The ESP32 and ESP32-S2 natively support asymmetric SPI transfers and this PR changes the driver to pass the correct lengths for the tx and rx individually, rather than the max.
In theory this should fix #2098 (EDIT: in practice it doesn't :sweat_smile:) but it'll still be broken for all the other chips (the HIL tests for those don't fail because the GDMA is being reset, ideally the test would run the transfer more than once to show the issue).

#### Testing
CI. This is a pretty straight forward change (and my S2 is buried somewhere).
