### PR TITLE
Fix UART when using RcFast clock source

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix SPI DMA alternating `write` and `read` for ESP32 and ESP32-S2 (#2131)
 - Fix I2C ending up in a state when only re-creating the peripheral makes it useable again (#2141)
 - Fix `SpiBus::transfer` transferring data twice in some cases (#2159)
+- Fixed UART freezing when using `RcFast` clock source on ESP32-C2/C3 (#2170)
 
 ### Removed
 

--- a/esp-hal/src/rtc_cntl/rtc/esp32c2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c2.rs
@@ -55,6 +55,15 @@ pub(crate) fn init() {
 }
 
 pub(crate) fn configure_clock() {
+    unsafe {
+        // from esp_clk_init:
+        let rtc_cntl = &*esp32c2::RTC_CNTL::ptr();
+        // clk_ll_rc_fast_enable();
+        rtc_cntl.clk_conf().modify(|_, w| w.enb_ck8m().clear_bit());
+        rtc_cntl.timer1().modify(|_, w| w.ck8m_wait().bits(5));
+        // esp_rom_delay_us(SOC_DELAY_RC_FAST_ENABLE);
+        crate::rom::ets_delay_us(50);
+    }
     RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
 
     let cal_val = loop {

--- a/esp-hal/src/rtc_cntl/rtc/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c3.rs
@@ -91,6 +91,15 @@ pub(crate) fn configure_clock() {
         XtalClock::RtcXtalFreq40M
     ));
 
+    unsafe {
+        // from esp_clk_init:
+        let rtc_cntl = &*esp32c3::RTC_CNTL::ptr();
+        // clk_ll_rc_fast_enable();
+        rtc_cntl.clk_conf().modify(|_, w| w.enb_ck8m().clear_bit());
+        rtc_cntl.timer1().modify(|_, w| w.ck8m_wait().bits(5));
+        // esp_rom_delay_us(SOC_DELAY_RC_FAST_ENABLE);
+        crate::rom::ets_delay_us(50);
+    }
     RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
 
     let cal_val = loop {

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -81,47 +81,23 @@ mod tests {
         // send/receive with some other common baud rates to ensure this is
         // working as expected. We will also using different clock sources
         // while we're at it.
+        let configs = [
+            #[cfg(not(any(esp32, esp32s2, esp32c3, esp32c2)))]
+            (9600, ClockSource::RcFast),
+            #[cfg(not(any(esp32, esp32s2)))]
+            (19_200, ClockSource::Xtal),
+            #[cfg(esp32s2)]
+            (9600, ClockSource::RefTick),
+            (921_600, ClockSource::Apb),
+        ];
 
-        #[cfg(not(feature = "esp32s2"))]
-        {
-            #[cfg(not(any(feature = "esp32", feature = "esp32c3", feature = "esp32c2")))]
-            {
-                // 9600 baud, RC FAST clock source:
-                ctx.uart.change_baud(9600, ClockSource::RcFast);
-                ctx.uart.write(7).ok();
-                let read = block!(ctx.uart.read());
-                assert_eq!(read, Ok(7));
-            }
-
-            // 19,200 baud, XTAL clock source:
-            #[cfg(not(feature = "esp32"))]
-            {
-                ctx.uart.change_baud(19_200, ClockSource::Xtal);
-                ctx.uart.write(55).ok();
-                let read = block!(ctx.uart.read());
-                assert_eq!(read, Ok(55));
-            }
-
-            // 921,600 baud, APB clock source:
-            ctx.uart.change_baud(921_600, ClockSource::Apb);
-            ctx.uart.write(253).ok();
+        let mut byte_to_write = 0xA5;
+        for (baud, clock_source) in &configs {
+            ctx.uart.change_baud(*baud, *clock_source);
+            ctx.uart.write(byte_to_write).ok();
             let read = block!(ctx.uart.read());
-            assert_eq!(read, Ok(253));
-        }
-
-        #[cfg(feature = "esp32s2")]
-        {
-            // 9600 baud, REF TICK clock source:
-            ctx.uart.change_baud(9600, ClockSource::RefTick);
-            ctx.uart.write(7).ok();
-            let read = block!(ctx.uart.read());
-            assert_eq!(read, Ok(7));
-
-            // 921,600 baud, APB clock source:
-            ctx.uart.change_baud(921_600, ClockSource::Apb);
-            ctx.uart.write(253).ok();
-            let read = block!(ctx.uart.read());
-            assert_eq!(read, Ok(253));
+            assert_eq!(read, Ok(byte_to_write));
+            byte_to_write = !byte_to_write;
         }
     }
 }

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -87,7 +87,7 @@ mod tests {
         // working as expected. We will also using different clock sources
         // while we're at it.
         let configs = [
-            #[cfg(not(any(esp32, esp32s2, esp32c3, esp32c2)))]
+            #[cfg(not(any(esp32, esp32s2)))]
             (9600, ClockSource::RcFast),
             #[cfg(not(any(esp32, esp32s2)))]
             (19_200, ClockSource::Xtal),

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -33,9 +33,14 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-        let (rx, tx) = hil_test::common_test_pins!(io);
+        let (_, pin) = hil_test::common_test_pins!(io);
 
-        let uart = Uart::new(peripherals.UART1, tx, rx).unwrap();
+        let uart = Uart::new(
+            peripherals.UART1,
+            pin.peripheral_input(),
+            pin.into_peripheral_output(),
+        )
+        .unwrap();
 
         Context { uart }
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The clock source was disabled, so after selecting it, nothing happened within the peripheral.

cc #1524

#### Testing

Locally run the HIL test on a C2