### PR TITLE
Migrate Camera to a move based API

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TWAI support for ESP32-H2 (#2199)
 - Make `DmaDescriptor` methods public (#2237)
 - Added a way to configure watchdogs in `esp_hal::init` (#2180)
+- Introduce `DmaRxStreamBuf` (#2242)
 - Implement `embedded_hal_async::delay::DelayNs` for `TIMGx` timers (#2084)
 
 ### Changed
@@ -52,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `NO_PIN` constant has been removed. (#2133)
 - MSRV bump to 1.79 (#2156)
 - Allow handling interrupts while trying to lock critical section on multi-core chips. (#2197)
+- Migrate `Camera` to a move based API (#2242).
 - Removed the PS-RAM related features, replaced by `quad-psram`/`octal-psram`, `init_psram` takes a configuration parameter, it's now possible to auto-detect PS-RAM size (#2178)
 - `EspTwaiFrame` constructors now accept any type that converts into `esp_hal::twai::Id` (#2207)
 - Change `DmaTxBuf` to support PSRAM on `esp32s3` (#2161)

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -19,14 +19,14 @@
 //! # use esp_hal::gpio::Io;
 //! # use esp_hal::lcd_cam::{cam::{Camera, RxEightBits}, LcdCam};
 //! # use fugit::RateExtU32;
-//! # use esp_hal::dma_buffers;
+//! # use esp_hal::dma_rx_stream_buffer;
 //! # use esp_hal::dma::{Dma, DmaPriority};
 //! # let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 //!
 //! # let dma = Dma::new(peripherals.DMA);
 //! # let channel = dma.channel0;
 //!
-//! # let (_, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32678, 0);
+//! # let dma_buf = dma_rx_stream_buffer!(20 * 1000, chunk_size = 1000);
 //!
 //! # let channel = channel.configure(
 //! #     false,
@@ -52,7 +52,6 @@
 //! let mut camera = Camera::new(
 //!     lcd_cam.cam,
 //!     channel.rx,
-//!     rx_descriptors,
 //!     data_pins,
 //!     20u32.MHz(),
 //! )
@@ -60,26 +59,27 @@
 //! .with_master_clock(mclk_pin)
 //! .with_pixel_clock(pclk_pin)
 //! .with_ctrl_pins(vsync_pin, href_pin);
+//!
+//! let transfer = camera.receive(dma_buf).map_err(|e| e.0).unwrap();
+//!
 //! # }
 //! ```
+
+use core::ops::{Deref, DerefMut};
 
 use fugit::HertzU32;
 
 use crate::{
     clock::Clocks,
     dma::{
-        dma_private::{DmaSupport, DmaSupportRx},
         ChannelRx,
-        DescriptorChain,
+        DmaBufferView,
         DmaChannel,
-        DmaDescriptor,
         DmaError,
         DmaPeripheral,
-        DmaTransferRx,
-        DmaTransferRxCircular,
+        DmaRxBuffer,
         LcdCamPeripheral,
         Rx,
-        WriteBuffer,
     },
     gpio::{InputPin, InputSignal, OutputPin, OutputSignal, Pull},
     lcd_cam::{cam::private::RxPins, private::calculate_clkm, BitOrder, ByteOrder},
@@ -129,9 +129,6 @@ pub struct Cam<'d> {
 pub struct Camera<'d, CH: DmaChannel> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
     rx_channel: ChannelRx<'d, CH>,
-    rx_chain: DescriptorChain,
-    // 1 or 2
-    bus_width: usize,
 }
 
 impl<'d, CH: DmaChannel> Camera<'d, CH>
@@ -142,7 +139,6 @@ where
     pub fn new<P: RxPins>(
         cam: Cam<'d>,
         channel: ChannelRx<'d, CH>,
-        descriptors: &'static mut [DmaDescriptor],
         _pins: P,
         frequency: HertzU32,
     ) -> Self {
@@ -176,7 +172,7 @@ where
             w.cam_rec_data_bytelen().bits(0);
             w.cam_line_int_num().bits(0);
             w.cam_vsync_filter_en().clear_bit();
-            w.cam_2byte_en().clear_bit();
+            w.cam_2byte_en().bit(P::BUS_WIDTH == 2);
             w.cam_clk_inv().clear_bit();
             w.cam_de_inv().clear_bit();
             w.cam_hsync_inv().clear_bit();
@@ -192,46 +188,7 @@ where
         Self {
             lcd_cam,
             rx_channel: channel,
-            rx_chain: DescriptorChain::new(descriptors),
-            bus_width: P::BUS_WIDTH,
         }
-    }
-}
-
-impl<'d, CH: DmaChannel> DmaSupport for Camera<'d, CH> {
-    fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
-        loop {
-            // Wait for IN_SUC_EOF (i.e. VSYNC)
-            if self.rx_channel.is_done() {
-                break;
-            }
-
-            // Or for IN_DSCR_EMPTY (i.e. No more buffer space)
-            if self.rx_channel.has_dscr_empty_error() {
-                break;
-            }
-
-            // Or for IN_DSCR_ERR (i.e. bad descriptor)
-            if self.rx_channel.has_error() {
-                break;
-            }
-        }
-    }
-
-    fn peripheral_dma_stop(&mut self) {
-        // TODO: Stop DMA?? self.instance.rx_channel.stop_transfer();
-    }
-}
-
-impl<'d, CH: DmaChannel> DmaSupportRx for Camera<'d, CH> {
-    type RX = ChannelRx<'d, CH>;
-
-    fn rx(&mut self) -> &mut Self::RX {
-        &mut self.rx_channel
-    }
-
-    fn chain(&mut self) -> &mut DescriptorChain {
-        &mut self.rx_chain
     }
 }
 
@@ -346,8 +303,12 @@ impl<'d, CH: DmaChannel> Camera<'d, CH> {
         self
     }
 
-    // Reset Camera control unit and Async Rx FIFO
-    fn reset_unit_and_fifo(&self) {
+    /// Starts a DMA transfer to receive data from the camera peripheral.
+    pub fn receive<BUF: DmaRxBuffer>(
+        mut self,
+        buf: BUF,
+    ) -> Result<CameraTransfer<'d, CH, BUF>, (DmaError, Self, BUF)> {
+        // Reset Camera control unit and Async Rx FIFO
         self.lcd_cam
             .cam_ctrl1()
             .modify(|_, w| w.cam_reset().set_bit());
@@ -360,60 +321,137 @@ impl<'d, CH: DmaChannel> Camera<'d, CH> {
         self.lcd_cam
             .cam_ctrl1()
             .modify(|_, w| w.cam_afifo_reset().clear_bit());
-    }
 
-    // Start the Camera unit to listen for incoming DVP stream.
-    fn start_unit(&self) {
-        self.lcd_cam
-            .cam_ctrl()
-            .modify(|_, w| w.cam_update().set_bit());
+        // Start DMA to receive incoming transfer.
+        let view = match self
+            .rx_channel
+            .prepare_and_start(DmaPeripheral::LcdCam, buf)
+        {
+            Ok(view) => view,
+            Err((err, buf)) => return Err((err, self, buf)),
+        };
+
+        // Start the Camera unit to listen for incoming DVP stream.
+        self.lcd_cam.cam_ctrl().modify(|_, w| {
+            // Automatically stops the camera unit once the GDMA Rx FIFO is full.
+            w.cam_stop_en().set_bit();
+
+            w.cam_update().set_bit()
+        });
         self.lcd_cam
             .cam_ctrl1()
             .modify(|_, w| w.cam_start().set_bit());
+
+        Ok(CameraTransfer {
+            camera: self,
+            buffer_view: view,
+        })
+    }
+}
+
+/// Represents an ongoing (or potentially stopped) transfer from the Camera to a
+/// DMA buffer.
+pub struct CameraTransfer<'d, CH: DmaChannel, BUF: DmaRxBuffer> {
+    camera: Camera<'d, CH>,
+    buffer_view: BUF::View,
+}
+
+impl<'d, CH: DmaChannel, BUF: DmaRxBuffer> CameraTransfer<'d, CH, BUF> {
+    /// Returns true when [Self::wait] will not block.
+    pub fn is_done(&self) -> bool {
+        // This peripheral doesn't really "complete". As long the camera (or anything
+        // pretending to be :D) sends data, it will receive it and pass it to the DMA.
+        // This implementation of is_done is an opinionated one. When the transfer is
+        // started, the CAM_STOP_EN bit is set, which tells the LCD_CAM to stop
+        // itself when the DMA stops emptying its async RX FIFO. This will
+        // typically be because the DMA ran out descriptors but there could be other
+        // reasons as well.
+
+        // In the future, a user of esp_hal may not want this behaviour, which would be
+        // a reasonable ask. At which point is_done and wait would go away, and
+        // the driver will stop pretending that this peripheral has some kind of
+        // finish line.
+
+        // For now, most people probably want this behaviour, so it shall be kept for
+        // the sake of familiarity and similarity with other drivers.
+
+        self.camera
+            .lcd_cam
+            .cam_ctrl1()
+            .read()
+            .cam_start()
+            .bit_is_clear()
     }
 
-    fn start_dma<RXBUF: WriteBuffer>(
-        &mut self,
-        circular: bool,
-        buf: &mut RXBUF,
-    ) -> Result<(), DmaError> {
-        let (ptr, len) = unsafe { buf.write_buffer() };
+    /// Stops this transfer on the spot and returns the peripheral and buffer.
+    pub fn stop(mut self) -> (Camera<'d, CH>, BUF) {
+        self.stop_peripherals();
+        let (camera, view) = self.release();
+        (camera, view.release())
+    }
 
-        assert!(len % self.bus_width == 0);
+    /// Waits for the transfer to stop and returns the peripheral and buffer.
+    ///
+    /// Note: The camera doesn't really "finish" its transfer, so what you're
+    /// really waiting for here is a DMA Error. You typically just want to
+    /// call [Self::stop] once you have the data you need.
+    pub fn wait(mut self) -> (Result<(), DmaError>, Camera<'d, CH>, BUF) {
+        while !self.is_done() {}
 
+        // Stop the DMA as it doesn't know that the camera has stopped.
+        self.camera.rx_channel.stop_transfer();
+
+        // Note: There is no "done" interrupt to clear.
+
+        let (camera, view) = self.release();
+
+        let result = if camera.rx_channel.has_error() {
+            Err(DmaError::DescriptorError)
+        } else {
+            Ok(())
+        };
+
+        (result, camera, view.release())
+    }
+
+    fn release(self) -> (Camera<'d, CH>, BUF::View) {
         unsafe {
-            self.rx_chain.fill_for_rx(circular, ptr as _, len)?;
-            self.rx_channel
-                .prepare_transfer_without_start(DmaPeripheral::LcdCam, &self.rx_chain)?;
+            let camera = core::ptr::read(&self.camera);
+            let view = core::ptr::read(&self.buffer_view);
+            core::mem::forget(self);
+            (camera, view)
         }
-        self.rx_channel.start_transfer()
     }
 
-    /// Starts a DMA transfer to receive data from the camera peripheral.
-    pub fn read_dma<'t, RXBUF: WriteBuffer>(
-        &'t mut self,
-        buf: &'t mut RXBUF,
-    ) -> Result<DmaTransferRx<'_, Self>, DmaError> {
-        self.reset_unit_and_fifo();
-        // Start DMA to receive incoming transfer.
-        self.start_dma(false, buf)?;
-        self.start_unit();
+    fn stop_peripherals(&mut self) {
+        // Stop the LCD_CAM peripheral.
+        self.camera
+            .lcd_cam
+            .cam_ctrl1()
+            .modify(|_, w| w.cam_start().clear_bit());
 
-        Ok(DmaTransferRx::new(self))
+        // Stop the DMA
+        self.camera.rx_channel.stop_transfer();
     }
+}
 
-    /// Starts a circular DMA transfer to receive data from the camera
-    /// peripheral.
-    pub fn read_dma_circular<'t, RXBUF: WriteBuffer>(
-        &'t mut self,
-        buf: &'t mut RXBUF,
-    ) -> Result<DmaTransferRxCircular<'_, Self>, DmaError> {
-        self.reset_unit_and_fifo();
-        // Start DMA to receive incoming transfer.
-        self.start_dma(true, buf)?;
-        self.start_unit();
+impl<'d, CH: DmaChannel, BUF: DmaRxBuffer> Deref for CameraTransfer<'d, CH, BUF> {
+    type Target = BUF::View;
 
-        Ok(DmaTransferRxCircular::new(self))
+    fn deref(&self) -> &Self::Target {
+        &self.buffer_view
+    }
+}
+
+impl<'d, CH: DmaChannel, BUF: DmaRxBuffer> DerefMut for CameraTransfer<'d, CH, BUF> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buffer_view
+    }
+}
+
+impl<'d, CH: DmaChannel, BUF: DmaRxBuffer> Drop for CameraTransfer<'d, CH, BUF> {
+    fn drop(&mut self) {
+        self.stop_peripherals();
     }
 }
 

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -26,7 +26,7 @@
 //! # let dma = Dma::new(peripherals.DMA);
 //! # let channel = dma.channel0;
 //!
-//! # let dma_buf = dma_rx_stream_buffer!(20 * 1000, chunk_size = 1000);
+//! # let dma_buf = dma_rx_stream_buffer!(20 * 1000, 1000);
 //!
 //! # let channel = channel.configure(
 //! #     false,

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -27,7 +27,7 @@ use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
-    dma_buffers,
+    dma_rx_stream_buffer,
     gpio::Io,
     i2c,
     i2c::I2C,
@@ -38,7 +38,7 @@ use esp_hal::{
     prelude::*,
     Blocking,
 };
-use esp_println::println;
+use esp_println::{print, println};
 
 #[entry]
 fn main() -> ! {
@@ -49,7 +49,7 @@ fn main() -> ! {
     let dma = Dma::new(peripherals.DMA);
     let channel = dma.channel0;
 
-    let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(32678, 0);
+    let dma_rx_buf = dma_rx_stream_buffer!(20 * 1000, 1000);
 
     let channel = channel.configure(false, DmaPriority::Priority0);
 
@@ -71,21 +71,12 @@ fn main() -> ! {
     );
 
     let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
-    let mut camera = Camera::new(
-        lcd_cam.cam,
-        channel.rx,
-        rx_descriptors,
-        cam_data_pins,
-        20u32.MHz(),
-    )
-    .with_master_clock(cam_xclk)
-    .with_pixel_clock(cam_pclk)
-    .with_ctrl_pins(cam_vsync, cam_href);
+    let camera = Camera::new(lcd_cam.cam, channel.rx, cam_data_pins, 20u32.MHz())
+        .with_master_clock(cam_xclk)
+        .with_pixel_clock(cam_pclk)
+        .with_ctrl_pins(cam_vsync, cam_href);
 
     let delay = Delay::new();
-
-    let mut buffer = rx_buffer;
-    buffer.fill(0u8);
 
     delay.delay_millis(500u32);
 
@@ -101,10 +92,6 @@ fn main() -> ! {
     let pid = sccb.read(OV2640_ADDRESS, 0x0A).unwrap();
     println!("Found PID of {:#02X}, and was expecting 0x26", pid);
 
-    // Start waiting for camera before initialising it to prevent missing the first few bytes.
-    // This can be improved with a VSYNC interrupt but would complicate this example.
-    let transfer = camera.read_dma(&mut buffer).unwrap();
-
     for (reg, value) in FIRST_BLOCK {
         sccb.write(OV2640_ADDRESS, *reg, *value).unwrap();
     }
@@ -116,20 +103,61 @@ fn main() -> ! {
         }
     }
 
-    transfer.wait().unwrap();
+    // Start receiving data from the camera.
+    let mut transfer = camera.receive(dma_rx_buf).map_err(|e| e.0).unwrap();
 
-    // Note: JPEGs starts with "FF, D8, FF, E0" and end with "FF, D9"
-
-    let index_of_end = buffer.windows(2).position(|c| c[0] == 0xFF && c[1] == 0xD9);
-    let index_of_end = if let Some(idx) = index_of_end {
-        idx + 2
-    } else {
-        println!("Failed to find JPEG terminator");
-        buffer.len()
-    };
+    // Skip the first 2 images. Each image ends with an EOF.
+    // We likely missed the first few bytes of the first image and the second image is likely
+    // garbage from the OV2640 focusing, calibrating, etc.
+    // Feel free to skip more images if the one captured below is still garbage.
+    for _ in 0..2 {
+        let mut total_bytes = 0;
+        loop {
+            let (data, ends_with_eof) = transfer.peek_until_eof();
+            if data.is_empty() {
+                if transfer.is_done() {
+                    panic!("We were too slow to read from the DMA");
+                }
+            } else {
+                let bytes_peeked = data.len();
+                transfer.consume(bytes_peeked);
+                total_bytes += bytes_peeked;
+                if ends_with_eof {
+                    // Found the end of the image/frame.
+                    println!("Skipped a {} byte image", total_bytes);
+                    break;
+                }
+            }
+        }
+    }
 
     println!("Frame data (parse with `xxd -r -p <uart>.txt image.jpg`):");
-    println!("{:02X?}", &buffer[..index_of_end]);
+
+    // Note: JPEGs starts with "FF, D8, FF, E0" and end with "FF, D9".
+    // The OV2640 also sends some trailing zeros after the JPEG. This is expected.
+
+    loop {
+        let (data, ends_with_eof) = transfer.peek_until_eof();
+        if data.is_empty() {
+            if transfer.is_done() {
+                panic!("We were too slow to read from the DMA");
+            }
+        } else {
+            for b in data {
+                print!("{:02X}, ", b);
+            }
+            let bytes_peeked = data.len();
+            transfer.consume(bytes_peeked);
+
+            if ends_with_eof {
+                // Found the end of the image/frame.
+                break;
+            }
+        }
+    }
+
+    // The full frame has been captured, the transfer can be stopped now.
+    let _ = transfer.stop();
 
     loop {}
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Similar to #2191, this PR migrates the `Camera` driver to move based API for the same reasons. `Camera` now accepts a `DmaRxBuffer` rather than a plain slice, providing flexibility with DMA.

~This PR depends on #2213 and #2191 (I need to refactor it to expose the new `View` type).~

This PR introduces a new `DmaRxBuffer` implementation called `DmaRxStreamBuf`. It's effectively the "circular transfer" version of `DmaRxBuf` but with an important difference, it doesn't create a circle of descriptors, which avoids the problem in #2021. It also provides a zero copy API and exposes EOFs (See #2033). There's more info on how it works in the doc of the struct.

To support this new `DmaRxBuffer` implementation, I've added an associated type `View` to `DmaRxBuffer` (and `DmaTxBuffer`) to allow limited but safe access to the buffer during the DMA transfer. This is what lets users read from the buffer during the transfer.

Now the choice of "one shot" or "circular" (or any other transfer type) is based on the dma buffer implementation rather than the driver, effectively achieving half of https://github.com/esp-rs/esp-hal/discussions/2035 .

I haven't provided a `with_buffer`/`SpiDmaBus` equivalent here because most people using this driver would typically just start one transfer and endlessly read from it for the rest of their application.
Users can easily create a wrapper if they have a more specific use case.

#### Testing
Ran the modified example on my devkit and it's even more reliable than before.
cc @MabezDev for running the example on your ESP32-S3-EYE. (I don't think anyone else on the team has a ESP32-S3 + OV2640 devkit).
