### PR TITLE
I2C: clean up and remove stop condition from the middle of `write_read`

### DIFF
--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -453,7 +453,7 @@ where
         address: u8,
         operations: &mut [embedded_hal::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
-        self.transaction(address, operations.iter_mut().map(|op| Operation::from(op)))
+        self.transaction(address, operations.iter_mut().map(Operation::from))
     }
 }
 
@@ -1152,7 +1152,7 @@ mod asynch {
             address: u8,
             operations: &mut [EhalOperation<'_>],
         ) -> Result<(), Self::Error> {
-            self.transaction(address, operations.iter_mut().map(|op| Operation::from(op)))
+            self.transaction(address, operations.iter_mut().map(Operation::from))
                 .await
         }
     }

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -2334,6 +2334,7 @@ impl Instance for crate::peripherals::I2C0 {
         OutputSignal::I2CEXT0_SDA
     }
 
+    #[inline(always)]
     fn sda_input_signal(&self) -> InputSignal {
         InputSignal::I2CEXT0_SDA
     }
@@ -2348,6 +2349,7 @@ impl Instance for crate::peripherals::I2C0 {
         0
     }
 
+    #[inline(always)]
     fn interrupt() -> crate::peripherals::Interrupt {
         crate::peripherals::Interrupt::I2C_EXT0
     }
@@ -2380,6 +2382,7 @@ impl Instance for crate::peripherals::I2C1 {
         OutputSignal::I2CEXT1_SDA
     }
 
+    #[inline(always)]
     fn sda_input_signal(&self) -> InputSignal {
         InputSignal::I2CEXT1_SDA
     }
@@ -2394,6 +2397,7 @@ impl Instance for crate::peripherals::I2C1 {
         1
     }
 
+    #[inline(always)]
     fn interrupt() -> crate::peripherals::Interrupt {
         crate::peripherals::Interrupt::I2C_EXT1
     }

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -1590,16 +1590,6 @@ pub trait Instance: crate::private::Sealed {
                 w.scl_high_period().bits(scl_high_period as u16)
             });
 
-            // we already did that above but on S2 we need this to make it work
-            // FIXME: do we need this twice on S2?
-            #[cfg(esp32s2)]
-            self.register_block().scl_high_period().write(|w| {
-                w.scl_wait_high_period()
-                    .bits(scl_wait_high_period as u16)
-                    .scl_high_period()
-                    .bits(scl_high_period as u16)
-            });
-
             // sda sample
             self.register_block()
                 .sda_hold()

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -473,19 +473,8 @@ where
     ) -> Self {
         crate::into_ref!(i2c, sda, scl);
 
-        PeripheralClockControl::reset(match i2c.i2c_number() {
-            0 => crate::system::Peripheral::I2cExt0,
-            #[cfg(i2c1)]
-            1 => crate::system::Peripheral::I2cExt1,
-            _ => unreachable!(), // will never happen
-        });
-
-        PeripheralClockControl::enable(match i2c.i2c_number() {
-            0 => crate::system::Peripheral::I2cExt0,
-            #[cfg(i2c1)]
-            1 => crate::system::Peripheral::I2cExt1,
-            _ => unreachable!(), // will never happen
-        });
+        PeripheralClockControl::reset(T::peripheral());
+        PeripheralClockControl::enable(T::peripheral());
 
         let i2c = I2C {
             peripheral: i2c,
@@ -536,19 +525,8 @@ where
     }
 
     fn internal_recover(&self) {
-        PeripheralClockControl::reset(match self.peripheral.i2c_number() {
-            0 => crate::system::Peripheral::I2cExt0,
-            #[cfg(i2c1)]
-            1 => crate::system::Peripheral::I2cExt1,
-            _ => unreachable!(), // will never happen
-        });
-
-        PeripheralClockControl::enable(match self.peripheral.i2c_number() {
-            0 => crate::system::Peripheral::I2cExt0,
-            #[cfg(i2c1)]
-            1 => crate::system::Peripheral::I2cExt1,
-            _ => unreachable!(), // will never happen
-        });
+        PeripheralClockControl::reset(T::peripheral());
+        PeripheralClockControl::enable(T::peripheral());
 
         self.peripheral.setup(self.frequency, self.timeout);
     }
@@ -1249,6 +1227,8 @@ pub trait Instance: crate::private::Sealed {
 
     /// Returns the interrupt associated with this I2C peripheral.
     fn interrupt() -> crate::peripherals::Interrupt;
+
+    fn peripheral() -> crate::system::Peripheral;
 
     /// Returns the SCL output signal for this I2C peripheral.
     fn scl_output_signal(&self) -> OutputSignal;
@@ -2343,6 +2323,11 @@ impl Instance for crate::peripherals::I2C0 {
     const I2C_NUMBER: usize = 0;
 
     #[inline(always)]
+    fn peripheral() -> crate::system::Peripheral {
+        crate::system::Peripheral::I2cExt0
+    }
+
+    #[inline(always)]
     fn scl_output_signal(&self) -> OutputSignal {
         OutputSignal::I2CEXT0_SCL
     }
@@ -2379,6 +2364,11 @@ impl Instance for crate::peripherals::I2C0 {
 #[cfg(i2c1)]
 impl Instance for crate::peripherals::I2C1 {
     const I2C_NUMBER: usize = 1;
+
+    #[inline(always)]
+    fn peripheral() -> crate::system::Peripheral {
+        crate::system::Peripheral::I2cExt1
+    }
 
     #[inline(always)]
     fn scl_output_signal(&self) -> OutputSignal {

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -58,10 +58,10 @@ mod tests {
 
         // do the real read which should succeed
         ctx.i2c
-            .transaction(0x77, &mut [Operation::Write(&[0x55])])
-            .ok();
-        ctx.i2c
-            .transaction(0x77, &mut [Operation::Read(&mut read_data)])
+            .transaction(
+                0x77,
+                &mut [Operation::Write(&[0xaa]), Operation::Read(&mut read_data)],
+            )
             .ok();
 
         assert_ne!(read_data, [0u8; 22])

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -5,7 +5,13 @@
 #![no_std]
 #![no_main]
 
-use esp_hal::{gpio::Io, i2c::I2C, peripherals::I2C0, prelude::*, Blocking};
+use esp_hal::{
+    gpio::Io,
+    i2c::{Operation, I2C},
+    peripherals::I2C0,
+    prelude::*,
+    Blocking,
+};
 use hil_test as _;
 
 struct Context {
@@ -41,6 +47,22 @@ mod tests {
 
         // do the real read which should succeed
         ctx.i2c.write_read(0x77, &[0xaa], &mut read_data).ok();
+
+        assert_ne!(read_data, [0u8; 22])
+    }
+
+    #[test]
+    #[timeout(3)]
+    fn test_read_cali_with_transactions(mut ctx: Context) {
+        let mut read_data = [0u8; 22];
+
+        // do the real read which should succeed
+        ctx.i2c
+            .transaction(
+                0x77,
+                &mut [Operation::Write(&[0x55]), Operation::Read(&mut read_data)],
+            )
+            .ok();
 
         assert_ne!(read_data, [0u8; 22])
     }

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -58,10 +58,10 @@ mod tests {
 
         // do the real read which should succeed
         ctx.i2c
-            .transaction(
-                0x77,
-                &mut [Operation::Write(&[0x55]), Operation::Read(&mut read_data)],
-            )
+            .transaction(0x77, &mut [Operation::Write(&[0x55])])
+            .ok();
+        ctx.i2c
+            .transaction(0x77, &mut [Operation::Read(&mut read_data)])
             .ok();
 
         assert_ne!(read_data, [0u8; 22])


### PR DESCRIPTION
@bjoernQ I hope you don't mind me messing with your latest changes.