### PR TITLE
Print test panics using `semihosting`

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix build when not using `panic-handler` (#2257)
+
 ### Removed
 
 ## 0.14.1 - 2024-09-06

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -4,10 +4,10 @@ use crate::MAX_BACKTRACE_ADDRESSES;
 
 // subtract 4 from the return address
 // the return address is the address following the JALR
-// we get better results (especially if the caller was the last function in the
-// calling function) if we report the address of the JALR itself
+// we get better results (especially if the caller was the last instruction in
+// the calling function) if we report the address of the JALR itself
 // even if it was a C.JALR we should get good results using RA - 4
-#[cfg(feature = "panic-handler")]
+#[allow(unused)]
 pub(super) const RA_OFFSET: usize = 4;
 
 /// Registers saved in trap handler

--- a/esp-backtrace/src/xtensa.rs
+++ b/esp-backtrace/src/xtensa.rs
@@ -6,7 +6,7 @@ use crate::MAX_BACKTRACE_ADDRESSES;
 // the return address is the address following the callxN
 // we get better results (especially if the caller was the last function in the
 // calling function) if we report the address of callxN itself
-#[cfg(feature = "panic-handler")]
+#[allow(unused)]
 pub(super) const RA_OFFSET: usize = 3;
 
 /// Exception Cause

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -185,7 +185,7 @@ embedded-hal-async = "1.0.0"
 embedded-hal-nb    = { version = "1.0.0", optional = true }
 esp-alloc          = { path = "../esp-alloc", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "defmt", "semihosting"] }
-esp-hal            = { path = "../esp-hal", features = ["defmt", "digest"], optional = true }
+esp-hal            = { path = "../esp-hal", features = ["digest"], optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 portable-atomic    = "1.7.0"
 static_cell        = { version = "2.1.0", features = ["nightly"] }
@@ -213,7 +213,7 @@ esp-metadata = { path = "../esp-metadata" }
 [features]
 default = ["embassy"]
 
-defmt = ["dep:defmt-rtt", "embedded-test/defmt"]
+defmt = ["dep:defmt-rtt", "esp-hal/defmt", "embedded-test/defmt"]
 
 # Device support (required!):
 esp32 = [

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -184,11 +184,12 @@ embedded-hal-02    = { version = "0.2.7", package = "embedded-hal", features = [
 embedded-hal-async = "1.0.0"
 embedded-hal-nb    = { version = "1.0.0", optional = true }
 esp-alloc          = { path = "../esp-alloc", optional = true }
-esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "panic-handler", "defmt", "semihosting"] }
+esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "defmt", "semihosting"] }
 esp-hal            = { path = "../esp-hal", features = ["defmt", "digest"], optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 portable-atomic    = "1.7.0"
 static_cell        = { version = "2.1.0", features = ["nightly"] }
+semihosting        = { version = "0.1", features= ["stdio", "panic-handler"] }
 
 [dev-dependencies]
 crypto-bigint       = { version = "0.5.5", default-features = false }

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -6,6 +6,8 @@
 // development, and when a test fails. In these cases, you can enable
 // the `defmt` feature to get the output.
 
+use esp_hal as _;
+
 #[cfg(not(feature = "defmt"))]
 #[defmt::global_logger]
 struct Logger;

--- a/hil-test/tests/aes.rs
+++ b/hil-test/tests/aes.rs
@@ -18,8 +18,6 @@ struct Context<'a> {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -22,8 +22,6 @@ const DMA_BUFFER_SIZE: usize = 16;
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/crc.rs
+++ b/hil-test/tests/crc.rs
@@ -13,8 +13,6 @@ use hil_test as _;
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/critical_section.rs
+++ b/hil-test/tests/critical_section.rs
@@ -14,6 +14,11 @@ use hil_test as _;
 mod tests {
     use esp_hal::sync::Locked;
 
+    #[init]
+    fn init() {
+        esp_hal::init(esp_hal::Config::default());
+    }
+
     #[test]
     fn critical_section_is_reentrant() {
         let mut flag = false;

--- a/hil-test/tests/dma_macros.rs
+++ b/hil-test/tests/dma_macros.rs
@@ -24,7 +24,10 @@ pub(crate) const fn compute_circular_size(size: usize, chunk_size: usize) -> usi
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
+    // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
+    // using defmt's non-const assert. Doing so would result in a compile error.
+    #[allow(unused_imports)]
+    use defmt::*;
 
     use super::*;
 
@@ -32,9 +35,9 @@ mod tests {
     fn test_dma_descriptors_same_size() {
         use esp_hal::dma::CHUNK_SIZE;
         let (rx_descriptors, tx_descriptors) = esp_hal::dma_descriptors!(DATA_SIZE);
-        assert_eq!(rx_descriptors.len(), tx_descriptors.len());
-        assert_eq!(rx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
-        assert_eq!(tx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
+        core::assert_eq!(rx_descriptors.len(), tx_descriptors.len());
+        core::assert_eq!(rx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
+        core::assert_eq!(tx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
     }
 
     #[test]
@@ -43,20 +46,20 @@ mod tests {
         const RX_SIZE: usize = DATA_SIZE / 2;
         const TX_SIZE: usize = DATA_SIZE;
         let (rx_descriptors, tx_descriptors) = esp_hal::dma_descriptors!(RX_SIZE, TX_SIZE);
-        assert_eq!(rx_descriptors.len(), compute_size(RX_SIZE, CHUNK_SIZE));
-        assert_eq!(tx_descriptors.len(), compute_size(TX_SIZE, CHUNK_SIZE));
+        core::assert_eq!(rx_descriptors.len(), compute_size(RX_SIZE, CHUNK_SIZE));
+        core::assert_eq!(tx_descriptors.len(), compute_size(TX_SIZE, CHUNK_SIZE));
     }
 
     #[test]
     fn test_dma_circular_descriptors_same_size() {
         use esp_hal::dma::CHUNK_SIZE;
         let (rx_descriptors, tx_descriptors) = esp_hal::dma_circular_descriptors!(DATA_SIZE);
-        assert_eq!(rx_descriptors.len(), tx_descriptors.len());
-        assert_eq!(
+        core::assert_eq!(rx_descriptors.len(), tx_descriptors.len());
+        core::assert_eq!(
             rx_descriptors.len(),
             compute_circular_size(DATA_SIZE, CHUNK_SIZE)
         );
-        assert_eq!(
+        core::assert_eq!(
             tx_descriptors.len(),
             compute_circular_size(DATA_SIZE, CHUNK_SIZE)
         );
@@ -68,11 +71,11 @@ mod tests {
         const RX_SIZE: usize = DATA_SIZE / 2;
         const TX_SIZE: usize = CHUNK_SIZE * 2;
         let (rx_descriptors, tx_descriptors) = esp_hal::dma_circular_descriptors!(RX_SIZE, TX_SIZE);
-        assert_eq!(
+        core::assert_eq!(
             rx_descriptors.len(),
             compute_circular_size(RX_SIZE, CHUNK_SIZE)
         );
-        assert_eq!(
+        core::assert_eq!(
             tx_descriptors.len(),
             compute_circular_size(TX_SIZE, CHUNK_SIZE)
         );
@@ -83,11 +86,11 @@ mod tests {
         use esp_hal::dma::CHUNK_SIZE;
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
             esp_hal::dma_buffers!(DATA_SIZE);
-        assert_eq!(rx_buffer.len(), DATA_SIZE);
-        assert_eq!(tx_buffer.len(), DATA_SIZE);
-        assert_eq!(tx_descriptors.len(), rx_descriptors.len());
-        assert_eq!(rx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
-        assert_eq!(tx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
+        core::assert_eq!(rx_buffer.len(), DATA_SIZE);
+        core::assert_eq!(tx_buffer.len(), DATA_SIZE);
+        core::assert_eq!(tx_descriptors.len(), rx_descriptors.len());
+        core::assert_eq!(rx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
+        core::assert_eq!(tx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
     }
 
     #[test]
@@ -98,10 +101,10 @@ mod tests {
 
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
             esp_hal::dma_buffers!(RX_SIZE, TX_SIZE);
-        assert_eq!(rx_buffer.len(), RX_SIZE);
-        assert_eq!(tx_buffer.len(), TX_SIZE);
-        assert_eq!(rx_descriptors.len(), compute_size(RX_SIZE, CHUNK_SIZE));
-        assert_eq!(tx_descriptors.len(), compute_size(TX_SIZE, CHUNK_SIZE));
+        core::assert_eq!(rx_buffer.len(), RX_SIZE);
+        core::assert_eq!(tx_buffer.len(), TX_SIZE);
+        core::assert_eq!(rx_descriptors.len(), compute_size(RX_SIZE, CHUNK_SIZE));
+        core::assert_eq!(tx_descriptors.len(), compute_size(TX_SIZE, CHUNK_SIZE));
     }
 
     #[test]
@@ -109,14 +112,14 @@ mod tests {
         use esp_hal::dma::CHUNK_SIZE;
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
             esp_hal::dma_circular_buffers!(DATA_SIZE);
-        assert_eq!(rx_buffer.len(), DATA_SIZE);
-        assert_eq!(tx_buffer.len(), DATA_SIZE);
-        assert_eq!(rx_descriptors.len(), tx_descriptors.len());
-        assert_eq!(
+        core::assert_eq!(rx_buffer.len(), DATA_SIZE);
+        core::assert_eq!(tx_buffer.len(), DATA_SIZE);
+        core::assert_eq!(rx_descriptors.len(), tx_descriptors.len());
+        core::assert_eq!(
             rx_descriptors.len(),
             compute_circular_size(DATA_SIZE, CHUNK_SIZE)
         );
-        assert_eq!(
+        core::assert_eq!(
             tx_descriptors.len(),
             compute_circular_size(DATA_SIZE, CHUNK_SIZE)
         );
@@ -129,13 +132,13 @@ mod tests {
         const TX_SIZE: usize = CHUNK_SIZE * 4;
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
             esp_hal::dma_circular_buffers!(RX_SIZE, TX_SIZE);
-        assert_eq!(rx_buffer.len(), RX_SIZE);
-        assert_eq!(tx_buffer.len(), TX_SIZE);
-        assert_eq!(
+        core::assert_eq!(rx_buffer.len(), RX_SIZE);
+        core::assert_eq!(tx_buffer.len(), TX_SIZE);
+        core::assert_eq!(
             rx_descriptors.len(),
             compute_circular_size(RX_SIZE, CHUNK_SIZE)
         );
-        assert_eq!(
+        core::assert_eq!(
             tx_descriptors.len(),
             compute_circular_size(TX_SIZE, CHUNK_SIZE)
         );
@@ -146,9 +149,9 @@ mod tests {
         const CHUNK_SIZE: usize = 2048;
         let (rx_descriptors, tx_descriptors) =
             esp_hal::dma_descriptors_chunk_size!(DATA_SIZE, CHUNK_SIZE);
-        assert_eq!(rx_descriptors.len(), tx_descriptors.len());
-        assert_eq!(rx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
-        assert_eq!(tx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
+        core::assert_eq!(rx_descriptors.len(), tx_descriptors.len());
+        core::assert_eq!(rx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
+        core::assert_eq!(tx_descriptors.len(), compute_size(DATA_SIZE, CHUNK_SIZE));
     }
 
     #[test]
@@ -158,8 +161,8 @@ mod tests {
         const TX_SIZE: usize = DATA_SIZE;
         let (rx_descriptors, tx_descriptors) =
             esp_hal::dma_descriptors_chunk_size!(RX_SIZE, TX_SIZE, CHUNK_SIZE);
-        assert_eq!(rx_descriptors.len(), compute_size(RX_SIZE, CHUNK_SIZE));
-        assert_eq!(tx_descriptors.len(), compute_size(TX_SIZE, CHUNK_SIZE));
+        core::assert_eq!(rx_descriptors.len(), compute_size(RX_SIZE, CHUNK_SIZE));
+        core::assert_eq!(tx_descriptors.len(), compute_size(TX_SIZE, CHUNK_SIZE));
     }
 
     #[test]
@@ -167,14 +170,14 @@ mod tests {
         const CHUNK_SIZE: usize = 2048;
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
             esp_hal::dma_circular_buffers_chunk_size!(DATA_SIZE, CHUNK_SIZE);
-        assert_eq!(rx_buffer.len(), DATA_SIZE);
-        assert_eq!(tx_buffer.len(), DATA_SIZE);
-        assert_eq!(rx_descriptors.len(), tx_descriptors.len());
-        assert_eq!(
+        core::assert_eq!(rx_buffer.len(), DATA_SIZE);
+        core::assert_eq!(tx_buffer.len(), DATA_SIZE);
+        core::assert_eq!(rx_descriptors.len(), tx_descriptors.len());
+        core::assert_eq!(
             rx_descriptors.len(),
             compute_circular_size(DATA_SIZE, CHUNK_SIZE)
         );
-        assert_eq!(
+        core::assert_eq!(
             tx_descriptors.len(),
             compute_circular_size(DATA_SIZE, CHUNK_SIZE)
         );
@@ -187,13 +190,13 @@ mod tests {
         const TX_SIZE: usize = DATA_SIZE;
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
             esp_hal::dma_circular_buffers_chunk_size!(RX_SIZE, TX_SIZE, CHUNK_SIZE);
-        assert_eq!(rx_buffer.len(), RX_SIZE);
-        assert_eq!(tx_buffer.len(), TX_SIZE);
-        assert_eq!(
+        core::assert_eq!(rx_buffer.len(), RX_SIZE);
+        core::assert_eq!(tx_buffer.len(), TX_SIZE);
+        core::assert_eq!(
             rx_descriptors.len(),
             compute_circular_size(RX_SIZE, CHUNK_SIZE)
         );
-        assert_eq!(
+        core::assert_eq!(
             tx_descriptors.len(),
             compute_circular_size(TX_SIZE, CHUNK_SIZE)
         );
@@ -207,10 +210,10 @@ mod tests {
         fn check(result: Result<DmaTxBuf, DmaBufError>, size: usize) {
             match result {
                 Ok(tx_buf) => {
-                    assert_eq!(tx_buf.len(), size);
+                    core::assert_eq!(tx_buf.len(), size);
                 }
                 Err(_) => {
-                    panic!("Failed to create DmaTxBuf");
+                    core::panic!("Failed to create DmaTxBuf");
                 }
             }
         }

--- a/hil-test/tests/dma_macros.rs
+++ b/hil-test/tests/dma_macros.rs
@@ -28,9 +28,6 @@ mod tests {
 
     use super::*;
 
-    #[init]
-    fn init() {}
-
     #[test]
     fn test_dma_descriptors_same_size() {
         use esp_hal::dma::CHUNK_SIZE;

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -34,8 +34,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/ecc.rs
+++ b/hil-test/tests/ecc.rs
@@ -50,8 +50,6 @@ struct Context<'a> {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -41,7 +41,6 @@ pub fn interrupt_handler() {
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
-    use defmt::assert_eq;
     use embassy_time::{Duration, Timer};
     use esp_hal::gpio::{Event, Flex, OutputOpenDrain};
     use portable_atomic::{AtomicUsize, Ordering};

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -14,8 +14,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_ne;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -101,11 +101,6 @@ fn enable_loopback() {
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
-    // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
-    // using defmt's non-const assert. Doing so would result in a compile error.
-    #[allow(unused_imports)]
-    use defmt::{assert, assert_eq, *};
-
     use super::*;
 
     struct Context {

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -40,11 +40,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
-    // using defmt's non-const assert. Doing so would result in a compile error.
-    #[allow(unused_imports)]
-    use defmt::{assert_eq, *};
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -40,6 +40,8 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
+    use defmt::info;
+
     use super::*;
 
     #[init]

--- a/hil-test/tests/parl_io_tx_async.rs
+++ b/hil-test/tests/parl_io_tx_async.rs
@@ -42,11 +42,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
-    // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
-    // using defmt's non-const assert. Doing so would result in a compile error.
-    #[allow(unused_imports)]
-    use defmt::{assert_eq, *};
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/parl_io_tx_async.rs
+++ b/hil-test/tests/parl_io_tx_async.rs
@@ -42,6 +42,8 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
+    use defmt::info;
+
     use super::*;
 
     #[init]

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -5,7 +5,6 @@
 #![no_std]
 #![no_main]
 
-use defmt::assert_eq;
 #[cfg(pcnt)]
 use esp_hal::pcnt::{channel::EdgeMode, unit::Unit, Pcnt};
 use esp_hal::{

--- a/hil-test/tests/rsa.rs
+++ b/hil-test/tests/rsa.rs
@@ -51,8 +51,6 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/rsa_async.rs
+++ b/hil-test/tests/rsa_async.rs
@@ -51,8 +51,6 @@ const fn compute_mprime(modulus: &U512) -> u32 {
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/sha.rs
+++ b/hil-test/tests/sha.rs
@@ -160,9 +160,6 @@ pub struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -46,8 +46,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]
@@ -104,12 +102,12 @@ mod tests {
     #[test]
     #[timeout(3)]
     fn test_asymmetric_transfer(mut ctx: Context) {
-        let write = [0xde, 0xad, 0xbe, 0xef];
+        let write = [0xde, 0xad, 0xbe, 0xee];
         let mut read: [u8; 4] = [0x00; 4];
 
         SpiBus::transfer(&mut ctx.spi, &mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
-        assert_eq!(write[0], read[0]);
+        assert_eq!(write[0], read[1]);
         assert_eq!(read[2], 0x00u8);
     }
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -102,12 +102,12 @@ mod tests {
     #[test]
     #[timeout(3)]
     fn test_asymmetric_transfer(mut ctx: Context) {
-        let write = [0xde, 0xad, 0xbe, 0xee];
+        let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read: [u8; 4] = [0x00; 4];
 
         SpiBus::transfer(&mut ctx.spi, &mut read[0..2], &write[..])
             .expect("Asymmetric transfer failed");
-        assert_eq!(write[0], read[1]);
+        assert_eq!(write[0], read[0]);
         assert_eq!(read[2], 0x00u8);
     }
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -37,8 +37,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -42,11 +42,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
-    // using defmt's non-const assert. Doing so would result in a compile error.
-    #[allow(unused_imports)]
-    use defmt::{assert_eq, *};
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -58,11 +58,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
-    // using defmt's non-const assert. Doing so would result in a compile error.
-    #[allow(unused_imports)]
-    use defmt::{assert_eq, *};
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -4,6 +4,7 @@
 
 #![no_std]
 #![no_main]
+use defmt::error;
 use esp_alloc as _;
 use esp_hal::{
     dma::{Dma, DmaBufBlkSize, DmaPriority, DmaRxBuf, DmaTxBuf},

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -23,8 +23,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -23,8 +23,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/uart_async.rs
+++ b/hil-test/tests/uart_async.rs
@@ -16,8 +16,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -23,8 +23,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]

--- a/hil-test/tests/uart_tx_rx_async.rs
+++ b/hil-test/tests/uart_tx_rx_async.rs
@@ -22,8 +22,6 @@ struct Context {
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
 mod tests {
-    use defmt::assert_eq;
-
     use super::*;
 
     #[init]


### PR DESCRIPTION
It seems we still don't get valuable stack traces on Xtensa. Although, even if we had, a panic's cause is unclear. In order to provide as much info as possible, this PR changes HIL tests to output panic messages using semihosting, which is a different mechanism based on breakpoints and debugger support.

This PR is pending on https://github.com/probe-rs/probe-rs/pull/2740 and https://github.com/probe-rs/probe-rs/pull/2841 (which are now deployed on the runners).

There is one downside: probe-rs doesn't capture test output yet, so the test logs contain the panic messages from `#[should_panic]` tests.

This PR disables `esp-hal/defmt` for tests so that if a panic happens inside the HAL, its message gets printed.