### PR TITLE
I2c: Inherent transaction function, lift size limits

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the PS-RAM related features, replaced by `quad-psram`/`octal-psram`, `init_psram` takes a configuration parameter, it's now possible to auto-detect PS-RAM size (#2178)
 - `EspTwaiFrame` constructors now accept any type that converts into `esp_hal::twai::Id` (#2207)
 - Change `DmaTxBuf` to support PSRAM on `esp32s3` (#2161)
+- I2c `transaction` is now also available as a inherent function, lift size limit on `write`,`read` and `write_read` (#2262)
 
 ### Fixed
 

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -1079,10 +1079,10 @@ mod asynch {
         ///   0 to indicate writing
         /// - `SR` = repeated start condition
         /// - `SP` = stop condition
-        async fn transaction(
+        async fn transaction<'a>(
             &mut self,
             address: u8,
-            operations: &mut [Operation<'_>],
+            operations: &mut [impl I2cOperation<'a>],
         ) -> Result<(), Error> {
             let mut last_op: Option<OpKind> = None;
             // filter out 0 length read operations

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -305,7 +305,7 @@ where
     ///   to indicate writing
     /// - `SR` = repeated start condition
     /// - `SP` = stop condition
-    pub fn transaction<'a>(
+    pub fn transaction(
         &mut self,
         address: u8,
         operations: &mut [impl I2cOperation],
@@ -1079,7 +1079,7 @@ mod asynch {
         ///   0 to indicate writing
         /// - `SR` = repeated start condition
         /// - `SP` = stop condition
-        async fn transaction<'a>(
+        async fn transaction(
             &mut self,
             address: u8,
             operations: &mut [impl I2cOperation],

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -308,7 +308,7 @@ where
     pub fn transaction<'a>(
         &mut self,
         address: u8,
-        operations: &mut [impl I2cOperation<'a>],
+        operations: &mut [impl I2cOperation],
     ) -> Result<(), Error> {
         let mut last_op: Option<OpKind> = None;
         // filter out 0 length read operations
@@ -1082,7 +1082,7 @@ mod asynch {
         async fn transaction<'a>(
             &mut self,
             address: u8,
-            operations: &mut [impl I2cOperation<'a>],
+            operations: &mut [impl I2cOperation],
         ) -> Result<(), Error> {
             let mut last_op: Option<OpKind> = None;
             // filter out 0 length read operations
@@ -1218,12 +1218,12 @@ mod private {
     }
 
     #[doc(hidden)]
-    pub trait I2cOperation<'a> {
+    pub trait I2cOperation {
         fn is_write(&self) -> bool;
 
         fn is_read(&self) -> bool;
 
-        fn write_buffer(&self) -> Option<&'a [u8]>;
+        fn write_buffer(&self) -> Option<&[u8]>;
 
         fn read_buffer(&mut self) -> Option<&mut [u8]>;
 
@@ -1232,7 +1232,7 @@ mod private {
         fn kind(&self) -> OpKind;
     }
 
-    impl<'a> I2cOperation<'a> for Operation<'a> {
+    impl<'a> I2cOperation for Operation<'a> {
         fn is_write(&self) -> bool {
             matches!(self, Operation::Write(_))
         }
@@ -1241,7 +1241,7 @@ mod private {
             matches!(self, Operation::Read(_))
         }
 
-        fn write_buffer(&self) -> Option<&'a [u8]> {
+        fn write_buffer(&self) -> Option<&[u8]> {
             match self {
                 Operation::Write(buffer) => Some(buffer),
                 Operation::Read(_) => None,
@@ -1270,7 +1270,7 @@ mod private {
         }
     }
 
-    impl<'a> I2cOperation<'a> for embedded_hal::i2c::Operation<'a> {
+    impl<'a> I2cOperation for embedded_hal::i2c::Operation<'a> {
         fn is_write(&self) -> bool {
             matches!(self, embedded_hal::i2c::Operation::Write(_))
         }
@@ -1279,7 +1279,7 @@ mod private {
             matches!(self, embedded_hal::i2c::Operation::Read(_))
         }
 
-        fn write_buffer(&self) -> Option<&'a [u8]> {
+        fn write_buffer(&self) -> Option<&[u8]> {
             match self {
                 embedded_hal::i2c::Operation::Write(buffer) => Some(buffer),
                 embedded_hal::i2c::Operation::Read(_) => None,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -314,7 +314,7 @@ where
         // filter out 0 length read operations
         let mut op_iter = operations
             .iter_mut()
-            .filter(|op| if op.is_write() { true } else { !op.is_empty() })
+            .filter(|op| op.is_write() || !op.is_empty())
             .peekable();
 
         while let Some(op) = op_iter.next() {
@@ -1088,7 +1088,7 @@ mod asynch {
             // filter out 0 length read operations
             let mut op_iter = operations
                 .iter_mut()
-                .filter(|op| if op.is_write() { true } else { !op.is_empty() })
+                .filter(|op| op.is_write() || !op.is_empty())
                 .peekable();
 
             while let Some(op) = op_iter.next() {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

- add inherent `transaction`
- lift limits on `read`,`write`,`write_read` (fixes #2174)

#### Testing
- examples still work
- some testing with a logic analyzer
- using a VL53L5CX sensor using new inherent transaction function and `write`/`write_read` functions
