### PR TITLE
Remove `esp_wifi::current_millis`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Efuse::read_bit` (#2259)
 - Limited SPI slave support for ESP32 (Modes 1 and 3 only) (#2278)
 - Added `Rtc::disable_rom_message_printing` (S3 and H2 only) (#2280)
+- Added `esp_hal::time::{Duration, Instant}` (#2304)
 
 ### Changed
 

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -2,6 +2,16 @@
 //!
 //! The `time` module offers a way to get the system now.
 
+/// Represents a duration of time.
+///
+/// The resolution is 1 microsecond, represented as a 64-bit unsigned integer.
+pub type Duration = fugit::Duration<u64, 1, 1_000_000>;
+
+/// Represents an instant in time.
+///
+/// The resolution is 1 microsecond, represented as a 64-bit unsigned integer.
+pub type Instant = fugit::Instant<u64, 1, 1_000_000>;
+
 /// Provides time since system start in microseconds precision.
 ///
 /// The counter won’t measure time in sleep-mode.
@@ -10,7 +20,7 @@
 #[cfg_attr(esp32, doc = "36_558 years")]
 #[cfg_attr(esp32s2, doc = "7_311 years")]
 #[cfg_attr(not(any(esp32, esp32s2)), doc = "more than 7 years")]
-pub fn now() -> fugit::Instant<u64, 1, 1_000_000> {
+pub fn now() -> Instant {
     #[cfg(esp32)]
     let (ticks, div) = {
         // on ESP32 use LACT
@@ -45,7 +55,7 @@ pub fn now() -> fugit::Instant<u64, 1, 1_000_000> {
         )
     };
 
-    fugit::Instant::<u64, 1, 1_000_000>::from_ticks(ticks / div)
+    Instant::from_ticks(ticks / div)
 }
 
 #[cfg(esp32)]

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `embedded-svc` traits and feature (#2235)
 - Removed the `log` feature from default features (#2253)
 - Removed the `enumset` feature (#2297)
+- Removed `esp_wifi::current_millis` (#2304)
 
 ## 0.9.1 - 2024-09-03
 

--- a/esp-wifi/MIGRATING-0.9.md
+++ b/esp-wifi/MIGRATING-0.9.md
@@ -93,7 +93,7 @@ pub extern "C" fn esp_wifi_allocate_from_internal_ram(size: usize) -> *mut u8 {
 
 It's important to allocate from internal memory (i.e. not PSRAM)
 
-### Tunable parameters are now set via esp-config
+## Tunable parameters are now set via esp-config
 
 We've replaced usage of `cfg_toml` with [esp-config](https://docs.rs/esp-config). Please remove any esp-wifi entries from `cfg.toml` and migrate the key value pairs to the `[env]` section of `.cargo/config.toml`.
 
@@ -104,9 +104,18 @@ We've replaced usage of `cfg_toml` with [esp-config](https://docs.rs/esp-config)
 + ESP_WIFI_RX_QUEUE_SIZE=40
 ```
 
-### `wifi-logs` feature renamed to `sys-logs`
+## `wifi-logs` feature renamed to `sys-logs`
 
 ```diff
 - features = ["wifi-logs"]
 + features = ["sys-logs"]
+```
+
+## Removed `esp_wifi::current_millis`
+
+You can use `esp_hal::time::now()` instead.
+
+```diff
+- let now = esp_wifi::current_millis();
++ let now = time::now().duration_since_epoch().to_millis();
 ```

--- a/esp-wifi/src/ble/npl.rs
+++ b/esp-wifi/src/ble/npl.rs
@@ -671,7 +671,7 @@ unsafe extern "C" fn ble_npl_time_ms_to_ticks(
 
 unsafe extern "C" fn ble_npl_time_get() -> u32 {
     trace!("ble_npl_time_get");
-    crate::current_millis() as u32
+    esp_hal::time::now().duration_since_epoch().to_millis() as u32
 }
 
 unsafe extern "C" fn ble_npl_callout_set_arg(

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -163,14 +163,15 @@ pub mod tasks;
 
 pub(crate) mod memory_fence;
 
-use timer::{get_systimer_count, ticks_to_millis};
-
 #[cfg(all(feature = "wifi", any(feature = "tcp", feature = "udp")))]
 pub mod wifi_interface;
 
-/// Return the current systimer time in milliseconds
-pub fn current_millis() -> u64 {
-    ticks_to_millis(get_systimer_count())
+// [esp_hal::time::now()] as a smoltcp [`Instant]`
+#[cfg(feature = "smoltcp")]
+fn timestamp() -> smoltcp::time::Instant {
+    smoltcp::time::Instant::from_micros(
+        esp_hal::time::now().duration_since_epoch().to_micros() as i64
+    )
 }
 
 // this is just to verify that we use the correct defaults in `build.rs`

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -1497,7 +1497,7 @@ pub unsafe extern "C" fn log_writev(
 ///
 /// *************************************************************************
 pub unsafe extern "C" fn log_timestamp() -> u32 {
-    crate::current_millis() as u32
+    esp_hal::time::now().duration_since_epoch().to_millis() as u32
 }
 
 /// **************************************************************************

--- a/esp-wifi/src/wifi/utils.rs
+++ b/esp-wifi/src/wifi/utils.rs
@@ -4,12 +4,11 @@
 use smoltcp::socket::dhcpv4::Socket as Dhcpv4Socket;
 use smoltcp::{
     iface::{Config, Interface, SocketSet, SocketStorage},
-    time::Instant,
     wire::{EthernetAddress, HardwareAddress},
 };
 
 use super::{WifiApDevice, WifiController, WifiDevice, WifiDeviceMode, WifiError, WifiStaDevice};
-use crate::{current_millis, EspWifiInitialization};
+use crate::{timestamp, EspWifiInitialization};
 
 fn setup_iface<'a, MODE: WifiDeviceMode>(
     device: &mut WifiDevice<'_, MODE>,
@@ -20,11 +19,7 @@ fn setup_iface<'a, MODE: WifiDeviceMode>(
     let hw_address = HardwareAddress::Ethernet(EthernetAddress::from_bytes(&mac));
 
     let config = Config::new(hw_address);
-    let iface = Interface::new(
-        config,
-        device,
-        Instant::from_millis(current_millis() as i64),
-    );
+    let iface = Interface::new(config, device, timestamp());
 
     #[allow(unused_mut)]
     let mut socket_set = SocketSet::new(storage);

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -17,7 +17,7 @@ use smoltcp::{
 };
 
 use crate::{
-    current_millis,
+    timestamp,
     wifi::{ipv4, WifiDevice, WifiDeviceMode},
 };
 
@@ -509,11 +509,6 @@ impl Display for WifiStackError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self)
     }
-}
-
-/// [current_millis] as an Instant
-pub fn timestamp() -> Instant {
-    Instant::from_millis(current_millis() as i64)
 }
 
 impl<MODE: WifiDeviceMode> WifiStack<'_, MODE> {

--- a/examples/src/bin/wifi_access_point.rs
+++ b/examples/src/bin/wifi_access_point.rs
@@ -16,10 +16,14 @@
 use embedded_io::*;
 use esp_alloc as _;
 use esp_backtrace as _;
-use esp_hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
+use esp_hal::{
+    prelude::*,
+    rng::Rng,
+    time::{self, Duration},
+    timer::timg::TimerGroup,
+};
 use esp_println::{print, println};
 use esp_wifi::{
-    current_millis,
     init,
     wifi::{
         utils::create_network_interface,
@@ -57,7 +61,8 @@ fn main() -> ! {
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
         create_network_interface(&init, &mut wifi, WifiApDevice, &mut socket_set_entries).unwrap();
-    let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
+    let now = || time::now().duration_since_epoch().to_millis();
+    let mut wifi_stack = WifiStack::new(iface, device, sockets, now);
 
     let client_config = Configuration::AccessPoint(AccessPointConfiguration {
         ssid: "esp-wifi".try_into().unwrap(),
@@ -107,26 +112,21 @@ fn main() -> ! {
             println!("Connected");
 
             let mut time_out = false;
-            let wait_end = current_millis() + 20 * 1000;
+            let deadline = time::now() + Duration::secs(20);
             let mut buffer = [0u8; 1024];
             let mut pos = 0;
-            loop {
-                if let Ok(len) = socket.read(&mut buffer[pos..]) {
-                    let to_print =
-                        unsafe { core::str::from_utf8_unchecked(&buffer[..(pos + len)]) };
+            while let Ok(len) = socket.read(&mut buffer[pos..]) {
+                let to_print = unsafe { core::str::from_utf8_unchecked(&buffer[..(pos + len)]) };
 
-                    if to_print.contains("\r\n\r\n") {
-                        print!("{}", to_print);
-                        println!();
-                        break;
-                    }
-
-                    pos += len;
-                } else {
+                if to_print.contains("\r\n\r\n") {
+                    print!("{}", to_print);
+                    println!();
                     break;
                 }
 
-                if current_millis() > wait_end {
+                pos += len;
+
+                if time::now() > deadline {
                     println!("Timeout");
                     time_out = true;
                     break;
@@ -155,8 +155,8 @@ fn main() -> ! {
             println!();
         }
 
-        let wait_end = current_millis() + 5 * 1000;
-        while current_millis() < wait_end {
+        let deadline = time::now() + Duration::secs(5);
+        while time::now() < deadline {
             socket.work();
         }
     }

--- a/examples/src/bin/wifi_ble.rs
+++ b/examples/src/bin/wifi_ble.rs
@@ -28,6 +28,7 @@ use esp_hal::{
     gpio::{Input, Io, Pull},
     prelude::*,
     rng::Rng,
+    time,
     timer::timg::TimerGroup,
 };
 use esp_println::println;
@@ -68,9 +69,10 @@ fn main() -> ! {
 
     let mut bluetooth = peripherals.BT;
 
+    let now = || time::now().duration_since_epoch().to_millis();
     loop {
         let connector = BleConnector::new(&init, &mut bluetooth);
-        let hci = HciConnector::new(connector, esp_wifi::current_millis);
+        let hci = HciConnector::new(connector, now);
         let mut ble = Ble::new(&hci);
 
         println!("{:?}", ble.init());

--- a/examples/src/bin/wifi_embassy_ble.rs
+++ b/examples/src/bin/wifi_embassy_ble.rs
@@ -31,6 +31,7 @@ use esp_hal::{
     gpio::{Input, Io, Pull},
     prelude::*,
     rng::Rng,
+    time,
     timer::timg::TimerGroup,
 };
 use esp_println::println;
@@ -80,7 +81,9 @@ async fn main(_spawner: Spawner) -> ! {
     let mut bluetooth = peripherals.BT;
 
     let connector = BleConnector::new(&init, &mut bluetooth);
-    let mut ble = Ble::new(connector, esp_wifi::current_millis);
+
+    let now = || time::now().duration_since_epoch().to_millis();
+    let mut ble = Ble::new(connector, now);
     println!("Connector created");
 
     let pin_ref = RefCell::new(button);

--- a/examples/src/bin/wifi_esp_now.rs
+++ b/examples/src/bin/wifi_esp_now.rs
@@ -10,10 +10,14 @@
 
 use esp_alloc as _;
 use esp_backtrace as _;
-use esp_hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
+use esp_hal::{
+    prelude::*,
+    rng::Rng,
+    time::{self, Duration},
+    timer::timg::TimerGroup,
+};
 use esp_println::println;
 use esp_wifi::{
-    current_millis,
     esp_now::{PeerInfo, BROADCAST_ADDRESS},
     init,
     EspWifiInitFor,
@@ -45,7 +49,7 @@ fn main() -> ! {
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 
-    let mut next_send_time = current_millis() + 5 * 1000;
+    let mut next_send_time = time::now() + Duration::secs(5);
     loop {
         let r = esp_now.receive();
         if let Some(r) = r {
@@ -70,8 +74,8 @@ fn main() -> ! {
             }
         }
 
-        if current_millis() >= next_send_time {
-            next_send_time = current_millis() + 5 * 1000;
+        if time::now() >= next_send_time {
+            next_send_time = time::now() + Duration::secs(5);
             println!("Send");
             let status = esp_now
                 .send(&BROADCAST_ADDRESS, b"0123456789")

--- a/examples/src/bin/wifi_static_ip.rs
+++ b/examples/src/bin/wifi_static_ip.rs
@@ -15,10 +15,14 @@
 use embedded_io::*;
 use esp_alloc as _;
 use esp_backtrace as _;
-use esp_hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
+use esp_hal::{
+    prelude::*,
+    rng::Rng,
+    time::{self, Duration},
+    timer::timg::TimerGroup,
+};
 use esp_println::{print, println};
 use esp_wifi::{
-    current_millis,
     init,
     wifi::{
         utils::create_network_interface,
@@ -63,7 +67,9 @@ fn main() -> ! {
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
         create_network_interface(&init, &mut wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
-    let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
+
+    let now = || time::now().duration_since_epoch().to_millis();
+    let mut wifi_stack = WifiStack::new(iface, device, sockets, now);
 
     let client_config = Configuration::Client(ClientConfiguration {
         ssid: SSID.try_into().unwrap(),
@@ -90,13 +96,9 @@ fn main() -> ! {
     // wait to get connected
     println!("Wait to get connected");
     loop {
-        let res = controller.is_connected();
-        match res {
-            Ok(connected) => {
-                if connected {
-                    break;
-                }
-            }
+        match controller.is_connected() {
+            Ok(true) => break,
+            Ok(false) => {}
             Err(err) => {
                 println!("{:?}", err);
                 loop {}
@@ -145,26 +147,21 @@ fn main() -> ! {
             println!("Connected");
 
             let mut time_out = false;
-            let wait_end = current_millis() + 20 * 1000;
+            let deadline = time::now() + Duration::secs(20);
             let mut buffer = [0u8; 1024];
             let mut pos = 0;
-            loop {
-                if let Ok(len) = socket.read(&mut buffer[pos..]) {
-                    let to_print =
-                        unsafe { core::str::from_utf8_unchecked(&buffer[..(pos + len)]) };
+            while let Ok(len) = socket.read(&mut buffer[pos..]) {
+                let to_print = unsafe { core::str::from_utf8_unchecked(&buffer[..(pos + len)]) };
 
-                    if to_print.contains("\r\n\r\n") {
-                        print!("{}", to_print);
-                        println!();
-                        break;
-                    }
-
-                    pos += len;
-                } else {
+                if to_print.contains("\r\n\r\n") {
+                    print!("{}", to_print);
+                    println!();
                     break;
                 }
 
-                if current_millis() > wait_end {
+                pos += len;
+
+                if time::now() > deadline {
                     println!("Timeout");
                     time_out = true;
                     break;
@@ -192,8 +189,8 @@ fn main() -> ! {
             println!();
         }
 
-        let wait_end = current_millis() + 5 * 1000;
-        while current_millis() < wait_end {
+        let deadline = time::now() + Duration::secs(5);
+        while time::now() < deadline {
             socket.work();
         }
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Closes #2300

`esp_hal::time::Instant` and `Duration` are pretty much a must have otherwise fugit requires specifying all generic parameters, which is a bit of a chore to push on users.

I've also taken the opportunity to clean up the examples I've touched just a bit.

To be honest I'm not sure this is as much of an improvement as expected 😅