### PR TITLE
Reimplement SPI DMA operations in terms of transfer

### DIFF
--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -169,28 +169,31 @@ impl DmaTxBuf {
         buffer: &'static mut [u8],
         block_size: Option<DmaBufBlkSize>,
     ) -> Result<Self, DmaBufError> {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s3)] {
-                // buffer can be either DRAM or PSRAM (if supported)
-                if !is_slice_in_dram(buffer) && !is_slice_in_psram(buffer) {
-                    return Err(DmaBufError::UnsupportedMemoryRegion);
-                }
-                // if its PSRAM, the block_size/alignment must be specified
-                if is_slice_in_psram(buffer) && block_size.is_none() {
-                    return Err(DmaBufError::InvalidAlignment);
-                }
-            } else {
-                #[cfg(any(esp32,esp32s2))]
-                if buffer.len() % 4 != 0 && buffer.as_ptr() as usize % 4 != 0 {
-                    // ESP32 requires word alignment for DMA buffers.
-                    // ESP32-S2 technically supports byte-aligned DMA buffers, but the
-                    // transfer ends up writing out of bounds if the buffer's length
-                    // is 2 or 3 (mod 4).
-                    return Err(DmaBufError::InvalidAlignment);
-                }
-                // buffer can only be DRAM
-                if !is_slice_in_dram(buffer) {
-                    return Err(DmaBufError::UnsupportedMemoryRegion);
+        #[allow(clippy::collapsible_if)] // Kind of a false positive with cfg_if
+        if !buffer.is_empty() {
+            cfg_if::cfg_if! {
+                if #[cfg(esp32s3)] {
+                    // buffer can be either DRAM or PSRAM (if supported)
+                    if !is_slice_in_dram(buffer) && !is_slice_in_psram(buffer) {
+                        return Err(DmaBufError::UnsupportedMemoryRegion);
+                    }
+                    // if its PSRAM, the block_size/alignment must be specified
+                    if is_slice_in_psram(buffer) && block_size.is_none() {
+                        return Err(DmaBufError::InvalidAlignment);
+                    }
+                } else {
+                    #[cfg(any(esp32,esp32s2))]
+                    if buffer.len() % 4 != 0 && buffer.as_ptr() as usize % 4 != 0 {
+                        // ESP32 requires word alignment for DMA buffers.
+                        // ESP32-S2 technically supports byte-aligned DMA buffers, but the
+                        // transfer ends up writing out of bounds if the buffer's length
+                        // is 2 or 3 (mod 4).
+                        return Err(DmaBufError::InvalidAlignment);
+                    }
+                    // buffer can only be DRAM
+                    if !is_slice_in_dram(buffer) {
+                        return Err(DmaBufError::UnsupportedMemoryRegion);
+                    }
                 }
             }
         }
@@ -207,9 +210,11 @@ impl DmaTxBuf {
             block_size,
         };
 
-        buf.descriptors
-            .link_with_buffer(buf.buffer, max_chunk_size(block_size))?;
-        buf.set_length(buf.capacity());
+        if !buf.descriptors.descriptors.is_empty() || !buf.buffer.is_empty() {
+            buf.descriptors
+                .link_with_buffer(buf.buffer, max_chunk_size(block_size))?;
+            buf.set_length(buf.capacity());
+        }
 
         Ok(buf)
     }
@@ -328,7 +333,7 @@ impl DmaRxBuf {
         descriptors: &'static mut [DmaDescriptor],
         buffer: &'static mut [u8],
     ) -> Result<Self, DmaBufError> {
-        if !is_slice_in_dram(buffer) {
+        if !buffer.is_empty() && !is_slice_in_dram(buffer) {
             return Err(DmaBufError::UnsupportedMemoryRegion);
         }
 
@@ -337,9 +342,11 @@ impl DmaRxBuf {
             buffer,
         };
 
-        buf.descriptors
-            .link_with_buffer(buf.buffer, max_chunk_size(None))?;
-        buf.set_length(buf.capacity());
+        if !buf.descriptors.descriptors.is_empty() || !buf.buffer.is_empty() {
+            buf.descriptors
+                .link_with_buffer(buf.buffer, max_chunk_size(None))?;
+            buf.set_length(buf.capacity());
+        }
 
         Ok(buf)
     }

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -914,7 +914,7 @@ impl DmaRxStreamBufView {
     }
 }
 
-static mut EMPTY: &mut [DmaDescriptor] = &mut [DmaDescriptor::EMPTY];
+static mut EMPTY: [DmaDescriptor; 1] = [DmaDescriptor::EMPTY];
 
 /// An empty buffer that can be used when you don't need to transfer any data.
 pub struct EmptyBuf;

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1076,11 +1076,13 @@ impl<'a> DescriptorSet<'a> {
     /// Creates a new `DescriptorSet` from a slice of descriptors and associates
     /// them with the given buffer.
     fn new(descriptors: &'a mut [DmaDescriptor]) -> Result<Self, DmaBufError> {
-        if !is_slice_in_dram(descriptors) {
-            return Err(DmaBufError::UnsupportedMemoryRegion);
-        }
+        if !descriptors.is_empty() {
+            if !is_slice_in_dram(descriptors) {
+                return Err(DmaBufError::UnsupportedMemoryRegion);
+            }
 
-        descriptors.fill(DmaDescriptor::EMPTY);
+            descriptors.fill(DmaDescriptor::EMPTY);
+        }
 
         Ok(unsafe { Self::new_unchecked(descriptors) })
     }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1076,13 +1076,11 @@ impl<'a> DescriptorSet<'a> {
     /// Creates a new `DescriptorSet` from a slice of descriptors and associates
     /// them with the given buffer.
     fn new(descriptors: &'a mut [DmaDescriptor]) -> Result<Self, DmaBufError> {
-        if !descriptors.is_empty() {
-            if !is_slice_in_dram(descriptors) {
-                return Err(DmaBufError::UnsupportedMemoryRegion);
-            }
-
-            descriptors.fill(DmaDescriptor::EMPTY);
+        if !is_slice_in_dram(descriptors) {
+            return Err(DmaBufError::UnsupportedMemoryRegion);
         }
+
+        descriptors.fill(DmaDescriptor::EMPTY);
 
         Ok(unsafe { Self::new_unchecked(descriptors) })
     }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -944,6 +944,7 @@ mod dma {
             DmaRxBuffer,
             DmaTxBuf,
             DmaTxBuffer,
+            EmptyBuf,
             Rx,
             Tx,
         },
@@ -1173,7 +1174,7 @@ mod dma {
             unsafe {
                 self.spi.start_transfer_dma(
                     false,
-                    &mut DmaRxBuf::empty(),
+                    &mut EmptyBuf,
                     &mut self.address_buffer,
                     &mut self.channel.rx,
                     &mut self.channel.tx,
@@ -1359,7 +1360,7 @@ mod dma {
 
             self.spi.start_transfer_dma(
                 true,
-                &mut DmaRxBuf::empty(),
+                &mut EmptyBuf,
                 buffer,
                 &mut self.channel.rx,
                 &mut self.channel.tx,
@@ -1399,7 +1400,7 @@ mod dma {
             self.spi.start_transfer_dma(
                 false,
                 buffer,
-                &mut DmaTxBuf::empty(),
+                &mut EmptyBuf,
                 &mut self.channel.rx,
                 &mut self.channel.tx,
             )
@@ -1500,7 +1501,7 @@ mod dma {
             self.spi.start_transfer_dma(
                 false,
                 buffer,
-                &mut DmaTxBuf::empty(),
+                &mut EmptyBuf,
                 &mut self.channel.rx,
                 &mut self.channel.tx,
             )
@@ -1566,7 +1567,7 @@ mod dma {
 
             self.spi.start_transfer_dma(
                 false,
-                &mut DmaRxBuf::empty(),
+                &mut EmptyBuf,
                 buffer,
                 &mut self.channel.rx,
                 &mut self.channel.tx,
@@ -1700,7 +1701,7 @@ mod dma {
 
                 unsafe {
                     self.spi_dma
-                        .start_dma_transfer(&mut self.rx_buf, &mut DmaTxBuf::empty())?;
+                        .start_dma_transfer(&mut self.rx_buf, &mut EmptyBuf)?;
                 }
 
                 self.wait_for_idle();
@@ -1720,7 +1721,7 @@ mod dma {
 
                 unsafe {
                     self.spi_dma
-                        .start_dma_transfer(&mut DmaRxBuf::empty(), &mut self.tx_buf)?;
+                        .start_dma_transfer(&mut EmptyBuf, &mut self.tx_buf)?;
                 }
 
                 self.wait_for_idle();
@@ -1945,7 +1946,7 @@ mod dma {
 
                     let mut spi = DropGuard::new(&mut self.spi_dma, |spi| spi.cancel_transfer());
 
-                    unsafe { spi.start_dma_transfer(&mut self.rx_buf, &mut DmaTxBuf::empty())? };
+                    unsafe { spi.start_dma_transfer(&mut self.rx_buf, &mut EmptyBuf)? };
 
                     spi.wait_for_idle_async().await;
 
@@ -1968,7 +1969,7 @@ mod dma {
                 for chunk in words.chunks(chunk_size) {
                     self.tx_buf.fill(chunk);
 
-                    unsafe { spi.start_dma_transfer(&mut DmaRxBuf::empty(), &mut self.tx_buf)? };
+                    unsafe { spi.start_dma_transfer(&mut EmptyBuf, &mut self.tx_buf)? };
 
                     spi.wait_for_idle_async().await;
                 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -951,13 +951,6 @@ mod dma {
         Mode,
     };
 
-    fn empty_rx_buf() -> DmaRxBuf {
-        unwrap!(DmaRxBuf::new(&mut [], &mut []))
-    }
-    fn empty_tx_buf() -> DmaTxBuf {
-        unwrap!(DmaTxBuf::new(&mut [], &mut []))
-    }
-
     /// A DMA capable SPI instance.
     ///
     /// Using `SpiDma` is not recommended unless you wish
@@ -1180,7 +1173,7 @@ mod dma {
             unsafe {
                 self.spi.start_transfer_dma(
                     false,
-                    &mut empty_rx_buf(),
+                    &mut DmaRxBuf::empty(),
                     &mut self.address_buffer,
                     &mut self.channel.rx,
                     &mut self.channel.tx,
@@ -1366,7 +1359,7 @@ mod dma {
 
             self.spi.start_transfer_dma(
                 true,
-                &mut empty_rx_buf(),
+                &mut DmaRxBuf::empty(),
                 buffer,
                 &mut self.channel.rx,
                 &mut self.channel.tx,
@@ -1406,7 +1399,7 @@ mod dma {
             self.spi.start_transfer_dma(
                 false,
                 buffer,
-                &mut empty_tx_buf(),
+                &mut DmaTxBuf::empty(),
                 &mut self.channel.rx,
                 &mut self.channel.tx,
             )
@@ -1507,7 +1500,7 @@ mod dma {
             self.spi.start_transfer_dma(
                 false,
                 buffer,
-                &mut empty_tx_buf(),
+                &mut DmaTxBuf::empty(),
                 &mut self.channel.rx,
                 &mut self.channel.tx,
             )
@@ -1573,7 +1566,7 @@ mod dma {
 
             self.spi.start_transfer_dma(
                 false,
-                &mut empty_rx_buf(),
+                &mut DmaRxBuf::empty(),
                 buffer,
                 &mut self.channel.rx,
                 &mut self.channel.tx,
@@ -1707,7 +1700,7 @@ mod dma {
 
                 unsafe {
                     self.spi_dma
-                        .start_dma_transfer(&mut self.rx_buf, &mut empty_tx_buf())?;
+                        .start_dma_transfer(&mut self.rx_buf, &mut DmaTxBuf::empty())?;
                 }
 
                 self.wait_for_idle();
@@ -1727,7 +1720,7 @@ mod dma {
 
                 unsafe {
                     self.spi_dma
-                        .start_dma_transfer(&mut empty_rx_buf(), &mut self.tx_buf)?;
+                        .start_dma_transfer(&mut DmaRxBuf::empty(), &mut self.tx_buf)?;
                 }
 
                 self.wait_for_idle();
@@ -1952,7 +1945,7 @@ mod dma {
 
                     let mut spi = DropGuard::new(&mut self.spi_dma, |spi| spi.cancel_transfer());
 
-                    unsafe { spi.start_dma_transfer(&mut self.rx_buf, &mut empty_tx_buf())? };
+                    unsafe { spi.start_dma_transfer(&mut self.rx_buf, &mut DmaTxBuf::empty())? };
 
                     spi.wait_for_idle_async().await;
 
@@ -1975,7 +1968,7 @@ mod dma {
                 for chunk in words.chunks(chunk_size) {
                     self.tx_buf.fill(chunk);
 
-                    unsafe { spi.start_dma_transfer(&mut empty_rx_buf(), &mut self.tx_buf)? };
+                    unsafe { spi.start_dma_transfer(&mut DmaRxBuf::empty(), &mut self.tx_buf)? };
 
                     spi.wait_for_idle_async().await;
                 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2236,7 +2236,7 @@ pub trait InstanceDma: Instance + DmaEligible {
         let tx_len = tx_buffer.length();
         self.configure_datalen(rx_len, tx_len);
 
-        // re-enable the MISO and MOSI
+        // enable the MISO and MOSI if needed
         reg_block
             .user()
             .modify(|_, w| w.usr_miso().bit(rx_len > 0).usr_mosi().bit(tx_len > 0));

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2295,36 +2295,24 @@ pub trait InstanceDma: Instance + DmaEligible {
     }
 
     fn reset_dma(&self) {
-        #[cfg(pdma)]
-        {
-            let reg_block = self.register_block();
+        fn set_reset_bit(reg_block: &RegisterBlock, bit: bool) {
+            #[cfg(pdma)]
             reg_block.dma_conf().modify(|_, w| {
-                w.out_rst().set_bit();
-                w.in_rst().set_bit();
-                w.ahbm_fifo_rst().set_bit();
-                w.ahbm_rst().set_bit()
+                w.out_rst().bit(bit);
+                w.in_rst().bit(bit);
+                w.ahbm_fifo_rst().bit(bit);
+                w.ahbm_rst().bit(bit)
             });
+            #[cfg(gdma)]
             reg_block.dma_conf().modify(|_, w| {
-                w.out_rst().clear_bit();
-                w.in_rst().clear_bit();
-                w.ahbm_fifo_rst().clear_bit();
-                w.ahbm_rst().clear_bit()
-            });
-        }
-        #[cfg(gdma)]
-        {
-            let reg_block = self.register_block();
-            reg_block.dma_conf().modify(|_, w| {
-                w.rx_afifo_rst().set_bit();
-                w.buf_afifo_rst().set_bit();
-                w.dma_afifo_rst().set_bit()
-            });
-            reg_block.dma_conf().modify(|_, w| {
-                w.rx_afifo_rst().clear_bit();
-                w.buf_afifo_rst().clear_bit();
-                w.dma_afifo_rst().clear_bit()
+                w.rx_afifo_rst().bit(bit);
+                w.buf_afifo_rst().bit(bit);
+                w.dma_afifo_rst().bit(bit)
             });
         }
+        let reg_block = self.register_block();
+        set_reset_bit(reg_block, true);
+        set_reset_bit(reg_block, false);
         self.clear_dma_interrupts();
     }
 


### PR DESCRIPTION
I'm not sure this warrants a changelog, the only visible change is that it's now possible to create empty `DmaRxBuf` and `DmaTxBuf`.