### PR TITLE
Clean up `impl_dma_eligible`

### DIFF
--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -169,10 +169,17 @@ mod peripheral_macros {
     #[doc(hidden)]
     #[macro_export]
     macro_rules! impl_dma_eligible {
-        ($name:ident,$dma:ident) => {
+        ($name:ident => $dma:ident) => {
             impl $crate::dma::DmaEligible for $name {
                 const DMA_PERIPHERAL: $crate::dma::DmaPeripheral = $crate::dma::DmaPeripheral::$dma;
             }
+        };
+
+        ($($(#[$cfg:meta])? $name:ident => $dma:ident),*) => {
+            $(
+                $(#[$cfg])?
+                $crate::impl_dma_eligible!($name => $dma);
+            )*
         };
     }
 
@@ -188,47 +195,58 @@ mod peripheral_macros {
                     $crate::create_peripheral!($(#[$cfg])? $name <= $from_pac);
                 )*
 
-                $crate::impl_dma_eligible!(SPI2,Spi2);
-                #[cfg(any(pdma, esp32s3))]
-                $crate::impl_dma_eligible!(SPI3,Spi3);
-                #[cfg(any(esp32c2, esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM1,Mem2Mem1);
-                #[cfg(any(esp32c3, esp32c6, esp32h2, esp32s3))]
-                $crate::impl_dma_eligible!(UHCI0,Uhci0);
-                #[cfg(any(esp32, esp32s2, esp32c3, esp32c6, esp32h2, esp32s3))]
-                $crate::impl_dma_eligible!(I2S0,I2s0);
-                #[cfg(any(esp32, esp32s3))]
-                $crate::impl_dma_eligible!(I2S1,I2s1);
+                $crate::impl_dma_eligible! {
+                    #[cfg(spi2)]
+                    SPI2 => Spi2,
+
+                    #[cfg(spi3)]
+                    SPI3 => Spi3,
+
+                    #[cfg(all(uhci0, gdma))] // TODO: S2?
+                    UHCI0 => Uhci0,
+
+                    #[cfg(i2s0)]
+                    I2S0 => I2s0,
+
+                    #[cfg(i2s1)]
+                    I2S1 => I2s1,
+
+                    #[cfg(esp32s3)]
+                    LCD_CAM => LcdCam,
+
+                    #[cfg(all(gdma, aes))]
+                    AES => Aes,
+
+                    #[cfg(all(gdma, sha))]
+                    SHA => Sha,
+
+                    #[cfg(any(esp32c3, esp32c6, esp32h2, esp32s3))]
+                    ADC1 => Adc,
+
+                    #[cfg(any(esp32c3, esp32s3))]
+                    ADC2 => Adc,
+
+                    #[cfg(esp32s3)]
+                    RMT => Rmt,
+
+                    #[cfg(parl_io)]
+                    PARL_IO => ParlIo,
+
+                    #[cfg(any(esp32c2, esp32c6, esp32h2))]
+                    MEM2MEM1 => Mem2Mem1
+                }
+
                 #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM4,Mem2Mem4);
-                #[cfg(esp32s3)]
-                $crate::impl_dma_eligible!(LCD_CAM,LcdCam);
-                #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM5,Mem2Mem5);
-                #[cfg(not(esp32c2))]
-                $crate::impl_dma_eligible!(AES,Aes);
-                #[cfg(gdma)]
-                $crate::impl_dma_eligible!(SHA,Sha);
-                #[cfg(any(esp32c3, esp32c6, esp32h2, esp32s3))]
-                $crate::impl_dma_eligible!(ADC1,Adc);
-                #[cfg(any(esp32c3, esp32s3))]
-                $crate::impl_dma_eligible!(ADC2,Adc);
-                #[cfg(esp32s3)]
-                $crate::impl_dma_eligible!(RMT,Rmt);
-                #[cfg(parl_io)]
-                $crate::impl_dma_eligible!(PARL_IO,ParlIo);
-                #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM10,Mem2Mem10);
-                #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM11,Mem2Mem11);
-                #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM12,Mem2Mem12);
-                #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM13,Mem2Mem13);
-                #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM14,Mem2Mem14);
-                #[cfg(any(esp32c6, esp32h2))]
-                $crate::impl_dma_eligible!(MEM2MEM15,Mem2Mem15);
+                $crate::impl_dma_eligible! {
+                    MEM2MEM4 => Mem2Mem4,
+                    MEM2MEM5 => Mem2Mem5,
+                    MEM2MEM10 => Mem2Mem10,
+                    MEM2MEM11 => Mem2Mem11,
+                    MEM2MEM12 => Mem2Mem12,
+                    MEM2MEM13 => Mem2Mem13,
+                    MEM2MEM14 => Mem2Mem14,
+                    MEM2MEM15 => Mem2Mem15
+                }
             }
 
             /// The `Peripherals` struct provides access to all of the hardware peripherals on the chip.


### PR DESCRIPTION
Trying to make this a bit more readable. Some cfg's can be simplified, but otherwise I'm just avoiding repeating the macro name.