### PR TITLE
Add `PeripheralRef::map_into`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `AnyPin` now implements `From<GpioPin<N>>`. (#2326)
+
 ### Changed
 
 ### Fixed

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -48,7 +48,7 @@ impl Clone for InputSignal {
 impl Peripheral for InputSignal {
     type P = Self;
 
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         self.clone()
     }
 }
@@ -187,7 +187,7 @@ pub struct OutputSignal {
 impl Peripheral for OutputSignal {
     type P = Self;
 
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         Self {
             pin: self.pin.clone_unchecked(),
             is_inverted: self.is_inverted,
@@ -345,7 +345,7 @@ pub struct AnyInputSignal(AnyInputSignalInner);
 impl Peripheral for AnyInputSignal {
     type P = Self;
 
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         self.clone()
     }
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -448,7 +448,7 @@ pub trait PeripheralOutput: PeripheralSignal {
 }
 
 /// Trait implemented by pins which can be used as inputs.
-pub trait InputPin: Pin + PeripheralInput {
+pub trait InputPin: Pin + PeripheralInput + Into<AnyPin> + 'static {
     /// Listen for interrupts
     #[doc(hidden)]
     fn listen(&mut self, event: Event, _: private::Internal) {
@@ -519,7 +519,7 @@ pub trait InputPin: Pin + PeripheralInput {
 }
 
 /// Trait implemented by pins which can be used as outputs.
-pub trait OutputPin: Pin + PeripheralOutput {}
+pub trait OutputPin: Pin + PeripheralOutput + Into<AnyPin> + 'static {}
 
 /// Trait implemented by pins which can be used as analog pins
 pub trait AnalogPin: Pin {
@@ -1609,10 +1609,7 @@ impl<'d> Output<'d> {
     /// initial output-level and [Pull] configuration.
     #[inline]
     pub fn new(pin: impl Peripheral<P = impl OutputPin> + 'd, initial_output: Level) -> Self {
-        Self::new_typed(
-            pin.into_ref().degrade_pin(private::Internal),
-            initial_output,
-        )
+        Self::new_typed(pin.map_into(), initial_output)
     }
 }
 
@@ -1715,7 +1712,7 @@ impl<'d> Input<'d> {
     /// configuration.
     #[inline]
     pub fn new(pin: impl Peripheral<P = impl InputPin> + 'd, pull: Pull) -> Self {
-        Self::new_typed(pin.into_ref().degrade_pin(private::Internal), pull)
+        Self::new_typed(pin.map_into(), pull)
     }
 }
 
@@ -1817,11 +1814,7 @@ impl<'d> OutputOpenDrain<'d> {
         initial_output: Level,
         pull: Pull,
     ) -> Self {
-        Self::new_typed(
-            pin.into_ref().degrade_pin(private::Internal),
-            initial_output,
-            pull,
-        )
+        Self::new_typed(pin.map_into(), initial_output, pull)
     }
 }
 
@@ -1947,8 +1940,8 @@ impl<'d> Flex<'d> {
     /// Create flexible pin driver for a [Pin].
     /// No mode change happens.
     #[inline]
-    pub fn new(pin: impl Peripheral<P = impl Pin> + 'd) -> Self {
-        Self::new_typed(pin.into_ref().degrade_pin(private::Internal))
+    pub fn new(pin: impl Peripheral<P = impl Into<AnyPin>> + 'd) -> Self {
+        Self::new_typed(pin.map_into())
     }
 }
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -776,7 +776,7 @@ where
 {
     type P = GpioPin<GPIONUM>;
 
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         core::ptr::read(self as *const _)
     }
 }
@@ -1149,20 +1149,14 @@ macro_rules! gpio {
             /// Type-erased GPIO pin
             pub struct AnyPin(pub(crate) AnyPinInner);
 
-            impl AnyPin {
-                pub(crate) unsafe fn clone_unchecked(&self) -> Self {
+            impl $crate::peripheral::Peripheral for AnyPin {
+                type P = AnyPin;
+                unsafe fn clone_unchecked(&self) ->  Self {
                     match self.0 {
                         $(AnyPinInner::[<Gpio $gpionum >](_) => {
                             Self(AnyPinInner::[< Gpio $gpionum >](unsafe { GpioPin::steal() }))
                         })+
                     }
-                }
-            }
-
-            impl $crate::peripheral::Peripheral for AnyPin {
-                type P = AnyPin;
-                unsafe fn clone_unchecked(&mut self) ->  Self {
-                    AnyPin::clone_unchecked(self)
                 }
             }
 
@@ -1605,7 +1599,7 @@ impl<P> private::Sealed for Output<'_, P> {}
 
 impl<'d, P> Peripheral for Output<'d, P> {
     type P = P;
-    unsafe fn clone_unchecked(&mut self) -> P {
+    unsafe fn clone_unchecked(&self) -> P {
         self.pin.clone_unchecked()
     }
 }
@@ -1711,7 +1705,7 @@ impl<P> private::Sealed for Input<'_, P> {}
 
 impl<'d, P> Peripheral for Input<'d, P> {
     type P = P;
-    unsafe fn clone_unchecked(&mut self) -> P {
+    unsafe fn clone_unchecked(&self) -> P {
         self.pin.clone_unchecked()
     }
 }
@@ -1809,7 +1803,7 @@ impl<P> private::Sealed for OutputOpenDrain<'_, P> {}
 
 impl<'d, P> Peripheral for OutputOpenDrain<'d, P> {
     type P = P;
-    unsafe fn clone_unchecked(&mut self) -> P {
+    unsafe fn clone_unchecked(&self) -> P {
         self.pin.clone_unchecked()
     }
 }
@@ -1944,7 +1938,7 @@ impl<P> private::Sealed for Flex<'_, P> {}
 
 impl<'d, P> Peripheral for Flex<'d, P> {
     type P = P;
-    unsafe fn clone_unchecked(&mut self) -> P {
+    unsafe fn clone_unchecked(&self) -> P {
         core::ptr::read(&*self.pin as *const _)
     }
 }

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -10,7 +10,7 @@ use super::*;
 impl crate::peripheral::Peripheral for Level {
     type P = Self;
 
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         *self
     }
 }
@@ -96,7 +96,7 @@ pub struct NoPin;
 impl crate::peripheral::Peripheral for NoPin {
     type P = Self;
 
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         Self
     }
 }

--- a/esp-hal/src/interrupt/software.rs
+++ b/esp-hal/src/interrupt/software.rs
@@ -138,7 +138,7 @@ impl<const NUM: u8> crate::peripheral::Peripheral for SoftwareInterrupt<NUM> {
     type P = SoftwareInterrupt<NUM>;
 
     #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         Self::steal()
     }
 }

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -44,7 +44,7 @@ impl<'a, T> PeripheralRef<'a, T> {
     /// You should strongly prefer using `reborrow()` instead. It returns a
     /// `PeripheralRef` that borrows `self`, which allows the borrow checker
     /// to enforce this at compile time.
-    pub unsafe fn clone_unchecked(&mut self) -> PeripheralRef<'a, T>
+    pub unsafe fn clone_unchecked(&self) -> PeripheralRef<'a, T>
     where
         T: Peripheral<P = T>,
     {
@@ -155,14 +155,14 @@ pub trait Peripheral: Sized + crate::private::Sealed {
     /// You should strongly prefer using `into_ref()` instead. It returns a
     /// `PeripheralRef`, which allows the borrow checker to enforce this at
     /// compile time.
-    unsafe fn clone_unchecked(&mut self) -> Self::P;
+    unsafe fn clone_unchecked(&self) -> Self::P;
 
     /// Convert a value into a `PeripheralRef`.
     ///
     /// When called on an owned `T`, yields a `PeripheralRef<'static, T>`.
     /// When called on an `&'a mut T`, yields a `PeripheralRef<'a, T>`.
     #[inline]
-    fn into_ref<'a>(mut self) -> PeripheralRef<'a, Self::P>
+    fn into_ref<'a>(self) -> PeripheralRef<'a, Self::P>
     where
         Self: 'a,
     {
@@ -176,7 +176,7 @@ where
 {
     type P = P;
 
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         T::clone_unchecked(self)
     }
 }
@@ -316,7 +316,7 @@ mod peripheral_macros {
                 type P = $name;
 
                 #[inline]
-                unsafe fn clone_unchecked(&mut self) -> Self::P {
+                unsafe fn clone_unchecked(&self) -> Self::P {
                     Self::steal()
                 }
             }
@@ -374,7 +374,7 @@ mod peripheral_macros {
                 type P = $name;
 
                 #[inline]
-                unsafe fn clone_unchecked(&mut self) -> Self::P {
+                unsafe fn clone_unchecked(&self) -> Self::P {
                     Self::steal()
                 }
             }

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -168,6 +168,19 @@ pub trait Peripheral: Sized + crate::private::Sealed {
     {
         PeripheralRef::new(unsafe { self.clone_unchecked() })
     }
+
+    /// Map the peripheral using `Into`.
+    ///
+    /// This converts from `Peripheral<P = T>` to `Peripheral<P = U>`,
+    /// using an `Into` impl to convert from `T` to `U`.
+    #[inline]
+    fn map_into<U>(self) -> U
+    where
+        Self::P: Into<U>,
+        U: Peripheral<P = U>,
+    {
+        unsafe { self.clone_unchecked().into() }
+    }
 }
 
 impl<T, P> Peripheral for &mut T
@@ -281,6 +294,17 @@ mod peripheral_macros {
             $(
                 #[allow(unused_mut)]
                 let mut $name = $name.into_ref();
+            )*
+        }
+    }
+
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! into_mapped_ref {
+        ($($name:ident),*) => {
+            $(
+                #[allow(unused_mut)]
+                let mut $name = $name.map_into().into_ref();
             )*
         }
     }

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -461,7 +461,7 @@ impl Peripheral for AnyTimer {
     type P = Self;
 
     #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         core::ptr::read(self as *const _)
     }
 }

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -1003,7 +1003,7 @@ where
     type P = Self;
 
     #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         core::ptr::read(self as *const _)
     }
 }

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -591,7 +591,7 @@ where
     type P = Self;
 
     #[inline]
-    unsafe fn clone_unchecked(&mut self) -> Self::P {
+    unsafe fn clone_unchecked(&self) -> Self::P {
         core::ptr::read(self as *const _)
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This is lifted from embassy-hal-internal to make it a bit nicer to implement peripheral type erasure.
