### PR TITLE
one typo; one misleading comment fixed

### DIFF
--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -49,7 +49,7 @@
 //!
 //! let mut systimer = SystemTimer::new(peripherals.SYSTIMER);
 //!
-//! // Get the current timestamp, in ticks of 16MHz (1/16 us):
+//! // Get the current tick count:
 //! let now = SystemTimer::now();
 //!
 //! let frozen_unit = FrozenUnit::new(&mut systimer.unit0);

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -49,7 +49,7 @@
 //!
 //! let mut systimer = SystemTimer::new(peripherals.SYSTIMER);
 //!
-//! // Get the current timestamp, in microseconds:
+//! // Get the current timestamp, in ticks of 16MHz (1/16 us):
 //! let now = SystemTimer::now();
 //!
 //! let frozen_unit = FrozenUnit::new(&mut systimer.unit0);

--- a/examples/src/bin/i2c_display.rs
+++ b/examples/src/bin/i2c_display.rs
@@ -53,7 +53,7 @@ fn main() -> ! {
         .build();
 
     loop {
-        // Fill display bufffer with a centered text with two lines (and two text
+        // Fill display buffer with a centered text with two lines (and two text
         // styles)
         Text::with_alignment(
             "esp-hal",


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝

- [x] I have updated existing examples or added new ones (if applicable).
- [~] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [-] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [-] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

*They are just 2 comment changes*

#### Extra:

- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Two unrelated lines, where I've noticed a typo, or an inconsistency. I've noticed good progress in simplifying the pins usage, and decided now is a nice time to let you know about these. 

#### Testing

>Describe how you tested your changes.

No testing, since only comments involved.