### PR TITLE
Pass --verify when running HIL tests

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -732,6 +732,8 @@ fn run_elfs(args: RunElfArgs) -> Result<()> {
             command.arg("--speed").arg("15000");
         };
 
+        command.arg("--verify");
+
         let mut command = command.spawn().context("Failed to execute probe-rs")?;
         let status = command
             .wait()


### PR DESCRIPTION
This change aims to at least detect cases when the test firmware is not correctly flashed. [example](https://github.com/esp-rs/esp-hal/actions/runs/10920797724/job/30311988092)