### PR TITLE
Remove FullDuplexMode and HalfDuplexMode type params

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `AnyTwai`. (#2359)
 - `Pins::steal()` to unsafely obtain GPIO. (#2335)
 - `I2c::with_timeout` (#2361)
+- `Spi::half_duplex_read` and `Spi::half_duplex_write` (#2373)
 
 ### Changed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Peripheral type erasure for I2S (#2367)
 - Peripheral type erasure for I2C (#2361)
 - Peripheral type erasure for TWAI (#2359)
+- The SPI driver has been rewritten to allow using half-duplex and full-duplex functionality on the same bus. See the migration guide for details. (#2373)
 
 ### Fixed
 
@@ -36,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `i2s::{I2sWrite, I2sWriteDma, I2sRead, I2sReadDma, I2sWriteDmaAsync, I2sReadDmaAsync}` traits have been removed. (#2316)
 - The `ledc::ChannelHW` trait is no longer generic. (#2387)
 - The `I2c::new_with_timeout` constructors have been removed (#2361)
+- The `spi::master::HalfDuplexReadWrite` trait has been removed. (#2373)
+- The `Spi::with_pins` methods have been removed. (#2373)
+- The `Spi::new_half_duplex` constructor have been removed. (#2373)
+- The `HalfDuplexMode` and `FullDuplexMode` parameters have been removed from `Spi`. (#2373)
 
 ## [0.21.1]
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Peripheral type erasure for I2C (#2361)
 - Peripheral type erasure for TWAI (#2359)
 - The SPI driver has been rewritten to allow using half-duplex and full-duplex functionality on the same bus. See the migration guide for details. (#2373)
+- Renamed `SpiDma` functions: `dma_transfer` to `transfer`, `dma_write` to `write`, `dma_read` to `read`. (#2373)
 
 ### Fixed
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -35,7 +35,10 @@
 //!     100.kHz(),
 //!     SpiMode::Mode0,
 //! )
-//! .with_pins(sclk, mosi, miso, cs)
+//! .with_sck(sclk)
+//! .with_mosi(mosi)
+//! .with_miso(miso)
+//! .with_cs(cs)
 //! .with_dma(dma_channel.configure(
 //!     false,
 //!     DmaPriority::Priority0,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1232,7 +1232,7 @@ mod dma {
         /// bytes.
         #[allow(clippy::type_complexity)]
         #[cfg_attr(place_spi_driver_in_ram, ram)]
-        pub fn dma_write<TX: DmaTxBuffer>(
+        pub fn write<TX: DmaTxBuffer>(
             mut self,
             mut buffer: TX,
         ) -> Result<SpiDmaTransfer<'d, M, TX, T>, (Error, Self, TX)> {
@@ -1271,7 +1271,7 @@ mod dma {
         /// received is 32736 bytes.
         #[allow(clippy::type_complexity)]
         #[cfg_attr(place_spi_driver_in_ram, ram)]
-        pub fn dma_read<RX: DmaRxBuffer>(
+        pub fn read<RX: DmaRxBuffer>(
             mut self,
             mut buffer: RX,
         ) -> Result<SpiDmaTransfer<'d, M, RX, T>, (Error, Self, RX)> {
@@ -1309,7 +1309,7 @@ mod dma {
         /// sent/received is 32736 bytes.
         #[allow(clippy::type_complexity)]
         #[cfg_attr(place_spi_driver_in_ram, ram)]
-        pub fn dma_transfer<RX: DmaRxBuffer, TX: DmaTxBuffer>(
+        pub fn transfer<RX: DmaRxBuffer, TX: DmaTxBuffer>(
             mut self,
             mut rx_buffer: RX,
             mut tx_buffer: TX,

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -76,9 +76,6 @@ pub enum SpiBitOrder {
     LSBFirst,
 }
 
-/// Trait marker for defining SPI duplex modes.
-pub trait DuplexMode: crate::private::Sealed {}
-
 /// SPI data mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -90,16 +87,6 @@ pub enum SpiDataMode {
     /// `Quad` Data Mode - 4 bit, 4 wires
     Quad,
 }
-
-/// Full-duplex operation
-pub struct FullDuplexMode {}
-impl DuplexMode for FullDuplexMode {}
-impl crate::private::Sealed for FullDuplexMode {}
-
-/// Half-duplex operation
-pub struct HalfDuplexMode {}
-impl DuplexMode for HalfDuplexMode {}
-impl crate::private::Sealed for HalfDuplexMode {}
 
 crate::any_peripheral! {
     /// Any SPI peripheral.

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -48,7 +48,7 @@
 //! let mut send = tx_buffer;
 //!
 //! let transfer = spi
-//!     .dma_transfer(&mut receive, &mut send)
+//!     .transfer(&mut receive, &mut send)
 //!     .unwrap();
 //!
 //! transfer.wait().unwrap();
@@ -313,7 +313,7 @@ pub mod dma {
         /// sent is 32736 bytes.
         ///
         /// The write is driven by the SPI master's sclk signal and cs line.
-        pub fn dma_write<'t, TXBUF>(
+        pub fn write<'t, TXBUF>(
             &'t mut self,
             words: &'t TXBUF,
         ) -> Result<DmaTransferTx<'t, Self>, Error>
@@ -348,7 +348,7 @@ pub mod dma {
         /// received is 32736 bytes.
         ///
         /// The read is driven by the SPI master's sclk signal and cs line.
-        pub fn dma_read<'t, RXBUF>(
+        pub fn read<'t, RXBUF>(
             &'t mut self,
             words: &'t mut RXBUF,
         ) -> Result<DmaTransferRx<'t, Self>, Error>
@@ -384,7 +384,7 @@ pub mod dma {
         ///
         /// The data transfer is driven by the SPI master's sclk signal and cs
         /// line.
-        pub fn dma_transfer<'t, RXBUF, TXBUF>(
+        pub fn transfer<'t, RXBUF, TXBUF>(
             &'t mut self,
             read_buffer: &'t mut RXBUF,
             words: &'t TXBUF,

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -59,7 +59,10 @@ async fn main(_spawner: Spawner) {
     let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
 
     let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
-        .with_pins(sclk, mosi, miso, cs)
+        .with_sck(sclk)
+        .with_mosi(mosi)
+        .with_miso(miso)
+        .with_cs(cs)
         .with_dma(dma_channel.configure_for_async(false, DmaPriority::Priority0))
         .with_buffers(dma_rx_buf, dma_tx_buf);
 

--- a/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -33,7 +33,7 @@ use esp_hal::{
     gpio::Io,
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi},
+        master::{Address, Command, Spi},
         SpiDataMode,
         SpiMode,
     },
@@ -63,15 +63,20 @@ fn main() -> ! {
         }
     }
 
-    let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
-        .with_pins(sclk, mosi, miso, sio2, sio3, cs);
+    let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
+        .with_sck(sclk)
+        .with_mosi(mosi)
+        .with_miso(miso)
+        .with_sio2(sio2)
+        .with_sio3(sio3)
+        .with_cs(cs);
 
     let delay = Delay::new();
 
     loop {
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
-        spi.read(
+        spi.half_duplex_read(
             SpiDataMode::Single,
             Command::Command8(0x90, SpiDataMode::Single),
             Address::Address24(0x000000, SpiDataMode::Single),
@@ -84,7 +89,7 @@ fn main() -> ! {
 
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
-        spi.read(
+        spi.half_duplex_read(
             SpiDataMode::Dual,
             Command::Command8(0x92, SpiDataMode::Single),
             Address::Address32(0x000000_00, SpiDataMode::Dual),
@@ -97,7 +102,7 @@ fn main() -> ! {
 
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
-        spi.read(
+        spi.half_duplex_read(
             SpiDataMode::Quad,
             Command::Command8(0x94, SpiDataMode::Single),
             Address::Address32(0x000000_00, SpiDataMode::Quad),

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -19,6 +19,7 @@ use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
     gpio::Io,
+    peripheral::Peripheral,
     prelude::*,
     spi::{master::Spi, SpiMode},
 };
@@ -33,11 +34,13 @@ fn main() -> ! {
     let miso_mosi = io.pins.gpio2;
     let cs = io.pins.gpio5;
 
-    let miso = miso_mosi.peripheral_input();
-    let mosi = miso_mosi.into_peripheral_output();
+    let miso = unsafe { miso_mosi.clone_unchecked() };
 
-    let mut spi =
-        Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0).with_pins(sclk, mosi, miso, cs);
+    let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
+        .with_sck(sclk)
+        .with_mosi(miso_mosi)
+        .with_miso(miso)
+        .with_cs(cs);
 
     let delay = Delay::new();
 

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -54,7 +54,10 @@ fn main() -> ! {
     let mut dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
 
     let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
-        .with_pins(sclk, mosi, miso, cs)
+        .with_sck(sclk)
+        .with_mosi(mosi)
+        .with_miso(miso)
+        .with_cs(cs)
         .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
 
     let delay = Delay::new();

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -74,7 +74,7 @@ fn main() -> ! {
         i = i.wrapping_add(1);
 
         let transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
         // here we could do something else while DMA transfer is in progress

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -111,7 +111,7 @@ fn main() -> ! {
         i = i.wrapping_add(1);
 
         let transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
 

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -2,7 +2,7 @@
 //!
 //! The following wiring is assumed:
 //! - SCLK => GPIO42
-//! - MISO => (loopback to MOSI via peripheral_input())
+//! - MISO => (looped back to MOSI via the GPIO MUX)
 //! - MOSI => GPIO48
 //! - CS   => GPIO38
 //!
@@ -27,6 +27,7 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaBufBlkSize, DmaPriority, DmaRxBuf, DmaTxBuf},
     gpio::Io,
+    peripheral::Peripheral,
     prelude::*,
     spi::{master::Spi, SpiMode},
 };
@@ -62,7 +63,7 @@ fn main() -> ! {
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio42;
     let mosi = io.pins.gpio48;
-    let miso = mosi.peripheral_input();
+    let miso = unsafe { mosi.clone_unchecked() };
     let cs = io.pins.gpio38;
 
     let dma = Dma::new(peripherals.DMA);
@@ -87,8 +88,13 @@ fn main() -> ! {
         rx_descriptors.len()
     );
     let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+    // Need to set miso first so that mosi can overwrite the
+    // output connection (because we are using the same pin to loop back)
     let mut spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
-        .with_pins(sclk, mosi, miso, cs)
+        .with_sck(sclk)
+        .with_miso(miso)
+        .with_mosi(mosi)
+        .with_cs(cs)
         .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
 
     delay.delay_millis(100); // delay to let the above messages display

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -107,11 +107,9 @@ fn main() -> ! {
 
         println!("Iteration {i}");
 
-        println!("Do `dma_transfer`");
+        println!("Do `transfer`");
 
-        let transfer = spi
-            .dma_transfer(&mut slave_receive, &mut slave_send)
-            .unwrap();
+        let transfer = spi.transfer(&mut slave_receive, &mut slave_send).unwrap();
 
         bitbang_master(
             master_send,
@@ -133,9 +131,9 @@ fn main() -> ! {
 
         delay.delay_millis(250);
 
-        println!("Do `dma_read`");
+        println!("Do `read`");
         slave_receive.fill(0xff);
-        let transfer = spi.dma_read(&mut slave_receive).unwrap();
+        let transfer = spi.read(&mut slave_receive).unwrap();
 
         bitbang_master(
             master_send,
@@ -155,8 +153,8 @@ fn main() -> ! {
 
         delay.delay_millis(250);
 
-        println!("Do `dma_write`");
-        let transfer = spi.dma_write(&mut slave_send).unwrap();
+        println!("Do `write`");
+        let transfer = spi.write(&mut slave_send).unwrap();
 
         master_receive.fill(0);
 

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -15,7 +15,6 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Spi, SpiDma},
-        FullDuplexMode,
         SpiMode,
     },
     timer::{timg::TimerGroup, AnyTimer},
@@ -34,7 +33,7 @@ macro_rules! mk_static {
 }
 
 #[embassy_executor::task]
-async fn interrupt_driven_task(spi: SpiDma<'static, FullDuplexMode, Async>) {
+async fn interrupt_driven_task(spi: SpiDma<'static, Async>) {
     let mut ticker = Ticker::every(Duration::from_millis(1));
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(128);

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -211,11 +211,11 @@ mod tests {
 
         for i in 1..4 {
             dma_rx_buf.as_mut_slice().copy_from_slice(&[5, 5, 5, 5, 5]);
-            let transfer = spi.dma_read(dma_rx_buf).map_err(|e| e.0).unwrap();
+            let transfer = spi.read(dma_rx_buf).map_err(|e| e.0).unwrap();
             (spi, dma_rx_buf) = transfer.wait();
             assert_eq!(dma_rx_buf.as_slice(), &[0, 0, 0, 0, 0]);
 
-            let transfer = spi.dma_write(dma_tx_buf).map_err(|e| e.0).unwrap();
+            let transfer = spi.write(dma_tx_buf).map_err(|e| e.0).unwrap();
             (spi, dma_tx_buf) = transfer.wait();
             assert_eq!(unit.get_value(), (i * 3 * DMA_BUFFER_SIZE) as _);
         }
@@ -244,12 +244,12 @@ mod tests {
 
         for i in 1..4 {
             dma_rx_buf.as_mut_slice().copy_from_slice(&[5, 5, 5, 5, 5]);
-            let transfer = spi.dma_read(dma_rx_buf).map_err(|e| e.0).unwrap();
+            let transfer = spi.read(dma_rx_buf).map_err(|e| e.0).unwrap();
             (spi, dma_rx_buf) = transfer.wait();
             assert_eq!(dma_rx_buf.as_slice(), &[0, 0, 0, 0, 0]);
 
             let transfer = spi
-                .dma_transfer(dma_rx_buf, dma_tx_buf)
+                .transfer(dma_rx_buf, dma_tx_buf)
                 .map_err(|e| e.0)
                 .unwrap();
             (spi, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
@@ -276,7 +276,7 @@ mod tests {
             dma_tx_buf.as_mut_slice()[0] = i as u8;
             *dma_tx_buf.as_mut_slice().last_mut().unwrap() = i as u8;
             let transfer = spi
-                .dma_transfer(dma_rx_buf, dma_tx_buf)
+                .transfer(dma_rx_buf, dma_tx_buf)
                 .map_err(|e| e.0)
                 .unwrap();
 
@@ -302,7 +302,7 @@ mod tests {
             .spi
             .with_dma(ctx.dma_channel.configure(false, DmaPriority::Priority0));
         let transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
         let (spi, (dma_rx_buf, mut dma_tx_buf)) = transfer.wait();
@@ -313,7 +313,7 @@ mod tests {
         dma_tx_buf.fill(&[0xaa, 0xdd, 0xef, 0xbe]);
 
         let transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
         let (_, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
@@ -471,18 +471,18 @@ mod tests {
 
         dma_tx_buf.fill(&[0xde, 0xad, 0xbe, 0xef]);
 
-        let transfer = spi.dma_write(dma_tx_buf).map_err(|e| e.0).unwrap();
+        let transfer = spi.write(dma_tx_buf).map_err(|e| e.0).unwrap();
         let (spi, dma_tx_buf) = transfer.wait();
 
         dma_rx_buf.as_mut_slice().fill(0);
-        let transfer = spi.dma_read(dma_rx_buf).map_err(|e| e.0).unwrap();
+        let transfer = spi.read(dma_rx_buf).map_err(|e| e.0).unwrap();
         let (spi, mut dma_rx_buf) = transfer.wait();
 
-        let transfer = spi.dma_write(dma_tx_buf).map_err(|e| e.0).unwrap();
+        let transfer = spi.write(dma_tx_buf).map_err(|e| e.0).unwrap();
         let (spi, _dma_tx_buf) = transfer.wait();
 
         dma_rx_buf.as_mut_slice().fill(0);
-        let transfer = spi.dma_read(dma_rx_buf).map_err(|e| e.0).unwrap();
+        let transfer = spi.read(dma_rx_buf).map_err(|e| e.0).unwrap();
         let (_, dma_rx_buf) = transfer.wait();
 
         assert_eq!(&[0xff, 0xff, 0xff, 0xff], dma_rx_buf.as_slice());
@@ -505,7 +505,7 @@ mod tests {
             .with_dma(ctx.dma_channel.configure(false, DmaPriority::Priority0));
 
         let mut transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
 
@@ -528,7 +528,7 @@ mod tests {
             .with_dma(ctx.dma_channel.configure(false, DmaPriority::Priority0));
 
         let mut transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
 
@@ -538,7 +538,7 @@ mod tests {
         spi.change_bus_frequency(10000.kHz());
 
         let transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
 
@@ -563,7 +563,7 @@ mod tests {
         );
 
         let mut transfer = spi
-            .dma_transfer(dma_rx_buf, dma_tx_buf)
+            .transfer(dma_rx_buf, dma_tx_buf)
             .map_err(|e| e.0)
             .unwrap();
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -11,8 +11,7 @@ use esp_hal::{
     gpio::{Io, Level, Output},
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDma},
-        HalfDuplexMode,
+        master::{Address, Command, Spi, SpiDma},
         SpiDataMode,
         SpiMode,
     },
@@ -21,7 +20,7 @@ use esp_hal::{
 use hil_test as _;
 
 struct Context {
-    spi: SpiDma<'static, HalfDuplexMode, Blocking>,
+    spi: SpiDma<'static, Blocking>,
     miso_mirror: Output<'static>,
 }
 
@@ -50,7 +49,7 @@ mod tests {
             }
         }
 
-        let spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
             .with_sck(sclk)
             .with_miso(miso)
             .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
@@ -72,7 +71,7 @@ mod tests {
         let mut spi = ctx.spi;
 
         let transfer = spi
-            .read(
+            .half_duplex_read(
                 SpiDataMode::Single,
                 Command::None,
                 Address::None,
@@ -89,7 +88,7 @@ mod tests {
         ctx.miso_mirror.set_high();
 
         let transfer = spi
-            .read(
+            .half_duplex_read(
                 SpiDataMode::Single,
                 Command::None,
                 Address::None,
@@ -120,7 +119,7 @@ mod tests {
         ctx.miso_mirror.set_low();
 
         let mut buffer = [0xAA; DMA_BUFFER_SIZE];
-        spi.read(
+        spi.half_duplex_read(
             SpiDataMode::Single,
             Command::None,
             Address::None,
@@ -134,7 +133,7 @@ mod tests {
         // SPI should read '1's from the MISO pin
         ctx.miso_mirror.set_high();
 
-        spi.read(
+        spi.half_duplex_read(
             SpiDataMode::Single,
             Command::None,
             Address::None,

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -12,8 +12,7 @@ use esp_hal::{
     pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDma},
-        HalfDuplexMode,
+        master::{Address, Command, Spi, SpiDma},
         SpiDataMode,
         SpiMode,
     },
@@ -22,7 +21,7 @@ use esp_hal::{
 use hil_test as _;
 
 struct Context {
-    spi: SpiDma<'static, HalfDuplexMode, Blocking>,
+    spi: SpiDma<'static, Blocking>,
     pcnt_unit: Unit<'static, 0>,
     pcnt_source: InputSignal,
 }
@@ -53,7 +52,7 @@ mod tests {
 
         let mosi_loopback = mosi.peripheral_input();
 
-        let spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
             .with_sck(sclk)
             .with_mosi(mosi)
             .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
@@ -84,7 +83,7 @@ mod tests {
         dma_tx_buf.fill(&[0b0110_1010; DMA_BUFFER_SIZE]);
 
         let transfer = spi
-            .write(
+            .half_duplex_write(
                 SpiDataMode::Single,
                 Command::None,
                 Address::None,
@@ -98,7 +97,7 @@ mod tests {
         assert_eq!(unit.get_value(), (3 * DMA_BUFFER_SIZE) as _);
 
         let transfer = spi
-            .write(
+            .half_duplex_write(
                 SpiDataMode::Single,
                 Command::None,
                 Address::None,
@@ -130,7 +129,7 @@ mod tests {
 
         let buffer = [0b0110_1010; DMA_BUFFER_SIZE];
         // Write the buffer where each byte has 3 pos edges.
-        spi.write(
+        spi.half_duplex_write(
             SpiDataMode::Single,
             Command::None,
             Address::None,
@@ -141,7 +140,7 @@ mod tests {
 
         assert_eq!(unit.get_value(), (3 * DMA_BUFFER_SIZE) as _);
 
-        spi.write(
+        spi.half_duplex_write(
             SpiDataMode::Single,
             Command::None,
             Address::None,

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -14,8 +14,7 @@ use esp_hal::{
     pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
     prelude::*,
     spi::{
-        master::{Address, Command, HalfDuplexReadWrite, Spi, SpiDma},
-        HalfDuplexMode,
+        master::{Address, Command, Spi, SpiDma},
         SpiDataMode,
         SpiMode,
     },
@@ -39,7 +38,7 @@ macro_rules! dma_alloc_buffer {
 }
 
 struct Context {
-    spi: SpiDma<'static, HalfDuplexMode, Blocking>,
+    spi: SpiDma<'static, Blocking>,
     pcnt_unit: Unit<'static, 0>,
     pcnt_source: InputSignal,
 }
@@ -65,7 +64,7 @@ mod tests {
 
         let mosi_loopback = mosi.peripheral_input();
 
-        let spi = Spi::new_half_duplex(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
+        let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
             .with_sck(sclk)
             .with_mosi(mosi)
             .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
@@ -99,7 +98,7 @@ mod tests {
         // Fill the buffer where each byte has 3 pos edges.
         dma_tx_buf.fill(&[0b0110_1010; DMA_BUFFER_SIZE]);
         let transfer = spi
-            .write(
+            .half_duplex_write(
                 SpiDataMode::Single,
                 Command::None,
                 Address::None,
@@ -113,7 +112,7 @@ mod tests {
         assert_eq!(unit.get_value(), (3 * DMA_BUFFER_SIZE) as _);
 
         let transfer = spi
-            .write(
+            .half_duplex_write(
                 SpiDataMode::Single,
                 Command::None,
                 Address::None,
@@ -151,7 +150,7 @@ mod tests {
 
         let buffer = [0b0110_1010; DMA_BUFFER_SIZE];
         // Write the buffer where each byte has 3 pos edges.
-        spi.write(
+        spi.half_duplex_write(
             SpiDataMode::Single,
             Command::None,
             Address::None,
@@ -162,7 +161,7 @@ mod tests {
 
         assert_eq!(unit.get_value(), (3 * DMA_BUFFER_SIZE) as _);
 
-        spi.write(
+        spi.half_duplex_write(
             SpiDataMode::Single,
             Command::None,
             Address::None,

--- a/hil-test/tests/spi_slave.rs
+++ b/hil-test/tests/spi_slave.rs
@@ -12,7 +12,7 @@ use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
     gpio::{interconnect::InputSignal, Io, Level, Output, PeripheralInput},
-    spi::{slave::Spi, FullDuplexMode, SpiMode},
+    spi::{slave::Spi, SpiMode},
 };
 use hil_test as _;
 
@@ -25,7 +25,7 @@ cfg_if::cfg_if! {
 }
 
 struct Context {
-    spi: Spi<'static, FullDuplexMode>,
+    spi: Spi<'static>,
     dma_channel: DmaChannelCreator,
     bitbang_spi: BitbangSpi,
 }

--- a/hil-test/tests/spi_slave.rs
+++ b/hil-test/tests/spi_slave.rs
@@ -170,7 +170,7 @@ mod tests {
         }
         slave_receive.fill(0xFF);
 
-        let transfer = spi.dma_transfer(slave_receive, &slave_send).unwrap();
+        let transfer = spi.transfer(slave_receive, &slave_send).unwrap();
 
         ctx.bitbang_spi.transfer_buf(master_receive, master_send);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The biggest change is the ability to use HD and FD devices on the same bus at the same time. The changes got a bit involved, though.