### PR TITLE
Overhaul peripheral signal system, first run

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the pin type parameters from `parl_io::{TxOneBit, TxTwoBits, TxFourBits, TxEightBits, TxSixteenBits}` (#2388)
 - Removed the pin type parameters from `parl_io::{RxOneBit, RxTwoBits, RxFourBits, RxEightBits, RxSixteenBits}` (#2388)
 - Removed the pin type parameters from `lcd_cam::lcd::i8080::{TxEightBits, TxSixteenBits}` (#2388)
-- Removed the pin type parameters from `lcd_cam::lcd::cam::{RxEightBits, RxSixteenBits}` (#2388)
+- Removed the pin type parameters from `lcd_cam::cam::{RxEightBits, RxSixteenBits}` (#2388)
 
 ## [0.21.1]
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -43,6 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Spi::with_pins` methods have been removed. (#2373)
 - The `Spi::new_half_duplex` constructor have been removed. (#2373)
 - The `HalfDuplexMode` and `FullDuplexMode` parameters have been removed from `Spi`. (#2373)
+- Removed the output pin type parameter from `ledc::{Channel, ChannelIFace}` (#2388)
+- Removed the output pin type parameter from `mcpwm::operator::{PwmPin, LinkedPins}` (#2388)
+- Removed the output pin type parameter from `parl_io::{ClkOutPin, ClkInPin, RxClkInPin}` (#2388)
+- Removed the valid pin type parameter from `parl_io::{TxPinConfigWithValidPin, RxPinConfigWithValidPin}` (#2388)
+- Removed the pin type parameters from `parl_io::{TxOneBit, TxTwoBits, TxFourBits, TxEightBits, TxSixteenBits}` (#2388)
+- Removed the pin type parameters from `parl_io::{RxOneBit, RxTwoBits, RxFourBits, RxEightBits, RxSixteenBits}` (#2388)
+- Removed the pin type parameters from `lcd_cam::lcd::i8080::{TxEightBits, TxSixteenBits}` (#2388)
+- Removed the pin type parameters from `lcd_cam::lcd::cam::{RxEightBits, RxSixteenBits}` (#2388)
 
 ## [0.21.1]
 

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -405,9 +405,9 @@ enum AnyInputSignalInner {
 
 /// A type-erased input signal.
 #[derive(Clone)]
-pub struct AnyInputSignal(AnyInputSignalInner);
+pub struct InputConnection(AnyInputSignalInner);
 
-impl Peripheral for AnyInputSignal {
+impl Peripheral for InputConnection {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -415,31 +415,31 @@ impl Peripheral for AnyInputSignal {
     }
 }
 
-impl From<InputSignal> for AnyInputSignal {
+impl From<InputSignal> for InputConnection {
     fn from(input: InputSignal) -> Self {
         Self(AnyInputSignalInner::Input(input))
     }
 }
 
-impl From<Level> for AnyInputSignal {
+impl From<Level> for InputConnection {
     fn from(level: Level) -> Self {
         Self(AnyInputSignalInner::Constant(level))
     }
 }
 
-impl From<NoPin> for AnyInputSignal {
+impl From<NoPin> for InputConnection {
     fn from(_pin: NoPin) -> Self {
         Self(AnyInputSignalInner::Constant(Level::Low))
     }
 }
 
-impl From<AnyPin> for AnyInputSignal {
+impl From<AnyPin> for InputConnection {
     fn from(input: AnyPin) -> Self {
         Self(AnyInputSignalInner::Input(input.peripheral_input()))
     }
 }
 
-impl<const GPIONUM: u8> From<GpioPin<GPIONUM>> for AnyInputSignal
+impl<const GPIONUM: u8> From<GpioPin<GPIONUM>> for InputConnection
 where
     GpioPin<GPIONUM>: InputPin,
 {
@@ -448,8 +448,8 @@ where
     }
 }
 
-impl Sealed for AnyInputSignal {}
-impl PeripheralSignal for AnyInputSignal {
+impl Sealed for InputConnection {}
+impl PeripheralSignal for InputConnection {
     delegate::delegate! {
         to match &self.0 {
             AnyInputSignalInner::Input(pin) => pin,
@@ -460,7 +460,7 @@ impl PeripheralSignal for AnyInputSignal {
     }
 }
 
-impl PeripheralInput for AnyInputSignal {
+impl PeripheralInput for InputConnection {
     delegate::delegate! {
         to match &self.0 {
             AnyInputSignalInner::Input(pin) => pin,

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -26,14 +26,12 @@ use crate::{
 ///
 /// Peripheral drivers are encouraged to accept types that implement this and
 /// [`PeripheralOutput`] as arguments instead of pin types.
-#[doc(hidden)]
 pub trait PeripheralInput: Into<InputConnection> + 'static {}
 
 /// A signal that can be connected to a peripheral input and/or output.
 ///
 /// Peripheral drivers are encouraged to accept types that implement this and
 /// [`PeripheralInput`] as arguments instead of pin types.
-#[doc(hidden)]
 pub trait PeripheralOutput: Into<OutputConnection> + 'static {}
 
 impl<P: InputPin> PeripheralInput for P {}
@@ -282,7 +280,7 @@ impl OutputSignal {
 impl OutputSignal {
     /// Connect the pin to a peripheral input signal.
     ///
-    /// Since there can only be one input signal connected to a peripheral at a
+    /// Since there can only be one signal connected to a peripheral input at a
     /// time, this function will disconnect any previously connected input
     /// signals.
     fn connect_input_to_peripheral(&mut self, signal: gpio::InputSignal, _: private::Internal) {

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -785,7 +785,7 @@ where
 
 impl<const GPIONUM: u8> PeripheralOutput for GpioPin<GPIONUM>
 where
-    Self: OutputPin + Pin,
+    Self: OutputPin,
 {
     fn set_to_open_drain_output(&mut self, _: private::Internal) {
         self.init_output(GPIO_FUNCTION, true);

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -396,7 +396,7 @@ pub trait PeripheralInput: PeripheralSignal {
 }
 
 /// Trait implemented by pins which can be used as peripheral outputs.
-pub trait PeripheralOutput: PeripheralSignal {
+pub trait PeripheralOutput: PeripheralInput {
     /// Configure open-drain mode
     #[doc(hidden)]
     fn set_to_open_drain_output(&mut self, _: private::Internal);

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -49,12 +49,9 @@ impl Level {
         unsafe { GPIO::steal() }
             .func_in_sel_cfg(signal as usize - FUNC_IN_SEL_OFFSET)
             .modify(|_, w| unsafe {
-                w.sel()
-                    .set_bit()
-                    .in_inv_sel()
-                    .bit(false)
-                    .in_sel()
-                    .bits(value)
+                w.sel().set_bit();
+                w.in_inv_sel().bit(false);
+                w.in_sel().bits(value)
             });
     }
 

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -15,26 +15,32 @@ impl crate::peripheral::Peripheral for Level {
     }
 }
 
-impl PeripheralSignal for Level {
-    fn pull_direction(&self, _pull: Pull, _internal: private::Internal) {}
-}
+impl Level {
+    pub(crate) fn pull_direction(&self, _pull: Pull, _internal: private::Internal) {}
 
-impl PeripheralInput for Level {
-    fn input_signals(&self, _: private::Internal) -> &[(AlternateFunction, InputSignal)] {
+    pub(crate) fn input_signals(
+        &self,
+        _: private::Internal,
+    ) -> &[(AlternateFunction, InputSignal)] {
         &[]
     }
 
-    fn init_input(&self, _pull: Pull, _: private::Internal) {}
+    pub(crate) fn init_input(&self, _pull: Pull, _: private::Internal) {}
 
-    fn enable_input(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn enable_input(&mut self, _on: bool, _: private::Internal) {}
 
-    fn enable_input_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn enable_input_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
 
-    fn is_input_high(&self, _: private::Internal) -> bool {
+    pub(crate) fn is_input_high(&self, _: private::Internal) -> bool {
         *self == Level::High
     }
 
-    fn connect_input_to_peripheral(&mut self, signal: InputSignal, _: private::Internal) {
+    #[doc(hidden)]
+    pub(crate) fn connect_input_to_peripheral(
+        &mut self,
+        signal: InputSignal,
+        _: private::Internal,
+    ) {
         let value = match self {
             Level::High => ONE_INPUT,
             Level::Low => ZERO_INPUT,
@@ -52,39 +58,46 @@ impl PeripheralInput for Level {
             });
     }
 
-    fn disconnect_input_from_peripheral(&mut self, _signal: InputSignal, _: private::Internal) {}
-}
+    pub(crate) fn disconnect_input_from_peripheral(
+        &mut self,
+        _signal: InputSignal,
+        _: private::Internal,
+    ) {
+    }
+    pub(crate) fn set_to_open_drain_output(&mut self, _: private::Internal) {}
+    pub(crate) fn set_to_push_pull_output(&mut self, _: private::Internal) {}
+    pub(crate) fn enable_output(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn set_output_high(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn set_drive_strength(&mut self, _strength: DriveStrength, _: private::Internal) {}
+    pub(crate) fn enable_open_drain(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn enable_output_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn internal_pull_up_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn internal_pull_down_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
 
-impl PeripheralOutput for Level {
-    fn set_to_open_drain_output(&mut self, _: private::Internal) {}
-
-    fn set_to_push_pull_output(&mut self, _: private::Internal) {}
-
-    fn enable_output(&mut self, _on: bool, _: private::Internal) {}
-
-    fn set_output_high(&mut self, _on: bool, _: private::Internal) {}
-
-    fn set_drive_strength(&mut self, _strength: DriveStrength, _: private::Internal) {}
-
-    fn enable_open_drain(&mut self, _on: bool, _: private::Internal) {}
-
-    fn enable_output_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
-
-    fn internal_pull_up_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
-
-    fn internal_pull_down_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
-
-    fn is_set_high(&self, _: private::Internal) -> bool {
+    pub(crate) fn is_set_high(&self, _: private::Internal) -> bool {
         false
     }
 
-    fn output_signals(&self, _: private::Internal) -> &[(AlternateFunction, OutputSignal)] {
+    pub(crate) fn output_signals(
+        &self,
+        _: private::Internal,
+    ) -> &[(AlternateFunction, OutputSignal)] {
         &[]
     }
 
-    fn connect_peripheral_to_output(&mut self, _signal: OutputSignal, _: private::Internal) {}
+    pub(crate) fn connect_peripheral_to_output(
+        &mut self,
+        _signal: OutputSignal,
+        _: private::Internal,
+    ) {
+    }
 
-    fn disconnect_from_peripheral_output(&mut self, _signal: OutputSignal, _: private::Internal) {}
+    pub(crate) fn disconnect_from_peripheral_output(
+        &mut self,
+        _signal: OutputSignal,
+        _: private::Internal,
+    ) {
+    }
 }
 
 /// Placeholder pin, used when no pin is required when using a peripheral.
@@ -102,44 +115,6 @@ impl crate::peripheral::Peripheral for NoPin {
 }
 
 impl private::Sealed for NoPin {}
-
-impl PeripheralSignal for NoPin {
-    fn pull_direction(&self, _pull: Pull, _internal: private::Internal) {}
-}
-
-impl PeripheralInput for NoPin {
-    delegate::delegate! {
-        to Level::Low {
-            fn init_input(&self, _pull: Pull, _internal: private::Internal);
-            fn enable_input(&mut self, _on: bool, _internal: private::Internal);
-            fn enable_input_in_sleep_mode(&mut self, _on: bool, _internal: private::Internal);
-            fn is_input_high(&self, _internal: private::Internal) -> bool;
-            fn connect_input_to_peripheral(&mut self, _signal: InputSignal, _internal: private::Internal);
-            fn disconnect_input_from_peripheral(&mut self, _signal: InputSignal, _internal: private::Internal);
-            fn input_signals(&self, _internal: private::Internal) -> &[(AlternateFunction, InputSignal)];
-        }
-    }
-}
-
-impl PeripheralOutput for NoPin {
-    delegate::delegate! {
-        to Level::Low {
-            fn set_to_open_drain_output(&mut self, _internal: private::Internal);
-            fn set_to_push_pull_output(&mut self, _internal: private::Internal);
-            fn enable_output(&mut self, _on: bool, _internal: private::Internal);
-            fn set_output_high(&mut self, _on: bool, _internal: private::Internal);
-            fn set_drive_strength(&mut self, _strength: DriveStrength, _internal: private::Internal);
-            fn enable_open_drain(&mut self, _on: bool, _internal: private::Internal);
-            fn enable_output_in_sleep_mode(&mut self, _on: bool, _internal: private::Internal);
-            fn internal_pull_up_in_sleep_mode(&mut self, _on: bool, _internal: private::Internal);
-            fn internal_pull_down_in_sleep_mode(&mut self, _on: bool, _internal: private::Internal);
-            fn is_set_high(&self, _internal: private::Internal) -> bool;
-            fn output_signals(&self, _internal: private::Internal) -> &[(AlternateFunction, OutputSignal)];
-            fn connect_peripheral_to_output(&mut self, _signal: OutputSignal, _internal: private::Internal);
-            fn disconnect_from_peripheral_output(&mut self, _signal: OutputSignal, _internal: private::Internal);
-        }
-    }
-}
 
 impl embedded_hal_02::digital::v2::OutputPin for NoPin {
     type Error = core::convert::Infallible;

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -59,7 +59,7 @@ use fugit::HertzU32;
 use crate::{
     clock::Clocks,
     dma::PeripheralMarker,
-    gpio::{InputSignal, OutputSignal, PeripheralOutput, Pull},
+    gpio::{interconnect::PeripheralOutput, InputSignal, OutputSignal, Pull},
     interrupt::InterruptHandler,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::i2c0::{RegisterBlock, COMD},
@@ -495,7 +495,8 @@ where
         scl: impl Peripheral<P = SCL> + 'd,
         frequency: HertzU32,
     ) -> Self {
-        crate::into_ref!(i2c, sda, scl);
+        crate::into_ref!(i2c);
+        crate::into_mapped_ref!(sda, scl);
 
         let i2c = I2c {
             i2c,

--- a/esp-hal/src/i2c.rs
+++ b/esp-hal/src/i2c.rs
@@ -59,7 +59,7 @@ use fugit::HertzU32;
 use crate::{
     clock::Clocks,
     dma::PeripheralMarker,
-    gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput, Pull},
+    gpio::{InputSignal, OutputSignal, PeripheralOutput, Pull},
     interrupt::InterruptHandler,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::i2c0::{RegisterBlock, COMD},
@@ -489,10 +489,7 @@ impl<'d, T, DM: Mode> I2c<'d, DM, T>
 where
     T: Instance,
 {
-    fn new_internal<
-        SDA: PeripheralOutput + PeripheralInput,
-        SCL: PeripheralOutput + PeripheralInput,
-    >(
+    fn new_internal<SDA: PeripheralOutput, SCL: PeripheralOutput>(
         i2c: impl Peripheral<P = T> + 'd,
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
@@ -562,7 +559,7 @@ impl<'d> I2c<'d, Blocking> {
     /// Create a new I2C instance
     /// This will enable the peripheral but the peripheral won't get
     /// automatically disabled when this gets dropped.
-    pub fn new<SDA: PeripheralOutput + PeripheralInput, SCL: PeripheralOutput + PeripheralInput>(
+    pub fn new<SDA: PeripheralOutput, SCL: PeripheralOutput>(
         i2c: impl Peripheral<P = impl Instance> + 'd,
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
@@ -579,10 +576,7 @@ where
     /// Create a new I2C instance
     /// This will enable the peripheral but the peripheral won't get
     /// automatically disabled when this gets dropped.
-    pub fn new_typed<
-        SDA: PeripheralOutput + PeripheralInput,
-        SCL: PeripheralOutput + PeripheralInput,
-    >(
+    pub fn new_typed<SDA: PeripheralOutput, SCL: PeripheralOutput>(
         i2c: impl Peripheral<P = T> + 'd,
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
@@ -607,10 +601,7 @@ impl<'d> I2c<'d, Async> {
     /// Create a new I2C instance
     /// This will enable the peripheral but the peripheral won't get
     /// automatically disabled when this gets dropped.
-    pub fn new_async<
-        SDA: PeripheralOutput + PeripheralInput,
-        SCL: PeripheralOutput + PeripheralInput,
-    >(
+    pub fn new_async<SDA: PeripheralOutput, SCL: PeripheralOutput>(
         i2c: impl Peripheral<P = impl Instance> + 'd,
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,
@@ -627,10 +618,7 @@ where
     /// Create a new I2C instance
     /// This will enable the peripheral but the peripheral won't get
     /// automatically disabled when this gets dropped.
-    pub fn new_async_typed<
-        SDA: PeripheralOutput + PeripheralInput,
-        SCL: PeripheralOutput + PeripheralInput,
-    >(
+    pub fn new_async_typed<SDA: PeripheralOutput, SCL: PeripheralOutput>(
         i2c: impl Peripheral<P = T> + 'd,
         sda: impl Peripheral<P = SDA> + 'd,
         scl: impl Peripheral<P = SCL> + 'd,

--- a/esp-hal/src/i2s.rs
+++ b/esp-hal/src/i2s.rs
@@ -103,9 +103,8 @@ use crate::{
         Tx,
         WriteBuffer,
     },
-    gpio::PeripheralOutput,
+    gpio::interconnect::PeripheralOutput,
     interrupt::InterruptHandler,
-    into_ref,
     peripheral::{Peripheral, PeripheralRef},
     system::PeripheralClockControl,
     InterruptConfigurable,
@@ -434,7 +433,7 @@ where
 
     /// Configures the I2S peripheral to use a master clock (MCLK) output pin.
     pub fn with_mclk<P: PeripheralOutput>(self, pin: impl Peripheral<P = P> + 'd) -> Self {
-        into_ref!(pin);
+        crate::into_mapped_ref!(pin);
         pin.set_to_push_pull_output(crate::private::Internal);
         pin.connect_peripheral_to_output(self.i2s_tx.i2s.mclk_signal(), crate::private::Internal);
 
@@ -750,10 +749,13 @@ mod private {
             DmaEligible,
             PeripheralMarker,
         },
-        gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput},
+        gpio::{
+            interconnect::{PeripheralInput, PeripheralOutput},
+            InputSignal,
+            OutputSignal,
+        },
         interrupt::InterruptHandler,
-        into_ref,
-        peripheral::PeripheralRef,
+        peripheral::{Peripheral, PeripheralRef},
         peripherals::I2S0,
         private,
         Mode,
@@ -784,33 +786,33 @@ mod private {
             }
         }
 
-        pub fn with_bclk<P>(self, pin: impl crate::peripheral::Peripheral<P = P> + 'd) -> Self
+        pub fn with_bclk<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
         where
             P: PeripheralOutput,
         {
-            into_ref!(pin);
+            crate::into_mapped_ref!(pin);
             pin.set_to_push_pull_output(private::Internal);
             pin.connect_peripheral_to_output(self.i2s.bclk_signal(), private::Internal);
 
             self
         }
 
-        pub fn with_ws<P>(self, pin: impl crate::peripheral::Peripheral<P = P> + 'd) -> Self
+        pub fn with_ws<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
         where
             P: PeripheralOutput,
         {
-            into_ref!(pin);
+            crate::into_mapped_ref!(pin);
             pin.set_to_push_pull_output(private::Internal);
             pin.connect_peripheral_to_output(self.i2s.ws_signal(), private::Internal);
 
             self
         }
 
-        pub fn with_dout<P>(self, pin: impl crate::peripheral::Peripheral<P = P> + 'd) -> Self
+        pub fn with_dout<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
         where
             P: PeripheralOutput,
         {
-            into_ref!(pin);
+            crate::into_mapped_ref!(pin);
             pin.set_to_push_pull_output(private::Internal);
             pin.connect_peripheral_to_output(self.i2s.dout_signal(), private::Internal);
 
@@ -843,33 +845,33 @@ mod private {
             }
         }
 
-        pub fn with_bclk<P>(self, pin: impl crate::peripheral::Peripheral<P = P> + 'd) -> Self
+        pub fn with_bclk<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
         where
             P: PeripheralOutput,
         {
-            into_ref!(pin);
+            crate::into_mapped_ref!(pin);
             pin.set_to_push_pull_output(private::Internal);
             pin.connect_peripheral_to_output(self.i2s.bclk_rx_signal(), private::Internal);
 
             self
         }
 
-        pub fn with_ws<P>(self, pin: impl crate::peripheral::Peripheral<P = P> + 'd) -> Self
+        pub fn with_ws<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
         where
             P: PeripheralOutput,
         {
-            into_ref!(pin);
+            crate::into_mapped_ref!(pin);
             pin.set_to_push_pull_output(private::Internal);
             pin.connect_peripheral_to_output(self.i2s.ws_rx_signal(), private::Internal);
 
             self
         }
 
-        pub fn with_din<P>(self, pin: impl crate::peripheral::Peripheral<P = P> + 'd) -> Self
+        pub fn with_din<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
         where
             P: PeripheralInput,
         {
-            into_ref!(pin);
+            crate::into_mapped_ref!(pin);
             pin.init_input(crate::gpio::Pull::None, private::Internal);
             pin.connect_input_to_peripheral(self.i2s.din_signal(), private::Internal);
 
@@ -878,11 +880,7 @@ mod private {
     }
 
     pub trait RegBlock:
-        crate::peripheral::Peripheral<P = Self>
-        + PeripheralMarker
-        + DmaEligible
-        + Into<super::AnyI2s>
-        + 'static
+        Peripheral<P = Self> + PeripheralMarker + DmaEligible + Into<super::AnyI2s> + 'static
     {
         fn register_block(&self) -> &RegisterBlock;
     }

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -484,26 +484,16 @@ impl RxEightBits {
     #[allow(clippy::too_many_arguments)]
     /// Creates a new instance of `RxEightBits`, configuring the specified pins
     /// as the 8-bit data bus.
-    pub fn new<'d, P0, P1, P2, P3, P4, P5, P6, P7>(
-        pin_0: impl Peripheral<P = P0> + 'd,
-        pin_1: impl Peripheral<P = P1> + 'd,
-        pin_2: impl Peripheral<P = P2> + 'd,
-        pin_3: impl Peripheral<P = P3> + 'd,
-        pin_4: impl Peripheral<P = P4> + 'd,
-        pin_5: impl Peripheral<P = P5> + 'd,
-        pin_6: impl Peripheral<P = P6> + 'd,
-        pin_7: impl Peripheral<P = P7> + 'd,
-    ) -> Self
-    where
-        P0: PeripheralInput,
-        P1: PeripheralInput,
-        P2: PeripheralInput,
-        P3: PeripheralInput,
-        P4: PeripheralInput,
-        P5: PeripheralInput,
-        P6: PeripheralInput,
-        P7: PeripheralInput,
-    {
+    pub fn new<'d>(
+        pin_0: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_1: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_2: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_3: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_4: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_5: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_6: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_7: impl Peripheral<P = impl PeripheralInput> + 'd,
+    ) -> Self {
         crate::into_mapped_ref!(pin_0);
         crate::into_mapped_ref!(pin_1);
         crate::into_mapped_ref!(pin_2);
@@ -513,22 +503,21 @@ impl RxEightBits {
         crate::into_mapped_ref!(pin_6);
         crate::into_mapped_ref!(pin_7);
 
-        pin_0.init_input(Pull::None, crate::private::Internal);
-        pin_0.connect_input_to_peripheral(InputSignal::CAM_DATA_0, crate::private::Internal);
-        pin_1.init_input(Pull::None, crate::private::Internal);
-        pin_1.connect_input_to_peripheral(InputSignal::CAM_DATA_1, crate::private::Internal);
-        pin_2.init_input(Pull::None, crate::private::Internal);
-        pin_2.connect_input_to_peripheral(InputSignal::CAM_DATA_2, crate::private::Internal);
-        pin_3.init_input(Pull::None, crate::private::Internal);
-        pin_3.connect_input_to_peripheral(InputSignal::CAM_DATA_3, crate::private::Internal);
-        pin_4.init_input(Pull::None, crate::private::Internal);
-        pin_4.connect_input_to_peripheral(InputSignal::CAM_DATA_4, crate::private::Internal);
-        pin_5.init_input(Pull::None, crate::private::Internal);
-        pin_5.connect_input_to_peripheral(InputSignal::CAM_DATA_5, crate::private::Internal);
-        pin_6.init_input(Pull::None, crate::private::Internal);
-        pin_6.connect_input_to_peripheral(InputSignal::CAM_DATA_6, crate::private::Internal);
-        pin_7.init_input(Pull::None, crate::private::Internal);
-        pin_7.connect_input_to_peripheral(InputSignal::CAM_DATA_7, crate::private::Internal);
+        let pairs = [
+            (pin_0, InputSignal::CAM_DATA_0),
+            (pin_1, InputSignal::CAM_DATA_1),
+            (pin_2, InputSignal::CAM_DATA_2),
+            (pin_3, InputSignal::CAM_DATA_3),
+            (pin_4, InputSignal::CAM_DATA_4),
+            (pin_5, InputSignal::CAM_DATA_5),
+            (pin_6, InputSignal::CAM_DATA_6),
+            (pin_7, InputSignal::CAM_DATA_7),
+        ];
+
+        for (mut pin, signal) in pairs.into_iter() {
+            pin.init_input(Pull::None, crate::private::Internal);
+            pin.connect_input_to_peripheral(signal, crate::private::Internal);
+        }
 
         Self { _pins: () }
     }
@@ -548,42 +537,24 @@ impl RxSixteenBits {
     #[allow(clippy::too_many_arguments)]
     /// Creates a new instance of `RxSixteenBits`, configuring the specified
     /// pins as the 16-bit data bus.
-    pub fn new<'d, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>(
-        pin_0: impl Peripheral<P = P0> + 'd,
-        pin_1: impl Peripheral<P = P1> + 'd,
-        pin_2: impl Peripheral<P = P2> + 'd,
-        pin_3: impl Peripheral<P = P3> + 'd,
-        pin_4: impl Peripheral<P = P4> + 'd,
-        pin_5: impl Peripheral<P = P5> + 'd,
-        pin_6: impl Peripheral<P = P6> + 'd,
-        pin_7: impl Peripheral<P = P7> + 'd,
-        pin_8: impl Peripheral<P = P8> + 'd,
-        pin_9: impl Peripheral<P = P9> + 'd,
-        pin_10: impl Peripheral<P = P10> + 'd,
-        pin_11: impl Peripheral<P = P11> + 'd,
-        pin_12: impl Peripheral<P = P12> + 'd,
-        pin_13: impl Peripheral<P = P13> + 'd,
-        pin_14: impl Peripheral<P = P14> + 'd,
-        pin_15: impl Peripheral<P = P15> + 'd,
-    ) -> Self
-    where
-        P0: PeripheralInput,
-        P1: PeripheralInput,
-        P2: PeripheralInput,
-        P3: PeripheralInput,
-        P4: PeripheralInput,
-        P5: PeripheralInput,
-        P6: PeripheralInput,
-        P7: PeripheralInput,
-        P8: PeripheralInput,
-        P9: PeripheralInput,
-        P10: PeripheralInput,
-        P11: PeripheralInput,
-        P12: PeripheralInput,
-        P13: PeripheralInput,
-        P14: PeripheralInput,
-        P15: PeripheralInput,
-    {
+    pub fn new<'d>(
+        pin_0: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_1: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_2: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_3: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_4: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_5: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_6: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_7: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_8: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_9: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_10: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_11: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_12: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_13: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_14: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_15: impl Peripheral<P = impl PeripheralInput> + 'd,
+    ) -> Self {
         crate::into_mapped_ref!(pin_0);
         crate::into_mapped_ref!(pin_1);
         crate::into_mapped_ref!(pin_2);
@@ -601,38 +572,29 @@ impl RxSixteenBits {
         crate::into_mapped_ref!(pin_14);
         crate::into_mapped_ref!(pin_15);
 
-        pin_0.init_input(Pull::None, crate::private::Internal);
-        pin_0.connect_input_to_peripheral(InputSignal::CAM_DATA_0, crate::private::Internal);
-        pin_1.init_input(Pull::None, crate::private::Internal);
-        pin_1.connect_input_to_peripheral(InputSignal::CAM_DATA_1, crate::private::Internal);
-        pin_2.init_input(Pull::None, crate::private::Internal);
-        pin_2.connect_input_to_peripheral(InputSignal::CAM_DATA_2, crate::private::Internal);
-        pin_3.init_input(Pull::None, crate::private::Internal);
-        pin_3.connect_input_to_peripheral(InputSignal::CAM_DATA_3, crate::private::Internal);
-        pin_4.init_input(Pull::None, crate::private::Internal);
-        pin_4.connect_input_to_peripheral(InputSignal::CAM_DATA_4, crate::private::Internal);
-        pin_5.init_input(Pull::None, crate::private::Internal);
-        pin_5.connect_input_to_peripheral(InputSignal::CAM_DATA_5, crate::private::Internal);
-        pin_6.init_input(Pull::None, crate::private::Internal);
-        pin_6.connect_input_to_peripheral(InputSignal::CAM_DATA_6, crate::private::Internal);
-        pin_7.init_input(Pull::None, crate::private::Internal);
-        pin_7.connect_input_to_peripheral(InputSignal::CAM_DATA_7, crate::private::Internal);
-        pin_8.init_input(Pull::None, crate::private::Internal);
-        pin_8.connect_input_to_peripheral(InputSignal::CAM_DATA_8, crate::private::Internal);
-        pin_9.init_input(Pull::None, crate::private::Internal);
-        pin_9.connect_input_to_peripheral(InputSignal::CAM_DATA_9, crate::private::Internal);
-        pin_10.init_input(Pull::None, crate::private::Internal);
-        pin_10.connect_input_to_peripheral(InputSignal::CAM_DATA_10, crate::private::Internal);
-        pin_11.init_input(Pull::None, crate::private::Internal);
-        pin_11.connect_input_to_peripheral(InputSignal::CAM_DATA_11, crate::private::Internal);
-        pin_12.init_input(Pull::None, crate::private::Internal);
-        pin_12.connect_input_to_peripheral(InputSignal::CAM_DATA_12, crate::private::Internal);
-        pin_13.init_input(Pull::None, crate::private::Internal);
-        pin_13.connect_input_to_peripheral(InputSignal::CAM_DATA_13, crate::private::Internal);
-        pin_14.init_input(Pull::None, crate::private::Internal);
-        pin_14.connect_input_to_peripheral(InputSignal::CAM_DATA_14, crate::private::Internal);
-        pin_15.init_input(Pull::None, crate::private::Internal);
-        pin_15.connect_input_to_peripheral(InputSignal::CAM_DATA_15, crate::private::Internal);
+        let pairs = [
+            (pin_0, InputSignal::CAM_DATA_0),
+            (pin_1, InputSignal::CAM_DATA_1),
+            (pin_2, InputSignal::CAM_DATA_2),
+            (pin_3, InputSignal::CAM_DATA_3),
+            (pin_4, InputSignal::CAM_DATA_4),
+            (pin_5, InputSignal::CAM_DATA_5),
+            (pin_6, InputSignal::CAM_DATA_6),
+            (pin_7, InputSignal::CAM_DATA_7),
+            (pin_8, InputSignal::CAM_DATA_8),
+            (pin_9, InputSignal::CAM_DATA_9),
+            (pin_10, InputSignal::CAM_DATA_10),
+            (pin_11, InputSignal::CAM_DATA_11),
+            (pin_12, InputSignal::CAM_DATA_12),
+            (pin_13, InputSignal::CAM_DATA_13),
+            (pin_14, InputSignal::CAM_DATA_14),
+            (pin_15, InputSignal::CAM_DATA_15),
+        ];
+
+        for (mut pin, signal) in pairs.into_iter() {
+            pin.init_input(Pull::None, crate::private::Internal);
+            pin.connect_input_to_peripheral(signal, crate::private::Internal);
+        }
 
         Self { _pins: () }
     }

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -75,7 +75,12 @@ use fugit::HertzU32;
 use crate::{
     clock::Clocks,
     dma::{ChannelRx, DmaChannelConvert, DmaEligible, DmaError, DmaPeripheral, DmaRxBuffer, Rx},
-    gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput, Pull},
+    gpio::{
+        interconnect::{PeripheralInput, PeripheralOutput},
+        InputSignal,
+        OutputSignal,
+        Pull,
+    },
     lcd_cam::{cam::private::RxPins, private::calculate_clkm, BitOrder, ByteOrder},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
@@ -237,7 +242,7 @@ impl<'d> Camera<'d> {
         self,
         mclk: impl Peripheral<P = MCLK> + 'd,
     ) -> Self {
-        crate::into_ref!(mclk);
+        crate::into_mapped_ref!(mclk);
         mclk.set_to_push_pull_output(crate::private::Internal);
         mclk.connect_peripheral_to_output(OutputSignal::CAM_CLK, crate::private::Internal);
         self
@@ -248,7 +253,7 @@ impl<'d> Camera<'d> {
         self,
         pclk: impl Peripheral<P = PCLK> + 'd,
     ) -> Self {
-        crate::into_ref!(pclk);
+        crate::into_mapped_ref!(pclk);
 
         pclk.init_input(Pull::None, crate::private::Internal);
         pclk.connect_input_to_peripheral(InputSignal::CAM_PCLK, crate::private::Internal);
@@ -263,8 +268,7 @@ impl<'d> Camera<'d> {
         vsync: impl Peripheral<P = VSYNC> + 'd,
         h_enable: impl Peripheral<P = HENABLE> + 'd,
     ) -> Self {
-        crate::into_ref!(vsync);
-        crate::into_ref!(h_enable);
+        crate::into_mapped_ref!(vsync, h_enable);
 
         vsync.init_input(Pull::None, crate::private::Internal);
         vsync.connect_input_to_peripheral(InputSignal::CAM_V_SYNC, crate::private::Internal);
@@ -290,9 +294,7 @@ impl<'d> Camera<'d> {
         hsync: impl Peripheral<P = HSYNC> + 'd,
         h_enable: impl Peripheral<P = HENABLE> + 'd,
     ) -> Self {
-        crate::into_ref!(vsync);
-        crate::into_ref!(hsync);
-        crate::into_ref!(h_enable);
+        crate::into_mapped_ref!(vsync, hsync, h_enable);
 
         vsync.init_input(Pull::None, crate::private::Internal);
         vsync.connect_input_to_peripheral(InputSignal::CAM_V_SYNC, crate::private::Internal);
@@ -502,14 +504,14 @@ impl RxEightBits {
         P6: PeripheralInput,
         P7: PeripheralInput,
     {
-        crate::into_ref!(pin_0);
-        crate::into_ref!(pin_1);
-        crate::into_ref!(pin_2);
-        crate::into_ref!(pin_3);
-        crate::into_ref!(pin_4);
-        crate::into_ref!(pin_5);
-        crate::into_ref!(pin_6);
-        crate::into_ref!(pin_7);
+        crate::into_mapped_ref!(pin_0);
+        crate::into_mapped_ref!(pin_1);
+        crate::into_mapped_ref!(pin_2);
+        crate::into_mapped_ref!(pin_3);
+        crate::into_mapped_ref!(pin_4);
+        crate::into_mapped_ref!(pin_5);
+        crate::into_mapped_ref!(pin_6);
+        crate::into_mapped_ref!(pin_7);
 
         pin_0.init_input(Pull::None, crate::private::Internal);
         pin_0.connect_input_to_peripheral(InputSignal::CAM_DATA_0, crate::private::Internal);
@@ -582,22 +584,22 @@ impl RxSixteenBits {
         P14: PeripheralInput,
         P15: PeripheralInput,
     {
-        crate::into_ref!(pin_0);
-        crate::into_ref!(pin_1);
-        crate::into_ref!(pin_2);
-        crate::into_ref!(pin_3);
-        crate::into_ref!(pin_4);
-        crate::into_ref!(pin_5);
-        crate::into_ref!(pin_6);
-        crate::into_ref!(pin_7);
-        crate::into_ref!(pin_8);
-        crate::into_ref!(pin_9);
-        crate::into_ref!(pin_10);
-        crate::into_ref!(pin_11);
-        crate::into_ref!(pin_12);
-        crate::into_ref!(pin_13);
-        crate::into_ref!(pin_14);
-        crate::into_ref!(pin_15);
+        crate::into_mapped_ref!(pin_0);
+        crate::into_mapped_ref!(pin_1);
+        crate::into_mapped_ref!(pin_2);
+        crate::into_mapped_ref!(pin_3);
+        crate::into_mapped_ref!(pin_4);
+        crate::into_mapped_ref!(pin_5);
+        crate::into_mapped_ref!(pin_6);
+        crate::into_mapped_ref!(pin_7);
+        crate::into_mapped_ref!(pin_8);
+        crate::into_mapped_ref!(pin_9);
+        crate::into_mapped_ref!(pin_10);
+        crate::into_mapped_ref!(pin_11);
+        crate::into_mapped_ref!(pin_12);
+        crate::into_mapped_ref!(pin_13);
+        crate::into_mapped_ref!(pin_14);
+        crate::into_mapped_ref!(pin_15);
 
         pin_0.init_input(Pull::None, crate::private::Internal);
         pin_0.connect_input_to_peripheral(InputSignal::CAM_DATA_0, crate::private::Internal);

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -583,14 +583,7 @@ impl From<u16> for Command<u16> {
 /// Represents a group of 8 output pins configured for 8-bit parallel data
 /// transmission.
 pub struct TxEightBits<'d> {
-    pin_0: PeripheralRef<'d, OutputConnection>,
-    pin_1: PeripheralRef<'d, OutputConnection>,
-    pin_2: PeripheralRef<'d, OutputConnection>,
-    pin_3: PeripheralRef<'d, OutputConnection>,
-    pin_4: PeripheralRef<'d, OutputConnection>,
-    pin_5: PeripheralRef<'d, OutputConnection>,
-    pin_6: PeripheralRef<'d, OutputConnection>,
-    pin_7: PeripheralRef<'d, OutputConnection>,
+    pins: [PeripheralRef<'d, OutputConnection>; 8],
 }
 
 impl<'d> TxEightBits<'d> {
@@ -616,66 +609,35 @@ impl<'d> TxEightBits<'d> {
         crate::into_mapped_ref!(pin_7);
 
         Self {
-            pin_0,
-            pin_1,
-            pin_2,
-            pin_3,
-            pin_4,
-            pin_5,
-            pin_6,
-            pin_7,
+            pins: [pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7],
         }
     }
 }
 
 impl<'d> TxPins for TxEightBits<'d> {
     fn configure(&mut self) {
-        self.pin_0.set_to_push_pull_output(crate::private::Internal);
-        self.pin_0
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_0, crate::private::Internal);
-        self.pin_1.set_to_push_pull_output(crate::private::Internal);
-        self.pin_1
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_1, crate::private::Internal);
-        self.pin_2.set_to_push_pull_output(crate::private::Internal);
-        self.pin_2
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_2, crate::private::Internal);
-        self.pin_3.set_to_push_pull_output(crate::private::Internal);
-        self.pin_3
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_3, crate::private::Internal);
-        self.pin_4.set_to_push_pull_output(crate::private::Internal);
-        self.pin_4
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_4, crate::private::Internal);
-        self.pin_5.set_to_push_pull_output(crate::private::Internal);
-        self.pin_5
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_5, crate::private::Internal);
-        self.pin_6.set_to_push_pull_output(crate::private::Internal);
-        self.pin_6
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_6, crate::private::Internal);
-        self.pin_7.set_to_push_pull_output(crate::private::Internal);
-        self.pin_7
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_7, crate::private::Internal);
+        const SIGNALS: [OutputSignal; 8] = [
+            OutputSignal::LCD_DATA_0,
+            OutputSignal::LCD_DATA_1,
+            OutputSignal::LCD_DATA_2,
+            OutputSignal::LCD_DATA_3,
+            OutputSignal::LCD_DATA_4,
+            OutputSignal::LCD_DATA_5,
+            OutputSignal::LCD_DATA_6,
+            OutputSignal::LCD_DATA_7,
+        ];
+
+        for (pin, signal) in self.pins.iter_mut().zip(SIGNALS.iter()) {
+            pin.set_to_push_pull_output(crate::private::Internal);
+            pin.connect_peripheral_to_output(*signal, crate::private::Internal);
+        }
     }
 }
 
 /// Represents a group of 16 output pins configured for 16-bit parallel data
 /// transmission.
 pub struct TxSixteenBits<'d> {
-    pin_0: PeripheralRef<'d, OutputConnection>,
-    pin_1: PeripheralRef<'d, OutputConnection>,
-    pin_2: PeripheralRef<'d, OutputConnection>,
-    pin_3: PeripheralRef<'d, OutputConnection>,
-    pin_4: PeripheralRef<'d, OutputConnection>,
-    pin_5: PeripheralRef<'d, OutputConnection>,
-    pin_6: PeripheralRef<'d, OutputConnection>,
-    pin_7: PeripheralRef<'d, OutputConnection>,
-    pin_8: PeripheralRef<'d, OutputConnection>,
-    pin_9: PeripheralRef<'d, OutputConnection>,
-    pin_10: PeripheralRef<'d, OutputConnection>,
-    pin_11: PeripheralRef<'d, OutputConnection>,
-    pin_12: PeripheralRef<'d, OutputConnection>,
-    pin_13: PeripheralRef<'d, OutputConnection>,
-    pin_14: PeripheralRef<'d, OutputConnection>,
-    pin_15: PeripheralRef<'d, OutputConnection>,
+    pins: [PeripheralRef<'d, OutputConnection>; 16],
 }
 
 impl<'d> TxSixteenBits<'d> {
@@ -699,100 +661,45 @@ impl<'d> TxSixteenBits<'d> {
         pin_14: impl Peripheral<P = impl PeripheralOutput> + 'd,
         pin_15: impl Peripheral<P = impl PeripheralOutput> + 'd,
     ) -> Self {
-        crate::into_mapped_ref!(pin_0);
-        crate::into_mapped_ref!(pin_1);
-        crate::into_mapped_ref!(pin_2);
-        crate::into_mapped_ref!(pin_3);
-        crate::into_mapped_ref!(pin_4);
-        crate::into_mapped_ref!(pin_5);
-        crate::into_mapped_ref!(pin_6);
-        crate::into_mapped_ref!(pin_7);
-        crate::into_mapped_ref!(pin_8);
-        crate::into_mapped_ref!(pin_9);
-        crate::into_mapped_ref!(pin_10);
-        crate::into_mapped_ref!(pin_11);
-        crate::into_mapped_ref!(pin_12);
-        crate::into_mapped_ref!(pin_13);
-        crate::into_mapped_ref!(pin_14);
-        crate::into_mapped_ref!(pin_15);
+        crate::into_mapped_ref!(
+            pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7, pin_8, pin_9, pin_10, pin_11,
+            pin_12, pin_13, pin_14, pin_15
+        );
 
         Self {
-            pin_0,
-            pin_1,
-            pin_2,
-            pin_3,
-            pin_4,
-            pin_5,
-            pin_6,
-            pin_7,
-            pin_8,
-            pin_9,
-            pin_10,
-            pin_11,
-            pin_12,
-            pin_13,
-            pin_14,
-            pin_15,
+            pins: [
+                pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7, pin_8, pin_9, pin_10,
+                pin_11, pin_12, pin_13, pin_14, pin_15,
+            ],
         }
     }
 }
 
 impl<'d> TxPins for TxSixteenBits<'d> {
     fn configure(&mut self) {
-        self.pin_0.set_to_push_pull_output(crate::private::Internal);
-        self.pin_0
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_0, crate::private::Internal);
-        self.pin_1.set_to_push_pull_output(crate::private::Internal);
-        self.pin_1
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_1, crate::private::Internal);
-        self.pin_2.set_to_push_pull_output(crate::private::Internal);
-        self.pin_2
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_2, crate::private::Internal);
-        self.pin_3.set_to_push_pull_output(crate::private::Internal);
-        self.pin_3
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_3, crate::private::Internal);
-        self.pin_4.set_to_push_pull_output(crate::private::Internal);
-        self.pin_4
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_4, crate::private::Internal);
-        self.pin_5.set_to_push_pull_output(crate::private::Internal);
-        self.pin_5
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_5, crate::private::Internal);
-        self.pin_6.set_to_push_pull_output(crate::private::Internal);
-        self.pin_6
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_6, crate::private::Internal);
-        self.pin_7.set_to_push_pull_output(crate::private::Internal);
-        self.pin_7
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_7, crate::private::Internal);
-        self.pin_8.set_to_push_pull_output(crate::private::Internal);
-        self.pin_8
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_8, crate::private::Internal);
-        self.pin_9.set_to_push_pull_output(crate::private::Internal);
-        self.pin_9
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_9, crate::private::Internal);
-        self.pin_10
-            .set_to_push_pull_output(crate::private::Internal);
-        self.pin_10
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_10, crate::private::Internal);
-        self.pin_11
-            .set_to_push_pull_output(crate::private::Internal);
-        self.pin_11
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_11, crate::private::Internal);
-        self.pin_12
-            .set_to_push_pull_output(crate::private::Internal);
-        self.pin_12
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_12, crate::private::Internal);
-        self.pin_13
-            .set_to_push_pull_output(crate::private::Internal);
-        self.pin_13
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_13, crate::private::Internal);
-        self.pin_14
-            .set_to_push_pull_output(crate::private::Internal);
-        self.pin_14
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_14, crate::private::Internal);
-        self.pin_15
-            .set_to_push_pull_output(crate::private::Internal);
-        self.pin_15
-            .connect_peripheral_to_output(OutputSignal::LCD_DATA_15, crate::private::Internal);
+        const SIGNALS: [OutputSignal; 16] = [
+            OutputSignal::LCD_DATA_0,
+            OutputSignal::LCD_DATA_1,
+            OutputSignal::LCD_DATA_2,
+            OutputSignal::LCD_DATA_3,
+            OutputSignal::LCD_DATA_4,
+            OutputSignal::LCD_DATA_5,
+            OutputSignal::LCD_DATA_6,
+            OutputSignal::LCD_DATA_7,
+            OutputSignal::LCD_DATA_8,
+            OutputSignal::LCD_DATA_9,
+            OutputSignal::LCD_DATA_10,
+            OutputSignal::LCD_DATA_11,
+            OutputSignal::LCD_DATA_12,
+            OutputSignal::LCD_DATA_13,
+            OutputSignal::LCD_DATA_14,
+            OutputSignal::LCD_DATA_15,
+        ];
+
+        for (pin, signal) in self.pins.iter_mut().zip(SIGNALS.iter()) {
+            pin.set_to_push_pull_output(crate::private::Internal);
+            pin.connect_peripheral_to_output(*signal, crate::private::Internal);
+        }
     }
 }
 

--- a/esp-hal/src/ledc/mod.rs
+++ b/esp-hal/src/ledc/mod.rs
@@ -65,7 +65,7 @@ use self::{
     timer::{Timer, TimerSpeed},
 };
 use crate::{
-    gpio::OutputPin,
+    gpio::interconnect::PeripheralOutput,
     peripheral::{Peripheral, PeripheralRef},
     system::{Peripheral as PeripheralEnable, PeripheralClockControl},
 };
@@ -165,11 +165,11 @@ impl<'d> Ledc<'d> {
     }
 
     /// Return a new channel
-    pub fn get_channel<S: TimerSpeed, O: OutputPin>(
+    pub fn get_channel<S: TimerSpeed>(
         &self,
         number: channel::Number,
-        output_pin: impl Peripheral<P = O> + 'd,
-    ) -> Channel<'d, S, O> {
+        output_pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
+    ) -> Channel<'d, S> {
         Channel::new(number, output_pin)
     }
 }

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -12,7 +12,7 @@
 use core::marker::PhantomData;
 
 use crate::{
-    gpio::PeripheralOutput,
+    gpio::interconnect::{OutputConnection, PeripheralOutput},
     mcpwm::{timer::Timer, PwmPeripheral},
     peripheral::{Peripheral, PeripheralRef},
     private,
@@ -204,34 +204,31 @@ impl<const OP: u8, PWM: PwmPeripheral> Operator<OP, PWM> {
     }
 
     /// Use the A output with the given pin and configuration
-    pub fn with_pin_a<'d, Pin: PeripheralOutput>(
+    pub fn with_pin_a<'d>(
         self,
-        pin: impl Peripheral<P = Pin> + 'd,
+        pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
         config: PwmPinConfig<true>,
-    ) -> PwmPin<'d, Pin, PWM, OP, true> {
+    ) -> PwmPin<'d, PWM, OP, true> {
         PwmPin::new(pin, config)
     }
 
     /// Use the B output with the given pin and configuration
-    pub fn with_pin_b<'d, Pin: PeripheralOutput>(
+    pub fn with_pin_b<'d>(
         self,
-        pin: impl Peripheral<P = Pin> + 'd,
+        pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
         config: PwmPinConfig<false>,
-    ) -> PwmPin<'d, Pin, PWM, OP, false> {
+    ) -> PwmPin<'d, PWM, OP, false> {
         PwmPin::new(pin, config)
     }
 
     /// Use both the A and the B output with the given pins and configurations
-    pub fn with_pins<'d, PinA: PeripheralOutput, PinB: PeripheralOutput>(
+    pub fn with_pins<'d>(
         self,
-        pin_a: impl Peripheral<P = PinA> + 'd,
+        pin_a: impl Peripheral<P = impl PeripheralOutput> + 'd,
         config_a: PwmPinConfig<true>,
-        pin_b: impl Peripheral<P = PinB> + 'd,
+        pin_b: impl Peripheral<P = impl PeripheralOutput> + 'd,
         config_b: PwmPinConfig<false>,
-    ) -> (
-        PwmPin<'d, PinA, PWM, OP, true>,
-        PwmPin<'d, PinB, PWM, OP, false>,
-    ) {
+    ) -> (PwmPin<'d, PWM, OP, true>, PwmPin<'d, PWM, OP, false>) {
         (PwmPin::new(pin_a, config_a), PwmPin::new(pin_b, config_b))
     }
 
@@ -239,14 +236,14 @@ impl<const OP: u8, PWM: PwmPeripheral> Operator<OP, PWM> {
     ///
     /// This is useful for complementary or mirrored signals with or without
     /// configured deadtime
-    pub fn with_linked_pins<'d, PinA: PeripheralOutput, PinB: PeripheralOutput>(
+    pub fn with_linked_pins<'d>(
         self,
-        pin_a: impl Peripheral<P = PinA> + 'd,
+        pin_a: impl Peripheral<P = impl PeripheralOutput> + 'd,
         config_a: PwmPinConfig<true>,
-        pin_b: impl Peripheral<P = PinB> + 'd,
+        pin_b: impl Peripheral<P = impl PeripheralOutput> + 'd,
         config_b: PwmPinConfig<false>,
         config_dt: DeadTimeCfg,
-    ) -> LinkedPins<'d, PinA, PinB, PWM, OP> {
+    ) -> LinkedPins<'d, PWM, OP> {
         LinkedPins::new(pin_a, config_a, pin_b, config_b, config_dt)
     }
 }
@@ -283,16 +280,17 @@ impl<const IS_A: bool> PwmPinConfig<IS_A> {
 }
 
 /// A pin driven by an MCPWM operator
-pub struct PwmPin<'d, Pin, PWM, const OP: u8, const IS_A: bool> {
-    pin: PeripheralRef<'d, Pin>,
+pub struct PwmPin<'d, PWM, const OP: u8, const IS_A: bool> {
+    pin: PeripheralRef<'d, OutputConnection>,
     phantom: PhantomData<PWM>,
 }
 
-impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    PwmPin<'d, Pin, PWM, OP, IS_A>
-{
-    fn new(pin: impl Peripheral<P = Pin> + 'd, config: PwmPinConfig<IS_A>) -> Self {
-        crate::into_ref!(pin);
+impl<'d, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<'d, PWM, OP, IS_A> {
+    fn new(
+        pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        config: PwmPinConfig<IS_A>,
+    ) -> Self {
+        crate::into_mapped_ref!(pin);
         let mut pin = PwmPin {
             pin,
             phantom: PhantomData,
@@ -415,8 +413,8 @@ impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bo
     }
 }
 
-impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    embedded_hal_02::PwmPin for PwmPin<'d, Pin, PWM, OP, IS_A>
+impl<'d, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> embedded_hal_02::PwmPin
+    for PwmPin<'d, PWM, OP, IS_A>
 {
     type Duty = u16;
 
@@ -449,15 +447,15 @@ impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bo
 }
 
 /// Implement no error type for the PwmPin because the method are infallible
-impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    embedded_hal::pwm::ErrorType for PwmPin<'d, Pin, PWM, OP, IS_A>
+impl<'d, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> embedded_hal::pwm::ErrorType
+    for PwmPin<'d, PWM, OP, IS_A>
 {
     type Error = core::convert::Infallible;
 }
 
 /// Implement the trait SetDutyCycle for PwmPin
-impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bool>
-    embedded_hal::pwm::SetDutyCycle for PwmPin<'d, Pin, PWM, OP, IS_A>
+impl<'d, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> embedded_hal::pwm::SetDutyCycle
+    for PwmPin<'d, PWM, OP, IS_A>
 {
     /// Get the max duty of the PwmPin
     fn max_duty_cycle(&self) -> u16 {
@@ -518,18 +516,16 @@ impl<'d, Pin: PeripheralOutput, PWM: PwmPeripheral, const OP: u8, const IS_A: bo
 /// // pin_b: ------_________-----------_________-----
 /// # }
 /// ```
-pub struct LinkedPins<'d, PinA, PinB, PWM, const OP: u8> {
-    pin_a: PwmPin<'d, PinA, PWM, OP, true>,
-    pin_b: PwmPin<'d, PinB, PWM, OP, false>,
+pub struct LinkedPins<'d, PWM, const OP: u8> {
+    pin_a: PwmPin<'d, PWM, OP, true>,
+    pin_b: PwmPin<'d, PWM, OP, false>,
 }
 
-impl<'d, PinA: PeripheralOutput, PinB: PeripheralOutput, PWM: PwmPeripheral, const OP: u8>
-    LinkedPins<'d, PinA, PinB, PWM, OP>
-{
+impl<'d, PWM: PwmPeripheral, const OP: u8> LinkedPins<'d, PWM, OP> {
     fn new(
-        pin_a: impl Peripheral<P = PinA> + 'd,
+        pin_a: impl Peripheral<P = impl PeripheralOutput> + 'd,
         config_a: PwmPinConfig<true>,
-        pin_b: impl Peripheral<P = PinB> + 'd,
+        pin_b: impl Peripheral<P = impl PeripheralOutput> + 'd,
         config_b: PwmPinConfig<false>,
         config_dt: DeadTimeCfg,
     ) -> Self {

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -83,16 +83,11 @@ impl<'d> Usb<'d> {
         unsafe {
             let usb_wrap = &*peripherals::USB_WRAP::PTR;
             usb_wrap.otg_conf().modify(|_, w| {
-                w.usb_pad_enable()
-                    .set_bit()
-                    .phy_sel()
-                    .clear_bit()
-                    .clk_en()
-                    .set_bit()
-                    .ahb_clk_force_on()
-                    .set_bit()
-                    .phy_clk_force_on()
-                    .set_bit()
+                w.usb_pad_enable().set_bit();
+                w.phy_sel().clear_bit();
+                w.clk_en().set_bit();
+                w.ahb_clk_force_on().set_bit();
+                w.phy_clk_force_on().set_bit()
             });
 
             #[cfg(esp32s3)]
@@ -102,7 +97,7 @@ impl<'d> Usb<'d> {
                     .modify(|_, w| w.sw_hw_usb_phy_sel().set_bit().sw_usb_phy_sel().set_bit());
             }
 
-            use crate::gpio::{Level, PeripheralInput};
+            use crate::gpio::Level;
 
             Level::High.connect_input_to_peripheral(InputSignal::USB_OTG_IDDIG, Internal); // connected connector is mini-B side
             Level::High.connect_input_to_peripheral(InputSignal::USB_SRP_BVALID, Internal); // HIGH to force USB device mode

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -11,7 +11,7 @@ use core::marker::PhantomData;
 
 pub use crate::peripherals::pcnt::unit::conf0::{CTRL_MODE as CtrlMode, EDGE_MODE as EdgeMode};
 use crate::{
-    gpio::{InputSignal, PeripheralInput},
+    gpio::{interconnect::PeripheralInput, InputSignal},
     peripheral::Peripheral,
 };
 
@@ -116,7 +116,7 @@ impl<'d, const UNIT: usize, const NUM: usize> Channel<'d, UNIT, NUM> {
         };
 
         if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
-            crate::into_ref!(source);
+            crate::into_mapped_ref!(source);
             source.enable_input(true, crate::private::Internal);
             source.connect_input_to_peripheral(signal, crate::private::Internal);
         }
@@ -174,7 +174,7 @@ impl<'d, const UNIT: usize, const NUM: usize> Channel<'d, UNIT, NUM> {
         };
 
         if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
-            crate::into_ref!(source);
+            crate::into_mapped_ref!(source);
             source.enable_input(true, crate::private::Internal);
             source.connect_input_to_peripheral(signal, crate::private::Internal);
         }

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -85,7 +85,7 @@ use core::marker::PhantomData;
 use fugit::HertzU32;
 
 use crate::{
-    gpio::{PeripheralInput, PeripheralOutput},
+    gpio::interconnect::{PeripheralInput, PeripheralOutput},
     interrupt::InterruptHandler,
     peripheral::Peripheral,
     rmt::private::CreateInstance,
@@ -320,7 +320,7 @@ fn configure_rx_channel<
         return Err(Error::InvalidArgument);
     }
 
-    crate::into_ref!(pin);
+    crate::into_mapped_ref!(pin);
     pin.init_input(crate::gpio::Pull::None, crate::private::Internal);
     pin.connect_input_to_peripheral(T::input_signal(), crate::private::Internal);
 
@@ -346,7 +346,7 @@ fn configure_tx_channel<
     pin: impl Peripheral<P = P> + 'd,
     config: TxChannelConfig,
 ) -> Result<T, Error> {
-    crate::into_ref!(pin);
+    crate::into_mapped_ref!(pin);
     pin.set_to_push_pull_output(crate::private::Internal);
     pin.connect_peripheral_to_output(T::output_signal(), crate::private::Internal);
 
@@ -571,7 +571,7 @@ macro_rules! impl_tx_channel_creator {
         impl<'d, P> $crate::rmt::TxChannelCreator<'d, $crate::rmt::Channel<$crate::Blocking, $channel>, P>
             for ChannelCreator<$crate::Blocking, $channel>
         where
-            P: $crate::gpio::PeripheralOutput,
+            P: $crate::gpio::interconnect::PeripheralOutput,
         {
         }
 
@@ -580,7 +580,7 @@ macro_rules! impl_tx_channel_creator {
         impl<'d, P> $crate::rmt::TxChannelCreatorAsync<'d, $crate::rmt::Channel<$crate::Async, $channel>, P>
             for ChannelCreator<$crate::Async, $channel>
         where
-            P: $crate::gpio::PeripheralOutput,
+            P: $crate::gpio::interconnect::PeripheralOutput,
         {
         }
 
@@ -593,7 +593,7 @@ macro_rules! impl_rx_channel_creator {
         impl<'d, P> $crate::rmt::RxChannelCreator<'d, $crate::rmt::Channel<$crate::Blocking, $channel>, P>
             for ChannelCreator<$crate::Blocking, $channel>
         where
-            P: $crate::gpio::PeripheralInput,
+            P: $crate::gpio::interconnect::PeripheralInput,
         {
         }
 
@@ -602,7 +602,7 @@ macro_rules! impl_rx_channel_creator {
         impl<'d, P> $crate::rmt::RxChannelCreatorAsync<'d, $crate::rmt::Channel<$crate::Async, $channel>, P>
         for ChannelCreator<$crate::Async, $channel>
         where
-            P: $crate::gpio::PeripheralInput,
+            P: $crate::gpio::interconnect::PeripheralInput,
         {
         }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -74,7 +74,12 @@ use super::{DmaError, Error, SpiBitOrder, SpiDataMode, SpiMode};
 use crate::{
     clock::Clocks,
     dma::{DmaChannelConvert, DmaEligible, DmaRxBuffer, DmaTxBuffer, PeripheralMarker, Rx, Tx},
-    gpio::{InputSignal, NoPin, OutputSignal, PeripheralInput, PeripheralOutput},
+    gpio::{
+        interconnect::{OutputConnection, PeripheralOutput},
+        InputSignal,
+        NoPin,
+        OutputSignal,
+    },
     interrupt::InterruptHandler,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::spi2::RegisterBlock,
@@ -517,19 +522,21 @@ where
 
         let is_qspi = spi.spi.sio2_input_signal().is_some();
         if is_qspi {
-            NoPin.connect_input_to_peripheral(
+            let mut signal = OutputConnection::from(NoPin);
+
+            signal.connect_input_to_peripheral(
                 unwrap!(spi.spi.sio2_input_signal()),
                 private::Internal,
             );
-            NoPin.connect_peripheral_to_output(
+            signal.connect_peripheral_to_output(
                 unwrap!(spi.spi.sio2_output_signal()),
                 private::Internal,
             );
-            NoPin.connect_input_to_peripheral(
+            signal.connect_input_to_peripheral(
                 unwrap!(spi.spi.sio3_input_signal()),
                 private::Internal,
             );
-            NoPin.connect_peripheral_to_output(
+            signal.connect_peripheral_to_output(
                 unwrap!(spi.spi.sio3_output_signal()),
                 private::Internal,
             );
@@ -543,8 +550,7 @@ where
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MOSI signal and SIO0 input signal.
     pub fn with_mosi<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
-        crate::into_ref!(mosi);
-
+        crate::into_mapped_ref!(mosi);
         mosi.enable_output(true, private::Internal);
         mosi.connect_peripheral_to_output(self.spi.mosi_signal(), private::Internal);
 
@@ -559,8 +565,7 @@ where
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MISO signal and SIO1 input signal.
     pub fn with_miso<MISO: PeripheralOutput>(self, miso: impl Peripheral<P = MISO> + 'd) -> Self {
-        crate::into_ref!(miso);
-
+        crate::into_mapped_ref!(miso);
         miso.enable_input(true, private::Internal);
         miso.connect_input_to_peripheral(self.spi.miso_signal(), private::Internal);
 
@@ -575,7 +580,7 @@ where
     /// Sets the specified pin to push-pull output and connects it to the SPI
     /// clock signal.
     pub fn with_sck<SCK: PeripheralOutput>(self, sclk: impl Peripheral<P = SCK> + 'd) -> Self {
-        crate::into_ref!(sclk);
+        crate::into_mapped_ref!(sclk);
         sclk.set_to_push_pull_output(private::Internal);
         sclk.connect_peripheral_to_output(self.spi.sclk_signal(), private::Internal);
 
@@ -587,7 +592,7 @@ where
     /// Sets the specified pin to push-pull output and connects it to the SPI CS
     /// signal.
     pub fn with_cs<CS: PeripheralOutput>(self, cs: impl Peripheral<P = CS> + 'd) -> Self {
-        crate::into_ref!(cs);
+        crate::into_mapped_ref!(cs);
         cs.set_to_push_pull_output(private::Internal);
         cs.connect_peripheral_to_output(self.spi.cs_signal(), private::Internal);
 
@@ -623,7 +628,7 @@ where
     where
         T: QspiInstance,
     {
-        crate::into_ref!(sio2);
+        crate::into_mapped_ref!(sio2);
         sio2.enable_input(true, private::Internal);
         sio2.enable_output(true, private::Internal);
 
@@ -644,7 +649,7 @@ where
     where
         T: QspiInstance,
     {
-        crate::into_ref!(sio3);
+        crate::into_mapped_ref!(sio3);
         sio3.enable_input(true, private::Internal);
         sio3.enable_output(true, private::Internal);
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -542,10 +542,7 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MOSI signal and SIO0 input signal.
-    pub fn with_mosi<MOSI: PeripheralOutput + PeripheralInput>(
-        self,
-        mosi: impl Peripheral<P = MOSI> + 'd,
-    ) -> Self {
+    pub fn with_mosi<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_ref!(mosi);
 
         mosi.enable_output(true, private::Internal);
@@ -561,10 +558,7 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MISO signal and SIO1 input signal.
-    pub fn with_miso<MISO: PeripheralOutput + PeripheralInput>(
-        self,
-        miso: impl Peripheral<P = MISO> + 'd,
-    ) -> Self {
+    pub fn with_miso<MISO: PeripheralOutput>(self, miso: impl Peripheral<P = MISO> + 'd) -> Self {
         crate::into_ref!(miso);
 
         miso.enable_input(true, private::Internal);
@@ -625,10 +619,7 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the SIO2 output and input signals.
-    pub fn with_sio2<SIO2: PeripheralOutput + PeripheralInput>(
-        self,
-        sio2: impl Peripheral<P = SIO2> + 'd,
-    ) -> Self
+    pub fn with_sio2<SIO2: PeripheralOutput>(self, sio2: impl Peripheral<P = SIO2> + 'd) -> Self
     where
         T: QspiInstance,
     {
@@ -649,10 +640,7 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the SIO3 output and input signals.
-    pub fn with_sio3<SIO3: PeripheralOutput + PeripheralInput>(
-        self,
-        sio3: impl Peripheral<P = SIO3> + 'd,
-    ) -> Self
+    pub fn with_sio3<SIO3: PeripheralOutput>(self, sio3: impl Peripheral<P = SIO3> + 'd) -> Self
     where
         T: QspiInstance,
     {

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -73,7 +73,11 @@
 use super::{Error, SpiMode};
 use crate::{
     dma::{DescriptorChain, DmaChannelConvert, DmaEligible, PeripheralMarker, Rx, Tx},
-    gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput},
+    gpio::{
+        interconnect::{PeripheralInput, PeripheralOutput},
+        InputSignal,
+        OutputSignal,
+    },
     peripheral::{Peripheral, PeripheralRef},
     peripherals::spi2::RegisterBlock,
     private,
@@ -129,7 +133,7 @@ where
         cs: impl Peripheral<P = CS> + 'd,
         mode: SpiMode,
     ) -> Spi<'d, T> {
-        crate::into_ref!(sclk, mosi, miso, cs);
+        crate::into_mapped_ref!(sclk, mosi, miso, cs);
 
         let this = Self::new_internal(spi, mode);
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -130,7 +130,12 @@ use core::marker::PhantomData;
 use self::filter::{Filter, FilterType};
 use crate::{
     dma::PeripheralMarker,
-    gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput, Pull},
+    gpio::{
+        interconnect::{PeripheralInput, PeripheralOutput},
+        InputSignal,
+        OutputSignal,
+        Pull,
+    },
     interrupt::InterruptHandler,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::twai0::RegisterBlock,
@@ -764,8 +769,8 @@ where
         no_transceiver: bool,
         mode: TwaiMode,
     ) -> Self {
-        // Set up the GPIO pins.
-        crate::into_ref!(twai, tx_pin, rx_pin);
+        crate::into_ref!(twai);
+        crate::into_mapped_ref!(tx_pin, rx_pin);
 
         // Enable the peripheral clock for the TWAI peripheral.
         PeripheralClockControl::enable(twai.peripheral());
@@ -792,6 +797,7 @@ where
                 .modify(|_, w| w.ext_mode().set_bit());
         }
 
+        // Set up the GPIO pins.
         let rx_pull = if no_transceiver {
             tx_pin.set_to_open_drain_output(crate::private::Internal);
             tx_pin.pull_direction(Pull::Up, crate::private::Internal);

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -131,7 +131,12 @@ use core::marker::PhantomData;
 use self::config::Config;
 use crate::{
     clock::Clocks,
-    gpio::{InputSignal, OutputSignal, PeripheralInput, PeripheralOutput, Pull},
+    gpio::{
+        interconnect::{PeripheralInput, PeripheralOutput},
+        InputSignal,
+        OutputSignal,
+        Pull,
+    },
     interrupt::InterruptHandler,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{uart0::RegisterBlock, Interrupt},
@@ -452,7 +457,7 @@ where
     }
 
     fn with_rx<RX: PeripheralInput>(self, rx: impl Peripheral<P = RX> + 'd) -> Self {
-        crate::into_ref!(rx);
+        crate::into_mapped_ref!(rx);
         rx.init_input(Pull::Up, Internal);
         rx.connect_input_to_peripheral(T::rx_signal(), Internal);
 
@@ -460,7 +465,7 @@ where
     }
 
     fn with_tx<TX: PeripheralOutput>(self, tx: impl Peripheral<P = TX> + 'd) -> Self {
-        crate::into_ref!(tx);
+        crate::into_mapped_ref!(tx);
         // Make sure we don't cause an unexpected low pulse on the pin.
         tx.set_output_high(true, Internal);
         tx.set_to_push_pull_output(Internal);
@@ -539,7 +544,7 @@ where
 
     /// Configure RTS pin
     pub fn with_rts<RTS: PeripheralOutput>(self, rts: impl Peripheral<P = RTS> + 'd) -> Self {
-        crate::into_ref!(rts);
+        crate::into_mapped_ref!(rts);
         rts.set_to_push_pull_output(Internal);
         rts.connect_peripheral_to_output(T::rts_signal(), Internal);
 
@@ -623,7 +628,7 @@ where
 
     /// Configure CTS pin
     pub fn with_cts<CTS: PeripheralInput>(self, cts: impl Peripheral<P = CTS> + 'd) -> Self {
-        crate::into_ref!(cts);
+        crate::into_mapped_ref!(cts);
         cts.init_input(Pull::None, Internal);
         cts.connect_input_to_peripheral(T::cts_signal(), Internal);
 
@@ -860,7 +865,7 @@ where
 
     /// Configure CTS pin
     pub fn with_cts<CTS: PeripheralInput>(self, cts: impl Peripheral<P = CTS> + 'd) -> Self {
-        crate::into_ref!(cts);
+        crate::into_mapped_ref!(cts);
         cts.init_input(Pull::None, Internal);
         cts.connect_input_to_peripheral(T::cts_signal(), Internal);
 
@@ -869,7 +874,7 @@ where
 
     /// Configure RTS pin
     pub fn with_rts<RTS: PeripheralOutput>(self, rts: impl Peripheral<P = RTS> + 'd) -> Self {
-        crate::into_ref!(rts);
+        crate::into_mapped_ref!(rts);
         rts.set_to_push_pull_output(Internal);
         rts.connect_peripheral_to_output(T::rts_signal(), Internal);
 

--- a/hil-test/tests/spi_slave.rs
+++ b/hil-test/tests/spi_slave.rs
@@ -11,7 +11,7 @@
 use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
-    gpio::{interconnect::InputSignal, Io, Level, Output, PeripheralInput},
+    gpio::{interconnect::InputSignal, Io, Level, Output},
     spi::{slave::Spi, SpiMode},
 };
 use hil_test as _;

--- a/hil-test/tests/uart_regression.rs
+++ b/hil-test/tests/uart_regression.rs
@@ -9,7 +9,7 @@
 #[embedded_test::tests]
 mod tests {
     use esp_hal::{
-        gpio::{Io, PeripheralOutput},
+        gpio::Io,
         prelude::*,
         uart::{UartRx, UartTx},
     };


### PR DESCRIPTION
This PR (also part of #2341) removes logic from the PeripheralInput and PeripheralOutput traits, and updates peripherals to use these traits, acquire the type-erased signals and work with those.

GPIO pins no longer have to implement signal functions directly, which is I think a big plus as it allows removing duplicate code from the gpio module.

As this PR is quite large, I did not complete all allowed cleanup opportunities.