### PR TITLE
Add burst transfer support to DMA buffers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add burst transfer support to DMA buffers (#2236)
 
 ### Changed
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1699,10 +1699,8 @@ where
     ) -> Result<(), DmaError> {
         let preparation = buffer.prepare();
 
-        // TODO: Get burst mode from DmaBuf.
-        if self.burst_mode {
-            return Err(DmaError::InvalidAlignment);
-        }
+        self.rx_impl
+            .set_burst_mode(self.burst_mode && preparation.is_burstable);
 
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
 
@@ -1912,13 +1910,15 @@ where
                     self.set_ext_mem_block_size(block_size.into());
                 }
             } else {
-                // we insure that block_size is some only for PSRAM addresses
+                // we ensure that block_size is some only for PSRAM addresses
                 if preparation.block_size.is_some() {
                     return Err(DmaError::UnsupportedMemoryRegion);
                 }
             }
         );
-        // TODO: Get burst mode from DmaBuf.
+
+        self.tx_impl
+            .set_burst_mode(self.burst_mode && preparation.is_burstable);
 
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds a `is_burstable` to `Preparation`, allowing DMA buffer implementations to declare whether they conform to the alignment required for burst transfers.

#### Testing
HIL tests
