### PR TITLE
Fix SPI DMA write/read for ESP32, ESP32-S2

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with DMA transfers potentially not waking up the correct async task (#2065)
 - Fixed an issue with LCD_CAM i8080 where it would send double the clocks in 16bit mode (#2085)
 - Fix i2c embedded-hal transaction (#2028)
+- Fix SPI DMA alternating `write` and `read` for ESP32 and ESP32-S2 (#2131)
 
 ### Removed
 

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -100,6 +100,10 @@ name    = "spi_full_duplex_dma_pcnt"
 harness = false
 
 [[test]]
+name    = "spi_full_duplex_dma_write_read"
+harness = false
+
+[[test]]
 name    = "spi_half_duplex_read"
 harness = false
 

--- a/hil-test/tests/spi_full_duplex_dma_write_read.rs
+++ b/hil-test/tests/spi_full_duplex_dma_write_read.rs
@@ -1,0 +1,108 @@
+//! SPI Full Duplex DMA write + read Test
+//! See issue #2059
+//!
+//! Folowing pins are used:
+//! SCLK    GPIO0
+//! MISO    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
+//! GPIO    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
+//!
+//! Connect MISO and GPIO pins.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+#![no_std]
+#![no_main]
+
+use esp_hal::{
+    dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma_buffers,
+    gpio::Io,
+    peripherals::SPI2,
+    prelude::*,
+    spi::{
+        master::{Spi, SpiDma},
+        FullDuplexMode,
+        SpiMode,
+    },
+    Blocking,
+};
+use hil_test as _;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(
+        feature = "esp32",
+        feature = "esp32s2",
+    ))] {
+        use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
+    } else {
+        use esp_hal::dma::DmaChannel0;
+    }
+}
+
+struct Context {
+    spi: SpiDma<'static, SPI2, DmaChannel0, FullDuplexMode, Blocking>,
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use defmt::assert_eq;
+    use esp_hal::gpio::{Level, Output};
+
+    use super::*;
+
+    #[init]
+    fn init() -> Context {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let sclk = io.pins.gpio0;
+        let (miso, gpio) = hil_test::common_test_pins!(io);
+        let _gpio = Output::new(gpio.degrade(), Level::High);
+
+        let dma = Dma::new(peripherals.DMA);
+
+        cfg_if::cfg_if! {
+            if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+                let dma_channel = dma.spi2channel;
+            } else {
+                let dma_channel = dma.channel0;
+            }
+        }
+
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
+            .with_sck(sclk)
+            .with_mosi(esp_hal::gpio::DummyPin::new())
+            .with_miso(miso)
+            .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
+
+        Context { spi }
+    }
+
+    #[test]
+    #[timeout(3)]
+    fn test_write_read(ctx: Context) {
+        let spi = ctx.spi;
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(4);
+        let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+        let mut dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+
+        dma_tx_buf.fill(&[0xde, 0xad, 0xbe, 0xef]);
+
+        let transfer = spi.dma_write(dma_tx_buf).map_err(|e| e.0).unwrap();
+        let (spi, dma_tx_buf) = transfer.wait();
+
+        dma_rx_buf.as_mut_slice().fill(0);
+        let transfer = spi.dma_read(dma_rx_buf).map_err(|e| e.0).unwrap();
+        let (spi, mut dma_rx_buf) = transfer.wait();
+
+        let transfer = spi.dma_write(dma_tx_buf).map_err(|e| e.0).unwrap();
+        let (spi, _dma_tx_buf) = transfer.wait();
+
+        dma_rx_buf.as_mut_slice().fill(0);
+        let transfer = spi.dma_read(dma_rx_buf).map_err(|e| e.0).unwrap();
+        let (_, dma_rx_buf) = transfer.wait();
+
+        assert_eq!(&[0xff, 0xff, 0xff, 0xff], dma_rx_buf.as_slice());
+    }
+}

--- a/hil-test/tests/spi_full_duplex_dma_write_read.rs
+++ b/hil-test/tests/spi_full_duplex_dma_write_read.rs
@@ -1,12 +1,7 @@
 //! SPI Full Duplex DMA write + read Test
 //! See issue #2059
 //!
-//! Folowing pins are used:
-//! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! GPIO    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect MISO and GPIO pins.
+//! Uses the [hil_test::common_test_pins] pair connected to each other.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -58,7 +53,7 @@ mod tests {
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let sclk = io.pins.gpio0;
         let (miso, gpio) = hil_test::common_test_pins!(io);
-        let _gpio = Output::new(gpio.degrade(), Level::High);
+        let _gpio = Output::new(gpio, Level::High);
 
         let dma = Dma::new(peripherals.DMA);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
On ESP32 and ESP32-S2 something like this didn't work
```rust
        embedded_hal_async::spi::SpiBus::write(&mut spi, &send_buffer)
            .await
            .unwrap();

        embedded_hal_async::spi::SpiBus::read(&mut spi, &mut buffer)
            .await
            .unwrap();
```

As already found in #2059 ESP32 needs some special handling to make it work.
For ESP32-S2 the solution was found by "trial and error" (also the problem there was a bit different: on S2 the first iteration worked but then it stopped working)

#### Testing
I added tests and you can modify `embassy_spi.rs` example to perform `write` and `read` in the loop like above
