### PR TITLE
Mark DMA buffer traits as unsafe to implement

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Introduce traits for the DMA buffer objects (#1976)
+- Introduce traits for the DMA buffer objects (#1976, #2213)
 - Implement `embedded-hal` output pin traits for `NoPin` (#2019, #2133)
 - Added `esp_hal::init` to simplify HAL initialisation (#1970, #1999)
 - Added GpioPin::degrade to create ErasePins easily. Same for AnyPin by accident. (#2075)

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1837,7 +1837,12 @@ pub struct Preparation {
 
 /// [DmaTxBuffer] is a DMA descriptor + memory combo that can be used for
 /// transmitting data from a DMA channel to a peripheral's FIFO.
-pub trait DmaTxBuffer {
+///
+/// # Safety
+///
+/// The implementing type must keep all its descriptors and the buffers they
+/// point to valid between each call to [Self::prepare].
+pub unsafe trait DmaTxBuffer {
     /// Prepares the buffer for an imminent transfer and returns
     /// information required to use this buffer.
     ///
@@ -1858,7 +1863,12 @@ pub trait DmaTxBuffer {
 /// Note: Implementations of this trait may only support having a single EOF bit
 /// which resides in the last descriptor. There will be a separate trait in
 /// future to support multiple EOFs.
-pub trait DmaRxBuffer {
+///
+/// # Safety
+///
+/// The implementing type must keep all its descriptors and the buffers they
+/// point to valid between each call to [Self::prepare].
+pub unsafe trait DmaRxBuffer {
     /// Prepares the buffer for an imminent transfer and returns
     /// information required to use this buffer.
     ///
@@ -2012,7 +2022,7 @@ impl DmaTxBuf {
     }
 }
 
-impl DmaTxBuffer for DmaTxBuf {
+unsafe impl DmaTxBuffer for DmaTxBuf {
     fn prepare(&mut self) -> Preparation {
         for desc in self.descriptors.iter_mut() {
             // Give ownership to the DMA
@@ -2240,7 +2250,7 @@ impl DmaRxBuf {
     }
 }
 
-impl DmaRxBuffer for DmaRxBuf {
+unsafe impl DmaRxBuffer for DmaRxBuf {
     fn prepare(&mut self) -> Preparation {
         for desc in self.descriptors.iter_mut() {
             // Give ownership to the DMA
@@ -2440,7 +2450,7 @@ impl DmaRxTxBuf {
     }
 }
 
-impl DmaTxBuffer for DmaRxTxBuf {
+unsafe impl DmaTxBuffer for DmaRxTxBuf {
     fn prepare(&mut self) -> Preparation {
         for desc in self.tx_descriptors.iter_mut() {
             // Give ownership to the DMA
@@ -2461,7 +2471,7 @@ impl DmaTxBuffer for DmaRxTxBuf {
     }
 }
 
-impl DmaRxBuffer for DmaRxTxBuf {
+unsafe impl DmaRxBuffer for DmaRxTxBuf {
     fn prepare(&mut self) -> Preparation {
         for desc in self.rx_descriptors.iter_mut() {
             // Give ownership to the DMA


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
PR title is pretty clear

#### Testing
It compiles
