### PR TITLE
Make our nightly CI checks pass

### DIFF
--- a/esp-hal/src/aes/esp32cX.rs
+++ b/esp-hal/src/aes/esp32cX.rs
@@ -3,7 +3,7 @@ use crate::{
     system::{Peripheral as PeripheralEnable, PeripheralClockControl},
 };
 
-impl<'d> Aes<'d> {
+impl Aes<'_> {
     pub(super) fn init(&mut self) {
         PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_dma(false);

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -301,13 +301,13 @@ pub mod dma {
         }
     }
 
-    impl<'d> core::fmt::Debug for AesDma<'d> {
+    impl core::fmt::Debug for AesDma<'_> {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             f.debug_struct("AesDma").finish()
         }
     }
 
-    impl<'d> DmaSupport for AesDma<'d> {
+    impl DmaSupport for AesDma<'_> {
         fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
             while self.aes.aes.state().read().state().bits() != 2 // DMA status DONE == 2
             && !self.channel.tx.is_done()
@@ -347,7 +347,7 @@ pub mod dma {
         }
     }
 
-    impl<'d> AesDma<'d> {
+    impl AesDma<'_> {
         /// Writes the encryption key to the AES hardware, checking that its
         /// length matches expected constraints.
         pub fn write_key<K>(&mut self, key: K)

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -530,8 +530,8 @@ impl super::AdcCalEfuse for crate::peripherals::ADC2 {
     }
 }
 
-impl<'d, ADCI, PIN, CS> embedded_hal_02::adc::OneShot<ADCI, u16, super::AdcPin<PIN, ADCI, CS>>
-    for Adc<'d, ADCI>
+impl<ADCI, PIN, CS> embedded_hal_02::adc::OneShot<ADCI, u16, super::AdcPin<PIN, ADCI, CS>>
+    for Adc<'_, ADCI>
 where
     PIN: embedded_hal_02::adc::Channel<ADCI, ID = u8> + super::AdcChannel,
     ADCI: RegisterAccess,

--- a/esp-hal/src/assist_debug.rs
+++ b/esp-hal/src/assist_debug.rs
@@ -228,7 +228,7 @@ impl<'d> DebugAssist<'d> {
 }
 
 #[cfg(assist_debug_region_monitor)]
-impl<'d> DebugAssist<'d> {
+impl DebugAssist<'_> {
     /// Enable region monitoring of read/write performed by the main CPU in a
     /// certain memory region0. Whenever the bus reads or writes in the
     /// specified memory region, an interrupt will be triggered. Two memory

--- a/esp-hal/src/assist_debug.rs
+++ b/esp-hal/src/assist_debug.rs
@@ -47,9 +47,9 @@ impl<'d> DebugAssist<'d> {
     }
 }
 
-impl<'d> crate::private::Sealed for DebugAssist<'d> {}
+impl crate::private::Sealed for DebugAssist<'_> {}
 
-impl<'d> InterruptConfigurable for DebugAssist<'d> {
+impl InterruptConfigurable for DebugAssist<'_> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         unsafe {
             crate::interrupt::bind_interrupt(
@@ -66,7 +66,7 @@ impl<'d> InterruptConfigurable for DebugAssist<'d> {
 }
 
 #[cfg(assist_debug_sp_monitor)]
-impl<'d> DebugAssist<'d> {
+impl DebugAssist<'_> {
     /// Enable SP monitoring on main core. When the SP exceeds the
     /// `lower_bound` or `upper_bound` threshold, the module will record the PC
     /// pointer and generate an interrupt.

--- a/esp-hal/src/dma/m2m.rs
+++ b/esp-hal/src/dma/m2m.rs
@@ -157,7 +157,7 @@ where
     }
 }
 
-impl<'d, MODE> DmaSupport for Mem2Mem<'d, MODE>
+impl<MODE> DmaSupport for Mem2Mem<'_, MODE>
 where
     MODE: Mode,
 {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -731,6 +731,7 @@ macro_rules! dma_tx_buffer {
 
 /// Convenience macro to create a [DmaRxStreamBuf] from buffer size and
 /// optional chunk size (uses max if unspecified).
+///
 /// The buffer and descriptors are statically allocated and
 /// used to create the [DmaRxStreamBuf].
 ///
@@ -1648,9 +1649,9 @@ where
     }
 }
 
-impl<'a, CH> crate::private::Sealed for ChannelRx<'a, CH> where CH: DmaChannel {}
+impl<CH> crate::private::Sealed for ChannelRx<'_, CH> where CH: DmaChannel {}
 
-impl<'a, CH> Rx for ChannelRx<'a, CH>
+impl<CH> Rx for ChannelRx<'_, CH>
 where
     CH: DmaChannel,
 {
@@ -1866,9 +1867,9 @@ where
     }
 }
 
-impl<'a, CH> crate::private::Sealed for ChannelTx<'a, CH> where CH: DmaChannel {}
+impl<CH> crate::private::Sealed for ChannelTx<'_, CH> where CH: DmaChannel {}
 
-impl<'a, CH> Tx for ChannelTx<'a, CH>
+impl<CH> Tx for ChannelTx<'_, CH>
 where
     CH: DmaChannel,
 {
@@ -2069,7 +2070,7 @@ where
     phantom: PhantomData<MODE>,
 }
 
-impl<'d, C> Channel<'d, C, crate::Blocking>
+impl<C> Channel<'_, C, crate::Blocking>
 where
     C: DmaChannel,
 {
@@ -2228,7 +2229,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferTx<'a, I>
+impl<I> Drop for DmaTransferTx<'_, I>
 where
     I: dma_private::DmaSupportTx,
 {
@@ -2281,7 +2282,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferRx<'a, I>
+impl<I> Drop for DmaTransferRx<'_, I>
 where
     I: dma_private::DmaSupportRx,
 {
@@ -2340,7 +2341,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferRxTx<'a, I>
+impl<I> Drop for DmaTransferRxTx<'_, I>
 where
     I: dma_private::DmaSupportTx + dma_private::DmaSupportRx,
 {
@@ -2413,7 +2414,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferTxCircular<'a, I>
+impl<I> Drop for DmaTransferTxCircular<'_, I>
 where
     I: dma_private::DmaSupportTx,
 {
@@ -2470,7 +2471,7 @@ where
     }
 }
 
-impl<'a, I> Drop for DmaTransferRxCircular<'a, I>
+impl<I> Drop for DmaTransferRxCircular<'_, I>
 where
     I: dma_private::DmaSupportRx,
 {
@@ -2501,7 +2502,7 @@ pub(crate) mod asynch {
         }
     }
 
-    impl<'a, TX> core::future::Future for DmaTxFuture<'a, TX>
+    impl<TX> core::future::Future for DmaTxFuture<'_, TX>
     where
         TX: Tx,
     {
@@ -2530,7 +2531,7 @@ pub(crate) mod asynch {
         }
     }
 
-    impl<'a, TX> Drop for DmaTxFuture<'a, TX>
+    impl<TX> Drop for DmaTxFuture<'_, TX>
     where
         TX: Tx,
     {
@@ -2557,7 +2558,7 @@ pub(crate) mod asynch {
         }
     }
 
-    impl<'a, RX> core::future::Future for DmaRxFuture<'a, RX>
+    impl<RX> core::future::Future for DmaRxFuture<'_, RX>
     where
         RX: Rx,
     {
@@ -2590,7 +2591,7 @@ pub(crate) mod asynch {
         }
     }
 
-    impl<'a, RX> Drop for DmaRxFuture<'a, RX>
+    impl<RX> Drop for DmaRxFuture<'_, RX>
     where
         RX: Rx,
     {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2624,7 +2624,7 @@ pub(crate) mod asynch {
     }
 
     #[cfg(any(i2s0, i2s1))]
-    impl<'a, TX> core::future::Future for DmaTxDoneChFuture<'a, TX>
+    impl<TX> core::future::Future for DmaTxDoneChFuture<'_, TX>
     where
         TX: Tx,
     {
@@ -2658,7 +2658,7 @@ pub(crate) mod asynch {
     }
 
     #[cfg(any(i2s0, i2s1))]
-    impl<'a, TX> Drop for DmaTxDoneChFuture<'a, TX>
+    impl<TX> Drop for DmaTxDoneChFuture<'_, TX>
     where
         TX: Tx,
     {
@@ -2688,7 +2688,7 @@ pub(crate) mod asynch {
     }
 
     #[cfg(any(i2s0, i2s1))]
-    impl<'a, RX> core::future::Future for DmaRxDoneChFuture<'a, RX>
+    impl<RX> core::future::Future for DmaRxDoneChFuture<'_, RX>
     where
         RX: Rx,
     {
@@ -2726,7 +2726,7 @@ pub(crate) mod asynch {
     }
 
     #[cfg(any(i2s0, i2s1))]
-    impl<'a, RX> Drop for DmaRxDoneChFuture<'a, RX>
+    impl<RX> Drop for DmaRxDoneChFuture<'_, RX>
     where
         RX: Rx,
     {

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -113,9 +113,9 @@ impl<'d> Ecc<'d, crate::Blocking> {
     }
 }
 
-impl<'d> crate::private::Sealed for Ecc<'d, crate::Blocking> {}
+impl crate::private::Sealed for Ecc<'_, crate::Blocking> {}
 
-impl<'d> InterruptConfigurable for Ecc<'d, crate::Blocking> {
+impl InterruptConfigurable for Ecc<'_, crate::Blocking> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         unsafe {
             crate::interrupt::bind_interrupt(crate::peripherals::Interrupt::ECC, handler.handler());
@@ -125,7 +125,7 @@ impl<'d> InterruptConfigurable for Ecc<'d, crate::Blocking> {
     }
 }
 
-impl<'d, DM: crate::Mode> Ecc<'d, DM> {
+impl<DM: crate::Mode> Ecc<'_, DM> {
     /// Resets the ECC peripheral.
     pub fn reset(&mut self) {
         self.ecc.mult_conf().reset()

--- a/esp-hal/src/etm.rs
+++ b/esp-hal/src/etm.rs
@@ -123,7 +123,7 @@ where
     _task: &'a T,
 }
 
-impl<'a, E, T, const C: u8> Drop for EtmConfiguredChannel<'a, E, T, C>
+impl<E, T, const C: u8> Drop for EtmConfiguredChannel<'_, E, T, C>
 where
     E: EtmEvent,
     T: EtmTask,

--- a/esp-hal/src/gpio/etm.rs
+++ b/esp-hal/src/gpio/etm.rs
@@ -202,12 +202,12 @@ where
     _pin: PeripheralRef<'d, PIN>,
 }
 
-impl<'d, PIN, const C: u8> private::Sealed for GpioEtmEventChannelRising<'d, PIN, C> where
+impl<PIN, const C: u8> private::Sealed for GpioEtmEventChannelRising<'_, PIN, C> where
     PIN: super::Pin
 {
 }
 
-impl<'d, PIN, const C: u8> crate::etm::EtmEvent for GpioEtmEventChannelRising<'d, PIN, C>
+impl<PIN, const C: u8> crate::etm::EtmEvent for GpioEtmEventChannelRising<'_, PIN, C>
 where
     PIN: super::Pin,
 {
@@ -225,12 +225,12 @@ where
     _pin: PeripheralRef<'d, PIN>,
 }
 
-impl<'d, PIN, const C: u8> private::Sealed for GpioEtmEventChannelFalling<'d, PIN, C> where
+impl<PIN, const C: u8> private::Sealed for GpioEtmEventChannelFalling<'_, PIN, C> where
     PIN: super::Pin
 {
 }
 
-impl<'d, PIN, const C: u8> crate::etm::EtmEvent for GpioEtmEventChannelFalling<'d, PIN, C>
+impl<PIN, const C: u8> crate::etm::EtmEvent for GpioEtmEventChannelFalling<'_, PIN, C>
 where
     PIN: super::Pin,
 {
@@ -248,12 +248,9 @@ where
     _pin: PeripheralRef<'d, PIN>,
 }
 
-impl<'d, PIN, const C: u8> private::Sealed for GpioEtmEventChannelAny<'d, PIN, C> where
-    PIN: super::Pin
-{
-}
+impl<PIN, const C: u8> private::Sealed for GpioEtmEventChannelAny<'_, PIN, C> where PIN: super::Pin {}
 
-impl<'d, PIN, const C: u8> crate::etm::EtmEvent for GpioEtmEventChannelAny<'d, PIN, C>
+impl<PIN, const C: u8> crate::etm::EtmEvent for GpioEtmEventChannelAny<'_, PIN, C>
 where
     PIN: super::Pin,
 {
@@ -372,9 +369,9 @@ where
     _pin: PeripheralRef<'d, PIN>,
 }
 
-impl<'d, PIN, const C: u8> private::Sealed for GpioEtmTaskSet<'d, PIN, C> where PIN: super::Pin {}
+impl<PIN, const C: u8> private::Sealed for GpioEtmTaskSet<'_, PIN, C> where PIN: super::Pin {}
 
-impl<'d, PIN, const C: u8> crate::etm::EtmTask for GpioEtmTaskSet<'d, PIN, C>
+impl<PIN, const C: u8> crate::etm::EtmTask for GpioEtmTaskSet<'_, PIN, C>
 where
     PIN: super::Pin,
 {
@@ -389,9 +386,9 @@ pub struct GpioEtmTaskClear<'d, PIN, const C: u8> {
     _pin: PeripheralRef<'d, PIN>,
 }
 
-impl<'d, PIN, const C: u8> private::Sealed for GpioEtmTaskClear<'d, PIN, C> where PIN: super::Pin {}
+impl<PIN, const C: u8> private::Sealed for GpioEtmTaskClear<'_, PIN, C> where PIN: super::Pin {}
 
-impl<'d, PIN, const C: u8> crate::etm::EtmTask for GpioEtmTaskClear<'d, PIN, C>
+impl<PIN, const C: u8> crate::etm::EtmTask for GpioEtmTaskClear<'_, PIN, C>
 where
     PIN: super::Pin,
 {
@@ -406,9 +403,9 @@ pub struct GpioEtmTaskToggle<'d, PIN, const C: u8> {
     _pin: PeripheralRef<'d, PIN>,
 }
 
-impl<'d, PIN, const C: u8> private::Sealed for GpioEtmTaskToggle<'d, PIN, C> where PIN: super::Pin {}
+impl<PIN, const C: u8> private::Sealed for GpioEtmTaskToggle<'_, PIN, C> where PIN: super::Pin {}
 
-impl<'d, PIN, const C: u8> crate::etm::EtmTask for GpioEtmTaskToggle<'d, PIN, C>
+impl<PIN, const C: u8> crate::etm::EtmTask for GpioEtmTaskToggle<'_, PIN, C>
 where
     PIN: super::Pin,
 {

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -90,7 +90,6 @@ pub mod lp_io;
 pub mod rtc_io;
 
 /// Convenience constant for `Option::None` pin
-
 static USER_INTERRUPT_HANDLER: CFnPtr = CFnPtr::new();
 
 struct CFnPtr(AtomicPtr<()>);
@@ -1596,7 +1595,7 @@ pub struct Output<'d, P = AnyPin> {
 
 impl<P> private::Sealed for Output<'_, P> {}
 
-impl<'d, P> Peripheral for Output<'d, P> {
+impl<P> Peripheral for Output<'_, P> {
     type P = P;
     unsafe fn clone_unchecked(&mut self) -> P {
         self.pin.clone_unchecked()
@@ -1700,7 +1699,7 @@ pub struct Input<'d, P = AnyPin> {
 
 impl<P> private::Sealed for Input<'_, P> {}
 
-impl<'d, P> Peripheral for Input<'d, P> {
+impl<P> Peripheral for Input<'_, P> {
     type P = P;
     unsafe fn clone_unchecked(&mut self) -> P {
         self.pin.clone_unchecked()
@@ -1804,7 +1803,7 @@ pub struct OutputOpenDrain<'d, P = AnyPin> {
 
 impl<P> private::Sealed for OutputOpenDrain<'_, P> {}
 
-impl<'d, P> Peripheral for OutputOpenDrain<'d, P> {
+impl<P> Peripheral for OutputOpenDrain<'_, P> {
     type P = P;
     unsafe fn clone_unchecked(&mut self) -> P {
         self.pin.clone_unchecked()
@@ -1943,7 +1942,7 @@ pub struct Flex<'d, P = AnyPin> {
 
 impl<P> private::Sealed for Flex<'_, P> {}
 
-impl<'d, P> Peripheral for Flex<'d, P> {
+impl<P> Peripheral for Flex<'_, P> {
     type P = P;
     unsafe fn clone_unchecked(&mut self) -> P {
         core::ptr::read(&*self.pin as *const _)
@@ -1974,7 +1973,7 @@ where
     }
 }
 
-impl<'d, P> Flex<'d, P>
+impl<P> Flex<'_, P>
 where
     P: InputPin,
 {
@@ -2043,7 +2042,7 @@ where
     }
 }
 
-impl<'d, P> Flex<'d, P>
+impl<P> Flex<'_, P>
 where
     P: OutputPin,
 {
@@ -2112,7 +2111,7 @@ where
     }
 }
 
-impl<'d, P> Flex<'d, P>
+impl<P> Flex<'_, P>
 where
     P: InputPin + OutputPin,
 {
@@ -2580,7 +2579,7 @@ mod embedded_hal_02_impls {
 
     use super::*;
 
-    impl<'d, P> digital::InputPin for Input<'d, P>
+    impl<P> digital::InputPin for Input<'_, P>
     where
         P: InputPin,
     {
@@ -2594,7 +2593,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::OutputPin for Output<'d, P>
+    impl<P> digital::OutputPin for Output<'_, P>
     where
         P: OutputPin,
     {
@@ -2610,7 +2609,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::StatefulOutputPin for Output<'d, P>
+    impl<P> digital::StatefulOutputPin for Output<'_, P>
     where
         P: OutputPin,
     {
@@ -2622,7 +2621,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::ToggleableOutputPin for Output<'d, P>
+    impl<P> digital::ToggleableOutputPin for Output<'_, P>
     where
         P: OutputPin,
     {
@@ -2634,7 +2633,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::InputPin for OutputOpenDrain<'d, P>
+    impl<P> digital::InputPin for OutputOpenDrain<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2648,7 +2647,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::OutputPin for OutputOpenDrain<'d, P>
+    impl<P> digital::OutputPin for OutputOpenDrain<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2665,7 +2664,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::StatefulOutputPin for OutputOpenDrain<'d, P>
+    impl<P> digital::StatefulOutputPin for OutputOpenDrain<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2677,7 +2676,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::ToggleableOutputPin for OutputOpenDrain<'d, P>
+    impl<P> digital::ToggleableOutputPin for OutputOpenDrain<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2689,7 +2688,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::InputPin for Flex<'d, P>
+    impl<P> digital::InputPin for Flex<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2703,7 +2702,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::OutputPin for Flex<'d, P>
+    impl<P> digital::OutputPin for Flex<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2719,7 +2718,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::StatefulOutputPin for Flex<'d, P>
+    impl<P> digital::StatefulOutputPin for Flex<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2731,7 +2730,7 @@ mod embedded_hal_02_impls {
         }
     }
 
-    impl<'d, P> digital::ToggleableOutputPin for Flex<'d, P>
+    impl<P> digital::ToggleableOutputPin for Flex<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2749,14 +2748,14 @@ mod embedded_hal_impls {
 
     use super::*;
 
-    impl<'d, P> digital::ErrorType for Input<'d, P>
+    impl<P> digital::ErrorType for Input<'_, P>
     where
         P: InputPin,
     {
         type Error = core::convert::Infallible;
     }
 
-    impl<'d, P> digital::InputPin for Input<'d, P>
+    impl<P> digital::InputPin for Input<'_, P>
     where
         P: InputPin,
     {
@@ -2769,14 +2768,14 @@ mod embedded_hal_impls {
         }
     }
 
-    impl<'d, P> digital::ErrorType for Output<'d, P>
+    impl<P> digital::ErrorType for Output<'_, P>
     where
         P: OutputPin,
     {
         type Error = core::convert::Infallible;
     }
 
-    impl<'d, P> digital::OutputPin for Output<'d, P>
+    impl<P> digital::OutputPin for Output<'_, P>
     where
         P: OutputPin,
     {
@@ -2791,7 +2790,7 @@ mod embedded_hal_impls {
         }
     }
 
-    impl<'d, P> digital::StatefulOutputPin for Output<'d, P>
+    impl<P> digital::StatefulOutputPin for Output<'_, P>
     where
         P: OutputPin,
     {
@@ -2804,7 +2803,7 @@ mod embedded_hal_impls {
         }
     }
 
-    impl<'d, P> digital::InputPin for OutputOpenDrain<'d, P>
+    impl<P> digital::InputPin for OutputOpenDrain<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2817,14 +2816,14 @@ mod embedded_hal_impls {
         }
     }
 
-    impl<'d, P> digital::ErrorType for OutputOpenDrain<'d, P>
+    impl<P> digital::ErrorType for OutputOpenDrain<'_, P>
     where
         P: InputPin + OutputPin,
     {
         type Error = core::convert::Infallible;
     }
 
-    impl<'d, P> digital::OutputPin for OutputOpenDrain<'d, P>
+    impl<P> digital::OutputPin for OutputOpenDrain<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2839,7 +2838,7 @@ mod embedded_hal_impls {
         }
     }
 
-    impl<'d, P> digital::StatefulOutputPin for OutputOpenDrain<'d, P>
+    impl<P> digital::StatefulOutputPin for OutputOpenDrain<'_, P>
     where
         P: InputPin + OutputPin,
     {
@@ -2852,7 +2851,7 @@ mod embedded_hal_impls {
         }
     }
 
-    impl<'d, P> digital::InputPin for Flex<'d, P>
+    impl<P> digital::InputPin for Flex<'_, P>
     where
         P: InputPin,
     {
@@ -2865,11 +2864,11 @@ mod embedded_hal_impls {
         }
     }
 
-    impl<'d, P> digital::ErrorType for Flex<'d, P> {
+    impl<P> digital::ErrorType for Flex<'_, P> {
         type Error = core::convert::Infallible;
     }
 
-    impl<'d, P> digital::OutputPin for Flex<'d, P>
+    impl<P> digital::OutputPin for Flex<'_, P>
     where
         P: OutputPin,
     {
@@ -2884,7 +2883,7 @@ mod embedded_hal_impls {
         }
     }
 
-    impl<'d, P> digital::StatefulOutputPin for Flex<'d, P>
+    impl<P> digital::StatefulOutputPin for Flex<'_, P>
     where
         P: OutputPin,
     {

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -590,9 +590,9 @@ where
     }
 }
 
-impl<'d, T> crate::private::Sealed for I2c<'d, T, Blocking> where T: Instance {}
+impl<T> crate::private::Sealed for I2c<'_, T, Blocking> where T: Instance {}
 
-impl<'d, T> InterruptConfigurable for I2c<'d, T, Blocking>
+impl<T> InterruptConfigurable for I2c<'_, T, Blocking>
 where
     T: Instance,
 {
@@ -765,7 +765,7 @@ mod asynch {
     }
 
     #[cfg(not(esp32))]
-    impl<'a, T> core::future::Future for I2cFuture<'a, T>
+    impl<T> core::future::Future for I2cFuture<'_, T>
     where
         T: Instance,
     {

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -376,7 +376,7 @@ where
     }
 }
 
-impl<'d, I, DmaMode> I2s<'d, I, DmaMode>
+impl<I, DmaMode> I2s<'_, I, DmaMode>
 where
     I: RegisterAccess,
     DmaMode: Mode,
@@ -409,14 +409,14 @@ where
     }
 }
 
-impl<'d, I, DmaMode> crate::private::Sealed for I2s<'d, I, DmaMode>
+impl<I, DmaMode> crate::private::Sealed for I2s<'_, I, DmaMode>
 where
     I: RegisterAccess,
     DmaMode: Mode,
 {
 }
 
-impl<'d, I, DmaMode> InterruptConfigurable for I2s<'d, I, DmaMode>
+impl<I, DmaMode> InterruptConfigurable for I2s<'_, I, DmaMode>
 where
     I: RegisterAccess,
     DmaMode: Mode,
@@ -479,7 +479,7 @@ where
     phantom: PhantomData<DmaMode>,
 }
 
-impl<'d, T, DmaMode> core::fmt::Debug for I2sTx<'d, T, DmaMode>
+impl<T, DmaMode> core::fmt::Debug for I2sTx<'_, T, DmaMode>
 where
     T: RegisterAccess,
     DmaMode: Mode,
@@ -489,7 +489,7 @@ where
     }
 }
 
-impl<'d, T, DmaMode> DmaSupport for I2sTx<'d, T, DmaMode>
+impl<T, DmaMode> DmaSupport for I2sTx<'_, T, DmaMode>
 where
     T: RegisterAccess,
     DmaMode: Mode,
@@ -593,7 +593,7 @@ where
     }
 }
 
-impl<'d, T, W, DmaMode> I2sWrite<W> for I2sTx<'d, T, DmaMode>
+impl<T, W, DmaMode> I2sWrite<W> for I2sTx<'_, T, DmaMode>
 where
     T: RegisterAccess,
     W: AcceptedWord,
@@ -643,7 +643,7 @@ where
     phantom: PhantomData<DmaMode>,
 }
 
-impl<'d, T, DmaMode> core::fmt::Debug for I2sRx<'d, T, DmaMode>
+impl<T, DmaMode> core::fmt::Debug for I2sRx<'_, T, DmaMode>
 where
     T: RegisterAccess,
     DmaMode: Mode,
@@ -653,7 +653,7 @@ where
     }
 }
 
-impl<'d, T, DmaMode> DmaSupport for I2sRx<'d, T, DmaMode>
+impl<T, DmaMode> DmaSupport for I2sRx<'_, T, DmaMode>
 where
     T: RegisterAccess,
     DmaMode: Mode,
@@ -755,7 +755,7 @@ where
     }
 }
 
-impl<'d, W, T, DmaMode> I2sRead<W> for I2sRx<'d, T, DmaMode>
+impl<W, T, DmaMode> I2sRead<W> for I2sRx<'_, T, DmaMode>
 where
     T: RegisterAccess,
     W: AcceptedWord,

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -306,7 +306,7 @@ mod ehal1 {
         }
     }
 
-    impl<'a, S: TimerSpeed, O: OutputPin> ErrorType for Channel<'a, S, O> {
+    impl<S: TimerSpeed, O: OutputPin> ErrorType for Channel<'_, S, O> {
         type Error = Error;
     }
 
@@ -337,7 +337,7 @@ mod ehal1 {
     }
 }
 
-impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, O> {
+impl<O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'_, S, O> {
     #[cfg(esp32)]
     fn set_channel(&mut self, timer_number: u8) {
         if S::IS_HS {
@@ -535,7 +535,7 @@ impl<'a, O: PeripheralOutput, S: crate::ledc::timer::TimerSpeed> Channel<'a, S, 
     }
 }
 
-impl<'a, O, S> ChannelHW<O> for Channel<'a, S, O>
+impl<O, S> ChannelHW<O> for Channel<'_, S, O>
 where
     O: PeripheralOutput,
     S: crate::ledc::timer::TimerSpeed,

--- a/esp-hal/src/ledc/timer.rs
+++ b/esp-hal/src/ledc/timer.rs
@@ -306,7 +306,7 @@ impl<'a, S: TimerSpeed> Timer<'a, S> {
 }
 
 /// Timer HW implementation for LowSpeed timers
-impl<'a> TimerHW<LowSpeed> for Timer<'a, LowSpeed> {
+impl TimerHW<LowSpeed> for Timer<'_, LowSpeed> {
     /// Get the current source timer frequency from the HW
     fn get_freq_hw(&self) -> Option<HertzU32> {
         self.clock_source.map(|source| match source {

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -415,8 +415,8 @@ impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bo
     }
 }
 
-impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    embedded_hal_02::PwmPin for PwmPin<'d, Pin, PWM, OP, IS_A>
+impl<Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
+    embedded_hal_02::PwmPin for PwmPin<'_, Pin, PWM, OP, IS_A>
 {
     type Duty = u16;
 
@@ -449,15 +449,15 @@ impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bo
 }
 
 /// Implement no error type for the PwmPin because the method are infallible
-impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    embedded_hal::pwm::ErrorType for PwmPin<'d, Pin, PWM, OP, IS_A>
+impl<Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
+    embedded_hal::pwm::ErrorType for PwmPin<'_, Pin, PWM, OP, IS_A>
 {
     type Error = core::convert::Infallible;
 }
 
 /// Implement the trait SetDutyCycle for PwmPin
-impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    embedded_hal::pwm::SetDutyCycle for PwmPin<'d, Pin, PWM, OP, IS_A>
+impl<Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
+    embedded_hal::pwm::SetDutyCycle for PwmPin<'_, Pin, PWM, OP, IS_A>
 {
     /// Get the max duty of the PwmPin
     fn max_duty_cycle(&self) -> u16 {

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -293,7 +293,7 @@ where
         Self { pin }
     }
 }
-impl<'d, P> TxClkPin for ClkOutPin<'d, P>
+impl<P> TxClkPin for ClkOutPin<'_, P>
 where
     P: PeripheralOutput,
 {
@@ -323,7 +323,7 @@ where
         Self { pin }
     }
 }
-impl<'d, P> TxClkPin for ClkInPin<'d, P>
+impl<P> TxClkPin for ClkInPin<'_, P>
 where
     P: PeripheralInput,
 {
@@ -359,7 +359,7 @@ where
         Self { pin, sample_edge }
     }
 }
-impl<'d, P> RxClkPin for RxClkInPin<'d, P>
+impl<P> RxClkPin for RxClkInPin<'_, P>
 where
     P: PeripheralInput,
 {
@@ -401,14 +401,14 @@ where
     }
 }
 
-impl<'d, P, VP> TxPins for TxPinConfigWithValidPin<'d, P, VP>
+impl<P, VP> TxPins for TxPinConfigWithValidPin<'_, P, VP>
 where
     P: NotContainsValidSignalPin + TxPins + ConfigurePins,
     VP: PeripheralOutput,
 {
 }
 
-impl<'d, P, VP> ConfigurePins for TxPinConfigWithValidPin<'d, P, VP>
+impl<P, VP> ConfigurePins for TxPinConfigWithValidPin<'_, P, VP>
 where
     P: NotContainsValidSignalPin + TxPins + ConfigurePins,
     VP: PeripheralOutput,
@@ -552,26 +552,26 @@ tx_pins!(
     P15 = PARL_TX_DATA15
 );
 
-impl<'d, P0> FullDuplex for TxOneBit<'d, P0> {}
+impl<P0> FullDuplex for TxOneBit<'_, P0> {}
 
-impl<'d, P0, P1> FullDuplex for TxTwoBits<'d, P0, P1> {}
+impl<P0, P1> FullDuplex for TxTwoBits<'_, P0, P1> {}
 
-impl<'d, P0, P1, P2, P3> FullDuplex for TxFourBits<'d, P0, P1, P2, P3> {}
+impl<P0, P1, P2, P3> FullDuplex for TxFourBits<'_, P0, P1, P2, P3> {}
 
-impl<'d, P0, P1, P2, P3, P4, P5, P6, P7> FullDuplex
-    for TxEightBits<'d, P0, P1, P2, P3, P4, P5, P6, P7>
+impl<P0, P1, P2, P3, P4, P5, P6, P7> FullDuplex
+    for TxEightBits<'_, P0, P1, P2, P3, P4, P5, P6, P7>
 {
 }
 
-impl<'d, P0> NotContainsValidSignalPin for TxOneBit<'d, P0> {}
+impl<P0> NotContainsValidSignalPin for TxOneBit<'_, P0> {}
 
-impl<'d, P0, P1> NotContainsValidSignalPin for TxTwoBits<'d, P0, P1> {}
+impl<P0, P1> NotContainsValidSignalPin for TxTwoBits<'_, P0, P1> {}
 
-impl<'d, P0, P1, P2, P3> NotContainsValidSignalPin for TxFourBits<'d, P0, P1, P2, P3> {}
+impl<P0, P1, P2, P3> NotContainsValidSignalPin for TxFourBits<'_, P0, P1, P2, P3> {}
 
 #[cfg(esp32c6)]
-impl<'d, P0, P1, P2, P3, P4, P5, P6, P7> NotContainsValidSignalPin
-    for TxEightBits<'d, P0, P1, P2, P3, P4, P5, P6, P7>
+impl<P0, P1, P2, P3, P4, P5, P6, P7> NotContainsValidSignalPin
+    for TxEightBits<'_, P0, P1, P2, P3, P4, P5, P6, P7>
 {
 }
 
@@ -582,9 +582,8 @@ impl<'d, P0, P1, P2, P3, P4, P5, P6, P7> ContainsValidSignalPin
 }
 
 #[cfg(esp32c6)]
-impl<'d, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
-    ContainsValidSignalPin
-    for TxSixteenBits<'d, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
+impl<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> ContainsValidSignalPin
+    for TxSixteenBits<'_, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
 {
 }
 
@@ -622,14 +621,14 @@ where
     }
 }
 
-impl<'d, P, VP> RxPins for RxPinConfigWithValidPin<'d, P, VP>
+impl<P, VP> RxPins for RxPinConfigWithValidPin<'_, P, VP>
 where
     P: NotContainsValidSignalPin + RxPins + ConfigurePins,
     VP: PeripheralInput,
 {
 }
 
-impl<'d, P, VP> ConfigurePins for RxPinConfigWithValidPin<'d, P, VP>
+impl<P, VP> ConfigurePins for RxPinConfigWithValidPin<'_, P, VP>
 where
     P: NotContainsValidSignalPin + RxPins + ConfigurePins,
     VP: PeripheralInput,
@@ -799,26 +798,26 @@ rx_pins!(
     P15 = PARL_RX_DATA15
 );
 
-impl<'d, P0> FullDuplex for RxOneBit<'d, P0> {}
+impl<P0> FullDuplex for RxOneBit<'_, P0> {}
 
-impl<'d, P0, P1> FullDuplex for RxTwoBits<'d, P0, P1> {}
+impl<P0, P1> FullDuplex for RxTwoBits<'_, P0, P1> {}
 
-impl<'d, P0, P1, P2, P3> FullDuplex for RxFourBits<'d, P0, P1, P2, P3> {}
+impl<P0, P1, P2, P3> FullDuplex for RxFourBits<'_, P0, P1, P2, P3> {}
 
-impl<'d, P0, P1, P2, P3, P4, P5, P6, P7> FullDuplex
-    for RxEightBits<'d, P0, P1, P2, P3, P4, P5, P6, P7>
+impl<P0, P1, P2, P3, P4, P5, P6, P7> FullDuplex
+    for RxEightBits<'_, P0, P1, P2, P3, P4, P5, P6, P7>
 {
 }
 
-impl<'d, P0> NotContainsValidSignalPin for RxOneBit<'d, P0> {}
+impl<P0> NotContainsValidSignalPin for RxOneBit<'_, P0> {}
 
-impl<'d, P0, P1> NotContainsValidSignalPin for RxTwoBits<'d, P0, P1> {}
+impl<P0, P1> NotContainsValidSignalPin for RxTwoBits<'_, P0, P1> {}
 
-impl<'d, P0, P1, P2, P3> NotContainsValidSignalPin for RxFourBits<'d, P0, P1, P2, P3> {}
+impl<P0, P1, P2, P3> NotContainsValidSignalPin for RxFourBits<'_, P0, P1, P2, P3> {}
 
 #[cfg(esp32c6)]
-impl<'d, P0, P1, P2, P3, P4, P5, P6, P7> NotContainsValidSignalPin
-    for RxEightBits<'d, P0, P1, P2, P3, P4, P5, P6, P7>
+impl<P0, P1, P2, P3, P4, P5, P6, P7> NotContainsValidSignalPin
+    for RxEightBits<'_, P0, P1, P2, P3, P4, P5, P6, P7>
 {
 }
 
@@ -829,9 +828,8 @@ impl<'d, P0, P1, P2, P3, P4, P5, P6, P7> ContainsValidSignalPin
 }
 
 #[cfg(esp32c6)]
-impl<'d, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
-    ContainsValidSignalPin
-    for RxSixteenBits<'d, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
+impl<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> ContainsValidSignalPin
+    for RxSixteenBits<'_, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
 {
 }
 
@@ -909,7 +907,7 @@ where
     phantom: PhantomData<DM>,
 }
 
-impl<'d, DM> core::fmt::Debug for ParlIoTx<'d, DM>
+impl<DM> core::fmt::Debug for ParlIoTx<'_, DM>
 where
     DM: Mode,
 {
@@ -988,7 +986,7 @@ where
     phantom: PhantomData<DM>,
 }
 
-impl<'d, DM> core::fmt::Debug for ParlIoRx<'d, DM>
+impl<DM> core::fmt::Debug for ParlIoRx<'_, DM>
 where
     DM: Mode,
 {
@@ -1117,7 +1115,7 @@ where
     }
 }
 
-impl<'d> ParlIoFullDuplex<'d, Blocking> {
+impl ParlIoFullDuplex<'_, Blocking> {
     /// Sets the interrupt handler, enables it with
     /// [crate::interrupt::Priority::min()]
     ///
@@ -1147,9 +1145,9 @@ impl<'d> ParlIoFullDuplex<'d, Blocking> {
     }
 }
 
-impl<'d> crate::private::Sealed for ParlIoFullDuplex<'d, Blocking> {}
+impl crate::private::Sealed for ParlIoFullDuplex<'_, Blocking> {}
 
-impl<'d> InterruptConfigurable for ParlIoFullDuplex<'d, Blocking> {
+impl InterruptConfigurable for ParlIoFullDuplex<'_, Blocking> {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         ParlIoFullDuplex::set_interrupt_handler(self, handler);
     }
@@ -1192,7 +1190,7 @@ where
     }
 }
 
-impl<'d> ParlIoTxOnly<'d, Blocking> {
+impl ParlIoTxOnly<'_, Blocking> {
     /// Sets the interrupt handler, enables it with
     /// [crate::interrupt::Priority::min()]
     ///
@@ -1222,9 +1220,9 @@ impl<'d> ParlIoTxOnly<'d, Blocking> {
     }
 }
 
-impl<'d> crate::private::Sealed for ParlIoTxOnly<'d, Blocking> {}
+impl crate::private::Sealed for ParlIoTxOnly<'_, Blocking> {}
 
-impl<'d> InterruptConfigurable for ParlIoTxOnly<'d, Blocking> {
+impl InterruptConfigurable for ParlIoTxOnly<'_, Blocking> {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         ParlIoTxOnly::set_interrupt_handler(self, handler);
     }
@@ -1267,7 +1265,7 @@ where
     }
 }
 
-impl<'d> ParlIoRxOnly<'d, Blocking> {
+impl ParlIoRxOnly<'_, Blocking> {
     /// Sets the interrupt handler, enables it with
     /// [crate::interrupt::Priority::min()]
     ///
@@ -1297,9 +1295,9 @@ impl<'d> ParlIoRxOnly<'d, Blocking> {
     }
 }
 
-impl<'d> crate::private::Sealed for ParlIoRxOnly<'d, Blocking> {}
+impl crate::private::Sealed for ParlIoRxOnly<'_, Blocking> {}
 
-impl<'d> InterruptConfigurable for ParlIoRxOnly<'d, Blocking> {
+impl InterruptConfigurable for ParlIoRxOnly<'_, Blocking> {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         ParlIoRxOnly::set_interrupt_handler(self, handler);
     }
@@ -1338,7 +1336,7 @@ fn internal_init(frequency: HertzU32) -> Result<(), Error> {
     Ok(())
 }
 
-impl<'d, DM> ParlIoTx<'d, DM>
+impl<DM> ParlIoTx<'_, DM>
 where
     DM: Mode,
 {
@@ -1393,7 +1391,7 @@ where
     }
 }
 
-impl<'d, DM> DmaSupport for ParlIoTx<'d, DM>
+impl<DM> DmaSupport for ParlIoTx<'_, DM>
 where
     DM: Mode,
 {
@@ -1482,7 +1480,7 @@ where
     }
 }
 
-impl<'d, DM> DmaSupport for ParlIoRx<'d, DM>
+impl<DM> DmaSupport for ParlIoRx<'_, DM>
 where
     DM: Mode,
 {

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -576,8 +576,8 @@ impl<P0, P1, P2, P3, P4, P5, P6, P7> NotContainsValidSignalPin
 }
 
 #[cfg(esp32h2)]
-impl<'d, P0, P1, P2, P3, P4, P5, P6, P7> ContainsValidSignalPin
-    for TxEightBits<'d, P0, P1, P2, P3, P4, P5, P6, P7>
+impl<P0, P1, P2, P3, P4, P5, P6, P7> ContainsValidSignalPin
+    for TxEightBits<'_, P0, P1, P2, P3, P4, P5, P6, P7>
 {
 }
 
@@ -822,8 +822,8 @@ impl<P0, P1, P2, P3, P4, P5, P6, P7> NotContainsValidSignalPin
 }
 
 #[cfg(esp32h2)]
-impl<'d, P0, P1, P2, P3, P4, P5, P6, P7> ContainsValidSignalPin
-    for RxEightBits<'d, P0, P1, P2, P3, P4, P5, P6, P7>
+impl<P0, P1, P2, P3, P4, P5, P6, P7> ContainsValidSignalPin
+    for RxEightBits<'_, P0, P1, P2, P3, P4, P5, P6, P7>
 {
 }
 

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -22,7 +22,7 @@ pub struct Channel<'d, const UNIT: usize, const NUM: usize> {
     _not_send: PhantomData<*const ()>,
 }
 
-impl<'d, const UNIT: usize, const NUM: usize> Channel<'d, UNIT, NUM> {
+impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
     /// return a new Channel
     pub(super) fn new() -> Self {
         Self {

--- a/esp-hal/src/pcnt/mod.rs
+++ b/esp-hal/src/pcnt/mod.rs
@@ -109,9 +109,9 @@ impl<'d> Pcnt<'d> {
     }
 }
 
-impl<'d> crate::private::Sealed for Pcnt<'d> {}
+impl crate::private::Sealed for Pcnt<'_> {}
 
-impl<'d> InterruptConfigurable for Pcnt<'d> {
+impl InterruptConfigurable for Pcnt<'_> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         unsafe {
             interrupt::bind_interrupt(Interrupt::PCNT, handler.handler());

--- a/esp-hal/src/pcnt/unit.rs
+++ b/esp-hal/src/pcnt/unit.rs
@@ -84,7 +84,7 @@ pub struct Unit<'d, const NUM: usize> {
     pub channel1: Channel<'d, NUM, 1>,
 }
 
-impl<'d, const NUM: usize> Unit<'d, NUM> {
+impl<const NUM: usize> Unit<'_, NUM> {
     /// return a new Unit
     pub(super) fn new() -> Self {
         Self {
@@ -301,14 +301,14 @@ impl<'d, const NUM: usize> Unit<'d, NUM> {
     }
 }
 
-impl<'d, const NUM: usize> Drop for Unit<'d, NUM> {
+impl<const NUM: usize> Drop for Unit<'_, NUM> {
     fn drop(&mut self) {
         // This is here to prevent the destructuring of Unit.
     }
 }
 
 // The entire Unit is Send but the individual channels are not.
-unsafe impl<'d, const NUM: usize> Send for Unit<'d, NUM> {}
+unsafe impl<const NUM: usize> Send for Unit<'_, NUM> {}
 
 /// Represents the counter within a pulse counter unit.
 #[derive(Clone)]
@@ -316,7 +316,7 @@ pub struct Counter<'d, const NUM: usize> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d, const NUM: usize> Counter<'d, NUM> {
+impl<const NUM: usize> Counter<'_, NUM> {
     fn new() -> Self {
         Self {
             _phantom: PhantomData,

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -64,7 +64,7 @@ impl<'a, T> PeripheralRef<'a, T> {
     }
 }
 
-impl<'a, T> Deref for PeripheralRef<'a, T> {
+impl<T> Deref for PeripheralRef<'_, T> {
     type Target = T;
 
     #[inline]
@@ -73,7 +73,7 @@ impl<'a, T> Deref for PeripheralRef<'a, T> {
     }
 }
 
-impl<'a, T> DerefMut for PeripheralRef<'a, T> {
+impl<T> DerefMut for PeripheralRef<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -275,9 +275,9 @@ impl<'d> Rmt<'d, crate::Blocking> {
     }
 }
 
-impl<'d> crate::private::Sealed for Rmt<'d, crate::Blocking> {}
+impl crate::private::Sealed for Rmt<'_, crate::Blocking> {}
 
-impl<'d> InterruptConfigurable for Rmt<'d, crate::Blocking> {
+impl InterruptConfigurable for Rmt<'_, crate::Blocking> {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         self.internal_set_interrupt_handler(handler);
     }
@@ -448,7 +448,7 @@ where
     data: &'a [T],
 }
 
-impl<'a, C, T: Into<u32> + Copy> SingleShotTxTransaction<'a, C, T>
+impl<C, T: Into<u32> + Copy> SingleShotTxTransaction<'_, C, T>
 where
     C: TxChannel,
 {
@@ -1045,7 +1045,7 @@ where
     data: &'a mut [T],
 }
 
-impl<'a, C, T: From<u32> + Copy> RxTransaction<'a, C, T>
+impl<C, T: From<u32> + Copy> RxTransaction<'_, C, T>
 where
     C: RxChannel,
 {

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -164,7 +164,6 @@ impl rand_core::RngCore for Rng {
 /// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin)).unwrap();
 /// # }
 /// ```
-
 pub struct Trng<'d> {
     /// The hardware random number generator instance.
     pub rng: Rng,
@@ -211,7 +210,7 @@ impl<'d> Trng<'d> {
     }
 }
 
-impl<'d> Drop for Trng<'d> {
+impl Drop for Trng<'_> {
     fn drop(&mut self) {
         crate::soc::trng::revert_trng();
     }

--- a/esp-hal/src/rsa/esp32cX.rs
+++ b/esp-hal/src/rsa/esp32cX.rs
@@ -10,7 +10,7 @@ use crate::rsa::{
     RsaMultiplication,
 };
 
-impl<'d, DM: crate::Mode> Rsa<'d, DM> {
+impl<DM: crate::Mode> Rsa<'_, DM> {
     /// After the RSA Accelerator is released from reset, the memory blocks
     /// needs to be initialized, only after that peripheral should be used.
     /// This function would return without an error if the memory is initialized
@@ -232,7 +232,7 @@ pub mod operand_sizes {
     );
 }
 
-impl<'a, 'd, T: RsaMode, DM: crate::Mode, const N: usize> RsaModularExponentiation<'a, 'd, T, DM>
+impl<'d, T: RsaMode, DM: crate::Mode, const N: usize> RsaModularExponentiation<'_, 'd, T, DM>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<'a, 'd, T: RsaMode, DM: crate::Mode, const N: usize> RsaModularMultiplication<'a, 'd, T, DM>
+impl<'d, T: RsaMode, DM: crate::Mode, const N: usize> RsaModularMultiplication<'_, 'd, T, DM>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -265,7 +265,7 @@ where
     }
 }
 
-impl<'a, 'd, T: RsaMode + Multi, DM: crate::Mode, const N: usize> RsaMultiplication<'a, 'd, T, DM>
+impl<'d, T: RsaMode + Multi, DM: crate::Mode, const N: usize> RsaMultiplication<'_, 'd, T, DM>
 where
     T: RsaMode<InputType = [u32; N]>,
 {

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -56,9 +56,9 @@ impl<'d> Rsa<'d, crate::Blocking> {
     }
 }
 
-impl<'d> crate::private::Sealed for Rsa<'d, crate::Blocking> {}
+impl crate::private::Sealed for Rsa<'_, crate::Blocking> {}
 
-impl<'d> InterruptConfigurable for Rsa<'d, crate::Blocking> {
+impl InterruptConfigurable for Rsa<'_, crate::Blocking> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         self.internal_set_interrupt_handler(handler);
     }

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -411,9 +411,9 @@ impl<'d> Rtc<'d> {
             .modify(|r, w| unsafe { w.bits(r.bits() | 1) });
     }
 }
-impl<'d> crate::private::Sealed for Rtc<'d> {}
+impl crate::private::Sealed for Rtc<'_> {}
 
-impl<'d> InterruptConfigurable for Rtc<'d> {
+impl InterruptConfigurable for Rtc<'_> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         unsafe {
             interrupt::bind_interrupt(

--- a/esp-hal/src/rtc_cntl/sleep/esp32c2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c2.rs
@@ -157,7 +157,7 @@ impl WakeSource for TimerWakeupSource {
     }
 }
 
-impl<'a, 'b> RtcioWakeupSource<'a, 'b> {
+impl RtcioWakeupSource<'_, '_> {
     fn apply_pin(&self, pin: &mut dyn RtcPinWithResistors, level: WakeupLevel) {
         // The pullup/pulldown part is like in gpio_deep_sleep_wakeup_prepare
         let level = match level {

--- a/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
@@ -157,7 +157,7 @@ impl WakeSource for TimerWakeupSource {
     }
 }
 
-impl<'a, 'b> RtcioWakeupSource<'a, 'b> {
+impl RtcioWakeupSource<'_, '_> {
     fn apply_pin(&self, pin: &mut dyn RtcPinWithResistors, level: WakeupLevel) {
         // The pullup/pulldown part is like in gpio_deep_sleep_wakeup_prepare
         let level = match level {

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -98,10 +98,10 @@ impl<'d> Sha<'d> {
     }
 }
 
-impl<'d> crate::private::Sealed for Sha<'d> {}
+impl crate::private::Sealed for Sha<'_> {}
 
 #[cfg(not(esp32))]
-impl<'d> crate::InterruptConfigurable for Sha<'d> {
+impl crate::InterruptConfigurable for Sha<'_> {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         unsafe {
             crate::interrupt::bind_interrupt(crate::peripherals::Interrupt::SHA, handler.handler());

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -508,7 +508,7 @@ where
     }
 }
 
-impl<'d, T> Spi<'d, T, FullDuplexMode>
+impl<T> Spi<'_, T, FullDuplexMode>
 where
     T: Instance,
 {
@@ -983,7 +983,7 @@ mod dma {
     {
     }
 
-    impl<'d, T, D, M> core::fmt::Debug for SpiDma<'d, T, D, M>
+    impl<T, D, M> core::fmt::Debug for SpiDma<'_, T, D, M>
     where
         T: InstanceDma,
         D: DuplexMode,
@@ -1206,7 +1206,7 @@ mod dma {
         }
     }
 
-    impl<'d, T, D, M> crate::private::Sealed for SpiDma<'d, T, D, M>
+    impl<T, D, M> crate::private::Sealed for SpiDma<'_, T, D, M>
     where
         T: InstanceDma,
         D: DuplexMode,
@@ -1214,7 +1214,7 @@ mod dma {
     {
     }
 
-    impl<'d, T, D, M> InterruptConfigurable for SpiDma<'d, T, D, M>
+    impl<T, D, M> InterruptConfigurable for SpiDma<'_, T, D, M>
     where
         T: InstanceDma,
         D: DuplexMode,
@@ -1310,7 +1310,7 @@ mod dma {
         }
     }
 
-    impl<'d, T, D, M, Buf> Drop for SpiDmaTransfer<'d, T, D, M, Buf>
+    impl<T, D, M, Buf> Drop for SpiDmaTransfer<'_, T, D, M, Buf>
     where
         T: InstanceDma,
         D: DuplexMode,
@@ -1668,7 +1668,7 @@ mod dma {
         }
     }
 
-    impl<'d, T, D, M> InterruptConfigurable for SpiDmaBus<'d, T, D, M>
+    impl<T, D, M> InterruptConfigurable for SpiDmaBus<'_, T, D, M>
     where
         T: InstanceDma,
         D: DuplexMode,
@@ -1680,7 +1680,7 @@ mod dma {
         }
     }
 
-    impl<'d, T, D, M> crate::private::Sealed for SpiDmaBus<'d, T, D, M>
+    impl<T, D, M> crate::private::Sealed for SpiDmaBus<'_, T, D, M>
     where
         T: InstanceDma,
         D: DuplexMode,
@@ -1688,7 +1688,7 @@ mod dma {
     {
     }
 
-    impl<'d, T, M> SpiDmaBus<'d, T, FullDuplexMode, M>
+    impl<T, M> SpiDmaBus<'_, T, FullDuplexMode, M>
     where
         T: InstanceDma,
         M: Mode,
@@ -1788,7 +1788,7 @@ mod dma {
         }
     }
 
-    impl<'d, T, M> HalfDuplexReadWrite for SpiDmaBus<'d, T, HalfDuplexMode, M>
+    impl<T, M> HalfDuplexReadWrite for SpiDmaBus<'_, T, HalfDuplexMode, M>
     where
         T: InstanceDma,
         M: Mode,
@@ -1859,8 +1859,8 @@ mod dma {
         }
     }
 
-    impl<'d, T> embedded_hal_02::blocking::spi::Transfer<u8>
-        for SpiDmaBus<'d, T, FullDuplexMode, crate::Blocking>
+    impl<T> embedded_hal_02::blocking::spi::Transfer<u8>
+        for SpiDmaBus<'_, T, FullDuplexMode, crate::Blocking>
     where
         T: InstanceDma,
     {
@@ -1872,8 +1872,8 @@ mod dma {
         }
     }
 
-    impl<'d, T> embedded_hal_02::blocking::spi::Write<u8>
-        for SpiDmaBus<'d, T, FullDuplexMode, crate::Blocking>
+    impl<T> embedded_hal_02::blocking::spi::Write<u8>
+        for SpiDmaBus<'_, T, FullDuplexMode, crate::Blocking>
     where
         T: InstanceDma,
     {
@@ -2078,7 +2078,7 @@ mod dma {
 
         use super::*;
 
-        impl<'d, T, M> ErrorType for SpiDmaBus<'d, T, FullDuplexMode, M>
+        impl<T, M> ErrorType for SpiDmaBus<'_, T, FullDuplexMode, M>
         where
             T: InstanceDma,
             M: Mode,
@@ -2086,7 +2086,7 @@ mod dma {
             type Error = Error;
         }
 
-        impl<'d, T, M> SpiBus for SpiDmaBus<'d, T, FullDuplexMode, M>
+        impl<T, M> SpiBus for SpiDmaBus<'_, T, FullDuplexMode, M>
         where
             T: InstanceDma,
             M: Mode,

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -203,7 +203,7 @@ pub mod dma {
         tx_chain: DescriptorChain,
     }
 
-    impl<'d, T, DmaMode> core::fmt::Debug for SpiDma<'d, T, DmaMode>
+    impl<T, DmaMode> core::fmt::Debug for SpiDma<'_, T, DmaMode>
     where
         T: InstanceDma,
         DmaMode: Mode,
@@ -213,7 +213,7 @@ pub mod dma {
         }
     }
 
-    impl<'d, T, DmaMode> DmaSupport for SpiDma<'d, T, DmaMode>
+    impl<T, DmaMode> DmaSupport for SpiDma<'_, T, DmaMode>
     where
         T: InstanceDma,
         DmaMode: Mode,

--- a/esp-hal/src/sync.rs
+++ b/esp-hal/src/sync.rs
@@ -248,7 +248,7 @@ pub(crate) fn lock<T>(lock: &Lock, f: impl FnOnce() -> T) -> T {
         }
     }
 
-    impl<'a> Drop for LockGuard<'a> {
+    impl Drop for LockGuard<'_> {
         fn drop(&mut self) {
             unsafe { self.lock.release(self.token) };
         }

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -201,9 +201,9 @@ where
     }
 }
 
-impl<'d, T> crate::private::Sealed for OneShotTimer<'d, T> where T: Timer {}
+impl<T> crate::private::Sealed for OneShotTimer<'_, T> where T: Timer {}
 
-impl<'d, T> InterruptConfigurable for OneShotTimer<'d, T>
+impl<T> InterruptConfigurable for OneShotTimer<'_, T>
 where
     T: Timer,
 {
@@ -212,7 +212,7 @@ where
     }
 }
 
-impl<'d, T, UXX> embedded_hal_02::blocking::delay::DelayMs<UXX> for OneShotTimer<'d, T>
+impl<T, UXX> embedded_hal_02::blocking::delay::DelayMs<UXX> for OneShotTimer<'_, T>
 where
     T: Timer,
     UXX: Into<u32>,
@@ -222,7 +222,7 @@ where
     }
 }
 
-impl<'d, T, UXX> embedded_hal_02::blocking::delay::DelayUs<UXX> for OneShotTimer<'d, T>
+impl<T, UXX> embedded_hal_02::blocking::delay::DelayUs<UXX> for OneShotTimer<'_, T>
 where
     T: Timer,
     UXX: Into<u32>,
@@ -232,7 +232,7 @@ where
     }
 }
 
-impl<'d, T> embedded_hal::delay::DelayNs for OneShotTimer<'d, T>
+impl<T> embedded_hal::delay::DelayNs for OneShotTimer<'_, T>
 where
     T: Timer,
 {
@@ -315,9 +315,9 @@ where
     }
 }
 
-impl<'d, T> crate::private::Sealed for PeriodicTimer<'d, T> where T: Timer {}
+impl<T> crate::private::Sealed for PeriodicTimer<'_, T> where T: Timer {}
 
-impl<'d, T> InterruptConfigurable for PeriodicTimer<'d, T>
+impl<T> InterruptConfigurable for PeriodicTimer<'_, T>
 where
     T: Timer,
 {
@@ -326,7 +326,7 @@ where
     }
 }
 
-impl<'d, T> embedded_hal_02::timer::CountDown for PeriodicTimer<'d, T>
+impl<T> embedded_hal_02::timer::CountDown for PeriodicTimer<'_, T>
 where
     T: Timer,
 {
@@ -344,7 +344,7 @@ where
     }
 }
 
-impl<'d, T> embedded_hal_02::timer::Cancel for PeriodicTimer<'d, T>
+impl<T> embedded_hal_02::timer::Cancel for PeriodicTimer<'_, T>
 where
     T: Timer,
 {
@@ -355,7 +355,7 @@ where
     }
 }
 
-impl<'d, T> embedded_hal_02::timer::Periodic for PeriodicTimer<'d, T> where T: Timer {}
+impl<T> embedded_hal_02::timer::Periodic for PeriodicTimer<'_, T> where T: Timer {}
 
 /// An enum of all timer types
 enum AnyTimerInner {

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -1176,13 +1176,13 @@ pub mod etm {
         }
     }
 
-    impl<'a, 'd, M, DM: crate::Mode, COMP: Comparator, UNIT: Unit> crate::private::Sealed
-        for SysTimerEtmEvent<'a, 'd, M, DM, COMP, UNIT>
+    impl<M, DM: crate::Mode, COMP: Comparator, UNIT: Unit> crate::private::Sealed
+        for SysTimerEtmEvent<'_, '_, M, DM, COMP, UNIT>
     {
     }
 
-    impl<'a, 'd, M, DM: crate::Mode, COMP: Comparator, UNIT: Unit> crate::etm::EtmEvent
-        for SysTimerEtmEvent<'a, 'd, M, DM, COMP, UNIT>
+    impl<M, DM: crate::Mode, COMP: Comparator, UNIT: Unit> crate::etm::EtmEvent
+        for SysTimerEtmEvent<'_, '_, M, DM, COMP, UNIT>
     {
         fn id(&self) -> u8 {
             50 + self.alarm.comparator.channel()

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -368,13 +368,13 @@ pub trait Unit {
 #[derive(Debug)]
 pub struct SpecificUnit<'d, const CHANNEL: u8>(PhantomData<&'d ()>);
 
-impl<'d, const CHANNEL: u8> SpecificUnit<'d, CHANNEL> {
+impl<const CHANNEL: u8> SpecificUnit<'_, CHANNEL> {
     fn new() -> Self {
         Self(PhantomData)
     }
 }
 
-impl<'d, const CHANNEL: u8> Unit for SpecificUnit<'d, CHANNEL> {
+impl<const CHANNEL: u8> Unit for SpecificUnit<'_, CHANNEL> {
     fn channel(&self) -> u8 {
         CHANNEL
     }
@@ -384,7 +384,7 @@ impl<'d, const CHANNEL: u8> Unit for SpecificUnit<'d, CHANNEL> {
 #[derive(Debug)]
 pub struct AnyUnit<'d>(PhantomData<&'d ()>, u8);
 
-impl<'d> Unit for AnyUnit<'d> {
+impl Unit for AnyUnit<'_> {
     fn channel(&self) -> u8 {
         self.1
     }
@@ -598,13 +598,13 @@ pub trait Comparator {
 #[derive(Debug)]
 pub struct SpecificComparator<'d, const CHANNEL: u8>(PhantomData<&'d ()>);
 
-impl<'d, const CHANNEL: u8> SpecificComparator<'d, CHANNEL> {
+impl<const CHANNEL: u8> SpecificComparator<'_, CHANNEL> {
     fn new() -> Self {
         Self(PhantomData)
     }
 }
 
-impl<'d, const CHANNEL: u8> Comparator for SpecificComparator<'d, CHANNEL> {
+impl<const CHANNEL: u8> Comparator for SpecificComparator<'_, CHANNEL> {
     fn channel(&self) -> u8 {
         CHANNEL
     }
@@ -614,7 +614,7 @@ impl<'d, const CHANNEL: u8> Comparator for SpecificComparator<'d, CHANNEL> {
 #[derive(Debug)]
 pub struct AnyComparator<'d>(PhantomData<&'d ()>, u8);
 
-impl<'d> Comparator for AnyComparator<'d> {
+impl Comparator for AnyComparator<'_> {
     fn channel(&self) -> u8 {
         self.1
     }
@@ -737,7 +737,7 @@ where
     _pd: PhantomData<(MODE, DM)>,
 }
 
-impl<'d, T, DM, COMP: Comparator, UNIT: Unit> Debug for Alarm<'d, T, DM, COMP, UNIT>
+impl<T, DM, COMP: Comparator, UNIT: Unit> Debug for Alarm<'_, T, DM, COMP, UNIT>
 where
     DM: Mode,
 {
@@ -771,9 +771,7 @@ impl<'d, T, COMP: Comparator, UNIT: Unit> Alarm<'d, T, Async, COMP, UNIT> {
     }
 }
 
-impl<'d, T, COMP: Comparator, UNIT: Unit> InterruptConfigurable
-    for Alarm<'d, T, Blocking, COMP, UNIT>
-{
+impl<T, COMP: Comparator, UNIT: Unit> InterruptConfigurable for Alarm<'_, T, Blocking, COMP, UNIT> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         self.comparator.set_interrupt_handler(handler)
     }
@@ -851,14 +849,12 @@ where
     }
 }
 
-impl<'d, T, DM, COMP: Comparator, UNIT: Unit> crate::private::Sealed
-    for Alarm<'d, T, DM, COMP, UNIT>
-where
-    DM: Mode,
+impl<T, DM, COMP: Comparator, UNIT: Unit> crate::private::Sealed for Alarm<'_, T, DM, COMP, UNIT> where
+    DM: Mode
 {
 }
 
-impl<'d, T, DM, COMP: Comparator, UNIT: Unit> super::Timer for Alarm<'d, T, DM, COMP, UNIT>
+impl<T, DM, COMP: Comparator, UNIT: Unit> super::Timer for Alarm<'_, T, DM, COMP, UNIT>
 where
     DM: Mode,
 {
@@ -996,7 +992,7 @@ where
     }
 }
 
-impl<'d, T, DM, COMP: Comparator, UNIT: Unit> Peripheral for Alarm<'d, T, DM, COMP, UNIT>
+impl<T, DM, COMP: Comparator, UNIT: Unit> Peripheral for Alarm<'_, T, DM, COMP, UNIT>
 where
     DM: Mode,
 {
@@ -1063,7 +1059,7 @@ mod asynch {
         }
     }
 
-    impl<'a, COMP: Comparator, UNIT: Unit> core::future::Future for AlarmFuture<'a, COMP, UNIT> {
+    impl<COMP: Comparator, UNIT: Unit> core::future::Future for AlarmFuture<'_, COMP, UNIT> {
         type Output = ();
 
         fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -1144,7 +1144,7 @@ mod asynch {
         }
     }
 
-    impl<'a, T> core::future::Future for TimerFuture<'a, T>
+    impl<T> core::future::Future for TimerFuture<'_, T>
     where
         T: Instance,
     {
@@ -1162,7 +1162,7 @@ mod asynch {
         }
     }
 
-    impl<'a, T> Drop for TimerFuture<'a, T>
+    impl<T> Drop for TimerFuture<'_, T>
     where
         T: Instance,
     {

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1045,9 +1045,9 @@ where
     }
 }
 
-impl<'d, T> crate::private::Sealed for TwaiConfiguration<'d, T, crate::Blocking> where T: Instance {}
+impl<T> crate::private::Sealed for TwaiConfiguration<'_, T, crate::Blocking> where T: Instance {}
 
-impl<'d, T> InterruptConfigurable for TwaiConfiguration<'d, T, crate::Blocking>
+impl<T> InterruptConfigurable for TwaiConfiguration<'_, T, crate::Blocking>
 where
     T: Instance,
 {
@@ -1192,7 +1192,7 @@ pub struct TwaiTx<'d, T, DM: crate::Mode> {
     phantom: PhantomData<DM>,
 }
 
-impl<'d, T, DM> TwaiTx<'d, T, DM>
+impl<T, DM> TwaiTx<'_, T, DM>
 where
     T: Instance,
     DM: crate::Mode,
@@ -1234,7 +1234,7 @@ pub struct TwaiRx<'d, T, DM: crate::Mode> {
     phantom: PhantomData<DM>,
 }
 
-impl<'d, T, DM> TwaiRx<'d, T, DM>
+impl<T, DM> TwaiRx<'_, T, DM>
 where
     T: Instance,
     DM: crate::Mode,
@@ -1331,7 +1331,7 @@ unsafe fn copy_to_data_register(dest: *mut u32, src: &[u8]) {
     }
 }
 
-impl<'d, T, DM> embedded_hal_02::can::Can for Twai<'d, T, DM>
+impl<T, DM> embedded_hal_02::can::Can for Twai<'_, T, DM>
 where
     T: Instance,
     DM: crate::Mode,
@@ -1355,7 +1355,7 @@ where
     }
 }
 
-impl<'d, T, DM> embedded_can::nb::Can for Twai<'d, T, DM>
+impl<T, DM> embedded_can::nb::Can for Twai<'_, T, DM>
 where
     T: Instance,
     DM: crate::Mode,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1104,7 +1104,7 @@ where
         }
 
         let max_div = 0b1111_1111_1111 - 1;
-        let clk_div = ((clk) + (max_div * baudrate) - 1) / (max_div * baudrate);
+        let clk_div = (clk).div_ceil(max_div * baudrate);
         T::register_block().clk_conf().write(|w| unsafe {
             w.sclk_sel()
                 .bits(match clock_source {
@@ -1897,7 +1897,7 @@ mod asynch {
         registered: bool,
     }
 
-    impl<'d, T: Instance> UartRxFuture<'d, T> {
+    impl<T: Instance> UartRxFuture<'_, T> {
         pub fn new(events: EnumSet<RxEvent>) -> Self {
             Self {
                 events,
@@ -1928,7 +1928,7 @@ mod asynch {
         }
     }
 
-    impl<'d, T: Instance> core::future::Future for UartRxFuture<'d, T> {
+    impl<T: Instance> core::future::Future for UartRxFuture<'_, T> {
         type Output = EnumSet<RxEvent>;
 
         fn poll(
@@ -1962,7 +1962,7 @@ mod asynch {
         }
     }
 
-    impl<'d, T: Instance> Drop for UartRxFuture<'d, T> {
+    impl<T: Instance> Drop for UartRxFuture<'_, T> {
         fn drop(&mut self) {
             // Although the isr disables the interrupt that occurred directly, we need to
             // disable the other interrupts (= the ones that did not occur), as
@@ -1984,7 +1984,7 @@ mod asynch {
         }
     }
 
-    impl<'d, T: Instance> UartTxFuture<'d, T> {
+    impl<T: Instance> UartTxFuture<'_, T> {
         pub fn new(events: EnumSet<TxEvent>) -> Self {
             Self {
                 events,
@@ -2006,7 +2006,7 @@ mod asynch {
         }
     }
 
-    impl<'d, T: Instance> core::future::Future for UartTxFuture<'d, T> {
+    impl<T: Instance> core::future::Future for UartTxFuture<'_, T> {
         type Output = ();
 
         fn poll(
@@ -2035,7 +2035,7 @@ mod asynch {
         }
     }
 
-    impl<'d, T: Instance> Drop for UartTxFuture<'d, T> {
+    impl<T: Instance> Drop for UartTxFuture<'_, T> {
         fn drop(&mut self) {
             // Although the isr disables the interrupt that occurred directly, we need to
             // disable the other interrupts (= the ones that did not occur), as

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -106,7 +106,7 @@ pub struct UsbSerialJtagRx<'d, M> {
     phantom: PhantomData<(&'d mut USB_DEVICE, M)>,
 }
 
-impl<'d, M> UsbSerialJtagTx<'d, M>
+impl<M> UsbSerialJtagTx<'_, M>
 where
     M: Mode,
 {
@@ -183,7 +183,7 @@ where
     }
 }
 
-impl<'d, M> UsbSerialJtagRx<'d, M>
+impl<M> UsbSerialJtagRx<'_, M>
 where
     M: Mode,
 {
@@ -265,9 +265,9 @@ impl<'d> UsbSerialJtag<'d, Blocking> {
     }
 }
 
-impl<'d> crate::private::Sealed for UsbSerialJtag<'d, Blocking> {}
+impl crate::private::Sealed for UsbSerialJtag<'_, Blocking> {}
 
-impl<'d> InterruptConfigurable for UsbSerialJtag<'d, Blocking> {
+impl InterruptConfigurable for UsbSerialJtag<'_, Blocking> {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         self.inner_set_interrupt_handler(handler);
     }
@@ -670,7 +670,7 @@ mod asynch {
         phantom: PhantomData<&'d mut USB_DEVICE>,
     }
 
-    impl<'d> UsbSerialJtagWriteFuture<'d> {
+    impl UsbSerialJtagWriteFuture<'_> {
         pub fn new() -> Self {
             // Set the interrupt enable bit for the USB_SERIAL_JTAG_SERIAL_IN_EMPTY_INT
             // interrupt
@@ -692,7 +692,7 @@ mod asynch {
         }
     }
 
-    impl<'d> core::future::Future for UsbSerialJtagWriteFuture<'d> {
+    impl core::future::Future for UsbSerialJtagWriteFuture<'_> {
         type Output = ();
 
         fn poll(
@@ -713,7 +713,7 @@ mod asynch {
         phantom: PhantomData<&'d mut USB_DEVICE>,
     }
 
-    impl<'d> UsbSerialJtagReadFuture<'d> {
+    impl UsbSerialJtagReadFuture<'_> {
         pub fn new() -> Self {
             // Set the interrupt enable bit for the USB_SERIAL_JTAG_SERIAL_OUT_RECV_PKT
             // interrupt
@@ -735,7 +735,7 @@ mod asynch {
         }
     }
 
-    impl<'d> core::future::Future for UsbSerialJtagReadFuture<'d> {
+    impl core::future::Future for UsbSerialJtagReadFuture<'_> {
         type Output = ();
 
         fn poll(

--- a/esp-ieee802154/src/lib.rs
+++ b/esp-ieee802154/src/lib.rs
@@ -305,7 +305,7 @@ impl<'a> Ieee802154<'a> {
     }
 }
 
-impl<'a> Drop for Ieee802154<'a> {
+impl Drop for Ieee802154<'_> {
     fn drop(&mut self) {
         self.clear_tx_done_callback();
         self.clear_tx_done_callback_fn();

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -52,3 +52,6 @@ defmt-espflash = ["dep:defmt", "defmt?/encoding-rzcobs"]
 
 # logging sub-features
 colors = []
+
+[lints.rust]
+static_mut_refs = "allow"

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -196,3 +196,6 @@ features = [
   "esp-hal/default",
 ]
 default-target = "riscv32imc-unknown-none-elf"
+
+[lints.rust]
+static_mut_refs = "allow"

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -224,7 +224,7 @@ pub struct EspNowManager<'d> {
     _rc: EspNowRc<'d>,
 }
 
-impl<'d> EspNowManager<'d> {
+impl EspNowManager<'_> {
     /// Set the wifi protocol.
     ///
     /// This will set the wifi protocol to the desired protocol
@@ -423,7 +423,7 @@ pub struct EspNowSender<'d> {
     _rc: EspNowRc<'d>,
 }
 
-impl<'d> EspNowSender<'d> {
+impl EspNowSender<'_> {
     /// Send data to peer
     ///
     /// The peer needs to be added to the peer list first.
@@ -453,7 +453,7 @@ impl<'d> EspNowSender<'d> {
 #[must_use]
 pub struct SendWaiter<'s>(PhantomData<&'s mut EspNowSender<'s>>);
 
-impl<'s> SendWaiter<'s> {
+impl SendWaiter<'_> {
     /// Wait for the previous sending to complete, i.e. the send callback is
     /// invoked with status of the sending.
     pub fn wait(self) -> Result<(), EspNowError> {
@@ -470,7 +470,7 @@ impl<'s> SendWaiter<'s> {
     }
 }
 
-impl<'s> Drop for SendWaiter<'s> {
+impl Drop for SendWaiter<'_> {
     /// wait for the send to complete to prevent the lock on `EspNowSender` get
     /// unlocked before a callback is invoked.
     fn drop(&mut self) {
@@ -484,7 +484,7 @@ pub struct EspNowReceiver<'d> {
     _rc: EspNowRc<'d>,
 }
 
-impl<'d> EspNowReceiver<'d> {
+impl EspNowReceiver<'_> {
     pub fn receive(&self) -> Option<ReceivedData> {
         critical_section::with(|cs| {
             let mut queue = RECEIVE_QUEUE.borrow_ref_mut(cs);
@@ -500,7 +500,7 @@ struct EspNowRc<'d> {
     inner: PhantomData<EspNow<'d>>,
 }
 
-impl<'d> EspNowRc<'d> {
+impl EspNowRc<'_> {
     fn new() -> Result<Self, EspNowError> {
         static ESP_NOW_RC: AtomicU8 = AtomicU8::new(0);
         // The reference counter is not 0, which means there is another instance of
@@ -516,7 +516,7 @@ impl<'d> EspNowRc<'d> {
     }
 }
 
-impl<'d> Clone for EspNowRc<'d> {
+impl Clone for EspNowRc<'_> {
     fn clone(&self) -> Self {
         self.rc.fetch_add(1, Ordering::Release);
         Self {
@@ -526,7 +526,7 @@ impl<'d> Clone for EspNowRc<'d> {
     }
 }
 
-impl<'d> Drop for EspNowRc<'d> {
+impl Drop for EspNowRc<'_> {
     fn drop(&mut self) {
         if self.rc.fetch_sub(1, Ordering::AcqRel) == 1 {
             unsafe {
@@ -808,7 +808,7 @@ mod asynch {
     pub(super) static ESP_NOW_TX_WAKER: AtomicWaker = AtomicWaker::new();
     pub(super) static ESP_NOW_RX_WAKER: AtomicWaker = AtomicWaker::new();
 
-    impl<'d> EspNowReceiver<'d> {
+    impl EspNowReceiver<'_> {
         /// This function takes mutable reference to self because the
         /// implementation of `ReceiveFuture` is not logically thread
         /// safe.
@@ -817,7 +817,7 @@ mod asynch {
         }
     }
 
-    impl<'d> EspNowSender<'d> {
+    impl EspNowSender<'_> {
         pub fn send_async<'s, 'r>(
             &'s mut self,
             addr: &'r [u8; 6],
@@ -832,7 +832,7 @@ mod asynch {
         }
     }
 
-    impl<'d> EspNow<'d> {
+    impl EspNow<'_> {
         /// This function takes mutable reference to self because the
         /// implementation of `ReceiveFuture` is not logically thread
         /// safe.
@@ -859,7 +859,7 @@ mod asynch {
         sent: bool,
     }
 
-    impl<'s, 'r> core::future::Future for SendFuture<'s, 'r> {
+    impl core::future::Future for SendFuture<'_, '_> {
         type Output = Result<(), EspNowError>;
 
         fn poll(mut self: core::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -892,7 +892,7 @@ mod asynch {
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct ReceiveFuture<'r>(PhantomData<&'r mut EspNowReceiver<'r>>);
 
-    impl<'r> core::future::Future for ReceiveFuture<'r> {
+    impl core::future::Future for ReceiveFuture<'_> {
         type Output = ReceivedData;
 
         fn poll(self: core::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -70,3 +70,6 @@ incremental      = false
 opt-level        = 3
 lto = 'fat'
 overflow-checks  = false
+
+[lints.rust]
+static_mut_refs = "allow"


### PR DESCRIPTION
These have been failing for awhile now, thanks to #2351 this became much easier to resolve.

Largely the failures were just due to lifetime elision, some small doc-comment related lint errors as well.

I have allowed the `static_mut_refs` package-wide for some packages; we are aware of the use of statics, I don't intend to rewrite these for this PR. Can be addressed at some other time.

No changes here warrant a `CHANGELOG.md` entry IMO.

Successful run: https://github.com/jessebraham/esp-hal/actions/runs/11365052005