### PR TITLE
Add stop_transfer method to DMA driver

### DIFF
--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -147,6 +147,12 @@ impl<const N: u8> RegisterAccess for Channel<N> {
             .modify(|_, w| w.outlink_start().set_bit());
     }
 
+    fn stop_out() {
+        Self::ch()
+            .out_link()
+            .modify(|_, w| w.outlink_stop().set_bit());
+    }
+
     fn last_out_dscr_address() -> usize {
         Self::ch()
             .out_eof_des_addr()
@@ -223,6 +229,12 @@ impl<const N: u8> RegisterAccess for Channel<N> {
         Self::ch()
             .in_link()
             .modify(|_, w| w.inlink_start().set_bit());
+    }
+
+    fn stop_in() {
+        Self::ch()
+            .in_link()
+            .modify(|_, w| w.inlink_stop().set_bit());
     }
 
     fn listen_out(interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1328,6 +1328,8 @@ pub trait Rx: crate::private::Sealed {
 
     fn start_transfer(&mut self) -> Result<(), DmaError>;
 
+    fn stop_transfer(&mut self);
+
     #[cfg(esp32s3)]
     fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize);
 
@@ -1403,6 +1405,10 @@ where
         } else {
             Ok(())
         }
+    }
+
+    fn stop_transfer(&mut self) {
+        R::stop_in();
     }
 
     fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker;
@@ -1499,6 +1505,10 @@ where
         self.rx_impl.start_transfer()
     }
 
+    fn stop_transfer(&mut self) {
+        self.rx_impl.stop_transfer()
+    }
+
     #[cfg(esp32s3)]
     fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize) {
         CH::Channel::set_in_ext_mem_block_size(size);
@@ -1572,6 +1582,8 @@ pub trait Tx: crate::private::Sealed {
 
     fn start_transfer(&mut self) -> Result<(), DmaError>;
 
+    fn stop_transfer(&mut self);
+
     #[cfg(esp32s3)]
     fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize);
 
@@ -1625,6 +1637,10 @@ where
         } else {
             Ok(())
         }
+    }
+
+    fn stop_transfer(&mut self) {
+        R::stop_out();
     }
 
     fn listen_out(&self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
@@ -1733,6 +1749,10 @@ where
         self.tx_impl.start_transfer()
     }
 
+    fn stop_transfer(&mut self) {
+        self.tx_impl.stop_transfer()
+    }
+
     #[cfg(esp32s3)]
     fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize) {
         CH::Channel::set_out_ext_mem_block_size(size);
@@ -1784,6 +1804,7 @@ pub trait RegisterAccess: crate::private::Sealed {
     fn set_out_descriptors(address: u32);
     fn set_out_peripheral(peripheral: u8);
     fn start_out();
+    fn stop_out();
 
     fn listen_out(interrupts: impl Into<EnumSet<DmaTxInterrupt>>);
     fn unlisten_out(interrupts: impl Into<EnumSet<DmaTxInterrupt>>);
@@ -1808,6 +1829,7 @@ pub trait RegisterAccess: crate::private::Sealed {
     fn set_in_descriptors(address: u32);
     fn set_in_peripheral(peripheral: u8);
     fn start_in();
+    fn stop_in();
 }
 
 /// DMA Channel

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -79,6 +79,11 @@ macro_rules! ImplSpiChannel {
                     spi.dma_out_link().modify(|_, w| w.outlink_start().set_bit());
                 }
 
+                fn stop_out() {
+                    let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
+                    spi.dma_out_link().modify(|_, w| w.outlink_stop().set_bit());
+                }
+
                 fn last_out_dscr_address() -> usize {
                     let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
                     spi.out_eof_des_addr().read().dma_out_eof_des_addr().bits() as usize
@@ -121,6 +126,11 @@ macro_rules! ImplSpiChannel {
                 fn start_in() {
                     let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
                     spi.dma_in_link().modify(|_, w| w.inlink_start().set_bit());
+                }
+
+                fn stop_in() {
+                    let spi = unsafe { &*crate::peripherals::[<SPI $num>]::PTR };
+                    spi.dma_in_link().modify(|_, w| w.inlink_stop().set_bit());
                 }
 
                 fn listen_out(interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
@@ -462,6 +472,11 @@ macro_rules! ImplI2sChannel {
                     reg_block.out_link().modify(|_, w| w.outlink_start().set_bit());
                 }
 
+                fn stop_out() {
+                    let reg_block = unsafe { &*crate::peripherals::[<$peripheral>]::PTR };
+                    reg_block.out_link().modify(|_, w| w.outlink_stop().set_bit());
+                }
+
                 fn last_out_dscr_address() -> usize {
                     let reg_block = unsafe { &*crate::peripherals::[<$peripheral>]::PTR };
                     reg_block.out_eof_des_addr().read().out_eof_des_addr().bits() as usize
@@ -508,6 +523,11 @@ macro_rules! ImplI2sChannel {
                 fn start_in() {
                     let reg_block = unsafe { &*crate::peripherals::[<$peripheral>]::PTR };
                     reg_block.in_link().modify(|_, w| w.inlink_start().set_bit());
+                }
+
+                fn stop_in() {
+                    let reg_block = unsafe { &*crate::peripherals::[<$peripheral>]::PTR };
+                    reg_block.in_link().modify(|_, w| w.inlink_stop().set_bit());
                 }
 
                 fn listen_out(interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds a stop transfer method to the DMA driver.
I added one in #2191 but I need it for another PR, so I'm sending it in earlier.

This method is internal, so no changelog.

#### Testing
It's a straight forward change already tested in #2191 and doesn't affect any existing code.
