### PR TITLE
DMA: Deduplicate descriptor operations

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -968,14 +968,7 @@ impl DescriptorChain {
             &mut self.descriptors[..required_descriptors],
             max_chunk_size,
             circular,
-        )
-        .map_err(|e| match e {
-            // TODO: DmaError::InvalidBuffer(e)
-            DmaBufError::InsufficientDescriptors => DmaError::OutOfDescriptors,
-            DmaBufError::UnsupportedMemoryRegion => DmaError::UnsupportedMemoryRegion,
-            DmaBufError::InvalidAlignment => DmaError::InvalidAlignment,
-            DmaBufError::InvalidChunkSize => DmaError::InvalidChunkSize,
-        })?;
+        )?;
         DescriptorSet::link_up_descriptors(&mut self.descriptors[..required_descriptors], circular);
         DescriptorSet::prepare_descriptors_impl(
             &mut self.descriptors[..required_descriptors],

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -905,10 +905,7 @@ pub struct DescriptorChain {
 
 impl DescriptorChain {
     pub fn new(descriptors: &'static mut [DmaDescriptor]) -> Self {
-        Self {
-            descriptors,
-            chunk_size: CHUNK_SIZE,
-        }
+        Self::new_with_chunk_size(descriptors, CHUNK_SIZE)
     }
 
     pub fn new_with_chunk_size(

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -989,12 +989,12 @@ impl DescriptorChain {
 
         DescriptorSet::link_with_buffer_impl(
             unsafe { core::slice::from_raw_parts_mut(data, len) },
-            &mut self.descriptors,
+            self.descriptors,
             max_chunk_size,
             circular,
         )?;
         DescriptorSet::prepare_descriptors_impl(
-            &mut self.descriptors,
+            self.descriptors,
             len,
             max_chunk_size,
             circular,
@@ -1222,12 +1222,12 @@ impl<'a> DescriptorSet<'a> {
     }
 
     /// Returns a slice of descriptors that can cover a buffer of length `len`.
-    fn descriptors_for_buffer_len<'d>(
-        descriptors: &'d mut [DmaDescriptor],
+    fn descriptors_for_buffer_len(
+        descriptors: &mut [DmaDescriptor],
         len: usize,
         chunk_size: usize,
         is_circular: bool,
-    ) -> Result<&'d mut [DmaDescriptor], DmaBufError> {
+    ) -> Result<&mut [DmaDescriptor], DmaBufError> {
         // First, pick enough descriptors to cover the buffer.
         let required_descriptors = Self::descriptor_count(len, chunk_size, is_circular);
         if descriptors.len() < required_descriptors {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1143,6 +1143,11 @@ impl<'a> DescriptorSet<'a> {
     fn reset_for_tx_circular(desc: &mut DmaDescriptor) {
         // Give ownership to the DMA
         desc.set_owner(Owner::Dma);
+
+        // The `suc_eof` bit doesn't affect the transfer itself, but signals when the
+        // hardware should trigger an interrupt request. In circular mode,
+        // we set the `suc_eof` bit for every buffer we send. We use this for
+        // I2S to track progress of a transfer by checking OUTLINK_DSCR_ADDR.
         desc.set_suc_eof(true);
     }
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -716,7 +716,7 @@ macro_rules! dma_tx_buffer {
     ($tx_size:expr) => {{
         let (tx_buffer, tx_descriptors) = $crate::dma_buffers_impl!(
             $tx_size,
-            $crate::dma::DescriptorSet::chunk_size(None),
+            $crate::dma::DmaTxBuf::compute_chunk_size(None),
             is_circular = false
         );
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -689,7 +689,13 @@ macro_rules! dma_descriptor_count {
             ::core::assert!($chunk_size <= 4095, "chunk size must be <= 4095");
             ::core::assert!($chunk_size > 0, "chunk size must be > 0");
         }
-        $crate::dma::DescriptorSet::descriptor_count($size, $chunk_size, $is_circular)
+
+        // We allow 0 in the macros as a "not needed" case.
+        if $size == 0 {
+            0
+        } else {
+            $crate::dma::DescriptorSet::descriptor_count($size, $chunk_size, $is_circular)
+        }
     }};
 }
 


### PR DESCRIPTION
This PR cleans up duplicate DMA descriptor related logic.