### PR TITLE
Allow building docs from different tags

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,12 +2,33 @@ name: Documentation
 
 on:
   workflow_dispatch:
+    inputs:
+      esp-hal:
+        description: "esp-hal tag"
+        required: true
+      esp-wifi:
+        description: "esp-wifi tag"
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: '[
+            { "name": "esp-hal",  "tag": "${{ github.event.inputs.esp-hal }}" },
+            { "name": "esp-wifi", "tag": "esp-wifi-${{ github.event.inputs.esp-wifi }}" }
+          ]'
+    steps:
+      - run: echo "Setup complete!"
   build:
+    needs: setup
+    strategy:
+      fail-fast: true
+      matrix:
+        packages: ${{ fromJson(needs.setup.outputs.packages) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,21 +37,48 @@ jobs:
           default: true
           ldproxy: false
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: esp-rs/esp-hal
+          ref: ${{ matrix.packages.tag }}
+
       - name: Build documentation
-        run: cargo xtask build-documentation --packages=esp-hal,esp-wifi
+        run: cargo xtask build-documentation --packages=${{ matrix.packages.name }}
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files
         run: find docs -name ".lock" -exec rm -f {} \;
 
+      - name: Upload docs for ${{ matrix.packages.name }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.packages.name }}
+          path: "docs/${{ matrix.packages.name }}"
+
+  assemble:
+    needs: [setup, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare
+        run: mkdir docs
+      - name: Download all docs
+        uses: actions/download-artifact@v4
+        with:
+          path: "docs/"
+      
+      - name: Create index.html
+        run: "cargo xtask build-documentation-index --packages=$(echo '${{ needs.setup.outputs.packages }}' | jq -r '[.[].name] | join(\",\")')"
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "docs"
+          path: "docs/"
 
   deploy:
-    # Add a dependency to the build job:
-    needs: build
+    # Add a dependency to the assemble job:
+    needs: assemble
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment:
     permissions:


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

This changes the documentation workflow to accept tags for esp-hal and esp-wifi.

Sub jobs will be checkout the chosen tag, and build the documentation. Those job artifacts are then "assembled" by downloading them, placing them in the correct place and running a new subcommand `cargo xtask build-documentation-index` which will create the `index.html`. The assemble job runs on the latest main, so it will always pick up the latest template and resources.

![image](https://github.com/user-attachments/assets/a2bb01a0-83af-4ef6-9b6b-ddf676130248)

Here is a deployment on my gh pages: https://mabezdev.github.io/esp-hal/

