### PR TITLE
Enable SPI_DMA_XX_ASYNC and _PCNT tests on ESP32 and S2, remove GPIO …

### DIFF
--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -1,8 +1,4 @@
 //! GPIO Test
-//!
-//! Folowing pins are used:
-//! GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -1,17 +1,4 @@
 //! I2C test
-//!
-//! Folowing pins are used:
-//! SDA     GPIO2   (esp32s2 and esp32s3)
-//!         GPIO6   (esp32c6)
-//!         GPIO18  (esp32c2)
-//!         GPIO4   (esp32h2 and esp32c3)
-//!         GPIO32  (esp32)
-//!
-//! SCL     GPIO3   (esp32s2 and esp32s3)
-//!         GPIO7   (esp32c6 and esp32c3)
-//!         GPIO22  (esp32h2)
-//!         GPIO19  (esp32c2)
-//!         GPIO33  (esp32)
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -1,8 +1,5 @@
 //! I2S Loopback Test
 //!
-//! It's assumed GPIO2 is connected to GPIO3
-//! (GPIO9 and GPIO10 for esp32s3)
-//!
 //! This test uses I2S TX to transmit known data to I2S RX (forced to slave mode
 //! with loopback mode enabled). It's using circular DMA mode
 

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -1,8 +1,5 @@
 //! I2S Loopback Test (Async)
 //!
-//! It's assumed GPIO2 is connected to GPIO3
-//! (GPIO9 and GPIO10 for esp32s3)
-//!
 //! This test uses I2S TX to transmit known data to I2S RX (forced to slave mode
 //! with loopback mode enabled). It's using circular DMA mode
 

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -1,8 +1,4 @@
 //! PCNT tests
-//!
-//! It's assumed GPIO2 is connected to GPIO3
-//! (GPIO9 and GPIO10 for esp32s2 and esp32s3)
-//! (GPIO26 and GPIO27 for esp32)
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/qspi_read.rs
+++ b/hil-test/tests/qspi_read.rs
@@ -1,11 +1,4 @@
 //! QSPI Read Test
-//!
-//! Following pins are used:
-//! MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//!
-//! GPIO    GPIO3 / GPIO10 (esp32s2 and esp32s3)
-//!
-//! Connect MISO and GPIO pins.
 
 //% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/qspi_write.rs
+++ b/hil-test/tests/qspi_write.rs
@@ -1,13 +1,4 @@
 //! QSPI Write Test
-//!
-//! This uses PCNT to count the edges of the MOSI signal
-//!
-//! Following pins are used:
-//! MOSI    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//!
-//! PCNT    GPIO3 / GPIO10 (esp32s2 and esp32s3)
-//!
-//! Connect MOSI and PCNT pins.
 
 //% CHIPS: esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/qspi_write_read.rs
+++ b/hil-test/tests/qspi_write_read.rs
@@ -1,13 +1,6 @@
 //! QSPI Write + Read Test
 //!
 //! Make sure issue #1860 doesn't affect us
-//!
-//! Following pins are used:
-//! MOSI/MISO    GPIO2 / GPIO9 (esp32s2 and esp32s3)
-//!
-//! GPIO         GPIO3 / GPIO10 (esp32s2 and esp32s3)
-//!
-//! Connect MOSI/MISO and GPIO pins.
 
 //% CHIPS: esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -1,8 +1,4 @@
 //! RMT Loopback Test
-//!
-//! It's assumed GPIO2 is connected to GPIO3
-//! (GPIO9 and GPIO10 for esp32s2 and esp32s3)
-//! (GPIO26 and GPIO27 for esp32)
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -1,11 +1,4 @@
 //! SPI Full Duplex Test
-//!
-//! Folowing pins are used:
-//! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! MOSI    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect MISO and MOSI pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -1,11 +1,4 @@
 //! SPI Full Duplex DMA ASYNC Test
-//!
-//! Folowing pins are used:
-//! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! MOSI    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect MISO and MOSI pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -1,19 +1,6 @@
 //! SPI Full Duplex DMA Test
-//!
-//! Following pins are used:
-//! SCLK    GPIO0
-//! MOSI    GPIO3 / GPIO10 (esp32s3)
-//! MISO    GPIO4
-//!
-//! PCNT    GPIO2 / GPIO9 (esp32s3)
-//! OUTPUT  GPIO5 (helper to keep MISO LOW)
-//!
-//! The idea of using PCNT (input) here is to connect MOSI to it and count the
-//! edges of whatever SPI writes (in this test case 3 pos edges).
-//!
-//! Connect PCNT and MOSI, MISO and GPIO5 pins.
 
-//% CHIPS: esp32c6 esp32h2 esp32s3
+//% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue
 
 #![no_std]

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -1,17 +1,6 @@
 //! SPI Full Duplex DMA ASYNC Test with PCNT readback.
-//!
-//! Folowing pins are used:
-//! SCLK    GPIO0
-//! MOSI    GPIO3 / GPIO10 (esp32s3)
-//! PCNT    GPIO2 / GPIO9 (esp32s3)
-//! OUTPUT  GPIO5 (helper to keep MISO LOW)
-//!
-//! The idea of using PCNT (input) here is to connect MOSI to it and count the
-//! edges of whatever SPI writes (in this test case 3 pos edges).
-//!
-//! Connect MISO and MOSI pins.
 
-//% CHIPS: esp32c6 esp32h2 esp32s3
+//% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -1,12 +1,4 @@
 //! SPI Half Duplex Read Test
-//!
-//! Folowing pins are used:
-//! SCLK    GPIO0
-//! MISO    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//!
-//! GPIO    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect MISO and GPIO pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -1,12 +1,4 @@
 //! SPI Half Duplex Write Test
-//!
-//! Following pins are used:
-//! SCLK    GPIO0
-//! MOSI    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//!
-//! PCNT    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect MOSI and PCNT pins.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -1,10 +1,4 @@
 //! TWAI test
-//!
-//! Folowing pins are used:
-//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect TX and RX pins.
 
 //% CHIPS: esp32c3 esp32c6 esp32s2 esp32s3
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -1,10 +1,4 @@
 //! UART Test
-//!
-//! Folowing pins are used:
-//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect TX and RX pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -1,10 +1,4 @@
 //! UART Test
-//!
-//! Folowing pins are used:
-//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect TX and RX pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -1,10 +1,4 @@
 //! UART TX/RX Test
-//!
-//! Folowing pins are used:
-//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect TX and RX pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -1,10 +1,4 @@
 //! UART TX/RX Async Test
-//!
-//! Folowing pins are used:
-//! TX    GPIO2 / GPIO9  (esp32s2 / esp32s3) / GPIO26 (esp32)
-//! RX    GPIO3 / GPIO10 (esp32s2 / esp32s3) / GPIO27 (esp32)
-//!
-//! Connect TX and RX pins.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue


### PR DESCRIPTION
…usage from description

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
`spi_full_duplex_dma_async` and `spi_full_duplex_dma_pcnt` didn't work on ESP32 and S2 - with https://github.com/esp-rs/esp-hal/pull/2131 merged, tests start passing. 
Removed the GPIO usage from test description.

Not sure if we can tick the tests in https://github.com/esp-rs/esp-hal/issues/1524 because of https://github.com/esp-rs/esp-hal/issues/2098, 

#### Testing
Ran HIL tests on ESP32 locally (for some reason my S2+PROG doesn't work - can't flash any test)
