### PR TITLE
Fix Matrix link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Ask questions in Matrix channel (Recommended)
-    url: https://github.com/esp-rs/esp-hal/discussions/new
+    url: https://matrix.to/#/#esp-rs:matrix.org
     about: Ask any questions directly in our Matrix channel.
   - name: Ask questions in GitHub Discussions
     url: https://github.com/esp-rs/esp-hal/discussions/new


### PR DESCRIPTION
After merging, I did some testing and noticed that I duplicated the gh discussion link instead of adding the matrix channel link 😓 