### PR TITLE
Only lock once in `is_slice_in_psram`, use `usize` and fix a few comparisons

### DIFF
--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -752,10 +752,10 @@ mod m2m {
                     64 => DmaExtMemBKSize::Size64,
                     _ => panic!("unsupported cache line size"),
                 };
-                if crate::soc::is_valid_psram_address(tx_ptr as u32) {
+                if crate::soc::is_valid_psram_address(tx_ptr as usize) {
                     self.channel.tx.set_ext_mem_block_size(align);
                 }
-                if crate::soc::is_valid_psram_address(rx_ptr as u32) {
+                if crate::soc::is_valid_psram_address(rx_ptr as usize) {
                     self.channel.rx.set_ext_mem_block_size(align);
                 }
             }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -944,10 +944,10 @@ impl DescriptorChain {
         data: *mut u8,
         len: usize,
     ) -> Result<(), DmaError> {
-        if !crate::soc::is_valid_ram_address(self.first() as u32)
-            || !crate::soc::is_valid_ram_address(self.last() as u32)
-            || !crate::soc::is_valid_memory_address(data as u32)
-            || !crate::soc::is_valid_memory_address(unsafe { data.add(len) } as u32)
+        if !crate::soc::is_valid_ram_address(self.first() as usize)
+            || !crate::soc::is_valid_ram_address(self.last() as usize)
+            || !crate::soc::is_valid_memory_address(data as usize)
+            || !crate::soc::is_valid_memory_address(unsafe { data.add(len) } as usize)
         {
             return Err(DmaError::UnsupportedMemoryRegion);
         }
@@ -1016,10 +1016,10 @@ impl DescriptorChain {
         data: *const u8,
         len: usize,
     ) -> Result<(), DmaError> {
-        if !crate::soc::is_valid_ram_address(self.first() as u32)
-            || !crate::soc::is_valid_ram_address(self.last() as u32)
-            || !crate::soc::is_valid_memory_address(data as u32)
-            || !crate::soc::is_valid_memory_address(unsafe { data.add(len) } as u32)
+        if !crate::soc::is_valid_ram_address(self.first() as usize)
+            || !crate::soc::is_valid_ram_address(self.last() as usize)
+            || !crate::soc::is_valid_memory_address(data as usize)
+            || !crate::soc::is_valid_memory_address(unsafe { data.add(len) } as usize)
         {
             return Err(DmaError::UnsupportedMemoryRegion);
         }
@@ -1522,7 +1522,7 @@ where
             // we are forcing the DMA alignment to the cache line size
             // required when we are using dcache
             let alignment = crate::soc::cache_get_dcache_line_size() as usize;
-            if crate::soc::is_valid_psram_address(des.buffer as u32) {
+            if crate::soc::is_valid_psram_address(des.buffer as usize) {
                 // both the size and address of the buffer must be aligned
                 if des.buffer as usize % alignment != 0 && des.size() % alignment != 0 {
                     return Err(DmaError::InvalidAlignment);
@@ -1760,7 +1760,7 @@ where
             // we are forcing the DMA alignment to the cache line size
             // required when we are using dcache
             let alignment = crate::soc::cache_get_dcache_line_size() as usize;
-            if crate::soc::is_valid_psram_address(des.buffer as u32) {
+            if crate::soc::is_valid_psram_address(des.buffer as usize) {
                 // both the size and address of the buffer must be aligned
                 if des.buffer as usize % alignment != 0 && des.size() % alignment != 0 {
                     return Err(DmaError::InvalidAlignment);
@@ -2236,7 +2236,7 @@ impl DmaTxBuffer for DmaTxBuf {
         }
 
         #[cfg(esp32s3)]
-        if crate::soc::is_valid_psram_address(self.buffer.as_ptr() as u32) {
+        if crate::soc::is_valid_psram_address(self.buffer.as_ptr() as usize) {
             unsafe {
                 crate::soc::cache_writeback_addr(
                     self.buffer.as_ptr() as u32,

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -38,9 +38,9 @@ pub(crate) mod constants {
     /// The size, in bytes, of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 64;
     /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: u32 = 0x3FFA_E000;
+    pub const SOC_DRAM_LOW: usize = 0x3FFA_E000;
     /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: u32 = 0x4000_0000;
+    pub const SOC_DRAM_HIGH: usize = 0x4000_0000;
     /// A reference clock tick of 1 MHz.
     pub const REF_TICK: fugit::HertzU32 = fugit::HertzU32::MHz(1);
 }

--- a/esp-hal/src/soc/esp32c2/mod.rs
+++ b/esp-hal/src/soc/esp32c2/mod.rs
@@ -28,9 +28,9 @@ pub(crate) mod registers {
 
 pub(crate) mod constants {
     /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: u32 = 0x3FCA_0000;
+    pub const SOC_DRAM_LOW: usize = 0x3FCA_0000;
     /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: u32 = 0x3FCE_0000;
+    pub const SOC_DRAM_HIGH: usize = 0x3FCE_0000;
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -42,13 +42,13 @@ pub(crate) mod constants {
     pub const RMT_CHANNEL_RAM_SIZE: usize = 48;
     /// RMT Clock source value.
     pub const RMT_CLOCK_SRC: u8 = 1;
-    /// RMT Clock source frequence.
+    /// RMT Clock source frequency.
     pub const RMT_CLOCK_SRC_FREQ: fugit::HertzU32 = fugit::HertzU32::MHz(80);
 
     /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: u32 = 0x3FC8_0000;
+    pub const SOC_DRAM_LOW: usize = 0x3FC8_0000;
     /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: u32 = 0x3FCE_0000;
+    pub const SOC_DRAM_HIGH: usize = 0x3FCE_0000;
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -54,9 +54,9 @@ pub(crate) mod constants {
     pub const PARL_IO_SCLK: u32 = 240_000_000;
 
     /// The lower address boundary for system DRAM.
-    pub const SOC_DRAM_LOW: u32 = 0x4080_0000;
+    pub const SOC_DRAM_LOW: usize = 0x4080_0000;
     /// The upper address boundary for system DRAM.
-    pub const SOC_DRAM_HIGH: u32 = 0x4088_0000;
+    pub const SOC_DRAM_HIGH: usize = 0x4088_0000;
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17_500);

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -54,9 +54,9 @@ pub(crate) mod constants {
     pub const PARL_IO_SCLK: u32 = 96_000_000;
 
     /// Start address of the system's DRAM (low range).
-    pub const SOC_DRAM_LOW: u32 = 0x4080_0000;
+    pub const SOC_DRAM_LOW: usize = 0x4080_0000;
     /// End address of the system's DRAM (high range).
-    pub const SOC_DRAM_HIGH: u32 = 0x4085_0000;
+    pub const SOC_DRAM_HIGH: usize = 0x4085_0000;
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -43,9 +43,9 @@ pub(crate) mod constants {
     /// Size of the RAM allocated per RMT channel, in bytes.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 64;
     /// Start address of the system's DRAM (low range).
-    pub const SOC_DRAM_LOW: u32 = 0x3FFB_0000;
+    pub const SOC_DRAM_LOW: usize = 0x3FFB_0000;
     /// End address of the system's DRAM (high range).
-    pub const SOC_DRAM_HIGH: u32 = 0x4000_0000;
+    pub const SOC_DRAM_HIGH: usize = 0x4000_0000;
     /// Reference clock tick frequency, set to 1 MHz.
     pub const REF_TICK: fugit::HertzU32 = fugit::HertzU32::MHz(1);
 }

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -46,13 +46,13 @@ pub(crate) mod constants {
     pub const RMT_CHANNEL_RAM_SIZE: usize = 48;
     /// RMT Clock source value.
     pub const RMT_CLOCK_SRC: u8 = 1;
-    /// RMT Clock source frequence.
+    /// RMT Clock source frequency.
     pub const RMT_CLOCK_SRC_FREQ: fugit::HertzU32 = fugit::HertzU32::MHz(80);
 
     /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: u32 = 0x3FC8_8000;
+    pub const SOC_DRAM_LOW: usize = 0x3FC8_8000;
     /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: u32 = 0x3FD0_0000;
+    pub const SOC_DRAM_HIGH: usize = 0x3FD0_0000;
 
     /// A reference clock tick of 1 MHz.
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

skip-changelog because it's a small internal change only
