### PR TITLE
Type-erase timers by default

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the parameters of `Spi::with_pins` to no longer be optional (#2133)
 - Renamed `DummyPin` to `NoPin` and removed all internal logic from it. (#2133)
 - The `NO_PIN` constant has been removed. (#2133)
+- `PeriodicTimer` and `OneShotTimer` are now type-erased by default. Use the new `new_typed` constructor to keep using the ZST pin types. (#?)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -112,6 +112,18 @@ have been removed. Use `new` or `new_async` instead.
 
 The `ErasedTimer` has been renamed to `AnyTimer`.
 
+### Type-erased timers
+
+`PeriodicTimer` and `OneShotTimer` are now type-erased by default. This unfortunately requires the
+timer to implement `Into<AnyTimer>`. In case you want to use a timer that does not (for example
+because you've used the async timer APIs of the same instance before), you can use the `new_typed`
+constructor.
+
+```rust
+let timer = PeriodicTimer::new(timg0.timer0); // timer will have the type `PeriodicTimer<'some>` (or `PeriodicTimer<'some, AnyTimer>` if you want to be explicit about it)
+let timer = PeriodicTimer::new_typed(timg0.timer0); // timer will have the type `PeriodicTimer<'some, Timer<Timer0<TIMG0>, Blocking>>`
+```
+
 ### `esp_hal::time::current_time` rename
 
 To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've renamed `esp_hal::time::current_time` to `esp_hal::time::now()`.

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -111,8 +111,18 @@ pub trait Timer: crate::private::Sealed {
 }
 
 /// A one-shot timer.
-pub struct OneShotTimer<'d, T> {
+pub struct OneShotTimer<'d, T = AnyTimer> {
     inner: PeripheralRef<'d, T>,
+}
+
+impl<'d> OneShotTimer<'d, AnyTimer> {
+    /// Construct a new instance of [`OneShotTimer`] with the timer
+    /// type-erased.
+    pub fn new<T: Timer + Into<AnyTimer>>(mut inner: impl Peripheral<P = T> + 'd) -> Self {
+        let inner = unsafe { inner.clone_unchecked() }.into();
+
+        Self::new_typed(inner)
+    }
 }
 
 impl<'d, T> OneShotTimer<'d, T>
@@ -120,7 +130,7 @@ where
     T: Timer,
 {
     /// Construct a new instance of [`OneShotTimer`].
-    pub fn new(inner: impl Peripheral<P = T> + 'd) -> Self {
+    pub fn new_typed(inner: impl Peripheral<P = T> + 'd) -> Self {
         crate::into_ref!(inner);
 
         Self { inner }
@@ -242,8 +252,18 @@ where
 }
 
 /// A periodic timer.
-pub struct PeriodicTimer<'d, T> {
+pub struct PeriodicTimer<'d, T = AnyTimer> {
     inner: PeripheralRef<'d, T>,
+}
+
+impl<'d> PeriodicTimer<'d, AnyTimer> {
+    /// Construct a new instance of [`PeriodicTimer`] with the timer
+    /// type-erased.
+    pub fn new<T: Timer + Into<AnyTimer>>(mut inner: impl Peripheral<P = T> + 'd) -> Self {
+        let inner = unsafe { inner.clone_unchecked() }.into();
+
+        Self::new_typed(inner)
+    }
 }
 
 impl<'d, T> PeriodicTimer<'d, T>
@@ -251,7 +271,7 @@ where
     T: Timer,
 {
     /// Construct a new instance of [`PeriodicTimer`].
-    pub fn new(inner: impl Peripheral<P = T> + 'd) -> Self {
+    pub fn new_typed(inner: impl Peripheral<P = T> + 'd) -> Self {
         crate::into_ref!(inner);
 
         Self { inner }
@@ -382,7 +402,7 @@ impl crate::private::Sealed for AnyTimer {}
 macro_rules! any_timer {
     ($ty:path => $var:ident) => {
         impl $ty {
-            /// Convert this timer into an [`AnyTimer`][crate::timer::AnyTimer].
+            /// Convert this timer into an [`AnyTimer`].
             pub fn degrade(self) -> AnyTimer {
                 AnyTimer(AnyTimerInner::$var(self))
             }

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -56,10 +56,7 @@ async fn main(_spawner: Spawner) {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    esp_hal_embassy::init([
-        timg0.timer0.degrade(),
-        timg0.timer1.degrade(),
-    ]);
+    esp_hal_embassy::init([timg0.timer0.degrade(), timg0.timer1.degrade()]);
 
     let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -56,9 +56,10 @@ async fn main(_spawner: Spawner) {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    let timer0: AnyTimer = timg0.timer0.into();
-    let timer1: AnyTimer = timg0.timer1.into();
-    esp_hal_embassy::init([timer0, timer1]);
+    esp_hal_embassy::init([
+        timg0.timer0.degrade(),
+        timg0.timer1.degrade(),
+    ]);
 
     let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     cpu_control::{CpuControl, Stack},
     get_core,
     gpio::{Io, Level, Output, Pin},
-    timer::{timg::TimerGroup, AnyTimer},
+    timer::timg::TimerGroup,
 };
 use esp_hal_embassy::Executor;
 use esp_println::println;

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -23,7 +23,7 @@ use esp_hal::{
     gpio::{Io, Level, Output, Pin},
     interrupt::{software::SoftwareInterruptControl, Priority},
     prelude::*,
-    timer::{timg::TimerGroup, AnyTimer},
+    timer::timg::TimerGroup,
 };
 use esp_hal_embassy::InterruptExecutor;
 use esp_println::println;

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -78,10 +78,7 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    esp_hal_embassy::init([
-        timg0.timer0.degrade(),
-        timg0.timer1.degrade(),
-    ]);
+    esp_hal_embassy::init([timg0.timer0.degrade(), timg0.timer1.degrade()]);
 
     let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -78,9 +78,10 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    let timer0: AnyTimer = timg0.timer0.into();
-    let timer1: AnyTimer = timg0.timer1.into();
-    esp_hal_embassy::init([timer0, timer1]);
+    esp_hal_embassy::init([
+        timg0.timer0.degrade(),
+        timg0.timer1.degrade(),
+    ]);
 
     let mut cpu_control = CpuControl::new(peripherals.CPU_CTRL);
 

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -88,10 +88,7 @@ async fn main(low_prio_spawner: Spawner) {
         }
     }
 
-    esp_hal_embassy::init([
-        timg0.timer0.degrade(),
-        timer1.degrade(),
-    ]);
+    esp_hal_embassy::init([timg0.timer0.degrade(), timer1.degrade()]);
 
     static EXECUTOR: StaticCell<InterruptExecutor<2>> = StaticCell::new();
     let executor = InterruptExecutor::new(sw_ints.software_interrupt2);

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -25,7 +25,7 @@ use embassy_time::{Duration, Instant, Ticker, Timer};
 use esp_backtrace as _;
 use esp_hal::{
     interrupt::{software::SoftwareInterruptControl, Priority},
-    timer::{timg::TimerGroup, AnyTimer},
+    timer::timg::TimerGroup,
 };
 use esp_hal_embassy::InterruptExecutor;
 use esp_println::println;

--- a/examples/src/bin/wifi_80211_tx.rs
+++ b/examples/src/bin/wifi_80211_tx.rs
@@ -12,12 +12,7 @@ use core::marker::PhantomData;
 
 use esp_alloc as _;
 use esp_backtrace as _;
-use esp_hal::{
-    delay::Delay,
-    prelude::*,
-    rng::Rng,
-    timer::{timg::TimerGroup, AnyTimer, PeriodicTimer},
-};
+use esp_hal::{delay::Delay, prelude::*, rng::Rng, timer::timg::TimerGroup};
 use esp_wifi::{initialize, wifi, EspWifiInitFor};
 use ieee80211::{
     common::{CapabilitiesInformation, FCFFlags},

--- a/examples/src/bin/wifi_80211_tx.rs
+++ b/examples/src/bin/wifi_80211_tx.rs
@@ -46,12 +46,9 @@ fn main() -> ! {
     let delay = Delay::new();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    let timer0: AnyTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
-
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
     )

--- a/examples/src/bin/wifi_sniffer.rs
+++ b/examples/src/bin/wifi_sniffer.rs
@@ -18,11 +18,7 @@ use core::cell::RefCell;
 
 use critical_section::Mutex;
 use esp_backtrace as _;
-use esp_hal::{
-    prelude::*,
-    rng::Rng,
-    timer::{timg::TimerGroup, AnyTimer, PeriodicTimer},
-};
+use esp_hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 use esp_println::println;
 use esp_wifi::{initialize, wifi, EspWifiInitFor};
 use ieee80211::{match_frames, mgmt_frame::BeaconFrame};

--- a/examples/src/bin/wifi_sniffer.rs
+++ b/examples/src/bin/wifi_sniffer.rs
@@ -41,12 +41,9 @@ fn main() -> ! {
     esp_alloc::heap_allocator!(72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    let timer0: AnyTimer = timg0.timer0.into();
-    let timer = PeriodicTimer::new(timer0);
-
     let init = initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
     )

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -218,10 +218,7 @@ mod test {
         let timg0 = TimerGroup::new(peripherals.TIMG0);
         let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
 
-        esp_hal_embassy::init([
-            timg0.timer0.degrade(),
-            systimer.alarm0.degrade(),
-        ]);
+        esp_hal_embassy::init([timg0.timer0.degrade(), systimer.alarm0.degrade()]);
 
         let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -64,7 +64,7 @@ mod test_cases {
     }
 
     pub fn run_test_periodic_timer<T: esp_hal::timer::Timer>(timer: impl Peripheral<P = T>) {
-        let mut periodic = PeriodicTimer::new(timer);
+        let mut periodic = PeriodicTimer::new_typed(timer);
 
         let t1 = esp_hal::time::now();
         periodic.start(100.millis()).unwrap();
@@ -81,7 +81,7 @@ mod test_cases {
     }
 
     pub fn run_test_oneshot_timer<T: esp_hal::timer::Timer>(timer: impl Peripheral<P = T>) {
-        let timer = OneShotTimer::new(timer);
+        let timer = OneShotTimer::new_typed(timer);
 
         let t1 = esp_hal::time::now();
         timer.delay_millis(50);

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -216,12 +216,12 @@ mod test {
     #[cfg(not(feature = "esp32"))]
     async fn test_interrupt_executor(peripherals: Peripherals) {
         let timg0 = TimerGroup::new(peripherals.TIMG0);
-        let timer0: AnyTimer = timg0.timer0.into();
-
         let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
-        let alarm0: AnyTimer = systimer.alarm0.into();
 
-        esp_hal_embassy::init([timer0, alarm0]);
+        esp_hal_embassy::init([
+            timg0.timer0.degrade(),
+            systimer.alarm0.degrade(),
+        ]);
 
         let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 


### PR DESCRIPTION
A bit of an experimental PR, trying to give timers the same treatment as GPIOs. Unfortunately due to async timers, this isn't exactly the same changeset. Internal code doesn't use this, and one test regressed to use `new_typed` because not every Timer can currently be turned into an AnyTimer, but I'm still interested whether this idea is worth pursuing outside of GPIO-land, too.