### PR TITLE
Test embedded-test update

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -212,7 +212,7 @@ digest              = { version = "0.10.7", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
 embassy-executor    = { version = "0.6.0", default-features = false }
 # Add the `embedded-test/defmt` feature for more verbose testing
-embedded-test       = { version = "0.4.0", default-features = false }
+embedded-test       = { version = "0.5.0", default-features = false }
 fugit               = "0.3.7"
 hex-literal         = "0.4.1"
 nb                  = "1.1.0"


### PR DESCRIPTION
Using embedded-test 0.4 meant we were using both embassy-executor 0.5 and 0.6 at the same time. This PR updates embedded-test so that we only use 0.6.