### PR TITLE
Fix incorrect QSPI setup

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: Fixed an issue where `wait` has returned before the DMA has finished writing the memory (#2179)
 - SPI: Fixed an issue where repeated calls to `dma_transfer` may end up looping indefinitely (#2179)
 - SPI: Fixed an issue that prevented correctly reading the first byte in a transaction (#2179)
+- SPI: ESP32: Send address with correct data mode even when no data is sent. (#2231)
 - PARL_IO: Fixed an issue that caused garbage to be output at the start of some requests (#2211)
 - TWAI on ESP32 (#2207)
 

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -128,11 +128,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     // emit config
     generate_config(
         "esp_hal",
-        &[(
-            "place-spi-driver-in-ram",
-            Value::Bool(false),
-            "Places the SPI driver in RAM for better performance",
-        )],
+        &[
+            (
+                "place-spi-driver-in-ram",
+                Value::Bool(false),
+                "Places the SPI driver in RAM for better performance",
+            ),
+            (
+                "esp32-spi-address-workaround",
+                Value::Bool(true),
+                "Enables a workaround for the issue where SPI incorrectly transmits the address on a single line if the data buffer is empty."
+            ),
+        ],
         true,
     );
 

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -135,9 +135,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                 "Places the SPI driver in RAM for better performance",
             ),
             (
-                "esp32-spi-address-workaround",
+                "spi-address-workaround",
                 Value::Bool(true),
-                "Enables a workaround for the issue where SPI incorrectly transmits the address on a single line if the data buffer is empty."
+                "(ESP32 only) Enables a workaround for the issue where SPI in half-duplex mode incorrectly transmits the address on a single line if the data buffer is empty.",
             ),
         ],
         true,

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1941,15 +1941,6 @@ pub struct Preparation {
 /// [DmaTxBuffer] is a DMA descriptor + memory combo that can be used for
 /// transmitting data from a DMA channel to a peripheral's FIFO.
 pub trait DmaTxBuffer {
-    /// Appends a single byte to the buffer.
-    fn push(&mut self, data: u8) -> Result<(), DmaBufError> {
-        self.extend_from_slice(&[data])?;
-        Ok(())
-    }
-
-    /// Appends a slice of bytes to the buffer.
-    fn extend_from_slice(&mut self, data: &[u8]) -> Result<usize, DmaBufError>;
-
     /// Prepares the buffer for an imminent transfer and returns
     /// information required to use this buffer.
     ///
@@ -2212,16 +2203,6 @@ impl DmaTxBuf {
 }
 
 impl DmaTxBuffer for DmaTxBuf {
-    fn extend_from_slice(&mut self, data: &[u8]) -> Result<usize, DmaBufError> {
-        let current_len = self.len();
-        if current_len + data.len() > self.capacity() {
-            return Err(DmaBufError::InsufficientDescriptors);
-        }
-        self.buffer[current_len..][..data.len()].copy_from_slice(data);
-        self.set_length(current_len + data.len());
-        Ok(data.len())
-    }
-
     fn prepare(&mut self) -> Preparation {
         for desc in self.descriptors.iter_mut() {
             // Give ownership to the DMA
@@ -2662,16 +2643,6 @@ impl DmaRxTxBuf {
 }
 
 impl DmaTxBuffer for DmaRxTxBuf {
-    fn extend_from_slice(&mut self, data: &[u8]) -> Result<usize, DmaBufError> {
-        let current_len = self.len();
-        if current_len + data.len() > self.capacity() {
-            return Err(DmaBufError::InsufficientDescriptors);
-        }
-        self.buffer[current_len..][..data.len()].copy_from_slice(data);
-        self.set_length(current_len + data.len());
-        Ok(data.len())
-    }
-
     fn prepare(&mut self) -> Preparation {
         for desc in self.tx_descriptors.iter_mut() {
             // Give ownership to the DMA

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -731,6 +731,18 @@ pub enum DmaError {
     InvalidChunkSize,
 }
 
+impl From<DmaBufError> for DmaError {
+    fn from(error: DmaBufError) -> Self {
+        // FIXME: use nested errors
+        match error {
+            DmaBufError::InsufficientDescriptors => DmaError::OutOfDescriptors,
+            DmaBufError::UnsupportedMemoryRegion => DmaError::UnsupportedMemoryRegion,
+            DmaBufError::InvalidAlignment => DmaError::InvalidAlignment,
+            DmaBufError::InvalidChunkSize => DmaError::InvalidChunkSize,
+        }
+    }
+}
+
 /// DMA Priorities
 #[cfg(gdma)]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1929,6 +1941,15 @@ pub struct Preparation {
 /// [DmaTxBuffer] is a DMA descriptor + memory combo that can be used for
 /// transmitting data from a DMA channel to a peripheral's FIFO.
 pub trait DmaTxBuffer {
+    /// Appends a single byte to the buffer.
+    fn push(&mut self, data: u8) -> Result<(), DmaBufError> {
+        self.extend_from_slice(&[data])?;
+        Ok(())
+    }
+
+    /// Appends a slice of bytes to the buffer.
+    fn extend_from_slice(&mut self, data: &[u8]) -> Result<usize, DmaBufError>;
+
     /// Prepares the buffer for an imminent transfer and returns
     /// information required to use this buffer.
     ///
@@ -2191,6 +2212,16 @@ impl DmaTxBuf {
 }
 
 impl DmaTxBuffer for DmaTxBuf {
+    fn extend_from_slice(&mut self, data: &[u8]) -> Result<usize, DmaBufError> {
+        let current_len = self.len();
+        if current_len + data.len() > self.capacity() {
+            return Err(DmaBufError::InsufficientDescriptors);
+        }
+        self.buffer[current_len..][..data.len()].copy_from_slice(data);
+        self.set_length(current_len + data.len());
+        Ok(data.len())
+    }
+
     fn prepare(&mut self) -> Preparation {
         for desc in self.descriptors.iter_mut() {
             // Give ownership to the DMA
@@ -2631,6 +2662,16 @@ impl DmaRxTxBuf {
 }
 
 impl DmaTxBuffer for DmaRxTxBuf {
+    fn extend_from_slice(&mut self, data: &[u8]) -> Result<usize, DmaBufError> {
+        let current_len = self.len();
+        if current_len + data.len() > self.capacity() {
+            return Err(DmaBufError::InsufficientDescriptors);
+        }
+        self.buffer[current_len..][..data.len()].copy_from_slice(data);
+        self.set_length(current_len + data.len());
+        Ok(data.len())
+    }
+
     fn prepare(&mut self) -> Preparation {
         for desc in self.tx_descriptors.iter_mut() {
             // Give ownership to the DMA

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -514,7 +514,7 @@ macro_rules! declare_aligned_dma_buffer {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! as_mut_byte_array {
-    ($name:ident, $size:expr) => {
+    ($name:expr, $size:expr) => {
         unsafe { &mut *($name.as_mut_ptr() as *mut [u8; $size]) }
     };
 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2498,6 +2498,7 @@ pub trait Instance: private::Sealed {
             }
             address_mode if address_mode == data_mode => {
                 reg_block.ctrl().modify(|_, w| {
+                    w.fastrd_mode().set_bit();
                     w.fread_dio().bit(address_mode == SpiDataMode::Dual);
                     w.fread_qio().bit(address_mode == SpiDataMode::Quad);
                     w.fread_dual().clear_bit();
@@ -2918,16 +2919,6 @@ pub trait Instance: private::Sealed {
         data_mode: SpiDataMode,
     ) {
         self.init_spi_data_mode(cmd.mode(), address.mode(), data_mode);
-
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)]
-            {
-                // Workaround: Without mosi and/or miso state, the addressing phase reverts to
-                // single bit mode.
-                _ = no_mosi_miso;
-                let no_mosi_miso = false;
-            }
-        }
 
         let reg_block = self.register_block();
         reg_block.user().modify(|_, w| {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -3110,25 +3110,17 @@ fn set_up_common_phases(reg_block: &RegisterBlock, cmd: Command, address: Addres
         });
     }
 
-    #[cfg(not(esp32))]
     if !address.is_none() {
         reg_block
             .user1()
             .modify(|_, w| unsafe { w.usr_addr_bitlen().bits((address.width() - 1) as u8) });
 
         let addr = address.value() << (32 - address.width());
+        #[cfg(not(esp32))]
         reg_block
             .addr()
             .write(|w| unsafe { w.usr_addr_value().bits(addr) });
-    }
-
     #[cfg(esp32)]
-    if !address.is_none() {
-        reg_block.user1().modify(|r, w| unsafe {
-            w.bits(r.bits() & !(0x3f << 26) | (((address.width() - 1) as u32) & 0x3f) << 26)
-        });
-
-        let addr = address.value() << (32 - address.width());
         reg_block.addr().write(|w| unsafe { w.bits(addr) });
     }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -998,6 +998,16 @@ mod dma {
         _mode: PhantomData<D>,
     }
 
+    #[cfg(all(esp32, esp32_spi_address_workaround))]
+    unsafe impl<'d, T, C, D, M> Send for SpiDma<'d, T, C, D, M>
+    where
+        C: DmaChannel,
+        C::P: SpiPeripheral,
+        D: DuplexMode,
+        M: Mode,
+    {
+    }
+
     impl<'d, T, C, D, M> core::fmt::Debug for SpiDma<'d, T, C, D, M>
     where
         C: DmaChannel,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2461,6 +2461,10 @@ pub trait Instance: private::Sealed {
             w.fread_dual().bit(data_mode == SpiDataMode::Dual);
             w.fread_quad().bit(data_mode == SpiDataMode::Quad)
         });
+        reg_block.user().modify(|_, w| {
+            w.fwrite_dual().bit(data_mode == SpiDataMode::Dual);
+            w.fwrite_quad().bit(data_mode == SpiDataMode::Quad)
+        });
     }
 
     #[cfg(esp32)]

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -830,7 +830,7 @@ where
         }
 
         cfg_if::cfg_if! {
-            if #[cfg(all(esp32, esp32_spi_address_workaround))] {
+            if #[cfg(all(esp32, spi_address_workaround))] {
                 let mut buffer = buffer;
                 let mut data_mode = data_mode;
                 let mut address = address;
@@ -993,12 +993,12 @@ mod dma {
     {
         pub(crate) spi: PeripheralRef<'d, T>,
         pub(crate) channel: Channel<'d, C, M>,
-        #[cfg(all(esp32, esp32_spi_address_workaround))]
+        #[cfg(all(esp32, spi_address_workaround))]
         address_buffer: DmaTxBuf,
         _mode: PhantomData<D>,
     }
 
-    #[cfg(all(esp32, esp32_spi_address_workaround))]
+    #[cfg(all(esp32, spi_address_workaround))]
     unsafe impl<'d, T, C, D, M> Send for SpiDma<'d, T, C, D, M>
     where
         C: DmaChannel,
@@ -1034,7 +1034,7 @@ mod dma {
     {
         fn new(spi: PeripheralRef<'d, T>, channel: Channel<'d, C, M>) -> Self {
             cfg_if::cfg_if! {
-                if #[cfg(all(esp32, esp32_spi_address_workaround))] {
+                if #[cfg(all(esp32, spi_address_workaround))] {
                     use crate::dma::DmaDescriptor;
                     const SPI_NUM: usize = 2;
                     static mut DESCRIPTORS: [[DmaDescriptor; 1]; SPI_NUM] =
@@ -1425,7 +1425,7 @@ mod dma {
                 return Err((Error::MaxDmaTransferSizeExceeded, self, buffer));
             }
 
-            #[cfg(all(esp32, esp32_spi_address_workaround))]
+            #[cfg(all(esp32, spi_address_workaround))]
             {
                 // On the ESP32, if we don't have data, the address is always sent
                 // on a single line, regardless of its data mode.

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2919,6 +2919,16 @@ pub trait Instance: private::Sealed {
     ) {
         self.init_spi_data_mode(cmd.mode(), address.mode(), data_mode);
 
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)]
+            {
+                // Workaround: Without mosi and/or miso state, the addressing phase reverts to
+                // single bit mode.
+                _ = no_mosi_miso;
+                let no_mosi_miso = false;
+            }
+        }
+
         let reg_block = self.register_block();
         reg_block.user().modify(|_, w| {
             w.usr_miso_highpart().clear_bit();

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -5,6 +5,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::assert_eq;
 #[cfg(pcnt)]
 use esp_hal::pcnt::{channel::EdgeMode, unit::Unit, Pcnt};
 use esp_hal::{

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -193,9 +193,9 @@ mod tests {
         let mut unconnected_pin = hil_test::unconnected_pin!(io);
 
         // Make sure pins have no pullups
-        let _ = Input::new(&mut pin, Pull::None);
-        let _ = Input::new(&mut pin_mirror, Pull::None);
-        let _ = Input::new(&mut unconnected_pin, Pull::None);
+        let _ = Input::new(&mut pin, Pull::Down);
+        let _ = Input::new(&mut pin_mirror, Pull::Down);
+        let _ = Input::new(&mut unconnected_pin, Pull::Down);
 
         let dma = Dma::new(peripherals.DMA);
 

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -140,7 +140,7 @@ fn execute_write(
     for command_data_mode in COMMAND_DATA_MODES {
         dma_tx_buf.fill(&[write; DMA_BUFFER_SIZE]);
 
-        // Send command + data.
+        // Send command + address + data.
         // Should read 8 high bits: 1 command bit, 3 address bits, 4 data bits
         unit0.clear();
         unit1.clear();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Two-parter:
- QSPI setup was unfixed in #2198.
- We didn't support multi-line address without data. Similar issue in esp-idf: https://github.com/espressif/esp-idf/issues/5684

This fixes #2229 and adds test code to make sure we don't break QSPI again. This PR also works around an ESP32 limitation.

#### Testing

Observed behaviour change using a logic analyzer and also the changed test cases fail before the fix.