### PR TITLE
Fix double writes

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix i2c embedded-hal transaction (#2028)
 - Fix SPI DMA alternating `write` and `read` for ESP32 and ESP32-S2 (#2131)
 - Fix I2C ending up in a state when only re-creating the peripheral makes it useable again (#2141)
+- Fix `SpiBus::transfer` transferring data twice in some cases (#2159)
 
 ### Removed
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2163,6 +2163,8 @@ mod ehal1 {
                     break;
                 }
 
+                // No need to flush here, `SpiBus::write` will do it for us
+
                 if write_to < read_to {
                     // Read more than we write, must pad writing part with zeros
                     let mut empty = [EMPTY_WRITE_PAD; FIFO_SIZE];
@@ -2172,9 +2174,8 @@ mod ehal1 {
                     SpiBus::write(self, &write[write_from..write_to])?;
                 }
 
-                SpiBus::flush(self)?;
-
                 if read_inc > 0 {
+                    SpiBus::flush(self)?;
                     self.spi
                         .read_bytes_from_fifo(&mut read[read_from..read_to])?;
                 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2143,9 +2143,9 @@ mod ehal1 {
         fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
             // Optimizations
             if read.is_empty() {
-                SpiBus::write(self, write)?;
+                return SpiBus::write(self, write);
             } else if write.is_empty() {
-                SpiBus::read(self, read)?;
+                return SpiBus::read(self, read);
             }
 
             let mut write_from = 0;

--- a/hil-test/tests/spi_full_duplex_dma_pcnt.rs
+++ b/hil-test/tests/spi_full_duplex_dma_pcnt.rs
@@ -1,4 +1,4 @@
-//! SPI Full Duplex DMA ASYNC Test with PCNT readback.
+//! SPI Full Duplex DMA Test with PCNT readback.
 
 //% CHIPS: esp32 esp32c6 esp32h2 esp32s2 esp32s3
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

A rather silly bug caused by a missing `return`.
