### PR TITLE
bump all semver compatible deps

### DIFF
--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -14,7 +14,7 @@ features       = ["esp32c3", "panic-handler", "exception-handler", "println", "e
 [dependencies]
 defmt       = { version = "0.3.8",  optional = true }
 esp-println = { version = "0.11.0", optional = true, default-features = false, path = "../esp-println" }
-semihosting = { version = "0.1.14", optional = true }
+semihosting = { version = "0.1.15", optional = true }
 
 [build-dependencies]
 esp-build = { version = "0.1.0", path = "../esp-build" }

--- a/esp-build/Cargo.toml
+++ b/esp-build/Cargo.toml
@@ -11,6 +11,6 @@ license      = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-quote     = "1.0.36"
+quote     = "1.0.37"
 syn       = { version = "2.0.71", features = ["fold", "full"] }
 termcolor = "1.4.1"

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -20,7 +20,7 @@ embassy-time-driver = { version = "0.1.0", features = [ "tick-hz-1_000_000" ] }
 esp-hal             = { version = "0.20.0", path = "../esp-hal" }
 log                 = { version = "0.4.22", optional = true }
 macros              = { version = "0.13.0", features = ["embassy"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-portable-atomic     = "1.7.0"
+portable-atomic     = "1.9.0"
 static_cell         = "2.1.0"
 
 [build-dependencies]

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -17,12 +17,12 @@ proc-macro = true
 darling           = "0.20.10"
 document-features = "0.2.10"
 litrs             = "0.4.1"
-object            = { version = "0.36.4", optional = true, default-features = false, features = ["read_core", "elf"] }
+object            = { version = "0.36.5", optional = true, default-features = false, features = ["read_core", "elf"] }
 proc-macro-crate  = "3.2.0"
-proc-macro-error2 = "2.0.0"
-proc-macro2       = "1.0.86"
+proc-macro-error2 = "2.0.1"
+proc-macro2       = "1.0.87"
 quote             = "1.0.37"
-syn               = { version = "2.0.76", features = ["extra-traits", "full"] }
+syn               = { version = "2.0.79", features = ["extra-traits", "full"] }
 
 [features]
 ## Provide a `#[main]` procmacro to mark the entry point for Embassy applications.

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args   = ["--cfg", "docsrs"]
 
 [dependencies]
 bitflags                 = "2.6.0"
-bytemuck                 = "1.17.1"
+bytemuck                 = "1.18.0"
 bitfield                 = "0.16.1"
 cfg-if                   = "1.0.0"
 chrono                   = { version = "0.4.38", default-features = false }
@@ -42,7 +42,7 @@ fugit                    = "0.3.7"
 log                      = { version = "0.4.22", optional = true }
 nb                       = "1.1.0"
 paste                    = "1.0.15"
-portable-atomic          = { version = "1.7.0", default-features = false }
+portable-atomic          = { version = "1.9.0", default-features = false }
 procmacros               = { version = "0.13.0", features = ["enum-dispatch", "interrupt", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 riscv                    = { version = "0.11.1", optional = true }
 strum                    = { version = "0.26.3", default-features = false, features = ["derive"] }
@@ -75,7 +75,7 @@ cfg-if       = "1.0.0"
 esp-build    = { version = "0.1.0", path = "../esp-build" }
 esp-metadata = { version = "0.3.0", path = "../esp-metadata" }
 esp-config   = { version = "0.1.0", path = "../esp-config", features = ["build"] }
-serde        = { version = "1.0.209", features = ["derive"] }
+serde        = { version = "1.0.210", features = ["derive"] }
 
 [features]
 default = []

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -8,8 +8,8 @@ repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 
 [dependencies]
-anyhow     = "1.0.86"
+anyhow     = "1.0.89"
 clap       = { version = "4.5.16", features = ["derive"], optional = true }
 basic-toml  = "0.1.9"
-serde       = { version = "1.0.209", features = ["derive"] }
+serde       = { version = "1.0.210", features = ["derive"] }
 strum       = { version = "0.26.3",  features = ["derive"] }

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -17,11 +17,11 @@ features       = ["esp32c3"]
 critical-section = { version = "1.1.3",  optional = true }
 defmt            = { version = "0.3.8",  optional = true }
 log              = { version = "0.4.22", optional = true }
-portable-atomic  = { version = "1.7.0",  optional = true, default-features = false }
+portable-atomic  = { version = "1.9.0",  optional = true, default-features = false }
 
 [build-dependencies]
 esp-build = { version = "0.1.0", path = "../esp-build" }
-log = "0.4.20"
+log = "0.4.22"
 
 [features]
 default          = ["critical-section", "colors", "auto"]

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -24,7 +24,7 @@ categories = [
 
 [dependencies]
 embedded-storage = "0.3.1"
-critical-section = { version =  "1.1.2", optional = true }
+critical-section = { version =  "1.1.3", optional = true }
 
 [build-dependencies]
 esp-build = { version = "0.1.0", path = "../esp-build" }

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -41,16 +41,16 @@ embassy-net-driver = { version = "0.2.0", optional = true }
 toml-cfg = "0.2.0"
 libm = "0.2.8"
 cfg-if = "1.0.0"
-portable-atomic = { version = "1.7.0", default-features = false }
+portable-atomic = { version = "1.9.0", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
 
-futures-util = { version = "0.3.30", default-features = false, features = [
+futures-util = { version = "0.3.31", default-features = false, features = [
   "portable-atomic",
 ] }
 atomic-waker = { version = "1.1.2", default-features = false, features = [
   "portable-atomic",
 ] }
-bt-hci = { version = "0.1.0", optional = true }
+bt-hci = { version = "0.1.1", optional = true }
 esp-config = { version = "0.1.0", path = "../esp-config" }
 
 [build-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 aes                 = "0.8.4"
 aligned             = { version = "0.4.2", optional = true }
 bleps               = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "a5148d8ae679e021b78f53fd33afb8bb35d0b62e", features = [ "macros", "async"] }
-bt-hci              = "0.1.0"
+bt-hci              = "0.1.1"
 cfg-if              = "1.0.0"
-critical-section    = "1.1.2"
+critical-section    = "1.1.3"
 crypto-bigint       = { version = "0.5.5", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
 embassy-executor    = { version = "0.6.0", features = ["task-arena-size-12288"] }
 embassy-futures     = "0.1.1"
 embassy-net = { version = "0.4.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 embassy-sync        = "0.6.0"
-embassy-time        = "0.3.1"
+embassy-time        = "0.3.2"
 embassy-time-driver = { version = "0.1.0", optional = true }
 embassy-usb         = { version = "0.2.0", default-features = false }
 embedded-can        = "0.4.1"
@@ -49,7 +49,7 @@ log                 = "0.4.22"
 nb                  = "1.1.0"
 p192                = { version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256                = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
-portable-atomic     = { version = "1.6.0",  default-features = false }
+portable-atomic     = { version = "1.9.0",  default-features = false }
 sha2                = { version = "0.10.8", default-features = false }
 smart-leds          = "0.4.0"
 smoltcp             = { version = "0.11.0", default-features = false, features = [ "medium-ethernet", "socket-raw"] }

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -191,7 +191,7 @@ esp-alloc          = { path = "../esp-alloc", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "defmt", "semihosting"] }
 esp-hal            = { path = "../esp-hal", features = ["digest"], optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
-portable-atomic    = "1.7.0"
+portable-atomic    = "1.9.0"
 static_cell        = { version = "2.1.0", features = ["nightly"] }
 semihosting        = { version = "0.1", features= ["stdio", "panic-handler"] }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow     = "1.0.86"
+anyhow     = "1.0.89"
 basic-toml = "0.1.9"
 chrono     = "0.4.38"
-clap       = { version = "4.5.4",  features = ["derive"] }
+clap       = { version = "4.5.19",  features = ["derive"] }
 csv        = "1.3.0"
-env_logger = "0.11.3"
-log        = "0.4.21"
-minijinja  = "2.0.1"
+env_logger = "0.11.5"
+log        = "0.4.22"
+minijinja  = "2.3.1"
 semver     = { version = "1.0.23",  features = ["serde"] }
-serde      = { version = "1.0.203", features = ["derive"] }
-strum      = { version = "0.26.2",  features = ["derive"] }
-toml_edit  = "0.22.13"
+serde      = { version = "1.0.210", features = ["derive"] }
+strum      = { version = "0.26.3",  features = ["derive"] }
+toml_edit  = "0.22.22"
 esp-metadata = { path = "../esp-metadata", features = ["clap"] }

--- a/xtensa-lx-rt/Cargo.toml
+++ b/xtensa-lx-rt/Cargo.toml
@@ -20,10 +20,10 @@ r0                = "1.0.0"
 xtensa-lx         = "0.9.0"
 
 [build-dependencies]
-anyhow          = "1.0.86"
-enum-as-inner   = "0.6.0"
-minijinja       = "2.2.0"
-serde           = { version = "1.0.209", features = ["derive"] }
+anyhow          = "1.0.89"
+enum-as-inner   = "0.6.1"
+minijinja       = "2.3.1"
+serde           = { version = "1.0.210", features = ["derive"] }
 strum           = { version = "0.26.3", features = ["derive"] }
 toml            = "0.8.19"
 

--- a/xtensa-lx/Cargo.toml
+++ b/xtensa-lx/Cargo.toml
@@ -15,7 +15,7 @@ features = ["spin"]
 
 [dependencies]
 bare-metal        = "1.0.0"
-document-features = "0.2.8"
+document-features = "0.2.10"
 mutex-trait       = "0.2.0"
 spin              = { version = "0.9.8", optional = true }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Updated with `cargo-edit` and `for d in */ ; do cargo upgrade --manifest-path=$d/Cargo.toml; done`

Everything built locally when targeting the C6, so lets see what CI says for the rest.
