### PR TITLE
Fix pin collision in I2S tests

### DIFF
--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -12,9 +12,8 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::Io,
+    gpio::{DummyPin, Io},
     i2s::{DataFormat, I2s, I2sReadDma, I2sWriteDma, Standard},
-    peripheral::Peripheral,
     prelude::*,
 };
 use hil_test as _;
@@ -76,15 +75,15 @@ mod tests {
 
         let mut i2s_tx = i2s
             .i2s_tx
-            .with_bclk(unsafe { io.pins.gpio0.clone_unchecked() })
-            .with_ws(unsafe { io.pins.gpio1.clone_unchecked() })
+            .with_bclk(DummyPin::new())
+            .with_ws(DummyPin::new())
             .with_dout(dout)
             .build();
 
         let mut i2s_rx = i2s
             .i2s_rx
-            .with_bclk(io.pins.gpio0)
-            .with_ws(io.pins.gpio1)
+            .with_bclk(DummyPin::new())
+            .with_ws(DummyPin::new())
             .with_din(din)
             .build();
 

--- a/hil-test/tests/i2s_async.rs
+++ b/hil-test/tests/i2s_async.rs
@@ -11,9 +11,8 @@
 
 use esp_hal::{
     dma::{Dma, DmaPriority},
-    gpio::Io,
+    gpio::{DummyPin, Io},
     i2s::{asynch::*, DataFormat, I2s, I2sTx, Standard},
-    peripheral::Peripheral,
     peripherals::I2S0,
     prelude::*,
     Async,
@@ -125,15 +124,15 @@ mod tests {
 
         let i2s_tx = i2s
             .i2s_tx
-            .with_bclk(unsafe { io.pins.gpio0.clone_unchecked() })
-            .with_ws(unsafe { io.pins.gpio1.clone_unchecked() })
+            .with_bclk(DummyPin::new())
+            .with_ws(DummyPin::new())
             .with_dout(dout)
             .build();
 
         let i2s_rx = i2s
             .i2s_rx
-            .with_bclk(io.pins.gpio0)
-            .with_ws(io.pins.gpio1)
+            .with_bclk(DummyPin::new())
+            .with_ws(DummyPin::new())
             .with_din(din)
             .build();
 


### PR DESCRIPTION
We probably don't want to connect output signals and HIL seems fine with the change, too.