### PR TITLE
Automatically add `rom_functions.x` to the linker scripts

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -152,6 +152,9 @@ octal-psram = []
 # This feature is intended for testing; you probably don't want to enable it:
 ci = ["defmt", "bluetooth"]
 
+# Internal feature set by esp-wifi
+__include_rom_functions = []
+
 [lints.clippy]
 mixed_attributes_style = "allow"
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -89,6 +89,7 @@ usb-otg = ["dep:embassy-usb-driver", "dep:embassy-usb-synopsys-otg", "dep:esp-sy
 
 __esp_hal_embassy = []
 __include_rom_functions = []
+__include_rom_coexist_and_phy = []
 
 ## Enable debug features in the HAL (used for development).
 debug = [

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -88,6 +88,7 @@ bluetooth = []
 usb-otg = ["dep:embassy-usb-driver", "dep:embassy-usb-synopsys-otg", "dep:esp-synopsys-usb-otg", "dep:usb-device"]
 
 __esp_hal_embassy = []
+__include_rom_functions = []
 
 ## Enable debug features in the HAL (used for development).
 debug = [
@@ -151,9 +152,6 @@ octal-psram = []
 
 # This feature is intended for testing; you probably don't want to enable it:
 ci = ["defmt", "bluetooth"]
-
-# Internal feature set by esp-wifi
-__include_rom_functions = []
 
 [lints.clippy]
 mixed_attributes_style = "allow"

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -74,6 +74,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     #[cfg(feature = "flip-link")]
     config_symbols.push("flip-link");
 
+    #[cfg(feature = "__include_rom_functions")]
+    config_symbols.push("__include_rom_functions");
+
     // Place all linker scripts in `OUT_DIR`, and instruct Cargo how to find these
     // files:
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/esp-hal/ld/esp32/linkall.x
+++ b/esp-hal/ld/esp32/linkall.x
@@ -3,3 +3,7 @@ INCLUDE "alias.x"
 INCLUDE "esp32.x"
 INCLUDE "hal-defaults.x"
 INCLUDE "rom-functions.x"
+
+#IF __include_rom_functions
+    INCLUDE "rom_functions.x"
+#ENDIF

--- a/esp-hal/ld/esp32/linkall.x
+++ b/esp-hal/ld/esp32/linkall.x
@@ -7,3 +7,8 @@ INCLUDE "rom-functions.x"
 #IF __include_rom_functions
     INCLUDE "rom_functions.x"
 #ENDIF
+
+#IF __include_rom_coexist_and_phy
+    INCLUDE "rom_coexist.x"
+    INCLUDE "rom_phy.x"
+#ENDIF

--- a/esp-hal/ld/esp32c2/linkall.x
+++ b/esp-hal/ld/esp32c2/linkall.x
@@ -9,3 +9,7 @@ REGION_ALIAS("RWTEXT", IRAM);
 INCLUDE "esp32c2.x"
 INCLUDE "hal-defaults.x"
 INCLUDE "rom-functions.x"
+
+#IF __include_rom_functions
+    INCLUDE "rom_functions.x"
+#ENDIF

--- a/esp-hal/ld/esp32c2/linkall.x
+++ b/esp-hal/ld/esp32c2/linkall.x
@@ -13,3 +13,8 @@ INCLUDE "rom-functions.x"
 #IF __include_rom_functions
     INCLUDE "rom_functions.x"
 #ENDIF
+
+#IF __include_rom_coexist_and_phy
+    INCLUDE "rom_coexist.x"
+    INCLUDE "rom_phy.x"
+#ENDIF

--- a/esp-hal/ld/esp32c3/linkall.x
+++ b/esp-hal/ld/esp32c3/linkall.x
@@ -16,3 +16,8 @@ INCLUDE "rom-functions.x"
 #IF __include_rom_functions
     INCLUDE "rom_functions.x"
 #ENDIF
+
+#IF __include_rom_coexist_and_phy
+    INCLUDE "rom_coexist.x"
+    INCLUDE "rom_phy.x"
+#ENDIF

--- a/esp-hal/ld/esp32c3/linkall.x
+++ b/esp-hal/ld/esp32c3/linkall.x
@@ -12,3 +12,7 @@ REGION_ALIAS("RTC_FAST_RWDATA", RTC_FAST);
 INCLUDE "esp32c3.x"
 INCLUDE "hal-defaults.x"
 INCLUDE "rom-functions.x"
+
+#IF __include_rom_functions
+    INCLUDE "rom_functions.x"
+#ENDIF

--- a/esp-hal/ld/esp32c6/linkall.x
+++ b/esp-hal/ld/esp32c6/linkall.x
@@ -16,3 +16,8 @@ INCLUDE "rom-functions.x"
 #IF __include_rom_functions
     INCLUDE "rom_functions.x"
 #ENDIF
+
+#IF __include_rom_coexist_and_phy
+    INCLUDE "rom_coexist.x"
+    INCLUDE "rom_phy.x"
+#ENDIF

--- a/esp-hal/ld/esp32c6/linkall.x
+++ b/esp-hal/ld/esp32c6/linkall.x
@@ -12,3 +12,7 @@ REGION_ALIAS("RTC_FAST_RWDATA", RTC_FAST);
 INCLUDE "esp32c6.x"
 INCLUDE "hal-defaults.x"
 INCLUDE "rom-functions.x"
+
+#IF __include_rom_functions
+    INCLUDE "rom_functions.x"
+#ENDIF

--- a/esp-hal/ld/esp32h2/linkall.x
+++ b/esp-hal/ld/esp32h2/linkall.x
@@ -16,3 +16,8 @@ INCLUDE "rom-functions.x"
 #IF __include_rom_functions
     INCLUDE "rom_functions.x"
 #ENDIF
+
+#IF __include_rom_coexist_and_phy
+    INCLUDE "rom_coexist.x"
+    INCLUDE "rom_phy.x"
+#ENDIF

--- a/esp-hal/ld/esp32h2/linkall.x
+++ b/esp-hal/ld/esp32h2/linkall.x
@@ -12,3 +12,7 @@ REGION_ALIAS("RTC_FAST_RWDATA", RTC_FAST);
 INCLUDE "esp32h2.x"
 INCLUDE "hal-defaults.x"
 INCLUDE "rom-functions.x"
+
+#IF __include_rom_functions
+    INCLUDE "rom_functions.x"
+#ENDIF

--- a/esp-hal/ld/esp32s2/linkall.x
+++ b/esp-hal/ld/esp32s2/linkall.x
@@ -7,3 +7,8 @@ INCLUDE "rom-functions.x"
 #IF __include_rom_functions
     INCLUDE "rom_functions.x"
 #ENDIF
+
+#IF __include_rom_coexist_and_phy
+    INCLUDE "rom_coexist.x"
+    INCLUDE "rom_phy.x"
+#ENDIF

--- a/esp-hal/ld/esp32s2/linkall.x
+++ b/esp-hal/ld/esp32s2/linkall.x
@@ -3,3 +3,7 @@ INCLUDE "alias.x"
 INCLUDE "esp32s2.x"
 INCLUDE "hal-defaults.x"
 INCLUDE "rom-functions.x"
+
+#IF __include_rom_functions
+    INCLUDE "rom_functions.x"
+#ENDIF

--- a/esp-hal/ld/esp32s3/linkall.x
+++ b/esp-hal/ld/esp32s3/linkall.x
@@ -3,3 +3,7 @@ INCLUDE "alias.x"
 INCLUDE "esp32s3.x"
 INCLUDE "hal-defaults.x"
 INCLUDE "rom-functions.x"
+
+#IF __include_rom_functions
+    INCLUDE "rom_functions.x"
+#ENDIF

--- a/esp-hal/ld/esp32s3/linkall.x
+++ b/esp-hal/ld/esp32s3/linkall.x
@@ -7,3 +7,8 @@ INCLUDE "rom-functions.x"
 #IF __include_rom_functions
     INCLUDE "rom_functions.x"
 #ENDIF
+
+#IF __include_rom_coexist_and_phy
+    INCLUDE "rom_coexist.x"
+    INCLUDE "rom_phy.x"
+#ENDIF

--- a/esp-ieee802154/CHANGELOG.md
+++ b/esp-ieee802154/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Automatically include the necessary linker scripts (#2339)
+
 ### Fixed
 
 ### Removed

--- a/esp-ieee802154/Cargo.toml
+++ b/esp-ieee802154/Cargo.toml
@@ -19,7 +19,7 @@ test  = false
 byte              = "0.2.7"
 critical-section  = "1.1.3"
 document-features = "0.2.10"
-esp-hal           = { version = "0.21.0", path = "../esp-hal" }
+esp-hal           = { version = "0.21.0", default-features = false, features = ["__include_rom_functions", "__include_rom_coexist_and_phy"], path = "../esp-hal" }
 esp-wifi-sys = { version = "0.6.0" }
 heapless          = "0.8.0"
 ieee802154        = "0.6.1"

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- No need to manually add `rom_functions.x` to the linker scripts (#2339)
+
 ### Fixed
 
 ### Removed

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -17,7 +17,7 @@ defmt = { version = "0.3.8", optional = true }
 log = { version = "0.4.22", optional = true }
 document-features  = "0.2.10"
 esp-alloc = { version = "0.5.0", path = "../esp-alloc", optional = true }
-esp-hal = { version = "0.21.0", path = "../esp-hal", default-features = false }
+esp-hal = { version = "0.21.0", path = "../esp-hal", default-features = false, features = ["__include_rom_functions"] }
 smoltcp = { version = "0.11.0", default-features = false, features = [
   "medium-ethernet",
   "socket-raw",

--- a/esp-wifi/MIGRATING-0.10.md
+++ b/esp-wifi/MIGRATING-0.10.md
@@ -1,1 +1,16 @@
 # Migration Guide from 0.10.x to v0.11.x
+
+## No need to add `rom_functions.x`
+
+Don't add `rom_functions.x` manually in `build.rs` or `config.toml`
+
+`build.rs`
+```diff
+- println!("cargo::rustc-link-arg=-Trom_functions.x");
+```
+
+`config.toml`
+```diff
+-     "-C", "link-arg=-Trom_functions.x",
+```
+

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -25,22 +25,6 @@
 //! features = ["esp32s3", "wifi", "esp-now"]
 //! ```
 //!
-//! ### Link configuration
-//!
-//! Make sure to include the rom functions for your target:
-//!
-//! ```toml
-//! # .cargo/config.toml
-//! rustflags = [
-//!     "-C", "link-arg=-Tlinkall.x",
-//!     "-C", "link-arg=-Trom_functions.x",
-//! ]
-//! ```
-//!
-//! At the time of writing, you will already have the `linkall` flag if you used
-//! `cargo generate`. Generating from a template does not include the
-//! `rom_functions` flag.
-//!
 //! ### Optimization Level
 //!
 //! It is necessary to build with optimization level 2 or 3 since otherwise, it

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,11 +1,4 @@
 fn main() {
-    if cfg!(feature = "esp32c6") || cfg!(feature = "esp32h2") {
-        // TODO this shouldn't be required to be done by the user but done in `linkall.x`
-        println!("cargo::rustc-link-arg=-Trom_coexist.x");
-        println!("cargo::rustc-link-arg=-Trom_functions.x");
-        println!("cargo::rustc-link-arg=-Trom_phy.x");
-    }
-
     // Allow building examples in CI in debug mode
     println!("cargo:rustc-check-cfg=cfg(is_not_release)");
     println!("cargo:rerun-if-env-changed=CI");

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     if cfg!(feature = "esp32c6") || cfg!(feature = "esp32h2") {
+        // TODO this shouldn't be required to be done by the user but done in `linkall.x`
         println!("cargo::rustc-link-arg=-Trom_coexist.x");
         println!("cargo::rustc-link-arg=-Trom_functions.x");
         println!("cargo::rustc-link-arg=-Trom_phy.x");

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -5,10 +5,6 @@ fn main() {
         println!("cargo::rustc-link-arg=-Trom_phy.x");
     }
 
-    if cfg!(feature = "esp-wifi") {
-        println!("cargo::rustc-link-arg=-Trom_functions.x");
-    }
-
     // Allow building examples in CI in debug mode
     println!("cargo:rustc-check-cfg=cfg(is_not_release)");
     println!("cargo:rerun-if-env-changed=CI");

--- a/hil-test/build.rs
+++ b/hil-test/build.rs
@@ -37,9 +37,5 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Define all necessary configuration symbols for the configured device:
     config.define_symbols();
 
-    if cfg!(feature = "esp-wifi") {
-        println!("cargo::rustc-link-arg=-Trom_functions.x");
-    }
-
     Ok(())
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Don't require users to manually add `rom_functions.x` when using `esp-wifi`

`esp-hal` now includes a (private) feature to do that. It's automatically activated by `esp-wifi` since we depend on `esp-hal` anyways

`skip-changelog` because of the added private feature in esp-hal

#### Testing
Examples still work. Apparently adding it manually in addition is not a problem (for lld .... but it is for gnu-ld)
