### PR TITLE
Slight timer cleanup

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -272,7 +272,7 @@ extern "C" fn EspDefaultHandler(_interrupt: peripherals::Interrupt) {
     );
 }
 
-/// A marker trait for intializing drivers in a specific mode.
+/// A marker trait for initializing drivers in a specific mode.
 pub trait Mode: crate::private::Sealed {}
 
 /// Driver initialized in blocking mode.
@@ -766,9 +766,9 @@ pub fn init(config: Config) -> Peripherals {
     rtc.rwdt.disable();
 
     unsafe {
-        crate::timer::timg::Wdt::<self::peripherals::TIMG0, Blocking>::set_wdt_enabled(false);
+        crate::timer::timg::Wdt::<self::peripherals::TIMG0>::set_wdt_enabled(false);
         #[cfg(timg1)]
-        crate::timer::timg::Wdt::<self::peripherals::TIMG1, Blocking>::set_wdt_enabled(false);
+        crate::timer::timg::Wdt::<self::peripherals::TIMG1>::set_wdt_enabled(false);
     }
 
     Clocks::init(config.cpu_clock);


### PR DESCRIPTION
- WDT has no async interface, no need to have a mode parameter
  - I'm slightly confused by the idea of an `async` WDT driver. If we want to allow using it as a general purpose one-shot timer, we should expose an async API using OneShotTimer.
- Only have a single function declaration, use cfg-if in implementation
  - This might just be personal preference but I'd keep `#[cfg(...)]` on a function for cases where a function may not even be defined for a certain MCU.
- Fix typo
- Avoid `#[inline(always)]` on configuration functions
  - The compiler will take care of inlining decisions anyway, and config functions are rarely hot enough to justify the code size cost
- Add `TG::wdt_interrupt` to avoid an unnecessary match statement