### PR TITLE
doc: add hint for feature flag in wifi examples

### DIFF
--- a/examples/src/bin/wifi_80211_tx.rs
+++ b/examples/src/bin/wifi_80211_tx.rs
@@ -1,6 +1,7 @@
 //! WiFi frame injection example
 //!
 //! Periodically transmits a beacon frame.
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: esp-wifi esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils esp-wifi/sniffer
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_access_point.rs
+++ b/examples/src/bin/wifi_access_point.rs
@@ -6,6 +6,7 @@
 //! Open http://192.168.2.1:8080/ in your browser
 //!
 //! On Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: esp-wifi esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_access_point_with_sta.rs
@@ -7,6 +7,7 @@
 //! Open http://192.168.2.1:8080/ in your browser - the example will perform an HTTP get request to some "random" server
 //!
 //! On Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: esp-wifi esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_bench.rs
+++ b/examples/src/bin/wifi_bench.rs
@@ -6,6 +6,7 @@
 //! cargo run --release
 //! ```
 //! Ensure you have set the IP of your local machine in the `HOST_IP` env variable. E.g `HOST_IP="192.168.0.24"` and also set SSID and PASSWORD env variable before running this example.
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: esp-wifi esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_coex.rs
+++ b/examples/src/bin/wifi_coex.rs
@@ -6,6 +6,7 @@
 //! - does BLE advertising (you cannot connect to it - it's just not implemented in the example)
 //!
 //! Note: On ESP32-C2 and ESP32-C3 you need a wifi-heap size of 70000, on ESP32-C6 you need 80000 and a tx_queue_size of 10
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: esp-wifi esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils esp-wifi/ble esp-wifi/coex
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_dhcp.rs
+++ b/examples/src/bin/wifi_dhcp.rs
@@ -4,6 +4,7 @@
 //! Set SSID and PASSWORD env variable before running this example.
 //!
 //! This gets an ip address via DHCP then performs an HTTP get request to some "random" server
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: esp-wifi esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -7,6 +7,7 @@
 //! On Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -10,6 +10,7 @@
 //! On Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -8,7 +8,7 @@
 //! Ensure you have set the IP of your local machine in the `HOST_IP` env variable. E.g `HOST_IP="192.168.0.24"` and also set SSID and PASSWORD env variable before running this example.
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2 and ESP32-C2
-//!
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c3 esp32c6

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -6,6 +6,7 @@
 //! This gets an ip address via DHCP then performs an HTTP get request to some "random" server
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
+//! When using USB-SERIAL-JTAG you have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/async esp-wifi/embassy-net esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_sniffer.rs
+++ b/examples/src/bin/wifi_sniffer.rs
@@ -1,6 +1,7 @@
 //! WiFi sniffer example
 //!
 //! Sniffs for beacon frames.
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: esp-wifi esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils esp-wifi/sniffer
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6

--- a/examples/src/bin/wifi_static_ip.rs
+++ b/examples/src/bin/wifi_static_ip.rs
@@ -5,6 +5,7 @@
 //! - might be necessary to configure your WiFi access point accordingly
 //! - uses the given static IP
 //! - responds with some HTML content when connecting to port 8080
+//! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
 //% FEATURES: esp-wifi esp-wifi/wifi-default esp-wifi/wifi esp-wifi/utils
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
I added a comment to the wifi examples that one may need to add the `phy-enable-us` feature

#2364 

#### Testing
-

