### PR TITLE
Add an option to configure `WDT` action

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+Add an option to configure `WDT` action (#2330)
 
 - A new config option `PLACE_SWITCH_TABLES_IN_RAM` to improve performance (especially for interrupts) at the cost of slightly more RAM usage (#2331)
 - A new config option `PLACE_ANON_IN_RAM` to improve performance (especially for interrupts) at the cost of RAM usage (#2331)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-Add an option to configure `WDT` action (#2330)
-
 - A new config option `PLACE_SWITCH_TABLES_IN_RAM` to improve performance (especially for interrupts) at the cost of slightly more RAM usage (#2331)
 - A new config option `PLACE_ANON_IN_RAM` to improve performance (especially for interrupts) at the cost of RAM usage (#2331)
 - Add burst transfer support to DMA buffers (#2336)
@@ -23,6 +21,7 @@ Add an option to configure `WDT` action (#2330)
 - `Spi::half_duplex_read` and `Spi::half_duplex_write` (#2373)
 - `Cpu::COUNT` and `Cpu::current()` (#2411)
 - `UartInterrupt` and related functions (#2406)
+- Add an option to configure `WDT` action (#2330)
 
 ### Changed
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -509,7 +509,7 @@ pub fn init(config: Config) -> Peripherals {
     match config.watchdog.rwdt {
         WatchdogStatus::Enabled(duration) => {
             rtc.rwdt.enable();
-            rtc.rwdt.set_timeout(duration);
+            rtc.rwdt.set_timeout(0, duration).unwrap();
         }
         WatchdogStatus::Disabled => {
             rtc.rwdt.disable();
@@ -520,7 +520,7 @@ pub fn init(config: Config) -> Peripherals {
         WatchdogStatus::Enabled(duration) => {
             let mut timg0_wd = crate::timer::timg::Wdt::<self::peripherals::TIMG0>::new();
             timg0_wd.enable();
-            timg0_wd.set_timeout(duration);
+            timg0_wd.set_timeout(0, duration).unwrap();
         }
         WatchdogStatus::Disabled => {
             crate::timer::timg::Wdt::<self::peripherals::TIMG0>::new().disable();
@@ -532,7 +532,7 @@ pub fn init(config: Config) -> Peripherals {
         WatchdogStatus::Enabled(duration) => {
             let mut timg1_wd = crate::timer::timg::Wdt::<self::peripherals::TIMG1>::new();
             timg1_wd.enable();
-            timg1_wd.set_timeout(duration);
+            timg1_wd.set_timeout(0, duration).unwrap();
         }
         WatchdogStatus::Disabled => {
             crate::timer::timg::Wdt::<self::peripherals::TIMG1>::new().disable();

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -509,7 +509,8 @@ pub fn init(config: Config) -> Peripherals {
     match config.watchdog.rwdt {
         WatchdogStatus::Enabled(duration) => {
             rtc.rwdt.enable();
-            rtc.rwdt.set_timeout(0, duration).unwrap();
+            rtc.rwdt
+                .set_timeout(crate::rtc_cntl::RwdtStage::Stage0, duration);
         }
         WatchdogStatus::Disabled => {
             rtc.rwdt.disable();
@@ -520,7 +521,7 @@ pub fn init(config: Config) -> Peripherals {
         WatchdogStatus::Enabled(duration) => {
             let mut timg0_wd = crate::timer::timg::Wdt::<self::peripherals::TIMG0>::new();
             timg0_wd.enable();
-            timg0_wd.set_timeout(0, duration).unwrap();
+            timg0_wd.set_timeout(crate::timer::timg::MwdtStage::Stage0, duration);
         }
         WatchdogStatus::Disabled => {
             crate::timer::timg::Wdt::<self::peripherals::TIMG0>::new().disable();
@@ -532,7 +533,7 @@ pub fn init(config: Config) -> Peripherals {
         WatchdogStatus::Enabled(duration) => {
             let mut timg1_wd = crate::timer::timg::Wdt::<self::peripherals::TIMG1>::new();
             timg1_wd.enable();
-            timg1_wd.set_timeout(0, duration).unwrap();
+            timg1_wd.set_timeout(crate::timer::timg::MwdtStage::Stage0, duration);
         }
         WatchdogStatus::Disabled => {
             crate::timer::timg::Wdt::<self::peripherals::TIMG1>::new().disable();

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -523,7 +523,7 @@ pub fn init(config: Config) -> Peripherals {
             timg0_wd.set_timeout(duration);
         }
         WatchdogStatus::Disabled => {
-            // crate::timer::timg::Wdt::<self::peripherals::TIMG0>::new().disable();
+            crate::timer::timg::Wdt::<self::peripherals::TIMG0>::new().disable();
         }
     }
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -523,7 +523,7 @@ pub fn init(config: Config) -> Peripherals {
             timg0_wd.set_timeout(duration);
         }
         WatchdogStatus::Disabled => {
-            crate::timer::timg::Wdt::<self::peripherals::TIMG0>::new().disable();
+            // crate::timer::timg::Wdt::<self::peripherals::TIMG0>::new().disable();
         }
     }
 

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -915,14 +915,12 @@ impl Rwdt {
         rtc_cntl.wdtwprotect().write(|w| unsafe { w.bits(wkey) });
     }
 
-        let rtc_cntl = unsafe { lpwr() };
-        let rtc_cntl = unsafe { lp_wdt() };
     fn set_enabled(&mut self, enable: bool) {
         let rtc_cntl = unsafe { lp_wdt() };
 
         self.set_write_protection(false);
 
-        if !enabled {
+        if !enable {
             rtc_cntl.wdtconfig0().modify(|_, w| unsafe { w.bits(0) });
         } else {
             rtc_cntl
@@ -931,7 +929,7 @@ impl Rwdt {
 
             rtc_cntl
                 .wdtconfig0()
-                .modify(|_, w| w.wdt_en().bit(enabled).wdt_pause_in_slp().bit(enabled));
+                .modify(|_, w| w.wdt_en().bit(enable).wdt_pause_in_slp().bit(enable));
 
             // Apply default settings for WDT
             unsafe {

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -837,7 +837,7 @@ impl Rwdt {
     }
 
     /// Enable the watchdog timer instance.
-    /// Watchdog starts with default settings (`stage 0`` resets the system, the
+    /// Watchdog starts with default settings (`stage 0` resets the system, the
     /// others are deactivated)
     pub fn enable(&mut self) {
         self.set_enabled(true);

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -26,6 +26,7 @@
 //! # use esp_hal::delay::Delay;
 //! # use esp_hal::rtc_cntl::Rtc;
 //! # use esp_hal::rtc_cntl::Rwdt;
+//! # use esp_hal::rtc_cntl::RwdtStage;
 //! # use crate::esp_hal::InterruptConfigurable;
 //! static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 //! let mut delay = Delay::new();
@@ -33,7 +34,7 @@
 //! let mut rtc = Rtc::new(peripherals.LPWR);
 //!
 //! rtc.set_interrupt_handler(interrupt_handler);
-//! rtc.rwdt.set_timeout(0, 2000.millis());
+//! rtc.rwdt.set_timeout(RwdtStage::Stage0, 2000.millis());
 //! rtc.rwdt.listen();
 //!
 //! critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
@@ -44,6 +45,7 @@
 //!
 //! # use critical_section::Mutex;
 //! # use esp_hal::rtc_cntl::Rwdt;
+//! # use esp_hal::rtc_cntl::RwdtStage;
 //!
 //! static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 //!
@@ -59,7 +61,7 @@
 //!
 //!         // esp_println::println!("Restarting in 5 seconds...");
 //!
-//!         rwdt.set_timeout(0, 5000u64.millis());
+//!         rwdt.set_timeout(RwdtStage::Stage0, 5000u64.millis());
 //!         rwdt.unlisten();
 //!     });
 //! }

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -33,7 +33,7 @@
 //! let mut rtc = Rtc::new(peripherals.LPWR);
 //!
 //! rtc.set_interrupt_handler(interrupt_handler);
-//! rtc.rwdt.set_timeout(2000.millis());
+//! rtc.rwdt.set_timeout(0, 2000.millis());
 //! rtc.rwdt.listen();
 //!
 //! critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
@@ -59,7 +59,7 @@
 //!
 //!         // esp_println::println!("Restarting in 5 seconds...");
 //!
-//!         rwdt.set_timeout(5000u64.millis());
+//!         rwdt.set_timeout(0, 5000u64.millis());
 //!         rwdt.unlisten();
 //!     });
 //! }

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -54,7 +54,7 @@
 //! let timg0 = TimerGroup::new(peripherals.TIMG0);
 //! let mut wdt = timg0.wdt;
 //!
-//! wdt.set_timeout(5_000.millis());
+//! wdt.set_timeout(0, 5_000.millis());
 //! wdt.enable();
 //!
 //! loop {

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -983,18 +983,18 @@ where
         if !enabled {
             reg_block.wdtconfig0().write(|w| unsafe { w.bits(0) });
         } else {
+            reg_block.wdtconfig0().write(|w| w.wdt_en().bit(true));
+
             reg_block
                 .wdtconfig0()
                 .write(|w| w.wdt_flashboot_mod_en().bit(false));
-
-            reg_block.wdtconfig0().write(|w| w.wdt_en().bit(true));
 
             #[cfg_attr(esp32, allow(unused_unsafe))]
             reg_block.wdtconfig0().write(|w| unsafe {
                 w.wdt_en()
                     .bit(true)
                     .wdt_stg0()
-                    .bits(MwdtStageAction::Off as u8)
+                    .bits(MwdtStageAction::ResetSystem as u8)
                     .wdt_cpu_reset_length()
                     .bits(7)
                     .wdt_sys_reset_length()

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -50,11 +50,12 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::timer::timg::TimerGroup;
+//! # use esp_hal::timer::timg::MwdtStage;
 //!
 //! let timg0 = TimerGroup::new(peripherals.TIMG0);
 //! let mut wdt = timg0.wdt;
 //!
-//! wdt.set_timeout(0, 5_000.millis());
+//! wdt.set_timeout(MwdtStage::Stage0, 5_000.millis());
 //! wdt.enable();
 //!
 //! loop {

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -1082,6 +1082,11 @@ where
     }
 
     /// Set the stage action of the MWDT for a specific stage.
+    ///
+    /// This function modifies MWDT behavior only if a custom bootloader with
+    /// the following modifications is used:
+    /// - `ESP_TASK_WDT_EN` parameter **disabled**
+    /// - `ESP_INT_WDT` parameter **disabled**
     pub fn set_stage_action(
         &mut self,
         stage: usize,

--- a/examples/src/bin/rtc_watchdog.rs
+++ b/examples/src/bin/rtc_watchdog.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
     rtc.set_interrupt_handler(interrupt_handler);
 
     rtc.rwdt.enable();
-    rtc.rwdt.set_timeout(0, 2000.millis()).unwrap();
+    rtc.rwdt.set_timeout(0, 2.secs()).unwrap();
     rtc.rwdt.listen();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
@@ -49,7 +49,7 @@ fn interrupt_handler() {
 
         println!("Restarting in 5 seconds...");
 
-        rwdt.set_timeout(0, 5000.millis()).unwrap();
+        rwdt.set_timeout(0, 5.secs()).unwrap();
         rwdt.unlisten();
     });
 }

--- a/examples/src/bin/rtc_watchdog.rs
+++ b/examples/src/bin/rtc_watchdog.rs
@@ -16,7 +16,7 @@ use esp_backtrace as _;
 use esp_hal::{
     interrupt::Priority,
     prelude::*,
-    rtc_cntl::{Rtc, Rwdt},
+    rtc_cntl::{Rtc, Rwdt, RwdtStage},
 };
 use esp_println::println;
 
@@ -30,7 +30,7 @@ fn main() -> ! {
     rtc.set_interrupt_handler(interrupt_handler);
 
     rtc.rwdt.enable();
-    rtc.rwdt.set_timeout(0, 2.secs()).unwrap();
+    rtc.rwdt.set_timeout(RwdtStage::Stage0, 2.secs());
     rtc.rwdt.listen();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
@@ -49,7 +49,7 @@ fn interrupt_handler() {
 
         println!("Restarting in 5 seconds...");
 
-        rwdt.set_timeout(0, 5.secs()).unwrap();
+        rwdt.set_timeout(RwdtStage::Stage0, 5.secs());
         rwdt.unlisten();
     });
 }

--- a/examples/src/bin/rtc_watchdog.rs
+++ b/examples/src/bin/rtc_watchdog.rs
@@ -28,7 +28,9 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.LPWR);
     rtc.set_interrupt_handler(interrupt_handler);
-    rtc.rwdt.set_timeout(2000.millis());
+
+    rtc.rwdt.enable();
+    rtc.rwdt.set_timeout(0, 2000.millis()).unwrap();
     rtc.rwdt.listen();
 
     critical_section::with(|cs| RWDT.borrow_ref_mut(cs).replace(rtc.rwdt));
@@ -47,7 +49,7 @@ fn interrupt_handler() {
 
         println!("Restarting in 5 seconds...");
 
-        rwdt.set_timeout(5000.millis());
+        rwdt.set_timeout(0, 5000.millis()).unwrap();
         rwdt.unlisten();
     });
 }

--- a/examples/src/bin/watchdog.rs
+++ b/examples/src/bin/watchdog.rs
@@ -21,7 +21,7 @@ fn main() -> ! {
     let timg0 = TimerGroup::new_async(peripherals.TIMG0);
     let mut wdt0 = timg0.wdt;
     wdt0.enable();
-    wdt0.set_timeout(2u64.secs());
+    wdt0.set_timeout(0, 2u64.secs()).unwrap();
 
     loop {
         wdt0.feed();

--- a/examples/src/bin/watchdog.rs
+++ b/examples/src/bin/watchdog.rs
@@ -4,28 +4,53 @@
 //! `wdt.feed()` the watchdog will reset the system.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: esp-hal/log
 
 #![no_std]
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, prelude::*, timer::timg::TimerGroup};
+use esp_hal::{delay::Delay, prelude::*, timer::timg::TimerGroup, interrupt::Priority};
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
-    let peripherals = esp_hal::init(esp_hal::Config::default());
+    // let peripherals = esp_hal::init(esp_hal::Config::default());
+    let peripherals = esp_hal::init(esp_hal::Config{
+        watchdog: esp_hal::config::WatchdogConfig{
+            swd: false,
+            rwdt: esp_hal::config::WatchdogStatus::Disabled,
+            timg0: esp_hal::config::WatchdogStatus::Disabled,
+            timg1: esp_hal::config::WatchdogStatus::Disabled,
+            // timg0: esp_hal::config::WatchdogStatus::Enabled(2.secs()),
+            // ..Default::default()
+        },
+        ..Default::default()
+    });
 
     let delay = Delay::new();
 
-    let timg0 = TimerGroup::new_async(peripherals.TIMG0);
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
     let mut wdt0 = timg0.wdt;
     wdt0.enable();
-    wdt0.set_timeout(2u64.secs());
+    wdt0.set_timeout(2.secs());
+
+    // wdt0.set_stage_action(0, esp_hal::timer::timg::MwdtStageAction::Interrupt).unwrap();
+    // wdt0.set_interrupt_handler(interrupt_handler);
+
 
     loop {
-        wdt0.feed();
+        // wdt0.feed();
         println!("Hello world!");
         delay.delay(1.secs());
     }
+}
+
+#[handler(priority = Priority::min())]
+fn interrupt_handler() {
+    critical_section::with(|cs| {
+        println!("RWDT Interrupt");
+
+       panic!();
+    });
 }

--- a/examples/src/bin/watchdog.rs
+++ b/examples/src/bin/watchdog.rs
@@ -4,53 +4,28 @@
 //! `wdt.feed()` the watchdog will reset the system.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: esp-hal/log
 
 #![no_std]
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, prelude::*, timer::timg::TimerGroup, interrupt::Priority};
+use esp_hal::{delay::Delay, prelude::*, timer::timg::TimerGroup};
 use esp_println::println;
 
 #[entry]
 fn main() -> ! {
-    // let peripherals = esp_hal::init(esp_hal::Config::default());
-    let peripherals = esp_hal::init(esp_hal::Config{
-        watchdog: esp_hal::config::WatchdogConfig{
-            swd: false,
-            rwdt: esp_hal::config::WatchdogStatus::Disabled,
-            timg0: esp_hal::config::WatchdogStatus::Disabled,
-            timg1: esp_hal::config::WatchdogStatus::Disabled,
-            // timg0: esp_hal::config::WatchdogStatus::Enabled(2.secs()),
-            // ..Default::default()
-        },
-        ..Default::default()
-    });
+    let peripherals = esp_hal::init(esp_hal::Config::default());
 
     let delay = Delay::new();
 
-    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    let timg0 = TimerGroup::new_async(peripherals.TIMG0);
     let mut wdt0 = timg0.wdt;
     wdt0.enable();
-    wdt0.set_timeout(2.secs());
-
-    // wdt0.set_stage_action(0, esp_hal::timer::timg::MwdtStageAction::Interrupt).unwrap();
-    // wdt0.set_interrupt_handler(interrupt_handler);
-
+    wdt0.set_timeout(2u64.secs());
 
     loop {
-        // wdt0.feed();
+        wdt0.feed();
         println!("Hello world!");
         delay.delay(1.secs());
     }
-}
-
-#[handler(priority = Priority::min())]
-fn interrupt_handler() {
-    critical_section::with(|cs| {
-        println!("RWDT Interrupt");
-
-       panic!();
-    });
 }

--- a/examples/src/bin/watchdog.rs
+++ b/examples/src/bin/watchdog.rs
@@ -9,7 +9,11 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, prelude::*, timer::timg::TimerGroup};
+use esp_hal::{
+    delay::Delay,
+    prelude::*,
+    timer::timg::{MwdtStage, TimerGroup},
+};
 use esp_println::println;
 
 #[entry]
@@ -21,7 +25,7 @@ fn main() -> ! {
     let timg0 = TimerGroup::new_async(peripherals.TIMG0);
     let mut wdt0 = timg0.wdt;
     wdt0.enable();
-    wdt0.set_timeout(0, 2u64.secs()).unwrap();
+    wdt0.set_timeout(MwdtStage::Stage0, 2u64.secs());
 
     loop {
         wdt0.feed();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
close #1831

Also made some small improvements in code quality, aligned mode names with the official Espressif documentation

Currently, setting up MWDT stages is only possible with custom bootloader. Also, I think we should document the whole process of creating a custom bootloader and using it with our driver (I've opened an issue for this: https://github.com/esp-rs/esp-hal/issues/2424)

#### Testing
Used implemented function in example.
