### PR TITLE
Better align `atoi` to what the C-library does

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a possible crash when parsing results from a radius server (#2380)
+
 ### Removed
 
 ## 0.10.1 - 2024-10-10

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -163,12 +163,12 @@ unsafe extern "C" fn atoi(str: *const i8) -> i32 {
     let mut idx = 0;
 
     // skip leading spaces
-    while str.add(idx).read_volatile() as u8 == b' ' {
+    while str.add(idx).read() as u8 == b' ' {
         idx += 1;
     }
 
     // check sign
-    let c = str.add(idx).read_volatile() as u8;
+    let c = str.add(idx).read() as u8;
     if c == b'-' || c == b'+' {
         if c == b'-' {
             sign = -1;
@@ -178,7 +178,7 @@ unsafe extern "C" fn atoi(str: *const i8) -> i32 {
 
     // parse number digit by digit
     loop {
-        let c = str.add(idx).read_volatile() as u8;
+        let c = str.add(idx).read() as u8;
 
         if !c.is_ascii_digit() {
             break;

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -180,7 +180,7 @@ unsafe extern "C" fn atoi(str: *const i8) -> i32 {
     loop {
         let c = str.add(idx).read_volatile() as u8;
 
-        if !(b'0'..=b'9').contains(&c) {
+        if !c.is_ascii_digit() {
             break;
         }
 

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -158,11 +158,37 @@ unsafe extern "C" fn strdup(str: *const i8) -> *const u8 {
 unsafe extern "C" fn atoi(str: *const i8) -> i32 {
     trace!("atoi {:?}", str);
 
-    unsafe {
-        let s = core::ffi::CStr::from_ptr(str);
-        let r = s.to_str().unwrap().parse().unwrap();
-        r
+    let mut sign: i32 = 1;
+    let mut res: i32 = 0;
+    let mut idx = 0;
+
+    while str.add(idx).read_volatile() as u8 == b' ' {
+        idx += 1;
     }
+
+    let c = str.add(idx).read_volatile() as u8;
+    if c == b'-' || c == b'+' {
+        if c == b'-' {
+            sign = -1;
+        }
+        idx += 1;
+    }
+
+    loop {
+        let c = str.add(idx).read_volatile() as u8;
+
+        if c < b'0' || c > b'9' {
+            break;
+        }
+
+        if res > i32::MAX / 10 || (res == i32::MAX / 10 && c - b'0' > 7) {
+            return if sign == 1 { i32::MAX } else { i32::MIN };
+        }
+
+        res = 10 * res + (c - b'0') as i32;
+        idx += 1;
+    }
+    return res * sign;
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -180,7 +180,7 @@ unsafe extern "C" fn atoi(str: *const i8) -> i32 {
     loop {
         let c = str.add(idx).read_volatile() as u8;
 
-        if c < b'0' || c > b'9' {
+        if !(b'0'..=b'9').contains(&c) {
             break;
         }
 
@@ -192,7 +192,7 @@ unsafe extern "C" fn atoi(str: *const i8) -> i32 {
         res = 10 * res + (c - b'0') as i32;
         idx += 1;
     }
-    return res * sign;
+    res * sign
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -162,10 +162,12 @@ unsafe extern "C" fn atoi(str: *const i8) -> i32 {
     let mut res: i32 = 0;
     let mut idx = 0;
 
+    // skip leading spaces
     while str.add(idx).read_volatile() as u8 == b' ' {
         idx += 1;
     }
 
+    // check sign
     let c = str.add(idx).read_volatile() as u8;
     if c == b'-' || c == b'+' {
         if c == b'-' {
@@ -174,6 +176,7 @@ unsafe extern "C" fn atoi(str: *const i8) -> i32 {
         idx += 1;
     }
 
+    // parse number digit by digit
     loop {
         let c = str.add(idx).read_volatile() as u8;
 
@@ -181,6 +184,7 @@ unsafe extern "C" fn atoi(str: *const i8) -> i32 {
             break;
         }
 
+        // if the result would exceed the bounds - return max-value
         if res > i32::MAX / 10 || (res == i32::MAX / 10 && c - b'0' > 7) {
             return if sign == 1 { i32::MAX } else { i32::MIN };
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The previous implementation of `atoi` wasn't exactly doing what (most) C-library implementations do. Especially it panicked when seeing extra non-digit characters etc.

`skip-changelog` since it's not a user-facing change

Fixes #2368 (but unable to repro this myself)

#### Testing
`esp-wifi` examples work as before - especially when using EAP
