### PR TITLE
Prevent reentry on single-core, add basic tests

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -237,7 +237,9 @@ pub mod uart;
 pub mod usb_serial_jtag;
 
 pub mod debugger;
-mod lock;
+
+#[doc(hidden)]
+pub mod sync;
 
 /// State of the CPU saved when entering exception or interrupt
 pub mod trapframe {

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -2,7 +2,7 @@ use portable_atomic::{AtomicU8, Ordering};
 
 pub use self::implementation::*;
 #[cfg(psram)]
-use crate::lock::Locked;
+use crate::sync::Locked;
 
 #[cfg_attr(esp32, path = "esp32/mod.rs")]
 #[cfg_attr(esp32c2, path = "esp32c2/mod.rs")]

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -79,9 +79,9 @@ use fugit::{Instant, MicrosDurationU32, MicrosDurationU64};
 use super::{Error, Timer as _};
 use crate::{
     interrupt::{self, InterruptHandler},
-    lock::{lock, Lock},
     peripheral::Peripheral,
     peripherals::{Interrupt, SYSTIMER},
+    sync::{lock, Lock},
     system::{Peripheral as PeripheralEnable, PeripheralClockControl},
     Async,
     Blocking,

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -76,10 +76,10 @@ use crate::soc::constants::TIMG_DEFAULT_CLK_SRC;
 use crate::{
     clock::Clocks,
     interrupt::{self, InterruptHandler},
-    lock::{lock, Lock},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{timg0::RegisterBlock, Interrupt, TIMG0},
     private::Sealed,
+    sync::{lock, Lock},
     system::{Peripheral as PeripheralEnable, PeripheralClockControl},
     Async,
     Blocking,

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -24,6 +24,10 @@ name    = "crc"
 harness = false
 
 [[test]]
+name    = "critical_section"
+harness = false
+
+[[test]]
 name    = "delay"
 harness = false
 

--- a/hil-test/tests/critical_section.rs
+++ b/hil-test/tests/critical_section.rs
@@ -1,0 +1,53 @@
+//! Ensure invariants of locks are upheld.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+
+// TODO: add multi-core tests
+
+#![no_std]
+#![no_main]
+
+use hil_test as _;
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    use esp_hal::sync::Locked;
+
+    #[test]
+    fn critical_section_is_reentrant() {
+        let mut flag = false;
+
+        critical_section::with(|_| {
+            critical_section::with(|_| {
+                flag = true;
+            });
+        });
+
+        assert!(flag);
+    }
+
+    #[test]
+    fn locked_can_provide_mutable_access() {
+        let flag = Locked::new(false);
+
+        flag.with(|f| {
+            *f = true;
+        });
+        flag.with(|f| {
+            assert!(*f);
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn locked_is_not_reentrant() {
+        let flag = Locked::new(false);
+
+        flag.with(|_f| {
+            flag.with(|f| {
+                *f = true;
+            });
+        });
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/esp-rs/esp-hal/pull/2178#discussion_r1768890301

There are arguments in favour of making this public, but I think we need to reason about what lock this is, exactly, and whether we can tie this into some bigger ecosystem, e.g. embassy-sync, somehow.