### PR TITLE
Slight TWAI corrections

### DIFF
--- a/esp-hal/src/soc/esp32c3/efuse/fields.rs
+++ b/esp-hal/src/soc/esp32c3/efuse/fields.rs
@@ -221,7 +221,7 @@ pub const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(EfuseBlock::Block0, 
 /// `[]` Set this bit to disable the function that forces chip into download
 /// mode
 pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(EfuseBlock::Block0, 44, 1);
-/// `[DIS_CAN]` Set this bit to disable CAN function
+/// `[DIS_CAN]` Set this bit to disable TWAI function
 pub const DIS_TWAI: EfuseField = EfuseField::new(EfuseBlock::Block0, 46, 1);
 /// `[]` Set this bit to enable selection between usb_to_jtag and pad_to_jtag
 /// through strapping gpio10 when both reg_dis_usb_jtag and reg_dis_pad_jtag are

--- a/esp-hal/src/soc/esp32s3/efuse/fields.rs
+++ b/esp-hal/src/soc/esp32s3/efuse/fields.rs
@@ -269,7 +269,7 @@ pub const DIS_DOWNLOAD_DCACHE: EfuseField = EfuseField::new(EfuseBlock::Block0, 
 pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(EfuseBlock::Block0, 44, 1);
 /// `[DIS_USB]` Set this bit to disable USB function
 pub const DIS_USB_OTG: EfuseField = EfuseField::new(EfuseBlock::Block0, 45, 1);
-/// `[DIS_CAN]` Set this bit to disable CAN function
+/// `[DIS_CAN]` Set this bit to disable TWAI function
 pub const DIS_TWAI: EfuseField = EfuseField::new(EfuseBlock::Block0, 46, 1);
 /// `[]` Disable app cpu
 pub const DIS_APP_CPU: EfuseField = EfuseField::new(EfuseBlock::Block0, 47, 1);

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -855,14 +855,18 @@ where
 
         #[cfg(esp32)]
         {
+            // From <https://github.com/espressif/esp-idf/blob/6e5a178b3120dced7fa5c29c655cc22ea182df3d/components/soc/esp32/register/soc/twai_struct.h#L79>
+            // and <https://github.com/espressif/esp-idf/blob/6e5a178b3120dced7fa5c29c655cc22ea182df3d/components/hal/esp32/include/hal/twai_ll.h#L528-L534>:
             if timing.baud_rate_prescaler > 128 {
-                // Enable /2 baudrate divider
+                // Enable /2 baudrate divider by setting `brp_div`.
+                // `brp_div` is not an interrupt, it will prescale BRP by 2. Only available on
+                // ESP32 Revision 2 or later. Reserved otherwise.
                 T::register_block()
                     .int_ena()
                     .modify(|r, w| unsafe { w.bits(r.bits() | 0x10) });
                 prescaler = timing.baud_rate_prescaler / 2;
             } else {
-                // Disable /2 baudrate divider
+                // Disable /2 baudrate divider by clearing brp_div.
                 T::register_block()
                     .int_ena()
                     .modify(|r, w| unsafe { w.bits(r.bits() & !0x10) });

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -772,19 +772,21 @@ where
                 .modify(|r, w| unsafe { w.bits(r.bits() | 0x80) });
         }
 
+        let rx_pull;
         if no_transceiver {
             tx_pin.set_to_open_drain_output(crate::private::Internal);
             tx_pin.pull_direction(Pull::Up, crate::private::Internal);
-            rx_pin.pull_direction(Pull::Up, crate::private::Internal);
+            rx_pull = Pull::Up;
         } else {
             tx_pin.set_to_push_pull_output(crate::private::Internal);
+            rx_pull = Pull::None;
         }
         tx_pin.connect_peripheral_to_output(T::OUTPUT_SIGNAL, crate::private::Internal);
 
         // Setting up RX pin later allows us to use a single pin in tests.
         // `set_to_push_pull_output` disables input, here we re-enable it if rx_pin
         // uses the same GPIO.
-        // rx_pin.init_input(Pull::None, crate::private::Internal);
+        rx_pin.init_input(rx_pull, crate::private::Internal);
         rx_pin.connect_input_to_peripheral(T::INPUT_SIGNAL, crate::private::Internal);
 
         // Freeze REC by changing to LOM mode
@@ -855,7 +857,7 @@ where
                 // Disable /2 baudrate divider
                 T::register_block()
                     .int_ena()
-                    .modify(|r, w| unsafe { w.bits(r.bits() & !0xEF) });
+                    .modify(|r, w| unsafe { w.bits(r.bits() & !0x10) });
             }
         }
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1790,19 +1790,12 @@ mod asynch {
 
         let async_state = T::async_state();
 
-        log::info!("irq: {:?}", intr_status.bits());
         if tx_int_status.bit_is_set() {
-            log::info!("tx irq");
             async_state.tx_waker.wake();
         }
 
         if rx_int_status.bit_is_set() {
             let status = register_block.status().read();
-            log::info!(
-                "rx irq: {:?} {:?}",
-                status.bus_off_st().bit_is_set(),
-                status.miss_st().bit_is_set(),
-            );
 
             let rx_queue = &async_state.rx_queue;
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -877,6 +877,11 @@ where
             w.time_seg2().bits(tseg_2);
             w.time_samp().bit(triple_sample)
         });
+
+        // disable CLKOUT
+        T::register_block()
+            .clock_divider()
+            .modify(|_, w| w.clock_off().set_bit());
     }
 
     /// Set up the acceptance filter on the device.

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -611,6 +611,8 @@ impl embedded_can::Frame for EspTwaiFrame {
 }
 
 /// The underlying timings for the TWAI peripheral.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TimingConfig {
     /// The baudrate prescaler is used to determine the period of each time
     /// quantum by dividing the TWAI controller's source clock.
@@ -635,6 +637,8 @@ pub struct TimingConfig {
 /// A selection of pre-determined baudrates for the TWAI driver.
 /// Currently these timings are sourced from the ESP IDF C driver which assumes
 /// an APB clock of 80MHz.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BaudRate {
     /// A baud rate of 125 Kbps.
     B125K,

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -695,10 +695,10 @@ impl BaudRate {
         #[cfg(esp32h2)]
         let timing = match self {
             Self::B125K => TimingConfig {
-                baud_rate_prescaler: 8,
+                baud_rate_prescaler: 16,
                 sync_jump_width: 3,
-                tseg_1: 23,
-                tseg_2: 8,
+                tseg_1: 11,
+                tseg_2: 4,
                 triple_sample: false,
             },
             Self::B250K => TimingConfig {

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -244,6 +244,7 @@ impl embedded_can::Error for ErrorKind {
 
 /// Specifies in which mode the TWAI controller will operate.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TwaiMode {
     /// Normal operating mode
     Normal,
@@ -256,6 +257,7 @@ pub enum TwaiMode {
 
 /// Standard 11-bit TWAI Identifier (`0..=0x7FF`).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StandardId(u16);
 
 impl StandardId {
@@ -321,6 +323,7 @@ impl From<embedded_can::StandardId> for StandardId {
 
 /// Extended 29-bit TWAI Identifier (`0..=1FFF_FFFF`).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ExtendedId(u32);
 
 impl ExtendedId {
@@ -392,6 +395,7 @@ impl From<embedded_can::ExtendedId> for ExtendedId {
 
 /// A TWAI Identifier (standard or extended).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Id {
     /// Standard 11-bit Identifier (`0..=0x7FF`).
     Standard(StandardId),
@@ -451,6 +455,7 @@ impl From<embedded_can::Id> for Id {
 
 /// Structure backing the embedded_hal_02::can::Frame/embedded_can::Frame trait.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct EspTwaiFrame {
     id: Id,
     dlc: usize,
@@ -776,15 +781,14 @@ where
                 .modify(|r, w| unsafe { w.bits(r.bits() | 0x80) });
         }
 
-        let rx_pull;
-        if no_transceiver {
+        let rx_pull = if no_transceiver {
             tx_pin.set_to_open_drain_output(crate::private::Internal);
             tx_pin.pull_direction(Pull::Up, crate::private::Internal);
-            rx_pull = Pull::Up;
+            Pull::Up
         } else {
             tx_pin.set_to_push_pull_output(crate::private::Internal);
-            rx_pull = Pull::None;
-        }
+            Pull::None
+        };
         tx_pin.connect_peripheral_to_output(T::OUTPUT_SIGNAL, crate::private::Internal);
 
         // Setting up RX pin later allows us to use a single pin in tests.

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -24,7 +24,7 @@
 //! * use `new()` function to create the TWAI configuration.
 //! * change the `tx_pin` and `rx_pin` to the appropriate pins for your boards.
 
-//% CHIPS: esp32 esp32c3 esp32c6 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: embassy embassy-generic-timers
 
 #![no_std]
@@ -149,7 +149,7 @@ async fn main(spawner: Spawner) {
     let channel = &*CHANNEL.init(Channel::new());
 
     spawner.spawn(receiver(rx, channel)).ok();
-    //spawner.spawn(transmitter(tx, channel)).ok();
+    spawner.spawn(transmitter(tx, channel)).ok();
 }
 
 fn print_frame(frame: &EspTwaiFrame) {

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -60,7 +60,8 @@ async fn receiver(
                 print_frame(&frame);
 
                 // Send a response
-                let frame = EspTwaiFrame::new(StandardId::new(1).unwrap(), &[4, 5, 6, 7, 8]).unwrap();
+                let frame =
+                    EspTwaiFrame::new(StandardId::new(1).unwrap(), &[4, 5, 6, 7, 8]).unwrap();
                 channel.send(frame).await;
             }
             Err(e) => {

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -107,8 +107,8 @@ async fn main(spawner: Spawner) {
     // Without an external transciever, we only need a single line between the two MCUs.
     let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transciever.
 
-    // The speed of the CAN bus.
-    const CAN_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;
+    // The speed of the bus.
+    const TWAI_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;
 
     // !!! Use `new_async` when using a transceiver. `new_async_no_transceiver` sets TX to open-drain
 
@@ -118,7 +118,7 @@ async fn main(spawner: Spawner) {
         peripherals.TWAI0,
         rx_pin,
         tx_pin,
-        CAN_BAUDRATE,
+        TWAI_BAUDRATE,
         TwaiMode::Normal,
     );
 

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -39,7 +39,7 @@ use esp_hal::{
     interrupt,
     peripherals::{self, TWAI0},
     timer::timg::TimerGroup,
-    twai::{self, EspTwaiFrame, TwaiMode, TwaiRx, TwaiTx},
+    twai::{self, EspTwaiFrame, StandardId, TwaiMode, TwaiRx, TwaiTx},
 };
 use esp_println::println;
 use static_cell::StaticCell;
@@ -59,7 +59,8 @@ async fn receiver(
                 println!("Received a frame:");
                 print_frame(&frame);
 
-                // repeat the frame back
+                // Send a response
+                let frame = EspTwaiFrame::new(StandardId::new(1).unwrap(), &[4, 5, 6, 7, 8]).unwrap();
                 channel.send(frame).await;
             }
             Err(e) => {
@@ -128,7 +129,7 @@ async fn main(spawner: Spawner) {
     // these partial acceptance filters to exactly match. A filter that matches
     // standard ids of an even value.
     const FILTER: twai::filter::SingleStandardFilter =
-        twai::filter::SingleStandardFilter::new(b"xxxxxxxxxxx", b"x", [b"xxxxxxxx", b"xxxxxxxx"]);
+        twai::filter::SingleStandardFilter::new(b"xxxxxxxxxx0", b"x", [b"xxxxxxxx", b"xxxxxxxx"]);
     twai_config.set_filter(FILTER);
 
     // Start the peripheral. This locks the configuration settings of the peripheral

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -82,6 +82,7 @@ async fn transmitter(
 
 #[esp_hal_embassy::main]
 async fn main(spawner: Spawner) {
+    esp_println::logger::init_logger_from_env();
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
@@ -89,11 +90,11 @@ async fn main(spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let can_tx_pin = io.pins.gpio0;
-    let can_rx_pin = io.pins.gpio2;
+    let can_tx_pin = io.pins.gpio2;
+    let can_rx_pin = io.pins.gpio3;
 
     // The speed of the CAN bus.
-    const CAN_BAUDRATE: twai::BaudRate = twai::BaudRate::B1000K;
+    const CAN_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;
 
     // !!! Use `new_async` when using a transceiver. `new_async_no_transceiver` sets TX to open-drain
 
@@ -114,7 +115,7 @@ async fn main(spawner: Spawner) {
     // these partial acceptance filters to exactly match. A filter that matches
     // standard ids of an even value.
     const FILTER: twai::filter::SingleStandardFilter =
-        twai::filter::SingleStandardFilter::new(b"xxxxxxxxxx0", b"x", [b"xxxxxxxx", b"xxxxxxxx"]);
+        twai::filter::SingleStandardFilter::new(b"xxxxxxxxxxx", b"x", [b"xxxxxxxx", b"xxxxxxxx"]);
     can_config.set_filter(FILTER);
 
     // Start the peripheral. This locks the configuration settings of the peripheral
@@ -135,7 +136,7 @@ async fn main(spawner: Spawner) {
     let channel = &*CHANNEL.init(Channel::new());
 
     spawner.spawn(receiver(rx, channel)).ok();
-    spawner.spawn(transmitter(tx, channel)).ok();
+    //spawner.spawn(transmitter(tx, channel)).ok();
 }
 
 fn print_frame(frame: &EspTwaiFrame) {

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -16,7 +16,7 @@
 //! ESP1/GND --- ESP2/GND
 //! ESP1/GPIO2 --- ESP2/GPIO2
 //!
-//! Notes for external transciever use:
+//! Notes for external transceiver use:
 //!
 //! The default setup assumes that two microcontrollers are connected directly without an external
 //! transceiver. If you want to use an external transceiver, you need to:
@@ -103,10 +103,10 @@ async fn main(spawner: Spawner) {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let tx_pin = io.pins.gpio2;
-    // let rx_pin = io.pins.gpio0; // Uncomment if you want to use an external transciever.
+    // let rx_pin = io.pins.gpio0; // Uncomment if you want to use an external transceiver.
 
-    // Without an external transciever, we only need a single line between the two MCUs.
-    let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transciever.
+    // Without an external transceiver, we only need a single line between the two MCUs.
+    let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transceiver.
 
     // The speed of the bus.
     const TWAI_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -72,7 +72,7 @@ fn main() -> ! {
     // these partial acceptance filters to exactly match.
     // A filter that matches StandardId::ZERO.
     twai_config.set_filter(
-        const { SingleStandardFilter::new(b"00000000000", b"x", [b"xxxxxxxx", b"xxxxxxxx"]) },
+        const { SingleStandardFilter::new(b"xxxxxxxxxx1", b"x", [b"xxxxxxxx", b"xxxxxxxx"]) },
     );
 
     // Start the peripheral. This locks the configuration settings of the peripheral
@@ -96,7 +96,8 @@ fn main() -> ! {
         println!("Received a frame: {frame:?}");
         delay.delay_millis(250);
 
-        // Transmit the frame back to the other ESP
+        let frame = EspTwaiFrame::new(StandardId::ZERO, &[1, 2, 3]).unwrap();
+        // Transmit a new frame back to the other ESP
         block!(can.transmit(&frame)).unwrap();
         println!("Sent a frame");
     }

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -1,21 +1,23 @@
 //! This example sends a TWAI message to another ESP and receives it back.
 //!
-//! This example works without TWAI transceivers by:
-//! * setting the tx pins to open drain
-//! * connecting all rx and tx pins together
-//! * adding a pull-up to the signal pins
-//!
-//! The following wiring is assumed:
-//! - TX => GPIO0
-//! - RX => GPIO2
-//!
-//! ESP1/GND --- ESP2/GND
-//! ESP1/GPIO0 --- ESP1/GPIO2 --- ESP2/GPIO0 --- ESP2/GPIO2 --- 4.8kOhm --- ESP1/5V
-//!
 //! `IS_FIRST_SENDER` below must be set to false on one of the ESP's
 //!
 //! In case you want to use `self-testing`, get rid of everything related to the aforementioned `IS_FIRST_SENDER`
 //! and follow the advice in the comments related to this mode.
+//!
+//! The following wiring is assumed:
+//! - TX/RX => GPIO2, connected internally and with internal pull-up resistor.
+//!
+//! ESP1/GND --- ESP2/GND
+//! ESP1/GPIO2 --- ESP2/GPIO2
+//!
+//! Notes for external transciever use:
+//!
+//! The default setup assumes that two microcontrollers are connected directly without an external
+//! transceiver. If you want to use an external transceiver, you need to:
+//! * uncomment the `rx_pin` line
+//! * use `new()` function to create the TWAI configuration.
+//! * change the `tx_pin` and `rx_pin` to the appropriate pins for your boards.
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -41,7 +43,10 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let tx_pin = io.pins.gpio2;
-    let rx_pin = io.pins.gpio4;
+    // let rx_pin = io.pins.gpio0; // Uncomment if you want to use an external transciever.
+
+    // Without an external transciever, we only need a single line between the two MCUs.
+    let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transciever.
 
     // The speed of the CAN bus.
     const TWAI_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -11,7 +11,7 @@
 //! ESP1/GND --- ESP2/GND
 //! ESP1/GPIO2 --- ESP2/GPIO2
 //!
-//! Notes for external transciever use:
+//! Notes for external transceiver use:
 //!
 //! The default setup assumes that two microcontrollers are connected directly without an external
 //! transceiver. If you want to use an external transceiver, you need to:
@@ -43,10 +43,10 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let tx_pin = io.pins.gpio2;
-    // let rx_pin = io.pins.gpio0; // Uncomment if you want to use an external transciever.
+    // let rx_pin = io.pins.gpio0; // Uncomment if you want to use an external transceiver.
 
-    // Without an external transciever, we only need a single line between the two MCUs.
-    let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transciever.
+    // Without an external transceiver, we only need a single line between the two MCUs.
+    let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transceiver.
 
     // The speed of the bus.
     const TWAI_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     // Without an external transciever, we only need a single line between the two MCUs.
     let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transciever.
 
-    // The speed of the CAN bus.
+    // The speed of the bus.
     const TWAI_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;
 
     // !!! Use `new` when using a transceiver. `new_no_transceiver` sets TX to open-drain
@@ -78,27 +78,27 @@ fn main() -> ! {
     // Start the peripheral. This locks the configuration settings of the peripheral
     // and puts it into operation mode, allowing packets to be sent and
     // received.
-    let mut can = twai_config.start();
+    let mut twai = twai_config.start();
 
     if IS_FIRST_SENDER {
         // Send a frame to the other ESP
         // Use `new_self_reception` if you want to use self-testing.
         let frame = EspTwaiFrame::new(StandardId::ZERO, &[1, 2, 3]).unwrap();
-        block!(can.transmit(&frame)).unwrap();
+        block!(twai.transmit(&frame)).unwrap();
         println!("Sent a frame");
     }
 
     let delay = Delay::new();
     loop {
         // Wait for a frame to be received.
-        let frame = block!(can.receive()).unwrap();
+        let frame = block!(twai.receive()).unwrap();
 
         println!("Received a frame: {frame:?}");
         delay.delay_millis(250);
 
         let frame = EspTwaiFrame::new(StandardId::ZERO, &[1, 2, 3]).unwrap();
         // Transmit a new frame back to the other ESP
-        block!(can.transmit(&frame)).unwrap();
+        block!(twai.transmit(&frame)).unwrap();
         println!("Sent a frame");
     }
 }

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -80,14 +80,24 @@ fn main() -> ! {
     // received.
     let mut can = twai_config.start();
 
-    loop {
+    if IS_FIRST_SENDER {
         // Send a frame to the other ESP
         // Use `new_self_reception` if you want to use self-testing.
         let frame = EspTwaiFrame::new(StandardId::ZERO, &[1, 2, 3]).unwrap();
-        println!("Sending a frame");
         block!(can.transmit(&frame)).unwrap();
         println!("Sent a frame");
+    }
 
-        Delay::new().delay_millis(500u32);
+    let delay = Delay::new();
+    loop {
+        // Wait for a frame to be received.
+        let frame = block!(can.receive()).unwrap();
+
+        println!("Received a frame: {frame:?}");
+        delay.delay_millis(250);
+
+        // Transmit the frame back to the other ESP
+        block!(can.transmit(&frame)).unwrap();
+        println!("Sent a frame");
     }
 }


### PR DESCRIPTION
- H2 had a 100Kbaud/s timing set up in place of 125K (this is an esp-idf bug, did not report yet)
- ESP32 brp bit's position was one off, and clearing double-inverted the mask. This resulted in incorrect baud rates.
- I've made slight changes to no_transciever where we now apply internal pullups
- We explicitly clear CLKOUT. This shouldn't make a difference, but esp-idf did it, too.
- I've updated examples to use a single wire and to not exit immediately.
- I've enabled the examples for the missing chips.
- We now correctly label self-reception frames.
- Examples no longer ping-pong the same frame.
- Removed still surviving CAN branding.