### PR TITLE
Erase DMA type params

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `esp_hal::spi::slave::prelude` (#2260)
 - Removed `esp_hal::spi::slave::WithDmaSpiN` traits (#2260)
 - The `WithDmaAes` trait has been removed (#2261)
+- The `I2s::new_i2s1` constructor has been removed (#2261)
 
 ## [0.20.1] - 2024-08-30
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -66,7 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I2c `transaction` is now also available as a inherent function, lift size limit on `write`,`read` and `write_read` (#2262)
 - SPI transactions are now cancelled if the transfer object (or async Future) is dropped. (#2216)
 - The DMA channel types have been removed from peripherals (#2261)
-- The channel type parameter of `dma::Channel` have been moved to the last position and can be erased using `degrade()` (#2261)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `DmaTxBuf` to support PSRAM on `esp32s3` (#2161)
 - I2c `transaction` is now also available as a inherent function, lift size limit on `write`,`read` and `write_read` (#2262)
 - SPI transactions are now cancelled if the transfer object (or async Future) is dropped. (#2216)
+- The DMA channel types have been removed from peripherals (#2261)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `place-spi-driver-in-ram` feature, this is now enabled via [esp-config](https://docs.rs/esp-config) (#2156)
 - Removed `esp_hal::spi::slave::prelude` (#2260)
 - Removed `esp_hal::spi::slave::WithDmaSpiN` traits (#2260)
+- The `WithDmaAes` trait has been removed (#2261)
 
 ## [0.20.1] - 2024-08-30
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I2c `transaction` is now also available as a inherent function, lift size limit on `write`,`read` and `write_read` (#2262)
 - SPI transactions are now cancelled if the transfer object (or async Future) is dropped. (#2216)
 - The DMA channel types have been removed from peripherals (#2261)
+- The channel type parameter of `dma::Channel` have been moved to the last position and can be erased using `degrade()` (#2261)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -340,6 +340,15 @@ A non-exhausitve list demonstrating this change:
 +SpiDma<'static, esp_hal::peripherals::SPI2, HalfDuplexMode, Blocking>
 ```
 
-You can now call `dma_channel.degrade()` to obtain a type-erased version of `Channel`. Note that
-on ESP32 and ESP32-S2, passing this channel to an incompatible peripheral (for example an
+The type parameters of `Channel` have been reordered. The channel type
+has been moved to the last position. For example:
+
+```diff
+-Channel<'d, DmaChannel0, Async>
++Channel<'d, Async, DmaChannel0>
+```
+
+You can now call `dma_channel.degrade()` to obtain a type-erased version of `Channel`. You
+don't have to spell out `Channel<'d, Mode, AnyDmaChannel>`, you can use `Channel<'d, Mode>` instead.
+Note that on ESP32 and ESP32-S2, passing this channel to an incompatible peripheral (for example an
 I2S-specific DMA channel to SPI) will result in a panic.

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -121,12 +121,14 @@ When using the asymmetric variant of the macro to create DMA buffers and descrip
 + let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 ```
 
-## Removed UART constructors
+## Removed constructors
+
+### UART
 
 The `Uart::new_with_default_pins` and `Uart::new_async_with_default_pins` constructors
 have been removed. Use `new` or `new_async` instead.
 
-## Removed I2S1-specific constructor
+### I2S1
 
 The `I2s::new_i2s1` constructor has been removed. Use `I2s::new` instead.
 
@@ -323,3 +325,21 @@ Diff of the `psram_quad.rs` example
 ## eFuse
 
 Calling `Efuse::read_field_le::<bool>()` no longer compiles. Use `Efuse::read_bit()` instead.
+
+## DMA
+
+The DMA channel types have been removed from peripherals.
+
+A non-exhausitve list demonstrating this change:
+
+```diff
+-I2sTx<'static, I2S0, DmaChannel0, Async>
++I2sTx<'static, I2S0, Async>
+
+-SpiDma<'static, esp_hal::peripherals::SPI2, DmaChannel0, HalfDuplexMode, Blocking>
++SpiDma<'static, esp_hal::peripherals::SPI2, HalfDuplexMode, Blocking>
+```
+
+You can now call `dma_channel.degrade()` to obtain a type-erased version of `Channel`. Note that
+on ESP32 and ESP32-S2, passing this channel to an incompatible peripheral (for example an
+I2S-specific DMA channel to SPI) will result in a panic.

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -126,6 +126,10 @@ When using the asymmetric variant of the macro to create DMA buffers and descrip
 The `Uart::new_with_default_pins` and `Uart::new_async_with_default_pins` constructors
 have been removed. Use `new` or `new_async` instead.
 
+## Removed I2S1-specific constructor
+
+The `I2s::new_i2s1` constructor has been removed. Use `I2s::new` instead.
+
 ## Timer changes
 
 ### `ErasedTimer` rename

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -340,15 +340,6 @@ A non-exhausitve list demonstrating this change:
 +SpiDma<'static, esp_hal::peripherals::SPI2, HalfDuplexMode, Blocking>
 ```
 
-The type parameters of `Channel` have been reordered. The channel type
-has been moved to the last position. For example:
-
-```diff
--Channel<'d, DmaChannel0, Async>
-+Channel<'d, Async, DmaChannel0>
-```
-
-You can now call `dma_channel.degrade()` to obtain a type-erased version of `Channel`. You
-don't have to spell out `Channel<'d, Mode, AnyDmaChannel>`, you can use `Channel<'d, Mode>` instead.
-Note that on ESP32 and ESP32-S2, passing this channel to an incompatible peripheral (for example an
+You can now call `dma_channel.degrade()` to obtain a type-erased version of `Channel`. Note that
+on ESP32 and ESP32-S2, passing this channel to an incompatible peripheral (for example an
 I2S-specific DMA channel to SPI) will result in a panic.

--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -339,7 +339,3 @@ A non-exhausitve list demonstrating this change:
 -SpiDma<'static, esp_hal::peripherals::SPI2, DmaChannel0, HalfDuplexMode, Blocking>
 +SpiDma<'static, esp_hal::peripherals::SPI2, HalfDuplexMode, Blocking>
 ```
-
-You can now call `dma_channel.degrade()` to obtain a type-erased version of `Channel`. Note that
-on ESP32 and ESP32-S2, passing this channel to an incompatible peripheral (for example an
-I2S-specific DMA channel to SPI) will result in a panic.

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -235,13 +235,13 @@ pub mod dma {
         aes::{Key, Mode},
         dma::{
             dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
-            AnyDmaChannel,
             Channel,
             ChannelRx,
             ChannelTx,
             DescriptorChain,
             DmaChannel,
             DmaDescriptor,
+            DmaEligible,
             DmaPeripheral,
             DmaTransferRxTx,
             ReadBuffer,
@@ -249,6 +249,7 @@ pub mod dma {
             Tx,
             WriteBuffer,
         },
+        peripherals::AES,
     };
 
     const ALIGN_SIZE: usize = core::mem::size_of::<u32>();
@@ -274,7 +275,7 @@ pub mod dma {
         /// The underlying [`Aes`](super::Aes) driver
         pub aes: super::Aes<'d>,
 
-        channel: Channel<'d, AnyDmaChannel, crate::Blocking>,
+        channel: Channel<'d, <AES as DmaEligible>::Dma, crate::Blocking>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
     }
@@ -289,7 +290,7 @@ pub mod dma {
         ) -> AesDma<'d>
         where
             Self: Sized,
-            C: DmaChannel,
+            C: DmaChannel<Degraded = <AES as DmaEligible>::Dma>,
         {
             AesDma {
                 aes: self,
@@ -323,7 +324,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportTx for AesDma<'d> {
-        type TX = ChannelTx<'d, AnyDmaChannel>;
+        type TX = ChannelTx<'d, <AES as DmaEligible>::Dma>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -335,7 +336,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportRx for AesDma<'d> {
-        type RX = ChannelRx<'d, AnyDmaChannel>;
+        type RX = ChannelRx<'d, <AES as DmaEligible>::Dma>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -235,6 +235,7 @@ pub mod dma {
         aes::{Key, Mode},
         dma::{
             dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
+            AnyDmaChannel,
             Channel,
             ChannelRx,
             ChannelTx,
@@ -273,7 +274,7 @@ pub mod dma {
         /// The underlying [`Aes`](super::Aes) driver
         pub aes: super::Aes<'d>,
 
-        channel: Channel<'d, crate::Blocking>,
+        channel: Channel<'d, AnyDmaChannel, crate::Blocking>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
     }
@@ -282,7 +283,7 @@ pub mod dma {
         /// Enable DMA for the current instance of the AES driver
         pub fn with_dma<C>(
             self,
-            channel: Channel<'d, crate::Blocking, C>,
+            channel: Channel<'d, C, crate::Blocking>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> AesDma<'d>
@@ -322,7 +323,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportTx for AesDma<'d> {
-        type TX = ChannelTx<'d>;
+        type TX = ChannelTx<'d, AnyDmaChannel>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -334,7 +335,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportRx for AesDma<'d> {
-        type RX = ChannelRx<'d>;
+        type RX = ChannelRx<'d, AnyDmaChannel>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -239,7 +239,7 @@ pub mod dma {
             ChannelRx,
             ChannelTx,
             DescriptorChain,
-            DmaChannel,
+            DmaChannelConvert,
             DmaDescriptor,
             DmaEligible,
             DmaPeripheral,
@@ -290,7 +290,7 @@ pub mod dma {
         ) -> AesDma<'d>
         where
             Self: Sized,
-            C: DmaChannel<Degraded = <AES as DmaEligible>::Dma>,
+            C: DmaChannelConvert<<AES as DmaEligible>::Dma>,
         {
             AesDma {
                 aes: self,

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -235,16 +235,15 @@ pub mod dma {
         aes::{Key, Mode},
         dma::{
             dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
-            AesPeripheral,
             AnyDmaChannel,
             Channel,
             ChannelRx,
             ChannelTx,
             DescriptorChain,
+            DmaChannel,
             DmaDescriptor,
             DmaPeripheral,
             DmaTransferRxTx,
-            PeripheralDmaChannel,
             ReadBuffer,
             Rx,
             Tx,
@@ -290,8 +289,7 @@ pub mod dma {
         ) -> AesDma<'d>
         where
             Self: Sized,
-            C: PeripheralDmaChannel,
-            C::P: AesPeripheral,
+            C: DmaChannel,
         {
             AesDma {
                 aes: self,

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -235,7 +235,6 @@ pub mod dma {
         aes::{Key, Mode},
         dma::{
             dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
-            AnyDmaChannel,
             Channel,
             ChannelRx,
             ChannelTx,
@@ -274,7 +273,7 @@ pub mod dma {
         /// The underlying [`Aes`](super::Aes) driver
         pub aes: super::Aes<'d>,
 
-        channel: Channel<'d, AnyDmaChannel, crate::Blocking>,
+        channel: Channel<'d, crate::Blocking>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
     }
@@ -283,7 +282,7 @@ pub mod dma {
         /// Enable DMA for the current instance of the AES driver
         pub fn with_dma<C>(
             self,
-            channel: Channel<'d, C, crate::Blocking>,
+            channel: Channel<'d, crate::Blocking, C>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> AesDma<'d>
@@ -323,7 +322,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportTx for AesDma<'d> {
-        type TX = ChannelTx<'d, AnyDmaChannel>;
+        type TX = ChannelTx<'d>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -335,7 +334,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportRx for AesDma<'d> {
-        type RX = ChannelRx<'d, AnyDmaChannel>;
+        type RX = ChannelRx<'d>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -416,11 +416,6 @@ impl<C: GdmaChannel> InterruptAccess<DmaRxInterrupt> for ChannelRxImpl<C> {
 #[non_exhaustive]
 pub struct ChannelCreator<const N: u8> {}
 
-#[non_exhaustive]
-#[doc(hidden)]
-pub struct SuitablePeripheral;
-impl PeripheralMarker for SuitablePeripheral {}
-
 impl DmaChannel for AnyDmaChannel {
     type Rx = ChannelRxImpl<AnyGdmaChannel>;
     type Tx = ChannelTxImpl<AnyGdmaChannel>;
@@ -435,15 +430,19 @@ impl DmaChannel for AnyDmaChannel {
 
 impl<CH: DmaChannel, M: Mode> Channel<'_, CH, M> {
     /// Asserts that the channel is compatible with the given peripheral.
-    pub fn runtime_ensure_compatible<P: PeripheralMarker>(&self, _peripheral: P) {
-        // GDMA channels are compatible with any peripheral
+    pub fn runtime_ensure_compatible<P: PeripheralMarker + DmaEligible>(
+        &self,
+        _peripheral: &PeripheralRef<'_, P>,
+    ) {
+        // No runtime checks; GDMA channels are compatible with any peripheral
     }
 }
 
+// Every DMA channel is compatible with every (DMA eligible) peripheral.
 impl<CH, P> DmaCompatible for (CH, P)
 where
     CH: DmaChannel,
-    P: PeripheralMarker,
+    P: PeripheralMarker + DmaEligible,
 {
 }
 

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -466,8 +466,6 @@ macro_rules! impl_channel {
             }
 
             impl DmaChannelExt for [<DmaChannel $num>] {
-                type Degraded = AnyDmaChannel;
-
                 fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     ChannelRxImpl(SpecificGdmaChannel::<$num> {})
                 }

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -421,24 +421,6 @@ pub struct ChannelCreator<const N: u8> {}
 pub struct SuitablePeripheral {}
 impl PeripheralMarker for SuitablePeripheral {}
 
-// with GDMA every channel can be used for any peripheral
-impl SpiPeripheral for SuitablePeripheral {}
-impl Spi2Peripheral for SuitablePeripheral {}
-#[cfg(spi3)]
-impl Spi3Peripheral for SuitablePeripheral {}
-#[cfg(any(i2s0, i2s1))]
-impl I2sPeripheral for SuitablePeripheral {}
-#[cfg(i2s0)]
-impl I2s0Peripheral for SuitablePeripheral {}
-#[cfg(i2s1)]
-impl I2s1Peripheral for SuitablePeripheral {}
-#[cfg(parl_io)]
-impl ParlIoPeripheral for SuitablePeripheral {}
-#[cfg(aes)]
-impl AesPeripheral for SuitablePeripheral {}
-#[cfg(lcd_cam)]
-impl LcdCamPeripheral for SuitablePeripheral {}
-
 impl DmaChannel for AnyDmaChannel {
     type Rx = ChannelRxImpl<AnyGdmaChannel>;
     type Tx = ChannelTxImpl<AnyGdmaChannel>;
@@ -449,10 +431,6 @@ impl DmaChannel for AnyDmaChannel {
     fn degrade_tx(tx: Self::Tx) -> ChannelTxImpl<AnyGdmaChannel> {
         tx
     }
-}
-
-impl PeripheralDmaChannel for AnyDmaChannel {
-    type P = SuitablePeripheral;
 }
 
 macro_rules! impl_channel {
@@ -474,9 +452,6 @@ macro_rules! impl_channel {
                 fn degrade_tx(tx: Self::Tx) -> ChannelTxImpl<AnyGdmaChannel> {
                     tx.degrade()
                 }
-            }
-            impl PeripheralDmaChannel for [<DmaChannel $num>] {
-                type P = SuitablePeripheral;
             }
 
             impl DmaChannelExt for [<DmaChannel $num>] {

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -554,6 +554,57 @@ cfg_if::cfg_if! {
     }
 }
 
+crate::impl_dma_eligible! {
+    AnyGdmaChannel {
+        #[cfg(spi2)]
+        SPI2 => Spi2,
+
+        #[cfg(spi3)]
+        SPI3 => Spi3,
+
+        #[cfg(uhci0)]
+        UHCI0 => Uhci0,
+
+        #[cfg(i2s0)]
+        I2S0 => I2s0,
+
+        #[cfg(i2s1)]
+        I2S1 => I2s1,
+
+        #[cfg(all(gdma, aes))]
+        AES => Aes,
+
+        #[cfg(all(gdma, sha))]
+        SHA => Sha,
+
+        #[cfg(any(esp32c3, esp32c6, esp32h2))]
+        ADC1 => Adc,
+
+        #[cfg(esp32c3)]
+        ADC2 => Adc,
+
+        #[cfg(parl_io)]
+        PARL_IO => ParlIo,
+
+        #[cfg(any(esp32c2, esp32c6, esp32h2))]
+        MEM2MEM1 => Mem2Mem1,
+    }
+}
+
+#[cfg(any(esp32c6, esp32h2))]
+crate::impl_dma_eligible! {
+    AnyGdmaChannel {
+        MEM2MEM4 => Mem2Mem4,
+        MEM2MEM5 => Mem2Mem5,
+        MEM2MEM10 => Mem2Mem10,
+        MEM2MEM11 => Mem2Mem11,
+        MEM2MEM12 => Mem2Mem12,
+        MEM2MEM13 => Mem2Mem13,
+        MEM2MEM14 => Mem2Mem14,
+        MEM2MEM15 => Mem2Mem15,
+    }
+}
+
 /// GDMA Peripheral
 ///
 /// This offers the available DMA channels.

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -571,17 +571,23 @@ crate::impl_dma_eligible! {
         #[cfg(i2s1)]
         I2S1 => I2s1,
 
+        #[cfg(esp32s3)]
+        LCD_CAM => LcdCam,
+
         #[cfg(all(gdma, aes))]
         AES => Aes,
 
         #[cfg(all(gdma, sha))]
         SHA => Sha,
 
-        #[cfg(any(esp32c3, esp32c6, esp32h2))]
+        #[cfg(any(esp32c3, esp32c6, esp32h2, esp32s3))]
         ADC1 => Adc,
 
-        #[cfg(esp32c3)]
+        #[cfg(any(esp32c3, esp32s3))]
         ADC2 => Adc,
+
+        #[cfg(esp32s3)]
+        RMT => Rmt,
 
         #[cfg(parl_io)]
         PARL_IO => ParlIo,

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -56,26 +56,26 @@ impl<C: GdmaChannel> crate::private::Sealed for ChannelTxImpl<C> {}
 
 impl<C: GdmaChannel> ChannelTxImpl<C> {
     #[inline(always)]
-    fn ch(&self) -> &'static crate::peripherals::dma::ch::CH {
+    fn ch(&self) -> &crate::peripherals::dma::ch::CH {
         let dma = unsafe { &*crate::peripherals::DMA::PTR };
         dma.ch(self.0.number() as usize)
     }
 
     #[cfg(any(esp32c2, esp32c3))]
     #[inline(always)]
-    fn int(&self) -> &'static crate::peripherals::dma::int_ch::INT_CH {
+    fn int(&self) -> &crate::peripherals::dma::int_ch::INT_CH {
         let dma = unsafe { &*crate::peripherals::DMA::PTR };
         dma.int_ch(self.0.number() as usize)
     }
     #[inline(always)]
     #[cfg(any(esp32c6, esp32h2))]
-    fn int(&self) -> &'static crate::peripherals::dma::out_int_ch::OUT_INT_CH {
+    fn int(&self) -> &crate::peripherals::dma::out_int_ch::OUT_INT_CH {
         let dma = unsafe { &*crate::peripherals::DMA::PTR };
         dma.out_int_ch(self.0.number() as usize)
     }
     #[cfg(esp32s3)]
     #[inline(always)]
-    fn int(&self) -> &'static crate::peripherals::dma::ch::out_int::OUT_INT {
+    fn int(&self) -> &crate::peripherals::dma::ch::out_int::OUT_INT {
         let dma = unsafe { &*crate::peripherals::DMA::PTR };
         dma.ch(self.0.number() as usize).out_int()
     }
@@ -222,7 +222,7 @@ impl<C: GdmaChannel> InterruptAccess<DmaTxInterrupt> for ChannelTxImpl<C> {
         result
     }
 
-    fn waker(&self) -> &'static AtomicWaker {
+    fn waker(&self) -> &AtomicWaker {
         &TX_WAKERS[self.0.number() as usize]
     }
 }
@@ -235,28 +235,28 @@ impl<C: GdmaChannel> crate::private::Sealed for ChannelRxImpl<C> {}
 
 impl<C: GdmaChannel> ChannelRxImpl<C> {
     #[inline(always)]
-    fn ch(&self) -> &'static crate::peripherals::dma::ch::CH {
+    fn ch(&self) -> &crate::peripherals::dma::ch::CH {
         let dma = unsafe { &*crate::peripherals::DMA::PTR };
         dma.ch(self.0.number() as usize)
     }
 
     #[cfg(any(esp32c2, esp32c3))]
     #[inline(always)]
-    fn int(&self) -> &'static crate::peripherals::dma::int_ch::INT_CH {
+    fn int(&self) -> &crate::peripherals::dma::int_ch::INT_CH {
         let dma = unsafe { &*crate::peripherals::DMA::PTR };
         dma.int_ch(self.0.number() as usize)
     }
 
     #[inline(always)]
     #[cfg(any(esp32c6, esp32h2))]
-    fn int(&self) -> &'static crate::peripherals::dma::in_int_ch::IN_INT_CH {
+    fn int(&self) -> &crate::peripherals::dma::in_int_ch::IN_INT_CH {
         let dma = unsafe { &*crate::peripherals::DMA::PTR };
         dma.in_int_ch(self.0.number() as usize)
     }
 
     #[cfg(esp32s3)]
     #[inline(always)]
-    fn int(&self) -> &'static crate::peripherals::dma::ch::in_int::IN_INT {
+    fn int(&self) -> &crate::peripherals::dma::ch::in_int::IN_INT {
         let dma = unsafe { &*crate::peripherals::DMA::PTR };
         dma.ch(self.0.number() as usize).in_int()
     }
@@ -407,7 +407,7 @@ impl<C: GdmaChannel> InterruptAccess<DmaRxInterrupt> for ChannelRxImpl<C> {
         result
     }
 
-    fn waker(&self) -> &'static AtomicWaker {
+    fn waker(&self) -> &AtomicWaker {
         &RX_WAKERS[self.0.number() as usize]
     }
 }

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -418,7 +418,7 @@ pub struct ChannelCreator<const N: u8> {}
 
 #[non_exhaustive]
 #[doc(hidden)]
-pub struct SuitablePeripheral {}
+pub struct SuitablePeripheral;
 impl PeripheralMarker for SuitablePeripheral {}
 
 impl DmaChannel for AnyDmaChannel {
@@ -431,6 +431,20 @@ impl DmaChannel for AnyDmaChannel {
     fn degrade_tx(tx: Self::Tx) -> ChannelTxImpl<AnyGdmaChannel> {
         tx
     }
+}
+
+impl<CH: DmaChannel, M: Mode> Channel<'_, CH, M> {
+    /// Asserts that the channel is compatible with the given peripheral.
+    pub fn runtime_ensure_compatible<P: PeripheralMarker>(&self, _peripheral: P) {
+        // GDMA channels are compatible with any peripheral
+    }
+}
+
+impl<CH, P> DmaCompatible for (CH, P)
+where
+    CH: DmaChannel,
+    P: PeripheralMarker,
+{
 }
 
 macro_rules! impl_channel {

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -428,7 +428,7 @@ impl DmaChannel for AnyDmaChannel {
     }
 }
 
-impl<CH: DmaChannel, M: Mode> Channel<'_, CH, M> {
+impl<CH: DmaChannel, M: Mode> Channel<'_, M, CH> {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible<P: PeripheralMarker + DmaEligible>(
         &self,
@@ -490,7 +490,7 @@ macro_rules! impl_channel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> crate::dma::Channel<'a, [<DmaChannel $num>], M> {
+                ) -> crate::dma::Channel<'a, M, [<DmaChannel $num>]> {
                     let tx_impl = ChannelTxImpl(SpecificGdmaChannel::<$num> {});
                     tx_impl.set_burst_mode(burst_mode);
                     tx_impl.set_priority(priority);
@@ -517,7 +517,7 @@ macro_rules! impl_channel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> crate::dma::Channel<'a, [<DmaChannel $num>], crate::Blocking> {
+                ) -> crate::dma::Channel<'a, crate::Blocking, [<DmaChannel $num>]> {
                     self.do_configure(burst_mode, priority)
                 }
 
@@ -529,7 +529,7 @@ macro_rules! impl_channel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> crate::dma::Channel<'a, [<DmaChannel $num>], $crate::Async> {
+                ) -> crate::dma::Channel<'a, $crate::Async, [<DmaChannel $num>]> {
                     let this = self.do_configure(burst_mode, priority);
 
                     [<DmaChannel $num>]::set_isr($async_handler);
@@ -648,7 +648,7 @@ mod m2m {
     where
         M: Mode,
     {
-        channel: Channel<'d, AnyDmaChannel, M>,
+        channel: Channel<'d, M>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
         peripheral: DmaPeripheral,
@@ -660,7 +660,7 @@ mod m2m {
     {
         /// Create a new Mem2Mem instance.
         pub fn new<CH>(
-            channel: Channel<'d, CH, M>,
+            channel: Channel<'d, M, CH>,
             peripheral: impl DmaEligible,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
@@ -681,7 +681,7 @@ mod m2m {
 
         /// Create a new Mem2Mem instance with specific chunk size.
         pub fn new_with_chunk_size<CH>(
-            channel: Channel<'d, CH, M>,
+            channel: Channel<'d, M, CH>,
             peripheral: impl DmaEligible,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
@@ -708,7 +708,7 @@ mod m2m {
         /// You must ensure that your not using DMA for the same peripheral and
         /// that your the only one using the DmaPeripheral.
         pub unsafe fn new_unsafe<CH>(
-            channel: Channel<'d, CH, M>,
+            channel: Channel<'d, M, CH>,
             peripheral: DmaPeripheral,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -222,7 +222,7 @@ impl<C: GdmaChannel> InterruptAccess<DmaTxInterrupt> for ChannelTxImpl<C> {
         result
     }
 
-    fn waker(&self) -> &AtomicWaker {
+    fn waker(&self) -> &'static AtomicWaker {
         &TX_WAKERS[self.0.number() as usize]
     }
 }
@@ -407,7 +407,7 @@ impl<C: GdmaChannel> InterruptAccess<DmaRxInterrupt> for ChannelRxImpl<C> {
         result
     }
 
-    fn waker(&self) -> &AtomicWaker {
+    fn waker(&self) -> &'static AtomicWaker {
         &RX_WAKERS[self.0.number() as usize]
     }
 }
@@ -439,15 +439,12 @@ impl AesPeripheral for SuitablePeripheral {}
 #[cfg(lcd_cam)]
 impl LcdCamPeripheral for SuitablePeripheral {}
 
-/// A description of any GDMA channel
-#[non_exhaustive]
-pub struct AnyDmaChannel {}
-
-impl crate::private::Sealed for AnyDmaChannel {}
-
 impl DmaChannel for AnyDmaChannel {
     type Rx = ChannelRxImpl<AnyGdmaChannel>;
     type Tx = ChannelTxImpl<AnyGdmaChannel>;
+}
+
+impl PeripheralDmaChannel for AnyDmaChannel {
     type P = SuitablePeripheral;
 }
 
@@ -463,6 +460,8 @@ macro_rules! impl_channel {
             impl DmaChannel for [<DmaChannel $num>] {
                 type Rx = ChannelRxImpl<SpecificGdmaChannel<$num>>;
                 type Tx = ChannelTxImpl<SpecificGdmaChannel<$num>>;
+            }
+            impl PeripheralDmaChannel for [<DmaChannel $num>] {
                 type P = SuitablePeripheral;
             }
 

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -442,6 +442,13 @@ impl LcdCamPeripheral for SuitablePeripheral {}
 impl DmaChannel for AnyDmaChannel {
     type Rx = ChannelRxImpl<AnyGdmaChannel>;
     type Tx = ChannelTxImpl<AnyGdmaChannel>;
+
+    fn degrade_rx(rx: Self::Rx) -> ChannelRxImpl<AnyGdmaChannel> {
+        rx
+    }
+    fn degrade_tx(tx: Self::Tx) -> ChannelTxImpl<AnyGdmaChannel> {
+        tx
+    }
 }
 
 impl PeripheralDmaChannel for AnyDmaChannel {
@@ -460,6 +467,13 @@ macro_rules! impl_channel {
             impl DmaChannel for [<DmaChannel $num>] {
                 type Rx = ChannelRxImpl<SpecificGdmaChannel<$num>>;
                 type Tx = ChannelTxImpl<SpecificGdmaChannel<$num>>;
+
+                fn degrade_rx(rx: Self::Rx) -> ChannelRxImpl<AnyGdmaChannel> {
+                    rx.degrade()
+                }
+                fn degrade_tx(tx: Self::Tx) -> ChannelTxImpl<AnyGdmaChannel> {
+                    tx.degrade()
+                }
             }
             impl PeripheralDmaChannel for [<DmaChannel $num>] {
                 type P = SuitablePeripheral;
@@ -472,13 +486,6 @@ macro_rules! impl_channel {
 
                 fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     ChannelTxImpl(SpecificGdmaChannel::<$num> {})
-                }
-
-                fn degrade_rx(rx: Self::Rx) -> ChannelRxImpl<AnyGdmaChannel> {
-                    rx.degrade()
-                }
-                fn degrade_tx(tx: Self::Tx) -> ChannelTxImpl<AnyGdmaChannel> {
-                    tx.degrade()
                 }
 
                 fn set_isr(handler: $crate::interrupt::InterruptHandler) {

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -428,7 +428,7 @@ impl DmaChannel for AnyDmaChannel {
     }
 }
 
-impl<CH: DmaChannel, M: Mode> Channel<'_, M, CH> {
+impl<CH: DmaChannel, M: Mode> Channel<'_, CH, M> {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible<P: PeripheralMarker + DmaEligible>(
         &self,
@@ -490,7 +490,7 @@ macro_rules! impl_channel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> crate::dma::Channel<'a, M, [<DmaChannel $num>]> {
+                ) -> crate::dma::Channel<'a, [<DmaChannel $num>], M> {
                     let tx_impl = ChannelTxImpl(SpecificGdmaChannel::<$num> {});
                     tx_impl.set_burst_mode(burst_mode);
                     tx_impl.set_priority(priority);
@@ -517,7 +517,7 @@ macro_rules! impl_channel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> crate::dma::Channel<'a, crate::Blocking, [<DmaChannel $num>]> {
+                ) -> crate::dma::Channel<'a, [<DmaChannel $num>], crate::Blocking> {
                     self.do_configure(burst_mode, priority)
                 }
 
@@ -529,7 +529,7 @@ macro_rules! impl_channel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> crate::dma::Channel<'a, $crate::Async, [<DmaChannel $num>]> {
+                ) -> crate::dma::Channel<'a, [<DmaChannel $num>], $crate::Async> {
                     let this = self.do_configure(burst_mode, priority);
 
                     [<DmaChannel $num>]::set_isr($async_handler);
@@ -648,7 +648,7 @@ mod m2m {
     where
         M: Mode,
     {
-        channel: Channel<'d, M>,
+        channel: Channel<'d, AnyDmaChannel, M>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
         peripheral: DmaPeripheral,
@@ -660,7 +660,7 @@ mod m2m {
     {
         /// Create a new Mem2Mem instance.
         pub fn new<CH>(
-            channel: Channel<'d, M, CH>,
+            channel: Channel<'d, CH, M>,
             peripheral: impl DmaEligible,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
@@ -681,7 +681,7 @@ mod m2m {
 
         /// Create a new Mem2Mem instance with specific chunk size.
         pub fn new_with_chunk_size<CH>(
-            channel: Channel<'d, M, CH>,
+            channel: Channel<'d, CH, M>,
             peripheral: impl DmaEligible,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
@@ -708,7 +708,7 @@ mod m2m {
         /// You must ensure that your not using DMA for the same peripheral and
         /// that your the only one using the DmaPeripheral.
         pub unsafe fn new_unsafe<CH>(
-            channel: Channel<'d, M, CH>,
+            channel: Channel<'d, CH, M>,
             peripheral: DmaPeripheral,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -892,11 +892,7 @@ impl From<u32> for Owner {
 
 #[doc(hidden)]
 pub trait DmaEligible {
-    /// The DMA peripheral
-    const DMA_PERIPHERAL: DmaPeripheral;
-    fn dma_peripheral(&self) -> DmaPeripheral {
-        Self::DMA_PERIPHERAL
-    }
+    fn dma_peripheral(&self) -> DmaPeripheral;
 }
 
 /// Marker trait

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -902,26 +902,13 @@ pub trait DmaEligible {
 
 /// Marker trait
 #[doc(hidden)]
-pub trait PeripheralMarker {}
+pub trait PeripheralMarker {
+    #[cfg(pdma)]
+    fn peripheral(&self) -> crate::system::Peripheral;
+}
 
 #[doc(hidden)]
 pub trait DmaCompatible {}
-
-#[cfg(gdma)]
-impl<CH, P> DmaCompatible for (CH, P)
-where
-    CH: DmaChannel,
-    P: PeripheralMarker,
-{
-}
-
-#[cfg(pdma)]
-impl<CH, P> DmaCompatible for (CH, P)
-where
-    CH: PeripheralDmaChannel<P = P>,
-    P: PeripheralMarker,
-{
-}
 
 #[doc(hidden)]
 #[derive(Debug)]
@@ -2004,6 +1991,9 @@ pub trait RegisterAccess: crate::private::Sealed {
 
     #[cfg(esp32s3)]
     fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize);
+
+    #[cfg(pdma)]
+    fn is_compatible_with<P: PeripheralMarker>(&self, peripheral: P) -> bool;
 }
 
 #[doc(hidden)]

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1550,13 +1550,11 @@ impl crate::private::Sealed for AnyDmaChannel {}
 
 #[doc(hidden)]
 pub trait DmaChannelExt: DmaChannel {
-    type Degraded: DmaChannel;
-
     fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt>;
     fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt>;
 
-    fn degrade_rx(rx: Self::Rx) -> <Self::Degraded as DmaChannel>::Rx;
-    fn degrade_tx(tx: Self::Tx) -> <Self::Degraded as DmaChannel>::Tx;
+    fn degrade_rx(rx: Self::Rx) -> <AnyDmaChannel as DmaChannel>::Rx;
+    fn degrade_tx(tx: Self::Tx) -> <AnyDmaChannel as DmaChannel>::Tx;
 
     #[doc(hidden)]
     fn set_isr(handler: InterruptHandler);
@@ -1644,7 +1642,7 @@ where
     }
 
     /// Return a type-erased (degraded) version of this channel.
-    pub fn degrade(self) -> ChannelRx<'a, CH::Degraded>
+    pub fn degrade(self) -> ChannelRx<'a, AnyDmaChannel>
     where
         CH: DmaChannelExt,
     {
@@ -1861,7 +1859,7 @@ where
     }
 
     /// Return a type-erased (degraded) version of this channel.
-    pub fn degrade(self) -> ChannelTx<'a, CH::Degraded>
+    pub fn degrade(self) -> ChannelTx<'a, AnyDmaChannel>
     where
         CH: DmaChannelExt,
     {
@@ -2137,7 +2135,7 @@ where
 {
     /// Return a type-erased (degraded) version of this channel (both rx and
     /// tx).
-    pub fn degrade(self) -> Channel<'d, C::Degraded, M> {
+    pub fn degrade(self) -> Channel<'d, AnyDmaChannel, M> {
         Channel {
             rx: self.rx.degrade(),
             tx: self.tx.degrade(),

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1594,7 +1594,7 @@ pub trait Rx: crate::private::Sealed {
 // DMA receive channel
 #[non_exhaustive]
 #[doc(hidden)]
-pub struct ChannelRx<'a, CH>
+pub struct ChannelRx<'a, CH = AnyDmaChannel>
 where
     CH: DmaChannel,
 {
@@ -1616,7 +1616,7 @@ where
     }
 
     /// Return a type-erased (degraded) version of this channel.
-    pub fn degrade(self) -> ChannelRx<'a, AnyDmaChannel> {
+    pub fn degrade(self) -> ChannelRx<'a> {
         ChannelRx {
             burst_mode: self.burst_mode,
             rx_impl: CH::degrade_rx(self.rx_impl),
@@ -1807,7 +1807,7 @@ pub trait Tx: crate::private::Sealed {
 
 /// DMA transmit channel
 #[doc(hidden)]
-pub struct ChannelTx<'a, CH>
+pub struct ChannelTx<'a, CH = AnyDmaChannel>
 where
     CH: DmaChannel,
 {
@@ -1830,7 +1830,7 @@ where
     }
 
     /// Return a type-erased (degraded) version of this channel.
-    pub fn degrade(self) -> ChannelTx<'a, AnyDmaChannel> {
+    pub fn degrade(self) -> ChannelTx<'a> {
         ChannelTx {
             burst_mode: self.burst_mode,
             tx_impl: CH::degrade_tx(self.tx_impl),
@@ -2030,7 +2030,7 @@ pub trait InterruptAccess<T: EnumSetType>: crate::private::Sealed {
 }
 
 /// DMA Channel
-pub struct Channel<'d, CH, MODE>
+pub struct Channel<'d, MODE, CH = AnyDmaChannel>
 where
     CH: DmaChannel,
     MODE: Mode,
@@ -2042,7 +2042,7 @@ where
     phantom: PhantomData<MODE>,
 }
 
-impl<'d, C> Channel<'d, C, crate::Blocking>
+impl<'d, C> Channel<'d, crate::Blocking, C>
 where
     C: DmaChannel,
 {
@@ -2100,13 +2100,13 @@ where
     }
 }
 
-impl<'d, C, M: Mode> Channel<'d, C, M>
+impl<'d, C, M: Mode> Channel<'d, M, C>
 where
     C: DmaChannel,
 {
     /// Return a type-erased (degraded) version of this channel (both rx and
     /// tx).
-    pub fn degrade(self) -> Channel<'d, AnyDmaChannel, M> {
+    pub fn degrade(self) -> Channel<'d, M> {
         Channel {
             rx: self.rx.degrade(),
             tx: self.tx.degrade(),

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1542,10 +1542,7 @@ pub trait DmaChannelExt: DmaChannel {
 
 #[doc(hidden)]
 pub trait DmaChannelConvert<DEG: DmaChannel>: DmaChannel {
-    // TODO: maybe document
-    #[doc(hidden)]
     fn degrade_rx(rx: Self::Rx) -> DEG::Rx;
-    #[doc(hidden)]
     fn degrade_tx(tx: Self::Tx) -> DEG::Tx;
 }
 
@@ -1641,6 +1638,7 @@ where
     }
 
     /// Return a less specific (degraded) version of this channel.
+    #[doc(hidden)]
     pub fn degrade<DEG: DmaChannel>(self) -> ChannelRx<'a, DEG>
     where
         CH: DmaChannelConvert<DEG>,
@@ -1858,6 +1856,7 @@ where
     }
 
     /// Return a less specific (degraded) version of this channel.
+    #[doc(hidden)]
     pub fn degrade<DEG: DmaChannel>(self) -> ChannelTx<'a, DEG>
     where
         CH: DmaChannelConvert<DEG>,
@@ -2137,6 +2136,7 @@ where
 {
     /// Return a less specific (degraded) version of this channel (both rx and
     /// tx).
+    #[doc(hidden)]
     pub fn degrade<DEG: DmaChannel>(self) -> Channel<'d, DEG, M>
     where
         CH: DmaChannelConvert<DEG>,

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -898,6 +898,31 @@ pub trait DmaEligible {
     fn dma_peripheral(&self) -> DmaPeripheral;
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_dma_eligible {
+    ([$dma_ch:ident] $name:ident => $dma:ident) => {
+        impl $crate::dma::DmaEligible for $crate::peripherals::$name {
+            type Dma = $dma_ch;
+
+            fn dma_peripheral(&self) -> $crate::dma::DmaPeripheral {
+                $crate::dma::DmaPeripheral::$dma
+            }
+        }
+    };
+
+    (
+        $dma_ch:ident {
+            $($(#[$cfg:meta])? $name:ident => $dma:ident,)*
+        }
+    ) => {
+        $(
+            $(#[$cfg])?
+            $crate::impl_dma_eligible!([$dma_ch] $name => $dma);
+        )*
+    };
+}
+
 /// Marker trait
 #[doc(hidden)]
 pub trait PeripheralMarker {
@@ -1615,7 +1640,7 @@ where
         }
     }
 
-    /// Return a type-erased (degraded) version of this channel.
+    /// Return a less specific (degraded) version of this channel.
     pub fn degrade<DEG: DmaChannel>(self) -> ChannelRx<'a, DEG>
     where
         CH: DmaChannelConvert<DEG>,
@@ -1832,7 +1857,7 @@ where
         }
     }
 
-    /// Return a type-erased (degraded) version of this channel.
+    /// Return a less specific (degraded) version of this channel.
     pub fn degrade<DEG: DmaChannel>(self) -> ChannelTx<'a, DEG>
     where
         CH: DmaChannelConvert<DEG>,
@@ -2110,7 +2135,7 @@ impl<'d, CH, M: Mode> Channel<'d, CH, M>
 where
     CH: DmaChannel,
 {
-    /// Return a type-erased (degraded) version of this channel (both rx and
+    /// Return a less specific (degraded) version of this channel (both rx and
     /// tx).
     pub fn degrade<DEG: DmaChannel>(self) -> Channel<'d, DEG, M>
     where

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1607,7 +1607,7 @@ pub trait Rx: crate::private::Sealed {
 
     fn clear_interrupts(&self);
 
-    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker;
+    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker;
 }
 
 // DMA receive channel
@@ -1773,7 +1773,7 @@ where
         self.rx_impl.clear_all();
     }
 
-    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker {
+    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker {
         self.rx_impl.waker()
     }
 }
@@ -1822,7 +1822,7 @@ pub trait Tx: crate::private::Sealed {
 
     fn clear_interrupts(&self);
 
-    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker;
+    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker;
 
     fn last_out_dscr_address(&self) -> usize;
 }
@@ -1974,7 +1974,7 @@ where
         self.tx_impl.pending_interrupts()
     }
 
-    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker {
+    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker {
         self.tx_impl.waker()
     }
 
@@ -2048,7 +2048,7 @@ pub trait InterruptAccess<T: EnumSetType>: crate::private::Sealed {
     fn is_listening(&self) -> EnumSet<T>;
     fn clear(&self, interrupts: impl Into<EnumSet<T>>);
     fn pending_interrupts(&self) -> EnumSet<T>;
-    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker;
+    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker;
 }
 
 /// DMA Channel

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -890,7 +890,6 @@ impl From<u32> for Owner {
     }
 }
 
-/// Marks channels as useable for SPI
 #[doc(hidden)]
 pub trait DmaEligible {
     /// The DMA peripheral
@@ -903,10 +902,12 @@ pub trait DmaEligible {
 /// Marker trait
 #[doc(hidden)]
 pub trait PeripheralMarker {
-    #[cfg(pdma)]
     fn peripheral(&self) -> crate::system::Peripheral;
 }
 
+/// Trait implemented for (DmaChannel, Peripheral) pairs that are compatible.
+/// This is used to statically verify that the DMA channel is compatible with
+/// the peripheral.
 #[doc(hidden)]
 pub trait DmaCompatible {}
 
@@ -1993,7 +1994,7 @@ pub trait RegisterAccess: crate::private::Sealed {
     fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize);
 
     #[cfg(pdma)]
-    fn is_compatible_with<P: PeripheralMarker>(&self, peripheral: P) -> bool;
+    fn is_compatible_with(&self, peripheral: &impl PeripheralMarker) -> bool;
 }
 
 #[doc(hidden)]

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -900,46 +900,28 @@ pub trait DmaEligible {
     }
 }
 
-/// Marks channels as useable for SPI
-#[doc(hidden)]
-pub trait SpiPeripheral: PeripheralMarker {}
-
-/// Marks channels as useable for SPI2
-#[doc(hidden)]
-pub trait Spi2Peripheral: SpiPeripheral + PeripheralMarker {}
-
-/// Marks channels as useable for SPI3
-#[cfg(any(esp32, esp32s2, esp32s3))]
-#[doc(hidden)]
-pub trait Spi3Peripheral: SpiPeripheral + PeripheralMarker {}
-
-/// Marks channels as useable for I2S
-#[doc(hidden)]
-pub trait I2sPeripheral: PeripheralMarker {}
-
-/// Marks channels as useable for I2S0
-#[doc(hidden)]
-pub trait I2s0Peripheral: I2sPeripheral + PeripheralMarker {}
-
-/// Marks channels as useable for I2S1
-#[doc(hidden)]
-pub trait I2s1Peripheral: I2sPeripheral + PeripheralMarker {}
-
-/// Marks channels as useable for PARL_IO
-#[doc(hidden)]
-pub trait ParlIoPeripheral: PeripheralMarker {}
-
-/// Marks channels as useable for AES
-#[doc(hidden)]
-pub trait AesPeripheral: PeripheralMarker {}
-
-/// Marks channels as usable for LCD_CAM
-#[doc(hidden)]
-pub trait LcdCamPeripheral: PeripheralMarker {}
-
 /// Marker trait
 #[doc(hidden)]
 pub trait PeripheralMarker {}
+
+#[doc(hidden)]
+pub trait DmaCompatible {}
+
+#[cfg(gdma)]
+impl<CH, P> DmaCompatible for (CH, P)
+where
+    CH: DmaChannel,
+    P: PeripheralMarker,
+{
+}
+
+#[cfg(pdma)]
+impl<CH, P> DmaCompatible for (CH, P)
+where
+    CH: PeripheralDmaChannel<P = P>,
+    P: PeripheralMarker,
+{
+}
 
 #[doc(hidden)]
 #[derive(Debug)]
@@ -1543,6 +1525,7 @@ pub trait DmaChannel: crate::private::Sealed {
 }
 
 /// A description of a DMA Channel that can be used with a peripheral.
+#[cfg(pdma)]
 pub trait PeripheralDmaChannel: DmaChannel {
     /// A suitable peripheral for this DMA channel.
     type P: PeripheralMarker;

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1524,13 +1524,6 @@ pub trait DmaChannel: crate::private::Sealed {
     type Tx: TxRegisterAccess + InterruptAccess<DmaTxInterrupt>;
 }
 
-/// A description of a DMA Channel that can be used with a peripheral.
-#[cfg(pdma)]
-pub trait PeripheralDmaChannel: DmaChannel {
-    /// A suitable peripheral for this DMA channel.
-    type P: PeripheralMarker;
-}
-
 #[doc(hidden)]
 pub trait DmaChannelExt: DmaChannel {
     fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt>;

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1534,10 +1534,19 @@ pub trait DmaChannel: crate::private::Sealed {
 
     /// A description of the TX half of a DMA Channel.
     type Tx: TxRegisterAccess + InterruptAccess<DmaTxInterrupt>;
+}
 
+/// A description of a DMA Channel that can be used with a peripheral.
+pub trait PeripheralDmaChannel: DmaChannel {
     /// A suitable peripheral for this DMA channel.
     type P: PeripheralMarker;
 }
+
+/// A description of any DMA channel
+#[non_exhaustive]
+pub struct AnyDmaChannel {}
+
+impl crate::private::Sealed for AnyDmaChannel {}
 
 #[doc(hidden)]
 pub trait DmaChannelExt: DmaChannel {
@@ -1607,7 +1616,7 @@ pub trait Rx: crate::private::Sealed {
 
     fn clear_interrupts(&self);
 
-    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker;
+    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker;
 }
 
 // DMA receive channel
@@ -1773,7 +1782,7 @@ where
         self.rx_impl.clear_all();
     }
 
-    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker {
+    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker {
         self.rx_impl.waker()
     }
 }
@@ -1822,7 +1831,7 @@ pub trait Tx: crate::private::Sealed {
 
     fn clear_interrupts(&self);
 
-    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker;
+    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker;
 
     fn last_out_dscr_address(&self) -> usize;
 }
@@ -1974,7 +1983,7 @@ where
         self.tx_impl.pending_interrupts()
     }
 
-    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker {
+    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker {
         self.tx_impl.waker()
     }
 
@@ -2048,7 +2057,7 @@ pub trait InterruptAccess<T: EnumSetType>: crate::private::Sealed {
     fn is_listening(&self) -> EnumSet<T>;
     fn clear(&self, interrupts: impl Into<EnumSet<T>>);
     fn pending_interrupts(&self) -> EnumSet<T>;
-    fn waker(&self) -> &embassy_sync::waitqueue::AtomicWaker;
+    fn waker(&self) -> &'static embassy_sync::waitqueue::AtomicWaker;
 }
 
 /// DMA Channel

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1590,7 +1590,7 @@ pub trait Rx: crate::private::Sealed {
 // DMA receive channel
 #[non_exhaustive]
 #[doc(hidden)]
-pub struct ChannelRx<'a, CH = AnyDmaChannel>
+pub struct ChannelRx<'a, CH>
 where
     CH: DmaChannel,
 {
@@ -1612,7 +1612,7 @@ where
     }
 
     /// Return a type-erased (degraded) version of this channel.
-    pub fn degrade(self) -> ChannelRx<'a> {
+    pub fn degrade(self) -> ChannelRx<'a, AnyDmaChannel> {
         ChannelRx {
             burst_mode: self.burst_mode,
             rx_impl: CH::degrade_rx(self.rx_impl),
@@ -1803,7 +1803,7 @@ pub trait Tx: crate::private::Sealed {
 
 /// DMA transmit channel
 #[doc(hidden)]
-pub struct ChannelTx<'a, CH = AnyDmaChannel>
+pub struct ChannelTx<'a, CH>
 where
     CH: DmaChannel,
 {
@@ -1826,7 +1826,7 @@ where
     }
 
     /// Return a type-erased (degraded) version of this channel.
-    pub fn degrade(self) -> ChannelTx<'a> {
+    pub fn degrade(self) -> ChannelTx<'a, AnyDmaChannel> {
         ChannelTx {
             burst_mode: self.burst_mode,
             tx_impl: CH::degrade_tx(self.tx_impl),
@@ -2026,7 +2026,7 @@ pub trait InterruptAccess<T: EnumSetType>: crate::private::Sealed {
 }
 
 /// DMA Channel
-pub struct Channel<'d, MODE, CH = AnyDmaChannel>
+pub struct Channel<'d, CH, MODE>
 where
     CH: DmaChannel,
     MODE: Mode,
@@ -2038,7 +2038,7 @@ where
     phantom: PhantomData<MODE>,
 }
 
-impl<'d, C> Channel<'d, crate::Blocking, C>
+impl<'d, C> Channel<'d, C, crate::Blocking>
 where
     C: DmaChannel,
 {
@@ -2096,13 +2096,13 @@ where
     }
 }
 
-impl<'d, C, M: Mode> Channel<'d, M, C>
+impl<'d, C, M: Mode> Channel<'d, C, M>
 where
     C: DmaChannel,
 {
     /// Return a type-erased (degraded) version of this channel (both rx and
     /// tx).
-    pub fn degrade(self) -> Channel<'d, M> {
+    pub fn degrade(self) -> Channel<'d, AnyDmaChannel, M> {
         Channel {
             rx: self.rx.degrade(),
             tx: self.tx.degrade(),

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -417,7 +417,7 @@ macro_rules! ImplSpiChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<Spi $num DmaChannel>], M> {
+                ) -> Channel<'a, M, [<Spi $num DmaChannel>]> {
                     #[cfg(esp32)]
                     {
                         // (only) on ESP32 we need to configure DPORT for the SPI DMA channels
@@ -450,7 +450,7 @@ macro_rules! ImplSpiChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<Spi $num DmaChannel>], $crate::Blocking> {
+                ) -> Channel<'a, $crate::Blocking, [<Spi $num DmaChannel>]> {
                     Self::do_configure(self, burst_mode, priority)
                 }
 
@@ -462,7 +462,7 @@ macro_rules! ImplSpiChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<Spi $num DmaChannel>], $crate::Async> {
+                ) -> Channel<'a, $crate::Async, [<Spi $num DmaChannel>]> {
                     let this = Self::do_configure(self, burst_mode, priority);
 
                     [<Spi $num DmaChannel>]::set_isr(super::asynch::interrupt::[< interrupt_handler_spi $num _dma >]);
@@ -860,7 +860,7 @@ macro_rules! ImplI2sChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<I2s $num DmaChannel>], M> {
+                ) -> Channel<'a, M, [<I2s $num DmaChannel>]> {
                     let tx_impl = I2sDmaTxChannelImpl([<I2s $num DmaChannel>] {});
                     tx_impl.set_burst_mode(burst_mode);
                     tx_impl.set_priority(priority);
@@ -884,7 +884,7 @@ macro_rules! ImplI2sChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<I2s $num DmaChannel>], $crate::Blocking> {
+                ) -> Channel<'a, $crate::Blocking, [<I2s $num DmaChannel>]> {
                     Self::do_configure(self, burst_mode, priority)
                 }
 
@@ -896,7 +896,7 @@ macro_rules! ImplI2sChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<I2s $num DmaChannel>], $crate::Async> {
+                ) -> Channel<'a, $crate::Async, [<I2s $num DmaChannel>]> {
                     let this = Self::do_configure(self, burst_mode, priority);
 
                     [<I2s $num DmaChannel>]::set_isr(super::asynch::interrupt::[< interrupt_handler_i2s $num >]);
@@ -1072,9 +1072,9 @@ impl TxRegisterAccess for AnyPdmaTxChannelImpl {
     }
 }
 
-impl<'d, C, M: Mode> Channel<'d, C, M>
+impl<'d, CH, M: Mode> Channel<'d, M, CH>
 where
-    C: DmaChannel,
+    CH: DmaChannel,
 {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible(&self, peripheral: &PeripheralRef<'_, impl PeripheralMarker>) {

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -805,7 +805,7 @@ macro_rules! ImplI2sChannel {
                 }
 
                 fn set_isr(handler: InterruptHandler) {
-                    let interrupt = $crate::peripherals::Interrupt::[< I2S $num  >];
+                    let interrupt = $crate::peripherals::Interrupt::[< I2S $num >];
                     unsafe {
                         crate::interrupt::bind_interrupt(interrupt, handler.handler());
                     }

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -349,6 +349,13 @@ macro_rules! ImplSpiChannel {
             impl DmaChannel for [<Spi $num DmaChannel>] {
                 type Rx = SpiDmaRxChannelImpl<Self>;
                 type Tx = SpiDmaTxChannelImpl<Self>;
+
+                fn degrade_rx(rx: Self::Rx) -> AnyPdmaRxChannelImpl {
+                    rx.degrade()
+                }
+                fn degrade_tx(tx: Self::Tx) -> AnyPdmaTxChannelImpl {
+                    tx.degrade()
+                }
             }
             impl PeripheralDmaChannel for [<Spi $num DmaChannel>] {
                 type P = [<Spi $num DmaSuitablePeripheral>];
@@ -360,13 +367,6 @@ macro_rules! ImplSpiChannel {
                 }
                 fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     SpiDmaTxChannelImpl(Self {})
-                }
-
-                fn degrade_rx(rx: Self::Rx) -> AnyPdmaRxChannelImpl {
-                    rx.degrade()
-                }
-                fn degrade_tx(tx: Self::Tx) -> AnyPdmaTxChannelImpl {
-                    tx.degrade()
                 }
 
                 fn set_isr(handler: InterruptHandler) {
@@ -784,6 +784,13 @@ macro_rules! ImplI2sChannel {
             impl DmaChannel for [<I2s $num DmaChannel>] {
                 type Rx = I2sDmaRxChannelImpl<Self>;
                 type Tx = I2sDmaTxChannelImpl<Self>;
+
+                fn degrade_rx(rx: Self::Rx) -> AnyPdmaRxChannelImpl {
+                    rx.degrade()
+                }
+                fn degrade_tx(tx: Self::Tx) -> AnyPdmaTxChannelImpl {
+                    tx.degrade()
+                }
             }
             impl PeripheralDmaChannel for [<I2s $num DmaChannel>] {
                 type P = [<I2s $num DmaSuitablePeripheral>];
@@ -795,13 +802,6 @@ macro_rules! ImplI2sChannel {
                 }
                 fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     I2sDmaTxChannelImpl(Self {})
-                }
-
-                fn degrade_rx(rx: Self::Rx) -> AnyPdmaRxChannelImpl {
-                    rx.degrade()
-                }
-                fn degrade_tx(tx: Self::Tx) -> AnyPdmaTxChannelImpl {
-                    tx.degrade()
                 }
 
                 fn set_isr(handler: InterruptHandler) {
@@ -965,6 +965,14 @@ pub enum AnyPdmaChannel {
 impl DmaChannel for AnyDmaChannel {
     type Rx = AnyPdmaRxChannelImpl;
     type Tx = AnyPdmaTxChannelImpl;
+
+    fn degrade_rx(rx: Self::Rx) -> AnyPdmaRxChannelImpl {
+        rx
+    }
+
+    fn degrade_tx(tx: Self::Tx) -> AnyPdmaTxChannelImpl {
+        tx
+    }
 }
 
 #[doc(hidden)]

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -405,7 +405,7 @@ macro_rules! ImplSpiChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, M, [<Spi $num DmaChannel>]> {
+                ) -> Channel<'a, [<Spi $num DmaChannel>], M> {
                     #[cfg(esp32)]
                     {
                         // (only) on ESP32 we need to configure DPORT for the SPI DMA channels
@@ -438,7 +438,7 @@ macro_rules! ImplSpiChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, $crate::Blocking, [<Spi $num DmaChannel>]> {
+                ) -> Channel<'a, [<Spi $num DmaChannel>], $crate::Blocking> {
                     Self::do_configure(self, burst_mode, priority)
                 }
 
@@ -450,7 +450,7 @@ macro_rules! ImplSpiChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, $crate::Async, [<Spi $num DmaChannel>]> {
+                ) -> Channel<'a, [<Spi $num DmaChannel>], $crate::Async> {
                     let this = Self::do_configure(self, burst_mode, priority);
 
                     [<Spi $num DmaChannel>]::set_isr(super::asynch::interrupt::[< interrupt_handler_spi $num _dma >]);
@@ -842,7 +842,7 @@ macro_rules! ImplI2sChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, M, [<I2s $num DmaChannel>]> {
+                ) -> Channel<'a, [<I2s $num DmaChannel>], M> {
                     let tx_impl = I2sDmaTxChannelImpl([<I2s $num DmaChannel>] {});
                     tx_impl.set_burst_mode(burst_mode);
                     tx_impl.set_priority(priority);
@@ -866,7 +866,7 @@ macro_rules! ImplI2sChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, $crate::Blocking, [<I2s $num DmaChannel>]> {
+                ) -> Channel<'a, [<I2s $num DmaChannel>], $crate::Blocking> {
                     Self::do_configure(self, burst_mode, priority)
                 }
 
@@ -878,7 +878,7 @@ macro_rules! ImplI2sChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, $crate::Async, [<I2s $num DmaChannel>]> {
+                ) -> Channel<'a, [<I2s $num DmaChannel>], $crate::Async> {
                     let this = Self::do_configure(self, burst_mode, priority);
 
                     [<I2s $num DmaChannel>]::set_isr(super::asynch::interrupt::[< interrupt_handler_i2s $num >]);
@@ -1101,9 +1101,9 @@ impl TxRegisterAccess for AnyPdmaTxChannelImpl {
     }
 }
 
-impl<'d, CH, M: Mode> Channel<'d, M, CH>
+impl<'d, C, M: Mode> Channel<'d, C, M>
 where
-    CH: DmaChannel,
+    C: DmaChannel,
 {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible(&self, peripheral: &PeripheralRef<'_, impl PeripheralMarker>) {

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -901,6 +901,15 @@ ImplI2sChannel!(0);
 #[cfg(i2s1)]
 ImplI2sChannel!(1);
 
+// Specific peripherals use specific channels. Note that this may be overly
+// restrictive (ESP32 allows configuring 2 SPI DMA channels between 3 different
+// peripherals), but for the current set of restrictions this is sufficient.
+crate::impl_dma_eligible!([Spi2DmaChannel] SPI2 => Spi2);
+crate::impl_dma_eligible!([Spi3DmaChannel] SPI3 => Spi3);
+crate::impl_dma_eligible!([I2s0DmaChannel] I2S0 => I2s0);
+#[cfg(i2s1)]
+crate::impl_dma_eligible!([I2s1DmaChannel] I2S1 => I2s1);
+
 /// DMA Peripheral
 ///
 /// This offers the available DMA channels.
@@ -959,7 +968,9 @@ macro_rules! define_enum {
     }
 }
 
-/// An arbitrary PDMA channel
+/// An arbitrary PDMA channel.
+// NOTE: this is unused currently (peripherals prescribe a specific channel) but type-erased
+// peripherals will require type-erased channels.
 #[non_exhaustive]
 pub struct AnyPdmaChannel;
 impl crate::private::Sealed for AnyPdmaChannel {}

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -887,35 +887,27 @@ macro_rules! ImplI2sChannel {
 #[non_exhaustive]
 pub struct Spi2DmaSuitablePeripheral {}
 impl PeripheralMarker for Spi2DmaSuitablePeripheral {}
-impl SpiPeripheral for Spi2DmaSuitablePeripheral {}
-impl Spi2Peripheral for Spi2DmaSuitablePeripheral {}
 
 #[doc(hidden)]
 #[non_exhaustive]
 pub struct Spi3DmaSuitablePeripheral {}
 impl PeripheralMarker for Spi3DmaSuitablePeripheral {}
-impl SpiPeripheral for Spi3DmaSuitablePeripheral {}
-impl Spi3Peripheral for Spi3DmaSuitablePeripheral {}
 
 ImplSpiChannel!(2);
+#[cfg(spi3)]
 ImplSpiChannel!(3);
 
 #[doc(hidden)]
 #[non_exhaustive]
 pub struct I2s0DmaSuitablePeripheral {}
 impl PeripheralMarker for I2s0DmaSuitablePeripheral {}
-impl I2sPeripheral for I2s0DmaSuitablePeripheral {}
-impl I2s0Peripheral for I2s0DmaSuitablePeripheral {}
-
-ImplI2sChannel!(0);
 
 #[doc(hidden)]
 #[non_exhaustive]
 pub struct I2s1DmaSuitablePeripheral {}
 impl PeripheralMarker for I2s1DmaSuitablePeripheral {}
-impl I2sPeripheral for I2s1DmaSuitablePeripheral {}
-impl I2s1Peripheral for I2s1DmaSuitablePeripheral {}
 
+ImplI2sChannel!(0);
 #[cfg(i2s1)]
 ImplI2sChannel!(1);
 

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -329,10 +329,6 @@ macro_rules! ImplSpiChannel {
                 type Tx = SpiDmaTxChannelImpl<Self>;
             }
 
-            impl PeripheralDmaChannel for [<Spi $num DmaChannel>] {
-                type P = crate::peripherals::[<SPI $num>];
-            }
-
             impl DmaChannelExt for [<Spi $num DmaChannel>] {
                 fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     SpiDmaRxChannelImpl(Self {})
@@ -744,10 +740,6 @@ macro_rules! ImplI2sChannel {
             impl DmaChannel for [<I2s $num DmaChannel>] {
                 type Rx = I2sDmaRxChannelImpl<Self>;
                 type Tx = I2sDmaTxChannelImpl<Self>;
-            }
-
-            impl PeripheralDmaChannel for [<I2s $num DmaChannel>] {
-                type P = crate::peripherals::[<I2S $num>];
             }
 
             impl DmaChannelExt for [<I2s $num DmaChannel>] {

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -343,6 +343,7 @@ macro_rules! ImplSpiChannel {
             pub struct [<Spi $num DmaChannel>] {}
 
             impl DmaChannel for [<Spi $num DmaChannel>] {
+                type Degraded = AnyPdmaChannel;
                 type Rx = SpiDmaRxChannelImpl<Self>;
                 type Tx = SpiDmaTxChannelImpl<Self>;
 
@@ -784,6 +785,7 @@ macro_rules! ImplI2sChannel {
             impl $crate::private::Sealed for [<I2s $num DmaChannel>] {}
 
             impl DmaChannel for [<I2s $num DmaChannel>] {
+                type Degraded = AnyPdmaChannel;
                 type Rx = I2sDmaRxChannelImpl<Self>;
                 type Tx = I2sDmaTxChannelImpl<Self>;
 
@@ -955,18 +957,13 @@ macro_rules! define_enum {
     }
 }
 
-define_enum! {
-    #[doc(hidden)]
-    pub enum AnyPdmaChannel {
-        Spi2(Spi2DmaChannel),
-        Spi3(Spi3DmaChannel),
-        I2s0(I2s0DmaChannel),
-        #[cfg(i2s1)]
-        I2s1(I2s1DmaChannel),
-    }
-}
+/// An arbitrary PDMA channel
+#[non_exhaustive]
+pub struct AnyPdmaChannel;
+impl crate::private::Sealed for AnyPdmaChannel {}
 
-impl DmaChannel for AnyDmaChannel {
+impl DmaChannel for AnyPdmaChannel {
+    type Degraded = Self;
     type Rx = AnyPdmaRxChannelImpl;
     type Tx = AnyPdmaTxChannelImpl;
 
@@ -1128,4 +1125,4 @@ where
 }
 
 #[cfg(pdma)]
-impl<P> DmaCompatible for (AnyDmaChannel, P) where P: PeripheralMarker {}
+impl<P> DmaCompatible for (AnyPdmaChannel, P) where P: PeripheralMarker {}

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -923,7 +923,7 @@ pub struct Dma<'d> {
     /// DMA channel for I2S0
     pub i2s0channel: I2s0DmaChannelCreator,
     /// DMA channel for I2S1
-    #[cfg(esp32)]
+    #[cfg(i2s1)]
     pub i2s1channel: I2s1DmaChannelCreator,
 }
 

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -355,8 +355,6 @@ macro_rules! ImplSpiChannel {
             }
 
             impl DmaChannelExt for [<Spi $num DmaChannel>] {
-                type Degraded = AnyDmaChannel;
-
                 fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     SpiDmaRxChannelImpl(Self {})
                 }
@@ -792,8 +790,6 @@ macro_rules! ImplI2sChannel {
             }
 
             impl DmaChannelExt for [<I2s $num DmaChannel>] {
-                type Degraded = AnyDmaChannel;
-
                 fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     I2sDmaRxChannelImpl(Self {})
                 }

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -954,7 +954,10 @@ macro_rules! define_enum {
     ) => {
         $(#[$meta])*
         $vis enum $ty {
-            $($variant($inner)),*
+            $(
+                $(#[$cfg])?
+                $variant($inner),
+            )*
         }
 
         $(

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -116,8 +116,8 @@ impl<C: SpiPdmaChannel> TxRegisterAccess for SpiDmaTxChannelImpl<C> {
 
 impl<C: SpiPdmaChannel> InterruptAccess<DmaTxInterrupt> for SpiDmaTxChannelImpl<C> {
     fn enable_listen(&self, interrupts: EnumSet<DmaTxInterrupt>, enable: bool) {
-        let spi = self.0.register_block();
-        spi.dma_int_ena().modify(|_, w| {
+        let reg_block = self.0.register_block();
+        reg_block.dma_int_ena().modify(|_, w| {
             for interrupt in interrupts {
                 match interrupt {
                     DmaTxInterrupt::TotalEof => w.out_total_eof().bit(enable),
@@ -238,8 +238,8 @@ impl<C: SpiPdmaChannel> RxRegisterAccess for SpiDmaRxChannelImpl<C> {}
 
 impl<C: SpiPdmaChannel> InterruptAccess<DmaRxInterrupt> for SpiDmaRxChannelImpl<C> {
     fn enable_listen(&self, interrupts: EnumSet<DmaRxInterrupt>, enable: bool) {
-        let spi = self.0.register_block();
-        spi.dma_int_ena().modify(|_, w| {
+        let reg_block = self.0.register_block();
+        reg_block.dma_int_ena().modify(|_, w| {
             for interrupt in interrupts {
                 match interrupt {
                     DmaRxInterrupt::SuccessfulEof => w.in_suc_eof().bit(enable),
@@ -677,7 +677,7 @@ impl<C: I2sPdmaChannel> RxRegisterAccess for I2sDmaRxChannelImpl<C> {}
 
 impl<C: I2sPdmaChannel> InterruptAccess<DmaRxInterrupt> for I2sDmaRxChannelImpl<C> {
     fn enable_listen(&self, interrupts: EnumSet<DmaRxInterrupt>, enable: bool) {
-        let spi = self.0.register_block();
+        let reg_block = self.0.register_block();
         reg_block.int_ena().modify(|_, w| {
             for interrupt in interrupts {
                 match interrupt {
@@ -980,8 +980,7 @@ impl InterruptAccess<DmaRxInterrupt> for AnyPdmaRxChannelImpl {
             #[cfg(i2s1)]
             AnyPdmaChannel::I2s1(channel) => unsafe { I2sDmaRxChannelImpl(channel.clone_unchecked()) },
         } {
-            fn listen(&self, interrupts: impl Into<EnumSet<DmaRxInterrupt>>);
-            fn unlisten(&self, interrupts: impl Into<EnumSet<DmaRxInterrupt>>);
+            fn enable_listen(&self, interrupts: EnumSet<DmaRxInterrupt>, enable: bool);
             fn is_listening(&self) -> EnumSet<DmaRxInterrupt>;
             fn clear(&self, interrupts: impl Into<EnumSet<DmaRxInterrupt>>);
             fn pending_interrupts(&self) -> EnumSet<DmaRxInterrupt>;
@@ -1000,7 +999,6 @@ impl RegisterAccess for AnyPdmaRxChannelImpl {
         } {
             fn set_burst_mode(&self, burst_mode: bool);
             fn set_priority(&self, priority: DmaPriority);
-            fn clear_interrupts(&self);
             fn reset(&self);
             fn set_link_addr(&self, address: u32);
             fn set_peripheral(&self, peripheral: u8);
@@ -1025,8 +1023,7 @@ impl InterruptAccess<DmaTxInterrupt> for AnyPdmaTxChannelImpl {
             #[cfg(i2s1)]
             AnyPdmaChannel::I2s1(channel) => unsafe { I2sDmaTxChannelImpl(channel.clone_unchecked()) },
         } {
-            fn listen(&self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>);
-            fn unlisten(&self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>);
+            fn enable_listen(&self, interrupts: EnumSet<DmaTxInterrupt>, enable: bool);
             fn is_listening(&self) -> EnumSet<DmaTxInterrupt>;
             fn clear(&self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>);
             fn pending_interrupts(&self) -> EnumSet<DmaTxInterrupt>;
@@ -1045,7 +1042,6 @@ impl RegisterAccess for AnyPdmaTxChannelImpl {
         } {
             fn set_burst_mode(&self, burst_mode: bool);
             fn set_priority(&self, priority: DmaPriority);
-            fn clear_interrupts(&self);
             fn reset(&self);
             fn set_link_addr(&self, address: u32);
             fn set_peripheral(&self, peripheral: u8);

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -915,7 +915,6 @@ macro_rules! ImplI2sChannel {
 }
 
 ImplSpiChannel!(2);
-#[cfg(spi3)]
 ImplSpiChannel!(3);
 
 ImplI2sChannel!(0);

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -435,7 +435,7 @@ where
 impl<'d, I, CH, DmaMode> I2s<'d, I, CH, DmaMode>
 where
     I: RegisterAccess,
-    CH: PeripheralDmaChannel,
+    CH: DmaChannel,
     DmaMode: Mode,
 {
     /// Construct a new I2S peripheral driver instance for the first I2S
@@ -452,6 +452,7 @@ where
     ) -> Self
     where
         I: I2s0Instance,
+        CH: PeripheralDmaChannel,
         CH::P: I2sPeripheral + I2s0Peripheral,
         DmaMode: Mode,
     {
@@ -481,6 +482,7 @@ where
     ) -> Self
     where
         I: I2s1Instance,
+        CH: PeripheralDmaChannel,
         CH::P: I2sPeripheral + I2s1Peripheral,
     {
         Self::new_internal(

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -102,6 +102,7 @@ use crate::{
         DmaTransferTxCircular,
         I2s0Peripheral,
         I2sPeripheral,
+        PeripheralDmaChannel,
         ReadBuffer,
         Rx,
         Tx,
@@ -434,7 +435,7 @@ where
 impl<'d, I, CH, DmaMode> I2s<'d, I, CH, DmaMode>
 where
     I: RegisterAccess,
-    CH: DmaChannel,
+    CH: PeripheralDmaChannel,
     DmaMode: Mode,
 {
     /// Construct a new I2S peripheral driver instance for the first I2S

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -102,7 +102,6 @@ use crate::{
         DmaTransferTx,
         DmaTransferTxCircular,
         I2s0Peripheral,
-        I2sPeripheral,
         PeripheralDmaChannel,
         ReadBuffer,
         Rx,
@@ -447,7 +446,7 @@ where
     where
         I: I2s0Instance,
         CH: PeripheralDmaChannel,
-        CH::P: I2sPeripheral + I2s0Peripheral,
+        CH::P: I2s0Peripheral,
         DmaMode: Mode,
     {
         Self::new_internal(
@@ -477,7 +476,7 @@ where
     where
         I: I2s1Instance,
         CH: PeripheralDmaChannel,
-        CH::P: I2sPeripheral + I2s1Peripheral,
+        CH::P: I2s1Peripheral,
     {
         Self::new_internal(
             i2s,

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -87,7 +87,6 @@ use private::*;
 use crate::{
     dma::{
         dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
-        AnyDmaChannel,
         Channel,
         ChannelRx,
         ChannelTx,
@@ -338,7 +337,7 @@ where
         standard: Standard,
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
-        channel: Channel<'d, CH, DmaMode>,
+        channel: Channel<'d, DmaMode, CH>,
         rx_descriptors: &'static mut [DmaDescriptor],
         tx_descriptors: &'static mut [DmaDescriptor],
     ) -> Self {
@@ -437,7 +436,7 @@ where
         standard: Standard,
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
-        channel: Channel<'d, CH, DmaMode>,
+        channel: Channel<'d, DmaMode, CH>,
         rx_descriptors: &'static mut [DmaDescriptor],
         tx_descriptors: &'static mut [DmaDescriptor],
     ) -> Self
@@ -473,7 +472,7 @@ where
     T: RegisterAccess,
 {
     register_access: PhantomData<T>,
-    tx_channel: ChannelTx<'d, AnyDmaChannel>,
+    tx_channel: ChannelTx<'d>,
     tx_chain: DescriptorChain,
     phantom: PhantomData<DmaMode>,
 }
@@ -507,7 +506,7 @@ where
     T: RegisterAccess,
     DmaMode: Mode,
 {
-    type TX = ChannelTx<'d, AnyDmaChannel>;
+    type TX = ChannelTx<'d>;
 
     fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
@@ -523,10 +522,7 @@ where
     T: RegisterAccess,
     DmaMode: Mode,
 {
-    fn new(
-        tx_channel: ChannelTx<'d, AnyDmaChannel>,
-        descriptors: &'static mut [DmaDescriptor],
-    ) -> Self {
+    fn new(tx_channel: ChannelTx<'d>, descriptors: &'static mut [DmaDescriptor]) -> Self {
         Self {
             register_access: PhantomData,
             tx_channel,
@@ -640,7 +636,7 @@ where
     DmaMode: Mode,
 {
     register_access: PhantomData<T>,
-    rx_channel: ChannelRx<'d, AnyDmaChannel>,
+    rx_channel: ChannelRx<'d>,
     rx_chain: DescriptorChain,
     phantom: PhantomData<DmaMode>,
 }
@@ -674,7 +670,7 @@ where
     T: RegisterAccess,
     DmaMode: Mode,
 {
-    type RX = ChannelRx<'d, AnyDmaChannel>;
+    type RX = ChannelRx<'d>;
 
     fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
@@ -690,10 +686,7 @@ where
     T: RegisterAccess,
     DmaMode: Mode,
 {
-    fn new(
-        rx_channel: ChannelRx<'d, AnyDmaChannel>,
-        descriptors: &'static mut [DmaDescriptor],
-    ) -> Self {
+    fn new(rx_channel: ChannelRx<'d>, descriptors: &'static mut [DmaDescriptor]) -> Self {
         Self {
             register_access: PhantomData,
             rx_channel,
@@ -832,15 +825,7 @@ mod private {
     #[cfg(any(esp32, esp32s3))]
     use crate::peripherals::{i2s1::RegisterBlock, I2S1};
     use crate::{
-        dma::{
-            AnyDmaChannel,
-            ChannelRx,
-            ChannelTx,
-            DmaDescriptor,
-            DmaEligible,
-            DmaPeripheral,
-            PeripheralMarker,
-        },
+        dma::{ChannelRx, ChannelTx, DmaDescriptor, DmaEligible, DmaPeripheral, PeripheralMarker},
         gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput},
         interrupt::InterruptHandler,
         into_ref,
@@ -856,7 +841,7 @@ mod private {
         DmaMode: Mode,
     {
         pub register_access: PhantomData<T>,
-        pub tx_channel: ChannelTx<'d, AnyDmaChannel>,
+        pub tx_channel: ChannelTx<'d>,
         pub descriptors: &'static mut [DmaDescriptor],
         pub(crate) phantom: PhantomData<DmaMode>,
     }
@@ -910,7 +895,7 @@ mod private {
         DmaMode: Mode,
     {
         pub register_access: PhantomData<T>,
-        pub rx_channel: ChannelRx<'d, AnyDmaChannel>,
+        pub rx_channel: ChannelRx<'d>,
         pub descriptors: &'static mut [DmaDescriptor],
         pub(crate) phantom: PhantomData<DmaMode>,
     }

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -91,8 +91,7 @@ use crate::{
         ChannelRx,
         ChannelTx,
         DescriptorChain,
-        DmaChannel,
-        DmaCompatible,
+        DmaChannelConvert,
         DmaDescriptor,
         DmaError,
         DmaTransferRx,
@@ -343,7 +342,7 @@ where
         tx_descriptors: &'static mut [DmaDescriptor],
     ) -> Self
     where
-        CH: DmaChannel<Degraded = I::Dma>,
+        CH: DmaChannelConvert<I::Dma>,
     {
         crate::into_ref!(i2s);
         channel.runtime_ensure_compatible(&i2s);
@@ -445,8 +444,7 @@ where
         tx_descriptors: &'static mut [DmaDescriptor],
     ) -> Self
     where
-        CH: DmaChannel<Degraded = I::Dma>,
-        (CH, I): DmaCompatible,
+        CH: DmaChannelConvert<I::Dma>,
         DmaMode: Mode,
     {
         Self::new_internal(

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -74,16 +74,7 @@ use fugit::HertzU32;
 
 use crate::{
     clock::Clocks,
-    dma::{
-        AnyDmaChannel,
-        ChannelRx,
-        DmaError,
-        DmaPeripheral,
-        DmaRxBuffer,
-        LcdCamPeripheral,
-        PeripheralDmaChannel,
-        Rx,
-    },
+    dma::{AnyDmaChannel, ChannelRx, DmaChannel, DmaError, DmaPeripheral, DmaRxBuffer, Rx},
     gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput, Pull},
     lcd_cam::{cam::private::RxPins, private::calculate_clkm, BitOrder, ByteOrder},
     peripheral::{Peripheral, PeripheralRef},
@@ -143,8 +134,7 @@ impl<'d> Camera<'d> {
         frequency: HertzU32,
     ) -> Self
     where
-        CH: PeripheralDmaChannel,
-        CH::P: LcdCamPeripheral,
+        CH: DmaChannel,
         P: RxPins,
     {
         let lcd_cam = cam.lcd_cam;

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -74,7 +74,16 @@ use fugit::HertzU32;
 
 use crate::{
     clock::Clocks,
-    dma::{AnyDmaChannel, ChannelRx, DmaChannel, DmaError, DmaPeripheral, DmaRxBuffer, Rx},
+    dma::{
+        ChannelRx,
+        DmaChannel,
+        DmaCompatible,
+        DmaEligible,
+        DmaError,
+        DmaPeripheral,
+        DmaRxBuffer,
+        Rx,
+    },
     gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput, Pull},
     lcd_cam::{cam::private::RxPins, private::calculate_clkm, BitOrder, ByteOrder},
     peripheral::{Peripheral, PeripheralRef},
@@ -122,7 +131,7 @@ pub struct Cam<'d> {
 /// Represents the camera interface with DMA support.
 pub struct Camera<'d> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
-    rx_channel: ChannelRx<'d, AnyDmaChannel>,
+    rx_channel: ChannelRx<'d, <LCD_CAM as DmaEligible>::Dma>,
 }
 
 impl<'d> Camera<'d> {
@@ -134,7 +143,8 @@ impl<'d> Camera<'d> {
         frequency: HertzU32,
     ) -> Self
     where
-        CH: DmaChannel,
+        CH: DmaChannel<Degraded = <LCD_CAM as DmaEligible>::Dma>,
+        (CH, LCD_CAM): DmaCompatible,
         P: RxPins,
     {
         let lcd_cam = cam.lcd_cam;

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -74,16 +74,7 @@ use fugit::HertzU32;
 
 use crate::{
     clock::Clocks,
-    dma::{
-        ChannelRx,
-        DmaChannel,
-        DmaCompatible,
-        DmaEligible,
-        DmaError,
-        DmaPeripheral,
-        DmaRxBuffer,
-        Rx,
-    },
+    dma::{ChannelRx, DmaChannelConvert, DmaEligible, DmaError, DmaPeripheral, DmaRxBuffer, Rx},
     gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput, Pull},
     lcd_cam::{cam::private::RxPins, private::calculate_clkm, BitOrder, ByteOrder},
     peripheral::{Peripheral, PeripheralRef},
@@ -143,8 +134,7 @@ impl<'d> Camera<'d> {
         frequency: HertzU32,
     ) -> Self
     where
-        CH: DmaChannel<Degraded = <LCD_CAM as DmaEligible>::Dma>,
-        (CH, LCD_CAM): DmaCompatible,
+        CH: DmaChannelConvert<<LCD_CAM as DmaEligible>::Dma>,
         P: RxPins,
     {
         let lcd_cam = cam.lcd_cam;

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -69,7 +69,7 @@ use fugit::HertzU32;
 
 use crate::{
     clock::Clocks,
-    dma::{ChannelTx, DmaChannel, DmaEligible, DmaError, DmaPeripheral, DmaTxBuffer, Tx},
+    dma::{ChannelTx, DmaChannelConvert, DmaEligible, DmaError, DmaPeripheral, DmaTxBuffer, Tx},
     gpio::{OutputSignal, PeripheralOutput},
     lcd_cam::{
         asynch::LCD_DONE_WAKER,
@@ -101,7 +101,7 @@ impl<'d, DM: Mode> I8080<'d, DM> {
         config: Config,
     ) -> Self
     where
-        CH: DmaChannel<Degraded = <LCD_CAM as DmaEligible>::Dma>,
+        CH: DmaChannelConvert<<LCD_CAM as DmaEligible>::Dma>,
         P: TxPins,
     {
         let lcd_cam = lcd.lcd_cam;

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -69,7 +69,7 @@ use fugit::HertzU32;
 
 use crate::{
     clock::Clocks,
-    dma::{AnyDmaChannel, ChannelTx, DmaChannel, DmaError, DmaPeripheral, DmaTxBuffer, Tx},
+    dma::{ChannelTx, DmaChannel, DmaEligible, DmaError, DmaPeripheral, DmaTxBuffer, Tx},
     gpio::{OutputSignal, PeripheralOutput},
     lcd_cam::{
         asynch::LCD_DONE_WAKER,
@@ -87,7 +87,7 @@ use crate::{
 /// Represents the I8080 LCD interface.
 pub struct I8080<'d, DM: Mode> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
-    tx_channel: ChannelTx<'d, AnyDmaChannel>,
+    tx_channel: ChannelTx<'d, <LCD_CAM as DmaEligible>::Dma>,
     _phantom: PhantomData<DM>,
 }
 
@@ -101,7 +101,7 @@ impl<'d, DM: Mode> I8080<'d, DM> {
         config: Config,
     ) -> Self
     where
-        CH: DmaChannel,
+        CH: DmaChannel<Degraded = <LCD_CAM as DmaEligible>::Dma>,
         P: TxPins,
     {
         let lcd_cam = lcd.lcd_cam;

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -69,7 +69,16 @@ use fugit::HertzU32;
 
 use crate::{
     clock::Clocks,
-    dma::{ChannelTx, DmaChannel, DmaError, DmaPeripheral, DmaTxBuffer, LcdCamPeripheral, Tx},
+    dma::{
+        ChannelTx,
+        DmaChannel,
+        DmaError,
+        DmaPeripheral,
+        DmaTxBuffer,
+        LcdCamPeripheral,
+        PeripheralDmaChannel,
+        Tx,
+    },
     gpio::{OutputSignal, PeripheralOutput},
     lcd_cam::{
         asynch::LCD_DONE_WAKER,
@@ -91,10 +100,7 @@ pub struct I8080<'d, CH: DmaChannel, DM: Mode> {
     _phantom: PhantomData<DM>,
 }
 
-impl<'d, CH: DmaChannel, DM: Mode> I8080<'d, CH, DM>
-where
-    CH::P: LcdCamPeripheral,
-{
+impl<'d, CH: DmaChannel, DM: Mode> I8080<'d, CH, DM> {
     /// Creates a new instance of the I8080 LCD interface.
     pub fn new<P: TxPins>(
         lcd: Lcd<'d, DM>,
@@ -102,7 +108,11 @@ where
         mut pins: P,
         frequency: HertzU32,
         config: Config,
-    ) -> Self {
+    ) -> Self
+    where
+        CH: PeripheralDmaChannel,
+        CH::P: LcdCamPeripheral,
+    {
         let lcd_cam = lcd.lcd_cam;
 
         let clocks = Clocks::get();

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -70,8 +70,8 @@ use fugit::HertzU32;
 use crate::{
     clock::Clocks,
     dma::{
+        AnyDmaChannel,
         ChannelTx,
-        DmaChannel,
         DmaError,
         DmaPeripheral,
         DmaTxBuffer,
@@ -94,15 +94,15 @@ use crate::{
 };
 
 /// Represents the I8080 LCD interface.
-pub struct I8080<'d, CH: DmaChannel, DM: Mode> {
+pub struct I8080<'d, DM: Mode> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
-    tx_channel: ChannelTx<'d, CH>,
+    tx_channel: ChannelTx<'d, AnyDmaChannel>,
     _phantom: PhantomData<DM>,
 }
 
-impl<'d, CH: DmaChannel, DM: Mode> I8080<'d, CH, DM> {
+impl<'d, DM: Mode> I8080<'d, DM> {
     /// Creates a new instance of the I8080 LCD interface.
-    pub fn new<P: TxPins>(
+    pub fn new<P, CH>(
         lcd: Lcd<'d, DM>,
         channel: ChannelTx<'d, CH>,
         mut pins: P,
@@ -112,6 +112,7 @@ impl<'d, CH: DmaChannel, DM: Mode> I8080<'d, CH, DM> {
     where
         CH: PeripheralDmaChannel,
         CH::P: LcdCamPeripheral,
+        P: TxPins,
     {
         let lcd_cam = lcd.lcd_cam;
 
@@ -215,13 +216,13 @@ impl<'d, CH: DmaChannel, DM: Mode> I8080<'d, CH, DM> {
 
         Self {
             lcd_cam,
-            tx_channel: channel,
+            tx_channel: channel.degrade(),
             _phantom: PhantomData,
         }
     }
 }
 
-impl<'d, CH: DmaChannel, DM: Mode> I8080<'d, CH, DM> {
+impl<'d, DM: Mode> I8080<'d, DM> {
     /// Configures the byte order for data transmission.
     pub fn set_byte_order(&mut self, byte_order: ByteOrder) -> &mut Self {
         let is_inverted = byte_order != ByteOrder::default();
@@ -280,7 +281,7 @@ impl<'d, CH: DmaChannel, DM: Mode> I8080<'d, CH, DM> {
         cmd: impl Into<Command<W>>,
         dummy: u8,
         mut data: BUF,
-    ) -> Result<I8080Transfer<'d, BUF, CH, DM>, (DmaError, Self, BUF)> {
+    ) -> Result<I8080Transfer<'d, BUF, DM>, (DmaError, Self, BUF)> {
         let cmd = cmd.into();
 
         // Reset LCD control unit and Async Tx FIFO
@@ -376,7 +377,7 @@ impl<'d, CH: DmaChannel, DM: Mode> I8080<'d, CH, DM> {
     }
 }
 
-impl<'d, CH: DmaChannel, DM: Mode> core::fmt::Debug for I8080<'d, CH, DM> {
+impl<'d, DM: Mode> core::fmt::Debug for I8080<'d, DM> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("I8080").finish()
     }
@@ -384,12 +385,12 @@ impl<'d, CH: DmaChannel, DM: Mode> core::fmt::Debug for I8080<'d, CH, DM> {
 
 /// Represents an ongoing (or potentially finished) transfer using the I8080 LCD
 /// interface
-pub struct I8080Transfer<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> {
-    i8080: ManuallyDrop<I8080<'d, CH, DM>>,
+pub struct I8080Transfer<'d, BUF: DmaTxBuffer, DM: Mode> {
+    i8080: ManuallyDrop<I8080<'d, DM>>,
     buf_view: ManuallyDrop<BUF::View>,
 }
 
-impl<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> I8080Transfer<'d, BUF, CH, DM> {
+impl<'d, BUF: DmaTxBuffer, DM: Mode> I8080Transfer<'d, BUF, DM> {
     /// Returns true when [Self::wait] will not block.
     pub fn is_done(&self) -> bool {
         self.i8080
@@ -401,7 +402,7 @@ impl<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> I8080Transfer<'d, BUF, CH, 
     }
 
     /// Stops this transfer on the spot and returns the peripheral and buffer.
-    pub fn cancel(mut self) -> (I8080<'d, CH, DM>, BUF) {
+    pub fn cancel(mut self) -> (I8080<'d, DM>, BUF) {
         self.stop_peripherals();
         let (_, i8080, buf) = self.wait();
         (i8080, buf)
@@ -411,7 +412,7 @@ impl<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> I8080Transfer<'d, BUF, CH, 
     ///
     /// Note: This also clears the transfer interrupt so it can be used in
     /// interrupt handlers to "handle" the interrupt.
-    pub fn wait(mut self) -> (Result<(), DmaError>, I8080<'d, CH, DM>, BUF) {
+    pub fn wait(mut self) -> (Result<(), DmaError>, I8080<'d, DM>, BUF) {
         while !self.is_done() {}
 
         // Clear "done" interrupt.
@@ -450,7 +451,7 @@ impl<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> I8080Transfer<'d, BUF, CH, 
     }
 }
 
-impl<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> Deref for I8080Transfer<'d, BUF, CH, DM> {
+impl<'d, BUF: DmaTxBuffer, DM: Mode> Deref for I8080Transfer<'d, BUF, DM> {
     type Target = BUF::View;
 
     fn deref(&self) -> &Self::Target {
@@ -458,13 +459,13 @@ impl<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> Deref for I8080Transfer<'d,
     }
 }
 
-impl<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> DerefMut for I8080Transfer<'d, BUF, CH, DM> {
+impl<'d, BUF: DmaTxBuffer, DM: Mode> DerefMut for I8080Transfer<'d, BUF, DM> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.buf_view
     }
 }
 
-impl<'d, BUF: DmaTxBuffer, CH: DmaChannel> I8080Transfer<'d, BUF, CH, crate::Async> {
+impl<'d, BUF: DmaTxBuffer> I8080Transfer<'d, BUF, crate::Async> {
     /// Waits for [Self::is_done] to return true.
     pub async fn wait_for_done(&mut self) {
         use core::{
@@ -503,7 +504,7 @@ impl<'d, BUF: DmaTxBuffer, CH: DmaChannel> I8080Transfer<'d, BUF, CH, crate::Asy
     }
 }
 
-impl<'d, BUF: DmaTxBuffer, CH: DmaChannel, DM: Mode> Drop for I8080Transfer<'d, BUF, CH, DM> {
+impl<'d, BUF: DmaTxBuffer, DM: Mode> Drop for I8080Transfer<'d, BUF, DM> {
     fn drop(&mut self) {
         self.stop_peripherals();
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -69,16 +69,7 @@ use fugit::HertzU32;
 
 use crate::{
     clock::Clocks,
-    dma::{
-        AnyDmaChannel,
-        ChannelTx,
-        DmaError,
-        DmaPeripheral,
-        DmaTxBuffer,
-        LcdCamPeripheral,
-        PeripheralDmaChannel,
-        Tx,
-    },
+    dma::{AnyDmaChannel, ChannelTx, DmaChannel, DmaError, DmaPeripheral, DmaTxBuffer, Tx},
     gpio::{OutputSignal, PeripheralOutput},
     lcd_cam::{
         asynch::LCD_DONE_WAKER,
@@ -110,8 +101,7 @@ impl<'d, DM: Mode> I8080<'d, DM> {
         config: Config,
     ) -> Self
     where
-        CH: PeripheralDmaChannel,
-        CH::P: LcdCamPeripheral,
+        CH: DmaChannel,
         P: TxPins,
     {
         let lcd_cam = lcd.lcd_cam;

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -136,6 +136,14 @@ pub mod asynch {
 }
 
 mod private {
+    use crate::{dma::PeripheralMarker, peripherals::LCD_CAM};
+
+    impl PeripheralMarker for LCD_CAM {
+        fn peripheral(&self) -> crate::system::Peripheral {
+            crate::system::Peripheral::LcdCam
+        }
+    }
+
     pub(crate) struct Instance;
 
     // NOTE: the LCD_CAM interrupt registers are shared between LCD and Camera and
@@ -143,21 +151,21 @@ mod private {
     // CriticalSection will be needed to protect these shared registers.
     impl Instance {
         pub(crate) fn listen_lcd_done() {
-            let lcd_cam = unsafe { crate::peripherals::LCD_CAM::steal() };
+            let lcd_cam = unsafe { LCD_CAM::steal() };
             lcd_cam
                 .lc_dma_int_ena()
                 .modify(|_, w| w.lcd_trans_done_int_ena().set_bit());
         }
 
         pub(crate) fn unlisten_lcd_done() {
-            let lcd_cam = unsafe { crate::peripherals::LCD_CAM::steal() };
+            let lcd_cam = unsafe { LCD_CAM::steal() };
             lcd_cam
                 .lc_dma_int_ena()
                 .modify(|_, w| w.lcd_trans_done_int_ena().clear_bit());
         }
 
         pub(crate) fn is_lcd_done_set() -> bool {
-            let lcd_cam = unsafe { crate::peripherals::LCD_CAM::steal() };
+            let lcd_cam = unsafe { LCD_CAM::steal() };
             lcd_cam
                 .lc_dma_int_raw()
                 .read()

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -38,13 +38,12 @@ use crate::{
         ChannelRx,
         ChannelTx,
         DescriptorChain,
+        DmaChannel,
         DmaDescriptor,
         DmaError,
         DmaPeripheral,
         DmaTransferRx,
         DmaTransferTx,
-        ParlIoPeripheral,
-        PeripheralDmaChannel,
         ReadBuffer,
         Rx,
         Tx,
@@ -1101,8 +1100,7 @@ where
         frequency: HertzU32,
     ) -> Result<Self, Error>
     where
-        CH: PeripheralDmaChannel,
-        CH::P: ParlIoPeripheral,
+        CH: DmaChannel,
     {
         internal_init(frequency)?;
 
@@ -1182,8 +1180,7 @@ where
         frequency: HertzU32,
     ) -> Result<Self, Error>
     where
-        CH: PeripheralDmaChannel,
-        CH::P: ParlIoPeripheral,
+        CH: DmaChannel,
     {
         internal_init(frequency)?;
 
@@ -1258,8 +1255,7 @@ where
         frequency: HertzU32,
     ) -> Result<Self, Error>
     where
-        CH: PeripheralDmaChannel,
-        CH::P: ParlIoPeripheral,
+        CH: DmaChannel,
     {
         internal_init(frequency)?;
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -44,6 +44,7 @@ use crate::{
         DmaTransferRx,
         DmaTransferTx,
         ParlIoPeripheral,
+        PeripheralDmaChannel,
         ReadBuffer,
         Rx,
         Tx,
@@ -1086,7 +1087,6 @@ fn internal_clear_interrupts(interrupts: EnumSet<ParlIoInterrupt>) {
 pub struct ParlIoFullDuplex<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     /// The transmitter (TX) channel responsible for handling DMA transfers in
@@ -1099,7 +1099,7 @@ where
 
 impl<'d, CH, DM> ParlIoFullDuplex<'d, CH, DM>
 where
-    CH: DmaChannel,
+    CH: PeripheralDmaChannel,
     CH::P: ParlIoPeripheral,
     DM: Mode,
 {
@@ -1131,7 +1131,6 @@ where
 impl<'d, CH> ParlIoFullDuplex<'d, CH, Blocking>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
 {
     /// Sets the interrupt handler, enables it with
     /// [crate::interrupt::Priority::min()]
@@ -1162,17 +1161,11 @@ where
     }
 }
 
-impl<'d, CH> crate::private::Sealed for ParlIoFullDuplex<'d, CH, Blocking>
-where
-    CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
-{
-}
+impl<'d, CH> crate::private::Sealed for ParlIoFullDuplex<'d, CH, Blocking> where CH: DmaChannel {}
 
 impl<'d, CH> InterruptConfigurable for ParlIoFullDuplex<'d, CH, Blocking>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         ParlIoFullDuplex::set_interrupt_handler(self, handler);
@@ -1183,7 +1176,6 @@ where
 pub struct ParlIoTxOnly<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     /// The transmitter (TX) channel responsible for handling DMA transfers in
@@ -1193,7 +1185,7 @@ where
 
 impl<'d, CH, DM> ParlIoTxOnly<'d, CH, DM>
 where
-    CH: DmaChannel,
+    CH: PeripheralDmaChannel,
     CH::P: ParlIoPeripheral,
     DM: Mode,
 {
@@ -1219,7 +1211,6 @@ where
 impl<'d, CH> ParlIoTxOnly<'d, CH, Blocking>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
 {
     /// Sets the interrupt handler, enables it with
     /// [crate::interrupt::Priority::min()]
@@ -1250,17 +1241,11 @@ where
     }
 }
 
-impl<'d, CH> crate::private::Sealed for ParlIoTxOnly<'d, CH, Blocking>
-where
-    CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
-{
-}
+impl<'d, CH> crate::private::Sealed for ParlIoTxOnly<'d, CH, Blocking> where CH: DmaChannel {}
 
 impl<'d, CH> InterruptConfigurable for ParlIoTxOnly<'d, CH, Blocking>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         ParlIoTxOnly::set_interrupt_handler(self, handler);
@@ -1271,7 +1256,6 @@ where
 pub struct ParlIoRxOnly<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     /// The receiver (RX) channel responsible for handling DMA transfers in the
@@ -1281,7 +1265,7 @@ where
 
 impl<'d, CH, DM> ParlIoRxOnly<'d, CH, DM>
 where
-    CH: DmaChannel,
+    CH: PeripheralDmaChannel,
     CH::P: ParlIoPeripheral,
     DM: Mode,
 {
@@ -1307,7 +1291,6 @@ where
 impl<'d, CH> ParlIoRxOnly<'d, CH, Blocking>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
 {
     /// Sets the interrupt handler, enables it with
     /// [crate::interrupt::Priority::min()]
@@ -1338,17 +1321,11 @@ where
     }
 }
 
-impl<'d, CH> crate::private::Sealed for ParlIoRxOnly<'d, CH, Blocking>
-where
-    CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
-{
-}
+impl<'d, CH> crate::private::Sealed for ParlIoRxOnly<'d, CH, Blocking> where CH: DmaChannel {}
 
 impl<'d, CH> InterruptConfigurable for ParlIoRxOnly<'d, CH, Blocking>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         ParlIoRxOnly::set_interrupt_handler(self, handler);
@@ -1391,7 +1368,6 @@ fn internal_init(frequency: HertzU32) -> Result<(), Error> {
 impl<'d, CH, DM> ParlIoTx<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     /// Perform a DMA write.
@@ -1452,7 +1428,6 @@ where
 impl<'d, CH, DM> DmaSupport for ParlIoTx<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
@@ -1469,7 +1444,6 @@ where
 impl<'d, CH, DM> DmaSupportTx for ParlIoTx<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     type TX = ChannelTx<'d, CH>;
@@ -1486,7 +1460,6 @@ where
 impl<'d, CH, DM> ParlIoRx<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     /// Perform a DMA read.
@@ -1547,7 +1520,6 @@ where
 impl<'d, CH, DM> DmaSupport for ParlIoRx<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
@@ -1571,7 +1543,6 @@ where
 impl<'d, CH, DM> DmaSupportRx for ParlIoRx<'d, CH, DM>
 where
     CH: DmaChannel,
-    CH::P: ParlIoPeripheral,
     DM: Mode,
 {
     type RX = ChannelRx<'d, CH>;
@@ -1638,7 +1609,7 @@ pub mod asynch {
 
     use super::{private::Instance, Error, ParlIoRx, ParlIoTx, MAX_DMA_SIZE};
     use crate::{
-        dma::{asynch::DmaRxFuture, DmaChannel, ParlIoPeripheral, ReadBuffer, WriteBuffer},
+        dma::{asynch::DmaRxFuture, DmaChannel, ReadBuffer, WriteBuffer},
         peripherals::Interrupt,
     };
 
@@ -1696,7 +1667,6 @@ pub mod asynch {
     impl<'d, CH> ParlIoTx<'d, CH, crate::Async>
     where
         CH: DmaChannel,
-        CH::P: ParlIoPeripheral,
     {
         /// Perform a DMA write.
         ///
@@ -1722,7 +1692,6 @@ pub mod asynch {
     impl<'d, CH> ParlIoRx<'d, CH, crate::Async>
     where
         CH: DmaChannel,
-        CH::P: ParlIoPeripheral,
     {
         /// Perform a DMA write.
         ///

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1099,8 +1099,7 @@ where
 
 impl<'d, CH, DM> ParlIoFullDuplex<'d, CH, DM>
 where
-    CH: PeripheralDmaChannel,
-    CH::P: ParlIoPeripheral,
+    CH: DmaChannel,
     DM: Mode,
 {
     /// Create a new instance of [ParlIoFullDuplex]
@@ -1110,7 +1109,11 @@ where
         tx_descriptors: &'static mut [DmaDescriptor],
         rx_descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, Error>
+    where
+        CH: PeripheralDmaChannel,
+        CH::P: ParlIoPeripheral,
+    {
         internal_init(frequency)?;
 
         Ok(Self {
@@ -1185,8 +1188,7 @@ where
 
 impl<'d, CH, DM> ParlIoTxOnly<'d, CH, DM>
 where
-    CH: PeripheralDmaChannel,
-    CH::P: ParlIoPeripheral,
+    CH: DmaChannel,
     DM: Mode,
 {
     /// Create a new [ParlIoTxOnly]
@@ -1195,7 +1197,11 @@ where
         dma_channel: Channel<'d, CH, DM>,
         descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, Error>
+    where
+        CH: PeripheralDmaChannel,
+        CH::P: ParlIoPeripheral,
+    {
         internal_init(frequency)?;
 
         Ok(Self {
@@ -1265,8 +1271,7 @@ where
 
 impl<'d, CH, DM> ParlIoRxOnly<'d, CH, DM>
 where
-    CH: PeripheralDmaChannel,
-    CH::P: ParlIoPeripheral,
+    CH: DmaChannel,
     DM: Mode,
 {
     /// Create a new [ParlIoRxOnly] instance
@@ -1275,7 +1280,11 @@ where
         dma_channel: Channel<'d, CH, DM>,
         descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, Error>
+    where
+        CH: PeripheralDmaChannel,
+        CH::P: ParlIoPeripheral,
+    {
         internal_init(frequency)?;
 
         Ok(Self {

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -33,7 +33,6 @@ use private::*;
 use crate::{
     dma::{
         dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
-        AnyDmaChannel,
         Channel,
         ChannelRx,
         ChannelTx,
@@ -904,7 +903,7 @@ pub struct ParlIoTx<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d, AnyDmaChannel>,
+    tx_channel: ChannelTx<'d>,
     tx_chain: DescriptorChain,
     phantom: PhantomData<DM>,
 }
@@ -983,7 +982,7 @@ pub struct ParlIoRx<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d, AnyDmaChannel>,
+    rx_channel: ChannelRx<'d>,
     rx_chain: DescriptorChain,
     phantom: PhantomData<DM>,
 }
@@ -1094,7 +1093,7 @@ where
     /// Create a new instance of [ParlIoFullDuplex]
     pub fn new<CH>(
         _parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
-        dma_channel: Channel<'d, CH, DM>,
+        dma_channel: Channel<'d, DM, CH>,
         tx_descriptors: &'static mut [DmaDescriptor],
         rx_descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
@@ -1175,7 +1174,7 @@ where
     // TODO: only take a TX DMA channel?
     pub fn new<CH>(
         _parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
-        dma_channel: Channel<'d, CH, DM>,
+        dma_channel: Channel<'d, DM, CH>,
         descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
     ) -> Result<Self, Error>
@@ -1250,7 +1249,7 @@ where
     // TODO: only take a RX DMA channel?
     pub fn new<CH>(
         _parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
-        dma_channel: Channel<'d, CH, DM>,
+        dma_channel: Channel<'d, DM, CH>,
         descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
     ) -> Result<Self, Error>
@@ -1418,7 +1417,7 @@ impl<'d, DM> DmaSupportTx for ParlIoTx<'d, DM>
 where
     DM: Mode,
 {
-    type TX = ChannelTx<'d, AnyDmaChannel>;
+    type TX = ChannelTx<'d>;
 
     fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
@@ -1460,7 +1459,7 @@ where
     }
 
     fn start_receive_bytes_dma(
-        rx_channel: &mut ChannelRx<'d, AnyDmaChannel>,
+        rx_channel: &mut ChannelRx<'d>,
         rx_chain: &mut DescriptorChain,
         ptr: *mut u8,
         len: usize,
@@ -1514,7 +1513,7 @@ impl<'d, DM> DmaSupportRx for ParlIoRx<'d, DM>
 where
     DM: Mode,
 {
-    type RX = ChannelRx<'d, AnyDmaChannel>;
+    type RX = ChannelRx<'d>;
 
     fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
@@ -1530,7 +1529,7 @@ pub struct TxCreator<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d, AnyDmaChannel>,
+    tx_channel: ChannelTx<'d>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1540,7 +1539,7 @@ pub struct RxCreator<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d, AnyDmaChannel>,
+    rx_channel: ChannelRx<'d>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1550,7 +1549,7 @@ pub struct TxCreatorFullDuplex<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d, AnyDmaChannel>,
+    tx_channel: ChannelTx<'d>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1560,7 +1559,7 @@ pub struct RxCreatorFullDuplex<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d, AnyDmaChannel>,
+    rx_channel: ChannelRx<'d>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -33,6 +33,7 @@ use private::*;
 use crate::{
     dma::{
         dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
+        AnyDmaChannel,
         Channel,
         ChannelRx,
         ChannelTx,
@@ -903,7 +904,7 @@ pub struct ParlIoTx<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d>,
+    tx_channel: ChannelTx<'d, AnyDmaChannel>,
     tx_chain: DescriptorChain,
     phantom: PhantomData<DM>,
 }
@@ -982,7 +983,7 @@ pub struct ParlIoRx<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d>,
+    rx_channel: ChannelRx<'d, AnyDmaChannel>,
     rx_chain: DescriptorChain,
     phantom: PhantomData<DM>,
 }
@@ -1093,7 +1094,7 @@ where
     /// Create a new instance of [ParlIoFullDuplex]
     pub fn new<CH>(
         _parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
-        dma_channel: Channel<'d, DM, CH>,
+        dma_channel: Channel<'d, CH, DM>,
         tx_descriptors: &'static mut [DmaDescriptor],
         rx_descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
@@ -1174,7 +1175,7 @@ where
     // TODO: only take a TX DMA channel?
     pub fn new<CH>(
         _parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
-        dma_channel: Channel<'d, DM, CH>,
+        dma_channel: Channel<'d, CH, DM>,
         descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
     ) -> Result<Self, Error>
@@ -1249,7 +1250,7 @@ where
     // TODO: only take a RX DMA channel?
     pub fn new<CH>(
         _parl_io: impl Peripheral<P = peripherals::PARL_IO> + 'd,
-        dma_channel: Channel<'d, DM, CH>,
+        dma_channel: Channel<'d, CH, DM>,
         descriptors: &'static mut [DmaDescriptor],
         frequency: HertzU32,
     ) -> Result<Self, Error>
@@ -1417,7 +1418,7 @@ impl<'d, DM> DmaSupportTx for ParlIoTx<'d, DM>
 where
     DM: Mode,
 {
-    type TX = ChannelTx<'d>;
+    type TX = ChannelTx<'d, AnyDmaChannel>;
 
     fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
@@ -1459,7 +1460,7 @@ where
     }
 
     fn start_receive_bytes_dma(
-        rx_channel: &mut ChannelRx<'d>,
+        rx_channel: &mut ChannelRx<'d, AnyDmaChannel>,
         rx_chain: &mut DescriptorChain,
         ptr: *mut u8,
         len: usize,
@@ -1513,7 +1514,7 @@ impl<'d, DM> DmaSupportRx for ParlIoRx<'d, DM>
 where
     DM: Mode,
 {
-    type RX = ChannelRx<'d>;
+    type RX = ChannelRx<'d, AnyDmaChannel>;
 
     fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
@@ -1529,7 +1530,7 @@ pub struct TxCreator<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d>,
+    tx_channel: ChannelTx<'d, AnyDmaChannel>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1539,7 +1540,7 @@ pub struct RxCreator<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d>,
+    rx_channel: ChannelRx<'d, AnyDmaChannel>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1549,7 +1550,7 @@ pub struct TxCreatorFullDuplex<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d>,
+    tx_channel: ChannelTx<'d, AnyDmaChannel>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1559,7 +1560,7 @@ pub struct RxCreatorFullDuplex<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d>,
+    rx_channel: ChannelRx<'d, AnyDmaChannel>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -37,7 +37,7 @@ use crate::{
         ChannelRx,
         ChannelTx,
         DescriptorChain,
-        DmaChannel,
+        DmaChannelConvert,
         DmaDescriptor,
         DmaEligible,
         DmaError,
@@ -1098,7 +1098,7 @@ where
         frequency: HertzU32,
     ) -> Result<Self, Error>
     where
-        CH: DmaChannel<Degraded = <PARL_IO as DmaEligible>::Dma>,
+        CH: DmaChannelConvert<<PARL_IO as DmaEligible>::Dma>,
     {
         internal_init(frequency)?;
 
@@ -1178,7 +1178,7 @@ where
         frequency: HertzU32,
     ) -> Result<Self, Error>
     where
-        CH: DmaChannel<Degraded = <PARL_IO as DmaEligible>::Dma>,
+        CH: DmaChannelConvert<<PARL_IO as DmaEligible>::Dma>,
     {
         internal_init(frequency)?;
 
@@ -1253,7 +1253,7 @@ where
         frequency: HertzU32,
     ) -> Result<Self, Error>
     where
-        CH: DmaChannel<Degraded = <PARL_IO as DmaEligible>::Dma>,
+        CH: DmaChannelConvert<<PARL_IO as DmaEligible>::Dma>,
     {
         internal_init(frequency)?;
 

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -171,6 +171,11 @@ mod peripheral_macros {
     macro_rules! impl_dma_eligible {
         ($name:ident => $dma:ident) => {
             impl $crate::dma::DmaEligible for $name {
+                #[cfg(pdma)]
+                type Dma = $crate::dma::AnyPdmaChannel;
+                #[cfg(gdma)]
+                type Dma = $crate::dma::AnyGdmaChannel;
+
                 fn dma_peripheral(&self) -> $crate::dma::DmaPeripheral {
                     $crate::dma::DmaPeripheral::$dma
                 }

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -171,7 +171,9 @@ mod peripheral_macros {
     macro_rules! impl_dma_eligible {
         ($name:ident => $dma:ident) => {
             impl $crate::dma::DmaEligible for $name {
-                const DMA_PERIPHERAL: $crate::dma::DmaPeripheral = $crate::dma::DmaPeripheral::$dma;
+                fn dma_peripheral(&self) -> $crate::dma::DmaPeripheral {
+                    $crate::dma::DmaPeripheral::$dma
+                }
             }
         };
 

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -168,30 +168,6 @@ impl<T> crate::private::Sealed for &mut T where T: crate::private::Sealed {}
 mod peripheral_macros {
     #[doc(hidden)]
     #[macro_export]
-    macro_rules! impl_dma_eligible {
-        ($name:ident => $dma:ident) => {
-            impl $crate::dma::DmaEligible for $name {
-                #[cfg(pdma)]
-                type Dma = $crate::dma::AnyPdmaChannel;
-                #[cfg(gdma)]
-                type Dma = $crate::dma::AnyGdmaChannel;
-
-                fn dma_peripheral(&self) -> $crate::dma::DmaPeripheral {
-                    $crate::dma::DmaPeripheral::$dma
-                }
-            }
-        };
-
-        ($($(#[$cfg:meta])? $name:ident => $dma:ident),*) => {
-            $(
-                $(#[$cfg])?
-                $crate::impl_dma_eligible!($name => $dma);
-            )*
-        };
-    }
-
-    #[doc(hidden)]
-    #[macro_export]
     macro_rules! peripherals {
         ($($(#[$cfg:meta])? $name:ident <= $from_pac:tt $(($($interrupt:ident),*))? ),*$(,)?) => {
 
@@ -201,59 +177,6 @@ mod peripheral_macros {
                 $(
                     $crate::create_peripheral!($(#[$cfg])? $name <= $from_pac);
                 )*
-
-                $crate::impl_dma_eligible! {
-                    #[cfg(spi2)]
-                    SPI2 => Spi2,
-
-                    #[cfg(spi3)]
-                    SPI3 => Spi3,
-
-                    #[cfg(all(uhci0, gdma))] // TODO: S2?
-                    UHCI0 => Uhci0,
-
-                    #[cfg(i2s0)]
-                    I2S0 => I2s0,
-
-                    #[cfg(i2s1)]
-                    I2S1 => I2s1,
-
-                    #[cfg(esp32s3)]
-                    LCD_CAM => LcdCam,
-
-                    #[cfg(all(gdma, aes))]
-                    AES => Aes,
-
-                    #[cfg(all(gdma, sha))]
-                    SHA => Sha,
-
-                    #[cfg(any(esp32c3, esp32c6, esp32h2, esp32s3))]
-                    ADC1 => Adc,
-
-                    #[cfg(any(esp32c3, esp32s3))]
-                    ADC2 => Adc,
-
-                    #[cfg(esp32s3)]
-                    RMT => Rmt,
-
-                    #[cfg(parl_io)]
-                    PARL_IO => ParlIo,
-
-                    #[cfg(any(esp32c2, esp32c6, esp32h2))]
-                    MEM2MEM1 => Mem2Mem1
-                }
-
-                #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible! {
-                    MEM2MEM4 => Mem2Mem4,
-                    MEM2MEM5 => Mem2Mem5,
-                    MEM2MEM10 => Mem2Mem10,
-                    MEM2MEM11 => Mem2Mem11,
-                    MEM2MEM12 => Mem2Mem12,
-                    MEM2MEM13 => Mem2Mem13,
-                    MEM2MEM14 => Mem2Mem14,
-                    MEM2MEM15 => Mem2Mem15
-                }
             }
 
             /// The `Peripherals` struct provides access to all of the hardware peripherals on the chip.

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -497,7 +497,7 @@ where
     /// operations.
     pub fn with_dma<CH, DmaMode>(
         self,
-        channel: crate::dma::Channel<'d, DmaMode, CH>,
+        channel: crate::dma::Channel<'d, CH, DmaMode>,
     ) -> SpiDma<'d, T, M, DmaMode>
     where
         CH: crate::dma::DmaChannel,
@@ -939,6 +939,7 @@ mod dma {
     use crate::{
         dma::{
             asynch::{DmaRxFuture, DmaTxFuture},
+            AnyDmaChannel,
             Channel,
             DmaChannel,
             DmaRxBuf,
@@ -965,7 +966,7 @@ mod dma {
         M: Mode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
-        pub(crate) channel: Channel<'d, M>,
+        pub(crate) channel: Channel<'d, AnyDmaChannel, M>,
         tx_transfer_in_progress: bool,
         rx_transfer_in_progress: bool,
         #[cfg(all(esp32, spi_address_workaround))]
@@ -1001,7 +1002,7 @@ mod dma {
         D: DuplexMode,
         M: Mode,
     {
-        pub(super) fn new<CH>(spi: PeripheralRef<'d, T>, channel: Channel<'d, M, CH>) -> Self
+        pub(super) fn new<CH>(spi: PeripheralRef<'d, T>, channel: Channel<'d, CH, M>) -> Self
         where
             CH: DmaChannel,
         {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -924,6 +924,7 @@ mod dma {
             DmaRxBuffer,
             DmaTxBuf,
             DmaTxBuffer,
+            PeripheralDmaChannel,
             Rx,
             Spi2Peripheral,
             SpiPeripheral,
@@ -947,7 +948,7 @@ mod dma {
             channel: Channel<'d, C, DmaMode>,
         ) -> SpiDma<'d, crate::peripherals::SPI2, C, M, DmaMode>
         where
-            C: DmaChannel,
+            C: PeripheralDmaChannel,
             C::P: SpiPeripheral + Spi2Peripheral,
             DmaMode: Mode,
         {
@@ -970,7 +971,7 @@ mod dma {
             channel: Channel<'d, C, DmaMode>,
         ) -> SpiDma<'d, crate::peripherals::SPI3, C, M, DmaMode>
         where
-            C: DmaChannel,
+            C: PeripheralDmaChannel,
             C::P: SpiPeripheral + Spi3Peripheral,
             DmaMode: Mode,
         {
@@ -988,7 +989,6 @@ mod dma {
     pub struct SpiDma<'d, T, C, D, M>
     where
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1005,7 +1005,6 @@ mod dma {
     unsafe impl<'d, T, C, D, M> Send for SpiDma<'d, T, C, D, M>
     where
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1014,7 +1013,6 @@ mod dma {
     impl<'d, T, C, D, M> core::fmt::Debug for SpiDma<'d, T, C, D, M>
     where
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1031,11 +1029,14 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
-        fn new(spi: PeripheralRef<'d, T>, channel: Channel<'d, C, M>) -> Self {
+        fn new(spi: PeripheralRef<'d, T>, channel: Channel<'d, C, M>) -> Self
+        where
+            C: PeripheralDmaChannel,
+            C::P: SpiPeripheral,
+        {
             #[cfg(all(esp32, spi_address_workaround))]
             let address_buffer = {
                 use crate::dma::DmaDescriptor;
@@ -1267,7 +1268,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1277,7 +1277,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1291,7 +1290,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1322,7 +1320,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1334,7 +1331,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1381,7 +1377,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1402,7 +1397,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
     {
         /// Waits for the DMA transfer to complete asynchronously.
@@ -1417,7 +1411,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         M: Mode,
     {
         /// # Safety:
@@ -1530,7 +1523,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         M: Mode,
     {
         /// # Safety:
@@ -1655,7 +1647,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1668,7 +1659,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1727,7 +1717,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1741,7 +1730,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         D: DuplexMode,
         M: Mode,
     {
@@ -1751,7 +1739,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         M: Mode,
     {
         /// Reads data from the SPI bus using DMA.
@@ -1847,7 +1834,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         M: Mode,
     {
         type Error = Error;
@@ -1921,7 +1907,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
     {
         type Error = Error;
 
@@ -1936,7 +1921,6 @@ mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
     {
         type Error = Error;
 
@@ -1997,7 +1981,6 @@ mod dma {
         where
             T: InstanceDma,
             C: DmaChannel,
-            C::P: SpiPeripheral,
         {
             /// Fill the given buffer with data from the bus.
             pub async fn read_async(&mut self, words: &mut [u8]) -> Result<(), Error> {
@@ -2115,7 +2098,6 @@ mod dma {
         where
             T: InstanceDma,
             C: DmaChannel,
-            C::P: SpiPeripheral,
         {
             async fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
                 self.read_async(words).await
@@ -2149,7 +2131,6 @@ mod dma {
         where
             T: InstanceDma,
             C: DmaChannel,
-            C::P: SpiPeripheral,
             M: Mode,
         {
             type Error = Error;
@@ -2159,7 +2140,6 @@ mod dma {
         where
             T: InstanceDma,
             C: DmaChannel,
-            C::P: SpiPeripheral,
             M: Mode,
         {
             fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -81,16 +81,7 @@ use super::{
 };
 use crate::{
     clock::Clocks,
-    dma::{
-        DmaChannel,
-        DmaCompatible,
-        DmaEligible,
-        DmaRxBuffer,
-        DmaTxBuffer,
-        PeripheralMarker,
-        Rx,
-        Tx,
-    },
+    dma::{DmaChannelConvert, DmaEligible, DmaRxBuffer, DmaTxBuffer, PeripheralMarker, Rx, Tx},
     gpio::{InputSignal, NoPin, OutputSignal, PeripheralInput, PeripheralOutput},
     interrupt::InterruptHandler,
     peripheral::{Peripheral, PeripheralRef},
@@ -510,8 +501,7 @@ where
         channel: crate::dma::Channel<'d, CH, DmaMode>,
     ) -> SpiDma<'d, T, M, DmaMode>
     where
-        CH: DmaChannel<Degraded = T::Dma>,
-        (CH, T): DmaCompatible,
+        CH: DmaChannelConvert<T::Dma>,
         DmaMode: Mode,
     {
         SpiDma::new(self.spi, channel)
@@ -950,7 +940,6 @@ mod dma {
         dma::{
             asynch::{DmaRxFuture, DmaTxFuture},
             Channel,
-            DmaChannel,
             DmaRxBuf,
             DmaRxBuffer,
             DmaTxBuf,
@@ -1016,7 +1005,7 @@ mod dma {
     {
         pub(super) fn new<CH>(spi: PeripheralRef<'d, T>, channel: Channel<'d, CH, M>) -> Self
         where
-            CH: DmaChannel<Degraded = T::Dma>,
+            CH: DmaChannelConvert<T::Dma>,
         {
             channel.runtime_ensure_compatible(&spi);
             #[cfg(all(esp32, spi_address_workaround))]

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -943,13 +943,13 @@ mod dma {
         /// This method prepares the SPI instance for DMA transfers. It
         /// initializes the DMA channel for transmission and returns an
         /// instance of `SpiDma` that supports DMA operations.
-        pub fn with_dma<C, DmaMode>(
+        pub fn with_dma<CH, DmaMode>(
             self,
-            channel: Channel<'d, C, DmaMode>,
+            channel: Channel<'d, CH, DmaMode>,
         ) -> SpiDma<'d, crate::peripherals::SPI2, M, DmaMode>
         where
-            C: PeripheralDmaChannel,
-            C::P: SpiPeripheral + Spi2Peripheral,
+            CH: PeripheralDmaChannel,
+            CH::P: Spi2Peripheral,
             DmaMode: Mode,
         {
             SpiDma::new(self.spi, channel)
@@ -966,13 +966,13 @@ mod dma {
         /// This method prepares the SPI instance for DMA transfers using SPI3
         /// and returns an instance of `SpiDma` that supports DMA
         /// operations.
-        pub fn with_dma<C, DmaMode>(
+        pub fn with_dma<CH, DmaMode>(
             self,
-            channel: Channel<'d, C, DmaMode>,
+            channel: Channel<'d, CH, DmaMode>,
         ) -> SpiDma<'d, crate::peripherals::SPI3, M, DmaMode>
         where
-            C: PeripheralDmaChannel,
-            C::P: SpiPeripheral + Spi3Peripheral,
+            CH: PeripheralDmaChannel,
+            CH::P: Spi3Peripheral,
             DmaMode: Mode,
         {
             SpiDma::new(self.spi, channel)

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -497,7 +497,7 @@ where
     /// operations.
     pub fn with_dma<CH, DmaMode>(
         self,
-        channel: crate::dma::Channel<'d, CH, DmaMode>,
+        channel: crate::dma::Channel<'d, DmaMode, CH>,
     ) -> SpiDma<'d, T, M, DmaMode>
     where
         CH: crate::dma::DmaChannel,
@@ -939,7 +939,6 @@ mod dma {
     use crate::{
         dma::{
             asynch::{DmaRxFuture, DmaTxFuture},
-            AnyDmaChannel,
             Channel,
             DmaChannel,
             DmaRxBuf,
@@ -966,7 +965,7 @@ mod dma {
         M: Mode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
-        pub(crate) channel: Channel<'d, AnyDmaChannel, M>,
+        pub(crate) channel: Channel<'d, M>,
         tx_transfer_in_progress: bool,
         rx_transfer_in_progress: bool,
         #[cfg(all(esp32, spi_address_workaround))]
@@ -1002,7 +1001,7 @@ mod dma {
         D: DuplexMode,
         M: Mode,
     {
-        pub(super) fn new<CH>(spi: PeripheralRef<'d, T>, channel: Channel<'d, CH, M>) -> Self
+        pub(super) fn new<CH>(spi: PeripheralRef<'d, T>, channel: Channel<'d, M, CH>) -> Self
         where
             CH: DmaChannel,
         {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -490,9 +490,9 @@ where
     T: InstanceDma,
     M: DuplexMode,
 {
-    /// Configures the SPI3 instance to use DMA with the specified channel.
+    /// Configures the SPI instance to use DMA with the specified channel.
     ///
-    /// This method prepares the SPI instance for DMA transfers using SPI3
+    /// This method prepares the SPI instance for DMA transfers using SPI
     /// and returns an instance of `SpiDma` that supports DMA
     /// operations.
     pub fn with_dma<CH, DmaMode>(

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -9,7 +9,7 @@
 //! more information on these modes, please refer to the documentation in their
 //! respective modules.
 
-use crate::dma::DmaError;
+use crate::dma::{DmaError, PeripheralMarker};
 
 pub mod master;
 pub mod slave;
@@ -100,3 +100,19 @@ impl crate::private::Sealed for FullDuplexMode {}
 pub struct HalfDuplexMode {}
 impl DuplexMode for HalfDuplexMode {}
 impl crate::private::Sealed for HalfDuplexMode {}
+
+#[cfg(spi2)]
+impl PeripheralMarker for crate::peripherals::SPI2 {
+    #[inline(always)]
+    fn peripheral(&self) -> crate::system::Peripheral {
+        crate::system::Peripheral::Spi2
+    }
+}
+
+#[cfg(spi3)]
+impl PeripheralMarker for crate::peripherals::SPI3 {
+    #[inline(always)]
+    fn peripheral(&self) -> crate::system::Peripheral {
+        crate::system::Peripheral::Spi3
+    }
+}

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -164,6 +164,7 @@ pub mod dma {
             DmaTransferRx,
             DmaTransferRxTx,
             DmaTransferTx,
+            PeripheralDmaChannel,
             ReadBuffer,
             Rx,
             Spi2Peripheral,
@@ -185,7 +186,7 @@ pub mod dma {
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> SpiDma<'d, crate::peripherals::SPI2, C, DmaMode>
         where
-            C: DmaChannel,
+            C: PeripheralDmaChannel,
             C::P: SpiPeripheral + Spi2Peripheral,
             DmaMode: Mode,
         {
@@ -211,7 +212,7 @@ pub mod dma {
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> SpiDma<'d, crate::peripherals::SPI3, C, DmaMode>
         where
-            C: DmaChannel,
+            C: PeripheralDmaChannel,
             C::P: SpiPeripheral + Spi3Peripheral,
             DmaMode: Mode,
         {
@@ -229,7 +230,6 @@ pub mod dma {
     pub struct SpiDma<'d, T, C, DmaMode>
     where
         C: DmaChannel,
-        C::P: SpiPeripheral,
         DmaMode: Mode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
@@ -241,7 +241,6 @@ pub mod dma {
     impl<'d, T, C, DmaMode> core::fmt::Debug for SpiDma<'d, T, C, DmaMode>
     where
         C: DmaChannel,
-        C::P: SpiPeripheral,
         DmaMode: Mode,
     {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -253,7 +252,6 @@ pub mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         DmaMode: Mode,
     {
         fn peripheral_wait_dma(&mut self, is_rx: bool, is_tx: bool) {
@@ -274,7 +272,6 @@ pub mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         DmaMode: Mode,
     {
         type TX = ChannelTx<'d, C>;
@@ -292,7 +289,6 @@ pub mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         DmaMode: Mode,
     {
         type RX = ChannelRx<'d, C>;
@@ -310,7 +306,6 @@ pub mod dma {
     where
         T: InstanceDma,
         C: DmaChannel,
-        C::P: SpiPeripheral,
         DmaMode: Mode,
     {
         /// Register a buffer for a DMA write.

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -73,7 +73,7 @@ use core::marker::PhantomData;
 
 use super::{Error, FullDuplexMode, SpiMode};
 use crate::{
-    dma::{DescriptorChain, DmaEligible, PeripheralMarker, Rx, Tx},
+    dma::{DescriptorChain, DmaChannelConvert, DmaEligible, PeripheralMarker, Rx, Tx},
     gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::spi2::RegisterBlock,
@@ -157,7 +157,6 @@ pub mod dma {
             ChannelRx,
             ChannelTx,
             DescriptorChain,
-            DmaChannel,
             DmaDescriptor,
             DmaTransferRx,
             DmaTransferRxTx,
@@ -184,8 +183,7 @@ pub mod dma {
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> SpiDma<'d, T, DmaMode>
         where
-            CH: DmaChannel<Degraded = T::Dma>,
-            (CH, T): crate::dma::DmaCompatible,
+            CH: DmaChannelConvert<T::Dma>,
             DmaMode: Mode,
         {
             self.spi.set_data_mode(self.data_mode, true);
@@ -278,7 +276,7 @@ pub mod dma {
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> Self
         where
-            CH: DmaChannel<Degraded = T::Dma>,
+            CH: DmaChannelConvert<T::Dma>,
         {
             channel.runtime_ensure_compatible(&spi);
             Self {

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -169,7 +169,6 @@ pub mod dma {
             ReadBuffer,
             Rx,
             Spi2Peripheral,
-            SpiPeripheral,
             Tx,
             WriteBuffer,
         },
@@ -180,15 +179,15 @@ pub mod dma {
         /// Configures the SPI3 peripheral with the provided DMA channel and
         /// descriptors.
         #[cfg_attr(esp32, doc = "\n\n**Note**: ESP32 only supports Mode 1 and 3.")]
-        pub fn with_dma<C, DmaMode>(
+        pub fn with_dma<CH, DmaMode>(
             mut self,
-            channel: Channel<'d, C, DmaMode>,
+            channel: Channel<'d, CH, DmaMode>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> SpiDma<'d, crate::peripherals::SPI2, DmaMode>
         where
-            C: PeripheralDmaChannel,
-            C::P: SpiPeripheral + Spi2Peripheral,
+            CH: PeripheralDmaChannel,
+            CH::P: Spi2Peripheral,
             DmaMode: Mode,
         {
             self.spi.set_data_mode(self.data_mode, true);
@@ -201,15 +200,15 @@ pub mod dma {
         /// Configures the SPI3 peripheral with the provided DMA channel and
         /// descriptors.
         #[cfg_attr(esp32, doc = "\n\n**Note**: ESP32 only supports Mode 1 and 3.")]
-        pub fn with_dma<C, DmaMode>(
+        pub fn with_dma<CH, DmaMode>(
             mut self,
-            channel: Channel<'d, C, DmaMode>,
+            channel: Channel<'d, CH, DmaMode>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> SpiDma<'d, crate::peripherals::SPI3, DmaMode>
         where
-            C: PeripheralDmaChannel,
-            C::P: SpiPeripheral + Spi3Peripheral,
+            CH: PeripheralDmaChannel,
+            CH::P: Spi3Peripheral,
             DmaMode: Mode,
         {
             self.spi.set_data_mode(self.data_mode, true);

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -548,8 +548,6 @@ impl InstanceDma for crate::peripherals::SPI3 {}
 pub trait Instance: private::Sealed + PeripheralMarker {
     fn register_block(&self) -> &RegisterBlock;
 
-    fn peripheral(&self) -> crate::system::Peripheral;
-
     fn sclk_signal(&self) -> InputSignal;
 
     fn mosi_signal(&self) -> InputSignal;
@@ -736,11 +734,6 @@ impl Instance for crate::peripherals::SPI2 {
     }
 
     #[inline(always)]
-    fn peripheral(&self) -> crate::system::Peripheral {
-        crate::system::Peripheral::Spi2
-    }
-
-    #[inline(always)]
     fn sclk_signal(&self) -> InputSignal {
         cfg_if::cfg_if! {
             if #[cfg(esp32)] {
@@ -795,11 +788,6 @@ impl Instance for crate::peripherals::SPI3 {
     #[inline(always)]
     fn spi_num(&self) -> u8 {
         3
-    }
-
-    #[inline(always)]
-    fn peripheral(&self) -> crate::system::Peripheral {
-        crate::system::Peripheral::Spi3
     }
 
     #[inline(always)]

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -153,7 +153,6 @@ pub mod dma {
     use crate::{
         dma::{
             dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
-            AnyDmaChannel,
             Channel,
             ChannelRx,
             ChannelTx,
@@ -180,7 +179,7 @@ pub mod dma {
         #[cfg_attr(esp32, doc = "\n\n**Note**: ESP32 only supports Mode 1 and 3.")]
         pub fn with_dma<CH, DmaMode>(
             mut self,
-            channel: Channel<'d, CH, DmaMode>,
+            channel: Channel<'d, DmaMode, CH>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> SpiDma<'d, T, DmaMode>
@@ -200,7 +199,7 @@ pub mod dma {
         DmaMode: Mode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
-        pub(crate) channel: Channel<'d, AnyDmaChannel, DmaMode>,
+        pub(crate) channel: Channel<'d, DmaMode>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
     }
@@ -238,7 +237,7 @@ pub mod dma {
         T: InstanceDma,
         DmaMode: Mode,
     {
-        type TX = ChannelTx<'d, AnyDmaChannel>;
+        type TX = ChannelTx<'d>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -254,7 +253,7 @@ pub mod dma {
         T: InstanceDma,
         DmaMode: Mode,
     {
-        type RX = ChannelRx<'d, AnyDmaChannel>;
+        type RX = ChannelRx<'d>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx
@@ -272,7 +271,7 @@ pub mod dma {
     {
         fn new<CH>(
             spi: PeripheralRef<'d, T>,
-            channel: Channel<'d, CH, DmaMode>,
+            channel: Channel<'d, DmaMode, CH>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> Self

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -153,6 +153,7 @@ pub mod dma {
     use crate::{
         dma::{
             dma_private::{DmaSupport, DmaSupportRx, DmaSupportTx},
+            AnyDmaChannel,
             Channel,
             ChannelRx,
             ChannelTx,
@@ -179,7 +180,7 @@ pub mod dma {
         #[cfg_attr(esp32, doc = "\n\n**Note**: ESP32 only supports Mode 1 and 3.")]
         pub fn with_dma<CH, DmaMode>(
             mut self,
-            channel: Channel<'d, DmaMode, CH>,
+            channel: Channel<'d, CH, DmaMode>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> SpiDma<'d, T, DmaMode>
@@ -199,7 +200,7 @@ pub mod dma {
         DmaMode: Mode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
-        pub(crate) channel: Channel<'d, DmaMode>,
+        pub(crate) channel: Channel<'d, AnyDmaChannel, DmaMode>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
     }
@@ -237,7 +238,7 @@ pub mod dma {
         T: InstanceDma,
         DmaMode: Mode,
     {
-        type TX = ChannelTx<'d>;
+        type TX = ChannelTx<'d, AnyDmaChannel>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -253,7 +254,7 @@ pub mod dma {
         T: InstanceDma,
         DmaMode: Mode,
     {
-        type RX = ChannelRx<'d>;
+        type RX = ChannelRx<'d, AnyDmaChannel>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx
@@ -271,7 +272,7 @@ pub mod dma {
     {
         fn new<CH>(
             spi: PeripheralRef<'d, T>,
-            channel: Channel<'d, DmaMode, CH>,
+            channel: Channel<'d, CH, DmaMode>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> Self

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -15,6 +15,8 @@ use crate::peripherals::SYSTEM;
 // FIXME: This enum needs to be public because it's exposed via a bunch of traits, but it's not
 // useful to users.
 #[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Peripheral {
     /// SPI2 peripheral.
     #[cfg(spi2)]

--- a/examples/src/bin/lcd_i8080.rs
+++ b/examples/src/bin/lcd_i8080.rs
@@ -25,7 +25,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaChannel0, DmaPriority, DmaTxBuf},
+    dma::{Dma, DmaPriority, DmaTxBuf},
     dma_tx_buffer,
     gpio::{Input, Io, Level, Output, Pull},
     lcd_cam::{
@@ -88,15 +88,12 @@ fn main() -> ! {
     // 8 vs 16 bit, non-native primitives like Rgb565, Rgb888, etc. This Bus is just provided as
     // an example of how to implement your own.
     struct Bus<'d> {
-        resources: Option<(I8080<'d, DmaChannel0, Blocking>, DmaTxBuf)>,
+        resources: Option<(I8080<'d, Blocking>, DmaTxBuf)>,
     }
     impl<'d> Bus<'d> {
         fn use_resources<T>(
             &mut self,
-            func: impl FnOnce(
-                I8080<'d, DmaChannel0, Blocking>,
-                DmaTxBuf,
-            ) -> (T, I8080<'d, DmaChannel0, Blocking>, DmaTxBuf),
+            func: impl FnOnce(I8080<'d, Blocking>, DmaTxBuf) -> (T, I8080<'d, Blocking>, DmaTxBuf),
         ) -> T {
             let (i8080, buf) = self.resources.take().unwrap();
             let (result, i8080, buf) = func(i8080, buf);

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -6,11 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    aes::{
-        dma::{CipherMode, WithDmaAes},
-        Aes,
-        Mode,
-    },
+    aes::{dma::CipherMode, Aes, Mode},
     dma::{Dma, DmaPriority},
     dma_buffers,
     peripherals::Peripherals,

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{AnyDmaChannel, Channel, Dma, DmaError, DmaPriority, Mem2Mem},
+    dma::{AnyGdmaChannel, Channel, Dma, DmaError, DmaPriority, Mem2Mem},
     dma_buffers,
     dma_buffers_chunk_size,
     dma_descriptors,
@@ -25,7 +25,7 @@ cfg_if::cfg_if! {
 }
 
 struct Context {
-    channel: Channel<'static, AnyDmaChannel, Blocking>,
+    channel: Channel<'static, AnyGdmaChannel, Blocking>,
     dma_peripheral: DmaPeripheralType,
 }
 

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{Channel, Dma, DmaError, DmaPriority, Mem2Mem},
+    dma::{AnyDmaChannel, Channel, Dma, DmaError, DmaPriority, Mem2Mem},
     dma_buffers,
     dma_buffers_chunk_size,
     dma_descriptors,
@@ -24,10 +24,8 @@ cfg_if::cfg_if! {
     }
 }
 
-use esp_hal::dma::DmaChannel0;
-
 struct Context {
-    channel: Channel<'static, DmaChannel0, Blocking>,
+    channel: Channel<'static, AnyDmaChannel, Blocking>,
     dma_peripheral: DmaPeripheralType,
 }
 
@@ -52,7 +50,9 @@ mod tests {
         }
 
         Context {
-            channel: dma_channel.configure(false, DmaPriority::Priority0),
+            channel: dma_channel
+                .configure(false, DmaPriority::Priority0)
+                .degrade(),
             dma_peripheral,
         }
     }

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{Channel, Dma, DmaError, DmaPriority, Mem2Mem},
+    dma::{AnyDmaChannel, Channel, Dma, DmaError, DmaPriority, Mem2Mem},
     dma_buffers,
     dma_buffers_chunk_size,
     dma_descriptors,
@@ -25,7 +25,7 @@ cfg_if::cfg_if! {
 }
 
 struct Context {
-    channel: Channel<'static, Blocking>,
+    channel: Channel<'static, AnyDmaChannel, Blocking>,
     dma_peripheral: DmaPeripheralType,
 }
 

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{AnyDmaChannel, Channel, Dma, DmaError, DmaPriority, Mem2Mem},
+    dma::{Channel, Dma, DmaError, DmaPriority, Mem2Mem},
     dma_buffers,
     dma_buffers_chunk_size,
     dma_descriptors,
@@ -25,7 +25,7 @@ cfg_if::cfg_if! {
 }
 
 struct Context {
-    channel: Channel<'static, AnyDmaChannel, Blocking>,
+    channel: Channel<'static, Blocking>,
     dma_peripheral: DmaPeripheralType,
 }
 

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -25,17 +25,6 @@ use esp_hal::{
 use esp_hal_embassy::InterruptExecutor;
 use hil_test as _;
 
-cfg_if::cfg_if! {
-    if #[cfg(any(
-        feature = "esp32",
-        feature = "esp32s2",
-    ))] {
-        use esp_hal::dma::Spi3DmaChannel as DmaChannel1;
-    } else {
-        use esp_hal::dma::DmaChannel1;
-    }
-}
-
 macro_rules! mk_static {
     ($t:ty,$val:expr) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
@@ -46,7 +35,7 @@ macro_rules! mk_static {
 }
 
 #[embassy_executor::task]
-async fn interrupt_driven_task(spi: SpiDma<'static, SPI3, DmaChannel1, FullDuplexMode, Async>) {
+async fn interrupt_driven_task(spi: SpiDma<'static, SPI3, FullDuplexMode, Async>) {
     let mut ticker = Ticker::every(Duration::from_millis(1));
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(128);

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -23,10 +23,8 @@ use hil_test as _;
 
 cfg_if::cfg_if! {
     if #[cfg(any(esp32, esp32s2))] {
-        use esp_hal::dma::I2s0DmaChannel as DmaChannel0;
         type DmaChannel0Creator = esp_hal::dma::I2s0DmaChannelCreator;
     } else {
-        use esp_hal::dma::DmaChannel0;
         type DmaChannel0Creator = esp_hal::dma::ChannelCreator<0>;
     }
 }
@@ -59,7 +57,7 @@ impl Iterator for SampleSource {
 }
 
 #[embassy_executor::task]
-async fn writer(tx_buffer: &'static mut [u8], i2s_tx: I2sTx<'static, I2S0, DmaChannel0, Async>) {
+async fn writer(tx_buffer: &'static mut [u8], i2s_tx: I2sTx<'static, I2S0, Async>) {
     let mut samples = SampleSource::new();
     for b in tx_buffer.iter_mut() {
         *b = samples.next().unwrap();

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -8,7 +8,7 @@
 #[cfg(pcnt)]
 use esp_hal::pcnt::{channel::EdgeMode, unit::Unit, Pcnt};
 use esp_hal::{
-    dma::{AnyDmaChannel, Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     gpio::{AnyPin, Input, Io, Level, NoPin, Output, Pull},
     prelude::*,
@@ -36,7 +36,7 @@ struct Context {
     spi: esp_hal::peripherals::SPI2,
     #[cfg(pcnt)]
     pcnt: esp_hal::peripherals::PCNT,
-    dma_channel: Channel<'static, AnyDmaChannel, Blocking>,
+    dma_channel: Channel<'static, Blocking>,
     gpios: [AnyPin; 3],
 }
 

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -8,7 +8,7 @@
 #[cfg(pcnt)]
 use esp_hal::pcnt::{channel::EdgeMode, unit::Unit, Pcnt};
 use esp_hal::{
-    dma::{AnyDmaChannel, Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     gpio::{AnyPin, Input, Io, Level, NoPin, Output, Pull},
     prelude::*,
@@ -21,6 +21,14 @@ use esp_hal::{
     Blocking,
 };
 use hil_test as _;
+
+cfg_if::cfg_if! {
+    if #[cfg(pdma)] {
+        use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
+    } else {
+        use esp_hal::dma::DmaChannel0;
+    }
+}
 
 cfg_if::cfg_if! {
     if #[cfg(esp32)] {
@@ -36,7 +44,7 @@ struct Context {
     spi: esp_hal::peripherals::SPI2,
     #[cfg(pcnt)]
     pcnt: esp_hal::peripherals::PCNT,
-    dma_channel: Channel<'static, AnyDmaChannel, Blocking>,
+    dma_channel: Channel<'static, DmaChannel0, Blocking>,
     gpios: [AnyPin; 3],
 }
 

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -205,9 +205,7 @@ mod tests {
             }
         }
 
-        let dma_channel = dma_channel
-            .configure(false, DmaPriority::Priority0)
-            .degrade();
+        let dma_channel = dma_channel.configure(false, DmaPriority::Priority0);
 
         Context {
             spi: peripherals.SPI2,

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -8,7 +8,7 @@
 #[cfg(pcnt)]
 use esp_hal::pcnt::{channel::EdgeMode, unit::Unit, Pcnt};
 use esp_hal::{
-    dma::{Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{AnyDmaChannel, Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     gpio::{AnyPin, Input, Io, Level, NoPin, Output, Pull},
     prelude::*,
@@ -36,7 +36,7 @@ struct Context {
     spi: esp_hal::peripherals::SPI2,
     #[cfg(pcnt)]
     pcnt: esp_hal::peripherals::PCNT,
-    dma_channel: Channel<'static, Blocking>,
+    dma_channel: Channel<'static, AnyDmaChannel, Blocking>,
     gpios: [AnyPin; 3],
 }
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -21,16 +21,8 @@ use esp_hal::{
 };
 use hil_test as _;
 
-cfg_if::cfg_if! {
-    if #[cfg(any(esp32, esp32s2))] {
-        use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
-    } else {
-        use esp_hal::dma::DmaChannel0;
-    }
-}
-
 struct Context {
-    spi: SpiDma<'static, SPI2, DmaChannel0, HalfDuplexMode, Blocking>,
+    spi: SpiDma<'static, SPI2, HalfDuplexMode, Blocking>,
     miso_mirror: Output<'static>,
 }
 

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -22,19 +22,8 @@ use esp_hal::{
 };
 use hil_test as _;
 
-cfg_if::cfg_if! {
-    if #[cfg(any(
-        feature = "esp32",
-        feature = "esp32s2",
-    ))] {
-        use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
-    } else {
-        use esp_hal::dma::DmaChannel0;
-    }
-}
-
 struct Context {
-    spi: SpiDma<'static, SPI2, DmaChannel0, HalfDuplexMode, Blocking>,
+    spi: SpiDma<'static, SPI2, HalfDuplexMode, Blocking>,
     pcnt_unit: Unit<'static, 0>,
     pcnt_source: InputSignal,
 }

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -25,17 +25,6 @@ use esp_hal::{
 use hil_test as _;
 extern crate alloc;
 
-cfg_if::cfg_if! {
-    if #[cfg(any(
-        feature = "esp32",
-        feature = "esp32s2",
-    ))] {
-        use esp_hal::dma::Spi2DmaChannel as DmaChannel0;
-    } else {
-        use esp_hal::dma::DmaChannel0;
-    }
-}
-
 macro_rules! dma_alloc_buffer {
     ($size:expr, $align:expr) => {{
         let layout = core::alloc::Layout::from_size_align($size, $align).unwrap();
@@ -51,7 +40,7 @@ macro_rules! dma_alloc_buffer {
 }
 
 struct Context {
-    spi: SpiDma<'static, SPI2, DmaChannel0, HalfDuplexMode, Blocking>,
+    spi: SpiDma<'static, SPI2, HalfDuplexMode, Blocking>,
     pcnt_unit: Unit<'static, 0>,
     pcnt_source: InputSignal,
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR implements DMA type erasure. In the current system, the peripherals prescribe the erased DMA channel type. This allows erase-using-ZST-types on PDMA devices, and will allow handling P4's different DMAs without a ton of peripheral-specific `#[cfg]` gates. Pretty good idea, thanks @Dominaezzz even if this was terribly tricky to implement 😅

There is no `AnyDmaChannel` type. The goal of this exercise was not to introduce one, but to remove the type parameter from peripherals, and the current implementation is a bit more information-rich with (barring `fn degrade`) the same user-facing API.

Fixes #2248