### PR TITLE
Fix known SPI issues

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `SpiBus::transfer` transferring data twice in some cases (#2159)
 - Fixed UART freezing when using `RcFast` clock source on ESP32-C2/C3 (#2170)
 - I2S: on ESP32 and ESP32-S2 data is now output to the right (WS=1) channel first. (#2194)
+- SPI: Fixed an issue where unexpected data was written outside of the read buffer (#2179)
+- SPI: Fixed an issue where `wait` has returned before the DMA has finished writing the memory (#2179)
+- SPI: Fixed an issue where repeated calls to `dma_transfer` may end up looping indefinitely (#2179)
+- SPI: Fixed an issue that prevented correctly reading the first byte in a transaction (#2179)
 
 ### Removed
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -205,6 +205,7 @@ where
 bitfield::bitfield! {
     #[doc(hidden)]
     #[derive(Clone, Copy)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct DmaDescriptorFlags(u32);
 
     u16;
@@ -227,6 +228,7 @@ impl Debug for DmaDescriptorFlags {
 
 /// A DMA transfer descriptor.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DmaDescriptor {
     pub(crate) flags: DmaDescriptorFlags,
     pub(crate) buffer: *mut u8,

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -103,7 +103,7 @@ pub(crate) fn get_io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
             37 => transmute::<&'static io_mux::GPIO37, &'static io_mux::GPIO0>(iomux.gpio37()),
             38 => transmute::<&'static io_mux::GPIO38, &'static io_mux::GPIO0>(iomux.gpio38()),
             39 => transmute::<&'static io_mux::GPIO39, &'static io_mux::GPIO0>(iomux.gpio39()),
-            _ => panic!(),
+            other => panic!("GPIO {} does not exist", other),
         }
     }
 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1153,8 +1153,10 @@ mod dma {
         ///
         /// This method blocks until the transfer is finished and returns the
         /// `SpiDma` instance and the associated buffer.
-        pub fn wait(mut self) -> (SpiDma<'d, T, C, D, M>, Buf) {
-            self.spi_dma.spi.flush().ok();
+        pub fn wait(self) -> (SpiDma<'d, T, C, D, M>, Buf) {
+            while !self.is_done() {
+                // Wait for the transfer to complete
+            }
             fence(Ordering::Acquire);
             (self.spi_dma, self.dma_buf)
         }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -109,9 +109,8 @@ const FIFO_SIZE: usize = 64;
 const FIFO_SIZE: usize = 72;
 
 /// Padding byte for empty write transfers
-const EMPTY_WRITE_PAD: u8 = 0x00u8;
+const EMPTY_WRITE_PAD: u8 = 0x00;
 
-#[allow(unused)]
 const MAX_DMA_SIZE: usize = 32736;
 
 /// SPI commands, each consisting of a 16-bit command value and a data mode.
@@ -490,7 +489,7 @@ impl<'d, T> Spi<'d, T, FullDuplexMode>
 where
     T: Instance,
 {
-    /// Read bytes from SPI.
+    /// Read a byte from SPI.
     ///
     /// Sends out a stuffing byte for every byte to read. This function doesn't
     /// perform flushing. If you want to read the response to something you

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_symmetric_dma_transfer(ctx: Context) {
-        // This test case sends a large amount of data, twice, to verify that
+        // This test case sends a large amount of data, multiple times to verify that
         // https://github.com/esp-rs/esp-hal/issues/2151 is and remains fixed.
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
         let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
@@ -274,7 +274,11 @@ mod tests {
                 .unwrap();
 
             (spi, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
-            assert_eq!(dma_tx_buf.as_slice(), dma_rx_buf.as_slice());
+            if dma_tx_buf.as_slice() != dma_rx_buf.as_slice() {
+                defmt::info!("dma_tx_buf: {:?}", dma_tx_buf.as_slice()[0..100]);
+                defmt::info!("dma_rx_buf: {:?}", dma_rx_buf.as_slice()[0..100]);
+                panic!("Mismatch at iteration {}", i);
+            }
         }
     }
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -253,7 +253,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(esp32))]
     fn test_symmetric_dma_transfer(ctx: Context) {
         // This test case sends a large amount of data, twice, to verify that
         // https://github.com/esp-rs/esp-hal/issues/2151 is and remains fixed.
@@ -284,7 +283,6 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    #[cfg(not(feature = "esp32s2"))]
     fn test_asymmetric_dma_transfer(ctx: Context) {
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(2, 4);
         let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -306,7 +306,7 @@ mod tests {
             .map_err(|e| e.0)
             .unwrap();
         let (_, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
-            assert_eq!(dma_tx_buf.as_slice()[0..2], dma_rx_buf.as_slice()[0..2]);
+        assert_eq!(dma_tx_buf.as_slice()[0..2], dma_rx_buf.as_slice()[0..2]);
     }
 
     #[test]

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -294,8 +294,19 @@ mod tests {
             .dma_transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
+        let (spi, (dma_rx_buf, mut dma_tx_buf)) = transfer.wait();
+        assert_eq!(dma_tx_buf.as_slice()[0..2], dma_rx_buf.as_slice()[0..2]);
+
+        // Try transfer again to make sure DMA isn't in a broken state.
+
+        dma_tx_buf.fill(&[0xaa, 0xdd, 0xef, 0xbe]);
+
+        let transfer = spi
+            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
         let (_, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
-        assert_eq!(dma_tx_buf.as_slice()[0..1], dma_rx_buf.as_slice()[0..1]);
+            assert_eq!(dma_tx_buf.as_slice()[0..2], dma_rx_buf.as_slice()[0..2]);
     }
 
     #[test]

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -27,10 +27,7 @@ use esp_hal::{
 use hil_test as _;
 
 cfg_if::cfg_if! {
-    if #[cfg(any(
-        feature = "esp32",
-        feature = "esp32s2",
-    ))] {
+    if #[cfg(any(esp32, esp32s2))] {
         type DmaChannelCreator = esp_hal::dma::Spi2DmaChannelCreator;
     } else {
         type DmaChannelCreator = esp_hal::dma::ChannelCreator<0>;
@@ -64,7 +61,7 @@ mod tests {
         let dma = Dma::new(peripherals.DMA);
 
         cfg_if::cfg_if! {
-            if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+            if #[cfg(any(esp32, esp32s2))] {
                 let dma_channel = dma.spi2channel;
             } else {
                 let dma_channel = dma.channel0;

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -315,28 +315,6 @@ mod tests {
 
     #[test]
     #[timeout(3)]
-    fn test_symmetric_dma_transfer_huge_buffer(ctx: Context) {
-        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(4096);
-        let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
-        let mut dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
-
-        for (i, d) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
-            *d = i as _;
-        }
-
-        let spi = ctx
-            .spi
-            .with_dma(ctx.dma_channel.configure(false, DmaPriority::Priority0));
-        let transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        let (_, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
-        assert_eq!(dma_tx_buf.as_slice(), dma_rx_buf.as_slice());
-    }
-
-    #[test]
-    #[timeout(3)]
     fn test_dma_bus_symmetric_transfer(ctx: Context) {
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(4);
         let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Changes include:
- Guarantee 4-byte alignment which is needed for some reason for PDMA
- Use `is_done` in `wait` to actually wait for the DMA to finish transferring from SPI to memory. This prevents weird test failures where an assert fails, then prints that the buffer and the expected value match.
- Clear interrupts after configuring DMA, which fixes the second call to `dma_transfer`
- Reintroduces a short wait for ESP32, which doesn't have an update bit so it starts transferring data before the DMA engine is ready.

Fixes #2098
Fixes #2186

#### Testing

yes
