### PR TITLE
Use `panic` instead of `process::exit` in `esp-build`

### DIFF
--- a/esp-build/src/lib.rs
+++ b/esp-build/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
-use std::{io::Write as _, process};
+use std::io::Write as _;
 
 use proc_macro::TokenStream;
 use quote::ToTokens;
@@ -26,7 +26,7 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 #[proc_macro]
 pub fn error(input: TokenStream) -> TokenStream {
     do_alert(Color::Red, input);
-    process::exit(1);
+    panic!("Build failed");
 }
 
 /// Print a build warning.


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
For whatever reason Rust-Analyzer (also) compiles build scripts w/o any features set, which makes `assert_unique_used_features!` fail

This makes Rust-Analyzer hate itself and the world and the IDE almost unusable (for me at least) - but it doesn't get mad about `panic!`

Even on command line things look better after the change IMHO

Before:
![image](https://github.com/user-attachments/assets/6b138820-f97a-462c-92a4-8472db13af1b)

After:
![image](https://github.com/user-attachments/assets/9b5d0a92-762f-4066-aaa5-78a2c25822bc)

(This time really no changelog entry needed IMHO)

#### Testing
Create a standalone project and test w/o selecting a chip feature

