### PR TITLE
Slight general cleanup, enable dma-macros test, allow using virtual mem2mem channel on c2

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- MSRV bump to 1.79 (#2156)
+
 ### Fixed
 
 ### Removed

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -2,7 +2,7 @@
 name         = "esp-hal-embassy"
 version      = "0.3.0"
 edition      = "2021"
-rust-version = "1.76.0"
+rust-version = "1.79.0"
 description  = "Embassy support for esp-hal"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"

--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -36,11 +36,8 @@ pub(super) struct EmbassyTimer {
     alarms: Mutex<[AlarmState; MAX_SUPPORTED_ALARM_COUNT]>,
 }
 
-#[allow(clippy::declare_interior_mutable_const)]
-const ALARM_STATE_NONE: AlarmState = AlarmState::new();
-
 embassy_time_driver::time_driver_impl!(static DRIVER: EmbassyTimer = EmbassyTimer {
-    alarms: Mutex::new([ALARM_STATE_NONE; MAX_SUPPORTED_ALARM_COUNT]),
+    alarms: Mutex::new([const { AlarmState::new() }; MAX_SUPPORTED_ALARM_COUNT]),
 });
 
 impl EmbassyTimer {

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -691,7 +691,7 @@ mod m2m {
         ///
         /// # Safety
         ///
-        /// You must insure that your not using DMA for the same peripheral and
+        /// You must ensure that your not using DMA for the same peripheral and
         /// that your the only one using the DmaPeripheral.
         pub unsafe fn new_unsafe(
             mut channel: Channel<'d, C, MODE>,

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -12,10 +12,6 @@
 //! GDMA peripheral can be initializes using the `new` function, which requires
 //! a DMA peripheral instance and a clock control reference.
 //!
-//! ## Usage
-//! This module implements DMA channels, such as `channel0`, `channel1` and so
-//! on. Each channel struct implements the `ChannelTypes` trait, which provides
-//! associated types for peripheral configuration.
 //! <em>PS: Note that the number of DMA channels is chip-specific.</em>
 
 use crate::{
@@ -28,12 +24,6 @@ use crate::{
 pub struct Channel<const N: u8> {}
 
 impl<const N: u8> crate::private::Sealed for Channel<N> {}
-
-#[doc(hidden)]
-#[non_exhaustive]
-pub struct ChannelInterruptBinder<const N: u8> {}
-
-impl<const N: u8> crate::private::Sealed for ChannelInterruptBinder<N> {}
 
 impl<const N: u8> Channel<N> {
     #[inline(always)]
@@ -102,10 +92,8 @@ impl<const N: u8> RegisterAccess for Channel<N> {
 
     fn set_out_burstmode(burst_mode: bool) {
         Self::ch().out_conf0().modify(|_, w| {
-            w.out_data_burst_en()
-                .bit(burst_mode)
-                .outdscr_burst_en()
-                .bit(burst_mode)
+            w.out_data_burst_en().bit(burst_mode);
+            w.outdscr_burst_en().bit(burst_mode)
         });
     }
 
@@ -222,10 +210,8 @@ impl<const N: u8> RegisterAccess for Channel<N> {
 
     fn set_in_burstmode(burst_mode: bool) {
         Self::ch().in_conf0().modify(|_, w| {
-            w.in_data_burst_en()
-                .bit(burst_mode)
-                .indscr_burst_en()
-                .bit(burst_mode)
+            w.in_data_burst_en().bit(burst_mode);
+            w.indscr_burst_en().bit(burst_mode)
         });
     }
 
@@ -422,12 +408,8 @@ pub struct ChannelTxImpl<const N: u8> {}
 
 use embassy_sync::waitqueue::AtomicWaker;
 
-#[allow(clippy::declare_interior_mutable_const)]
-const INIT: AtomicWaker = AtomicWaker::new();
-
-static TX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [INIT; CHANNEL_COUNT];
-
-static RX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [INIT; CHANNEL_COUNT];
+static TX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [const { AtomicWaker::new() }; CHANNEL_COUNT];
+static RX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [const { AtomicWaker::new() }; CHANNEL_COUNT];
 
 impl<const N: u8> crate::private::Sealed for ChannelTxImpl<N> {}
 
@@ -479,22 +461,7 @@ impl<const N: u8> LcdCamPeripheral for SuitablePeripheral<N> {}
 macro_rules! impl_channel {
     ($num: literal, $async_handler: path, $($interrupt: ident),* ) => {
         paste::paste! {
-            #[doc(hidden)]
-            pub type [<Channel $num>] = Channel<$num>;
-
-            #[doc(hidden)]
-            pub type [<Channel $num TxImpl>] = ChannelTxImpl<$num>;
-
-            #[doc(hidden)]
-            pub type [<Channel $num RxImpl>] = ChannelRxImpl<$num>;
-
-            #[doc(hidden)]
-            pub type [<ChannelCreator $num>] = ChannelCreator<$num>;
-
-            #[doc(hidden)]
-            pub type [<Channel $num InterruptBinder>] = ChannelInterruptBinder<$num>;
-
-            impl InterruptBinder for ChannelInterruptBinder<$num> {
+            impl ChannelTypes for Channel<$num> {
                 fn set_isr(handler: $crate::interrupt::InterruptHandler) {
                     let mut dma = unsafe { crate::peripherals::DMA::steal() };
                     $(
@@ -502,10 +469,6 @@ macro_rules! impl_channel {
                         $crate::interrupt::enable($crate::peripherals::Interrupt::$interrupt, handler.priority()).unwrap();
                     )*
                 }
-            }
-
-            impl ChannelTypes for Channel<$num> {
-                type Binder = ChannelInterruptBinder<$num>;
             }
 
             /// A description of a GDMA channel
@@ -559,7 +522,7 @@ macro_rules! impl_channel {
                     let mut rx_impl = ChannelRxImpl {};
                     rx_impl.init(burst_mode, priority);
 
-                    <Channel<$num> as ChannelTypes>::Binder::set_isr($async_handler);
+                    <Channel<$num> as ChannelTypes>::set_isr($async_handler);
 
                     crate::dma::Channel {
                         tx: ChannelTx::new(tx_impl, burst_mode),
@@ -593,7 +556,7 @@ cfg_if::cfg_if! {
         impl_channel!(2, super::asynch::interrupt::interrupt_handler_ch2, DMA_IN_CH2, DMA_OUT_CH2);
         impl_channel!(3, super::asynch::interrupt::interrupt_handler_ch3, DMA_IN_CH3, DMA_OUT_CH3);
         impl_channel!(4, super::asynch::interrupt::interrupt_handler_ch4, DMA_IN_CH4, DMA_OUT_CH4);
-  }
+    }
 }
 
 /// GDMA Peripheral

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -461,10 +461,13 @@ impl<const N: u8> PeripheralMarker for SuitablePeripheral<N> {}
 // with GDMA every channel can be used for any peripheral
 impl<const N: u8> SpiPeripheral for SuitablePeripheral<N> {}
 impl<const N: u8> Spi2Peripheral for SuitablePeripheral<N> {}
-#[cfg(esp32s3)]
+#[cfg(spi3)]
 impl<const N: u8> Spi3Peripheral for SuitablePeripheral<N> {}
+#[cfg(any(i2s0, i2s1))]
 impl<const N: u8> I2sPeripheral for SuitablePeripheral<N> {}
+#[cfg(i2s0)]
 impl<const N: u8> I2s0Peripheral for SuitablePeripheral<N> {}
+#[cfg(i2s1)]
 impl<const N: u8> I2s1Peripheral for SuitablePeripheral<N> {}
 #[cfg(parl_io)]
 impl<const N: u8> ParlIoPeripheral for SuitablePeripheral<N> {}

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -3292,6 +3292,7 @@ pub(crate) mod asynch {
             handle_interrupt::<Channel, ChannelRxImpl, ChannelTxImpl>();
         }
 
+        #[cfg(spi3)]
         #[handler(priority = crate::interrupt::Priority::max())]
         pub(crate) fn interrupt_handler_spi3_dma() {
             use crate::dma::pdma::{
@@ -3303,6 +3304,7 @@ pub(crate) mod asynch {
             handle_interrupt::<Channel, ChannelRxImpl, ChannelTxImpl>();
         }
 
+        #[cfg(i2s0)]
         #[handler(priority = crate::interrupt::Priority::max())]
         pub(crate) fn interrupt_handler_i2s0() {
             use crate::dma::pdma::{

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -641,7 +641,7 @@ pub enum DmaPeripheral {
     Spi2      = 0,
     #[cfg(any(pdma, esp32s3))]
     Spi3      = 1,
-    #[cfg(any(esp32c6, esp32h2))]
+    #[cfg(any(esp32c2, esp32c6, esp32h2))]
     Mem2Mem1  = 1,
     #[cfg(any(esp32c3, esp32c6, esp32h2, esp32s3))]
     Uhci0     = 2,

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1888,11 +1888,6 @@ pub trait RegisterAccess: crate::private::Sealed {
 
 #[doc(hidden)]
 pub trait ChannelTypes: crate::private::Sealed {
-    type Binder: InterruptBinder;
-}
-
-#[doc(hidden)]
-pub trait InterruptBinder: crate::private::Sealed {
     fn set_isr(handler: InterruptHandler);
 }
 
@@ -1918,7 +1913,7 @@ where
     ///
     /// Interrupts are not enabled at the peripheral level here.
     pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
-        <C::Channel as ChannelTypes>::Binder::set_isr(handler);
+        <C::Channel as ChannelTypes>::set_isr(handler);
     }
 
     /// Listen for the given interrupts
@@ -3213,65 +3208,39 @@ pub(crate) mod asynch {
     pub(crate) mod interrupt {
         use procmacros::handler;
 
-        use super::*;
+        pub(crate) fn interrupt_handler_ch<const CH: u8>() {
+            use crate::dma::gdma::{Channel, ChannelRxImpl, ChannelTxImpl};
+
+            super::handle_interrupt::<Channel<CH>, ChannelRxImpl<CH>, ChannelTxImpl<CH>>();
+        }
 
         #[handler(priority = crate::interrupt::Priority::max())]
         pub(crate) fn interrupt_handler_ch0() {
-            use crate::dma::gdma::{
-                Channel0 as Channel,
-                Channel0RxImpl as ChannelRxImpl,
-                Channel0TxImpl as ChannelTxImpl,
-            };
-
-            handle_interrupt::<Channel, ChannelRxImpl, ChannelTxImpl>();
+            interrupt_handler_ch::<0>();
         }
 
         #[cfg(not(esp32c2))]
         #[handler(priority = crate::interrupt::Priority::max())]
         pub(crate) fn interrupt_handler_ch1() {
-            use crate::dma::gdma::{
-                Channel1 as Channel,
-                Channel1RxImpl as ChannelRxImpl,
-                Channel1TxImpl as ChannelTxImpl,
-            };
-
-            handle_interrupt::<Channel, ChannelRxImpl, ChannelTxImpl>();
+            interrupt_handler_ch::<1>();
         }
 
         #[cfg(not(esp32c2))]
         #[handler(priority = crate::interrupt::Priority::max())]
         pub(crate) fn interrupt_handler_ch2() {
-            use crate::dma::gdma::{
-                Channel2 as Channel,
-                Channel2RxImpl as ChannelRxImpl,
-                Channel2TxImpl as ChannelTxImpl,
-            };
-
-            handle_interrupt::<Channel, ChannelRxImpl, ChannelTxImpl>();
+            interrupt_handler_ch::<2>();
         }
 
         #[cfg(esp32s3)]
         #[handler(priority = crate::interrupt::Priority::max())]
         pub(crate) fn interrupt_handler_ch3() {
-            use crate::dma::gdma::{
-                Channel3 as Channel,
-                Channel3RxImpl as ChannelRxImpl,
-                Channel3TxImpl as ChannelTxImpl,
-            };
-
-            handle_interrupt::<Channel, ChannelRxImpl, ChannelTxImpl>();
+            interrupt_handler_ch::<3>();
         }
 
         #[cfg(esp32s3)]
         #[handler(priority = crate::interrupt::Priority::max())]
         pub(crate) fn interrupt_handler_ch4() {
-            use crate::dma::gdma::{
-                Channel4 as Channel,
-                Channel4RxImpl as ChannelRxImpl,
-                Channel4TxImpl as ChannelTxImpl,
-            };
-
-            handle_interrupt::<Channel, ChannelRxImpl, ChannelTxImpl>();
+            interrupt_handler_ch::<4>();
         }
     }
 

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -854,7 +854,7 @@ impl PeripheralMarker for I2s1DmaSuitablePeripheral {}
 impl I2sPeripheral for I2s1DmaSuitablePeripheral {}
 impl I2s1Peripheral for I2s1DmaSuitablePeripheral {}
 
-#[cfg(esp32)]
+#[cfg(i2s1)]
 ImplI2sChannel!(1, "I2S1");
 
 /// DMA Peripheral
@@ -885,7 +885,7 @@ impl<'d> Dma<'d> {
             spi2channel: Spi2DmaChannelCreator {},
             spi3channel: Spi3DmaChannelCreator {},
             i2s0channel: I2s0DmaChannelCreator {},
-            #[cfg(esp32)]
+            #[cfg(i2s1)]
             i2s1channel: I2s1DmaChannelCreator {},
         }
     }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -91,12 +91,13 @@ pub mod rtc_io;
 
 /// Convenience constant for `Option::None` pin
 
-static USER_INTERRUPT_HANDLER: CFnPtr = CFnPtr::NULL;
+static USER_INTERRUPT_HANDLER: CFnPtr = CFnPtr::new();
 
 struct CFnPtr(AtomicPtr<()>);
 impl CFnPtr {
-    #[allow(clippy::declare_interior_mutable_const)]
-    pub const NULL: Self = Self(AtomicPtr::new(core::ptr::null_mut()));
+    pub const fn new() -> Self {
+        Self(AtomicPtr::new(core::ptr::null_mut()))
+    }
 
     pub fn store(&self, f: extern "C" fn()) {
         self.0.store(f as *mut (), Ordering::Relaxed);
@@ -2488,9 +2489,8 @@ mod asynch {
 
     use super::*;
 
-    #[allow(clippy::declare_interior_mutable_const)]
-    const NEW_AW: AtomicWaker = AtomicWaker::new();
-    pub(super) static PIN_WAKERS: [AtomicWaker; NUM_PINS] = [NEW_AW; NUM_PINS];
+    pub(super) static PIN_WAKERS: [AtomicWaker; NUM_PINS] =
+        [const { AtomicWaker::new() }; NUM_PINS];
 
     impl<'d, P> Flex<'d, P>
     where

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -533,23 +533,14 @@ mod asynch {
         task::{Context, Poll},
     };
 
-    use cfg_if::cfg_if;
     use embassy_sync::waitqueue::AtomicWaker;
     use embedded_hal::i2c::Operation;
     use procmacros::handler;
 
     use super::*;
 
-    cfg_if! {
-        if #[cfg(all(i2c0, i2c1))] {
-            const NUM_I2C: usize = 2;
-        } else if #[cfg(i2c0)] {
-            const NUM_I2C: usize = 1;
-        }
-    }
-    #[allow(clippy::declare_interior_mutable_const)]
-    const INIT: AtomicWaker = AtomicWaker::new();
-    static WAKERS: [AtomicWaker; NUM_I2C] = [INIT; NUM_I2C];
+    const NUM_I2C: usize = 1 + cfg!(i2c1) as usize;
+    static WAKERS: [AtomicWaker; NUM_I2C] = [const { AtomicWaker::new() }; NUM_I2C];
 
     #[cfg_attr(esp32, allow(dead_code))]
     pub(crate) enum Event {

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -84,7 +84,7 @@ use core::marker::PhantomData;
 use enumset::{EnumSet, EnumSetType};
 use private::*;
 
-#[cfg(any(esp32, esp32s3))]
+#[cfg(i2s1)]
 use crate::dma::I2s1Peripheral;
 use crate::{
     dma::{
@@ -469,7 +469,7 @@ where
     /// Construct a new I2S peripheral driver instance for the second I2S
     /// peripheral
     #[allow(clippy::too_many_arguments)]
-    #[cfg(any(esp32s3, esp32))]
+    #[cfg(i2s1)]
     pub fn new_i2s1(
         i2s: impl Peripheral<P = I> + 'd,
         standard: Standard,

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -188,11 +188,10 @@ mod peripheral_macros {
                     $crate::create_peripheral!($(#[$cfg])? $name <= $from_pac);
                 )*
 
-
                 $crate::impl_dma_eligible!(SPI2,Spi2);
                 #[cfg(any(pdma, esp32s3))]
                 $crate::impl_dma_eligible!(SPI3,Spi3);
-                #[cfg(any(esp32c6, esp32h2))]
+                #[cfg(any(esp32c2, esp32c6, esp32h2))]
                 $crate::impl_dma_eligible!(MEM2MEM1,Mem2Mem1);
                 #[cfg(any(esp32c3, esp32c6, esp32h2, esp32s3))]
                 $crate::impl_dma_eligible!(UHCI0,Uhci0);

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1124,9 +1124,7 @@ pub mod asynch {
     #[cfg(not(any(esp32, esp32s3)))]
     const NUM_CHANNELS: usize = 4;
 
-    #[allow(clippy::declare_interior_mutable_const)]
-    const INIT: AtomicWaker = AtomicWaker::new();
-    static WAKER: [AtomicWaker; NUM_CHANNELS] = [INIT; NUM_CHANNELS];
+    static WAKER: [AtomicWaker; NUM_CHANNELS] = [const { AtomicWaker::new() }; NUM_CHANNELS];
 
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub(crate) struct RmtTxFuture<T>

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -1025,9 +1025,7 @@ mod asynch {
 
     const NUM_ALARMS: usize = 3;
 
-    #[allow(clippy::declare_interior_mutable_const)]
-    const INIT: AtomicWaker = AtomicWaker::new();
-    static WAKERS: [AtomicWaker; NUM_ALARMS] = [INIT; NUM_ALARMS];
+    static WAKERS: [AtomicWaker; NUM_ALARMS] = [const { AtomicWaker::new() }; NUM_ALARMS];
 
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub(crate) struct AlarmFuture<'a, COMP: Comparator, UNIT: Unit> {

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -536,9 +536,8 @@ mod asynch {
 
     const NUM_TOUCH_PINS: usize = 10;
 
-    #[allow(clippy::declare_interior_mutable_const)]
-    const NEW_AW: AtomicWaker = AtomicWaker::new();
-    static TOUCH_WAKERS: [AtomicWaker; NUM_TOUCH_PINS] = [NEW_AW; NUM_TOUCH_PINS];
+    static TOUCH_WAKERS: [AtomicWaker; NUM_TOUCH_PINS] =
+        [const { AtomicWaker::new() }; NUM_TOUCH_PINS];
 
     // Helper variable to store which pins need handling.
     static TOUCHED_PINS: AtomicU16 = AtomicU16::new(0);

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1671,9 +1671,8 @@ mod asynch {
     }
 
     const NUM_TWAI: usize = 1 + cfg!(twai1) as usize;
-    #[allow(clippy::declare_interior_mutable_const)]
-    const NEW_STATE: TwaiAsyncState = TwaiAsyncState::new();
-    pub(crate) static TWAI_STATE: [TwaiAsyncState; NUM_TWAI] = [NEW_STATE; NUM_TWAI];
+    pub(crate) static TWAI_STATE: [TwaiAsyncState; NUM_TWAI] =
+        [const { TwaiAsyncState::new() }; NUM_TWAI];
 
     impl<T> Twai<'_, T, crate::Async>
     where

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1849,7 +1849,6 @@ where
 mod asynch {
     use core::task::Poll;
 
-    use cfg_if::cfg_if;
     use embassy_sync::waitqueue::AtomicWaker;
     use enumset::{EnumSet, EnumSetType};
     use procmacros::handler;
@@ -1857,20 +1856,10 @@ mod asynch {
     use super::*;
     use crate::Async;
 
-    cfg_if! {
-        if #[cfg(all(uart0, uart1, uart2))] {
-            const NUM_UART: usize = 3;
-        } else if #[cfg(all(uart0, uart1))] {
-            const NUM_UART: usize = 2;
-        } else if #[cfg(uart0)] {
-            const NUM_UART: usize = 1;
-        }
-    }
+    const NUM_UART: usize = 1 + cfg!(uart1) as usize + cfg!(uart2) as usize;
 
-    #[allow(clippy::declare_interior_mutable_const)]
-    const INIT: AtomicWaker = AtomicWaker::new();
-    static TX_WAKERS: [AtomicWaker; NUM_UART] = [INIT; NUM_UART];
-    static RX_WAKERS: [AtomicWaker; NUM_UART] = [INIT; NUM_UART];
+    static TX_WAKERS: [AtomicWaker; NUM_UART] = [const { AtomicWaker::new() }; NUM_UART];
+    static RX_WAKERS: [AtomicWaker; NUM_UART] = [const { AtomicWaker::new() }; NUM_UART];
 
     #[derive(EnumSetType, Debug)]
     pub(crate) enum TxEvent {

--- a/hil-test/tests/dma_macros.rs
+++ b/hil-test/tests/dma_macros.rs
@@ -1,6 +1,6 @@
-//! DMA Mem2Mem Tests
+//! DMA macro tests
 
-//% CHIPS: esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -1,12 +1,12 @@
 //! DMA Mem2Mem Tests
 
-//% CHIPS: esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
+//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
 
 #![no_std]
 #![no_main]
 
 use esp_hal::{
-    dma::{Channel, Dma, DmaChannel0, DmaError, DmaPriority, Mem2Mem},
+    dma::{Channel, Dma, DmaError, DmaPriority, Mem2Mem},
     dma_buffers,
     dma_buffers_chunk_size,
     dma_descriptors,
@@ -17,10 +17,18 @@ use hil_test as _;
 const DATA_SIZE: usize = 1024 * 10;
 
 cfg_if::cfg_if! {
-    if #[cfg(any(feature = "esp32c2", feature = "esp32c3", feature = "esp32s3"))] {
-        type DmaPeripheralType = esp_hal::peripherals::SPI2;
-    } else {
+    if #[cfg(any(esp32c2, esp32c6, esp32h2))] {
         type DmaPeripheralType = esp_hal::peripherals::MEM2MEM1;
+    } else {
+        type DmaPeripheralType = esp_hal::peripherals::SPI2;
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(any(esp32, esp32s2))] {
+        use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
+    } else {
+        use esp_hal::dma::DmaChannel0;
     }
 }
 
@@ -41,18 +49,25 @@ mod tests {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
         let dma = Dma::new(peripherals.DMA);
-        let channel = dma.channel0.configure(false, DmaPriority::Priority0);
 
         cfg_if::cfg_if! {
-            if #[cfg(any(feature = "esp32c2", feature = "esp32c3", feature = "esp32s3"))] {
-                let dma_peripheral = peripherals.SPI2;
+            if #[cfg(any(esp32, esp32s2))] {
+                let dma_channel = dma.spi2channel;
             } else {
+                let dma_channel = dma.channel0;
+            }
+        }
+
+        cfg_if::cfg_if! {
+            if #[cfg(any(esp32c2, esp32c6, esp32h2))] {
                 let dma_peripheral = peripherals.MEM2MEM1;
+            } else {
+                let dma_peripheral = peripherals.SPI2;
             }
         }
 
         Context {
-            channel,
+            channel: dma_channel.configure(false, DmaPriority::Priority0),
             dma_peripheral,
         }
     }

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -24,13 +24,7 @@ cfg_if::cfg_if! {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(any(esp32, esp32s2))] {
-        use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
-    } else {
-        use esp_hal::dma::DmaChannel0;
-    }
-}
+use esp_hal::dma::DmaChannel0;
 
 struct Context {
     channel: Channel<'static, DmaChannel0, Blocking>,
@@ -49,14 +43,7 @@ mod tests {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
         let dma = Dma::new(peripherals.DMA);
-
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2))] {
-                let dma_channel = dma.spi2channel;
-            } else {
-                let dma_channel = dma.channel0;
-            }
-        }
+        let dma_channel = dma.channel0;
 
         cfg_if::cfg_if! {
             if #[cfg(any(esp32c2, esp32c6, esp32h2))] {

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -22,10 +22,7 @@ use esp_hal::{
 use hil_test as _;
 
 cfg_if::cfg_if! {
-    if #[cfg(any(
-        feature = "esp32",
-        feature = "esp32s2",
-    ))] {
+    if #[cfg(any(esp32, esp32s2))] {
         use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
     } else {
         use esp_hal::dma::DmaChannel0;


### PR DESCRIPTION
- Record MSRV change in embassy crate
- change cfgs to peripherals
- use const blocks instead of interior mutable consts
- remove some unnecessary internal type aliasses
- enables `dma_macros` for ESP32 and S2
- allow using MEM2MEM1 on ESP32C2. The DMA seems to ignore the peripheral selection bit for in-memory transactions