### PR TITLE
Add missing `description` field to Cargo manifest for `esp-config`

### DIFF
--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -3,6 +3,7 @@ name         = "esp-config"
 version      = "0.1.0"
 edition      = "2021"
 rust-version = "1.79.0"
+description  = "Configure projects using esp-hal and related packages"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
🙃 