### PR TITLE
Wait more before re-enabling USB power

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -201,7 +201,7 @@ jobs:
               sudo uhubctl -a off -l $hub
             done
 
-            sleep 0.5
+            sleep 5
 
             # Enable all used hubs
             for hub in ${{ matrix.target.hubs }}; do


### PR DESCRIPTION
The ESP32 runner can get into a state where it's not flashing correctly. The most reliable workaround I know is to manually disable USB power for some longer time (then erasing flash with espflash but that might not be necessary). Let's try doing that automatically - hopefully the extra 5s won't be significant in the CI time.