### PR TITLE
feat(esp-alloc): Add heap usage stats

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `esp_alloc::get_info!()` can now be used to get heap usage informations (#2137)
+- `esp_alloc::HEAP.stats()` can now be used to get heap usage informations (#2137)
 
 ### Changed
 

--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `esp_alloc::get_info!()` can now be used to get heap usage informations (#2137)
+
 ### Changed
 
 - a global allocator is created in esp-alloc, now you need to add individual memory regions (up to 3) to the allocator (#2099)

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -27,14 +27,16 @@ cfg-if                = "1.0.0"
 critical-section      = "1.1.3"
 enumset               = "1.1.5"
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
+document-features = "0.2.10"
 
 [features]
 default = []
 nightly = []
 
-# Enable this feature if you want to keep stats about the internal heap usage such as:
-# - Max memory usage since initialization of the heap
-# - Total allocated memory since initialization of the heap
-# - Total freed memory since initialization of the heap
-# Note: Enabling this feature will require extra computation every time alloc/dealloc is called.
+## Enable this feature if you want to keep stats about the internal heap usage such as:
+## - Max memory usage since initialization of the heap
+## - Total allocated memory since initialization of the heap
+## - Total freed memory since initialization of the heap
+##
+## ⚠️ Note: Enabling this feature will require extra computation every time alloc/dealloc is called.
 internal-heap-stats = []

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -23,6 +23,7 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["nightly"]
 
 [dependencies]
+cfg-if                = "1.0.0"
 critical-section      = "1.1.3"
 enumset               = "1.1.5"
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
@@ -30,3 +31,10 @@ linked_list_allocator = { version = "0.10.5", default-features = false, features
 [features]
 default = []
 nightly = []
+
+# Enable this feature if you want to keep stats about the internal heap usage such as:
+# - Max memory usage since initialization of the heap
+# - Total allocated memory since initialization of the heap
+# - Total freed memory since initialization of the heap
+# Note: Enabling this feature will require extra computation every time alloc/dealloc is called.
+internal-heap-stats = []

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -23,6 +23,7 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["nightly"]
 
 [dependencies]
+defmt                 = { version = "0.3.8", optional = true }
 cfg-if                = "1.0.0"
 critical-section      = "1.1.3"
 enumset               = "1.1.5"
@@ -32,6 +33,9 @@ document-features = "0.2.10"
 [features]
 default = []
 nightly = []
+
+## Implement `defmt::Format` on certain types.
+defmt = ["dep:defmt"]
 
 ## Enable this feature if you want to keep stats about the internal heap usage such as:
 ## - Max memory usage since initialization of the heap

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -158,6 +158,13 @@ impl Display for RegionStats {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for RegionStats {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{}", defmt::Display2Format(self))
+    }
+}
+
 /// A memory region to be used as heap memory
 pub struct HeapRegion {
     heap: Heap,
@@ -250,6 +257,13 @@ impl Display for HeapStats {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for HeapStats {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{}", defmt::Display2Format(self))
     }
 }
 

--- a/esp-alloc/src/macros.rs
+++ b/esp-alloc/src/macros.rs
@@ -41,3 +41,16 @@ macro_rules! psram_allocator {
         }
     }};
 }
+
+/// Gets the usage stats for the current memory heap
+///
+/// # Usage
+/// ```rust, no_run
+/// esp_alloc::get_info!();
+/// ```
+#[macro_export]
+macro_rules! get_info {
+    () => {{
+        $crate::HEAP.stats()
+    }};
+}

--- a/esp-alloc/src/macros.rs
+++ b/esp-alloc/src/macros.rs
@@ -41,16 +41,3 @@ macro_rules! psram_allocator {
         }
     }};
 }
-
-/// Gets the usage stats for the current memory heap
-///
-/// # Usage
-/// ```rust, no_run
-/// esp_alloc::get_info!();
-/// ```
-#[macro_export]
-macro_rules! get_info {
-    () => {{
-        $crate::HEAP.stats()
-    }};
-}

--- a/examples/src/bin/psram_quad.rs
+++ b/examples/src/bin/psram_quad.rs
@@ -51,7 +51,7 @@ fn main() -> ! {
     let string = String::from("A string allocated in PSRAM");
     println!("'{}' allocated at {:p}", &string, string.as_ptr());
 
-    println!("{}", esp_alloc::get_info!());
+    println!("{}", esp_alloc::HEAP.stats());
 
     println!("done");
 

--- a/examples/src/bin/psram_quad.rs
+++ b/examples/src/bin/psram_quad.rs
@@ -3,7 +3,7 @@
 //! You need an ESP32, ESP32-S2 or ESP32-S3 with at least 2 MB of PSRAM memory.
 
 //% CHIPS: esp32 esp32s2 esp32s3
-//% FEATURES: psram-2m
+//% FEATURES: psram-2m esp-alloc/internal-heap-stats
 
 #![no_std]
 #![no_main]
@@ -50,6 +50,8 @@ fn main() -> ! {
 
     let string = String::from("A string allocated in PSRAM");
     println!("'{}' allocated at {:p}", &string, string.as_ptr());
+
+    println!("{}", esp_alloc::get_info!());
 
     println!("done");
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR provides a way to easily see the current heap usage of `esp_alloc`. This adds `HeapRegion::stats()` and `EspHeap::stats()`, to return `RegionStats` and `HeapStats` respectively.

Both also implement `core::fmt::Display` to easily pretty-print the heap usage as following:
```rust
println!("{}", esp_alloc::get_info!());
```
```
HEAP INFO
Size: 117760
Current usage: 47280
Max usage: 70060
Total freed: 103012
Total allocated: 150292
Memory Layout: 
Internal | ██████████████░░░░░░░░░░░░░░░░░░░░░ | Used: 47280 / Total: 117760 (Free: 70480)
Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |
Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |
```

#### Testing
I have tested with a few examples locally and with `esp-mbedtls`, and everything works fine.
I haven't tested with PSRAM as I don't have any.