### PR TITLE
Enable I2S tests on ESP32 and work around first sample issue

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix I2C ending up in a state when only re-creating the peripheral makes it useable again (#2141)
 - Fix `SpiBus::transfer` transferring data twice in some cases (#2159)
 - Fixed UART freezing when using `RcFast` clock source on ESP32-C2/C3 (#2170)
+- I2S: on ESP32 and ESP32-S2 data is now output to the right (WS=1) channel first. (#2194)
 
 ### Removed
 

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -1137,8 +1137,9 @@ mod private {
                 // Short frame synchronization
                 w.tx_short_sync().bit(false);
                 w.rx_short_sync().bit(false);
-                w.tx_msb_right().clear_bit();
-                w.rx_msb_right().clear_bit();
+                // Send MSB to the right channel to be consistent with ESP32-S3 et al.
+                w.tx_msb_right().set_bit();
+                w.rx_msb_right().set_bit();
                 // ESP32 generates two clock pulses first. If the WS is low, those first clock
                 // pulses are indistinguishable from real data, which corrupts the first few
                 // samples. So we send the right channel first (which means WS is high during

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -1139,8 +1139,12 @@ mod private {
                 w.rx_short_sync().bit(false);
                 w.tx_msb_right().clear_bit();
                 w.rx_msb_right().clear_bit();
-                w.tx_right_first().clear_bit();
-                w.rx_right_first().clear_bit();
+                // ESP32 generates two clock pulses first. If the WS is low, those first clock
+                // pulses are indistinguishable from real data, which corrupts the first few
+                // samples. So we send the right channel first (which means WS is high during
+                // the first sample) to prevent this issue.
+                w.tx_right_first().set_bit();
+                w.rx_right_first().set_bit();
                 w.tx_mono().clear_bit();
                 w.rx_mono().clear_bit();
                 w.sig_loopback().clear_bit()

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -51,11 +51,9 @@ macro_rules! common_test_pins {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32s2, esp32s3))] {
                 ($io.pins.gpio9, $io.pins.gpio10)
-            }
-            else if #[cfg(esp32)] {
+            } else if #[cfg(esp32)] {
                 ($io.pins.gpio26, $io.pins.gpio27)
-            }
-            else {
+            } else {
                 ($io.pins.gpio2, $io.pins.gpio3)
             }
         }

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -3,7 +3,7 @@
 //! This test uses I2S TX to transmit known data to I2S RX (forced to slave mode
 //! with loopback mode enabled).
 
-//% CHIPS: esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue
 
 #![no_std]


### PR DESCRIPTION
Before, note that WS starts from low and corresponds to 18 instead of 16 clock pulses. Also note the order or halfwords (we generate 00, 05, 0A, 0F, 14, ... bytes, or 0500, 0F0A, 1914, ... halfwords)

![i2s-esp32-ws-low](https://github.com/user-attachments/assets/50015426-61ab-461b-8fd3-b91610507e63)

After, notice the 2 clock pulses before WS goes high:

![image](https://github.com/user-attachments/assets/b01cb1ea-b015-4e4a-bcc5-b59868ab4658)

As a comparison, the following capture is from an S3, demonstrating that we're outputting data a) to the same channel and b) we output channels in the flipped order.

![i2s-s3-correct](https://github.com/user-attachments/assets/75ff0741-f9e4-48d1-84ce-2175bbcd2bb7)
