### PR TITLE
Be more clear about the `esp-alloc` feature in esp-wifi's migration g…

### DIFF
--- a/esp-wifi/MIGRATING-0.9.md
+++ b/esp-wifi/MIGRATING-0.9.md
@@ -40,7 +40,7 @@ You no longer have to set up clocks and pass them to `esp_wifi::initialize`.
 
 ## Memory allocation
 
-You now need to have a global allocator provided by `esp-alloc` providing allocations from internal memory
+By default the `esp-alloc` feature is enabled which means you need to have a global allocator provided by `esp-alloc` allowing allocations from internal memory
 
 ```diff
  #![no_std]
@@ -64,6 +64,9 @@ You now need to have a global allocator provided by `esp-alloc` providing alloca
 The size of the heap depends on what you are going to use esp-wifi for and if you are using the heap for your own allocations or not.
 
 E.g. when using `coex` you need around 92k. If not using `coex`, going lower than 72k you will observe some failed allocations but it might still work. Going even lower will make things fail.
+
+If you see linker errors regarding undefined symbols for `esp_wifi_free_internal_heap` and `esp_wifi_allocate_from_internal_ram` you either want to opt-in to use the `esp-alloc` feature 
+or provide your own allocator (see below)
 
 ### Using your own allocator
 


### PR DESCRIPTION
…uide

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Just some clarification in esp-wifi's migration guide

#### Testing
n/a
