### PR TITLE
Bind "IRQ handlers" to GPIO pins

### DIFF
--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -11,11 +11,11 @@
 //! ## Example
 //!
 //! ```rust,ignore
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let io = peripherals.GPIO.pins();
 //! let rmt = Rmt::new(peripherals.RMT, 80.MHz(), None).unwrap();
 //!
 //! let rmt_buffer = smartLedBuffer!(1);
-//! let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio2, rmt_buffer);
+//! let mut led = SmartLedsAdapter::new(rmt.channel0, io.gpio2, rmt_buffer);
 //! ```
 //!
 //! ## Feature Flags

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -31,14 +31,10 @@
 //! # use esp_hal::analog::adc::Attenuation;
 //! # use esp_hal::analog::adc::Adc;
 //! # use esp_hal::delay::Delay;
-//! # use esp_hal::gpio::Io;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-#![cfg_attr(esp32, doc = "let analog_pin = io.pins.gpio32;")]
-#![cfg_attr(any(esp32s2, esp32s3), doc = "let analog_pin = io.pins.gpio3;")]
-#![cfg_attr(
-    not(any(esp32, esp32s2, esp32s3)),
-    doc = "let analog_pin = io.pins.gpio2;"
-)]
+//! # let io = peripherals.GPIO.pins();
+#![cfg_attr(esp32, doc = "let analog_pin = io.gpio32;")]
+#![cfg_attr(any(esp32s2, esp32s3), doc = "let analog_pin = io.gpio3;")]
+#![cfg_attr(not(any(esp32, esp32s2, esp32s3)), doc = "let analog_pin = io.gpio2;")]
 //! let mut adc1_config = AdcConfig::new();
 //! let mut pin = adc1_config.enable_pin(
 //!     analog_pin,

--- a/esp-hal/src/analog/dac.rs
+++ b/esp-hal/src/analog/dac.rs
@@ -17,14 +17,13 @@
 //! ### Write a value to a DAC channel
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::analog::dac::Dac;
 //! # use esp_hal::delay::Delay;
 //! # use embedded_hal::delay::DelayNs;
 //!
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-#![cfg_attr(esp32, doc = "let dac1_pin = io.pins.gpio25;")]
-#![cfg_attr(esp32s2, doc = "let dac1_pin = io.pins.gpio17;")]
+//! let io = peripherals.GPIO.pins();
+#![cfg_attr(esp32, doc = "let dac1_pin = io.gpio25;")]
+#![cfg_attr(esp32s2, doc = "let dac1_pin = io.gpio17;")]
 //! let mut dac1 = Dac::new(peripherals.DAC1, dac1_pin);
 //!
 //! let mut delay = Delay::new();

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -18,17 +18,16 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::dma_buffers;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::spi::{master::Spi, SpiMode};
 //! # use esp_hal::dma::{Dma, DmaPriority};
 //! let dma = Dma::new(peripherals.DMA);
 #![cfg_attr(any(esp32, esp32s2), doc = "let dma_channel = dma.spi2channel;")]
 #![cfg_attr(not(any(esp32, esp32s2)), doc = "let dma_channel = dma.channel0;")]
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let sclk = io.pins.gpio0;
-//! let miso = io.pins.gpio2;
-//! let mosi = io.pins.gpio4;
-//! let cs = io.pins.gpio5;
+//! let io = peripherals.GPIO.pins();
+//! let sclk = io.gpio0;
+//! let miso = io.gpio2;
+//! let mosi = io.gpio4;
+//! let cs = io.gpio5;
 //!
 //! let mut spi = Spi::new(
 //!     peripherals.SPI2,

--- a/esp-hal/src/etm.rs
+++ b/esp-hal/src/etm.rs
@@ -23,7 +23,6 @@
 //! ## Examples
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::gpio::etm::GpioEtmChannels;
 //! # use esp_hal::etm::Etm;
 //! # use esp_hal::gpio::etm::GpioEtmInputConfig;
@@ -31,9 +30,9 @@
 //! # use esp_hal::gpio::Pull;
 //! # use esp_hal::gpio::Level;
 //!
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let mut led = io.pins.gpio1;
-//! let button = io.pins.gpio9;
+//! let io = peripherals.GPIO.pins();
+//! let mut led = io.gpio1;
+//! let button = io.gpio9;
 //!
 //! // setup ETM
 //! let gpio_ext = GpioEtmChannels::new(peripherals.GPIO_SD);

--- a/esp-hal/src/gpio/etm.rs
+++ b/esp-hal/src/gpio/etm.rs
@@ -25,7 +25,6 @@
 //! ### Toggle an LED When a Button is Pressed
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::gpio::etm::GpioEtmChannels;
 //! # use esp_hal::etm::Etm;
 //! # use esp_hal::gpio::etm::GpioEtmInputConfig;
@@ -33,9 +32,9 @@
 //! # use esp_hal::gpio::Pull;
 //! # use esp_hal::gpio::Level;
 //!
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut led = io.pins.gpio1;
-//! # let button = io.pins.gpio9;
+//! # let io = peripherals.GPIO.pins();
+//! # let mut led = io.gpio1;
+//! # let button = io.gpio9;
 //!
 //! let gpio_ext = GpioEtmChannels::new(peripherals.GPIO_SD);
 //! let led_task = gpio_ext.channel0_task.toggle(

--- a/esp-hal/src/gpio/lp_io.rs
+++ b/esp-hal/src/gpio/lp_io.rs
@@ -18,11 +18,10 @@
 //! ## Configure a LP Pin as Output
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! use esp_hal::gpio::Io;
 //! use esp_hal::gpio::lp_io::LowPowerOutput;
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let io = peripherals.GPIO.pins();
 //! // configure GPIO 1 as LP output pin
-//! let lp_pin: LowPowerOutput<'_, 1> = LowPowerOutput::new(io.pins.gpio1);
+//! let lp_pin: LowPowerOutput<'_, 1> = LowPowerOutput::new(io.gpio1);
 //! # }
 //! ```
 

--- a/esp-hal/src/gpio/rtc_io.rs
+++ b/esp-hal/src/gpio/rtc_io.rs
@@ -23,10 +23,9 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::gpio::rtc_io::LowPowerOutput;
-//! # use esp_hal::gpio::Io;
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let io = peripherals.GPIO.pins();
 //! // configure GPIO 1 as ULP output pin
-//! let lp_pin = LowPowerOutput::<'static, 1>::new(io.pins.gpio1);
+//! let lp_pin = LowPowerOutput::<'static, 1>::new(io.gpio1);
 //! # }
 //! ```
 

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -32,15 +32,14 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::i2c::I2C;
-//! # use esp_hal::gpio::Io;
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let io = peripherals.GPIO.pins();
 //!
 //! // Create a new peripheral object with the described wiring
 //! // and standard I2C clock speed.
 //! let mut i2c = I2C::new(
 //!     peripherals.I2C0,
-//!     io.pins.gpio1,
-//!     io.pins.gpio2,
+//!     io.gpio1,
+//!     io.gpio2,
 //!     100.kHz(),
 //! );
 //!

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -33,10 +33,9 @@
 //! # use esp_hal::i2s::Standard;
 //! # use esp_hal::i2s::DataFormat;
 //! # use esp_hal::i2s::I2sReadDma;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::dma_buffers;
 //! # use esp_hal::dma::{Dma, DmaPriority};
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let io = peripherals.GPIO.pins();
 //! let dma = Dma::new(peripherals.DMA);
 #![cfg_attr(any(esp32, esp32s2), doc = "let dma_channel = dma.i2s0channel;")]
 #![cfg_attr(not(any(esp32, esp32s2)), doc = "let dma_channel = dma.channel0;")]
@@ -55,11 +54,11 @@
 //!     rx_descriptors,
 //!     tx_descriptors,
 //! );
-#![cfg_attr(not(esp32), doc = "let i2s = i2s.with_mclk(io.pins.gpio0);")]
+#![cfg_attr(not(esp32), doc = "let i2s = i2s.with_mclk(io.gpio0);")]
 //! let mut i2s_rx = i2s.i2s_rx
-//!     .with_bclk(io.pins.gpio1)
-//!     .with_ws(io.pins.gpio2)
-//!     .with_din(io.pins.gpio5)
+//!     .with_bclk(io.gpio1)
+//!     .with_ws(io.gpio2)
+//!     .with_din(io.gpio5)
 //!     .build();
 //!
 //! let mut transfer = i2s_rx.read_dma_circular(&mut rx_buffer).unwrap();

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -404,7 +404,7 @@ mod vectored {
         }
     }
 
-    /// Enables a interrupt at a given priority
+    /// Enables a interrupt at a given priority.
     ///
     /// Note that interrupts still need to be enabled globally for interrupts
     /// to be serviced.
@@ -422,7 +422,7 @@ mod vectored {
         Ok(())
     }
 
-    /// Bind the given interrupt to the given handler
+    /// Binds the given interrupt to the given handler.
     ///
     /// # Safety
     ///
@@ -764,6 +764,7 @@ mod plic {
             .bits();
         core::mem::transmute::<u8, Priority>(prio)
     }
+
     #[no_mangle]
     #[link_section = ".trap"]
     pub(super) unsafe extern "C" fn _handle_priority() -> u32 {

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -427,10 +427,22 @@ mod vectored {
     /// # Safety
     ///
     /// This will replace any previously bound interrupt handler
-    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn() -> ()) {
+    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn()) {
         let ptr = &peripherals::__EXTERNAL_INTERRUPTS[interrupt as usize]._handler as *const _
-            as *mut unsafe extern "C" fn() -> ();
+            as *mut unsafe extern "C" fn();
         ptr.write_volatile(handler);
+    }
+
+    /// Returns the currently bound interrupt handler.
+    pub fn bound_handler(interrupt: Interrupt) -> Option<unsafe extern "C" fn()> {
+        unsafe {
+            let addr = peripherals::__EXTERNAL_INTERRUPTS[interrupt as usize]._handler;
+            if addr as usize == 0 {
+                return None;
+            }
+
+            Some(addr)
+        }
     }
 
     #[no_mangle]

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -419,10 +419,22 @@ mod vectored {
     /// # Safety
     ///
     /// This will replace any previously bound interrupt handler
-    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn() -> ()) {
+    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn()) {
         let ptr = &peripherals::__INTERRUPTS[interrupt as usize]._handler as *const _
-            as *mut unsafe extern "C" fn() -> ();
+            as *mut unsafe extern "C" fn();
         ptr.write_volatile(handler);
+    }
+
+    /// Returns the currently bound interrupt handler.
+    pub fn bound_handler(interrupt: Interrupt) -> Option<unsafe extern "C" fn()> {
+        unsafe {
+            let addr = peripherals::__INTERRUPTS[interrupt as usize]._handler;
+            if addr as usize == 0 {
+                return None;
+            }
+
+            Some(addr)
+        }
     }
 
     fn interrupt_level_to_cpu_interrupt(

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -414,7 +414,7 @@ mod vectored {
         Ok(())
     }
 
-    /// Bind the given interrupt to the given handler
+    /// Binds the given interrupt to the given handler.
     ///
     /// # Safety
     ///

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -16,12 +16,11 @@
 //! master mode.
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::lcd_cam::{cam::{Camera, RxEightBits}, LcdCam};
 //! # use fugit::RateExtU32;
 //! # use esp_hal::dma_buffers;
 //! # use esp_hal::dma::{Dma, DmaPriority};
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let io = peripherals.GPIO.pins();
 //!
 //! # let dma = Dma::new(peripherals.DMA);
 //! # let channel = dma.channel0;
@@ -33,19 +32,19 @@
 //! #     DmaPriority::Priority0,
 //! # );
 //!
-//! let mclk_pin = io.pins.gpio15;
-//! let vsync_pin = io.pins.gpio6;
-//! let href_pin = io.pins.gpio7;
-//! let pclk_pin = io.pins.gpio13;
+//! let mclk_pin = io.gpio15;
+//! let vsync_pin = io.gpio6;
+//! let href_pin = io.gpio7;
+//! let pclk_pin = io.gpio13;
 //! let data_pins = RxEightBits::new(
-//!     io.pins.gpio11,
-//!     io.pins.gpio9,
-//!     io.pins.gpio8,
-//!     io.pins.gpio10,
-//!     io.pins.gpio12,
-//!     io.pins.gpio18,
-//!     io.pins.gpio17,
-//!     io.pins.gpio16,
+//!     io.gpio11,
+//!     io.gpio9,
+//!     io.gpio8,
+//!     io.gpio10,
+//!     io.gpio12,
+//!     io.gpio18,
+//!     io.gpio17,
+//!     io.gpio16,
 //! );
 //!
 //! let lcd_cam = LcdCam::new(peripherals.LCD_CAM);

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -15,11 +15,10 @@
 //!
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::lcd_cam::{LcdCam, lcd::i8080::{Config, I8080, TxEightBits}};
 //! # use esp_hal::dma_buffers;
 //! # use esp_hal::dma::{Dma, DmaPriority};
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let io = peripherals.GPIO.pins();
 //!
 //! # let dma = Dma::new(peripherals.DMA);
 //! # let channel = dma.channel0;
@@ -32,14 +31,14 @@
 //! # );
 //!
 //! let tx_pins = TxEightBits::new(
-//!     io.pins.gpio9,
-//!     io.pins.gpio46,
-//!     io.pins.gpio3,
-//!     io.pins.gpio8,
-//!     io.pins.gpio18,
-//!     io.pins.gpio17,
-//!     io.pins.gpio16,
-//!     io.pins.gpio15,
+//!     io.gpio9,
+//!     io.gpio46,
+//!     io.gpio3,
+//!     io.gpio8,
+//!     io.gpio18,
+//!     io.gpio17,
+//!     io.gpio16,
+//!     io.gpio15,
 //! );
 //! let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
 //!
@@ -51,7 +50,7 @@
 //!     20.MHz(),
 //!     Config::default(),
 //! )
-//! .with_ctrl_pins(io.pins.gpio0, io.pins.gpio47);
+//! .with_ctrl_pins(io.gpio0, io.gpio47);
 //!
 //! i8080.send(0x3A, 0, &[0x55]).unwrap(); // RGB565
 //! # }

--- a/esp-hal/src/ledc/mod.rs
+++ b/esp-hal/src/ledc/mod.rs
@@ -29,9 +29,8 @@
 //! # use esp_hal::ledc::timer;
 //! # use esp_hal::ledc::LowSpeed;
 //! # use esp_hal::ledc::channel;
-//! # use esp_hal::gpio::Io;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let led = io.pins.gpio0;
+//! # let io = peripherals.GPIO.pins();
+//! # let led = io.gpio0;
 //!
 //! let mut ledc = Ledc::new(peripherals.LEDC);
 //! ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -364,6 +364,11 @@ pub enum Cpu {
     AppCpu = 1,
 }
 
+impl Cpu {
+    /// The number of available cores.
+    pub const COUNT: usize = 1 + cfg!(multi_core) as usize;
+}
+
 /// Which core the application is currently executing on
 #[inline(always)]
 pub fn get_core() -> Cpu {

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -67,7 +67,7 @@
 //! # }
 //! use esp_hal::{
 //!     delay::Delay,
-//!     gpio::{Io, Level, Output},
+//!     gpio::{Level, Output},
 //!     prelude::*,
 //! };
 //!
@@ -76,8 +76,8 @@
 //!     let peripherals = esp_hal::init(esp_hal::Config::default());
 //!
 //!     // Set GPIO0 as an output, and set its state high initially.
-//!     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//!     let mut led = Output::new(io.pins.gpio0, Level::High);
+//!     let io = peripherals.GPIO.pins();
+//!     let mut led = Output::new(io.gpio0, Level::High);
 //!
 //!     let delay = Delay::new();
 //!
@@ -90,7 +90,7 @@
 //!
 //! The steps here are:
 //! - Call [`init`] with the desired [`CpuClock`] configuration
-//! - Create [`gpio::Io`] which provides access to the GPIO pins
+//! - Grab the pins using [`GPIO.pins()`][crate::peripherals::GPIO::pins].
 //! - Create an [`gpio::Output`] pin driver which lets us control the logical
 //!   level of an output pin
 //! - Create a [`delay::Delay`] driver

--- a/esp-hal/src/mcpwm/mod.rs
+++ b/esp-hal/src/mcpwm/mod.rs
@@ -52,10 +52,9 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::mcpwm::{operator::{DeadTimeCfg, PWMStream, PwmPinConfig}, timer::PwmWorkingMode, McPwm, PeripheralClockConfig};
-//! # use esp_hal::gpio::Io;
 //!
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let pin = io.pins.gpio0;
+//! # let io = peripherals.GPIO.pins();
+//! # let pin = io.gpio0;
 //!
 //! // initialize peripheral
 #![cfg_attr(

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -483,8 +483,7 @@ impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bo
 /// # use esp_hal::{mcpwm, prelude::*};
 /// # use esp_hal::mcpwm::{McPwm, PeripheralClockConfig};
 /// # use esp_hal::mcpwm::operator::{DeadTimeCfg, PwmPinConfig, PWMStream};
-/// # use esp_hal::gpio::Io;
-/// # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+/// # let io = peripherals.GPIO.pins();
 /// // active high complementary using PWMA input
 /// let bridge_active = DeadTimeCfg::new_ahc();
 /// // use PWMB as input for both outputs
@@ -501,9 +500,9 @@ impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bo
 /// let mut mcpwm = McPwm::new(peripherals.MCPWM0, clock_cfg);
 ///
 /// let mut pins = mcpwm.operator0.with_linked_pins(
-///     io.pins.gpio0,
+///     io.gpio0,
 ///     PwmPinConfig::UP_DOWN_ACTIVE_HIGH, // use PWMA as our main input
-///     io.pins.gpio1,
+///     io.gpio1,
 ///     PwmPinConfig::EMPTY, // keep PWMB "low"
 ///     bridge_off,
 /// );

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -329,7 +329,7 @@ mod peripheral_macros {
                         $(
                             paste::paste!{
                                 /// Binds an interrupt handler to the corresponding interrupt for this peripheral.
-                                pub fn [<bind_ $interrupt:lower _interrupt >](&mut self, handler: unsafe extern "C" fn() -> ()) {
+                                pub fn [<bind_ $interrupt:lower _interrupt >](&mut self, handler: unsafe extern "C" fn()) {
                                     unsafe { $crate::interrupt::bind_interrupt($crate::peripherals::Interrupt::$interrupt, handler); }
                                 }
                             }

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -54,16 +54,15 @@
 //! # use esp_hal::peripherals::Peripherals;
 //! # use esp_hal::rmt::TxChannelConfig;
 //! # use esp_hal::rmt::Rmt;
-//! # use esp_hal::gpio::Io;
 //! # use crate::esp_hal::rmt::TxChannelCreator;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let io = peripherals.GPIO.pins();
 #![cfg_attr(esp32h2, doc = "let freq = 32.MHz();")]
 #![cfg_attr(not(esp32h2), doc = "let freq = 80.MHz();")]
 //! let rmt = Rmt::new(peripherals.RMT, freq).unwrap();
 //! let mut channel = rmt
 //!     .channel0
 //!     .configure(
-//!         io.pins.gpio1,
+//!         io.gpio1,
 //!         TxChannelConfig {
 //!             clk_divider: 1,
 //!             idle_output_level: false,

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -141,9 +141,8 @@ impl rand_core::RngCore for Rng {
 /// # use esp_hal::peripherals::Peripherals;
 /// # use esp_hal::peripherals::ADC1;
 /// # use esp_hal::analog::adc::{AdcConfig, Attenuation, Adc};
-/// # use esp_hal::gpio::Io;
 ///
-/// let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+/// let io = peripherals.GPIO.pins();
 /// let mut buf = [0u8; 16];
 ///
 /// // ADC is not available from now
@@ -152,8 +151,8 @@ impl rand_core::RngCore for Rng {
 /// let mut true_rand = trng.random();
 /// let mut rng = trng.downgrade();
 /// // ADC is available now
-#[cfg_attr(esp32, doc = "let analog_pin = io.pins.gpio32;")]
-#[cfg_attr(not(esp32), doc = "let analog_pin = io.pins.gpio3;")]
+#[cfg_attr(esp32, doc = "let analog_pin = io.gpio32;")]
+#[cfg_attr(not(esp32), doc = "let analog_pin = io.gpio3;")]
 /// let mut adc1_config = AdcConfig::new();
 /// let mut adc1_pin = adc1_config.enable_pin(analog_pin,
 /// Attenuation::Attenuation11dB); let mut adc1 =

--- a/esp-hal/src/rom/md5.rs
+++ b/esp-hal/src/rom/md5.rs
@@ -32,11 +32,10 @@
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::rom::md5;
 //! # use esp_hal::uart::Uart;
-//! # use esp_hal::gpio::Io;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut uart0 = Uart::new(peripherals.UART0, io.pins.gpio1, io.pins.gpio2).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut uart0 = Uart::new(peripherals.UART0, io.gpio1, io.gpio2).unwrap();
 //! # let data = "Dummy";
 //! let d: md5::Digest = md5::compute(&data);
 //! writeln!(uart0, "{}", d);
@@ -48,11 +47,10 @@
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::rom::md5;
 //! # use esp_hal::uart::Uart;
-//! # use esp_hal::gpio::Io;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut uart0 = Uart::new(peripherals.UART0, io.pins.gpio1, io.pins.gpio2).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut uart0 = Uart::new(peripherals.UART0, io.gpio1, io.gpio2).unwrap();
 //! # let data0 = "Dummy";
 //! # let data1 = "Dummy";
 //! #

--- a/esp-hal/src/soc/esp32/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32/efuse/mod.rs
@@ -24,12 +24,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut serial_tx = Uart::new(peripherals.UART0, io.pins.gpio4, io.pins.gpio5).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut serial_tx = Uart::new(peripherals.UART0, io.gpio4, io.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32c2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c2/efuse/mod.rs
@@ -21,12 +21,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut serial_tx = Uart::new(peripherals.UART0, io.pins.gpio4, io.pins.gpio5).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut serial_tx = Uart::new(peripherals.UART0, io.gpio4, io.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32c3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c3/efuse/mod.rs
@@ -22,12 +22,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut serial_tx = Uart::new(peripherals.UART0, io.pins.gpio4, io.pins.gpio5).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut serial_tx = Uart::new(peripherals.UART0, io.gpio4, io.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32c6/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c6/efuse/mod.rs
@@ -22,12 +22,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut serial_tx = Uart::new(peripherals.UART0, io.pins.gpio4, io.pins.gpio5).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut serial_tx = Uart::new(peripherals.UART0, io.gpio4, io.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32h2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32h2/efuse/mod.rs
@@ -22,12 +22,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut serial_tx = Uart::new(peripherals.UART0, io.pins.gpio4, io.pins.gpio5).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut serial_tx = Uart::new(peripherals.UART0, io.gpio4, io.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32s2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32s2/efuse/mod.rs
@@ -24,12 +24,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut serial_tx = Uart::new(peripherals.UART0, io.pins.gpio4, io.pins.gpio5).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut serial_tx = Uart::new(peripherals.UART0, io.gpio4, io.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/soc/esp32s3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32s3/efuse/mod.rs
@@ -22,12 +22,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::efuse::Efuse;
-//! # use esp_hal::gpio::Io;
 //! # use esp_hal::uart::Uart;
 //! # use core::writeln;
 //! # use core::fmt::Write;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! # let mut serial_tx = Uart::new(peripherals.UART0, io.pins.gpio4, io.pins.gpio5).unwrap();
+//! # let io = peripherals.GPIO.pins();
+//! # let mut serial_tx = Uart::new(peripherals.UART0, io.gpio4, io.gpio5).unwrap();
 //! let mac_address = Efuse::read_base_mac_address();
 //! writeln!(
 //!     serial_tx,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -39,12 +39,11 @@
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::spi::SpiMode;
 //! # use esp_hal::spi::master::Spi;
-//! # use esp_hal::gpio::Io;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let sclk = io.pins.gpio0;
-//! let miso = io.pins.gpio2;
-//! let mosi = io.pins.gpio1;
-//! let cs = io.pins.gpio5;
+//! # let io = peripherals.GPIO.pins();
+//! let sclk = io.gpio0;
+//! let miso = io.gpio2;
+//! let mosi = io.gpio1;
+//! let cs = io.gpio5;
 //!
 //! let mut spi = Spi::new(
 //!     peripherals.SPI2,

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -20,15 +20,14 @@
 //! # use esp_hal::spi::SpiMode;
 //! # use esp_hal::spi::slave::{prelude::*, Spi};
 //! # use esp_hal::dma::Dma;
-//! # use esp_hal::gpio::Io;
 //! let dma = Dma::new(peripherals.DMA);
 #![cfg_attr(esp32s2, doc = "let dma_channel = dma.spi2channel;")]
 #![cfg_attr(not(esp32s2), doc = "let dma_channel = dma.channel0;")]
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let sclk = io.pins.gpio0;
-//! let miso = io.pins.gpio1;
-//! let mosi = io.pins.gpio2;
-//! let cs = io.pins.gpio3;
+//! let io = peripherals.GPIO.pins();
+//! let sclk = io.gpio0;
+//! let miso = io.gpio1;
+//! let mosi = io.gpio2;
+//! let cs = io.gpio3;
 //!
 //! let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
 //! dma_buffers!(32000); let mut spi = Spi::new(

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -10,9 +10,8 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::touch::{Touch, TouchPad};
-//! # use esp_hal::gpio::Io;
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-//! let touch_pin0 = io.pins.gpio2;
+//! let io = peripherals.GPIO.pins();
+//! let touch_pin0 = io.gpio2;
 //! let touch = Touch::continuous_mode(peripherals.TOUCH, None);
 //! let mut touchpad = TouchPad::new(touch_pin0, &touch);
 //! // ... give the peripheral some time for the measurement

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -32,14 +32,13 @@
 //! # use esp_hal::twai::TwaiConfiguration;
 //! # use esp_hal::twai::BaudRate;
 //! # use esp_hal::twai::TwaiMode;
-//! # use esp_hal::gpio::Io;
 //! # use embedded_can::Frame;
 //! # use nb::block;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let io = peripherals.GPIO.pins();
 //! // Use GPIO pins 2 and 3 to connect to the respective pins on the TWAI
 //! // transceiver.
-//! let can_rx_pin = io.pins.gpio3;
-//! let can_tx_pin = io.pins.gpio2;
+//! let can_rx_pin = io.gpio3;
+//! let can_tx_pin = io.gpio2;
 //!
 //! // The speed of the TWAI bus.
 //! const TWAI_BAUDRATE: twai::BaudRate = BaudRate::B1000K;
@@ -87,14 +86,13 @@
 //! # use esp_hal::twai::EspTwaiFrame;
 //! # use esp_hal::twai::StandardId;
 //! # use esp_hal::twai::TwaiMode;
-//! # use esp_hal::gpio::Io;
 //! # use embedded_can::Frame;
 //! # use nb::block;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let io = peripherals.GPIO.pins();
 //! // Use GPIO pins 2 and 3 to connect to the respective pins on the TWAI
 //! // transceiver.
-//! let can_rx_pin = io.pins.gpio3;
-//! let can_tx_pin = io.pins.gpio2;
+//! let can_rx_pin = io.gpio3;
+//! let can_tx_pin = io.gpio2;
 //!
 //! // The speed of the TWAI bus.
 //! const TWAI_BAUDRATE: twai::BaudRate = BaudRate::B1000K;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -23,14 +23,13 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::uart::Uart;
-//! use esp_hal::gpio::Io;
 //!
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let io = peripherals.GPIO.pins();
 //!
 //! let mut uart1 = Uart::new(
 //!     peripherals.UART1,
-//!     io.pins.gpio1,
-//!     io.pins.gpio2,
+//!     io.gpio1,
+//!     io.gpio2,
 //! ).unwrap();
 //! # }
 //! ```
@@ -56,13 +55,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::uart::{config::Config, Uart};
-//! # use esp_hal::gpio::Io;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let io = peripherals.GPIO.pins();
 //! # let mut uart1 = Uart::new_with_config(
 //! #     peripherals.UART1,
 //! #     Config::default(),
-//! #     io.pins.gpio1,
-//! #     io.pins.gpio2,
+//! #     io.gpio1,
+//! #     io.gpio2,
 //! # ).unwrap();
 //! // Write bytes out over the UART:
 //! uart1.write_bytes(b"Hello, world!").expect("write error!");
@@ -73,13 +71,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::uart::{config::Config, Uart};
-//! # use esp_hal::gpio::Io;
-//! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! # let io = peripherals.GPIO.pins();
 //! # let mut uart1 = Uart::new_with_config(
 //! #     peripherals.UART1,
 //! #     Config::default(),
-//! #     io.pins.gpio1,
-//! #     io.pins.gpio2,
+//! #     io.gpio1,
+//! #     io.gpio2,
 //! # ).unwrap();
 //! // The UART can be split into separate Transmit and Receive components:
 //! let (mut rx, mut tx) = uart1.split();
@@ -94,12 +91,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::uart::Uart;
-//! use esp_hal::gpio::Io;
 //!
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let io = peripherals.GPIO.pins();
 //!
-//! let rx = io.pins.gpio2.peripheral_input().inverted();
-//! let tx = io.pins.gpio1.into_peripheral_output().inverted();
+//! let rx = io.gpio2.peripheral_input().inverted();
+//! let tx = io.gpio1.into_peripheral_output().inverted();
 //! let mut uart1 = Uart::new(
 //!     peripherals.UART1,
 //!     rx,
@@ -112,12 +108,11 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::uart::{UartTx, UartRx};
-//! use esp_hal::gpio::Io;
 //!
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let io = peripherals.GPIO.pins();
 //!
-//! let tx = UartTx::new(peripherals.UART0, io.pins.gpio1).unwrap();
-//! let rx = UartRx::new(peripherals.UART1, io.pins.gpio2).unwrap();
+//! let tx = UartTx::new(peripherals.UART0, io.gpio1).unwrap();
+//! let rx = UartRx::new(peripherals.UART1, io.gpio2).unwrap();
 //! # }
 //! ```
 //! 

--- a/examples/src/bin/adc.rs
+++ b/examples/src/bin/adc.rs
@@ -20,7 +20,6 @@ use esp_backtrace as _;
 use esp_hal::{
     analog::adc::{Adc, AdcConfig, Attenuation},
     delay::Delay,
-    gpio::Io,
     prelude::*,
 };
 use esp_println::println;
@@ -29,14 +28,14 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let analog_pin = io.pins.gpio32;
+            let analog_pin = io.gpio32;
         } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
-            let analog_pin = io.pins.gpio3;
+            let analog_pin = io.gpio3;
         } else {
-            let analog_pin = io.pins.gpio2;
+            let analog_pin = io.gpio2;
         }
     }
 

--- a/examples/src/bin/adc_cal.rs
+++ b/examples/src/bin/adc_cal.rs
@@ -16,7 +16,6 @@ use esp_backtrace as _;
 use esp_hal::{
     analog::adc::{Adc, AdcConfig, Attenuation},
     delay::Delay,
-    gpio::Io,
     prelude::*,
 };
 use esp_println::println;
@@ -25,12 +24,12 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32s3")] {
-            let analog_pin = io.pins.gpio3;
+            let analog_pin = io.gpio3;
         } else {
-            let analog_pin = io.pins.gpio2;
+            let analog_pin = io.gpio2;
         }
     }
 

--- a/examples/src/bin/advanced_serial.rs
+++ b/examples/src/bin/advanced_serial.rs
@@ -13,7 +13,7 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, gpio::Io, prelude::*, uart::Uart};
+use esp_hal::{delay::Delay, prelude::*, uart::Uart};
 use esp_println::println;
 use nb::block;
 
@@ -21,9 +21,9 @@ use nb::block;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let mut serial1 = Uart::new(peripherals.UART1, io.pins.gpio4, io.pins.gpio5).unwrap();
+    let mut serial1 = Uart::new(peripherals.UART1, io.gpio4, io.gpio5).unwrap();
 
     let delay = Delay::new();
 

--- a/examples/src/bin/blinky.rs
+++ b/examples/src/bin/blinky.rs
@@ -11,7 +11,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::{Io, Level, Output},
+    gpio::{Level, Output},
     prelude::*,
 };
 
@@ -20,8 +20,8 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     // Set GPIO0 as an output, and set its state high initially.
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let mut led = Output::new(io.pins.gpio0, Level::High);
+    let io = peripherals.GPIO.pins();
+    let mut led = Output::new(io.gpio0, Level::High);
 
     let delay = Delay::new();
 

--- a/examples/src/bin/blinky_erased_pins.rs
+++ b/examples/src/bin/blinky_erased_pins.rs
@@ -14,7 +14,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::{Input, Io, Level, Output, Pin, Pull},
+    gpio::{Input, Level, Output, Pin, Pull},
     prelude::*,
 };
 
@@ -22,18 +22,18 @@ use esp_hal::{
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Set LED GPIOs as an output:
-    let led1 = Output::new(io.pins.gpio2.degrade(), Level::Low);
-    let led2 = Output::new(io.pins.gpio4.degrade(), Level::Low);
-    let led3 = Output::new(io.pins.gpio5.degrade(), Level::Low);
+    let led1 = Output::new(io.gpio2.degrade(), Level::Low);
+    let led2 = Output::new(io.gpio4.degrade(), Level::Low);
+    let led3 = Output::new(io.gpio5.degrade(), Level::Low);
 
     // Use boot button as an input:
     #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
-    let button = io.pins.gpio0.degrade();
+    let button = io.gpio0.degrade();
     #[cfg(not(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3")))]
-    let button = io.pins.gpio9.degrade();
+    let button = io.gpio9.degrade();
 
     let button = Input::new(button, Pull::Up);
 

--- a/examples/src/bin/dac.rs
+++ b/examples/src/bin/dac.rs
@@ -19,21 +19,21 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{analog::dac::Dac, delay::Delay, gpio::Io, prelude::*};
+use esp_hal::{analog::dac::Dac, delay::Delay, prelude::*};
 
 #[entry]
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let dac1_pin = io.pins.gpio25;
-            let dac2_pin = io.pins.gpio26;
+            let dac1_pin = io.gpio25;
+            let dac2_pin = io.gpio26;
         } else if #[cfg(feature = "esp32s2")] {
-            let dac1_pin = io.pins.gpio17;
-            let dac2_pin = io.pins.gpio18;
+            let dac1_pin = io.gpio17;
+            let dac2_pin = io.gpio18;
         }
     }
 

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -19,7 +19,7 @@
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
-use esp_hal::{gpio::Io, i2c::I2C, prelude::*, timer::timg::TimerGroup};
+use esp_hal::{i2c::I2C, prelude::*, timer::timg::TimerGroup};
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
 
 #[esp_hal_embassy::main]
@@ -29,9 +29,9 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let i2c0 = I2C::new_async(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 400.kHz());
+    let i2c0 = I2C::new_async(peripherals.I2C0, io.gpio4, io.gpio5, 400.kHz());
 
     let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
     lis3dh.set_range(Range::G8).await.unwrap();

--- a/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -20,7 +20,7 @@
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
-use esp_hal::{gpio::Io, i2c::I2C, prelude::*, timer::timg::TimerGroup};
+use esp_hal::{i2c::I2C, prelude::*, timer::timg::TimerGroup};
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -29,9 +29,9 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let mut i2c = I2C::new_async(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 400.kHz());
+    let mut i2c = I2C::new_async(peripherals.I2C0, io.gpio4, io.gpio5, 400.kHz());
 
     loop {
         let mut data = [0u8; 22];

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -22,7 +22,6 @@ use esp_backtrace as _;
 use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     prelude::*,
     timer::timg::TimerGroup,
@@ -37,7 +36,7 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let dma = Dma::new(peripherals.DMA);
     #[cfg(any(feature = "esp32", feature = "esp32s2"))]
@@ -58,13 +57,13 @@ async fn main(_spawner: Spawner) {
     );
 
     #[cfg(not(feature = "esp32"))]
-    let i2s = i2s.with_mclk(io.pins.gpio0);
+    let i2s = i2s.with_mclk(io.gpio0);
 
     let i2s_rx = i2s
         .i2s_rx
-        .with_bclk(io.pins.gpio2)
-        .with_ws(io.pins.gpio4)
-        .with_din(io.pins.gpio5)
+        .with_bclk(io.gpio2)
+        .with_ws(io.gpio4)
+        .with_din(io.gpio5)
         .build();
 
     let buffer = rx_buffer;

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -36,7 +36,6 @@ use esp_backtrace as _;
 use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     i2s::{asynch::*, DataFormat, I2s, Standard},
     prelude::*,
     timer::timg::TimerGroup,
@@ -59,7 +58,7 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let dma = Dma::new(peripherals.DMA);
     #[cfg(any(feature = "esp32", feature = "esp32s2"))]
@@ -81,9 +80,9 @@ async fn main(_spawner: Spawner) {
 
     let i2s_tx = i2s
         .i2s_tx
-        .with_bclk(io.pins.gpio2)
-        .with_ws(io.pins.gpio4)
-        .with_dout(io.pins.gpio5)
+        .with_bclk(io.gpio2)
+        .with_ws(io.gpio4)
+        .with_dout(io.gpio5)
         .build();
 
     let data =

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -21,7 +21,7 @@ use esp_backtrace as _;
 use esp_hal::{
     cpu_control::{CpuControl, Stack},
     get_core,
-    gpio::{Io, Level, Output, Pin},
+    gpio::{Level, Output, Pin},
     timer::{timg::TimerGroup, AnyTimer},
 };
 use esp_hal_embassy::Executor;
@@ -53,7 +53,7 @@ async fn control_led(
 async fn main(_spawner: Spawner) {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let timer0: AnyTimer = timg0.timer0.into();
@@ -65,7 +65,7 @@ async fn main(_spawner: Spawner) {
     static LED_CTRL: StaticCell<Signal<CriticalSectionRawMutex, bool>> = StaticCell::new();
     let led_ctrl_signal = &*LED_CTRL.init(Signal::new());
 
-    let led = Output::new(io.pins.gpio0.degrade(), Level::Low);
+    let led = Output::new(io.gpio0.degrade(), Level::Low);
 
     let _guard = cpu_control
         .start_app_core(unsafe { &mut *addr_of_mut!(APP_CORE_STACK) }, move || {

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -20,7 +20,7 @@ use esp_backtrace as _;
 use esp_hal::{
     cpu_control::{CpuControl, Stack},
     get_core,
-    gpio::{Io, Level, Output, Pin},
+    gpio::{Level, Output, Pin},
     interrupt::{software::SoftwareInterruptControl, Priority},
     prelude::*,
     timer::{timg::TimerGroup, AnyTimer},
@@ -75,7 +75,7 @@ fn main() -> ! {
 
     let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let timer0: AnyTimer = timg0.timer0.into();
@@ -87,7 +87,7 @@ fn main() -> ! {
     static LED_CTRL: StaticCell<Signal<CriticalSectionRawMutex, bool>> = StaticCell::new();
     let led_ctrl_signal = &*LED_CTRL.init(Signal::new());
 
-    let led = Output::new(io.pins.gpio0.degrade(), Level::Low);
+    let led = Output::new(io.gpio0.degrade(), Level::Low);
 
     static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<1>> = StaticCell::new();
     let executor_core1 = InterruptExecutor::new(sw_ints.software_interrupt1);

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -16,7 +16,6 @@ use esp_backtrace as _;
 use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     parl_io::{no_clk_pin, BitPackOrder, ParlIoRxOnly, RxFourBits},
     prelude::*,
     timer::systimer::{SystemTimer, Target},
@@ -31,14 +30,14 @@ async fn main(_spawner: Spawner) {
     let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
     esp_hal_embassy::init(systimer.alarm0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(32000, 0);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
+    let mut rx_pins = RxFourBits::new(io.gpio1, io.gpio2, io.gpio3, io.gpio4);
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -20,7 +20,6 @@ use esp_backtrace as _;
 use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     parl_io::{
         BitPackOrder,
         ClkOutPin,
@@ -42,16 +41,16 @@ async fn main(_spawner: Spawner) {
     let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
     esp_hal_embassy::init(systimer.alarm0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
+    let tx_pins = TxFourBits::new(io.gpio1, io.gpio2, io.gpio3, io.gpio4);
 
-    let mut pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.pins.gpio5);
+    let mut pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.gpio5);
 
     let parl_io = ParlIoTxOnly::new(
         peripherals.PARL_IO,
@@ -61,7 +60,7 @@ async fn main(_spawner: Spawner) {
     )
     .unwrap();
 
-    let mut clock_pin = ClkOutPin::new(io.pins.gpio8);
+    let mut clock_pin = ClkOutPin::new(io.gpio8);
 
     let mut parl_io_tx = parl_io
         .tx

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -13,7 +13,7 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{Io, Level, Output},
+    gpio::{Level, Output},
     prelude::*,
     rmt::{asynch::RxChannelAsync, PulseCode, Rmt, RxChannelConfig, RxChannelCreatorAsync},
     timer::timg::TimerGroup,
@@ -44,7 +44,7 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
@@ -63,16 +63,16 @@ async fn main(spawner: Spawner) {
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
-            let mut channel = rmt.channel0.configure(io.pins.gpio4, rx_config).unwrap();
+            let mut channel = rmt.channel0.configure(io.gpio4, rx_config).unwrap();
         } else if #[cfg(feature = "esp32s3")] {
-            let mut channel = rmt.channel7.configure(io.pins.gpio4, rx_config).unwrap();
+            let mut channel = rmt.channel7.configure(io.gpio4, rx_config).unwrap();
         } else {
-            let mut channel = rmt.channel2.configure(io.pins.gpio4, rx_config).unwrap();
+            let mut channel = rmt.channel2.configure(io.gpio4, rx_config).unwrap();
         }
     }
 
     spawner
-        .spawn(signal_task(Output::new(io.pins.gpio5, Level::Low)))
+        .spawn(signal_task(Output::new(io.gpio5, Level::Low)))
         .unwrap();
 
     let mut data = [PulseCode {

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -15,7 +15,6 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     prelude::*,
     rmt::{asynch::TxChannelAsync, PulseCode, Rmt, TxChannelConfig, TxChannelCreatorAsync},
     timer::timg::TimerGroup,
@@ -30,7 +29,7 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
@@ -45,7 +44,7 @@ async fn main(_spawner: Spawner) {
     let mut channel = rmt
         .channel0
         .configure(
-            io.pins.gpio4,
+            io.gpio4,
             TxChannelConfig {
                 clk_divider: 255,
                 ..TxChannelConfig::default()

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -13,7 +13,6 @@ use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     peripherals::UART0,
     timer::timg::TimerGroup,
     uart::{
@@ -83,22 +82,22 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Default pins for Uart/Serial communication
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+            let (tx_pin, rx_pin) = (io.gpio1, io.gpio3);
         } else if #[cfg(feature = "esp32c2")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+            let (tx_pin, rx_pin) = (io.gpio20, io.gpio19);
         } else if #[cfg(feature = "esp32c3")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+            let (tx_pin, rx_pin) = (io.gpio21, io.gpio20);
         } else if #[cfg(feature = "esp32c6")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+            let (tx_pin, rx_pin) = (io.gpio16, io.gpio17);
         } else if #[cfg(feature = "esp32h2")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+            let (tx_pin, rx_pin) = (io.gpio24, io.gpio23);
         } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
-            let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+            let (tx_pin, rx_pin) = (io.gpio43, io.gpio44);
         }
     }
 

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -24,7 +24,6 @@ use esp_backtrace as _;
 use esp_hal::{
     dma::*,
     dma_buffers,
-    gpio::Io,
     prelude::*,
     spi::{master::Spi, SpiMode},
     timer::timg::TimerGroup,
@@ -38,11 +37,11 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio0;
-    let miso = io.pins.gpio2;
-    let mosi = io.pins.gpio4;
-    let cs = io.pins.gpio5;
+    let io = peripherals.GPIO.pins();
+    let sclk = io.gpio0;
+    let miso = io.gpio2;
+    let mosi = io.gpio4;
+    let cs = io.gpio5;
 
     let dma = Dma::new(peripherals.DMA);
 

--- a/examples/src/bin/embassy_touch.rs
+++ b/examples/src/bin/embassy_touch.rs
@@ -17,7 +17,6 @@ use embassy_futures::select::{select, Either};
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     rtc_cntl::Rtc,
     timer::timg::TimerGroup,
     touch::{Touch, TouchConfig, TouchPad},
@@ -32,11 +31,11 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
     let mut rtc = Rtc::new(peripherals.LPWR);
 
-    let touch_pin0 = io.pins.gpio2;
-    let touch_pin1 = io.pins.gpio4;
+    let touch_pin0 = io.gpio2;
+    let touch_pin1 = io.gpio4;
 
     let touch_cfg = Some(TouchConfig {
         measurement_duration: Some(0x2000),

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -25,7 +25,6 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
 use embedded_can::{Frame, Id};
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     interrupt,
     peripherals::{self, TWAI0},
     timer::timg::TimerGroup,
@@ -87,10 +86,10 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let can_tx_pin = io.pins.gpio0;
-    let can_rx_pin = io.pins.gpio2;
+    let can_tx_pin = io.gpio0;
+    let can_rx_pin = io.gpio2;
 
     // The speed of the CAN bus.
     const CAN_BAUDRATE: twai::BaudRate = twai::BaudRate::B1000K;

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -21,7 +21,6 @@ use embassy_usb::{
 };
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     otg_fs::{
         asynch::{Config, Driver},
         Usb,
@@ -37,9 +36,9 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let usb = Usb::new(peripherals.USB0, io.pins.gpio20, io.pins.gpio19);
+    let usb = Usb::new(peripherals.USB0, io.gpio20, io.gpio19);
 
     // Create the driver, from the HAL.
     let mut ep_out_buffer = [0u8; 1024];

--- a/examples/src/bin/embassy_wait.rs
+++ b/examples/src/bin/embassy_wait.rs
@@ -12,7 +12,7 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{Input, Io, Pull},
+    gpio::{Input, Pull},
     timer::timg::TimerGroup,
 };
 
@@ -24,13 +24,13 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
-            let mut input = Input::new(io.pins.gpio0, Pull::Down);
+            let mut input = Input::new(io.gpio0, Pull::Down);
         } else {
-            let mut input = Input::new(io.pins.gpio9, Pull::Down);
+            let mut input = Input::new(io.gpio9, Pull::Down);
         }
     }
 

--- a/examples/src/bin/etm_blinky_systimer.rs
+++ b/examples/src/bin/etm_blinky_systimer.rs
@@ -13,7 +13,6 @@ use esp_hal::{
     etm::Etm,
     gpio::{
         etm::{GpioEtmChannels, GpioEtmOutputConfig},
-        Io,
         Level,
         Pull,
     },
@@ -31,8 +30,8 @@ fn main() -> ! {
     let mut alarm0 = syst_alarms.alarm0;
     alarm0.set_period(1u32.secs());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let mut led = io.pins.gpio1;
+    let io = peripherals.GPIO.pins();
+    let mut led = io.gpio1;
 
     // setup ETM
     let gpio_ext = GpioEtmChannels::new(peripherals.GPIO_SD);

--- a/examples/src/bin/etm_gpio.rs
+++ b/examples/src/bin/etm_gpio.rs
@@ -13,7 +13,6 @@ use esp_hal::{
     etm::Etm,
     gpio::{
         etm::{GpioEtmChannels, GpioEtmInputConfig, GpioEtmOutputConfig},
-        Io,
         Level,
         Output,
         Pull,
@@ -25,9 +24,9 @@ use esp_hal::{
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let mut led = Output::new(io.pins.gpio1, Level::Low);
-    let button = io.pins.gpio9;
+    let io = peripherals.GPIO.pins();
+    let mut led = Output::new(io.gpio1, Level::Low);
+    let button = io.gpio9;
 
     led.set_high();
 

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -18,7 +18,7 @@ use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::{Event, Input, Io, Level, Output, Pull},
+    gpio::{Event, Input, Level, Output, Pull},
     macros::ram,
     prelude::*,
 };
@@ -30,19 +30,20 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     // Set GPIO2 as an output, and set its state high initially.
-    let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    io.set_interrupt_handler(handler);
-    let mut led = Output::new(io.pins.gpio2, Level::Low);
+    let io = peripherals.GPIO.pins();
+    let mut led = Output::new(io.gpio2, Level::Low);
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
-            let button = io.pins.gpio0;
+            let button = io.gpio0;
         } else {
-            let button = io.pins.gpio9;
+            let button = io.gpio9;
         }
     }
 
     let mut button = Input::new(button, Pull::Up);
+
+    button.set_interrupt_handler(handler);
 
     critical_section::with(|cs| {
         button.listen(Event::FallingEdge);

--- a/examples/src/bin/hello_rgb.rs
+++ b/examples/src/bin/hello_rgb.rs
@@ -25,7 +25,7 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, gpio::Io, prelude::*, rmt::Rmt};
+use esp_hal::{delay::Delay, prelude::*, rmt::Rmt};
 use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness,
@@ -38,21 +38,21 @@ use smart_leds::{
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Each devkit uses a unique GPIO for the RGB LED, so in order to support
     // all chips we must unfortunately use `#[cfg]`s:
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let led_pin = io.pins.gpio33;
+            let led_pin = io.gpio33;
         } else if #[cfg(feature = "esp32c3")] {
-            let led_pin = io.pins.gpio8;
+            let led_pin = io.gpio8;
         } else if #[cfg(any(feature = "esp32c6", feature = "esp32h2"))] {
-            let led_pin = io.pins.gpio8;
+            let led_pin = io.gpio8;
         } else if #[cfg(feature = "esp32s2")] {
-            let led_pin = io.pins.gpio18;
+            let led_pin = io.gpio18;
         } else if #[cfg(feature = "esp32s3")] {
-            let led_pin = io.pins.gpio48;
+            let led_pin = io.gpio48;
         }
     }
 

--- a/examples/src/bin/hello_world.rs
+++ b/examples/src/bin/hello_world.rs
@@ -15,7 +15,7 @@
 use core::fmt::Write;
 
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, gpio::Io, prelude::*, uart::Uart};
+use esp_hal::{delay::Delay, prelude::*, uart::Uart};
 
 #[entry]
 fn main() -> ! {
@@ -23,22 +23,22 @@ fn main() -> ! {
 
     let delay = Delay::new();
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Default pins for Uart/Serial communication
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let (mut tx_pin, mut rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+            let (mut tx_pin, mut rx_pin) = (io.gpio1, io.gpio3);
         } else if #[cfg(feature = "esp32c2")] {
-            let (mut tx_pin, mut rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+            let (mut tx_pin, mut rx_pin) = (io.gpio20, io.gpio19);
         } else if #[cfg(feature = "esp32c3")] {
-            let (mut tx_pin, mut rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+            let (mut tx_pin, mut rx_pin) = (io.gpio21, io.gpio20);
         } else if #[cfg(feature = "esp32c6")] {
-            let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+            let (mut tx_pin, mut rx_pin) = (io.gpio16, io.gpio17);
         } else if #[cfg(feature = "esp32h2")] {
-            let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+            let (mut tx_pin, mut rx_pin) = (io.gpio24, io.gpio23);
         } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
-            let (mut tx_pin, mut rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+            let (mut tx_pin, mut rx_pin) = (io.gpio43, io.gpio44);
         }
     }
 

--- a/examples/src/bin/i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/i2c_bmp180_calibration_data.rs
@@ -12,18 +12,18 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{gpio::Io, i2c::I2C, prelude::*};
+use esp_hal::{i2c::I2C, prelude::*};
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Create a new peripheral object with the described wiring and standard
     // I2C clock speed:
-    let mut i2c = I2C::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 100.kHz());
+    let mut i2c = I2C::new(peripherals.I2C0, io.gpio4, io.gpio5, 100.kHz());
 
     loop {
         let mut data = [0u8; 22];

--- a/examples/src/bin/i2c_display.rs
+++ b/examples/src/bin/i2c_display.rs
@@ -22,7 +22,7 @@ use embedded_graphics::{
     text::{Alignment, Text},
 };
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, gpio::Io, i2c::I2C, prelude::*};
+use esp_hal::{delay::Delay, i2c::I2C, prelude::*};
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 
 #[entry]
@@ -30,11 +30,11 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     let delay = Delay::new();
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Create a new peripheral object with the described wiring
     // and standard I2C clock speed
-    let i2c = I2C::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 100.kHz());
+    let i2c = I2C::new(peripherals.I2C0, io.gpio4, io.gpio5, 100.kHz());
 
     // Initialize display
     let interface = I2CDisplayInterface::new(i2c);

--- a/examples/src/bin/i2s_read.rs
+++ b/examples/src/bin/i2s_read.rs
@@ -20,7 +20,6 @@ use esp_backtrace as _;
 use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     i2s::{DataFormat, I2s, I2sReadDma, Standard},
     prelude::*,
 };
@@ -30,7 +29,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let dma = Dma::new(peripherals.DMA);
     #[cfg(any(feature = "esp32", feature = "esp32s2"))]
@@ -55,13 +54,13 @@ fn main() -> ! {
     );
 
     #[cfg(not(feature = "esp32"))]
-    let i2s = i2s.with_mclk(io.pins.gpio0);
+    let i2s = i2s.with_mclk(io.gpio0);
 
     let mut i2s_rx = i2s
         .i2s_rx
-        .with_bclk(io.pins.gpio2)
-        .with_ws(io.pins.gpio4)
-        .with_din(io.pins.gpio5)
+        .with_bclk(io.gpio2)
+        .with_ws(io.gpio4)
+        .with_din(io.gpio5)
         .build();
 
     let mut transfer = i2s_rx.read_dma_circular(&mut rx_buffer).unwrap();

--- a/examples/src/bin/i2s_sound.rs
+++ b/examples/src/bin/i2s_sound.rs
@@ -34,7 +34,6 @@ use esp_backtrace as _;
 use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     i2s::{DataFormat, I2s, I2sWriteDma, Standard},
     prelude::*,
 };
@@ -51,7 +50,7 @@ const SINE: [i16; 64] = [
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let dma = Dma::new(peripherals.DMA);
     #[cfg(any(feature = "esp32", feature = "esp32s2"))]
@@ -73,9 +72,9 @@ fn main() -> ! {
 
     let mut i2s_tx = i2s
         .i2s_tx
-        .with_bclk(io.pins.gpio2)
-        .with_ws(io.pins.gpio4)
-        .with_dout(io.pins.gpio5)
+        .with_bclk(io.gpio2)
+        .with_ws(io.gpio4)
+        .with_dout(io.gpio5)
         .build();
 
     let data =

--- a/examples/src/bin/ieee802154_sniffer.rs
+++ b/examples/src/bin/ieee802154_sniffer.rs
@@ -8,7 +8,7 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{gpio::Io, prelude::*, reset::software_reset, uart::Uart};
+use esp_hal::{prelude::*, reset::software_reset, uart::Uart};
 use esp_ieee802154::{Config, Ieee802154};
 use esp_println::println;
 
@@ -16,14 +16,14 @@ use esp_println::println;
 fn main() -> ! {
     let mut peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Default pins for Uart/Serial communication
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32c6")] {
-            let (mut tx_pin, mut rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+            let (mut tx_pin, mut rx_pin) = (io.gpio16, io.gpio17);
         } else if #[cfg(feature = "esp32h2")] {
-            let (mut tx_pin, mut rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+            let (mut tx_pin, mut rx_pin) = (io.gpio24, io.gpio23);
         }
     }
 

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -28,7 +28,6 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     i2c,
     i2c::I2C,
     lcd_cam::{
@@ -44,7 +43,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let dma = Dma::new(peripherals.DMA);
     let channel = dma.channel0;
@@ -53,21 +52,14 @@ fn main() -> ! {
 
     let channel = channel.configure(false, DmaPriority::Priority0);
 
-    let cam_siod = io.pins.gpio4;
-    let cam_sioc = io.pins.gpio5;
-    let cam_xclk = io.pins.gpio15;
-    let cam_vsync = io.pins.gpio6;
-    let cam_href = io.pins.gpio7;
-    let cam_pclk = io.pins.gpio13;
+    let cam_siod = io.gpio4;
+    let cam_sioc = io.gpio5;
+    let cam_xclk = io.gpio15;
+    let cam_vsync = io.gpio6;
+    let cam_href = io.gpio7;
+    let cam_pclk = io.gpio13;
     let cam_data_pins = RxEightBits::new(
-        io.pins.gpio11,
-        io.pins.gpio9,
-        io.pins.gpio8,
-        io.pins.gpio10,
-        io.pins.gpio12,
-        io.pins.gpio18,
-        io.pins.gpio17,
-        io.pins.gpio16,
+        io.gpio11, io.gpio9, io.gpio8, io.gpio10, io.gpio12, io.gpio18, io.gpio17, io.gpio16,
     );
 
     let lcd_cam = LcdCam::new(peripherals.LCD_CAM);

--- a/examples/src/bin/lcd_i8080.rs
+++ b/examples/src/bin/lcd_i8080.rs
@@ -26,7 +26,7 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::{Io, Level, Output},
+    gpio::{Level, Output},
     lcd_cam::{
         lcd::i8080::{Config, TxEightBits, I8080},
         LcdCam,
@@ -39,13 +39,13 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let lcd_backlight = io.pins.gpio45;
-    let lcd_reset = io.pins.gpio4;
-    let lcd_rs = io.pins.gpio0; // Command/Data selection
-    let lcd_wr = io.pins.gpio47; // Write clock
-    let _lcd_te = io.pins.gpio48; // Frame sync
+    let lcd_backlight = io.gpio45;
+    let lcd_reset = io.gpio4;
+    let lcd_rs = io.gpio0; // Command/Data selection
+    let lcd_wr = io.gpio47; // Write clock
+    let _lcd_te = io.gpio48; // Frame sync
 
     let dma = Dma::new(peripherals.DMA);
     let channel = dma.channel0;
@@ -60,14 +60,7 @@ fn main() -> ! {
     let mut reset = Output::new(lcd_reset, Level::Low);
 
     let tx_pins = TxEightBits::new(
-        io.pins.gpio9,
-        io.pins.gpio46,
-        io.pins.gpio3,
-        io.pins.gpio8,
-        io.pins.gpio18,
-        io.pins.gpio17,
-        io.pins.gpio16,
-        io.pins.gpio15,
+        io.gpio9, io.gpio46, io.gpio3, io.gpio8, io.gpio18, io.gpio17, io.gpio16, io.gpio15,
     );
 
     let lcd_cam = LcdCam::new(peripherals.LCD_CAM);

--- a/examples/src/bin/ledc.rs
+++ b/examples/src/bin/ledc.rs
@@ -11,7 +11,6 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     ledc::{
         channel::{self, ChannelIFace},
         timer::{self, TimerIFace},
@@ -26,8 +25,8 @@ use esp_hal::{
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let led = io.pins.gpio0;
+    let io = peripherals.GPIO.pins();
+    let led = io.gpio0;
 
     let mut ledc = Ledc::new(peripherals.LEDC);
 

--- a/examples/src/bin/lp_core_basic.rs
+++ b/examples/src/bin/lp_core_basic.rs
@@ -15,7 +15,7 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{lp_io::LowPowerOutput, Io},
+    gpio::lp_io::LowPowerOutput,
     lp_core::{LpCore, LpCoreWakeupSource},
     prelude::*,
 };

--- a/examples/src/bin/lp_core_basic.rs
+++ b/examples/src/bin/lp_core_basic.rs
@@ -26,8 +26,8 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     // configure GPIO 1 as LP output pin
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let lp_pin = LowPowerOutput::new(io.pins.gpio1);
+    let io = peripherals.GPIO.pins();
+    let lp_pin = LowPowerOutput::new(io.gpio1);
 
     let mut lp_core = LpCore::new(peripherals.LP_CORE);
     lp_core.stop();

--- a/examples/src/bin/lp_core_i2c.rs
+++ b/examples/src/bin/lp_core_i2c.rs
@@ -27,10 +27,10 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let lp_sda = LowPowerOutputOpenDrain::new(io.pins.gpio6);
-    let lp_scl = LowPowerOutputOpenDrain::new(io.pins.gpio7);
+    let lp_sda = LowPowerOutputOpenDrain::new(io.gpio6);
+    let lp_scl = LowPowerOutputOpenDrain::new(io.gpio7);
 
     let lp_i2c = LpI2c::new(peripherals.LP_I2C0, lp_sda, lp_scl, 100.kHz());
 

--- a/examples/src/bin/lp_core_i2c.rs
+++ b/examples/src/bin/lp_core_i2c.rs
@@ -16,7 +16,7 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{lp_io::LowPowerOutputOpenDrain, Io},
+    gpio::lp_io::LowPowerOutputOpenDrain,
     i2c::lp_i2c::LpI2c,
     lp_core::{LpCore, LpCoreWakeupSource},
     prelude::*,

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -16,10 +16,7 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{
-        lp_io::{LowPowerInput, LowPowerOutput},
-        Io,
-    },
+    gpio::lp_io::{LowPowerInput, LowPowerOutput},
     lp_core::{LpCore, LpCoreWakeupSource},
     prelude::*,
     uart::{config::Config, lp_uart::LpUart, Uart},
@@ -30,21 +27,16 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Set up (HP) UART1:
 
-    let mut uart1 = Uart::new_with_config(
-        peripherals.UART1,
-        Config::default(),
-        io.pins.gpio6,
-        io.pins.gpio7,
-    )
-    .unwrap();
+    let mut uart1 =
+        Uart::new_with_config(peripherals.UART1, Config::default(), io.gpio6, io.gpio7).unwrap();
 
     // Set up (LP) UART:
-    let lp_tx = LowPowerOutput::new(io.pins.gpio5);
-    let lp_rx = LowPowerInput::new(io.pins.gpio4);
+    let lp_tx = LowPowerOutput::new(io.gpio5);
+    let lp_rx = LowPowerInput::new(io.gpio4);
     let lp_uart = LpUart::new(peripherals.LP_UART, lp_tx, lp_rx);
 
     let mut lp_core = LpCore::new(peripherals.LP_CORE);

--- a/examples/src/bin/mcpwm.rs
+++ b/examples/src/bin/mcpwm.rs
@@ -11,7 +11,6 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     mcpwm::{operator::PwmPinConfig, timer::PwmWorkingMode, McPwm, PeripheralClockConfig},
     prelude::*,
 };
@@ -20,8 +19,8 @@ use esp_hal::{
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pin = io.pins.gpio0;
+    let io = peripherals.GPIO.pins();
+    let pin = io.gpio0;
 
     // initialize peripheral
     cfg_if::cfg_if! {

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -14,7 +14,6 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     parl_io::{no_clk_pin, BitPackOrder, ParlIoRxOnly, RxFourBits},
     prelude::*,
 };
@@ -24,14 +23,14 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(32000, 0);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let mut rx_pins = RxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
+    let mut rx_pins = RxFourBits::new(io.gpio1, io.gpio2, io.gpio3, io.gpio4);
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,

--- a/examples/src/bin/parl_io_tx.rs
+++ b/examples/src/bin/parl_io_tx.rs
@@ -18,7 +18,6 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
     parl_io::{
         BitPackOrder,
         ClkOutPin,
@@ -35,16 +34,16 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let tx_pins = TxFourBits::new(io.pins.gpio1, io.pins.gpio2, io.pins.gpio3, io.pins.gpio4);
+    let tx_pins = TxFourBits::new(io.gpio1, io.gpio2, io.gpio3, io.gpio4);
 
-    let mut pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.pins.gpio5);
+    let mut pin_conf = TxPinConfigWithValidPin::new(tx_pins, io.gpio5);
 
     let parl_io = ParlIoTxOnly::new(
         peripherals.PARL_IO,
@@ -54,7 +53,7 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let mut clock_pin = ClkOutPin::new(io.pins.gpio6);
+    let mut clock_pin = ClkOutPin::new(io.gpio6);
 
     let mut parl_io_tx = parl_io
         .tx

--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -49,8 +49,8 @@ fn main() -> ! {
 
     println!("setup channel 0");
     let ch0 = &u0.channel0;
-    let pin_a = Input::new(io.pins.gpio4, Pull::Up);
-    let pin_b = Input::new(io.pins.gpio5, Pull::Up);
+    let pin_a = Input::new(io.gpio4, Pull::Up);
+    let pin_b = Input::new(io.gpio5, Pull::Up);
 
     ch0.set_ctrl_signal(pin_a.peripheral_input());
     ch0.set_edge_signal(pin_b.peripheral_input());

--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -20,7 +20,7 @@ use core::{cell::RefCell, cmp::min, sync::atomic::Ordering};
 use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{Input, Io, Pull},
+    gpio::{Input, Pull},
     interrupt::Priority,
     pcnt::{channel, unit, Pcnt},
     prelude::*,
@@ -35,7 +35,7 @@ static VALUE: AtomicI32 = AtomicI32::new(0);
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Set up a pulse counter:
     println!("setup pulse counter unit 0");

--- a/examples/src/bin/qspi_flash.rs
+++ b/examples/src/bin/qspi_flash.rs
@@ -32,7 +32,6 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::Io,
     prelude::*,
     spi::{
         master::{Address, Command, Spi},
@@ -46,22 +45,22 @@ use esp_println::{print, println};
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let sclk = io.pins.gpio0;
-            let miso = io.pins.gpio2;
-            let mosi = io.pins.gpio4;
-            let sio2 = io.pins.gpio5;
-            let sio3 = io.pins.gpio13;
-            let cs = io.pins.gpio14;
+            let sclk = io.gpio0;
+            let miso = io.gpio2;
+            let mosi = io.gpio4;
+            let sio2 = io.gpio5;
+            let sio3 = io.gpio13;
+            let cs = io.gpio14;
         } else {
-            let sclk = io.pins.gpio0;
-            let miso = io.pins.gpio1;
-            let mosi = io.pins.gpio2;
-            let sio2 = io.pins.gpio3;
-            let sio3 = io.pins.gpio4;
-            let cs = io.pins.gpio5;
+            let sclk = io.gpio0;
+            let miso = io.gpio1;
+            let mosi = io.gpio2;
+            let sio2 = io.gpio3;
+            let sio3 = io.gpio4;
+            let cs = io.gpio5;
         }
     }
 

--- a/examples/src/bin/rmt_rx.rs
+++ b/examples/src/bin/rmt_rx.rs
@@ -14,7 +14,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::{Io, Level, Output},
+    gpio::{Level, Output},
     prelude::*,
     rmt::{PulseCode, Rmt, RxChannel, RxChannelConfig, RxChannelCreator},
 };
@@ -26,8 +26,8 @@ const WIDTH: usize = 80;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let mut out = Output::new(io.pins.gpio5, Level::Low);
+    let io = peripherals.GPIO.pins();
+    let mut out = Output::new(io.gpio5, Level::Low);
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
@@ -47,11 +47,11 @@ fn main() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
-            let mut channel = rmt.channel0.configure(io.pins.gpio4, rx_config).unwrap();
+            let mut channel = rmt.channel0.configure(io.gpio4, rx_config).unwrap();
         } else if #[cfg(feature = "esp32s3")] {
-            let mut channel = rmt.channel7.configure(io.pins.gpio4, rx_config).unwrap();
+            let mut channel = rmt.channel7.configure(io.gpio4, rx_config).unwrap();
         } else {
-            let mut channel = rmt.channel2.configure(io.pins.gpio4, rx_config).unwrap();
+            let mut channel = rmt.channel2.configure(io.gpio4, rx_config).unwrap();
         }
     }
 

--- a/examples/src/bin/rmt_tx.rs
+++ b/examples/src/bin/rmt_tx.rs
@@ -13,7 +13,6 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::Io,
     prelude::*,
     rmt::{PulseCode, Rmt, TxChannel, TxChannelConfig, TxChannelCreator},
 };
@@ -22,7 +21,7 @@ use esp_hal::{
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
@@ -39,7 +38,7 @@ fn main() -> ! {
         ..TxChannelConfig::default()
     };
 
-    let mut channel = rmt.channel0.configure(io.pins.gpio4, tx_config).unwrap();
+    let mut channel = rmt.channel0.configure(io.gpio4, tx_config).unwrap();
 
     let delay = Delay::new();
 

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -13,7 +13,6 @@ use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::Io,
     peripherals::UART0,
     prelude::*,
     uart::{
@@ -31,22 +30,22 @@ fn main() -> ! {
 
     let delay = Delay::new();
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     // Default pins for Uart/Serial communication
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio1, io.pins.gpio3);
+            let (tx_pin, rx_pin) = (io.gpio1, io.gpio3);
         } else if #[cfg(feature = "esp32c2")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio20, io.pins.gpio19);
+            let (tx_pin, rx_pin) = (io.gpio20, io.gpio19);
         } else if #[cfg(feature = "esp32c3")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio21, io.pins.gpio20);
+            let (tx_pin, rx_pin) = (io.gpio21, io.gpio20);
         } else if #[cfg(feature = "esp32c6")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio16, io.pins.gpio17);
+            let (tx_pin, rx_pin) = (io.gpio16, io.gpio17);
         } else if #[cfg(feature = "esp32h2")] {
-            let (tx_pin, rx_pin) = (io.pins.gpio24, io.pins.gpio23);
+            let (tx_pin, rx_pin) = (io.gpio24, io.gpio23);
         } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
-            let (tx_pin, rx_pin) = (io.pins.gpio43, io.pins.gpio44);
+            let (tx_pin, rx_pin) = (io.gpio43, io.gpio44);
         }
     }
     let config = Config::default().rx_fifo_full_threshold(30);

--- a/examples/src/bin/sleep_timer_ext0.rs
+++ b/examples/src/bin/sleep_timer_ext0.rs
@@ -14,7 +14,7 @@ use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
     entry,
-    gpio::{Input, Io, Pull},
+    gpio::{Input, Pull},
     rtc_cntl::{
         get_reset_reason,
         get_wakeup_cause,
@@ -32,8 +32,8 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.LPWR);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let ext0_pin = Input::new(io.pins.gpio4, Pull::None);
+    let io = peripherals.GPIO.pins();
+    let ext0_pin = Input::new(io.gpio4, Pull::None);
 
     println!("up and runnning!");
     let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);

--- a/examples/src/bin/sleep_timer_ext1.rs
+++ b/examples/src/bin/sleep_timer_ext1.rs
@@ -14,7 +14,7 @@ use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
     entry,
-    gpio::{Input, Io, Pull, RtcPin},
+    gpio::{Input, Pull, RtcPin},
     peripheral::Peripheral,
     rtc_cntl::{
         get_reset_reason,
@@ -33,9 +33,9 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.LPWR);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pin_0 = Input::new(io.pins.gpio4, Pull::None);
-    let mut pin_2 = io.pins.gpio2;
+    let io = peripherals.GPIO.pins();
+    let pin_0 = Input::new(io.gpio4, Pull::None);
+    let mut pin_2 = io.gpio2;
 
     println!("up and runnning!");
     let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);

--- a/examples/src/bin/sleep_timer_lpio.rs
+++ b/examples/src/bin/sleep_timer_lpio.rs
@@ -15,7 +15,7 @@ use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
     entry,
-    gpio::{Input, Io, Pull, RtcPinWithResistors},
+    gpio::{Input, Pull, RtcPinWithResistors},
     peripheral::Peripheral,
     rtc_cntl::{
         get_reset_reason,
@@ -34,9 +34,9 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.LPWR);
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pin2 = Input::new(io.pins.gpio2, Pull::None);
-    let mut pin3 = io.pins.gpio3;
+    let io = peripherals.GPIO.pins();
+    let pin2 = Input::new(io.gpio2, Pull::None);
+    let mut pin3 = io.gpio3;
 
     println!("up and runnning!");
     let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);

--- a/examples/src/bin/sleep_timer_rtcio.rs
+++ b/examples/src/bin/sleep_timer_rtcio.rs
@@ -19,7 +19,7 @@ use esp_hal::{
     delay::Delay,
     entry,
     gpio,
-    gpio::{Input, Io, Pull},
+    gpio::{Input, Pull},
     peripheral::Peripheral,
     rtc_cntl::{
         get_reset_reason,
@@ -36,7 +36,7 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
     let mut rtc = Rtc::new(peripherals.LPWR);
 
     println!("up and runnning!");
@@ -50,16 +50,16 @@ fn main() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32c3", feature = "esp32c2"))] {
-            let pin2 = Input::new(io.pins.gpio2, Pull::None);
-            let mut pin3 = io.pins.gpio3;
+            let pin2 = Input::new(io.gpio2, Pull::None);
+            let mut pin3 = io.gpio3;
 
             let wakeup_pins: &mut [(&mut dyn gpio::RtcPinWithResistors, WakeupLevel)] = &mut [
                 (&mut *pin2.into_ref(), WakeupLevel::Low),
                 (&mut pin3, WakeupLevel::High),
             ];
         } else if #[cfg(feature = "esp32s3")] {
-            let pin17 = Input::new(io.pins.gpio17, Pull::None);
-            let mut pin18 = io.pins.gpio18;
+            let pin17 = Input::new(io.gpio17, Pull::None);
+            let mut pin18 = io.gpio18;
 
             let wakeup_pins: &mut [(&mut dyn gpio::RtcPin, WakeupLevel)] = &mut [
                 (&mut *pin17.into_ref(), WakeupLevel::Low),

--- a/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -30,7 +30,6 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::Io,
     prelude::*,
     spi::{
         master::{Address, Command, HalfDuplexReadWrite, Spi},
@@ -44,22 +43,22 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let sclk = io.pins.gpio0;
-            let miso = io.pins.gpio2;
-            let mosi = io.pins.gpio4;
-            let sio2 = io.pins.gpio5;
-            let sio3 = io.pins.gpio13;
-            let cs = io.pins.gpio14;
+            let sclk = io.gpio0;
+            let miso = io.gpio2;
+            let mosi = io.gpio4;
+            let sio2 = io.gpio5;
+            let sio3 = io.gpio13;
+            let cs = io.gpio14;
         } else {
-            let sclk = io.pins.gpio0;
-            let miso = io.pins.gpio1;
-            let mosi = io.pins.gpio2;
-            let sio2 = io.pins.gpio3;
-            let sio3 = io.pins.gpio4;
-            let cs = io.pins.gpio5;
+            let sclk = io.gpio0;
+            let miso = io.gpio1;
+            let mosi = io.gpio2;
+            let sio2 = io.gpio3;
+            let sio3 = io.gpio4;
+            let cs = io.gpio5;
         }
     }
 

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -18,7 +18,6 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::Io,
     prelude::*,
     spi::{master::Spi, SpiMode},
 };
@@ -28,10 +27,10 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio0;
-    let miso_mosi = io.pins.gpio2;
-    let cs = io.pins.gpio5;
+    let io = peripherals.GPIO.pins();
+    let sclk = io.gpio0;
+    let miso_mosi = io.gpio2;
+    let cs = io.gpio5;
 
     let miso = miso_mosi.peripheral_input();
     let mosi = miso_mosi.into_peripheral_output();

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -23,7 +23,6 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::Io,
     prelude::*,
     spi::{master::Spi, SpiMode},
 };
@@ -33,11 +32,11 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio0;
-    let miso = io.pins.gpio2;
-    let mosi = io.pins.gpio4;
-    let cs = io.pins.gpio5;
+    let io = peripherals.GPIO.pins();
+    let sclk = io.gpio0;
+    let miso = io.gpio2;
+    let mosi = io.gpio4;
+    let cs = io.gpio5;
 
     let dma = Dma::new(peripherals.DMA);
 

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -34,7 +34,7 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::{Input, Io, Level, Output, Pull},
+    gpio::{Input, Level, Output, Pull},
     prelude::*,
     spi::{
         slave::{prelude::*, Spi},
@@ -47,17 +47,17 @@ use esp_println::println;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let mut master_sclk = Output::new(io.pins.gpio4, Level::Low);
-    let master_miso = Input::new(io.pins.gpio5, Pull::None);
-    let mut master_mosi = Output::new(io.pins.gpio8, Level::Low);
-    let mut master_cs = Output::new(io.pins.gpio9, Level::High);
+    let mut master_sclk = Output::new(io.gpio4, Level::Low);
+    let master_miso = Input::new(io.gpio5, Pull::None);
+    let mut master_mosi = Output::new(io.gpio8, Level::Low);
+    let mut master_cs = Output::new(io.gpio9, Level::High);
 
-    let slave_sclk = io.pins.gpio0;
-    let slave_miso = io.pins.gpio1;
-    let slave_mosi = io.pins.gpio2;
-    let slave_cs = io.pins.gpio3;
+    let slave_sclk = io.gpio0;
+    let slave_miso = io.gpio1;
+    let slave_mosi = io.gpio2;
+    let slave_cs = io.gpio3;
 
     let dma = Dma::new(peripherals.DMA);
     cfg_if::cfg_if! {

--- a/examples/src/bin/touch.rs
+++ b/examples/src/bin/touch.rs
@@ -49,13 +49,13 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     let mut rtc = Rtc::new(peripherals.LPWR);
     rtc.set_interrupt_handler(interrupt_handler);
 
-    let touch_pin0 = io.pins.gpio2;
-    let touch_pin1 = io.pins.gpio4;
+    let touch_pin0 = io.gpio2;
+    let touch_pin1 = io.gpio4;
 
     let touch_cfg = Some(TouchConfig {
         measurement_duration: Some(0x2000),

--- a/examples/src/bin/touch.rs
+++ b/examples/src/bin/touch.rs
@@ -17,7 +17,7 @@ use critical_section::Mutex;
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    gpio::{GpioPin, Io},
+    gpio::GpioPin,
     macros::ram,
     prelude::*,
     rtc_cntl::Rtc,

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -26,7 +26,6 @@ const IS_FIRST_SENDER: bool = true;
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     prelude::*,
     twai::{self, filter::SingleStandardFilter, EspTwaiFrame, StandardId, TwaiMode},
 };
@@ -37,10 +36,10 @@ use nb::block;
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let can_tx_pin = io.pins.gpio0;
-    let can_rx_pin = io.pins.gpio2;
+    let can_tx_pin = io.gpio0;
+    let can_rx_pin = io.gpio2;
 
     // The speed of the CAN bus.
     const CAN_BAUDRATE: twai::BaudRate = twai::BaudRate::B1000K;

--- a/examples/src/bin/ulp_riscv_core_basic.rs
+++ b/examples/src/bin/ulp_riscv_core_basic.rs
@@ -12,11 +12,7 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{
-    gpio::{rtc_io::*, Io},
-    prelude::*,
-    ulp_core,
-};
+use esp_hal::{gpio::rtc_io::*, prelude::*, ulp_core};
 use esp_println::{print, println};
 
 #[entry]

--- a/examples/src/bin/ulp_riscv_core_basic.rs
+++ b/examples/src/bin/ulp_riscv_core_basic.rs
@@ -23,8 +23,8 @@ use esp_println::{print, println};
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-    let pin = LowPowerOutput::new(io.pins.gpio1);
+    let io = peripherals.GPIO.pins();
+    let pin = LowPowerOutput::new(io.gpio1);
 
     let mut ulp_core = ulp_core::UlpCore::new(peripherals.ULP_RISCV_CORE);
 

--- a/examples/src/bin/usb_serial.rs
+++ b/examples/src/bin/usb_serial.rs
@@ -15,7 +15,6 @@ use core::ptr::addr_of_mut;
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Io,
     otg_fs::{Usb, UsbBus},
     prelude::*,
 };
@@ -28,9 +27,9 @@ static mut EP_MEMORY: [u32; 1024] = [0; 1024];
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
-    let usb = Usb::new(peripherals.USB0, io.pins.gpio20, io.pins.gpio19);
+    let usb = Usb::new(peripherals.USB0, io.gpio20, io.gpio19);
     let usb_bus = UsbBus::new(usb, unsafe { &mut *addr_of_mut!(EP_MEMORY) });
 
     let mut serial = SerialPort::new(&usb_bus);

--- a/examples/src/bin/wifi_ble.rs
+++ b/examples/src/bin/wifi_ble.rs
@@ -25,7 +25,7 @@ use bleps::{
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{Input, Io, Pull},
+    gpio::{Input, Pull},
     prelude::*,
     rng::Rng,
     timer::timg::TimerGroup,
@@ -54,13 +54,13 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
-            let button = Input::new(io.pins.gpio0, Pull::Down);
+            let button = Input::new(io.gpio0, Pull::Down);
         } else {
-            let button = Input::new(io.pins.gpio9, Pull::Down);
+            let button = Input::new(io.gpio9, Pull::Down);
         }
     }
 

--- a/examples/src/bin/wifi_embassy_ble.rs
+++ b/examples/src/bin/wifi_embassy_ble.rs
@@ -28,7 +28,7 @@ use embassy_executor::Spawner;
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::{Input, Io, Pull},
+    gpio::{Input, Pull},
     prelude::*,
     rng::Rng,
     timer::timg::TimerGroup,
@@ -57,12 +57,12 @@ async fn main(_spawner: Spawner) -> ! {
     )
     .unwrap();
 
-    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = peripherals.GPIO.pins();
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
-            let button = Input::new(io.pins.gpio0, Pull::Down);
+            let button = Input::new(io.gpio0, Pull::Down);
         } else {
-            let button = Input::new(io.pins.gpio9, Pull::Down);
+            let button = Input::new(io.gpio9, Pull::Down);
         }
     }
 

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -29,17 +29,17 @@ macro_rules! i2c_pins {
         // Order: (SDA, SCL)
         cfg_if::cfg_if! {
             if #[cfg(any(esp32s2, esp32s3))] {
-                ($io.pins.gpio2, $io.pins.gpio3)
+                ($io.gpio2, $io.gpio3)
             } else if #[cfg(esp32)] {
-                ($io.pins.gpio32, $io.pins.gpio33)
+                ($io.gpio32, $io.gpio33)
             } else if #[cfg(esp32c6)] {
-                ($io.pins.gpio6, $io.pins.gpio7)
+                ($io.gpio6, $io.gpio7)
             } else if #[cfg(esp32h2)] {
-                ($io.pins.gpio12, $io.pins.gpio22)
+                ($io.gpio12, $io.gpio22)
             } else if #[cfg(esp32c2)] {
-                ($io.pins.gpio18, $io.pins.gpio9)
+                ($io.gpio18, $io.gpio9)
             } else {
-                ($io.pins.gpio4, $io.pins.gpio5)
+                ($io.gpio4, $io.gpio5)
             }
         }
     }};
@@ -50,13 +50,13 @@ macro_rules! common_test_pins {
     ($io:expr) => {{
         cfg_if::cfg_if! {
             if #[cfg(any(esp32s2, esp32s3))] {
-                ($io.pins.gpio9, $io.pins.gpio10)
+                ($io.gpio9, $io.gpio10)
             }
             else if #[cfg(esp32)] {
-                ($io.pins.gpio26, $io.pins.gpio27)
+                ($io.gpio26, $io.gpio27)
             }
             else {
-                ($io.pins.gpio2, $io.pins.gpio3)
+                ($io.gpio2, $io.gpio3)
             }
         }
     }};

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -11,7 +11,7 @@ use core::cell::RefCell;
 use critical_section::Mutex;
 use esp_hal::{
     delay::Delay,
-    gpio::{AnyPin, Input, Io, Level, Output, Pin, Pull},
+    gpio::{AnyPin, Input, Level, Output, Pin, Pull},
     macros::handler,
     timer::timg::TimerGroup,
     InterruptConfigurable,
@@ -52,8 +52,7 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        io.set_interrupt_handler(interrupt_handler);
+        let io = peripherals.GPIO.pins();
 
         let delay = Delay::new();
 
@@ -143,6 +142,8 @@ mod tests {
     #[test]
     fn test_gpio_interrupt(ctx: Context) {
         let mut test_gpio1 = Input::new(ctx.test_gpio1, Pull::Down);
+        test_gpio1.set_interrupt_handler(interrupt_handler);
+
         let mut test_gpio2 = Output::new(ctx.test_gpio2, Level::Low);
 
         critical_section::with(|cs| {

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -5,7 +5,7 @@
 #![no_std]
 #![no_main]
 
-use esp_hal::{gpio::Io, i2c::I2C, peripherals::I2C0, prelude::*, Blocking};
+use esp_hal::{i2c::I2C, peripherals::I2C0, prelude::*, Blocking};
 use hil_test as _;
 
 struct Context {
@@ -21,7 +21,7 @@ mod tests {
     #[init]
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (sda, scl) = hil_test::i2c_pins!(io);
 

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -12,7 +12,7 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::{Io, NoPin},
+    gpio::NoPin,
     i2s::{DataFormat, I2s, I2sReadDma, I2sWriteDma, Standard},
     prelude::*,
 };
@@ -52,7 +52,7 @@ mod tests {
     fn test_i2s_loopback() {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let delay = Delay::new();
 

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -11,7 +11,7 @@
 
 use esp_hal::{
     dma::{Dma, DmaPriority},
-    gpio::{Io, NoPin},
+    gpio::NoPin,
     i2s::{asynch::*, DataFormat, I2s, I2sTx, Standard},
     peripherals::I2S0,
     prelude::*,
@@ -95,7 +95,7 @@ mod tests {
 
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let dma = Dma::new(peripherals.DMA);
 

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -7,7 +7,7 @@
 
 use esp_hal::{
     delay::Delay,
-    gpio::{AnyPin, Input, Io, Level, Output, Pin, Pull},
+    gpio::{AnyPin, Input, Level, Output, Pin, Pull},
     pcnt::{channel::EdgeMode, Pcnt},
 };
 use hil_test as _;
@@ -28,7 +28,7 @@ mod tests {
     fn init() -> Context<'static> {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (din, dout) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/qspi_read.rs
+++ b/hil-test/tests/qspi_read.rs
@@ -8,7 +8,7 @@
 use esp_hal::{
     dma::{Channel, Dma, DmaPriority, DmaRxBuf},
     dma_buffers,
-    gpio::{AnyPin, Io, Level, NoPin, Output},
+    gpio::{AnyPin, Level, NoPin, Output},
     prelude::*,
     spi::{
         master::{Address, Command, Spi, SpiDma},
@@ -92,7 +92,7 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (miso, miso_mirror) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/qspi_write.rs
+++ b/hil-test/tests/qspi_write.rs
@@ -8,7 +8,7 @@
 use esp_hal::{
     dma::{Channel, Dma, DmaPriority, DmaTxBuf},
     dma_buffers,
-    gpio::{interconnect::InputSignal, AnyPin, Io, NoPin},
+    gpio::{interconnect::InputSignal, AnyPin, NoPin},
     pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     prelude::*,
     spi::{
@@ -97,7 +97,7 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (mosi, _) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/qspi_write_read.rs
+++ b/hil-test/tests/qspi_write_read.rs
@@ -10,7 +10,7 @@
 use esp_hal::{
     dma::{Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{AnyPin, Io, Level, NoPin, Output},
+    gpio::{AnyPin, Level, NoPin, Output},
     prelude::*,
     spi::{
         master::{Address, Command, Spi, SpiDma},
@@ -94,7 +94,7 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (mosi, mosi_mirror) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -6,7 +6,6 @@
 #![no_main]
 
 use esp_hal::{
-    gpio::Io,
     prelude::*,
     rmt::{PulseCode, Rmt, RxChannel, RxChannelConfig, TxChannel, TxChannelConfig},
 };
@@ -25,7 +24,7 @@ mod tests {
     fn rmt_loopback() {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "esp32h2")] {

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -12,7 +12,6 @@ use esp_hal::{
     pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
 };
 use esp_hal::{
-    gpio::Io,
     peripherals::SPI2,
     prelude::*,
     spi::{master::Spi, FullDuplexMode, SpiMode},
@@ -38,9 +37,9 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
-        let sclk = io.pins.gpio0;
+        let sclk = io.gpio0;
         let (_, mosi) = hil_test::common_test_pins!(io);
 
         let mosi_loopback = mosi.peripheral_input();

--- a/hil-test/tests/spi_full_duplex_dma.rs
+++ b/hil-test/tests/spi_full_duplex_dma.rs
@@ -8,7 +8,6 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::Io,
     peripherals::SPI2,
     prelude::*,
     spi::{
@@ -46,8 +45,8 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let sclk = io.pins.gpio0;
+        let io = peripherals.GPIO.pins();
+        let sclk = io.gpio0;
         let (_, mosi) = hil_test::common_test_pins!(io);
 
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/spi_full_duplex_dma_async.rs
+++ b/hil-test/tests/spi_full_duplex_dma_async.rs
@@ -10,7 +10,7 @@ use embedded_hal_async::spi::SpiBus;
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{interconnect::InputSignal, Io},
+    gpio::interconnect::InputSignal,
     pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     peripherals::SPI2,
     prelude::*,
@@ -53,9 +53,9 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
         let pcnt = Pcnt::new(peripherals.PCNT);
-        let sclk = io.pins.gpio0;
+        let sclk = io.gpio0;
 
         let (_, mosi) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -8,7 +8,7 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{interconnect::InputSignal, Io},
+    gpio::interconnect::InputSignal,
     pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     peripherals::SPI2,
     prelude::*,
@@ -49,8 +49,8 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let sclk = io.pins.gpio0;
+        let io = peripherals.GPIO.pins();
+        let sclk = io.gpio0;
         let (_, mosi) = hil_test::common_test_pins!(io);
 
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/spi_full_duplex_dma_write_read.rs
+++ b/hil-test/tests/spi_full_duplex_dma_write_read.rs
@@ -11,7 +11,6 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::Io,
     peripherals::SPI2,
     prelude::*,
     spi::{
@@ -50,8 +49,8 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let sclk = io.pins.gpio0;
+        let io = peripherals.GPIO.pins();
+        let sclk = io.gpio0;
         let (miso, gpio) = hil_test::common_test_pins!(io);
         let _gpio = Output::new(gpio, Level::High);
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -8,7 +8,7 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{Io, Level, Output},
+    gpio::{Level, Output},
     peripherals::SPI2,
     prelude::*,
     spi::{
@@ -48,8 +48,8 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let sclk = io.pins.gpio0;
+        let io = peripherals.GPIO.pins();
+        let sclk = io.gpio0;
         let (miso, miso_mirror) = hil_test::common_test_pins!(io);
 
         let miso_mirror = Output::new(miso_mirror, Level::High);

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -8,7 +8,7 @@
 use esp_hal::{
     dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
-    gpio::{interconnect::InputSignal, Io},
+    gpio::interconnect::InputSignal,
     pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     peripherals::SPI2,
     prelude::*,
@@ -53,8 +53,8 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
-        let sclk = io.pins.gpio0;
+        let io = peripherals.GPIO.pins();
+        let sclk = io.gpio0;
         let (mosi, _) = hil_test::common_test_pins!(io);
 
         let pcnt = Pcnt::new(peripherals.PCNT);

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -7,7 +7,6 @@
 
 use embedded_hal_02::can::Frame;
 use esp_hal::{
-    gpio::Io,
     peripherals::TWAI0,
     prelude::*,
     twai::{self, filter::SingleStandardFilter, EspTwaiFrame, StandardId, TwaiMode},
@@ -31,7 +30,7 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (can_tx_pin, can_rx_pin) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -7,7 +7,6 @@
 
 use embedded_hal_02::serial::{Read, Write};
 use esp_hal::{
-    gpio::Io,
     peripherals::UART1,
     prelude::*,
     uart::{ClockSource, Uart},
@@ -31,7 +30,7 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (rx, tx) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -6,7 +6,7 @@
 #![no_std]
 #![no_main]
 
-use esp_hal::{gpio::Io, peripherals::UART0, uart::Uart, Async};
+use esp_hal::{peripherals::UART0, uart::Uart, Async};
 use hil_test as _;
 
 struct Context {
@@ -24,7 +24,7 @@ mod tests {
     async fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (rx, tx) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -6,7 +6,6 @@
 #![no_main]
 
 use esp_hal::{
-    gpio::Io,
     peripherals::{UART0, UART1},
     prelude::*,
     uart::{UartRx, UartTx},
@@ -31,7 +30,7 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (rx, tx) = hil_test::common_test_pins!(io);
 

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -7,7 +7,6 @@
 #![no_main]
 
 use esp_hal::{
-    gpio::Io,
     peripherals::{UART0, UART1},
     uart::{UartRx, UartTx},
     Async,
@@ -30,7 +29,7 @@ mod tests {
     async fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        let io = peripherals.GPIO.pins();
 
         let (rx, tx) = hil_test::common_test_pins!(io);
 


### PR DESCRIPTION
Second attempt at this.

We now register interrupt handlers on-demand. Surprising behaviour may be:

- The GPIO interrupts are handled at the maximum configured level. This is probably the point I have the most issues with.
- Calling `async` functions overwrite any configured interrupt handlers. As an alternative, we could try restoring the handler, keeping both handlers in parallel and re-enabling the IRQ, or simply panicking if a user handler is set. I'm undecided, but "replace and keep working" is as equally valid a strategy as any.
- There is no way to *globally* replace the IRQ handler using runtime binding. I don't find this a big negative.

All documentation is missing because it wasn't necessary to demonstrate the idea.

cc #2009