### PR TITLE
Erase DMA channel type from Camera and AesDma drivers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I8080 driver now decides bus width at transfer time rather than construction time. (#2171)
 - Replaced `AnyPin` with `InputSignal` and `OutputSignal` and renamed `ErasedPin` to `AnyPin` (#2128)
 - Replaced the `ErasedTimer` enum with the `AnyTimer` struct. (#2144)
+- `Camera` and `AesDma` now support erasing the DMA channel type (#2258)
 - Changed the parameters of `Spi::with_pins` to no longer be optional (#2133)
 - Renamed `DummyPin` to `NoPin` and removed all internal logic from it. (#2133)
 - The `NO_PIN` constant has been removed. (#2133)

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -251,6 +251,11 @@ pub mod dma {
         },
     };
 
+    #[cfg(gdma)]
+    type DefaultChannel = crate::dma::AnyDmaChannel;
+    #[cfg(pdma)]
+    type DefaultChannel = (); // Replace with PDMA channel once support is added.
+
     const ALIGN_SIZE: usize = core::mem::size_of::<u32>();
 
     /// Specifies the block cipher modes available for AES operations.
@@ -270,7 +275,7 @@ pub mod dma {
     }
 
     /// A DMA capable AES instance.
-    pub struct AesDma<'d, C>
+    pub struct AesDma<'d, C = DefaultChannel>
     where
         C: DmaChannel,
         C::P: AesPeripheral,

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -371,11 +371,20 @@ macro_rules! ImplSpiChannel {
             }
 
             impl DmaChannelExt for [<Spi $num DmaChannel>] {
+                type Degraded = Self;
+
                 fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     SpiDmaRxChannelImpl::<Self>(PhantomData)
                 }
                 fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     SpiDmaTxChannelImpl::<Self>(PhantomData)
+                }
+
+                fn degrade_rx(rx: Self::Rx) -> Self::Rx {
+                    rx
+                }
+                fn degrade_tx(tx: Self::Tx) -> Self::Tx {
+                    tx
                 }
 
                 fn set_isr(handler: InterruptHandler) {
@@ -830,11 +839,20 @@ macro_rules! ImplI2sChannel {
             }
 
             impl DmaChannelExt for [<I2s $num DmaChannel>] {
+                type Degraded = Self;
+
                 fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     I2sDmaRxChannelImpl::<Self>(PhantomData)
                 }
                 fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     I2sDmaTxChannelImpl::<Self>(PhantomData)
+                }
+
+                fn degrade_rx(rx: Self::Rx) -> Self::Rx {
+                    rx
+                }
+                fn degrade_tx(tx: Self::Tx) -> Self::Tx {
+                    tx
                 }
 
                 fn set_isr(handler: InterruptHandler) {

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -69,6 +69,7 @@ use crate::{
     clock::Clocks,
     dma::{
         dma_private::{DmaSupport, DmaSupportRx},
+        AnyDmaChannel,
         ChannelRx,
         DescriptorChain,
         DmaChannel,
@@ -126,7 +127,7 @@ pub struct Cam<'d> {
 }
 
 /// Represents the camera interface with DMA support.
-pub struct Camera<'d, CH: DmaChannel> {
+pub struct Camera<'d, CH: DmaChannel = AnyDmaChannel> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
     rx_channel: ChannelRx<'d, CH>,
     rx_chain: DescriptorChain,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR gives users the ability to degrade a DMA channel into a less specific type.
On GDMA chips this is a transformation from `DmaChannel0`/`DmaChannel1`/`DmaChannel2`/etc to `AnyDmaChannel`.
On PDMA chips this does nothing (For now).

I've added a default generic parameter to `Camera` and `AesDma`.
i.e. `pub struct Camera<'d, CH: DmaChannel = AnyDmaChannel>`

So now users can do this.
```Rust
let dma = Dma::new(peripherals.DMA);
let channel = dma.channel0;

let channel = channel.configure(false, DmaPriority::Priority0).degrade(); // <---- DEGRADE!!!
let rx_channel = channel.rx;

// Users can also do this.
// let channel = channel.configure(false, DmaPriority::Priority0);
// let rx_channel = channel.rx.degrade(); <--- DEGRADE!!!!

let mut camera = Camera::new(
    lcd_cam.cam,
    rx_channel,
    rx_descriptors,
    cam_data_pins,
    20u32.MHz(),
);
```

I've only done `Camera` and `AesDma` as those two didn't require breaking changes to add.
`I8080` for example has this type signature `struct I8080<'d, CH: DmaChannel, DM: Mode>`.
To add the erased DMA channel type I have to do reorder the generics like so `struct I8080<'d, DM: Mode, CH: DmaChannel = AnyDmaChannel>`, which is a breaking change. There's the option of adding a default mode as well but I'm not interested in making this decision nor carrying out the admin for the breaking changes.

For the PDMA side, having an "Any" type isn't as important because there is always a single answer to the question "What DMA channel do I need to use for this peripheral?" (Except on the ESP32 SPI DMA but we won't get into that here).
In this case I think it's reasonable to use a conditional type alias, like what I did for Aes.

```Rust
#[cfg(gdma)]
type DefaultChannel = crate::dma::AnyDmaChannel;
#[cfg(pdma)]
type DefaultChannel = (); // Replace with PDMA channel once support is added.

pub struct AesDma<'d, C = DefaultChannel> { /* ... */ }
```

The nice this about this is that PDMA chips always have "type erasure" in the sense that you'll never have to name the channel, even if you don't call `degrade()`.

For SPI and I2S that have multiple instances, an associated type can be used.
```Rust
trait Instance {
    type DefaultChannel: DmaChannel;

    // .... write, read, etc.
}

impl Instance for SPI2 {
    #[cfg(gdma)]
    type DefaultChannel = crate::dma::AnyDmaChannel;
    #[cfg(pdma)]
    type DefaultChannel = Spi2DmaChannel;
}

impl Instance for SPI3 {
    #[cfg(gdma)]
    type DefaultChannel = crate::dma::AnyDmaChannel;
    #[cfg(pdma)]
    type DefaultChannel = Spi3DmaChannel;
}

struct SpiDma<'d, T, ...., CH = T::DefaultChannel> { /* ... */ }
```

If you don't like my proposal for the PDMA, you can land this PR since it implements erasure on the GDMA side and build PDMA erasure on top of it I guess.
If you choose to take this path of further erasure, just beware of the ESP32-P4 because the GDMA isn't as universal as the current chips. Half of the channels work on some peripherals and the other half on a different set of peripherals. (The difference is PSRAM support)

This is the finish line for me, I've done the heavy lifting. Someone else can pick up the admin of updating all the other drivers and creating migration guides :smile: .

#### Testing
It builds. I was also able to name `Camera` without specifying the channel type after calling `degrade()`.
