### PR TITLE
Avoid moving inside `SpiDmaBus`, abort dropped transfers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EspTwaiFrame` constructors now accept any type that converts into `esp_hal::twai::Id` (#2207)
 - Change `DmaTxBuf` to support PSRAM on `esp32s3` (#2161)
 - I2c `transaction` is now also available as a inherent function, lift size limit on `write`,`read` and `write_read` (#2262)
+- SPI transactions are now cancelled if the transfer object (or async Future) is dropped. (#2216)
 
 ### Fixed
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1874,7 +1874,7 @@ mod dma {
         C::P: SpiPeripheral,
         M: Mode,
     {
-        type Error = super::Error;
+        type Error = Error;
 
         /// Half-duplex read.
         fn read(
@@ -1886,7 +1886,7 @@ mod dma {
             buffer: &mut [u8],
         ) -> Result<(), Self::Error> {
             if buffer.len() > self.rx_buf.capacity() {
-                return Err(super::Error::DmaError(DmaError::Overflow));
+                return Err(Error::DmaError(DmaError::Overflow));
             }
             self.rx_buf.set_length(buffer.len());
 
@@ -1918,7 +1918,7 @@ mod dma {
             buffer: &[u8],
         ) -> Result<(), Self::Error> {
             if buffer.len() > self.tx_buf.capacity() {
-                return Err(super::Error::DmaError(DmaError::Overflow));
+                return Err(Error::DmaError(DmaError::Overflow));
             }
             self.tx_buf.fill(buffer);
 
@@ -1946,7 +1946,7 @@ mod dma {
         C: DmaChannel,
         C::P: SpiPeripheral,
     {
-        type Error = super::Error;
+        type Error = Error;
 
         fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
             self.transfer_in_place(words)?;
@@ -1961,7 +1961,7 @@ mod dma {
         C: DmaChannel,
         C::P: SpiPeripheral,
     {
-        type Error = super::Error;
+        type Error = Error;
 
         fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
             self.write(words)?;
@@ -1982,7 +1982,7 @@ mod dma {
             C::P: SpiPeripheral,
         {
             /// Fill the given buffer with data from the bus.
-            pub async fn read_async(&mut self, words: &mut [u8]) -> Result<(), super::Error> {
+            pub async fn read_async(&mut self, words: &mut [u8]) -> Result<(), Error> {
                 let chunk_size = self.rx_buf.capacity();
 
                 for chunk in words.chunks_mut(chunk_size) {
@@ -2003,7 +2003,7 @@ mod dma {
             }
 
             /// Transmit the given buffer to the bus.
-            pub async fn write_async(&mut self, words: &[u8]) -> Result<(), super::Error> {
+            pub async fn write_async(&mut self, words: &[u8]) -> Result<(), Error> {
                 let chunk_size = self.tx_buf.capacity();
 
                 for chunk in words.chunks(chunk_size) {
@@ -2024,7 +2024,7 @@ mod dma {
                 &mut self,
                 read: &mut [u8],
                 write: &[u8],
-            ) -> Result<(), super::Error> {
+            ) -> Result<(), Error> {
                 let chunk_size = min(self.tx_buf.capacity(), self.rx_buf.capacity());
 
                 let common_length = min(read.len(), write.len());
@@ -2060,10 +2060,7 @@ mod dma {
 
             /// Transfer by writing out a buffer and reading the response from
             /// the bus into the same buffer.
-            pub async fn transfer_in_place_async(
-                &mut self,
-                words: &mut [u8],
-            ) -> Result<(), super::Error> {
+            pub async fn transfer_in_place_async(&mut self, words: &mut [u8]) -> Result<(), Error> {
                 for chunk in words.chunks_mut(self.tx_buf.capacity()) {
                     self.tx_buf.fill(chunk);
                     self.rx_buf.set_length(chunk.len());
@@ -2165,7 +2162,7 @@ mod ehal1 {
     use super::*;
 
     impl<T, M> embedded_hal::spi::ErrorType for Spi<'_, T, M> {
-        type Error = super::Error;
+        type Error = Error;
     }
 
     impl<T> FullDuplex for Spi<'_, T, FullDuplexMode>

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -922,8 +922,10 @@ mod dma {
             DmaChannel,
             DmaRxBuf,
             DmaRxBuffer,
+            DmaRxBufferRef,
             DmaTxBuf,
             DmaTxBuffer,
+            DmaTxBufferRef,
             Rx,
             Spi2Peripheral,
             SpiPeripheral,
@@ -1842,7 +1844,8 @@ mod dma {
             for chunk in words.chunks_mut(self.rx_buf.capacity()) {
                 self.rx_buf.set_length(chunk.len());
 
-                match (&mut self.spi_dma).do_dma_read(&mut self.rx_buf) {
+                let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                match (&mut self.spi_dma).do_dma_read(rx_buffer) {
                     Ok(transfer) => transfer.wait(),
                     Err((e, _, _)) => return Err(e),
                 };
@@ -1859,7 +1862,8 @@ mod dma {
             for chunk in words.chunks(self.tx_buf.capacity()) {
                 self.tx_buf.fill(chunk);
 
-                match (&mut self.spi_dma).do_dma_write(&mut self.tx_buf) {
+                let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                match (&mut self.spi_dma).do_dma_write(tx_buffer) {
                     Ok(transfer) => transfer.wait(),
                     Err((e, _, _)) => return Err(e),
                 };
@@ -1883,7 +1887,9 @@ mod dma {
                 self.tx_buf.fill(write_chunk);
                 self.rx_buf.set_length(read_chunk.len());
 
-                match (&mut self.spi_dma).do_dma_transfer(&mut self.rx_buf, &mut self.tx_buf) {
+                let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                match (&mut self.spi_dma).do_dma_transfer(rx_buffer, tx_buffer) {
                     Ok(transfer) => transfer.wait(),
                     Err((e, _, _, _)) => return Err(e),
                 };
@@ -1909,7 +1915,9 @@ mod dma {
                 self.tx_buf.fill(chunk);
                 self.rx_buf.set_length(chunk.len());
 
-                match (&mut self.spi_dma).do_dma_transfer(&mut self.rx_buf, &mut self.tx_buf) {
+                let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                match (&mut self.spi_dma).do_dma_transfer(rx_buffer, tx_buffer) {
                     Ok(transfer) => transfer.wait(),
                     Err((e, _, _, _)) => return Err(e),
                 };
@@ -1945,13 +1953,9 @@ mod dma {
             }
             self.rx_buf.set_length(buffer.len());
 
-            match (&mut self.spi_dma).do_half_duplex_read(
-                data_mode,
-                cmd,
-                address,
-                dummy,
-                &mut self.rx_buf,
-            ) {
+            let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+            match (&mut self.spi_dma).do_half_duplex_read(data_mode, cmd, address, dummy, rx_buffer)
+            {
                 Ok(transfer) => transfer.wait(),
                 Err((e, _, _)) => return Err(e),
             };
@@ -1976,13 +1980,10 @@ mod dma {
             }
             self.tx_buf.fill(buffer);
 
-            match (&mut self.spi_dma).do_half_duplex_write(
-                data_mode,
-                cmd,
-                address,
-                dummy,
-                &mut self.tx_buf,
-            ) {
+            let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+            match (&mut self.spi_dma)
+                .do_half_duplex_write(data_mode, cmd, address, dummy, tx_buffer)
+            {
                 Ok(transfer) => {
                     transfer.wait();
 
@@ -2042,7 +2043,8 @@ mod dma {
                 for chunk in words.chunks_mut(chunk_size) {
                     self.rx_buf.set_length(chunk.len());
 
-                    match (&mut self.spi_dma).do_dma_read(&mut self.rx_buf) {
+                    let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                    match (&mut self.spi_dma).do_dma_read(rx_buffer) {
                         Ok(mut transfer) => transfer.wait_for_done().await,
                         Err((e, _, _)) => return Err(e),
                     }
@@ -2061,7 +2063,8 @@ mod dma {
                 for chunk in words.chunks(chunk_size) {
                     self.tx_buf.fill(chunk);
 
-                    match (&mut self.spi_dma).do_dma_write(&mut self.tx_buf) {
+                    let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                    match (&mut self.spi_dma).do_dma_write(tx_buffer) {
                         Ok(mut transfer) => transfer.wait_for_done().await,
                         Err((e, _, _)) => return Err(e),
                     }
@@ -2090,7 +2093,9 @@ mod dma {
                     self.tx_buf.fill(write_chunk);
                     self.rx_buf.set_length(read_chunk.len());
 
-                    match (&mut self.spi_dma).do_dma_transfer(&mut self.rx_buf, &mut self.tx_buf) {
+                    let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                    let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                    match (&mut self.spi_dma).do_dma_transfer(rx_buffer, tx_buffer) {
                         Ok(mut transfer) => transfer.wait_for_done().await,
                         Err((e, _, _, _)) => return Err(e),
                     }
@@ -2115,7 +2120,9 @@ mod dma {
                     self.tx_buf.fill(chunk);
                     self.rx_buf.set_length(chunk.len());
 
-                    match (&mut self.spi_dma).do_dma_transfer(&mut self.rx_buf, &mut self.tx_buf) {
+                    let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                    let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                    match (&mut self.spi_dma).do_dma_transfer(rx_buffer, tx_buffer) {
                         Ok(mut transfer) => transfer.wait_for_done().await,
                         Err((e, _, _, _)) => return Err(e),
                     }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -919,13 +919,12 @@ mod dma {
         dma::{
             asynch::{DmaRxFuture, DmaTxFuture},
             Channel,
+            DmaBufferRef,
             DmaChannel,
             DmaRxBuf,
             DmaRxBuffer,
-            DmaRxBufferRef,
             DmaTxBuf,
             DmaTxBuffer,
-            DmaTxBufferRef,
             Rx,
             Spi2Peripheral,
             SpiPeripheral,
@@ -1872,7 +1871,7 @@ mod dma {
             for chunk in words.chunks_mut(self.rx_buf.capacity()) {
                 self.rx_buf.set_length(chunk.len());
 
-                let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                let rx_buffer = DmaBufferRef::new(&mut self.rx_buf);
                 match (&mut self.spi_dma).do_dma_read(rx_buffer) {
                     Ok(transfer) => transfer.wait(),
                     Err((e, _, _)) => return Err(e),
@@ -1891,7 +1890,7 @@ mod dma {
             for chunk in words.chunks(self.tx_buf.capacity()) {
                 self.tx_buf.fill(chunk);
 
-                let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                let tx_buffer = DmaBufferRef::new(&mut self.tx_buf);
                 match (&mut self.spi_dma).do_dma_write(tx_buffer) {
                     Ok(transfer) => transfer.wait(),
                     Err((e, _, _)) => return Err(e),
@@ -1917,8 +1916,8 @@ mod dma {
                 self.tx_buf.fill(write_chunk);
                 self.rx_buf.set_length(read_chunk.len());
 
-                let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
-                let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                let rx_buffer = DmaBufferRef::new(&mut self.rx_buf);
+                let tx_buffer = DmaBufferRef::new(&mut self.tx_buf);
                 match (&mut self.spi_dma).do_dma_transfer(rx_buffer, tx_buffer) {
                     Ok(transfer) => transfer.wait(),
                     Err((e, _, _, _)) => return Err(e),
@@ -1946,8 +1945,8 @@ mod dma {
                 self.tx_buf.fill(chunk);
                 self.rx_buf.set_length(chunk.len());
 
-                let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
-                let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                let tx_buffer = DmaBufferRef::new(&mut self.tx_buf);
+                let rx_buffer = DmaBufferRef::new(&mut self.rx_buf);
                 match (&mut self.spi_dma).do_dma_transfer(rx_buffer, tx_buffer) {
                     Ok(transfer) => transfer.wait(),
                     Err((e, _, _, _)) => return Err(e),
@@ -1985,7 +1984,7 @@ mod dma {
             self.wait_for_idle();
             self.rx_buf.set_length(buffer.len());
 
-            let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+            let rx_buffer = DmaBufferRef::new(&mut self.rx_buf);
             match (&mut self.spi_dma).do_half_duplex_read(data_mode, cmd, address, dummy, rx_buffer)
             {
                 Ok(transfer) => transfer.wait(),
@@ -2013,7 +2012,7 @@ mod dma {
             self.wait_for_idle();
             self.tx_buf.fill(buffer);
 
-            let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+            let tx_buffer = DmaBufferRef::new(&mut self.tx_buf);
             match (&mut self.spi_dma)
                 .do_half_duplex_write(data_mode, cmd, address, dummy, tx_buffer)
             {
@@ -2090,7 +2089,7 @@ mod dma {
                 for chunk in words.chunks_mut(chunk_size) {
                     self.rx_buf.set_length(chunk.len());
 
-                    let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
+                    let rx_buffer = DmaBufferRef::new(&mut self.rx_buf);
                     match (&mut self.spi_dma).do_dma_read(rx_buffer) {
                         Ok(mut transfer) => transfer.wait_for_done().await,
                         Err((e, _, _)) => return Err(e),
@@ -2111,7 +2110,7 @@ mod dma {
                 for chunk in words.chunks(chunk_size) {
                     self.tx_buf.fill(chunk);
 
-                    let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                    let tx_buffer = DmaBufferRef::new(&mut self.tx_buf);
                     match (&mut self.spi_dma).do_dma_write(tx_buffer) {
                         Ok(mut transfer) => transfer.wait_for_done().await,
                         Err((e, _, _)) => return Err(e),
@@ -2142,8 +2141,8 @@ mod dma {
                     self.tx_buf.fill(write_chunk);
                     self.rx_buf.set_length(read_chunk.len());
 
-                    let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
-                    let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                    let rx_buffer = DmaBufferRef::new(&mut self.rx_buf);
+                    let tx_buffer = DmaBufferRef::new(&mut self.tx_buf);
                     match (&mut self.spi_dma).do_dma_transfer(rx_buffer, tx_buffer) {
                         Ok(mut transfer) => transfer.wait_for_done().await,
                         Err((e, _, _, _)) => return Err(e),
@@ -2170,8 +2169,8 @@ mod dma {
                     self.tx_buf.fill(chunk);
                     self.rx_buf.set_length(chunk.len());
 
-                    let rx_buffer = DmaRxBufferRef::new(&mut self.rx_buf);
-                    let tx_buffer = DmaTxBufferRef::new(&mut self.tx_buf);
+                    let rx_buffer = DmaBufferRef::new(&mut self.rx_buf);
+                    let tx_buffer = DmaBufferRef::new(&mut self.tx_buf);
                     match (&mut self.spi_dma).do_dma_transfer(rx_buffer, tx_buffer) {
                         Ok(mut transfer) => transfer.wait_for_done().await,
                         Err((e, _, _, _)) => return Err(e),

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1434,7 +1434,12 @@ mod dma {
         fn drop(&mut self) {
             if !self.is_done() {
                 self.spi_dma.cancel_transfer();
-                self.spi_dma.wait_for_idle()
+                self.spi_dma.wait_for_idle();
+
+                unsafe {
+                    ManuallyDrop::drop(&mut self.spi_dma);
+                    ManuallyDrop::drop(&mut self.dma_buf);
+                }
             }
         }
     }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1371,8 +1371,6 @@ mod dma {
     {
         spi_dma: ManuallyDrop<SpiDma<'d, T, C, D, M>>,
         dma_buf: ManuallyDrop<Buf>,
-
-        _marker: PhantomData<&'d ()>,
     }
 
     impl<'d, T, C, D, M, Buf> SpiDmaTransfer<'d, T, C, D, M, Buf>
@@ -1387,7 +1385,6 @@ mod dma {
             Self {
                 spi_dma: ManuallyDrop::new(spi_dma),
                 dma_buf: ManuallyDrop::new(dma_buf),
-                _marker: PhantomData,
             }
         }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1654,6 +1654,14 @@ mod dma {
             }
         }
 
+        /// Checks if the transfer is complete.
+        ///
+        /// This method returns `true` if both RX and TX operations are done,
+        /// and the SPI instance is no longer busy.
+        pub fn is_done(&self) -> bool {
+            self.spi_dma.is_done()
+        }
+
         /// Waits for the DMA transfer to complete.
         ///
         /// This method blocks until the transfer is finished and returns the

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1578,6 +1578,7 @@ mod dma {
         pub fn cancel(&mut self) {
             if !self.is_done() {
                 self.spi_dma.spi_mut().configure_datalen(0, 0);
+                self.spi_dma.spi_mut().update();
                 if self.is_tx {
                     self.spi_dma.channel_mut().tx.stop_transfer();
                     self.is_tx = false;

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1637,6 +1637,8 @@ mod dma {
         }
 
         fn do_cancel(&mut self) {
+            // The SPI peripheral is controlling how much data we transfer, so let's
+            // update its counter.
             // 0 doesn't take effect on ESP32 and cuts the currently transmitted byte
             // immediately.
             // 1 seems to stop after transmitting the current byte which is somewhat less
@@ -1644,6 +1646,7 @@ mod dma {
             self.spi_dma.spi_mut().configure_datalen(1, 1);
             self.spi_dma.spi_mut().update();
 
+            // We need to stop the DMA transfer, too.
             if self.spi_dma.is_tx_in_progress() {
                 self.spi_dma.channel_mut().tx.stop_transfer();
                 self.spi_dma.set_tx_in_progress(false);

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1637,14 +1637,11 @@ mod dma {
         }
 
         fn do_cancel(&mut self) {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
-                    // TODO: examine what happens exactly. (0, 0) just doesn't take effect.
-                    self.spi_dma.spi_mut().configure_datalen(1, 1);
-                } else {
-                    self.spi_dma.spi_mut().configure_datalen(0, 0);
-                }
-            };
+            // 0 doesn't take effect on ESP32 and cuts the currently transmitted byte
+            // immediately.
+            // 1 seems to stop after transmitting the current byte which is somewhat less
+            // impolite.
+            self.spi_dma.spi_mut().configure_datalen(1, 1);
             self.spi_dma.spi_mut().update();
 
             if self.spi_dma.is_tx_in_progress() {

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -488,10 +488,12 @@ mod tests {
     }
 
     #[test]
-    #[timeout(3)]
+    #[timeout(2)]
     fn cancel_stops_transaction(mut ctx: Context) {
-        // Slow down
-        ctx.spi.change_bus_frequency(100.Hz());
+        // Slow down. At 80kHz, the transfer is supposed to take a bit over 3 seconds.
+        // This means that without working cancellation, the test case should
+        // fail.
+        ctx.spi.change_bus_frequency(80.kHz());
 
         // Set up a large buffer that would trigger a timeout
         let dma_rx_buf = DmaRxBuf::new(ctx.rx_descriptors, ctx.rx_buffer).unwrap();
@@ -513,8 +515,8 @@ mod tests {
     #[test]
     #[timeout(3)]
     fn can_transmit_after_cancel(mut ctx: Context) {
-        // Slow down
-        ctx.spi.change_bus_frequency(100.Hz());
+        // Slow down. At 80kHz, the transfer is supposed to take a bit over 3 seconds.
+        ctx.spi.change_bus_frequency(80.kHz());
 
         // Set up a large buffer that would trigger a timeout
         let mut dma_rx_buf = DmaRxBuf::new(ctx.rx_descriptors, ctx.rx_buffer).unwrap();

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -554,9 +554,10 @@ mod tests {
         let dma_rx_buf = DmaRxBuf::new(ctx.rx_descriptors, ctx.rx_buffer).unwrap();
         let dma_tx_buf = DmaTxBuf::new(ctx.tx_descriptors, ctx.tx_buffer).unwrap();
 
-        let spi = ctx
-            .spi
-            .with_dma(ctx.dma_channel.configure_for_async(false, DmaPriority::Priority0));
+        let spi = ctx.spi.with_dma(
+            ctx.dma_channel
+                .configure_for_async(false, DmaPriority::Priority0),
+        );
 
         let mut transfer = spi
             .dma_transfer(dma_rx_buf, dma_tx_buf)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR simplifies SPI implementation by not relying on the move API **internally**. The PR also implements stopping transfers when their corresponding handle is dropped. This is probbaly better in line with embedded-hal expectations, and this change is necessary to enable zero-copy implementations of the embedded-hal traits (where applicable, of course. We still need to copy if the source data can't be accessed by the DMA).

#### Testing

Added and ran HIL tests, observed SPI waveforms using a logic analyzer on ESP32 and ESP32-C6.
