### PR TITLE
I2C error recovery

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with LCD_CAM i8080 where it would send double the clocks in 16bit mode (#2085)
 - Fix i2c embedded-hal transaction (#2028)
 - Fix SPI DMA alternating `write` and `read` for ESP32 and ESP32-S2 (#2131)
+- Fix I2C ending up in a state when only re-creating the peripheral makes it useable again (#2141)
 
 ### Removed
 

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -199,14 +199,14 @@ where
     pub fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
         self.peripheral
             .master_read(address, buffer)
-            .inspect_err(|_| self.recover())
+            .inspect_err(|_| self.internal_recover())
     }
 
     /// Writes bytes to slave with address `address`
     pub fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
         self.peripheral
             .master_write(addr, bytes)
-            .inspect_err(|_| self.recover())
+            .inspect_err(|_| self.internal_recover())
     }
 
     /// Writes bytes to slave with address `address` and then reads enough bytes
@@ -219,7 +219,7 @@ where
     ) -> Result<(), Error> {
         self.peripheral
             .master_write_read(address, bytes, buffer)
-            .inspect_err(|_| self.recover())
+            .inspect_err(|_| self.internal_recover())
     }
 }
 
@@ -232,7 +232,7 @@ where
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
         self.peripheral
             .master_read(address, buffer)
-            .inspect_err(|_| self.recover())
+            .inspect_err(|_| self.internal_recover())
     }
 }
 
@@ -245,7 +245,7 @@ where
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         self.peripheral
             .master_write(addr, bytes)
-            .inspect_err(|_| self.recover())
+            .inspect_err(|_| self.internal_recover())
     }
 }
 
@@ -263,7 +263,7 @@ where
     ) -> Result<(), Self::Error> {
         self.peripheral
             .master_write_read(address, bytes, buffer)
-            .inspect_err(|_| self.recover())
+            .inspect_err(|_| self.internal_recover())
     }
 }
 
@@ -309,7 +309,7 @@ where
                             next_op == Op::None,
                             cmd_iterator,
                         )
-                        .inspect_err(|_| self.recover())?;
+                        .inspect_err(|_| self.internal_recover())?;
                     last_op = Op::Write;
                 }
                 Operation::Read(buffer) => {
@@ -326,7 +326,7 @@ where
                             next_op == Op::Read,
                             cmd_iterator,
                         )
-                        .inspect_err(|_| self.recover())?;
+                        .inspect_err(|_| self.internal_recover())?;
                     last_op = Op::Read;
                 }
             }
@@ -408,8 +408,7 @@ where
         }
     }
 
-    /// Recover from error condition
-    pub fn recover(&self) {
+    fn internal_recover(&self) {
         PeripheralClockControl::reset(match self.peripheral.i2c_number() {
             0 => crate::system::Peripheral::I2cExt0,
             #[cfg(i2c1)]

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -183,10 +183,24 @@ impl From<Ack> for u32 {
     }
 }
 
+macro_rules! maybe_recover {
+    ($self:expr, $b:block) => {
+        match $b {
+            Err(err) => {
+                $self.recover();
+                Err(err)
+            }
+            Ok(ok) => Ok(ok),
+        }
+    };
+}
+
 /// I2C peripheral container (I2C)
 pub struct I2C<'d, T, DM: crate::Mode> {
     peripheral: PeripheralRef<'d, T>,
     phantom: PhantomData<DM>,
+    frequency: HertzU32,
+    timeout: Option<u32>,
 }
 
 impl<T> I2C<'_, T, crate::Blocking>
@@ -195,12 +209,12 @@ where
 {
     /// Reads enough bytes from slave with `address` to fill `buffer`
     pub fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
-        self.peripheral.master_read(address, buffer)
+        maybe_recover!(self, { self.peripheral.master_read(address, buffer) })
     }
 
     /// Writes bytes to slave with address `address`
     pub fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
-        self.peripheral.master_write(addr, bytes)
+        maybe_recover!(self, { self.peripheral.master_write(addr, bytes) })
     }
 
     /// Writes bytes to slave with address `address` and then reads enough bytes
@@ -211,7 +225,9 @@ where
         bytes: &[u8],
         buffer: &mut [u8],
     ) -> Result<(), Error> {
-        self.peripheral.master_write_read(address, bytes, buffer)
+        maybe_recover!(self, {
+            self.peripheral.master_write_read(address, bytes, buffer)
+        })
     }
 }
 
@@ -222,7 +238,7 @@ where
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.peripheral.master_read(address, buffer)
+        maybe_recover!(self, { self.peripheral.master_read(address, buffer) })
     }
 }
 
@@ -233,7 +249,7 @@ where
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        self.peripheral.master_write(addr, bytes)
+        maybe_recover!(self, { self.peripheral.master_write(addr, bytes) })
     }
 }
 
@@ -249,7 +265,9 @@ where
         bytes: &[u8],
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
-        self.peripheral.master_write_read(address, bytes, buffer)
+        maybe_recover!(self, {
+            self.peripheral.master_write_read(address, bytes, buffer)
+        })
     }
 }
 
@@ -287,13 +305,15 @@ where
                     // execute a write operation:
                     // - issue START/RSTART if op is different from previous
                     // - issue STOP if op is the last one
-                    self.peripheral.write_operation(
-                        address,
-                        bytes,
-                        last_op != Op::Write,
-                        next_op == Op::None,
-                        cmd_iterator,
-                    )?;
+                    maybe_recover!(self, {
+                        self.peripheral.write_operation(
+                            address,
+                            bytes,
+                            last_op != Op::Write,
+                            next_op == Op::None,
+                            cmd_iterator,
+                        )
+                    })?;
                     last_op = Op::Write;
                 }
                 Operation::Read(buffer) => {
@@ -301,14 +321,16 @@ where
                     // - issue START/RSTART if op is different from previous
                     // - issue STOP if op is the last one
                     // - will_continue is true if there is another read operation next
-                    self.peripheral.read_operation(
-                        address,
-                        buffer,
-                        last_op != Op::Read,
-                        next_op == Op::None,
-                        next_op == Op::Read,
-                        cmd_iterator,
-                    )?;
+                    maybe_recover!(self, {
+                        self.peripheral.read_operation(
+                            address,
+                            buffer,
+                            last_op != Op::Read,
+                            next_op == Op::None,
+                            next_op == Op::Read,
+                            cmd_iterator,
+                        )
+                    })?;
                     last_op = Op::Read;
                 }
             }
@@ -344,9 +366,11 @@ where
             _ => unreachable!(), // will never happen
         });
 
-        let mut i2c = I2C {
+        let i2c = I2C {
             peripheral: i2c,
             phantom: PhantomData,
+            frequency,
+            timeout,
         };
 
         // avoid SCL/SDA going low during configuration
@@ -386,6 +410,25 @@ where
             crate::interrupt::bind_interrupt(T::interrupt(), handler.handler());
             crate::interrupt::enable(T::interrupt(), handler.priority()).unwrap();
         }
+    }
+
+    /// Recover from error condition
+    pub fn recover(&self) {
+        PeripheralClockControl::reset(match self.peripheral.i2c_number() {
+            0 => crate::system::Peripheral::I2cExt0,
+            #[cfg(i2c1)]
+            1 => crate::system::Peripheral::I2cExt1,
+            _ => unreachable!(), // will never happen
+        });
+
+        PeripheralClockControl::enable(match self.peripheral.i2c_number() {
+            0 => crate::system::Peripheral::I2cExt0,
+            #[cfg(i2c1)]
+            1 => crate::system::Peripheral::I2cExt1,
+            _ => unreachable!(), // will never happen
+        });
+
+        self.peripheral.setup(self.frequency, self.timeout);
     }
 }
 
@@ -1075,7 +1118,7 @@ pub trait Instance: crate::private::Sealed {
 
     /// Configures the I2C peripheral with the specified frequency, clocks, and
     /// optional timeout.
-    fn setup(&mut self, frequency: HertzU32, timeout: Option<u32>) {
+    fn setup(&self, frequency: HertzU32, timeout: Option<u32>) {
         self.register_block().ctr().modify(|_, w| unsafe {
             // Clear register
             w.bits(0)
@@ -1156,7 +1199,7 @@ pub trait Instance: crate::private::Sealed {
 
     /// Sets the filter with a supplied threshold in clock cycles for which a
     /// pulse must be present to pass the filter
-    fn set_filter(&mut self, sda_threshold: Option<u8>, scl_threshold: Option<u8>) {
+    fn set_filter(&self, sda_threshold: Option<u8>, scl_threshold: Option<u8>) {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32, esp32s2))] {
                 let sda_register = &self.register_block().sda_filter_cfg();
@@ -1188,7 +1231,7 @@ pub trait Instance: crate::private::Sealed {
     /// Sets the frequency of the I2C interface by calculating and applying the
     /// associated timings - corresponds to i2c_ll_cal_bus_clk and
     /// i2c_ll_set_bus_timing in ESP-IDF
-    fn set_frequency(&mut self, source_clk: HertzU32, bus_freq: HertzU32, timeout: Option<u32>) {
+    fn set_frequency(&self, source_clk: HertzU32, bus_freq: HertzU32, timeout: Option<u32>) {
         let source_clk = source_clk.raw();
         let bus_freq = bus_freq.raw();
 
@@ -1266,7 +1309,7 @@ pub trait Instance: crate::private::Sealed {
     /// Sets the frequency of the I2C interface by calculating and applying the
     /// associated timings - corresponds to i2c_ll_cal_bus_clk and
     /// i2c_ll_set_bus_timing in ESP-IDF
-    fn set_frequency(&mut self, source_clk: HertzU32, bus_freq: HertzU32, timeout: Option<u32>) {
+    fn set_frequency(&self, source_clk: HertzU32, bus_freq: HertzU32, timeout: Option<u32>) {
         let source_clk = source_clk.raw();
         let bus_freq = bus_freq.raw();
 
@@ -1324,7 +1367,7 @@ pub trait Instance: crate::private::Sealed {
     /// Sets the frequency of the I2C interface by calculating and applying the
     /// associated timings - corresponds to i2c_ll_cal_bus_clk and
     /// i2c_ll_set_bus_timing in ESP-IDF
-    fn set_frequency(&mut self, source_clk: HertzU32, bus_freq: HertzU32, timeout: Option<u32>) {
+    fn set_frequency(&self, source_clk: HertzU32, bus_freq: HertzU32, timeout: Option<u32>) {
         let source_clk = source_clk.raw();
         let bus_freq = bus_freq.raw();
 
@@ -1397,7 +1440,7 @@ pub trait Instance: crate::private::Sealed {
     #[allow(clippy::too_many_arguments, unused)]
     /// Configures the clock and timing parameters for the I2C peripheral.
     fn configure_clock(
-        &mut self,
+        &self,
         sclk_div: u32,
         scl_low_period: u32,
         scl_high_period: u32,
@@ -2064,7 +2107,7 @@ pub trait Instance: crate::private::Sealed {
 
     /// Send data bytes from the `bytes` array to a target slave with the
     /// address `addr`
-    fn master_write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+    fn master_write(&self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
         // Clear all I2C interrupts
         self.clear_all_interrupts();
         self.write_operation(
@@ -2080,7 +2123,7 @@ pub trait Instance: crate::private::Sealed {
     /// Read bytes from a target slave with the address `addr`
     /// The number of read bytes is deterimed by the size of the `buffer`
     /// argument
-    fn master_read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
+    fn master_read(&self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
         // Clear all I2C interrupts
         self.clear_all_interrupts();
         self.read_operation(
@@ -2096,12 +2139,7 @@ pub trait Instance: crate::private::Sealed {
 
     /// Write bytes from the `bytes` array first and then read n bytes into
     /// the `buffer` array with n being the size of the array.
-    fn master_write_read(
-        &mut self,
-        addr: u8,
-        bytes: &[u8],
-        buffer: &mut [u8],
-    ) -> Result<(), Error> {
+    fn master_write_read(&self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
         // it would be possible to combine the write and read
         // in one transaction but filling the tx fifo with
         // the current code is somewhat slow even in release mode

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -197,17 +197,17 @@ where
 {
     /// Reads enough bytes from slave with `address` to fill `buffer`
     pub fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
-        self.peripheral.master_read(address, buffer).or_else(|e| {
+        self.peripheral.master_read(address, buffer).map_err(|e| {
             self.recover();
-            Err(e)
+            e
         })
     }
 
     /// Writes bytes to slave with address `address`
     pub fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
-        self.peripheral.master_write(addr, bytes).or_else(|e| {
+        self.peripheral.master_write(addr, bytes).map_err(|e| {
             self.recover();
-            Err(e)
+            e
         })
     }
 
@@ -221,9 +221,9 @@ where
     ) -> Result<(), Error> {
         self.peripheral
             .master_write_read(address, bytes, buffer)
-            .or_else(|e| {
+            .map_err(|e| {
                 self.recover();
-                Err(e)
+                e
             })
     }
 }
@@ -235,9 +235,9 @@ where
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.peripheral.master_read(address, buffer).or_else(|e| {
+        self.peripheral.master_read(address, buffer).map_err(|e| {
             self.recover();
-            Err(e)
+            e
         })
     }
 }
@@ -249,9 +249,9 @@ where
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        self.peripheral.master_write(addr, bytes).or_else(|e| {
+        self.peripheral.master_write(addr, bytes).map_err(|e| {
             self.recover();
-            Err(e)
+            e
         })
     }
 }
@@ -270,9 +270,9 @@ where
     ) -> Result<(), Self::Error> {
         self.peripheral
             .master_write_read(address, bytes, buffer)
-            .or_else(|e| {
+            .map_err(|e| {
                 self.recover();
-                Err(e)
+                e
             })
     }
 }
@@ -319,9 +319,9 @@ where
                             next_op == Op::None,
                             cmd_iterator,
                         )
-                        .or_else(|e| {
+                        .map_err(|e| {
                             self.recover();
-                            Err(e)
+                            e
                         })?;
                     last_op = Op::Write;
                 }
@@ -339,9 +339,9 @@ where
                             next_op == Op::Read,
                             cmd_iterator,
                         )
-                        .or_else(|e| {
+                        .map_err(|e| {
                             self.recover();
-                            Err(e)
+                            e
                         })?;
                     last_op = Op::Read;
                 }

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -197,18 +197,16 @@ where
 {
     /// Reads enough bytes from slave with `address` to fill `buffer`
     pub fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
-        self.peripheral.master_read(address, buffer).map_err(|e| {
-            self.recover();
-            e
-        })
+        self.peripheral
+            .master_read(address, buffer)
+            .inspect_err(|_| self.recover())
     }
 
     /// Writes bytes to slave with address `address`
     pub fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
-        self.peripheral.master_write(addr, bytes).map_err(|e| {
-            self.recover();
-            e
-        })
+        self.peripheral
+            .master_write(addr, bytes)
+            .inspect_err(|_| self.recover())
     }
 
     /// Writes bytes to slave with address `address` and then reads enough bytes
@@ -221,10 +219,7 @@ where
     ) -> Result<(), Error> {
         self.peripheral
             .master_write_read(address, bytes, buffer)
-            .map_err(|e| {
-                self.recover();
-                e
-            })
+            .inspect_err(|_| self.recover())
     }
 }
 
@@ -235,10 +230,9 @@ where
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.peripheral.master_read(address, buffer).map_err(|e| {
-            self.recover();
-            e
-        })
+        self.peripheral
+            .master_read(address, buffer)
+            .inspect_err(|_| self.recover())
     }
 }
 
@@ -249,10 +243,9 @@ where
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        self.peripheral.master_write(addr, bytes).map_err(|e| {
-            self.recover();
-            e
-        })
+        self.peripheral
+            .master_write(addr, bytes)
+            .inspect_err(|_| self.recover())
     }
 }
 
@@ -270,10 +263,7 @@ where
     ) -> Result<(), Self::Error> {
         self.peripheral
             .master_write_read(address, bytes, buffer)
-            .map_err(|e| {
-                self.recover();
-                e
-            })
+            .inspect_err(|_| self.recover())
     }
 }
 
@@ -319,10 +309,7 @@ where
                             next_op == Op::None,
                             cmd_iterator,
                         )
-                        .map_err(|e| {
-                            self.recover();
-                            e
-                        })?;
+                        .inspect_err(|_| self.recover())?;
                     last_op = Op::Write;
                 }
                 Operation::Read(buffer) => {
@@ -339,10 +326,7 @@ where
                             next_op == Op::Read,
                             cmd_iterator,
                         )
-                        .map_err(|e| {
-                            self.recover();
-                            e
-                        })?;
+                        .inspect_err(|_| self.recover())?;
                     last_op = Op::Read;
                 }
             }

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -37,6 +37,11 @@ mod tests {
     fn test_read_cali(mut ctx: Context) {
         let mut read_data = [0u8; 22];
 
+        // have a failing read which might could leave the peripheral in an undesirable
+        // state
+        ctx.i2c.write_read(0x55, &[0xaa], &mut read_data).ok();
+
+        // do the real read which should succeed
         ctx.i2c.write_read(0x77, &[0xaa], &mut read_data).ok();
 
         assert_ne!(read_data, [0u8; 22])


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1790

Recovering from an error didn't work as expected for I2C - this does it "the hard way" by resetting and re-initializing the whole peripheral (since nothing else seemed to help).

In theory a user could drop the driver and re-create it but in real-life code that can become very cumbersome - so now after running into an error the peripheral is always reset and re-initialized

#### Testing
I adapted the test to check the undesired behavior.

Additionally having this in examples resembles the code from the linked issue and can be used to test this locally (make sure to have something detectable connected)
```rust
//! - SDA => GPIO4
//! - SCL => GPIO5

//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3

#![no_std]
#![no_main]

use esp_backtrace as _;
use esp_hal::{gpio::Io, i2c::I2C, prelude::*};
use esp_println::println;

#[entry]
fn main() -> ! {
    let mut peripherals = esp_hal::init(esp_hal::Config::default());

    let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);

    // Create a new peripheral object with the described wiring and standard
    // I2C clock speed:
    let mut i2c0 = I2C::new(
        &mut peripherals.I2C0,
        &mut io.pins.gpio4,
        &mut io.pins.gpio5,
        100.kHz(),
    );

    let delay = esp_hal::delay::Delay::new();

    for addr in 0..=127 {
        println!("Scan {}", addr as u8);
        let res = i2c0.read(addr, &mut [0]);

        match res {
            Ok(_) => println!("Dev Found @ {}", addr as u8),
            Err(e) => {
                println!("No Dev {:?}", e);
            }
        }

        delay.delay_millis(5);
    }

    loop {}
}
```
