### PR TITLE
TWAI: Return error instead of crashing

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: ESP32: Send address with correct data mode even when no data is sent. (#2231)
 - PARL_IO: Fixed an issue that caused garbage to be output at the start of some requests (#2211)
 - TWAI on ESP32 (#2207)
+- TWAI should no longer panic when receiving a non-compliant frame (#2255)
 
 ### Removed
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1757,10 +1757,8 @@ mod asynch {
         }
     }
 
-    #[handler]
-    pub(super) fn twai0() {
-        let register_block = TWAI0::register_block();
-
+    fn handle_interrupt<T: Instance>() {
+        let register_block = T::register_block();
         cfg_if::cfg_if! {
             if #[cfg(any(esp32, esp32c3, esp32s2, esp32s3))] {
                 let intr_enable = register_block.int_ena().read();
@@ -1781,7 +1779,7 @@ mod asynch {
             }
         }
 
-        let async_state = TWAI0::async_state();
+        let async_state = T::async_state();
 
         if tx_int_status.bit_is_set() {
             async_state.tx_waker.wake();
@@ -1800,7 +1798,7 @@ mod asynch {
                 let _ = rx_queue.try_send(Err(EspTwaiError::EmbeddedHAL(ErrorKind::Overrun)));
             }
 
-            match TWAI0::read_frame() {
+            match T::read_frame() {
                 Ok(frame) => {
                     let _ = rx_queue.try_send(Ok(frame));
                 }
@@ -1818,48 +1816,14 @@ mod asynch {
         }
     }
 
+    #[handler]
+    pub(super) fn twai0() {
+        handle_interrupt::<TWAI0>();
+    }
+
     #[cfg(twai1)]
     #[handler]
     pub(super) fn twai1() {
-        let register_block = TWAI1::register_block();
-
-        let intr_enable = register_block.interrupt_enable().read();
-        let intr_status = register_block.interrupt().read();
-
-        let async_state = TWAI1::async_state();
-
-        if intr_status.transmit_int_st().bit_is_set() {
-            async_state.tx_waker.wake();
-        }
-
-        if intr_status.receive_int_st().bit_is_set() {
-            let status = register_block.status().read();
-
-            let rx_queue = &async_state.rx_queue;
-
-            if status.bus_off_st().bit_is_set() {
-                let _ = rx_queue.try_send(Err(EspTwaiError::BusOff));
-            }
-
-            if status.miss_st().bit_is_set() {
-                let _ = rx_queue.try_send(Err(EspTwaiError::EmbeddedHAL(ErrorKind::Overrun)));
-            }
-
-            let frame = TWAI1::read_frame();
-
-            let _ = rx_queue.try_send(Ok(frame));
-
-            register_block.cmd().write(|w| w.release_buf().set_bit());
-        }
-
-        if intr_status.bits() & 0b11111100 > 0 {
-            async_state.err_waker.wake();
-        }
-
-        unsafe {
-            register_block
-                .interrupt_enable()
-                .modify(|_, w| w.bits(intr_enable.bits() & (!intr_status.bits() | 1)));
-        }
+        handle_interrupt::<TWAI1>();
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Fixes #2252 by returning an error instead. For async, we print a warning-level log line when we encounter a malformed frame.