### PR TITLE
Remove SPI slave prelude

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -96,8 +96,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `uart::{DefaultRxPin, DefaultTxPin}` (#2132)
 - Removed `PcntSource` and `PcntInputConfig`. (#2134)
 - Removed the `place-spi-driver-in-ram` feature, this is now enabled via [esp-config](https://docs.rs/esp-config) (#2156)
-- Removed `esp_hal::spi::slave::prelude` (#?)
-- Removed `esp_hal::spi::slave::WithDmaSpiN` traits (#?)
+- Removed `esp_hal::spi::slave::prelude` (#2260)
+- Removed `esp_hal::spi::slave::WithDmaSpiN` traits (#2260)
 
 ## [0.20.1] - 2024-08-30
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -96,6 +96,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `uart::{DefaultRxPin, DefaultTxPin}` (#2132)
 - Removed `PcntSource` and `PcntInputConfig`. (#2134)
 - Removed the `place-spi-driver-in-ram` feature, this is now enabled via [esp-config](https://docs.rs/esp-config) (#2156)
+- Removed `esp_hal::spi::slave::prelude` (#?)
+- Removed `esp_hal::spi::slave::WithDmaSpiN` traits (#?)
 
 ## [0.20.1] - 2024-08-30
 

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -205,7 +205,7 @@ pub mod dma {
         ) -> SpiDma<'d, crate::peripherals::SPI3, C, DmaMode>
         where
             C: DmaChannel,
-            C::P: SpiPeripheral + Spi2Peripheral,
+            C::P: SpiPeripheral + Spi3Peripheral,
             DmaMode: Mode,
         {
             SpiDma {

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -18,7 +18,7 @@
 //! # use esp_hal::dma::DmaPriority;
 //! # use esp_hal::dma_buffers;
 //! # use esp_hal::spi::SpiMode;
-//! # use esp_hal::spi::slave::{prelude::*, Spi};
+//! # use esp_hal::spi::slave::Spi;
 //! # use esp_hal::dma::Dma;
 //! # use esp_hal::gpio::Io;
 //! let dma = Dma::new(peripherals.DMA);
@@ -79,17 +79,6 @@ use crate::{
     private,
     system::PeripheralClockControl,
 };
-
-/// Prelude for the SPI (Slave) driver
-pub mod prelude {
-    #[cfg(spi3)]
-    pub use super::dma::WithDmaSpi3 as _esp_hal_spi_slave_dma_WithDmaSpi3;
-    pub use super::{
-        dma::WithDmaSpi2 as _esp_hal_spi_slave_dma_WithDmaSpi2,
-        Instance as _esp_hal_spi_slave_Instance,
-        InstanceDma as _esp_hal_spi_slave_InstanceDma,
-    };
-}
 
 const MAX_DMA_SIZE: usize = 32768 - 32;
 
@@ -181,54 +170,20 @@ pub mod dma {
         Mode,
     };
 
-    /// Trait for configuring DMA with SPI2 peripherals in slave mode.
-    pub trait WithDmaSpi2<'d, C, DmaMode>
-    where
-        C: DmaChannel,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
-        /// Configures the SPI2 peripheral with the provided DMA channel and
-        /// descriptors.
-        fn with_dma(
-            self,
-            channel: Channel<'d, C, DmaMode>,
-            rx_descriptors: &'static mut [DmaDescriptor],
-            tx_descriptors: &'static mut [DmaDescriptor],
-        ) -> SpiDma<'d, crate::peripherals::SPI2, C, DmaMode>;
-    }
-
-    /// Trait for configuring DMA with SPI3 peripherals in slave mode.
-    #[cfg(spi3)]
-    pub trait WithDmaSpi3<'d, C, DmaMode>
-    where
-        C: DmaChannel,
-        C::P: SpiPeripheral,
-        DmaMode: Mode,
-    {
+    impl<'d> Spi<'d, crate::peripherals::SPI2, FullDuplexMode> {
         /// Configures the SPI3 peripheral with the provided DMA channel and
         /// descriptors.
-        fn with_dma(
+        pub fn with_dma<C, DmaMode>(
             self,
             channel: Channel<'d, C, DmaMode>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
-        ) -> SpiDma<'d, crate::peripherals::SPI3, C, DmaMode>;
-    }
-
-    impl<'d, C, DmaMode> WithDmaSpi2<'d, C, DmaMode>
-        for Spi<'d, crate::peripherals::SPI2, FullDuplexMode>
-    where
-        C: DmaChannel,
-        C::P: SpiPeripheral + Spi2Peripheral,
-        DmaMode: Mode,
-    {
-        fn with_dma(
-            self,
-            channel: Channel<'d, C, DmaMode>,
-            rx_descriptors: &'static mut [DmaDescriptor],
-            tx_descriptors: &'static mut [DmaDescriptor],
-        ) -> SpiDma<'d, crate::peripherals::SPI2, C, DmaMode> {
+        ) -> SpiDma<'d, crate::peripherals::SPI2, C, DmaMode>
+        where
+            C: DmaChannel,
+            C::P: SpiPeripheral + Spi2Peripheral,
+            DmaMode: Mode,
+        {
             SpiDma {
                 spi: self.spi,
                 channel,
@@ -239,19 +194,20 @@ pub mod dma {
     }
 
     #[cfg(spi3)]
-    impl<'d, C, DmaMode> WithDmaSpi3<'d, C, DmaMode>
-        for Spi<'d, crate::peripherals::SPI3, FullDuplexMode>
-    where
-        C: DmaChannel,
-        C::P: SpiPeripheral + Spi3Peripheral,
-        DmaMode: Mode,
-    {
-        fn with_dma(
+    impl<'d> Spi<'d, crate::peripherals::SPI3, FullDuplexMode> {
+        /// Configures the SPI3 peripheral with the provided DMA channel and
+        /// descriptors.
+        pub fn with_dma<C, DmaMode>(
             self,
             channel: Channel<'d, C, DmaMode>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
-        ) -> SpiDma<'d, crate::peripherals::SPI3, C, DmaMode> {
+        ) -> SpiDma<'d, crate::peripherals::SPI3, C, DmaMode>
+        where
+            C: DmaChannel,
+            C::P: SpiPeripheral + Spi2Peripheral,
+            DmaMode: Mode,
+        {
             SpiDma {
                 spi: self.spi,
                 channel,

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -36,10 +36,7 @@ use esp_hal::{
     dma_buffers,
     gpio::{Input, Io, Level, Output, Pull},
     prelude::*,
-    spi::{
-        slave::{prelude::*, Spi},
-        SpiMode,
-    },
+    spi::{slave::Spi, SpiMode},
 };
 use esp_println::println;
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Master doesn't have a prelude, so slave shouldn't have one, either.
