### PR TITLE
Make sure we can compile with `defmt`

### DIFF
--- a/.github/actions/check-esp-hal/action.yml
+++ b/.github/actions/check-esp-hal/action.yml
@@ -29,7 +29,7 @@ runs:
     # Clippy and docs checks
     - name: Clippy
       shell: bash
-      run: DEFMT_LOG=trace cargo $LINTING_TOOLCHAIN xtask lint-packages --chips ${{ inputs.device }}
+      run: cargo $LINTING_TOOLCHAIN xtask lint-packages --chips ${{ inputs.device }}
     - name: Check doc-tests
       shell: bash
       run: cargo $LINTING_TOOLCHAIN xtask run-doc-test esp-hal ${{ inputs.device }}

--- a/.github/actions/check-esp-hal/action.yml
+++ b/.github/actions/check-esp-hal/action.yml
@@ -29,7 +29,7 @@ runs:
     # Clippy and docs checks
     - name: Clippy
       shell: bash
-      run: cargo $LINTING_TOOLCHAIN xtask lint-packages --chips ${{ inputs.device }}
+      run: DEFMT_LOG=trace cargo $LINTING_TOOLCHAIN xtask lint-packages --chips ${{ inputs.device }}
     - name: Check doc-tests
       shell: bash
       run: cargo $LINTING_TOOLCHAIN xtask run-doc-test esp-hal ${{ inputs.device }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,30 +129,30 @@ jobs:
       # Verify the MSRV for all RISC-V chips.
       - name: msrv RISCV (esp-hal)
         run: |
-          DEFMT_LOG=trace cargo xtask build-package --features=esp32c2,ci --target=riscv32imc-unknown-none-elf   esp-hal
-          DEFMT_LOG=trace cargo xtask build-package --features=esp32c3,ci --target=riscv32imc-unknown-none-elf   esp-hal
-          DEFMT_LOG=trace cargo xtask build-package --features=esp32c6,ci --target=riscv32imac-unknown-none-elf  esp-hal
-          DEFMT_LOG=trace cargo xtask build-package --features=esp32h2,ci --target=riscv32imac-unknown-none-elf  esp-hal
+          cargo xtask build-package --features=esp32c2,ci --target=riscv32imc-unknown-none-elf   esp-hal
+          cargo xtask build-package --features=esp32c3,ci --target=riscv32imc-unknown-none-elf   esp-hal
+          cargo xtask build-package --features=esp32c6,ci --target=riscv32imac-unknown-none-elf  esp-hal
+          cargo xtask build-package --features=esp32h2,ci --target=riscv32imac-unknown-none-elf  esp-hal
 
       - name: msrv RISCV (esp-wifi)
         run: |
-          DEFMT_LOG=trace cargo xtask build-package --features=esp32c2,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
-          DEFMT_LOG=trace cargo xtask build-package --features=esp32c3,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
-          DEFMT_LOG=trace cargo xtask build-package --features=esp32c6,wifi,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
-          DEFMT_LOG=trace cargo xtask build-package --features=esp32h2,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
+          cargo xtask build-package --features=esp32c2,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
+          cargo xtask build-package --features=esp32c3,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
+          cargo xtask build-package --features=esp32c6,wifi,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
+          cargo xtask build-package --features=esp32h2,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
 
         # Verify the MSRV for all Xtensa chips:
       - name: msrv Xtensa (esp-hal)
         run: |
-          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32,ci   --target=xtensa-esp32-none-elf   esp-hal
-          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32s2,ci --target=xtensa-esp32s2-none-elf esp-hal
-          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32s3,ci --target=xtensa-esp32s3-none-elf esp-hal
+          cargo xtask build-package --toolchain=esp --features=esp32,ci   --target=xtensa-esp32-none-elf   esp-hal
+          cargo xtask build-package --toolchain=esp --features=esp32s2,ci --target=xtensa-esp32s2-none-elf esp-hal
+          cargo xtask build-package --toolchain=esp --features=esp32s3,ci --target=xtensa-esp32s3-none-elf esp-hal
 
       - name: msrv Xtensa (esp-wifi)
         run: |
-          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32,wifi,ble,async   --target=xtensa-esp32-none-elf   esp-wifi
-          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32s2,wifi,async --target=xtensa-esp32s2-none-elf esp-wifi
-          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32s3,wifi,ble,async --target=xtensa-esp32s3-none-elf esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32,wifi,ble,async   --target=xtensa-esp32-none-elf   esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32s2,wifi,async --target=xtensa-esp32s2-none-elf esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32s3,wifi,ble,async --target=xtensa-esp32s3-none-elf esp-wifi
 
       - name: msrv (esp-lp-hal)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,30 +129,30 @@ jobs:
       # Verify the MSRV for all RISC-V chips.
       - name: msrv RISCV (esp-hal)
         run: |
-          cargo xtask build-package --features=esp32c2,ci --target=riscv32imc-unknown-none-elf   esp-hal
-          cargo xtask build-package --features=esp32c3,ci --target=riscv32imc-unknown-none-elf   esp-hal
-          cargo xtask build-package --features=esp32c6,ci --target=riscv32imac-unknown-none-elf  esp-hal
-          cargo xtask build-package --features=esp32h2,ci --target=riscv32imac-unknown-none-elf  esp-hal
+          DEFMT_LOG=trace cargo xtask build-package --features=esp32c2,ci --target=riscv32imc-unknown-none-elf   esp-hal
+          DEFMT_LOG=trace cargo xtask build-package --features=esp32c3,ci --target=riscv32imc-unknown-none-elf   esp-hal
+          DEFMT_LOG=trace cargo xtask build-package --features=esp32c6,ci --target=riscv32imac-unknown-none-elf  esp-hal
+          DEFMT_LOG=trace cargo xtask build-package --features=esp32h2,ci --target=riscv32imac-unknown-none-elf  esp-hal
 
       - name: msrv RISCV (esp-wifi)
         run: |
-          cargo xtask build-package --features=esp32c2,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
-          cargo xtask build-package --features=esp32c3,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
-          cargo xtask build-package --features=esp32c6,wifi,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
-          cargo xtask build-package --features=esp32h2,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
+          DEFMT_LOG=trace cargo xtask build-package --features=esp32c2,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
+          DEFMT_LOG=trace cargo xtask build-package --features=esp32c3,wifi,ble,async --target=riscv32imc-unknown-none-elf   esp-wifi
+          DEFMT_LOG=trace cargo xtask build-package --features=esp32c6,wifi,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
+          DEFMT_LOG=trace cargo xtask build-package --features=esp32h2,ble,async --target=riscv32imac-unknown-none-elf  esp-wifi
 
         # Verify the MSRV for all Xtensa chips:
       - name: msrv Xtensa (esp-hal)
         run: |
-          cargo xtask build-package --toolchain=esp --features=esp32,ci   --target=xtensa-esp32-none-elf   esp-hal
-          cargo xtask build-package --toolchain=esp --features=esp32s2,ci --target=xtensa-esp32s2-none-elf esp-hal
-          cargo xtask build-package --toolchain=esp --features=esp32s3,ci --target=xtensa-esp32s3-none-elf esp-hal
+          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32,ci   --target=xtensa-esp32-none-elf   esp-hal
+          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32s2,ci --target=xtensa-esp32s2-none-elf esp-hal
+          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32s3,ci --target=xtensa-esp32s3-none-elf esp-hal
 
       - name: msrv Xtensa (esp-wifi)
         run: |
-          cargo xtask build-package --toolchain=esp --features=esp32,wifi,ble,async   --target=xtensa-esp32-none-elf   esp-wifi
-          cargo xtask build-package --toolchain=esp --features=esp32s2,wifi,async --target=xtensa-esp32s2-none-elf esp-wifi
-          cargo xtask build-package --toolchain=esp --features=esp32s3,wifi,ble,async --target=xtensa-esp32s3-none-elf esp-wifi
+          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32,wifi,ble,async   --target=xtensa-esp32-none-elf   esp-wifi
+          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32s2,wifi,async --target=xtensa-esp32s2-none-elf esp-wifi
+          DEFMT_LOG=trace cargo xtask build-package --toolchain=esp --features=esp32s3,wifi,ble,async --target=xtensa-esp32s3-none-elf esp-wifi
 
       - name: msrv (esp-lp-hal)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MSRV: "1.77.0"
   RUSTDOCFLAGS: -Dwarnings
+  DEFMT_LOG: trace
 
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -9,6 +9,7 @@ env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RUSTDOCFLAGS: -Dwarnings
+  DEFMT_LOG: trace
 
 jobs:
 

--- a/esp-hal/src/soc/esp32/psram.rs
+++ b/esp-hal/src/soc/esp32/psram.rs
@@ -199,6 +199,7 @@ pub(crate) mod utils {
     }
 
     #[derive(PartialEq, Eq, Clone, Copy, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[allow(unused)]
     enum PsramCacheSpeed {
         PsramCacheF80mS40m = 0,
@@ -220,6 +221,7 @@ pub(crate) mod utils {
     }
 
     #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum PsramClkMode {
         PsramClkModeNorm = 0, // Normal SPI mode
         PsramClkModeDclk = 1, // Two extra clock cycles after CS is set high level

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -189,7 +189,7 @@ dhcpv4 = ["wifi", "utils", "smoltcp?/proto-dhcpv4", "smoltcp?/socket-dhcpv4"]
 wifi-default = ["ipv4", "tcp", "udp", "icmp", "igmp", "dns", "dhcpv4"]
 
 ## Enable support for `defmt`
-defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt"]
+defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt", "bt-hci?/defmt"]
 
 ## Enable support for the `log` crate
 log = ["dep:log", "esp-hal/log"]

--- a/esp-wifi/src/ble/controller/mod.rs
+++ b/esp-wifi/src/ble/controller/mod.rs
@@ -204,13 +204,8 @@ pub mod asynch {
                         }
                     }
                 }
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "log")] {
-                        warn!("[hci] error parsing packet: {:?}", e);
-                    } else {
-                        warn!("[hci] error parsing packet");
-                    }
-                }
+                warn!("[hci] error parsing packet: {:?}", e);
+
                 Err(BleConnectorError::Unknown)
             }
         }

--- a/esp-wifi/src/ble/controller/mod.rs
+++ b/esp-wifi/src/ble/controller/mod.rs
@@ -204,7 +204,13 @@ pub mod asynch {
                         }
                     }
                 }
-                warn!("[hci] error parsing packet: {:?}", e);
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "log")] {
+                        warn!("[hci] error parsing packet: {:?}", e);
+                    } else {
+                        warn!("[hci] error parsing packet");
+                    }
+                }
                 Err(BleConnectorError::Unknown)
             }
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Turns out: If we don't set DEFMT_LOG most defmt macros are not evaluated and we are unable to catch a few compile time errors

I think this doesn't deserve a CHANGELOG entry 

#### Testing
Build failed, build works again after fixing
