### PR TITLE
Make ieee802154 RX queue size configurable

### DIFF
--- a/esp-ieee802154/CHANGELOG.md
+++ b/esp-ieee802154/CHANGELOG.md
@@ -23,20 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added board-specific consts for c6 and h2 when caluclating transmit power conversion
+- Added board-specific consts for c6 and h2 when caluclating transmit power conversion (#2114)
 - Added `defmt` and `log` features (#2183)
+- Make RX queue size configurable using esp-config (#2324)
 
 ### Changed
 
-- Modified CCA threshold value to default of -60
+- Modified CCA threshold value to default of -60 (#2114)
 - The driver now take `RADIO_CLK` by value to avoid a collision with esp-wifi's usage (#2183)
 - `binary-logs` feature renamed to `sys-logs` (#2183)
 - Updated PHY driver to v5.3.1 (#2239)
 
 ### Fixed
 
-- Fixed possible integer underflow in array access
-- Fixed compile error when building sys-logs feature
+- Fixed possible integer underflow in array access (#2114)
+- Fixed compile error when building sys-logs feature (#2114)
 
 ## 0.2.0 - 2024-08-29
 

--- a/esp-ieee802154/Cargo.toml
+++ b/esp-ieee802154/Cargo.toml
@@ -20,19 +20,21 @@ byte              = "0.2.7"
 critical-section  = "1.1.3"
 document-features = "0.2.10"
 esp-hal           = { version = "0.21.0", path = "../esp-hal" }
-esp-wifi-sys = { version = "0.6.0" }
+esp-wifi-sys      = { version = "0.6.0" }
 heapless          = "0.8.0"
 ieee802154        = "0.6.1"
 cfg-if            = "1.0.0"
+esp-config        = { version = "0.1.0", path = "../esp-config" }
+defmt             = { version = "0.3.8", optional = true }
+log               = { version = "0.4.22", optional = true }
 
-defmt = { version = "0.3.8", optional = true }
-log = { version = "0.4.22", optional = true }
+[build-dependencies]
+esp-config        = { version = "0.1.0", path = "../esp-config" }
 
 
 [features]
 esp32c6 = ["esp-hal/esp32c6", "esp-wifi-sys/esp32c6"]
 esp32h2 = ["esp-hal/esp32h2", "esp-wifi-sys/esp32h2"]
 sys-logs = ["esp-wifi-sys/sys-logs"]
-
 log = ["dep:log", "esp-wifi-sys/log"]
 defmt = ["dep:defmt", "esp-wifi-sys/defmt"]

--- a/esp-ieee802154/build.rs
+++ b/esp-ieee802154/build.rs
@@ -1,6 +1,19 @@
 use std::{env, path::PathBuf};
 
+use esp_config::{generate_config, Value};
+
 fn main() {
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     println!("cargo:rustc-link-search={}", out.display());
+
+    // emit config
+    generate_config(
+        "esp_ieee802154",
+        &[(
+            "rx_queue_size",
+            Value::UnsignedInteger(50),
+            "Size of the RX queue in frames",
+        )],
+        true,
+    );
 }

--- a/esp-ieee802154/src/lib.rs
+++ b/esp-ieee802154/src/lib.rs
@@ -18,6 +18,7 @@ use core::{cell::RefCell, marker::PhantomData};
 
 use byte::{BytesExt, TryRead};
 use critical_section::Mutex;
+use esp_config::*;
 use esp_hal::peripherals::{IEEE802154, RADIO_CLK};
 use heapless::Vec;
 use ieee802154::mac::{self, FooterMode, FrameSerDesContext};
@@ -57,6 +58,14 @@ impl From<byte::Error> for Error {
         }
     }
 }
+
+struct QueueConfig {
+    rx_queue_size: usize,
+}
+
+pub(crate) const CONFIG: QueueConfig = QueueConfig {
+    rx_queue_size: esp_config_int!(usize, "ESP_IEEE802154_RX_QUEUE_SIZE"),
+};
 
 /// IEEE 802.15.4 driver configuration
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/esp-ieee802154/src/raw.rs
+++ b/esp-ieee802154/src/raw.rs
@@ -33,7 +33,8 @@ use crate::{
 const PHY_ENABLE_VERSION_PRINT: u32 = 1;
 
 static mut RX_BUFFER: [u8; FRAME_SIZE] = [0u8; FRAME_SIZE];
-static RX_QUEUE: Mutex<RefCell<Queue<RawReceived, 20>>> = Mutex::new(RefCell::new(Queue::new()));
+static RX_QUEUE: Mutex<RefCell<Queue<RawReceived, { crate::CONFIG.rx_queue_size }>>> =
+    Mutex::new(RefCell::new(Queue::new()));
 static STATE: Mutex<RefCell<Ieee802154State>> = Mutex::new(RefCell::new(Ieee802154State::Idle));
 
 extern "C" {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds an `esp-config` option to configure the size of the RX queue. It was hardcoded to 20 but I bumped it to 50 by default.

#### Testing
Tested with the `esp-openthread` library basic example, on esp32-c6 and esp32-h2 dev boards
