### PR TITLE
fix wifi async fn disconnect hanging if not connected when called

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a possible crash when parsing results from a radius server (#2380)
-- Fixed `async fn WifiController::disconnect` hanging forever when awaited if not connected when called.
+- Fixed `async fn WifiController::disconnect` hanging forever when awaited if not connected when called (#2392).
 
 ### Removed
 

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a possible crash when parsing results from a radius server (#2380)
+- Fixed `async fn WifiController::disconnect` hanging forever when awaited if not connected when called.
 
 ### Removed
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -3368,6 +3368,7 @@ mod asynch {
         pub async fn disconnect(&mut self) -> Result<(), WifiError> {
             // If not connected, this will do nothing.
             // It will also wait forever for a `StaDisconnected` event that will never come.
+            // Return early instead of hanging.
             if !matches!(self.is_connected(), Ok(true)) {
                 return Ok(());
             }

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -3366,6 +3366,12 @@ mod asynch {
         /// Async version of [`crate::wifi::WifiController`]'s `Disconnect`
         /// method
         pub async fn disconnect(&mut self) -> Result<(), WifiError> {
+            // If not connected, this will do nothing.
+            // It will also wait forever for a `StaDisconnected` event that will never come.
+            if !matches!(self.is_connected(), Ok(true)) {
+                return Ok(());
+            }
+
             Self::clear_events(WifiEvent::StaDisconnected);
             crate::wifi::WifiController::disconnect_impl(self)?;
             WifiEventFuture::new(WifiEvent::StaDisconnected).await;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Add a check in `WifiController::disconnect` on `async` in esp-wifi for an active connection. This prevents hanging forever if not connected when called.

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.
Above

#### Testing
Describe how you tested your changes

Ran the new code on an `esp32-WROOM-32` dev board and repeated disconnecting and reconnecting to other esp32's WIFI-AP using the first's WIFI-STA. Before change the disconnect would hang on `await` if not connected. Now it doesn't and works as expected.