### PR TITLE
feat(esp-wifi): Implement `serde:{Deserialize, Serialize}` for wifi structs

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `serde` support through the `serde` feature (#2346)
+
 ### Changed
 
 ### Fixed

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -32,7 +32,6 @@ heapless = { version = "0.8.0", default-features = false, features = [
 ] }
 num-derive = { version = "0.4.2" }
 num-traits = { version = "0.2.19", default-features = false }
-no-std-net = { version = "0.6.0", optional = true }
 esp-wifi-sys = { version = "0.6.0" }
 embassy-sync = { version = "0.6.0", optional = true }
 embassy-net-driver = { version = "0.2.0", optional = true }
@@ -45,6 +44,7 @@ bt-hci = { version = "0.1.1", optional = true }
 esp-config = { version = "0.1.0", path = "../esp-config" }
 
 xtensa-lx-rt = { version = "0.17.1", path = "../xtensa-lx-rt", optional = true }
+serde = { version = "1.0.210", default-features = false, features = ["derive"], optional = true }
 
 [build-dependencies]
 esp-build    = { version = "0.1.0", path = "../esp-build" }
@@ -126,7 +126,7 @@ smoltcp = ["dep:smoltcp"]
 utils = ["smoltcp"]
 
 ## Enable WiFi support
-wifi = ["dep:enumset", "dep:no-std-net"]
+wifi = ["dep:enumset"]
 
 ## Enable BLE support
 ble = ["esp-hal/bluetooth"]
@@ -181,6 +181,9 @@ sniffer = ["wifi"]
 
 # Don't include `strchr` - not shown in docs
 have-strchr = []
+
+# Implement serde Serialize / Deserialize
+serde = ["dep:serde"]
 
 [package.metadata.docs.rs]
 features = [

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -183,7 +183,7 @@ sniffer = ["wifi"]
 have-strchr = []
 
 # Implement serde Serialize / Deserialize
-serde = ["dep:serde"]
+serde = ["dep:serde", "enumset?/serde", "heapless/serde"]
 
 [package.metadata.docs.rs]
 features = [

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -55,6 +55,8 @@ pub(crate) use os_adapter::*;
 #[cfg(feature = "sniffer")]
 use portable_atomic::AtomicBool;
 use portable_atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "smoltcp")]
 use smoltcp::phy::{Device, DeviceCapabilities, RxToken, TxToken};
 pub use state::*;
@@ -142,6 +144,7 @@ use crate::{
 
 #[derive(EnumSetType, Debug, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Default)]
 pub enum AuthMethod {
     None,
@@ -158,6 +161,7 @@ pub enum AuthMethod {
 
 #[derive(EnumSetType, Debug, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Default)]
 pub enum Protocol {
     P802D11B,
@@ -171,6 +175,7 @@ pub enum Protocol {
 
 #[derive(EnumSetType, Debug, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Default)]
 pub enum SecondaryChannel {
     // TODO: Need to extend that for 5GHz
@@ -182,6 +187,7 @@ pub enum SecondaryChannel {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct AccessPointInfo {
     pub ssid: heapless::String<32>,
     pub bssid: [u8; 6],
@@ -195,6 +201,7 @@ pub struct AccessPointInfo {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct AccessPointConfiguration {
     pub ssid: heapless::String<32>,
     pub ssid_hidden: bool,
@@ -224,6 +231,7 @@ impl Default for AccessPointConfiguration {
 
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ClientConfiguration {
     pub ssid: heapless::String<32>,
     pub bssid: Option<[u8; 6]>,
@@ -258,6 +266,7 @@ impl Default for ClientConfiguration {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EapFastConfig {
     pub fast_provisioning: u8,
     pub fast_max_pac_list_len: u8,
@@ -266,6 +275,7 @@ pub struct EapFastConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum TtlsPhase2Method {
     Eap,
     Mschapv2,
@@ -298,6 +308,7 @@ impl TtlsPhase2Method {
 
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EapClientConfiguration {
     pub ssid: heapless::String<32>,
     pub bssid: Option<[u8; 6]>,
@@ -363,6 +374,7 @@ impl Default for EapClientConfiguration {
 
 #[derive(EnumSetType, Debug, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Capability {
     Client,
     AccessPoint,
@@ -371,6 +383,7 @@ pub enum Capability {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Default)]
 #[allow(clippy::large_enum_variant)]
 pub enum Configuration {
@@ -379,6 +392,7 @@ pub enum Configuration {
     Client(ClientConfiguration),
     AccessPoint(AccessPointConfiguration),
     Mixed(ClientConfiguration, AccessPointConfiguration),
+    #[cfg_attr(feature = "serde", serde(skip))]
     EapClient(EapClientConfiguration),
 }
 
@@ -471,12 +485,15 @@ impl Configuration {
 }
 
 pub mod ipv4 {
+    pub use core::net::Ipv4Addr;
     use core::{fmt::Display, str::FromStr};
 
-    pub use no_std_net::*;
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub struct Mask(pub u8);
 
     impl FromStr for Mask {
@@ -536,6 +553,7 @@ pub mod ipv4 {
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub struct Subnet {
         #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
         pub gateway: Ipv4Addr,
@@ -571,6 +589,7 @@ pub mod ipv4 {
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub struct ClientSettings {
         #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
         pub ip: Ipv4Addr,
@@ -597,12 +616,14 @@ pub mod ipv4 {
 
     #[derive(Default, Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub struct DHCPClientSettings {
         pub hostname: Option<heapless::String<30>>,
     }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub enum ClientConfiguration {
         DHCP(DHCPClientSettings),
         Fixed(ClientSettings),
@@ -635,6 +656,7 @@ pub mod ipv4 {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub struct RouterConfiguration {
         pub subnet: Subnet,
         pub dhcp_enabled: bool,
@@ -660,6 +682,7 @@ pub mod ipv4 {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub enum Configuration {
         Client(ClientConfiguration),
         Router(RouterConfiguration),
@@ -673,6 +696,7 @@ pub mod ipv4 {
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub struct IpInfo {
         #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
         pub ip: Ipv4Addr,
@@ -723,6 +747,7 @@ impl AuthMethodExt for AuthMethod {
 /// Wifi Mode (Sta and/or Ap)
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum WifiMode {
     Sta,
     Ap,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Since support for `embedded-svc` was dropped in https://github.com/esp-rs/esp-hal/commit/fd57488ce37bc2eb5db4f725f47e894af36bd162, code that previously relied on those traits can migrate to the equivalent from `esp-wifi`. Except that traits in `embedded-svc` implement `serde::{Serialize, Deserialize}`, so it was not a drop-in equivalent. This PR adds this functionality.

- Since `no-std-net` is currently broken when building with serde (See: https://github.com/dunmatt/no-std-net/issues/15), I decided to remove it and use `core::net` types instead.
- `EapClientConfiguration` uses `'static` as lifetimes, so I had to use `#[serde(skip)]` for it. If a `'static` lifetime isn't a strict requirement, it would be easier to loosen the lifetime.

#### Testing
I tested in a custom app I'm developing that this works as a drop-in replacement after implementing the serde traits.