### PR TITLE
Remove `PcntSource`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `Rtc::get_time_raw` (#1883)
 - Removed `_with_default_pins` UART constructors (#2132)
 - Removed `uart::{DefaultRxPin, DefaultTxPin}` (#2132)
+- Removed `PcntSource` and `PcntInputConfig`. (#2134)
 
 ## [0.20.1] - 2024-08-30
 

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -125,3 +125,24 @@ let rtc = Rtc::new(peripherals.LPWR);
 - let current_time_ms = rtc.get_time_ms();
 + let current_time_ms = rtc.current_time().and_utc().timestamp_millis(); // assuming UTC
 ```
+
+## PCNT input config
+
+The `PcntSource` and `PcntInputConfig` have been removed. You can use `Input` or `Flex` instead to
+configure an input pin, and pass it to `set_edge_signal` or `set_ctrl_signal`.
+
+```diff
+-   let mut pin_a = io.pins.gpio4;
+-   ch0.set_ctrl_signal(PcntSource::from_pin(
+-       &mut pin_a,
+-       PcntInputConfig { pull: Pull::Up },
+-   ));
++   ch0.set_ctrl_signal(Input::new(io.pins.gpio4, Pull::Up));
+ 
+-   let mut pin_b = io.pins.gpio5;
+-   ch0.set_edge_signal(PcntSource::from_pin(
+-       &mut pin_b,
+-       PcntInputConfig { pull: Pull::Down },
+-   ));
++   ch0.set_edge_signal(Input::new(io.pins.gpio5, Pull::Down));
+```

--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -20,13 +20,9 @@ use core::{cell::RefCell, cmp::min, sync::atomic::Ordering};
 use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{Io, Pull},
+    gpio::{Input, Io, Pull},
     interrupt::Priority,
-    pcnt::{
-        channel::{self, PcntInputConfig, PcntSource},
-        unit,
-        Pcnt,
-    },
+    pcnt::{channel, unit, Pcnt},
     prelude::*,
 };
 use esp_println::println;
@@ -53,30 +49,18 @@ fn main() -> ! {
 
     println!("setup channel 0");
     let ch0 = &u0.channel0;
-    let pin_a = io.pins.gpio4;
-    let pin_b = io.pins.gpio5;
+    let pin_a = Input::new(io.pins.gpio4, Pull::Up);
+    let pin_b = Input::new(io.pins.gpio5, Pull::Up);
 
-    ch0.set_ctrl_signal(PcntSource::from(
-        pin_a.peripheral_input(),
-        PcntInputConfig { pull: Pull::Up },
-    ));
-    ch0.set_edge_signal(PcntSource::from(
-        pin_b.peripheral_input(),
-        PcntInputConfig { pull: Pull::Up },
-    ));
+    ch0.set_ctrl_signal(pin_a.peripheral_input());
+    ch0.set_edge_signal(pin_b.peripheral_input());
     ch0.set_ctrl_mode(channel::CtrlMode::Reverse, channel::CtrlMode::Keep);
     ch0.set_input_mode(channel::EdgeMode::Increment, channel::EdgeMode::Decrement);
 
     println!("setup channel 1");
     let ch1 = &u0.channel1;
-    ch1.set_ctrl_signal(PcntSource::from(
-        pin_b.peripheral_input(),
-        PcntInputConfig { pull: Pull::Up },
-    ));
-    ch1.set_edge_signal(PcntSource::from(
-        pin_a.peripheral_input(),
-        PcntInputConfig { pull: Pull::Up },
-    ));
+    ch1.set_ctrl_signal(pin_b.peripheral_input());
+    ch1.set_edge_signal(pin_a.peripheral_input());
     ch1.set_ctrl_mode(channel::CtrlMode::Reverse, channel::CtrlMode::Keep);
     ch1.set_input_mode(channel::EdgeMode::Decrement, channel::EdgeMode::Increment);
 

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -7,11 +7,8 @@
 
 use esp_hal::{
     delay::Delay,
-    gpio::{AnyPin, Io, Level, Output, Pin, Pull},
-    pcnt::{
-        channel::{EdgeMode, PcntInputConfig, PcntSource},
-        Pcnt,
-    },
+    gpio::{AnyPin, Input, Io, Level, Output, Pin, Pull},
+    pcnt::{channel::EdgeMode, Pcnt},
 };
 use hil_test as _;
 
@@ -51,10 +48,8 @@ mod tests {
         let unit = ctx.pcnt.unit0;
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
-        unit.channel0.set_edge_signal(PcntSource::from(
-            ctx.input,
-            PcntInputConfig { pull: Pull::Down },
-        ));
+        unit.channel0
+            .set_edge_signal(Input::new(ctx.input, Pull::Down));
         unit.channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
@@ -90,10 +85,8 @@ mod tests {
         let unit = ctx.pcnt.unit1;
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
-        unit.channel0.set_edge_signal(PcntSource::from(
-            ctx.input,
-            PcntInputConfig { pull: Pull::Up },
-        ));
+        unit.channel0
+            .set_edge_signal(Input::new(ctx.input, Pull::Up));
         unit.channel0
             .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
 
@@ -131,10 +124,8 @@ mod tests {
         unit.set_high_limit(Some(3)).unwrap();
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
-        unit.channel0.set_edge_signal(PcntSource::from(
-            ctx.input,
-            PcntInputConfig { pull: Pull::Up },
-        ));
+        unit.channel0
+            .set_edge_signal(Input::new(ctx.input, Pull::Up));
         unit.channel0
             .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
 
@@ -194,10 +185,8 @@ mod tests {
         unit.clear();
 
         // Setup channel 0 to increment the count when gpio2 does LOW -> HIGH
-        unit.channel0.set_edge_signal(PcntSource::from(
-            ctx.input,
-            PcntInputConfig { pull: Pull::Up },
-        ));
+        unit.channel0
+            .set_edge_signal(Input::new(ctx.input, Pull::Up));
         unit.channel0
             .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
 
@@ -261,10 +250,8 @@ mod tests {
         unit.clear();
 
         // Setup channel 0 to decrement the count when gpio2 does LOW -> HIGH
-        unit.channel0.set_edge_signal(PcntSource::from(
-            ctx.input,
-            PcntInputConfig { pull: Pull::Up },
-        ));
+        unit.channel0
+            .set_edge_signal(Input::new(ctx.input, Pull::Up));
         unit.channel0
             .set_input_mode(EdgeMode::Decrement, EdgeMode::Hold);
 
@@ -319,10 +306,8 @@ mod tests {
         let unit = ctx.pcnt.unit2;
 
         // Setup channel 1 to increment the count when gpio2 does LOW -> HIGH
-        unit.channel1.set_edge_signal(PcntSource::from(
-            ctx.input,
-            PcntInputConfig { pull: Pull::Up },
-        ));
+        unit.channel1
+            .set_edge_signal(Input::new(ctx.input, Pull::Up));
         unit.channel1
             .set_input_mode(EdgeMode::Increment, EdgeMode::Hold);
 

--- a/hil-test/tests/qspi_write.rs
+++ b/hil-test/tests/qspi_write.rs
@@ -8,12 +8,8 @@
 use esp_hal::{
     dma::{Channel, Dma, DmaPriority, DmaTxBuf},
     dma_buffers,
-    gpio::{AnyPin, Io, Pull},
-    pcnt::{
-        channel::{EdgeMode, PcntInputConfig, PcntSource},
-        unit::Unit,
-        Pcnt,
-    },
+    gpio::{interconnect::InputSignal, AnyPin, Io, Pull},
+    pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     prelude::*,
     spi::{
         master::{Address, Command, Spi, SpiDma},
@@ -38,7 +34,7 @@ cfg_if::cfg_if! {
 
 struct Context {
     spi: esp_hal::peripherals::SPI2,
-    pcnt_source: PcntSource,
+    pcnt_source: InputSignal,
     pcnt: esp_hal::peripherals::PCNT,
     dma_channel: Channel<'static, DmaChannel0, Blocking>,
     mosi: AnyPin,
@@ -121,10 +117,7 @@ mod tests {
 
         Context {
             spi: peripherals.SPI2,
-            pcnt_source: PcntSource::from(
-                mosi.peripheral_input(),
-                PcntInputConfig { pull: Pull::None },
-            ),
+            pcnt_source: mosi.peripheral_input(),
             pcnt: peripherals.PCNT,
             dma_channel,
             mosi,

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -10,12 +10,8 @@ use embedded_hal_async::spi::SpiBus;
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{Io, Pull},
-    pcnt::{
-        channel::{EdgeMode, PcntInputConfig, PcntSource},
-        unit::Unit,
-        Pcnt,
-    },
+    gpio::{interconnect::InputSignal, Io},
+    pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     peripherals::SPI2,
     prelude::*,
     spi::{
@@ -42,7 +38,7 @@ const DMA_BUFFER_SIZE: usize = 5;
 
 struct Context {
     spi: SpiDmaBus<'static, SPI2, DmaChannel0, FullDuplexMode, Async>,
-    pcnt_source: PcntSource,
+    pcnt_source: InputSignal,
     pcnt_unit: Unit<'static, 0>,
 }
 
@@ -88,7 +84,7 @@ mod tests {
 
         Context {
             spi,
-            pcnt_source: PcntSource::from(mosi_loopback_pcnt, PcntInputConfig { pull: Pull::Down }),
+            pcnt_source: mosi_loopback_pcnt,
             pcnt_unit: pcnt.unit0,
         }
     }

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -8,12 +8,8 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{Io, Pull},
-    pcnt::{
-        channel::{EdgeMode, PcntInputConfig, PcntSource},
-        unit::Unit,
-        Pcnt,
-    },
+    gpio::{interconnect::InputSignal, Io},
+    pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     peripherals::SPI2,
     prelude::*,
     spi::{
@@ -38,7 +34,7 @@ cfg_if::cfg_if! {
 
 struct Context {
     spi: SpiDma<'static, SPI2, DmaChannel0, FullDuplexMode, Blocking>,
-    pcnt_source: PcntSource,
+    pcnt_source: InputSignal,
     pcnt_unit: Unit<'static, 0>,
 }
 
@@ -79,7 +75,7 @@ mod tests {
 
         Context {
             spi,
-            pcnt_source: PcntSource::from(mosi_loopback_pcnt, PcntInputConfig { pull: Pull::Down }),
+            pcnt_source: mosi_loopback_pcnt,
             pcnt_unit: pcnt.unit0,
         }
     }

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -8,12 +8,8 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{Io, Pull},
-    pcnt::{
-        channel::{EdgeMode, PcntInputConfig, PcntSource},
-        unit::Unit,
-        Pcnt,
-    },
+    gpio::{interconnect::InputSignal, Io},
+    pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     peripherals::SPI2,
     prelude::*,
     spi::{
@@ -40,7 +36,7 @@ cfg_if::cfg_if! {
 struct Context {
     spi: SpiDma<'static, SPI2, DmaChannel0, HalfDuplexMode, Blocking>,
     pcnt_unit: Unit<'static, 0>,
-    pcnt_source: PcntSource,
+    pcnt_source: InputSignal,
 }
 
 #[cfg(test)]
@@ -81,8 +77,8 @@ mod tests {
 
         Context {
             spi,
-            pcnt_source: PcntSource::from(mosi_loopback, PcntInputConfig { pull: Pull::Down }),
             pcnt_unit: pcnt.unit0,
+            pcnt_source: mosi_loopback,
         }
     }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

These are no longer necessary, users can just configure a pin and pass it to PCNT.