### PR TITLE
Fix I2S examples

### DIFF
--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -85,8 +85,8 @@ To avoid confusion with the `Rtc::current_time` wall clock time APIs, we've rena
 
 ## RX/TX Order
 
-Previously, our API was pretty inconsitent with the RX/TX ordering, and different peripherals had different order. Now, all
-the peripherals use rx-tx. Make sure your methods are expecting the rigth RX/TX order, for example an SPI DMA app should be updated to:
+Previously, our API was pretty inconsistent with the RX/TX ordering, and different peripherals had different order. Now, all
+the peripherals use rx-tx. Make sure your methods are expecting the right RX/TX order, for example an SPI DMA app should be updated to:
 
 ```diff
 - let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) = dma_buffers!(4);
@@ -101,6 +101,13 @@ let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
 +    .dma_transfer(dma_rx_buf, dma_tx_buf)
     .map_err(|e| e.0)
     .unwrap();
+```
+
+When using the asymmetric variant of the macro to create DMA buffers and descriptors make sure to swap the order of parameters
+
+```diff
+- let (tx_buffer, tx_descriptors, _, _) = dma_buffers!(32000, 0);
++ let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 ```
 
 ## Removed UART constructors

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -45,7 +45,7 @@ async fn main(_spawner: Spawner) {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (rx_buffer, rx_descriptors, _, tx_descriptors) = dma_buffers!(0, 4092 * 4);
+    let (rx_buffer, rx_descriptors, _, tx_descriptors) = dma_buffers!(4092 * 4, 0);
 
     let i2s = I2s::new(
         peripherals.I2S0,

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -67,7 +67,7 @@ async fn main(_spawner: Spawner) {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (_, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000, 0);
+    let (_, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 
     let i2s = I2s::new(
         peripherals.I2S0,

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -33,7 +33,7 @@ async fn main(_spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(0, 32000);
+    let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(32000, 0);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(32000, 0);
+    let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;

--- a/examples/src/bin/i2s_read.rs
+++ b/examples/src/bin/i2s_read.rs
@@ -38,7 +38,7 @@ fn main() -> ! {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (mut rx_buffer, rx_descriptors, _, tx_descriptors) = dma_buffers!(0, 4 * 4092);
+    let (mut rx_buffer, rx_descriptors, _, tx_descriptors) = dma_buffers!(4 * 4092, 0);
 
     // Here we test that the type is
     // 1) reasonably simple (or at least this will flag changes that may make it

--- a/examples/src/bin/i2s_sound.rs
+++ b/examples/src/bin/i2s_sound.rs
@@ -59,7 +59,7 @@ fn main() -> ! {
     #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
     let dma_channel = dma.channel0;
 
-    let (_, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000, 0);
+    let (_, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 
     let i2s = I2s::new(
         peripherals.I2S0,

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -49,7 +49,7 @@ fn main() -> ! {
     let dma = Dma::new(peripherals.DMA);
     let channel = dma.channel0;
 
-    let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(0, 32678);
+    let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(32678, 0);
 
     let channel = channel.configure(false, DmaPriority::Priority0);
 

--- a/examples/src/bin/lcd_i8080.rs
+++ b/examples/src/bin/lcd_i8080.rs
@@ -50,7 +50,7 @@ fn main() -> ! {
     let dma = Dma::new(peripherals.DMA);
     let channel = dma.channel0;
 
-    let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(32678, 0);
+    let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32678);
 
     let channel = channel.configure(false, DmaPriority::Priority0);
 

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -26,7 +26,7 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(0, 32000);
+    let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(32000, 0);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;

--- a/examples/src/bin/parl_io_tx.rs
+++ b/examples/src/bin/parl_io_tx.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(32000, 0);
+    let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;

--- a/examples/src/bin/qspi_flash.rs
+++ b/examples/src/bin/qspi_flash.rs
@@ -75,7 +75,7 @@ fn main() -> ! {
         }
     }
 
-    let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(256, 320);
+    let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(320, 256);
     let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
     let mut dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Well, this was a very easy one

The macros to conveniently create descriptors and buffers were changed to RX-TX but in the example code the requested buffer size wasn't swapped in the parameter list of the macro invocation

No changelog - just examples changed

#### Testing
The changed examples work, again
