### PR TITLE
Expose LCD_CAM interrupt bits

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Expose LCD_CAM interrupt bits (#2338)
 
 ### Changed
+- Async I8080 driver is now created with `into_async()` (#2338)
 
 ### Fixed
 

--- a/esp-hal/src/lcd_cam/lcd/mod.rs
+++ b/esp-hal/src/lcd_cam/lcd/mod.rs
@@ -15,12 +15,9 @@ use crate::{peripheral::PeripheralRef, peripherals::LCD_CAM};
 pub mod i8080;
 
 /// Represents an LCD interface.
-pub struct Lcd<'d, DM: crate::Mode> {
+pub struct Lcd<'d> {
     /// The `LCD_CAM` peripheral reference for managing the LCD functionality.
     pub(crate) lcd_cam: PeripheralRef<'d, LCD_CAM>,
-
-    /// A marker for the mode of operation (blocking or asynchronous).
-    pub(crate) _mode: core::marker::PhantomData<DM>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/esp-hal/src/lcd_cam/lcd/mod.rs
+++ b/esp-hal/src/lcd_cam/lcd/mod.rs
@@ -10,14 +10,17 @@
 //! ## Implementation State
 //! - RGB is not supported yet
 
+use core::marker::PhantomData;
+
 use crate::{peripheral::PeripheralRef, peripherals::LCD_CAM};
 
 pub mod i8080;
 
 /// Represents an LCD interface.
-pub struct Lcd<'d> {
+pub struct Lcd<'d, M> {
     /// The `LCD_CAM` peripheral reference for managing the LCD functionality.
     pub(crate) lcd_cam: PeripheralRef<'d, LCD_CAM>,
+    pub(super) mode: PhantomData<M>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/hil-test/tests/lcd_cam_i8080_async.rs
+++ b/hil-test/tests/lcd_cam_i8080_async.rs
@@ -59,7 +59,7 @@ mod tests {
             20.MHz(),
             Config::default(),
         )
-        .into_async(ctx.lcd_cam.interrupts);
+        .into_async();
 
         let mut transfer = i8080.send(Command::<u8>::None, 0, ctx.dma_buf).unwrap();
 
@@ -86,7 +86,7 @@ mod tests {
             20.MHz(),
             Config::default(),
         )
-        .into_async(ctx.lcd_cam.interrupts);
+        .into_async();
 
         let mut transfer = i8080.send(Command::<u8>::None, 0, ctx.dma_buf).unwrap();
 

--- a/hil-test/tests/lcd_cam_i8080_async.rs
+++ b/hil-test/tests/lcd_cam_i8080_async.rs
@@ -21,7 +21,7 @@ use hil_test as _;
 const DATA_SIZE: usize = 1024 * 10;
 
 struct Context<'d> {
-    lcd_cam: LcdCam<'d, esp_hal::Async>,
+    lcd_cam: LcdCam<'d>,
     dma: Dma<'d>,
     dma_buf: DmaTxBuf,
 }
@@ -36,7 +36,7 @@ mod tests {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
         let dma = Dma::new(peripherals.DMA);
-        let lcd_cam = LcdCam::new_async(peripherals.LCD_CAM);
+        let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
         let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, DATA_SIZE);
         let dma_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
 
@@ -58,7 +58,8 @@ mod tests {
             pins,
             20.MHz(),
             Config::default(),
-        );
+        )
+        .into_async(ctx.lcd_cam.interrupts);
 
         let mut transfer = i8080.send(Command::<u8>::None, 0, ctx.dma_buf).unwrap();
 
@@ -84,7 +85,8 @@ mod tests {
             pins,
             20.MHz(),
             Config::default(),
-        );
+        )
+        .into_async(ctx.lcd_cam.interrupts);
 
         let mut transfer = i8080.send(Command::<u8>::None, 0, ctx.dma_buf).unwrap();
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The main goal of this PR was to expose a separate object for accessing the interrupt bits of the LCD_CAM.
Other drivers in the hal (like DMA and SPI) expose `listen`, `unlisten`, `clear`, etc. directly on the driver objects themselves, which means you have to put the entire driver in a critical section just because you want to clear some interrupts.
Having a separate object means you can keep your driver wherever and this separate object can go in the critical section.
Having a separate object also gives you the freedom to implement async for both the camera and lcd as necessary, with any locking mechanism of your choosing.

As a consequence of having this separate object, it now needs to be provided to create an async driver. So I've also provided an `into_async()` and `into_blocking()` to allow users to switch between the default async implementation and theirs when necessary. 

Ideally the whole `set_interrupt_handler` business should be moved out of the driver file and into a chip specific "interrupt driver" but I'm not about to commit to sort of change in this PR.

Related #2321 .

#### Testing
(pending)
