### PR TITLE
Fix overflowing subtraction

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Feature `wifi-logs` doesn't break the build anymore (#2117)
+- Fixed a panic when overflow-checks are enabled (#2164)
 
 ### Removed
 

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -63,7 +63,7 @@ impl RawQueue {
     }
 
     fn enqueue(&mut self, item: *mut c_void) -> i32 {
-        if (self.current_write - self.current_read) % self.count < self.count {
+        if self.count() < self.count {
             unsafe {
                 let p = self.storage.byte_add(self.item_size * self.current_write);
                 p.copy_from(item as *mut u8, self.item_size);
@@ -77,7 +77,7 @@ impl RawQueue {
     }
 
     fn try_dequeue(&mut self, item: *mut c_void) -> bool {
-        if (self.current_write - self.current_read) % self.count > 0 {
+        if self.count() > 0 {
             unsafe {
                 let p = self.storage.byte_add(self.item_size * self.current_read) as *const c_void;
                 item.copy_from(p, self.item_size);
@@ -90,7 +90,11 @@ impl RawQueue {
     }
 
     fn count(&self) -> usize {
-        (self.current_write - self.current_read) % self.count
+        if self.current_write >= self.current_read {
+            self.current_write - self.current_read
+        } else {
+            self.count - self.current_read + self.current_write
+        }
     }
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This was most likely missed because the release profile disables overflow checks and the subtraction turns into a wrapping operation, but debug builds just crash.

#### Testing

Tried the patch in card-io-fw
