### PR TITLE
Add esp-alloc to trouble ble example

### DIFF
--- a/examples/src/bin/wifi_embassy_trouble.rs
+++ b/examples/src/bin/wifi_embassy_trouble.rs
@@ -25,7 +25,10 @@ use static_cell::StaticCell;
 use trouble_host::{
     advertise::{AdStructure, Advertisement, BR_EDR_NOT_SUPPORTED, LE_GENERAL_DISCOVERABLE},
     attribute::{AttributeTable, CharacteristicProp, Service, Uuid},
-    Address, BleHost, BleHostResources, PacketQos,
+    Address,
+    BleHost,
+    BleHostResources,
+    PacketQos,
 };
 
 #[esp_hal_embassy::main]

--- a/examples/src/bin/wifi_embassy_trouble.rs
+++ b/examples/src/bin/wifi_embassy_trouble.rs
@@ -16,6 +16,7 @@ use embassy_executor::Spawner;
 use embassy_futures::join::join3;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::{Duration, Timer};
+use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{prelude::*, timer::timg::TimerGroup};
 use esp_wifi::ble::controller::asynch::BleConnector;
@@ -24,10 +25,7 @@ use static_cell::StaticCell;
 use trouble_host::{
     advertise::{AdStructure, Advertisement, BR_EDR_NOT_SUPPORTED, LE_GENERAL_DISCOVERABLE},
     attribute::{AttributeTable, CharacteristicProp, Service, Uuid},
-    Address,
-    BleHost,
-    BleHostResources,
-    PacketQos,
+    Address, BleHost, BleHostResources, PacketQos,
 };
 
 #[esp_hal_embassy::main]
@@ -38,6 +36,9 @@ async fn main(_s: Spawner) {
         config.cpu_clock = CpuClock::max();
         config
     });
+
+    esp_alloc::heap_allocator!(72 * 1024);
+
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
     let init = esp_wifi::initialize(


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [+ ] I have updated existing examples or added new ones (if applicable).
- [+ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [+ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [+ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

After https://github.com/esp-rs/esp-hal/pull/2099 we need to explicitly setup heap for esp-wifi crate. The `wifi_embassy_ble.rs` example was updated, but the `wifi_embassy_trouble.rs`, which was introduces by another PR in the same day isn't updated yet. This small PR fixes the example so it's consistent with the other esp-wifi examples.