### PR TITLE
Remove `I2SxInstance` traits

### DIFF
--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -451,7 +451,6 @@ where
     ) -> I2s<'d, I2S0, CH, DmaMode>
     where
         CH::P: I2sPeripheral + I2s0Peripheral,
-        DmaMode: Mode,
     {
         I2s::new_internal(
             i2s,

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -331,7 +331,6 @@ where
     pub i2s_rx: RxCreator<'d, I, CH, DmaMode>,
     /// Handles the transmission (TX) side of the I2S peripheral.
     pub i2s_tx: TxCreator<'d, I, CH, DmaMode>,
-    phantom: PhantomData<DmaMode>,
 }
 
 impl<'d, I, CH, DmaMode> I2s<'d, I, CH, DmaMode>
@@ -374,7 +373,6 @@ where
                 descriptors: tx_descriptors,
                 phantom: PhantomData,
             },
-            phantom: PhantomData,
         }
     }
 }


### PR DESCRIPTION
In this case I'm not sure if I like the result better, but those traits would need to be changed to `#[cfg(i2s1)]` anyway, so why not get rid of them instead.

I would very much like to remove `new_i2s1` but that needs either a conceptual change of how we describe compatible DMA channels, or separating out a `with_dma` method which doesn't make much sense here.