### PR TITLE
[WIP] refactor ledc and introduce overflow interrupt handing

### DIFF
--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -13,7 +13,6 @@ use super::timer::{TimerIFace, TimerSpeed};
 use crate::{
     gpio::{OutputSignal, PeripheralOutput},
     peripheral::{Peripheral, PeripheralRef},
-    peripherals::ledc::RegisterBlock,
 };
 
 /// Fade parameter sub-errors
@@ -141,11 +140,43 @@ pub trait ChannelHW<O: PeripheralOutput> {
 
     /// Check whether a duty-cycle fade is running HW
     fn is_duty_fade_running_hw(&self) -> bool;
+
+    /// Enable signal output on this channel by setting LEDC_SIG_OUT_EN_CHn.
+    /// The LEDC_SIG_OUT_EN_CHn register should also set when calling
+    /// [`ChannelHW::configure_hw`] and
+    /// [`ChannelHW::configure_hw_with_pin_config`].
+    fn enable_signal_output(&self);
+
+    /// Disable signal output on this channel by clearing LEDC_SIG_OUT_EN_CHn.
+    fn disable_signal_output(&self);
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32s3")] {
+            /// Enable the overflow counter and set the number of counter overflows needed to generate an interrupt.
+            fn enable_counter_with_overflow(&self, overflow_num: u16);
+
+            /// Disable the overflow counter by clearing the appropriate register.
+            fn disable_counter(&self);
+
+            /// Enables the overflow counting interrupt for this channel.
+            fn enable_overflow_interrupt(&self);
+
+            /// Disables the overflow counting interrupt for this channel.
+            fn disable_overflow_interrupt(&self);
+
+            /// Returns true if the overflow counting interrupt is active for this channel.
+            /// Note that this function will return from the raw interrupt status register
+            /// instead of the masked interrupt status register.
+            fn is_overflow_interrupt_active(&self) -> bool;
+
+            /// Clears the overflow counting interrupt flag for this channel.
+            fn clear_overflow_interrupt(&self);
+        }
+    }
 }
 
 /// Channel struct
 pub struct Channel<'a, S: TimerSpeed, O: PeripheralOutput> {
-    ledc: &'a RegisterBlock,
     timer: Option<&'a dyn TimerIFace<S>>,
     number: Number,
     output_pin: PeripheralRef<'a, O>,
@@ -155,9 +186,7 @@ impl<'a, S: TimerSpeed, O: PeripheralOutput> Channel<'a, S, O> {
     /// Return a new channel
     pub fn new(number: Number, output_pin: impl Peripheral<P = O> + 'a) -> Self {
         crate::into_ref!(output_pin);
-        let ledc = unsafe { &*crate::peripherals::LEDC::ptr() };
         Channel {
-            ledc,
             timer: None,
             number,
             output_pin,
@@ -341,12 +370,12 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(esp32)]
     fn set_channel(&mut self, timer_number: u8) {
         if S::IS_HS {
-            let ch = self.ledc.hsch(self.number as usize);
+            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.hsch(self.number as usize);
             ch.hpoint().write(|w| unsafe { w.hpoint().bits(0x0) });
             ch.conf0()
                 .modify(|_, w| unsafe { w.sig_out_en().set_bit().timer_sel().bits(timer_number) });
         } else {
-            let ch = self.ledc.lsch(self.number as usize);
+            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.lsch(self.number as usize);
             ch.hpoint().write(|w| unsafe { w.hpoint().bits(0x0) });
             ch.conf0()
                 .modify(|_, w| unsafe { w.sig_out_en().set_bit().timer_sel().bits(timer_number) });
@@ -356,7 +385,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(not(esp32))]
     fn set_channel(&mut self, timer_number: u8) {
         {
-            let ch = self.ledc.ch(self.number as usize);
+            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.ch(self.number as usize);
             ch.hpoint().write(|w| unsafe { w.hpoint().bits(0x0) });
             ch.conf0().modify(|_, w| {
                 w.sig_out_en().set_bit();
@@ -369,7 +398,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(esp32)]
     fn start_duty_without_fading(&self) {
         if S::IS_HS {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .hsch(self.number as usize)
                 .conf1()
                 .write(|w| unsafe {
@@ -380,7 +409,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
                     w.duty_scale().bits(0x0)
                 });
         } else {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .lsch(self.number as usize)
                 .conf1()
                 .write(|w| unsafe {
@@ -395,30 +424,35 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(any(esp32c6, esp32h2))]
     fn start_duty_without_fading(&self) {
         let cnum = self.number as usize;
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .ch(cnum)
             .conf1()
             .write(|w| w.duty_start().set_bit());
-        self.ledc.ch_gamma_wr(cnum).write(|w| {
-            w.ch_gamma_duty_inc().set_bit();
-            unsafe {
-                w.ch_gamma_duty_num().bits(0x1);
-                w.ch_gamma_duty_cycle().bits(0x1);
-                w.ch_gamma_scale().bits(0x0)
-            }
-        });
+        unsafe { &*crate::peripherals::LEDC::ptr() }
+            .ch_gamma_wr(cnum)
+            .write(|w| {
+                w.ch_gamma_duty_inc().set_bit();
+                unsafe {
+                    w.ch_gamma_duty_num().bits(0x1);
+                    w.ch_gamma_duty_cycle().bits(0x1);
+                    w.ch_gamma_scale().bits(0x0)
+                }
+            });
     }
     #[cfg(not(any(esp32, esp32c6, esp32h2)))]
     fn start_duty_without_fading(&self) {
-        self.ledc.ch(self.number as usize).conf1().write(|w| {
-            w.duty_start().set_bit();
-            w.duty_inc().set_bit();
-            unsafe {
-                w.duty_num().bits(0x1);
-                w.duty_cycle().bits(0x1);
-                w.duty_scale().bits(0x0)
-            }
-        });
+        unsafe { &*crate::peripherals::LEDC::ptr() }
+            .ch(self.number as usize)
+            .conf1()
+            .write(|w| {
+                w.duty_start().set_bit();
+                w.duty_inc().set_bit();
+                unsafe {
+                    w.duty_num().bits(0x1);
+                    w.duty_cycle().bits(0x1);
+                    w.duty_scale().bits(0x0)
+                }
+            });
     }
 
     #[cfg(esp32)]
@@ -430,7 +464,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
         duty_per_cycle: u16,
     ) {
         if S::IS_HS {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .hsch(self.number as usize)
                 .conf1()
                 .write(|w| unsafe {
@@ -446,7 +480,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
                         .bits(duty_per_cycle)
                 });
         } else {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .lsch(self.number as usize)
                 .conf1()
                 .write(|w| unsafe {
@@ -473,24 +507,26 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
         duty_per_cycle: u16,
     ) {
         let cnum = self.number as usize;
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .ch(cnum)
             .conf1()
             .write(|w| w.duty_start().set_bit());
-        self.ledc.ch_gamma_wr(cnum).write(|w| unsafe {
-            w.ch_gamma_duty_inc()
-                .variant(duty_inc)
-                .ch_gamma_duty_num() // count of incs before stopping
-                .bits(duty_steps)
-                .ch_gamma_duty_cycle() // overflows between incs
-                .bits(cycles_per_step)
-                .ch_gamma_scale()
-                .bits(duty_per_cycle)
-        });
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
+            .ch_gamma_wr(cnum)
+            .write(|w| unsafe {
+                w.ch_gamma_duty_inc()
+                    .variant(duty_inc)
+                    .ch_gamma_duty_num() // count of incs before stopping
+                    .bits(duty_steps)
+                    .ch_gamma_duty_cycle() // overflows between incs
+                    .bits(cycles_per_step)
+                    .ch_gamma_scale()
+                    .bits(duty_per_cycle)
+            });
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .ch_gamma_wr_addr(cnum)
             .write(|w| unsafe { w.ch_gamma_wr_addr().bits(0) });
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .ch_gamma_conf(cnum)
             .write(|w| unsafe { w.ch_gamma_entry_num().bits(0x1) });
     }
@@ -503,7 +539,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
         cycles_per_step: u16,
         duty_per_cycle: u16,
     ) {
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .ch(self.number as usize)
             .conf1()
             .write(|w| unsafe {
@@ -520,7 +556,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(esp32)]
     fn update_channel(&self) {
         if !S::IS_HS {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .lsch(self.number as usize)
                 .conf0()
                 .modify(|_, w| w.para_up().set_bit());
@@ -528,7 +564,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     }
     #[cfg(not(esp32))]
     fn update_channel(&self) {
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .ch(self.number as usize)
             .conf0()
             .modify(|_, w| w.para_up().set_bit());
@@ -618,12 +654,12 @@ where
     #[cfg(esp32)]
     fn set_duty_hw(&self, duty: u32) {
         if S::IS_HS {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .hsch(self.number as usize)
                 .duty()
                 .write(|w| unsafe { w.duty().bits(duty << 4) });
         } else {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .lsch(self.number as usize)
                 .duty()
                 .write(|w| unsafe { w.duty().bits(duty << 4) });
@@ -635,7 +671,7 @@ where
     /// Set duty in channel HW
     #[cfg(not(esp32))]
     fn set_duty_hw(&self, duty: u32) {
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .ch(self.number as usize)
             .duty()
             .write(|w| unsafe { w.duty().bits(duty << 4) });
@@ -654,19 +690,19 @@ where
         duty_per_cycle: u16,
     ) {
         if S::IS_HS {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .hsch(self.number as usize)
                 .duty()
                 .write(|w| unsafe { w.duty().bits(start_duty << 4) });
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .int_clr()
                 .write(|w| w.duty_chng_end_hsch(self.number as u8).clear_bit_by_one());
         } else {
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .lsch(self.number as usize)
                 .duty()
                 .write(|w| unsafe { w.duty().bits(start_duty << 4) });
-            self.ledc
+            unsafe { &*crate::peripherals::LEDC::ptr() }
                 .int_clr()
                 .write(|w| w.duty_chng_end_lsch(self.number as u8).clear_bit_by_one());
         }
@@ -684,11 +720,11 @@ where
         cycles_per_step: u16,
         duty_per_cycle: u16,
     ) {
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .ch(self.number as usize)
             .duty()
             .write(|w| unsafe { w.duty().bits(start_duty << 4) });
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .int_clr()
             .write(|w| w.duty_chng_end_ch(self.number as u8).clear_bit_by_one());
         self.start_duty_fade_inner(duty_inc, duty_steps, cycles_per_step, duty_per_cycle);
@@ -697,7 +733,9 @@ where
 
     #[cfg(esp32)]
     fn is_duty_fade_running_hw(&self) -> bool {
-        let reg = self.ledc.int_raw().read();
+        let reg = unsafe { &*crate::peripherals::LEDC::ptr() }
+            .int_raw()
+            .read();
         if S::IS_HS {
             reg.duty_chng_end_hsch(self.number as u8).bit_is_clear()
         } else {
@@ -707,10 +745,110 @@ where
 
     #[cfg(not(esp32))]
     fn is_duty_fade_running_hw(&self) -> bool {
-        self.ledc
+        unsafe { &*crate::peripherals::LEDC::ptr() }
             .int_raw()
             .read()
             .duty_chng_end_ch(self.number as u8)
             .bit_is_clear()
+    }
+
+    /// Enable signal output on this channel by setting LEDC_SIG_OUT_EN_CHn.
+    /// The LEDC_SIG_OUT_EN_CHn register should also set when calling
+    /// [`ChannelHW::configure_hw`] and
+    /// [`ChannelHW::configure_hw_with_pin_config`].
+    #[cfg(esp32)]
+    fn enable_signal_output(&self) {
+        if S::IS_HS {
+            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.hsch(self.number as usize);
+            ch.conf0().modify(|_, w| w.sig_out_en().set_bit());
+        } else {
+            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.lsch(self.number as usize);
+            ch.conf0()
+                .modify(|_, w| w.sig_out_en().set_bit().para_up().set_bit());
+        }
+    }
+
+    /// Enable signal output on this channel by setting LEDC_SIG_OUT_EN_CHn.
+    /// The LEDC_SIG_OUT_EN_CHn register should also set when calling
+    /// [`ChannelHW::configure_hw`] and
+    /// [`ChannelHW::configure_hw_with_pin_config`].
+    #[cfg(not(esp32))]
+    fn enable_signal_output(&self) {
+        unsafe { &*crate::peripherals::LEDC::ptr() }
+            .ch(self.number as usize)
+            .conf0()
+            .modify(|_, w| w.sig_out_en().set_bit().para_up().set_bit());
+    }
+
+    /// Disable signal output on this channel by clearing LEDC_SIG_OUT_EN_CHn.
+    #[cfg(esp32)]
+    fn disable_signal_output(&self) {
+        if S::IS_HS {
+            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.hsch(self.number as usize);
+            ch.conf0().modify(|_, w| w.sig_out_en().clear_bit());
+        } else {
+            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.lsch(self.number as usize);
+            ch.conf0()
+                .modify(|_, w| w.sig_out_en().clear_bit().para_up().set_bit());
+        }
+    }
+
+    /// Disable signal output on this channel by clearing LEDC_SIG_OUT_EN_CHn.
+    #[cfg(not(esp32))]
+    fn disable_signal_output(&self) {
+        unsafe { &*crate::peripherals::LEDC::ptr() }
+            .ch(self.number as usize)
+            .conf0()
+            .modify(|_, w| w.sig_out_en().clear_bit().para_up().set_bit());
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32s3")] {
+    /// Enables the overflow counting interrupt for this channel.
+    fn enable_overflow_interrupt(&self) {
+        critical_section::with(|_cs| {
+            unsafe { &*crate::peripherals::LEDC::ptr() }.int_ena().modify(|_, w| w.ovf_cnt_ch(self.number as u8).set_bit())
+        })
+    }
+
+    /// Disables the overflow counting interrupt for this channel.
+    fn disable_overflow_interrupt(&self) {
+        critical_section::with(|_cs| {
+            unsafe { &*crate::peripherals::LEDC::ptr() }.int_ena().modify(|_, w| w.ovf_cnt_ch(self.number as u8).clear_bit())
+        })
+    }
+
+    /// Enable the overflow counter and set the number of counter overflows needed to generate an interrupt.
+    ///
+    /// # Arguments
+    ///
+    /// * `overflow_num` - The number of counter overflows before generating an interrupt.
+    ///                    This is a 10-bit number, so it should be in the range of 1 to 1024.
+    fn enable_counter_with_overflow(&self, overflow_num: u16) {
+        assert!(overflow_num > 0 && overflow_num <= 1024, "Overflow number must be in the range of 1 to 1024");
+        unsafe { &*crate::peripherals::LEDC::ptr() }.ch(self.number as usize).conf0().modify(|_, w| unsafe {
+            w.ovf_cnt_en().set_bit().ovf_num().bits(overflow_num - 1).para_up().set_bit()
+        });
+    }
+
+    /// Disable the overflow counter by clearing the appropriate register.
+    fn disable_counter(&self){
+        unsafe { &*crate::peripherals::LEDC::ptr() }.ch(self.number as usize).conf0().modify(|_, w| {
+            w.ovf_cnt_en().clear_bit().para_up().set_bit()
+        });
+    }
+
+    /// Returns true if the overflow counting interrupt is active for this channel.
+    /// Note that this function will return from the raw interrupt status register
+    /// instead of the masked interrupt status register.
+    fn is_overflow_interrupt_active(&self) -> bool {
+        unsafe { &*crate::peripherals::LEDC::ptr() }.int_raw().read().ovf_cnt_ch(self.number as u8).bit_is_set()
+    }
+
+    /// Clears the overflow counting interrupt flag for this channel.
+    fn clear_overflow_interrupt(&self) {
+        unsafe { &*crate::peripherals::LEDC::ptr() }.int_clr().write(|w| w.ovf_cnt_ch(self.number as u8).clear_bit_by_one())
+    }
+        }
     }
 }

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -9,7 +9,10 @@
 //! `Pulse-Width Modulation (PWM)` applications by offering configurable duty
 //! cycles and frequencies.
 
-use super::timer::{TimerIFace, TimerSpeed};
+use super::{
+    timer::{TimerIFace, TimerSpeed},
+    Ledc,
+};
 use crate::{
     gpio::{OutputSignal, PeripheralOutput},
     peripheral::{Peripheral, PeripheralRef},
@@ -151,12 +154,15 @@ pub trait ChannelHW<O: PeripheralOutput> {
     fn disable_signal_output(&self);
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32s3")] {
+        if #[cfg(not(esp32))] {
             /// Enable the overflow counter and set the number of counter overflows needed to generate an interrupt.
             fn enable_counter_with_overflow(&self, overflow_num: u16);
 
             /// Disable the overflow counter by clearing the appropriate register.
             fn disable_counter(&self);
+
+            /// Resets the overflow counter by clearing `LEDC_OVF_CNT_RESET_CHn``.
+            fn reset_counter(&self);
 
             /// Enables the overflow counting interrupt for this channel.
             fn enable_overflow_interrupt(&self);
@@ -370,12 +376,12 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(esp32)]
     fn set_channel(&mut self, timer_number: u8) {
         if S::IS_HS {
-            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.hsch(self.number as usize);
+            let ch = Ledc::register_block().hsch(self.number as usize);
             ch.hpoint().write(|w| unsafe { w.hpoint().bits(0x0) });
             ch.conf0()
                 .modify(|_, w| unsafe { w.sig_out_en().set_bit().timer_sel().bits(timer_number) });
         } else {
-            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.lsch(self.number as usize);
+            let ch = Ledc::register_block().lsch(self.number as usize);
             ch.hpoint().write(|w| unsafe { w.hpoint().bits(0x0) });
             ch.conf0()
                 .modify(|_, w| unsafe { w.sig_out_en().set_bit().timer_sel().bits(timer_number) });
@@ -385,7 +391,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(not(esp32))]
     fn set_channel(&mut self, timer_number: u8) {
         {
-            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.ch(self.number as usize);
+            let ch = Ledc::register_block().ch(self.number as usize);
             ch.hpoint().write(|w| unsafe { w.hpoint().bits(0x0) });
             ch.conf0().modify(|_, w| {
                 w.sig_out_en().set_bit();
@@ -398,7 +404,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(esp32)]
     fn start_duty_without_fading(&self) {
         if S::IS_HS {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .hsch(self.number as usize)
                 .conf1()
                 .write(|w| unsafe {
@@ -409,7 +415,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
                     w.duty_scale().bits(0x0)
                 });
         } else {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .lsch(self.number as usize)
                 .conf1()
                 .write(|w| unsafe {
@@ -424,24 +430,22 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(any(esp32c6, esp32h2))]
     fn start_duty_without_fading(&self) {
         let cnum = self.number as usize;
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(cnum)
             .conf1()
             .write(|w| w.duty_start().set_bit());
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .ch_gamma_wr(cnum)
-            .write(|w| {
-                w.ch_gamma_duty_inc().set_bit();
-                unsafe {
-                    w.ch_gamma_duty_num().bits(0x1);
-                    w.ch_gamma_duty_cycle().bits(0x1);
-                    w.ch_gamma_scale().bits(0x0)
-                }
-            });
+        Ledc::register_block().ch_gamma_wr(cnum).write(|w| {
+            w.ch_gamma_duty_inc().set_bit();
+            unsafe {
+                w.ch_gamma_duty_num().bits(0x1);
+                w.ch_gamma_duty_cycle().bits(0x1);
+                w.ch_gamma_scale().bits(0x0)
+            }
+        });
     }
     #[cfg(not(any(esp32, esp32c6, esp32h2)))]
     fn start_duty_without_fading(&self) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(self.number as usize)
             .conf1()
             .write(|w| {
@@ -464,7 +468,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
         duty_per_cycle: u16,
     ) {
         if S::IS_HS {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .hsch(self.number as usize)
                 .conf1()
                 .write(|w| unsafe {
@@ -480,7 +484,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
                         .bits(duty_per_cycle)
                 });
         } else {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .lsch(self.number as usize)
                 .conf1()
                 .write(|w| unsafe {
@@ -507,26 +511,24 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
         duty_per_cycle: u16,
     ) {
         let cnum = self.number as usize;
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(cnum)
             .conf1()
             .write(|w| w.duty_start().set_bit());
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .ch_gamma_wr(cnum)
-            .write(|w| unsafe {
-                w.ch_gamma_duty_inc()
-                    .variant(duty_inc)
-                    .ch_gamma_duty_num() // count of incs before stopping
-                    .bits(duty_steps)
-                    .ch_gamma_duty_cycle() // overflows between incs
-                    .bits(cycles_per_step)
-                    .ch_gamma_scale()
-                    .bits(duty_per_cycle)
-            });
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block().ch_gamma_wr(cnum).write(|w| unsafe {
+            w.ch_gamma_duty_inc()
+                .variant(duty_inc)
+                .ch_gamma_duty_num() // count of incs before stopping
+                .bits(duty_steps)
+                .ch_gamma_duty_cycle() // overflows between incs
+                .bits(cycles_per_step)
+                .ch_gamma_scale()
+                .bits(duty_per_cycle)
+        });
+        Ledc::register_block()
             .ch_gamma_wr_addr(cnum)
             .write(|w| unsafe { w.ch_gamma_wr_addr().bits(0) });
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch_gamma_conf(cnum)
             .write(|w| unsafe { w.ch_gamma_entry_num().bits(0x1) });
     }
@@ -539,7 +541,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
         cycles_per_step: u16,
         duty_per_cycle: u16,
     ) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(self.number as usize)
             .conf1()
             .write(|w| unsafe {
@@ -556,7 +558,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     #[cfg(esp32)]
     fn update_channel(&self) {
         if !S::IS_HS {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .lsch(self.number as usize)
                 .conf0()
                 .modify(|_, w| w.para_up().set_bit());
@@ -564,7 +566,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     }
     #[cfg(not(esp32))]
     fn update_channel(&self) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(self.number as usize)
             .conf0()
             .modify(|_, w| w.para_up().set_bit());
@@ -582,10 +584,6 @@ where
     }
     fn configure_hw_with_pin_config(&mut self, cfg: config::PinConfig) -> Result<(), Error> {
         if let Some(timer) = self.timer {
-            if !timer.is_configured() {
-                return Err(Error::Timer);
-            }
-
             match cfg {
                 config::PinConfig::PushPull => self
                     .output_pin
@@ -654,12 +652,12 @@ where
     #[cfg(esp32)]
     fn set_duty_hw(&self, duty: u32) {
         if S::IS_HS {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .hsch(self.number as usize)
                 .duty()
                 .write(|w| unsafe { w.duty().bits(duty << 4) });
         } else {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .lsch(self.number as usize)
                 .duty()
                 .write(|w| unsafe { w.duty().bits(duty << 4) });
@@ -671,7 +669,7 @@ where
     /// Set duty in channel HW
     #[cfg(not(esp32))]
     fn set_duty_hw(&self, duty: u32) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(self.number as usize)
             .duty()
             .write(|w| unsafe { w.duty().bits(duty << 4) });
@@ -690,19 +688,19 @@ where
         duty_per_cycle: u16,
     ) {
         if S::IS_HS {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .hsch(self.number as usize)
                 .duty()
                 .write(|w| unsafe { w.duty().bits(start_duty << 4) });
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .int_clr()
                 .write(|w| w.duty_chng_end_hsch(self.number as u8).clear_bit_by_one());
         } else {
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .lsch(self.number as usize)
                 .duty()
                 .write(|w| unsafe { w.duty().bits(start_duty << 4) });
-            unsafe { &*crate::peripherals::LEDC::ptr() }
+            Ledc::register_block()
                 .int_clr()
                 .write(|w| w.duty_chng_end_lsch(self.number as u8).clear_bit_by_one());
         }
@@ -720,11 +718,11 @@ where
         cycles_per_step: u16,
         duty_per_cycle: u16,
     ) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(self.number as usize)
             .duty()
             .write(|w| unsafe { w.duty().bits(start_duty << 4) });
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .int_clr()
             .write(|w| w.duty_chng_end_ch(self.number as u8).clear_bit_by_one());
         self.start_duty_fade_inner(duty_inc, duty_steps, cycles_per_step, duty_per_cycle);
@@ -733,9 +731,7 @@ where
 
     #[cfg(esp32)]
     fn is_duty_fade_running_hw(&self) -> bool {
-        let reg = unsafe { &*crate::peripherals::LEDC::ptr() }
-            .int_raw()
-            .read();
+        let reg = Ledc::register_block().int_raw().read();
         if S::IS_HS {
             reg.duty_chng_end_hsch(self.number as u8).bit_is_clear()
         } else {
@@ -745,7 +741,7 @@ where
 
     #[cfg(not(esp32))]
     fn is_duty_fade_running_hw(&self) -> bool {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .int_raw()
             .read()
             .duty_chng_end_ch(self.number as u8)
@@ -759,10 +755,10 @@ where
     #[cfg(esp32)]
     fn enable_signal_output(&self) {
         if S::IS_HS {
-            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.hsch(self.number as usize);
+            let ch = Ledc::register_block().hsch(self.number as usize);
             ch.conf0().modify(|_, w| w.sig_out_en().set_bit());
         } else {
-            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.lsch(self.number as usize);
+            let ch = Ledc::register_block().lsch(self.number as usize);
             ch.conf0()
                 .modify(|_, w| w.sig_out_en().set_bit().para_up().set_bit());
         }
@@ -774,7 +770,7 @@ where
     /// [`ChannelHW::configure_hw_with_pin_config`].
     #[cfg(not(esp32))]
     fn enable_signal_output(&self) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(self.number as usize)
             .conf0()
             .modify(|_, w| w.sig_out_en().set_bit().para_up().set_bit());
@@ -784,10 +780,10 @@ where
     #[cfg(esp32)]
     fn disable_signal_output(&self) {
         if S::IS_HS {
-            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.hsch(self.number as usize);
+            let ch = Ledc::register_block().hsch(self.number as usize);
             ch.conf0().modify(|_, w| w.sig_out_en().clear_bit());
         } else {
-            let ch = unsafe { &*crate::peripherals::LEDC::ptr() }.lsch(self.number as usize);
+            let ch = Ledc::register_block().lsch(self.number as usize);
             ch.conf0()
                 .modify(|_, w| w.sig_out_en().clear_bit().para_up().set_bit());
         }
@@ -796,25 +792,25 @@ where
     /// Disable signal output on this channel by clearing LEDC_SIG_OUT_EN_CHn.
     #[cfg(not(esp32))]
     fn disable_signal_output(&self) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
+        Ledc::register_block()
             .ch(self.number as usize)
             .conf0()
             .modify(|_, w| w.sig_out_en().clear_bit().para_up().set_bit());
     }
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32s3")] {
+        if #[cfg(not(esp32))] {
     /// Enables the overflow counting interrupt for this channel.
     fn enable_overflow_interrupt(&self) {
         critical_section::with(|_cs| {
-            unsafe { &*crate::peripherals::LEDC::ptr() }.int_ena().modify(|_, w| w.ovf_cnt_ch(self.number as u8).set_bit())
+            Ledc::register_block().int_ena().modify(|_, w| w.ovf_cnt_ch(self.number as u8).set_bit())
         })
     }
 
     /// Disables the overflow counting interrupt for this channel.
     fn disable_overflow_interrupt(&self) {
         critical_section::with(|_cs| {
-            unsafe { &*crate::peripherals::LEDC::ptr() }.int_ena().modify(|_, w| w.ovf_cnt_ch(self.number as u8).clear_bit())
+            Ledc::register_block().int_ena().modify(|_, w| w.ovf_cnt_ch(self.number as u8).clear_bit())
         })
     }
 
@@ -826,28 +822,36 @@ where
     ///                    This is a 10-bit number, so it should be in the range of 1 to 1024.
     fn enable_counter_with_overflow(&self, overflow_num: u16) {
         assert!(overflow_num > 0 && overflow_num <= 1024, "Overflow number must be in the range of 1 to 1024");
-        unsafe { &*crate::peripherals::LEDC::ptr() }.ch(self.number as usize).conf0().modify(|_, w| unsafe {
+        Ledc::register_block().ch(self.number as usize).conf0().modify(|_, w| unsafe {
             w.ovf_cnt_en().set_bit().ovf_num().bits(overflow_num - 1).para_up().set_bit()
         });
     }
 
     /// Disable the overflow counter by clearing the appropriate register.
     fn disable_counter(&self){
-        unsafe { &*crate::peripherals::LEDC::ptr() }.ch(self.number as usize).conf0().modify(|_, w| {
+        Ledc::register_block().ch(self.number as usize).conf0().modify(|_, w| {
             w.ovf_cnt_en().clear_bit().para_up().set_bit()
         });
+    }
+
+    /// Resets the overflow counter by clearing `LEDC_OVF_CNT_RESET_CHn``.
+    fn reset_counter(&self) {
+        Ledc::register_block()
+            .ch(self.number as usize)
+            .conf0()
+            .modify(|_, w| w.ovf_cnt_reset().set_bit());
     }
 
     /// Returns true if the overflow counting interrupt is active for this channel.
     /// Note that this function will return from the raw interrupt status register
     /// instead of the masked interrupt status register.
     fn is_overflow_interrupt_active(&self) -> bool {
-        unsafe { &*crate::peripherals::LEDC::ptr() }.int_raw().read().ovf_cnt_ch(self.number as u8).bit_is_set()
+        Ledc::register_block().int_raw().read().ovf_cnt_ch(self.number as u8).bit_is_set()
     }
 
     /// Clears the overflow counting interrupt flag for this channel.
     fn clear_overflow_interrupt(&self) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }.int_clr().write(|w| w.ovf_cnt_ch(self.number as u8).clear_bit_by_one())
+        Ledc::register_block().int_clr().write(|w| w.ovf_cnt_ch(self.number as u8).clear_bit_by_one())
     }
         }
     }

--- a/esp-hal/src/ledc/timer.rs
+++ b/esp-hal/src/ledc/timer.rs
@@ -11,11 +11,14 @@
 //!
 //! LEDC uses APB as clock source.
 
+use core::marker::PhantomData;
+
+use config::Duty;
 use fugit::HertzU32;
 
 #[cfg(esp32)]
 use super::HighSpeed;
-use super::{LowSpeed, Speed};
+use super::{Ledc, LowSpeed, Speed};
 use crate::clock::Clocks;
 
 const LEDC_TIMER_DIV_NUM_MAX: u64 = 0x3FFFF;
@@ -28,23 +31,84 @@ pub enum Error {
     Divisor,
 }
 
+/// This trait describes the clock source for one specific timer
+/// In esp32 and esp32s2, there is a mux to select the clock source in each
+/// timer, which is decided by `LEDC_TICK_SEL_TIMERx` register.
+/// If the value is 0, the clock source is the LEDC_PWM_CLK, which is configured
+/// by the `LEDC_APB_CLK_SEL` register. Otherwise, the clock source is the
+/// REF_TICK.
+pub trait ClockSource: Sized {
+    #[cfg(any(esp32, esp32s2))]
+    /// REF_TICK clock is used as the backup clock source for timers when the
+    /// divisor is too high.
+    const REF_TICK: Self;
+    /// Get the clock frequency of the clock source
+    fn get_clock_freq(&self) -> HertzU32;
+}
+
 #[cfg(esp32)]
 /// Clock source for HS Timers
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum HSClockSource {
-    /// APB clock.
-    APBClk,
-    // TODO RefTick,
+    /// LEDC_PWM_CLK
+    LedcPwmClk,
+    /// REF_TICK.
+    RefTick,
+}
+
+#[cfg(esp32)]
+impl ClockSource for HSClockSource {
+    /// Get the clock frequency of the clock source
+    /// esp32 has two clock sources for HS timers: APB_CLK and REF_TICK
+    fn get_clock_freq(&self) -> HertzU32 {
+        match self {
+            HSClockSource::LedcPwmClk => {
+                let clocks = Clocks::get();
+                clocks.apb_clock
+            }
+            HSClockSource::RefTick => HertzU32::from(crate::soc::constants::REF_TICK),
+        }
+    }
+    const REF_TICK: Self = Self::RefTick;
 }
 
 /// Clock source for LS Timers
+/// Only esp32 and esp32s2 have REF_TICK
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LSClockSource {
-    /// APB clock.
-    APBClk,
-    // TODO SLOWClk
+    /// LEDC_PWM_CLK
+    LedcPwmClk,
+    #[cfg(any(esp32, esp32s2))]
+    /// REF_TICK clock.
+    RefTick,
+}
+
+impl ClockSource for LSClockSource {
+    /// Get the clock frequency of the clock source
+    /// For slow-speed timers, there are multiple clock sources:
+    /// For example, if LEDC_APB_CLK_SEL is set to 1, the clock source is
+    /// APB_CLK. if LEDC_APB_CLK_SEL is set to 2, the clock source is
+    /// RC_FAST_CLK. if LEDC_APB_CLK_SEL is set to 3, the clock source is
+    /// XTAL_CLK. Currently, only APB_CLK is supported.
+    fn get_clock_freq(&self) -> HertzU32 {
+        match self {
+            LSClockSource::LedcPwmClk => {
+                let source = Ledc::get_global_slow_clock().expect("Global slow clock not set.");
+                match source {
+                    super::LSGlobalClkSource::APBClk => {
+                        let clocks = Clocks::get();
+                        clocks.apb_clock
+                    }
+                }
+            }
+            #[cfg(any(esp32, esp32s2))]
+            LSClockSource::RefTick => HertzU32::from(crate::soc::constants::REF_TICK),
+        }
+    }
+    #[cfg(any(esp32, esp32s2))]
+    const REF_TICK: Self = Self::RefTick;
 }
 
 /// Timer number
@@ -63,8 +127,6 @@ pub enum Number {
 
 /// Timer configuration
 pub mod config {
-    use fugit::HertzU32;
-
     /// Number of bits reserved for duty cycle adjustment
     #[derive(PartialEq, Eq, Copy, Clone, Debug)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -97,48 +159,254 @@ pub mod config {
         Duty13Bit,
         /// 14-bit resolution for duty cycle adjustment.
         Duty14Bit,
-        #[cfg(esp32)]
+        #[cfg(any(esp32, esp32c6, esp32h2))]
         /// 15-bit resolution for duty cycle adjustment.
         Duty15Bit,
-        #[cfg(esp32)]
+        #[cfg(any(esp32, esp32c6, esp32h2))]
         /// 16-bit resolution for duty cycle adjustment.
         Duty16Bit,
-        #[cfg(esp32)]
+        #[cfg(any(esp32, esp32c6, esp32h2))]
         /// 17-bit resolution for duty cycle adjustment.
         Duty17Bit,
-        #[cfg(esp32)]
+        #[cfg(any(esp32, esp32c6, esp32h2))]
         /// 18-bit resolution for duty cycle adjustment.
         Duty18Bit,
-        #[cfg(esp32)]
+        #[cfg(any(esp32, esp32c6, esp32h2))]
         /// 19-bit resolution for duty cycle adjustment.
         Duty19Bit,
-        #[cfg(esp32)]
+        #[cfg(any(esp32, esp32c6, esp32h2))]
         /// 20-bit resolution for duty cycle adjustment.
         Duty20Bit,
     }
 
-    /// Timer configuration
-    #[derive(Copy, Clone)]
-    pub struct Config<CS> {
-        /// The duty cycle resolution.
-        pub duty: Duty,
-        /// The clock source for the timer.
-        pub clock_source: CS,
-        /// The frequency of the PWM signal in Hertz.
-        pub frequency: HertzU32,
+    impl TryFrom<u8> for Duty {
+        type Error = ();
+
+        fn try_from(value: u8) -> Result<Self, Self::Error> {
+            Ok(match value {
+                1 => Self::Duty1Bit,
+                2 => Self::Duty2Bit,
+                3 => Self::Duty3Bit,
+                4 => Self::Duty4Bit,
+                5 => Self::Duty5Bit,
+                6 => Self::Duty6Bit,
+                7 => Self::Duty7Bit,
+                8 => Self::Duty8Bit,
+                9 => Self::Duty9Bit,
+                10 => Self::Duty10Bit,
+                11 => Self::Duty11Bit,
+                12 => Self::Duty12Bit,
+                13 => Self::Duty13Bit,
+                14 => Self::Duty14Bit,
+                #[cfg(any(esp32, esp32c6, esp32h2))]
+                15 => Self::Duty15Bit,
+                #[cfg(any(esp32, esp32c6, esp32h2))]
+                16 => Self::Duty16Bit,
+                #[cfg(any(esp32, esp32c6, esp32h2))]
+                17 => Self::Duty17Bit,
+                #[cfg(any(esp32, esp32c6, esp32h2))]
+                18 => Self::Duty18Bit,
+                #[cfg(any(esp32, esp32c6, esp32h2))]
+                19 => Self::Duty19Bit,
+                #[cfg(any(esp32, esp32c6, esp32h2))]
+                20 => Self::Duty20Bit,
+                _ => Err(())?,
+            })
+        }
     }
 }
 
 /// Trait defining the type of timer source
 pub trait TimerSpeed: Speed {
     /// The type of clock source used by the timer in this speed mode.
-    type ClockSourceType: Sync;
+    type ClockSourceType: ClockSource;
+
+    #[cfg(any(esp32, esp32s2))]
+    /// esp32 and esp32s2 have a mux to select the clock source in each timer,
+    /// which allows the user to select the clock source for each timer.
+    fn select_timer(number: Number, source: Self::ClockSourceType);
+    /// Get the clock source of the timer
+    fn get_clock_source(number: Number) -> Self::ClockSourceType;
+    /// Get the raw duty number of the timer, the number can be 0 if the timer
+    /// is not configured.
+    fn get_duty_bits(number: Number) -> u8;
+    /// Set the duty number of the timer
+    fn set_duty(number: Number, duty: config::Duty);
+    /// Get the raw divisor number of the timer, the number can be 0 if the
+    /// timer is not configured.
+    fn get_divisor_bits(number: Number) -> u32;
+    /// Set the divisor number of the timer
+    fn set_divisor(number: Number, divisor: u32);
+    /// Set the pause bit of the timer
+    fn set_pause_bit(number: Number, pause: bool);
+    /// Set the reset bit of the timer
+    fn set_reset_bit(number: Number, reset: bool);
+    /// Update the parameters of the timer
+    fn param_update(number: Number);
+    /// Get the counter value of the timer
+    fn get_counter(number: Number) -> u32;
 }
 
 /// Timer source type for LowSpeed timers
 impl TimerSpeed for LowSpeed {
     /// The clock source type for low-speed timers.
     type ClockSourceType = LSClockSource;
+
+    #[cfg(any(esp32, esp32s2))]
+    fn get_clock_source(number: Number) -> Self::ClockSourceType {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                let timer = Ledc::register_block()
+                .lstimer(number as usize);
+            } else {
+                let timer = Ledc::register_block()
+                .timer(number as usize);
+            }
+        };
+        match timer.conf().read().tick_sel().bit() {
+            true => LSClockSource::LedcPwmClk,
+            false => LSClockSource::RefTick,
+        }
+    }
+
+    #[cfg(not(any(esp32, esp32s2)))]
+    fn get_clock_source(_number: Number) -> Self::ClockSourceType {
+        LSClockSource::LedcPwmClk
+    }
+
+    #[cfg(any(esp32, esp32s2))]
+    fn select_timer(number: Number, source: Self::ClockSourceType) {
+        let source = match source {
+            LSClockSource::LedcPwmClk => true,
+            LSClockSource::RefTick => false,
+        };
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                let timer = Ledc::register_block()
+                .lstimer(number as usize);
+            } else {
+                let timer = Ledc::register_block()
+                .timer(number as usize);
+            }
+        };
+        timer.conf().modify(|_, w| w.tick_sel().bit(source));
+    }
+
+    fn get_duty_bits(number: Number) -> u8 {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                let timer = Ledc::register_block()
+                .lstimer(number as usize);
+            } else {
+                let timer = Ledc::register_block()
+                .timer(number as usize);
+            }
+        };
+        timer.conf().read().duty_res().bits()
+    }
+
+    fn set_duty(number: Number, duty: config::Duty) {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                let timer = Ledc::register_block()
+                .lstimer(number as usize);
+            } else {
+                let timer = Ledc::register_block()
+                .timer(number as usize);
+            }
+        };
+        timer
+            .conf()
+            .modify(|_, w| unsafe { w.duty_res().bits(duty as u8) });
+    }
+
+    #[cfg(not(esp32))]
+    fn get_divisor_bits(number: Number) -> u32 {
+        Ledc::register_block()
+            .timer(number as usize)
+            .conf()
+            .read()
+            .clk_div()
+            .bits()
+    }
+
+    #[cfg(esp32)]
+    fn get_divisor_bits(number: Number) -> u32 {
+        Ledc::register_block()
+            .lstimer(number as usize)
+            .conf()
+            .read()
+            .div_num()
+            .bits()
+    }
+
+    #[cfg(not(esp32))]
+    fn set_divisor(number: Number, divisor: u32) {
+        Ledc::register_block()
+            .timer(number as usize)
+            .conf()
+            .modify(|_, w| unsafe { w.clk_div().bits(divisor) });
+    }
+
+    #[cfg(esp32)]
+    fn set_divisor(number: Number, divisor: u32) {
+        Ledc::register_block()
+            .lstimer(number as usize)
+            .conf()
+            .modify(|_, w| unsafe { w.div_num().bits(divisor) });
+    }
+
+    fn set_pause_bit(number: Number, pause: bool) {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                let timer = Ledc::register_block()
+                .lstimer(number as usize);
+            } else {
+                let timer = Ledc::register_block()
+                .timer(number as usize);
+            }
+        };
+        timer.conf().modify(|_, w| w.pause().bit(pause));
+    }
+
+    fn set_reset_bit(number: Number, reset: bool) {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                let timer = Ledc::register_block()
+                .lstimer(number as usize);
+            } else {
+                let timer = Ledc::register_block()
+                .timer(number as usize);
+            }
+        };
+        timer.conf().modify(|_, w| w.rst().bit(reset));
+    }
+
+    fn param_update(number: Number) {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                let timer = Ledc::register_block()
+                .lstimer(number as usize);
+            } else {
+                let timer = Ledc::register_block()
+                .timer(number as usize);
+            }
+        };
+        timer.conf().modify(|_, w| w.para_up().set_bit());
+    }
+
+    fn get_counter(number: Number) -> u32 {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                let timer = Ledc::register_block()
+                .lstimer(number as usize);
+            } else {
+                let timer = Ledc::register_block()
+                .timer(number as usize);
+            }
+        };
+        timer.value().read().cnt().bits() as _
+    }
 }
 
 #[cfg(esp32)]
@@ -146,19 +414,194 @@ impl TimerSpeed for LowSpeed {
 impl TimerSpeed for HighSpeed {
     /// The clock source type for high-speed timers.
     type ClockSourceType = HSClockSource;
+
+    fn get_clock_source(number: Number) -> Self::ClockSourceType {
+        match Ledc::register_block()
+            .hstimer(number as usize)
+            .conf()
+            .read()
+            .tick_sel()
+            .bit()
+        {
+            true => HSClockSource::LedcPwmClk,
+            false => HSClockSource::RefTick,
+        }
+    }
+
+    fn select_timer(number: Number, source: Self::ClockSourceType) {
+        let source = match source {
+            HSClockSource::LedcPwmClk => true,
+            HSClockSource::RefTick => false,
+        };
+        Ledc::register_block()
+            .hstimer(number as usize)
+            .conf()
+            .modify(|_, w| w.tick_sel().bit(source));
+    }
+
+    fn get_duty_bits(number: Number) -> u8 {
+        Ledc::register_block()
+            .hstimer(number as usize)
+            .conf()
+            .read()
+            .duty_res()
+            .bits()
+    }
+
+    fn set_duty(number: Number, duty: config::Duty) {
+        Ledc::register_block()
+            .hstimer(number as usize)
+            .conf()
+            .modify(|_, w| unsafe { w.duty_res().bits(duty as u8) });
+    }
+
+    fn get_divisor_bits(number: Number) -> u32 {
+        Ledc::register_block()
+            .hstimer(number as usize)
+            .conf()
+            .read()
+            .div_num()
+            .bits()
+    }
+
+    fn set_divisor(number: Number, divisor: u32) {
+        Ledc::register_block()
+            .hstimer(number as usize)
+            .conf()
+            .modify(|_, w| unsafe { w.div_num().bits(divisor) });
+    }
+
+    fn set_pause_bit(number: Number, pause: bool) {
+        Ledc::register_block()
+            .hstimer(number as usize)
+            .conf()
+            .modify(|_, w| w.pause().bit(pause));
+    }
+
+    fn set_reset_bit(number: Number, reset: bool) {
+        Ledc::register_block()
+            .hstimer(number as usize)
+            .conf()
+            .modify(|_, w| w.rst().bit(reset));
+    }
+
+    fn param_update(_: Number) {
+        // The parameters will be updated in the next cycle
+    }
+
+    fn get_counter(number: Number) -> u32 {
+        Ledc::register_block()
+            .hstimer(number as usize)
+            .value()
+            .read()
+            .cnt()
+            .bits() as _
+    }
+}
+
+/// Builder for Timer
+pub struct TimerBuilder<S: TimerSpeed> {
+    phantom: PhantomData<S>,
+    number: Number,
+}
+
+impl<S: TimerSpeed> TimerBuilder<S> {
+    /// Create a new instance of a timer builder
+    /// `number`, `duty`, `clock_source` and `frequency` are the required
+    /// parameters. other parameters can be set by calling the corresponding
+    /// methods.
+    pub fn new(
+        _ledc: &Ledc<'_>,
+        number: Number,
+        duty: Duty,
+        clock_source: S::ClockSourceType,
+        frequency: HertzU32,
+    ) -> Result<TimerBuilder<S>, Error> {
+        S::set_duty(number, duty);
+        let builder = TimerBuilder {
+            phantom: PhantomData,
+            number,
+        };
+        builder.set_frequency(duty, clock_source, frequency)
+    }
+
+    /// Create a new instance of a timer builder from a configured timer
+    pub fn from_configured_timer(timer: Timer<S>) -> TimerBuilder<S> {
+        TimerBuilder {
+            phantom: PhantomData,
+            number: timer.number,
+        }
+    }
+
+    /// Set the frequency of the timer
+    pub fn set_frequency(
+        &self,
+        duty: Duty,
+        clock_source: S::ClockSourceType,
+        frequency: HertzU32,
+    ) -> Result<Self, Error> {
+        let clock_frequency = clock_source.get_clock_freq();
+        let precision = 1 << duty as u32;
+        let frequency = frequency.to_Hz() as u64;
+
+        #[cfg(any(esp32, esp32s2))]
+        let mut clock_source = clock_source;
+
+        #[cfg(any(esp32, esp32s2))]
+        let mut divisor = ((clock_frequency.to_Hz() as u64) << 8) / frequency / precision as u64;
+
+        #[cfg(not(any(esp32, esp32s2)))]
+        let divisor = ((clock_frequency.to_Hz() as u64) << 8) / frequency / precision as u64;
+
+        #[cfg(any(esp32, esp32s2))]
+        if divisor > LEDC_TIMER_DIV_NUM_MAX {
+            // APB_CLK results in divisor which too high. Try using REF_TICK as clock
+            // source.
+            clock_source = S::ClockSourceType::REF_TICK;
+            divisor = (1_000_000u64 << 8) / frequency / precision as u64;
+        }
+
+        if !(256..LEDC_TIMER_DIV_NUM_MAX).contains(&divisor) {
+            return Err(Error::Divisor);
+        }
+
+        #[cfg(any(esp32, esp32s2))]
+        S::select_timer(self.number, clock_source);
+        S::set_divisor(self.number, divisor as u32);
+        Ok(TimerBuilder {
+            phantom: PhantomData,
+            number: self.number,
+        })
+    }
+
+    /// pause the timer
+    pub fn pause(self) -> Self {
+        S::set_pause_bit(self.number, true);
+        self
+    }
+
+    /// resume the timer
+    pub fn resume(self) -> Self {
+        S::set_pause_bit(self.number, false);
+        self
+    }
+
+    /// reset the timer
+    pub fn reset(self) -> Self {
+        S::set_reset_bit(self.number, true);
+        self
+    }
+
+    /// build the timer
+    pub fn build(self) -> Timer<S> {
+        S::param_update(self.number);
+        S::set_reset_bit(self.number, false);
+        Timer::new(self.number)
+    }
 }
 
 /// Interface for Timers
 pub trait TimerIFace<S: TimerSpeed>: Sync {
-    /// Return the frequency of the timer
-    fn get_freq(&self) -> Option<HertzU32>;
-
-    /// Configure the timer
-    fn configure(&mut self, config: config::Config<S::ClockSourceType>) -> Result<(), Error>;
-
-    /// Check if the timer has been configured
-    fn is_configured(&self) -> bool;
-
     /// Return the duty resolution of the timer
     fn get_duty(&self) -> Option<config::Duty>;
 
@@ -169,86 +612,21 @@ pub trait TimerIFace<S: TimerSpeed>: Sync {
     fn get_frequency(&self) -> u32;
 }
 
-/// Interface for HW configuration of timer
-pub trait TimerHW<S: TimerSpeed> {
-    /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<HertzU32>;
-
-    /// Configure the HW for the timer
-    fn configure_hw(&self, divisor: u32);
-
-    /// Update the timer in HW
-    fn update_hw(&self);
-
-    /// Pause the timer
-    fn pause(&self);
-
-    /// Resume the timer
-    fn resume(&self);
-
-    /// Reset the timer
-    fn reset(&self);
-}
-
 /// Timer struct
+#[derive(Clone, Copy)]
 pub struct Timer<S: TimerSpeed> {
+    phantom: PhantomData<S>,
     number: Number,
-    duty: Option<config::Duty>,
-    frequency: u32,
-    configured: bool,
-    use_ref_tick: bool,
-    clock_source: Option<S::ClockSourceType>,
 }
 
-impl<S: TimerSpeed> TimerIFace<S> for Timer<S>
-where
-    Timer<S>: TimerHW<S>,
-{
-    /// Return the frequency of the timer
-    fn get_freq(&self) -> Option<HertzU32> {
-        self.get_freq_hw()
-    }
-
-    /// Configure the timer
-    fn configure(&mut self, config: config::Config<S::ClockSourceType>) -> Result<(), Error> {
-        self.duty = Some(config.duty);
-        self.clock_source = Some(config.clock_source);
-
-        // TODO: we should return some error here if `unwrap()` fails
-        let src_freq: u32 = self.get_freq().unwrap().to_Hz();
-        let precision = 1 << config.duty as u32;
-        let frequency: u32 = config.frequency.raw();
-        self.frequency = frequency;
-
-        let mut divisor = ((src_freq as u64) << 8) / frequency as u64 / precision as u64;
-
-        if divisor > LEDC_TIMER_DIV_NUM_MAX {
-            // APB_CLK results in divisor which too high. Try using REF_TICK as clock
-            // source.
-            self.use_ref_tick = true;
-            divisor = (1_000_000u64 << 8) / frequency as u64 / precision as u64;
-        }
-
-        if !(256..LEDC_TIMER_DIV_NUM_MAX).contains(&divisor) {
-            return Err(Error::Divisor);
-        }
-
-        self.configure_hw(divisor as u32);
-        self.update_hw();
-
-        self.configured = true;
-
-        Ok(())
-    }
-
-    /// Check if the timer has been configured
-    fn is_configured(&self) -> bool {
-        self.configured
-    }
-
+impl<S: TimerSpeed> TimerIFace<S> for Timer<S> {
     /// Return the duty resolution of the timer
     fn get_duty(&self) -> Option<config::Duty> {
-        self.duty
+        let duty = LowSpeed::get_duty_bits(self.number);
+        if duty == 0 {
+            return None;
+        }
+        Some(Duty::try_from(duty).expect("Unexpect duty value from the ledc register."))
     }
 
     /// Return the timer number
@@ -258,181 +636,26 @@ where
 
     /// Return the timer frequency
     fn get_frequency(&self) -> u32 {
-        self.frequency
+        let clock = S::get_clock_source(self.number).get_clock_freq();
+        let divisor = S::get_divisor_bits(self.number);
+        if divisor == 0 {
+            return 0;
+        }
+        let duty = match self.get_duty() {
+            Some(duty) => duty,
+            None => return 0,
+        } as u8;
+        let precision = 1 << duty as u64;
+        (((clock.to_Hz() as u64) << 8) / precision / (divisor as u64)) as u32
     }
 }
 
 impl<S: TimerSpeed> Timer<S> {
     /// Create a new instance of a timer
-    pub fn new(number: Number) -> Self {
+    fn new(number: Number) -> Self {
         Timer {
+            phantom: PhantomData,
             number,
-            duty: None,
-            frequency: 0u32,
-            configured: false,
-            use_ref_tick: false,
-            clock_source: None,
         }
-    }
-}
-
-/// Timer HW implementation for LowSpeed timers
-impl TimerHW<LowSpeed> for Timer<LowSpeed> {
-    /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<HertzU32> {
-        self.clock_source.map(|source| match source {
-            LSClockSource::APBClk => {
-                let clocks = Clocks::get();
-                clocks.apb_clock
-            }
-        })
-    }
-
-    #[cfg(esp32)]
-    /// Configure the HW for the timer
-    fn configure_hw(&self, divisor: u32) {
-        let duty = unwrap!(self.duty) as u8;
-        let use_apb = !self.use_ref_tick;
-
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .lstimer(self.number as usize)
-            .conf()
-            .modify(|_, w| unsafe {
-                w.tick_sel().bit(use_apb);
-                w.rst().clear_bit();
-                w.pause().clear_bit();
-                w.div_num().bits(divisor);
-                w.duty_res().bits(duty)
-            });
-    }
-
-    #[cfg(not(esp32))]
-    /// Configure the HW for the timer
-    fn configure_hw(&self, divisor: u32) {
-        let duty = unwrap!(self.duty) as u8;
-        let use_ref_tick = self.use_ref_tick;
-
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .timer(self.number as usize)
-            .conf()
-            .modify(|_, w| unsafe {
-                w.tick_sel().bit(use_ref_tick);
-                w.rst().clear_bit();
-                w.pause().clear_bit();
-                w.clk_div().bits(divisor);
-                w.duty_res().bits(duty)
-            });
-    }
-
-    /// Update the timer in HW
-    fn update_hw(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
-                let tmr =  unsafe { &*crate::peripherals::LEDC::ptr() }.lstimer(self.number as usize);
-            } else {
-                let tmr =  unsafe { &*crate::peripherals::LEDC::ptr() }.timer(self.number as usize);
-            }
-        }
-
-        tmr.conf().modify(|_, w| w.para_up().set_bit());
-    }
-
-    /// Pause the timer
-    fn pause(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
-                 unsafe { &*crate::peripherals::LEDC::ptr() }.lstimer(self.number as usize).conf().modify(|_, w| w.pause().set_bit());
-            } else {
-                 unsafe { &*crate::peripherals::LEDC::ptr() }.timer(self.number as usize).conf().modify(|_, w| w.pause().set_bit());
-            }
-        }
-    }
-
-    /// Resume the timer
-    fn resume(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
-                 unsafe { &*crate::peripherals::LEDC::ptr() }.lstimer(self.number as usize).conf().modify(|_, w| w.pause().clear_bit());
-            } else {
-                 unsafe { &*crate::peripherals::LEDC::ptr() }.timer(self.number as usize).conf().modify(|_, w| w.pause().clear_bit());
-            }
-        }
-    }
-
-    /// Reset the timer
-    fn reset(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
-                 unsafe { &*crate::peripherals::LEDC::ptr() }.lstimer(self.number as usize).conf().modify(|_, w| w.rst().set_bit());
-                 unsafe { &*crate::peripherals::LEDC::ptr() }.lstimer(self.number as usize).conf().modify(|_, w| w.rst().clear_bit());
-            } else {
-                 unsafe { &*crate::peripherals::LEDC::ptr() }.timer(self.number as usize).conf().modify(|_, w| w.rst().set_bit());
-                 unsafe { &*crate::peripherals::LEDC::ptr() }.timer(self.number as usize).conf().modify(|_, w| w.rst().clear_bit());
-            }
-        }
-    }
-}
-
-#[cfg(esp32)]
-/// Timer HW implementation for HighSpeed timers
-impl TimerHW<HighSpeed> for Timer<HighSpeed> {
-    /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<HertzU32> {
-        self.clock_source.map(|source| match source {
-            HSClockSource::APBClk => {
-                let clocks = Clocks::get();
-                clocks.apb_clock
-            }
-        })
-    }
-
-    /// Configure the HW for the timer
-    fn configure_hw(&self, divisor: u32) {
-        let duty = unwrap!(self.duty) as u8;
-        let sel_hstimer = self.clock_source == Some(HSClockSource::APBClk);
-
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .hstimer(self.number as usize)
-            .conf()
-            .modify(|_, w| unsafe {
-                w.tick_sel().bit(sel_hstimer);
-                w.rst().clear_bit();
-                w.pause().clear_bit();
-                w.div_num().bits(divisor);
-                w.duty_res().bits(duty)
-            });
-    }
-
-    /// Update the timer in HW
-    fn update_hw(&self) {
-        // Nothing to do for HS timers
-    }
-
-    /// Pause the timer
-    fn pause(&self) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .hstimer(self.number as usize)
-            .conf()
-            .modify(|_, w| w.pause().set_bit());
-    }
-
-    /// Resume the timer
-    fn resume(&self) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .hstimer(self.number as usize)
-            .conf()
-            .modify(|_, w| w.pause().clear_bit());
-    }
-
-    /// Reset the timer
-    fn reset(&self) {
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .hstimer(self.number as usize)
-            .conf()
-            .modify(|_, w| w.rst().set_bit());
-        unsafe { &*crate::peripherals::LEDC::ptr() }
-            .hstimer(self.number as usize)
-            .conf()
-            .modify(|_, w| w.rst().clear_bit());
     }
 }

--- a/esp-hal/src/prelude.rs
+++ b/esp-hal/src/prelude.rs
@@ -27,7 +27,7 @@ pub use crate::ledc::{
         ChannelHW as _esp_hal_ledc_channel_ChannelHW,
         ChannelIFace as _esp_hal_ledc_channel_ChannelIFace,
     },
-    timer::{TimerHW as _esp_hal_ledc_timer_TimerHW, TimerIFace as _esp_hal_ledc_timer_TimerIFace},
+    timer::TimerIFace as _esp_hal_ledc_timer_TimerIFace,
 };
 #[cfg(any(timg0, timg1))]
 pub use crate::timer::timg::{

--- a/examples/src/bin/ledc.rs
+++ b/examples/src/bin/ledc.rs
@@ -14,7 +14,7 @@ use esp_hal::{
     gpio::Io,
     ledc::{
         channel::{self, ChannelIFace},
-        timer::{self, TimerIFace},
+        timer::{self, LSClockSource, TimerBuilder},
         LSGlobalClkSource,
         Ledc,
         LowSpeed,
@@ -33,15 +33,15 @@ fn main() -> ! {
 
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 
-    let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer0);
-
-    lstimer0
-        .configure(timer::config::Config {
-            duty: timer::config::Duty::Duty5Bit,
-            clock_source: timer::LSClockSource::APBClk,
-            frequency: 24.kHz(),
-        })
-        .unwrap();
+    let lstimer0 = TimerBuilder::<LowSpeed>::new(
+        &ledc,
+        timer::Number::Timer0,
+        timer::config::Duty::Duty5Bit,
+        LSClockSource::LedcPwmClk,
+        24.kHz(),
+    )
+    .unwrap()
+    .build();
 
     let mut channel0 = ledc.get_channel(channel::Number::Channel0, led);
     channel0

--- a/examples/src/bin/ledc_pulse_counting.rs
+++ b/examples/src/bin/ledc_pulse_counting.rs
@@ -1,0 +1,98 @@
+//! Generates a PWM signal on LEDC channel 0 with a duty cycle of 50% and a
+//! frequency of 24 kHz. The PWM signal will be generated for 100 cycles and
+//! then the signal will be disabled.
+//!
+//! The following wiring is assumed:
+//! - LED => GPIO0
+
+//% CHIPS: esp32s3
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use critical_section::Mutex;
+use esp_backtrace as _;
+use esp_hal::{
+    gpio::{GpioPin, Io},
+    interrupt::Priority,
+    ledc::{
+        channel::{self, Channel, ChannelIFace},
+        timer::{self, Timer, TimerIFace},
+        LSGlobalClkSource,
+        Ledc,
+        LowSpeed,
+    },
+    prelude::*,
+};
+use esp_println as _;
+use static_cell::StaticCell;
+
+const DESIRED_PULSE_COUNT: u16 = 100;
+
+static CHANNEL0: Mutex<RefCell<Option<Channel<'_, LowSpeed, GpioPin<0>>>>> =
+    Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let led = io.pins.gpio0;
+
+    let mut ledc = Ledc::new(peripherals.LEDC);
+
+    ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
+    ledc.set_interrupt_handler(interrupt_handler);
+
+    let lstimer0 = {
+        static LSTIMER0: StaticCell<Timer<LowSpeed>> = StaticCell::new();
+        LSTIMER0.init_with(|| {
+            let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer0);
+            lstimer0
+                .configure(timer::config::Config {
+                    duty: timer::config::Duty::Duty1Bit,
+                    clock_source: timer::LSClockSource::APBClk,
+                    frequency: 24.kHz(),
+                })
+                .unwrap();
+            lstimer0
+        })
+    };
+
+    let channel0 = ledc.get_channel(channel::Number::Channel0, led);
+
+    channel0.enable_counter_with_overflow(DESIRED_PULSE_COUNT);
+    critical_section::with(|cs| {
+        CHANNEL0.borrow_ref_mut(cs).replace(channel0);
+        let mut channel0 = CHANNEL0.borrow(cs).borrow_mut();
+        let channel0 = channel0.as_mut().unwrap();
+        channel0.enable_overflow_interrupt();
+        channel0
+            .configure(channel::config::Config {
+                timer: lstimer0,
+                duty_pct: 50,
+                pin_config: channel::config::PinConfig::PushPull,
+            })
+            .unwrap();
+    });
+
+    loop {}
+}
+
+#[handler(priority = Priority::Priority1)]
+#[ram]
+fn interrupt_handler() {
+    critical_section::with(|cs| {
+        let channel0 = CHANNEL0.borrow(cs).borrow();
+        if let Some(channel0) = channel0.as_ref() {
+            if channel0.is_overflow_interrupt_active() {
+                // Disable the signal output and clear the overflow interrupt
+                // Note that the timer is not stopped
+                channel0.disable_signal_output();
+                channel0.clear_overflow_interrupt();
+            }
+        }
+    })
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

Here are the two sections you requested for your Pull Request:

---

### Pull Request Details 📖

#### Description
This patch refactors the `ledc` (LED PWM Controller) module, simplifying the code by removing direct references to `RegisterBlock`. This change eliminates the need for a lifetime specifier in certain structs, making the code more flexible and easier to maintain. 

Additionally, new functionality has been added to support overflow counter management and overflow interrupt handling for channels on specific chips like ESP32S3.

Key changes include:
- Added methods to enable and disable signal output for channels.
- Introduced overflow counter and interrupt handling mechanisms, including methods to enable/disable the counter, configure overflow thresholds, and manage interrupts.
- Extended the timer interface with additional methods like pause, resume, and reset for better control over timers.

An example (`ledc_pulse_counting.rs`) has been added, showcasing how to generate a PWM signal with a predefined number of pulses and handle the overflow interrupt.

#### Testing
Testing was performed using the `ledc_pulse_counting.rs` example, which generates a PWM signal with a duty cycle of 50% at a frequency of 24kHz for 100 pulses, then disables the signal output using overflow interrupt handling. No additional HIL tests were performed, but I can add more HIL tests if necessary when I am available.
