### PR TITLE
[DMA 3/8] Remove ChannelCreator types, temporarily disable burst mode

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- The `configure` DMA channel functions has been removed (#2403)
+- The `configure` and `configure_for_async` DMA channel functions has been removed (#2403)
 
 ## [0.22.0] - 2024-11-20
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ESP32-S3: Added SDMMC signals (#2556)
+- `dma::{Channel, ChannelRx, ChannelTx}::set_priority` for GDMA devices (#2403)
 
 ### Changed
 
 ### Fixed
 
 ### Removed
+
+- The `configure` DMA channel functions has been removed (#2403)
 
 ## [0.22.0] - 2024-11-20
 

--- a/esp-hal/MIGRATING-0.22.md
+++ b/esp-hal/MIGRATING-0.22.md
@@ -1,1 +1,17 @@
 # Migration Guide from 0.22.x to v1.0.0-beta.0
+
+## DMA configuration changes
+
+- `configure_for_async` and `configure` have been removed
+- PDMA devices (ESP32, ESP32-S2) provide no configurability
+- GDMA devices provide `set_priority` to change DMA in/out channel priority
+
+```diff
+ let mut spi = Spi::new_with_config(
+     peripherals.SPI2,
+     Config::default(),
+ )
+ // other setup
+-.with_dma(dma_channel.configure(false, DmaPriority::Priority0));
++.with_dma(dma_channel);
+```

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -45,8 +45,15 @@ pub struct Preparation {
 
     /// Block size for PSRAM transfers.
     ///
-    /// The implementation of the buffer must provide a block size if the data
-    /// is in PSRAM.
+    /// If the buffer is in PSRAM, the implementation must ensure the following:
+    ///
+    /// - The implementation of the buffer must provide a non-`None` block size.
+    /// - For [`TransferDirection::In`] transfers, the implementation of the
+    ///   buffer must invalidate the cache that contains the buffer before the
+    ///   DMA starts.
+    /// - For [`TransferDirection::Out`] transfers, the implementation of the
+    ///   buffer must write back the cache that contains the buffer before the
+    ///   DMA starts.
     #[cfg(esp32s3)]
     pub external_memory_block_size: Option<DmaBufBlkSize>,
 
@@ -55,9 +62,10 @@ pub struct Preparation {
     /// The implementation of the buffer must ensure that burst mode is only
     /// enabled when alignment requirements are met.
     ///
-    /// There are no additional alignment requirements for TX burst transfers,
-    /// but RX transfers require all descriptors to have buffer pointers and
-    /// sizes that are a multiple of 4 (word aligned).
+    /// There are no additional alignment requirements for
+    /// [`TransferDirection::Out`] burst transfers, but
+    /// [`TransferDirection::In`] transfers require all descriptors to have
+    /// buffer pointers and sizes that are a multiple of 4 (word aligned).
     pub burst_transfer: BurstTransfer,
 
     /// Configures the "check owner" feature of the DMA channel.

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -1163,8 +1163,11 @@ unsafe impl DmaTxBuffer for DmaLoopBuf {
     fn prepare(&mut self) -> Preparation {
         Preparation {
             start: self.descriptor,
-            block_size: None,
-            is_burstable: true,
+            direction: TransferDirection::Out,
+            // TODO: support external memory access.
+            #[cfg(esp32s3)]
+            external_memory_block_size: None,
+            burst_transfer: BurstTransfer::Disabled,
             // The DMA must not check the owner bit, as it is never set.
             check_owner: Some(false),
         }

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -17,15 +17,15 @@ pub struct Preparation {
     #[cfg_attr(not(esp32s3), allow(dead_code))]
     pub block_size: Option<DmaBufBlkSize>,
 
-    /// Specifies whether descriptor linked list specified in `start` conforms
-    /// to the alignment requirements required to enable burst transfers.
+    /// Specifies whether the data should be transferred in burst mode.
     ///
-    /// Note: This only applies to burst transfer of the buffer data, not the
-    /// descriptors themselves.
+    /// The implementation of the buffer must ensure that burst mode is only
+    /// enabled when alignment requirements are met.
     ///
     /// There are no additional alignment requirements for TX burst transfers,
     /// but RX transfers require all descriptors to have buffer pointers and
     /// sizes that are a multiple of 4 (word aligned).
+    // TODO: currently unused, buffers should not hardcode their preference.
     pub is_burstable: bool,
 
     /// Configures the "check owner" feature of the DMA channel.

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -8,16 +8,49 @@ use crate::soc::is_slice_in_dram;
 #[cfg(esp32s3)]
 use crate::soc::is_slice_in_psram;
 
+/// Burst transfer configuration.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum BurstTransfer {
+    /// Burst mode is disabled.
+    Disabled,
+
+    /// Burst mode is enabled.
+    Enabled,
+}
+
+impl BurstTransfer {
+    pub(super) fn is_burst_enabled(self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+}
+
+/// The direction of the DMA transfer.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TransferDirection {
+    /// DMA transfer from peripheral or external memory to memory.
+    In,
+    /// DMA transfer from memory to peripheral or external memory.
+    Out,
+}
+
 /// Holds all the information needed to configure a DMA channel for a transfer.
 pub struct Preparation {
     /// The descriptor the DMA will start from.
     pub start: *mut DmaDescriptor,
 
-    /// Block size for PSRAM transfers
-    #[cfg_attr(not(esp32s3), allow(dead_code))]
-    pub block_size: Option<DmaBufBlkSize>,
+    /// The direction of the DMA transfer.
+    pub direction: TransferDirection,
 
-    /// Specifies whether the data should be transferred in burst mode.
+    /// Block size for PSRAM transfers.
+    ///
+    /// The implementation of the buffer must provide a block size if the data
+    /// is in PSRAM.
+    #[cfg(esp32s3)]
+    pub external_memory_block_size: Option<DmaBufBlkSize>,
+
+    /// Configures the DMA to transfer data in bursts.
     ///
     /// The implementation of the buffer must ensure that burst mode is only
     /// enabled when alignment requirements are met.
@@ -25,8 +58,7 @@ pub struct Preparation {
     /// There are no additional alignment requirements for TX burst transfers,
     /// but RX transfers require all descriptors to have buffer pointers and
     /// sizes that are a multiple of 4 (word aligned).
-    // TODO: currently unused, buffers should not hardcode their preference.
-    pub is_burstable: bool,
+    pub burst_transfer: BurstTransfer,
 
     /// Configures the "check owner" feature of the DMA channel.
     ///
@@ -331,9 +363,11 @@ unsafe impl DmaTxBuffer for DmaTxBuf {
 
         Preparation {
             start: self.descriptors.head(),
-            block_size: self.block_size,
-            // This is TX, the DMA channel is free to do a burst transfer.
-            is_burstable: true,
+            direction: TransferDirection::Out,
+            #[cfg(esp32s3)]
+            external_memory_block_size: self.block_size,
+            // TODO: support burst transfers.
+            burst_transfer: BurstTransfer::Disabled,
             check_owner: None,
         }
     }
@@ -480,11 +514,16 @@ unsafe impl DmaRxBuffer for DmaRxBuf {
 
         Preparation {
             start: self.descriptors.head(),
-            block_size: None,
-            // DmaRxBuf doesn't currently enforce the alignment requirements required for bursting.
-            // In the future, it could either enforce the alignment or calculate if the alignment
-            // requirements happen to be met.
-            is_burstable: false,
+            direction: TransferDirection::In,
+
+            // TODO: support external memory access.
+            #[cfg(esp32s3)]
+            external_memory_block_size: None,
+
+            // TODO: DmaRxBuf doesn't currently enforce the alignment requirements required for
+            // bursting. In the future, it could either enforce the alignment or
+            // calculate if the alignment requirements happen to be met.
+            burst_transfer: BurstTransfer::Disabled,
             check_owner: None,
         }
     }
@@ -609,10 +648,14 @@ unsafe impl DmaTxBuffer for DmaRxTxBuf {
 
         Preparation {
             start: self.tx_descriptors.head(),
-            block_size: None, // TODO: support block size!
+            direction: TransferDirection::Out,
 
-            // This is TX, the DMA channel is free to do a burst transfer.
-            is_burstable: true,
+            // TODO: support external memory access.
+            #[cfg(esp32s3)]
+            external_memory_block_size: None,
+
+            // TODO: This is TX, the DMA channel is free to do a burst transfer.
+            burst_transfer: BurstTransfer::Disabled,
             check_owner: None,
         }
     }
@@ -640,11 +683,15 @@ unsafe impl DmaRxBuffer for DmaRxTxBuf {
 
         Preparation {
             start: self.rx_descriptors.head(),
-            block_size: None, // TODO: support block size!
+            direction: TransferDirection::In,
 
-            // DmaRxTxBuf doesn't currently enforce the alignment requirements required for
+            // TODO: support external memory access.
+            #[cfg(esp32s3)]
+            external_memory_block_size: None,
+
+            // TODO: DmaRxTxBuf doesn't currently enforce the alignment requirements required for
             // bursting.
-            is_burstable: false,
+            burst_transfer: BurstTransfer::Disabled,
             check_owner: None,
         }
     }
@@ -781,11 +828,15 @@ unsafe impl DmaRxBuffer for DmaRxStreamBuf {
         }
         Preparation {
             start: self.descriptors.as_mut_ptr(),
-            block_size: None,
+            direction: TransferDirection::In,
 
-            // DmaRxStreamBuf doesn't currently enforce the alignment requirements required for
-            // bursting.
-            is_burstable: false,
+            // TODO: support external memory access.
+            #[cfg(esp32s3)]
+            external_memory_block_size: None,
+
+            // TODO: DmaRxStreamBuf doesn't currently enforce the alignment requirements required
+            // for bursting.
+            burst_transfer: BurstTransfer::Disabled,
 
             // Whilst we give ownership of the descriptors the DMA, the correctness of this buffer
             // implementation doesn't rely on the DMA checking for descriptor ownership.
@@ -995,10 +1046,10 @@ unsafe impl DmaTxBuffer for EmptyBuf {
         #[allow(unused_unsafe)] // stable requires unsafe, nightly complains about it
         Preparation {
             start: unsafe { core::ptr::addr_of_mut!(EMPTY).cast() },
-            block_size: None,
-
-            // This is TX, the DMA channel is free to do a burst transfer.
-            is_burstable: true,
+            direction: TransferDirection::Out,
+            #[cfg(esp32s3)]
+            external_memory_block_size: None,
+            burst_transfer: BurstTransfer::Disabled,
 
             // As we don't give ownership of the descriptor to the DMA, it's important that the DMA
             // channel does *NOT* check for ownership, otherwise the channel will return an error.
@@ -1026,10 +1077,10 @@ unsafe impl DmaRxBuffer for EmptyBuf {
         #[allow(unused_unsafe)] // stable requires unsafe, nightly complains about it
         Preparation {
             start: unsafe { core::ptr::addr_of_mut!(EMPTY).cast() },
-            block_size: None,
-
-            // As much as bursting is meaningless here, the descriptor does meet the requirements.
-            is_burstable: true,
+            direction: TransferDirection::In,
+            #[cfg(esp32s3)]
+            external_memory_block_size: None,
+            burst_transfer: BurstTransfer::Disabled,
 
             // As we don't give ownership of the descriptor to the DMA, it's important that the DMA
             // channel does *NOT* check for ownership, otherwise the channel will return an error.

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -11,7 +11,7 @@ use crate::soc::is_slice_in_psram;
 /// Burst transfer configuration.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum BurstTransfer {
+pub enum BurstConfig {
     /// Burst mode is disabled.
     Disabled,
 
@@ -19,7 +19,7 @@ pub enum BurstTransfer {
     Enabled,
 }
 
-impl BurstTransfer {
+impl BurstConfig {
     pub(super) fn is_burst_enabled(self) -> bool {
         !matches!(self, Self::Disabled)
     }
@@ -66,7 +66,7 @@ pub struct Preparation {
     /// [`TransferDirection::Out`] burst transfers, but
     /// [`TransferDirection::In`] transfers require all descriptors to have
     /// buffer pointers and sizes that are a multiple of 4 (word aligned).
-    pub burst_transfer: BurstTransfer,
+    pub burst_transfer: BurstConfig,
 
     /// Configures the "check owner" feature of the DMA channel.
     ///
@@ -375,7 +375,7 @@ unsafe impl DmaTxBuffer for DmaTxBuf {
             #[cfg(esp32s3)]
             external_memory_block_size: self.block_size,
             // TODO: support burst transfers.
-            burst_transfer: BurstTransfer::Disabled,
+            burst_transfer: BurstConfig::Disabled,
             check_owner: None,
         }
     }
@@ -531,7 +531,7 @@ unsafe impl DmaRxBuffer for DmaRxBuf {
             // TODO: DmaRxBuf doesn't currently enforce the alignment requirements required for
             // bursting. In the future, it could either enforce the alignment or
             // calculate if the alignment requirements happen to be met.
-            burst_transfer: BurstTransfer::Disabled,
+            burst_transfer: BurstConfig::Disabled,
             check_owner: None,
         }
     }
@@ -663,7 +663,7 @@ unsafe impl DmaTxBuffer for DmaRxTxBuf {
             external_memory_block_size: None,
 
             // TODO: This is TX, the DMA channel is free to do a burst transfer.
-            burst_transfer: BurstTransfer::Disabled,
+            burst_transfer: BurstConfig::Disabled,
             check_owner: None,
         }
     }
@@ -699,7 +699,7 @@ unsafe impl DmaRxBuffer for DmaRxTxBuf {
 
             // TODO: DmaRxTxBuf doesn't currently enforce the alignment requirements required for
             // bursting.
-            burst_transfer: BurstTransfer::Disabled,
+            burst_transfer: BurstConfig::Disabled,
             check_owner: None,
         }
     }
@@ -844,7 +844,7 @@ unsafe impl DmaRxBuffer for DmaRxStreamBuf {
 
             // TODO: DmaRxStreamBuf doesn't currently enforce the alignment requirements required
             // for bursting.
-            burst_transfer: BurstTransfer::Disabled,
+            burst_transfer: BurstConfig::Disabled,
 
             // Whilst we give ownership of the descriptors the DMA, the correctness of this buffer
             // implementation doesn't rely on the DMA checking for descriptor ownership.
@@ -1057,7 +1057,7 @@ unsafe impl DmaTxBuffer for EmptyBuf {
             direction: TransferDirection::Out,
             #[cfg(esp32s3)]
             external_memory_block_size: None,
-            burst_transfer: BurstTransfer::Disabled,
+            burst_transfer: BurstConfig::Disabled,
 
             // As we don't give ownership of the descriptor to the DMA, it's important that the DMA
             // channel does *NOT* check for ownership, otherwise the channel will return an error.
@@ -1088,7 +1088,7 @@ unsafe impl DmaRxBuffer for EmptyBuf {
             direction: TransferDirection::In,
             #[cfg(esp32s3)]
             external_memory_block_size: None,
-            burst_transfer: BurstTransfer::Disabled,
+            burst_transfer: BurstConfig::Disabled,
 
             // As we don't give ownership of the descriptor to the DMA, it's important that the DMA
             // channel does *NOT* check for ownership, otherwise the channel will return an error.
@@ -1167,7 +1167,7 @@ unsafe impl DmaTxBuffer for DmaLoopBuf {
             // TODO: support external memory access.
             #[cfg(esp32s3)]
             external_memory_block_size: None,
-            burst_transfer: BurstTransfer::Disabled,
+            burst_transfer: BurstConfig::Disabled,
             // The DMA must not check the owner bit, as it is never set.
             check_owner: Some(false),
         }

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -169,10 +169,10 @@ impl<C: GdmaChannel> RegisterAccess for ChannelTxImpl<C> {
         conf0.modify(|_, w| w.out_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: bool) {
+    fn set_burst_mode(&self, burst_mode: BurstTransfer) {
         self.ch()
             .out_conf0()
-            .modify(|_, w| w.out_data_burst_en().bit(burst_mode));
+            .modify(|_, w| w.out_data_burst_en().bit(burst_mode.is_burst_enabled()));
     }
 
     fn set_descr_burst_mode(&self, burst_mode: bool) {
@@ -393,10 +393,10 @@ impl<C: GdmaChannel> RegisterAccess for ChannelRxImpl<C> {
         conf0.modify(|_, w| w.in_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: bool) {
+    fn set_burst_mode(&self, burst_mode: BurstTransfer) {
         self.ch()
             .in_conf0()
-            .modify(|_, w| w.in_data_burst_en().bit(burst_mode));
+            .modify(|_, w| w.in_data_burst_en().bit(burst_mode.is_burst_enabled()));
     }
 
     fn set_descr_burst_mode(&self, burst_mode: bool) {

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -169,7 +169,7 @@ impl<C: GdmaChannel> RegisterAccess for ChannelTxImpl<C> {
         conf0.modify(|_, w| w.out_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: BurstTransfer) {
+    fn set_burst_mode(&self, burst_mode: BurstConfig) {
         self.ch()
             .out_conf0()
             .modify(|_, w| w.out_data_burst_en().bit(burst_mode.is_burst_enabled()));
@@ -393,7 +393,7 @@ impl<C: GdmaChannel> RegisterAccess for ChannelRxImpl<C> {
         conf0.modify(|_, w| w.in_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: BurstTransfer) {
+    fn set_burst_mode(&self, burst_mode: BurstConfig) {
         self.ch()
             .in_conf0()
             .modify(|_, w| w.in_data_burst_en().bit(burst_mode.is_burst_enabled()));

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -559,10 +559,6 @@ impl<C: GdmaChannel> InterruptAccess<DmaRxInterrupt> for ChannelRxImpl<C> {
     }
 }
 
-/// A Channel can be created from this
-#[non_exhaustive]
-pub struct ChannelCreator<const N: u8> {}
-
 impl<CH: DmaChannel, M: Mode> Channel<'_, M, CH> {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible<P: DmaEligible>(&self, _peripheral: &PeripheralRef<'_, P>) {
@@ -621,19 +617,19 @@ macro_rules! impl_channel {
                 }
             }
 
-            impl ChannelCreator<$num> {
-                /// Configure the channel for use with blocking APIs
-                pub fn configure<'a>(
-                    self,
-                    burst_mode: bool,
-                    priority: DmaPriority,
-                ) -> Channel<'a, Blocking, [<DmaChannel $num>]> {
+            impl [<DmaChannel $num>] {
+                /// Unsafely constructs a new DMA channel.
+                ///
+                /// # Safety
+                ///
+                /// The caller must ensure that only a single instance is used.
+                pub unsafe fn steal<'a>() -> Channel<'a, Blocking, Self> {
                     let mut this = Channel {
                         tx: ChannelTx::new(ChannelTxImpl(SpecificGdmaChannel::<$num> {})),
                         rx: ChannelRx::new(ChannelRxImpl(SpecificGdmaChannel::<$num> {})),
                     };
 
-                    this.configure(burst_mode, priority);
+                    this.set_priority(DmaPriority::Priority0);
 
                     this
                 }
@@ -731,19 +727,19 @@ crate::impl_dma_eligible! {
 pub struct Dma<'d> {
     _inner: PeripheralRef<'d, crate::peripherals::DMA>,
     /// Channel 0
-    pub channel0: ChannelCreator<0>,
+    pub channel0: Channel<'d, Blocking, DmaChannel0>,
     /// Channel 1
     #[cfg(not(esp32c2))]
-    pub channel1: ChannelCreator<1>,
+    pub channel1: Channel<'d, Blocking, DmaChannel1>,
     /// Channel 2
     #[cfg(not(esp32c2))]
-    pub channel2: ChannelCreator<2>,
+    pub channel2: Channel<'d, Blocking, DmaChannel2>,
     /// Channel 3
     #[cfg(esp32s3)]
-    pub channel3: ChannelCreator<3>,
+    pub channel3: Channel<'d, Blocking, DmaChannel3>,
     /// Channel 4
     #[cfg(esp32s3)]
-    pub channel4: ChannelCreator<4>,
+    pub channel4: Channel<'d, Blocking, DmaChannel4>,
 }
 
 impl<'d> Dma<'d> {
@@ -761,17 +757,19 @@ impl<'d> Dma<'d> {
             .modify(|_, w| w.ahbm_rst_inter().clear_bit());
         dma.misc_conf().modify(|_, w| w.clk_en().set_bit());
 
-        Dma {
-            _inner: dma,
-            channel0: ChannelCreator {},
-            #[cfg(not(esp32c2))]
-            channel1: ChannelCreator {},
-            #[cfg(not(esp32c2))]
-            channel2: ChannelCreator {},
-            #[cfg(esp32s3)]
-            channel3: ChannelCreator {},
-            #[cfg(esp32s3)]
-            channel4: ChannelCreator {},
+        unsafe {
+            Dma {
+                _inner: dma,
+                channel0: DmaChannel0::steal(),
+                #[cfg(not(esp32c2))]
+                channel1: DmaChannel1::steal(),
+                #[cfg(not(esp32c2))]
+                channel2: DmaChannel2::steal(),
+                #[cfg(esp32s3)]
+                channel3: DmaChannel3::steal(),
+                #[cfg(esp32s3)]
+                channel4: DmaChannel4::steal(),
+            }
         }
     }
 }

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -170,10 +170,15 @@ impl<C: GdmaChannel> RegisterAccess for ChannelTxImpl<C> {
     }
 
     fn set_burst_mode(&self, burst_mode: bool) {
-        self.ch().out_conf0().modify(|_, w| {
-            w.out_data_burst_en().bit(burst_mode);
-            w.outdscr_burst_en().bit(burst_mode)
-        });
+        self.ch()
+            .out_conf0()
+            .modify(|_, w| w.out_data_burst_en().bit(burst_mode));
+    }
+
+    fn set_descr_burst_mode(&self, burst_mode: bool) {
+        self.ch()
+            .out_conf0()
+            .modify(|_, w| w.outdscr_burst_en().bit(burst_mode));
     }
 
     fn set_priority(&self, priority: DmaPriority) {
@@ -389,10 +394,15 @@ impl<C: GdmaChannel> RegisterAccess for ChannelRxImpl<C> {
     }
 
     fn set_burst_mode(&self, burst_mode: bool) {
-        self.ch().in_conf0().modify(|_, w| {
-            w.in_data_burst_en().bit(burst_mode);
-            w.indscr_burst_en().bit(burst_mode)
-        });
+        self.ch()
+            .in_conf0()
+            .modify(|_, w| w.in_data_burst_en().bit(burst_mode));
+    }
+
+    fn set_descr_burst_mode(&self, burst_mode: bool) {
+        self.ch()
+            .in_conf0()
+            .modify(|_, w| w.indscr_burst_en().bit(burst_mode));
     }
 
     fn set_priority(&self, priority: DmaPriority) {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1847,7 +1847,7 @@ where
                 #[cfg(esp32s3)]
                 external_memory_block_size: None,
                 direction: TransferDirection::In,
-                burst_transfer: BurstTransfer::Disabled,
+                burst_transfer: BurstConfig::Disabled,
                 check_owner: Some(false),
             },
             peri,
@@ -2142,7 +2142,7 @@ where
                 #[cfg(esp32s3)]
                 external_memory_block_size: None,
                 direction: TransferDirection::Out,
-                burst_transfer: BurstTransfer::Disabled,
+                burst_transfer: BurstConfig::Disabled,
                 check_owner: Some(false),
             },
             peri,
@@ -2227,7 +2227,7 @@ pub trait RegisterAccess: crate::private::Sealed {
 
     /// Enable/Disable INCR burst transfer for channel reading
     /// accessing data in internal RAM.
-    fn set_burst_mode(&self, burst_mode: BurstTransfer);
+    fn set_burst_mode(&self, burst_mode: BurstConfig);
 
     /// Enable/Disable burst transfer for channel reading
     /// descriptors in internal RAM.

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1844,6 +1844,7 @@ where
         let preparation = buffer.prepare();
 
         self.rx_impl.set_burst_mode(false);
+        self.rx_impl.set_descr_burst_mode(true);
         self.rx_impl.set_check_owner(preparation.check_owner);
 
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
@@ -2132,6 +2133,7 @@ where
         );
 
         self.tx_impl.set_burst_mode(false);
+        self.tx_impl.set_descr_burst_mode(true);
         self.tx_impl.set_check_owner(preparation.check_owner);
 
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
@@ -2205,8 +2207,12 @@ pub trait RegisterAccess: crate::private::Sealed {
     fn reset(&self);
 
     /// Enable/Disable INCR burst transfer for channel reading
-    /// descriptor and accessing data in internal RAM.
+    /// accessing data in internal RAM.
     fn set_burst_mode(&self, burst_mode: bool);
+
+    /// Enable/Disable burst transfer for channel reading
+    /// descriptors in internal RAM.
+    fn set_descr_burst_mode(&self, burst_mode: bool);
 
     /// The priority of the channel. The larger the value, the higher the
     /// priority.

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -63,8 +63,6 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
             .modify(|_, w| w.outdscr_burst_en().bit(burst_mode));
     }
 
-    fn set_priority(&self, _priority: DmaPriority) {}
-
     fn set_peripheral(&self, _peripheral: u8) {
         // no-op
     }
@@ -223,8 +221,6 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
         spi.dma_conf()
             .modify(|_, w| w.indscr_burst_en().bit(burst_mode));
     }
-
-    fn set_priority(&self, _priority: DmaPriority) {}
 
     fn set_peripheral(&self, _peripheral: u8) {
         // no-op
@@ -442,25 +438,17 @@ macro_rules! ImplSpiChannel {
 
             impl $crate::private::Sealed for [<Spi $num DmaChannel>] {}
 
-            #[doc = concat!("Creates a channel for SPI", $num)]
-            #[non_exhaustive]
-            pub struct [<Spi $num DmaChannelCreator>] {}
-
-            impl [<Spi $num DmaChannelCreator>] {
-                /// Configure the channel for use with blocking APIs
-                pub fn configure<'a>(
-                    self,
-                    burst_mode: bool,
-                    priority: DmaPriority,
-                ) -> Channel<'a, Blocking, [<Spi $num DmaChannel>]> {
-                    let mut this = Channel {
+            impl [<Spi $num DmaChannel>] {
+                /// Unsafely constructs a new DMA channel.
+                ///
+                /// # Safety
+                ///
+                /// The caller must ensure that only a single instance is used.
+                pub unsafe fn steal<'a>() -> Channel<'a, Blocking, Self> {
+                    Channel {
                         tx: ChannelTx::new(SpiDmaTxChannelImpl([<Spi $num DmaChannel>] {})),
                         rx: ChannelRx::new(SpiDmaRxChannelImpl([<Spi $num DmaChannel>] {})),
-                    };
-
-                    this.configure(burst_mode, priority);
-
-                    this
+                    }
                 }
             }
         }
@@ -484,8 +472,6 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDma
             .lc_conf()
             .modify(|_, w| w.outdscr_burst_en().bit(burst_mode));
     }
-
-    fn set_priority(&self, _priority: DmaPriority) {}
 
     fn reset(&self) {
         let reg_block = self.0.register_block();
@@ -658,8 +644,6 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDma
             .lc_conf()
             .modify(|_, w| w.indscr_burst_en().bit(burst_mode));
     }
-
-    fn set_priority(&self, _priority: DmaPriority) {}
 
     fn reset(&self) {
         let reg_block = self.0.register_block();
@@ -881,24 +865,17 @@ macro_rules! ImplI2sChannel {
                 }
             }
 
-            #[doc = concat!("Creates a channel for I2S", $num)]
-            pub struct [<I2s $num DmaChannelCreator>] {}
-
-            impl [<I2s $num DmaChannelCreator>] {
-                /// Configure the channel for use with blocking APIs
-                pub fn configure<'a>(
-                    self,
-                    burst_mode: bool,
-                    priority: DmaPriority,
-                ) -> Channel<'a, Blocking, [<I2s $num DmaChannel>]> {
-                    let mut this = Channel {
+            impl [<I2s $num DmaChannel>] {
+                /// Unsafely constructs a new DMA channel.
+                ///
+                /// # Safety
+                ///
+                /// The caller must ensure that only a single instance is used.
+                pub unsafe fn steal<'a>() -> Channel<'a, Blocking, Self> {
+                    Channel {
                         tx: ChannelTx::new(I2sDmaTxChannelImpl([<I2s $num DmaChannel>] {})),
                         rx: ChannelRx::new(I2sDmaRxChannelImpl([<I2s $num DmaChannel>] {})),
-                    };
-
-                    this.configure(burst_mode, priority);
-
-                    this
+                    }
                 }
             }
         }
@@ -927,14 +904,14 @@ crate::impl_dma_eligible!([I2s1DmaChannel] I2S1 => I2s1);
 pub struct Dma<'d> {
     _inner: PeripheralRef<'d, crate::peripherals::DMA>,
     /// DMA channel for SPI2
-    pub spi2channel: Spi2DmaChannelCreator,
+    pub spi2channel: Channel<'d, Blocking, Spi2DmaChannel>,
     /// DMA channel for SPI3
-    pub spi3channel: Spi3DmaChannelCreator,
+    pub spi3channel: Channel<'d, Blocking, Spi3DmaChannel>,
     /// DMA channel for I2S0
-    pub i2s0channel: I2s0DmaChannelCreator,
+    pub i2s0channel: Channel<'d, Blocking, I2s0DmaChannel>,
     /// DMA channel for I2S1
     #[cfg(i2s1)]
-    pub i2s1channel: I2s1DmaChannelCreator,
+    pub i2s1channel: Channel<'d, Blocking, I2s1DmaChannel>,
 }
 
 impl<'d> Dma<'d> {
@@ -959,13 +936,15 @@ impl<'d> Dma<'d> {
             });
         }
 
-        Dma {
-            _inner: dma.into_ref(),
-            spi2channel: Spi2DmaChannelCreator {},
-            spi3channel: Spi3DmaChannelCreator {},
-            i2s0channel: I2s0DmaChannelCreator {},
-            #[cfg(i2s1)]
-            i2s1channel: I2s1DmaChannelCreator {},
+        unsafe {
+            Dma {
+                _inner: dma.into_ref(),
+                spi2channel: Spi2DmaChannel::steal(),
+                spi3channel: Spi3DmaChannel::steal(),
+                i2s0channel: I2s0DmaChannel::steal(),
+                #[cfg(i2s1)]
+                i2s1channel: I2s1DmaChannel::steal(),
+            }
         }
     }
 }

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -57,7 +57,7 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
         spi.dma_conf().modify(|_, w| w.out_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: BurstTransfer) {
+    fn set_burst_mode(&self, burst_mode: BurstConfig) {
         let spi = self.0.register_block();
         spi.dma_conf()
             .modify(|_, w| w.out_data_burst_en().bit(burst_mode.is_burst_enabled()));
@@ -222,7 +222,7 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
         spi.dma_conf().modify(|_, w| w.in_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, _burst_mode: BurstTransfer) {}
+    fn set_burst_mode(&self, _burst_mode: BurstConfig) {}
 
     fn set_descr_burst_mode(&self, burst_mode: bool) {
         let spi = self.0.register_block();
@@ -480,7 +480,7 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDma
         reg_block.lc_conf().modify(|_, w| w.out_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: BurstTransfer) {
+    fn set_burst_mode(&self, burst_mode: BurstConfig) {
         let reg_block = self.0.register_block();
         reg_block
             .lc_conf()
@@ -659,7 +659,7 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDma
         reg_block.lc_conf().modify(|_, w| w.in_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, _burst_mode: BurstTransfer) {}
+    fn set_burst_mode(&self, _burst_mode: BurstConfig) {}
 
     fn set_descr_burst_mode(&self, burst_mode: bool) {
         let reg_block = self.0.register_block();

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -57,10 +57,10 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
         spi.dma_conf().modify(|_, w| w.out_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: bool) {
+    fn set_burst_mode(&self, burst_mode: BurstTransfer) {
         let spi = self.0.register_block();
         spi.dma_conf()
-            .modify(|_, w| w.out_data_burst_en().bit(burst_mode));
+            .modify(|_, w| w.out_data_burst_en().bit(burst_mode.is_burst_enabled()));
     }
 
     fn set_descr_burst_mode(&self, burst_mode: bool) {
@@ -222,7 +222,7 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
         spi.dma_conf().modify(|_, w| w.in_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, _burst_mode: bool) {}
+    fn set_burst_mode(&self, _burst_mode: BurstTransfer) {}
 
     fn set_descr_burst_mode(&self, burst_mode: bool) {
         let spi = self.0.register_block();
@@ -480,11 +480,11 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDma
         reg_block.lc_conf().modify(|_, w| w.out_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: bool) {
+    fn set_burst_mode(&self, burst_mode: BurstTransfer) {
         let reg_block = self.0.register_block();
         reg_block
             .lc_conf()
-            .modify(|_, w| w.out_data_burst_en().bit(burst_mode));
+            .modify(|_, w| w.out_data_burst_en().bit(burst_mode.is_burst_enabled()));
     }
 
     fn set_descr_burst_mode(&self, burst_mode: bool) {
@@ -659,7 +659,7 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDma
         reg_block.lc_conf().modify(|_, w| w.in_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, _burst_mode: bool) {}
+    fn set_burst_mode(&self, _burst_mode: BurstTransfer) {}
 
     fn set_descr_burst_mode(&self, burst_mode: bool) {
         let reg_block = self.0.register_block();

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -60,6 +60,12 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
     fn set_burst_mode(&self, burst_mode: bool) {
         let spi = self.0.register_block();
         spi.dma_conf()
+            .modify(|_, w| w.out_data_burst_en().bit(burst_mode));
+    }
+
+    fn set_descr_burst_mode(&self, burst_mode: bool) {
+        let spi = self.0.register_block();
+        spi.dma_conf()
             .modify(|_, w| w.outdscr_burst_en().bit(burst_mode));
     }
 
@@ -216,7 +222,9 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
         spi.dma_conf().modify(|_, w| w.in_rst().clear_bit());
     }
 
-    fn set_burst_mode(&self, burst_mode: bool) {
+    fn set_burst_mode(&self, _burst_mode: bool) {}
+
+    fn set_descr_burst_mode(&self, burst_mode: bool) {
         let spi = self.0.register_block();
         spi.dma_conf()
             .modify(|_, w| w.indscr_burst_en().bit(burst_mode));
@@ -466,17 +474,24 @@ pub struct I2sDmaTxChannelImpl<C>(C);
 impl<C> crate::private::Sealed for I2sDmaTxChannelImpl<C> {}
 
 impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDmaTxChannelImpl<C> {
-    fn set_burst_mode(&self, burst_mode: bool) {
-        let reg_block = self.0.register_block();
-        reg_block
-            .lc_conf()
-            .modify(|_, w| w.outdscr_burst_en().bit(burst_mode));
-    }
-
     fn reset(&self) {
         let reg_block = self.0.register_block();
         reg_block.lc_conf().modify(|_, w| w.out_rst().set_bit());
         reg_block.lc_conf().modify(|_, w| w.out_rst().clear_bit());
+    }
+
+    fn set_burst_mode(&self, burst_mode: bool) {
+        let reg_block = self.0.register_block();
+        reg_block
+            .lc_conf()
+            .modify(|_, w| w.out_data_burst_en().bit(burst_mode));
+    }
+
+    fn set_descr_burst_mode(&self, burst_mode: bool) {
+        let reg_block = self.0.register_block();
+        reg_block
+            .lc_conf()
+            .modify(|_, w| w.outdscr_burst_en().bit(burst_mode));
     }
 
     fn set_link_addr(&self, address: u32) {
@@ -638,17 +653,19 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> InterruptAccess<DmaTxInte
 }
 
 impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDmaRxChannelImpl<C> {
-    fn set_burst_mode(&self, burst_mode: bool) {
-        let reg_block = self.0.register_block();
-        reg_block
-            .lc_conf()
-            .modify(|_, w| w.indscr_burst_en().bit(burst_mode));
-    }
-
     fn reset(&self) {
         let reg_block = self.0.register_block();
         reg_block.lc_conf().modify(|_, w| w.in_rst().set_bit());
         reg_block.lc_conf().modify(|_, w| w.in_rst().clear_bit());
+    }
+
+    fn set_burst_mode(&self, _burst_mode: bool) {}
+
+    fn set_descr_burst_mode(&self, burst_mode: bool) {
+        let reg_block = self.0.register_block();
+        reg_block
+            .lc_conf()
+            .modify(|_, w| w.indscr_burst_en().bit(burst_mode));
     }
 
     fn set_link_addr(&self, address: u32) {

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -31,7 +31,7 @@
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::i2s::master::{I2s, Standard, DataFormat};
 //! # use esp_hal::dma_buffers;
-//! # use esp_hal::dma::{Dma, DmaPriority};
+//! # use esp_hal::dma::Dma;
 //! let dma = Dma::new(peripherals.DMA);
 #![cfg_attr(any(esp32, esp32s2), doc = "let dma_channel = dma.i2s0channel;")]
 #![cfg_attr(not(any(esp32, esp32s2)), doc = "let dma_channel = dma.channel0;")]
@@ -43,10 +43,7 @@
 //!     Standard::Philips,
 //!     DataFormat::Data16Channel16,
 //!     44100.Hz(),
-//!     dma_channel.configure(
-//!         false,
-//!         DmaPriority::Priority0,
-//!     ),
+//!     dma_channel,
 //!     rx_descriptors,
 //!     tx_descriptors,
 //! );

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -427,7 +427,7 @@ where
         )
     }
 
-    /// Converts the SPI instance into async mode.
+    /// Converts the I2S instance into async mode.
     pub fn into_async(self) -> I2s<'d, Async, T> {
         I2s {
             i2s_rx: RxCreator {

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -19,17 +19,12 @@
 //! # use esp_hal::lcd_cam::{cam::{Camera, RxEightBits}, LcdCam};
 //! # use fugit::RateExtU32;
 //! # use esp_hal::dma_rx_stream_buffer;
-//! # use esp_hal::dma::{Dma, DmaPriority};
+//! # use esp_hal::dma::Dma;
 //!
 //! # let dma = Dma::new(peripherals.DMA);
 //! # let channel = dma.channel0;
 //!
 //! # let dma_buf = dma_rx_stream_buffer!(20 * 1000, 1000);
-//!
-//! # let channel = channel.configure(
-//! #     false,
-//! #     DmaPriority::Priority0,
-//! # );
 //!
 //! let mclk_pin = peripherals.GPIO15;
 //! let vsync_pin = peripherals.GPIO6;

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -31,11 +31,6 @@
 //!
 //! # let mut dma_buf = dma_loop_buffer!(32);
 //!
-//! # let channel = channel.configure(
-//! #     false,
-//! #     DmaPriority::Priority0,
-//! # );
-//!
 //! let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
 //!
 //! let mut config = dpi::Config::default();

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -17,17 +17,12 @@
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::lcd_cam::{LcdCam, lcd::i8080::{Config, I8080, TxEightBits}};
 //! # use esp_hal::dma_tx_buffer;
-//! # use esp_hal::dma::{Dma, DmaPriority, DmaTxBuf};
+//! # use esp_hal::dma::{Dma, DmaTxBuf};
 //!
 //! # let dma = Dma::new(peripherals.DMA);
 //! # let channel = dma.channel0;
 //!
 //! # let mut dma_buf = dma_tx_buffer!(32678).unwrap();
-//!
-//! # let channel = channel.configure(
-//! #     false,
-//! #     DmaPriority::Priority0,
-//! # );
 //!
 //! let tx_pins = TxEightBits::new(
 //!     peripherals.GPIO9,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -867,6 +867,8 @@ mod dma {
             Rx,
             Tx,
         },
+        Async,
+        Blocking,
         InterruptConfigurable,
     };
 

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -15,7 +15,6 @@
 //!
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::dma::DmaPriority;
 //! # use esp_hal::dma_buffers;
 //! # use esp_hal::spi::SpiMode;
 //! # use esp_hal::spi::slave::Spi;
@@ -39,10 +38,7 @@
 //! .with_miso(miso)
 //! .with_cs(cs)
 //! .with_dma(
-//!     dma_channel.configure(
-//!         false,
-//!         DmaPriority::Priority0,
-//!     ),
+//!     dma_channel,
 //!     rx_descriptors,
 //!     tx_descriptors,
 //! );

--- a/examples/src/bin/dma_extmem2mem.rs
+++ b/examples/src/bin/dma_extmem2mem.rs
@@ -11,7 +11,7 @@ use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority, Mem2Mem},
+    dma::{Dma, Mem2Mem},
     dma_descriptors_chunk_size,
     prelude::*,
 };
@@ -68,11 +68,10 @@ fn main() -> ! {
     let (rx_descriptors, tx_descriptors) = dma_descriptors_chunk_size!(DATA_SIZE, CHUNK_SIZE);
 
     let dma = Dma::new(peripherals.DMA);
-    let channel = dma.channel0.configure(false, DmaPriority::Priority0);
     let dma_peripheral = peripherals.SPI2;
 
     let mut mem2mem = Mem2Mem::new_with_chunk_size(
-        channel,
+        dma.channel0,
         dma_peripheral,
         rx_descriptors,
         tx_descriptors,

--- a/examples/src/bin/dma_mem2mem.rs
+++ b/examples/src/bin/dma_mem2mem.rs
@@ -9,7 +9,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority, Mem2Mem},
+    dma::{Dma, Mem2Mem},
     dma_buffers,
     prelude::*,
 };
@@ -28,14 +28,13 @@ fn main() -> ! {
     let (mut rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(DATA_SIZE);
 
     let dma = Dma::new(peripherals.DMA);
-    let channel = dma.channel0.configure(false, DmaPriority::Priority0);
     #[cfg(any(feature = "esp32c2", feature = "esp32c3", feature = "esp32s3"))]
     let dma_peripheral = peripherals.SPI2;
     #[cfg(not(any(feature = "esp32c2", feature = "esp32c3", feature = "esp32s3")))]
     let dma_peripheral = peripherals.MEM2MEM1;
 
     let mut mem2mem =
-        Mem2Mem::new(channel, dma_peripheral, rx_descriptors, tx_descriptors).unwrap();
+        Mem2Mem::new(dma.channel0, dma_peripheral, rx_descriptors, tx_descriptors).unwrap();
 
     for i in 0..core::mem::size_of_val(tx_buffer) {
         tx_buffer[i] = (i % 256) as u8;

--- a/examples/src/bin/embassy_i2s_parallel.rs
+++ b/examples/src/bin/embassy_i2s_parallel.rs
@@ -18,7 +18,7 @@ use embassy_executor::Spawner;
 use embassy_time::Timer;
 use esp_backtrace as _;
 use esp_hal::{
-    dma::{Dma, DmaPriority, DmaTxBuf},
+    dma::{Dma, DmaTxBuf},
     dma_buffers,
     i2s::parallel::{I2sParallel, TxEightBits},
     prelude::*,
@@ -56,15 +56,7 @@ async fn main(_spawner: Spawner) {
     );
 
     let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, BUFFER_SIZE);
-    let mut parallel = I2sParallel::new(
-        i2s,
-        dma_channel
-            .configure(false, DmaPriority::Priority0)
-            .into_async(),
-        1.MHz(),
-        pins,
-        clock,
-    );
+    let mut parallel = I2sParallel::new(i2s, dma_channel, 1.MHz(), pins, clock).into_async();
 
     for (i, data) in tx_buffer.chunks_mut(4).enumerate() {
         let offset = i * 4;

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -20,7 +20,7 @@
 use embassy_executor::Spawner;
 use esp_backtrace as _;
 use esp_hal::{
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     i2s::master::{DataFormat, I2s, Standard},
     prelude::*,
@@ -49,7 +49,7 @@ async fn main(_spawner: Spawner) {
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
-        dma_channel.configure(false, DmaPriority::Priority0),
+        dma_channel,
         rx_descriptors,
         tx_descriptors,
     )

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -14,7 +14,7 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     gpio::NoPin,
     parl_io::{BitPackOrder, ParlIoRxOnly, RxFourBits},
@@ -34,7 +34,6 @@ async fn main(_spawner: Spawner) {
     let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(32000, 0);
 
     let dma = Dma::new(peripherals.DMA);
-    let dma_channel = dma.channel0;
 
     let mut rx_pins = RxFourBits::new(
         peripherals.GPIO1,
@@ -46,9 +45,7 @@ async fn main(_spawner: Spawner) {
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,
-        dma_channel
-            .configure(false, DmaPriority::Priority0)
-            .into_async(),
+        dma.channel0.into_async(),
         rx_descriptors,
         1.MHz(),
     )

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -18,7 +18,7 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     parl_io::{
         BitPackOrder,
@@ -44,7 +44,6 @@ async fn main(_spawner: Spawner) {
     let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 
     let dma = Dma::new(peripherals.DMA);
-    let dma_channel = dma.channel0;
 
     let tx_pins = TxFourBits::new(
         peripherals.GPIO1,
@@ -57,9 +56,7 @@ async fn main(_spawner: Spawner) {
 
     let parl_io = ParlIoTxOnly::new(
         peripherals.PARL_IO,
-        dma_channel
-            .configure(false, DmaPriority::Priority0)
-            .into_async(),
+        dma.channel0.into_async(),
         tx_descriptors,
         1.MHz(),
     )

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -71,7 +71,7 @@ async fn main(_spawner: Spawner) {
     .with_mosi(mosi)
     .with_miso(miso)
     .with_cs(cs)
-    .with_dma(dma_channel.configure(false, DmaPriority::Priority0))
+    .with_dma(dma_channel)
     .with_buffers(dma_rx_buf, dma_tx_buf)
     .into_async();
 

--- a/examples/src/bin/i2s_parallel.rs
+++ b/examples/src/bin/i2s_parallel.rs
@@ -16,7 +16,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority, DmaTxBuf},
+    dma::{Dma, DmaTxBuf},
     dma_buffers,
     i2s::parallel::{I2sParallel, TxEightBits},
     prelude::*,
@@ -50,13 +50,7 @@ fn main() -> ! {
     );
 
     let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, BUFFER_SIZE);
-    let mut parallel = I2sParallel::new(
-        i2s,
-        dma_channel.configure(false, DmaPriority::Priority0),
-        1.MHz(),
-        pins,
-        clock,
-    );
+    let mut parallel = I2sParallel::new(i2s, dma_channel, 1.MHz(), pins, clock);
 
     for (i, data) in tx_buffer.chunks_mut(4).enumerate() {
         let offset = i * 4;

--- a/examples/src/bin/i2s_read.rs
+++ b/examples/src/bin/i2s_read.rs
@@ -18,7 +18,7 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     i2s::master::{DataFormat, I2s, Standard},
     prelude::*,
@@ -46,7 +46,7 @@ fn main() -> ! {
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100.Hz(),
-        dma_channel.configure(false, DmaPriority::Priority0),
+        dma_channel,
         rx_descriptors,
         tx_descriptors,
     );

--- a/examples/src/bin/lcd_dpi.rs
+++ b/examples/src/bin/lcd_dpi.rs
@@ -34,7 +34,7 @@ use core::iter::{empty, once};
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_loop_buffer,
     gpio::{Level, Output},
     i2c,
@@ -71,7 +71,7 @@ fn main() -> ! {
     .with_scl(peripherals.GPIO48);
 
     let dma = Dma::new(peripherals.DMA);
-    let channel = dma.channel2.configure(true, DmaPriority::Priority0);
+    let channel = dma.channel2;
     let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
 
     let mut expander = Tca9554::new(i2c);

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -12,7 +12,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     gpio::NoPin,
     parl_io::{BitPackOrder, ParlIoRxOnly, RxFourBits},
@@ -37,13 +37,8 @@ fn main() -> ! {
     );
     let mut rx_clk_pin = NoPin;
 
-    let parl_io = ParlIoRxOnly::new(
-        peripherals.PARL_IO,
-        dma_channel.configure(false, DmaPriority::Priority0),
-        rx_descriptors,
-        1.MHz(),
-    )
-    .unwrap();
+    let parl_io =
+        ParlIoRxOnly::new(peripherals.PARL_IO, dma_channel, rx_descriptors, 1.MHz()).unwrap();
 
     let mut parl_io_rx = parl_io
         .rx

--- a/examples/src/bin/parl_io_tx.rs
+++ b/examples/src/bin/parl_io_tx.rs
@@ -16,7 +16,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     parl_io::{
         BitPackOrder,
@@ -48,13 +48,8 @@ fn main() -> ! {
 
     let mut pin_conf = TxPinConfigWithValidPin::new(tx_pins, peripherals.GPIO5);
 
-    let parl_io = ParlIoTxOnly::new(
-        peripherals.PARL_IO,
-        dma_channel.configure(false, DmaPriority::Priority0),
-        tx_descriptors,
-        1.MHz(),
-    )
-    .unwrap();
+    let parl_io =
+        ParlIoTxOnly::new(peripherals.PARL_IO, dma_channel, tx_descriptors, 1.MHz()).unwrap();
 
     let mut clock_pin = ClkOutPin::new(peripherals.GPIO6);
 

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -21,7 +21,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Dma, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     prelude::*,
     spi::{
@@ -66,7 +66,7 @@ fn main() -> ! {
     .with_mosi(mosi)
     .with_miso(miso)
     .with_cs(cs)
-    .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
+    .with_dma(dma_channel);
 
     let delay = Delay::new();
 

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -25,7 +25,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaBufBlkSize, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Dma, DmaBufBlkSize, DmaRxBuf, DmaTxBuf},
     peripheral::Peripheral,
     prelude::*,
     spi::{
@@ -103,7 +103,7 @@ fn main() -> ! {
     .with_miso(miso)
     .with_mosi(mosi)
     .with_cs(cs)
-    .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
+    .with_dma(dma_channel);
 
     delay.delay_millis(100); // delay to let the above messages display
 

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -32,7 +32,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     gpio::{Input, Level, Output, Pull},
     prelude::*,
@@ -70,11 +70,7 @@ fn main() -> ! {
         .with_mosi(slave_mosi)
         .with_miso(slave_miso)
         .with_cs(slave_cs)
-        .with_dma(
-            dma_channel.configure(false, DmaPriority::Priority0),
-            rx_descriptors,
-            tx_descriptors,
-        );
+        .with_dma(dma_channel, rx_descriptors, tx_descriptors);
 
     let delay = Delay::new();
 

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -7,7 +7,7 @@
 
 use esp_hal::{
     aes::{dma::CipherMode, Aes, Mode},
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     peripherals::Peripherals,
 };
@@ -32,11 +32,8 @@ mod tests {
 
         let (mut output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
-        let mut aes = Aes::new(peripherals.AES).with_dma(
-            dma_channel.configure(false, DmaPriority::Priority0),
-            rx_descriptors,
-            tx_descriptors,
-        );
+        let mut aes =
+            Aes::new(peripherals.AES).with_dma(dma_channel, rx_descriptors, tx_descriptors);
 
         let keytext = b"SUp4SeCp@sSw0rd";
         let mut keybuf = [0_u8; 16];
@@ -74,11 +71,8 @@ mod tests {
 
         let (mut output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
-        let mut aes = Aes::new(peripherals.AES).with_dma(
-            dma_channel.configure(false, DmaPriority::Priority0),
-            rx_descriptors,
-            tx_descriptors,
-        );
+        let mut aes =
+            Aes::new(peripherals.AES).with_dma(dma_channel, rx_descriptors, tx_descriptors);
 
         let keytext = b"SUp4SeCp@sSw0rd";
         let mut keybuf = [0_u8; 16];
@@ -115,11 +109,8 @@ mod tests {
 
         let (mut output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
-        let mut aes = Aes::new(peripherals.AES).with_dma(
-            dma_channel.configure(false, DmaPriority::Priority0),
-            rx_descriptors,
-            tx_descriptors,
-        );
+        let mut aes =
+            Aes::new(peripherals.AES).with_dma(dma_channel, rx_descriptors, tx_descriptors);
 
         let keytext = b"SUp4SeCp@sSw0rd";
         let mut keybuf = [0_u8; 16];
@@ -157,11 +148,8 @@ mod tests {
 
         let (mut output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
 
-        let mut aes = Aes::new(peripherals.AES).with_dma(
-            dma_channel.configure(false, DmaPriority::Priority0),
-            rx_descriptors,
-            tx_descriptors,
-        );
+        let mut aes =
+            Aes::new(peripherals.AES).with_dma(dma_channel, rx_descriptors, tx_descriptors);
 
         let keytext = b"SUp4SeCp@sSw0rd";
         let mut keybuf = [0_u8; 16];

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{AnyGdmaChannel, Channel, Dma, DmaError, DmaPriority, Mem2Mem},
+    dma::{AnyGdmaChannel, Channel, Dma, DmaError, Mem2Mem},
     dma_buffers,
     dma_buffers_chunk_size,
     dma_descriptors,
@@ -50,9 +50,7 @@ mod tests {
         }
 
         Context {
-            channel: dma_channel
-                .configure(false, DmaPriority::Priority0)
-                .degrade(),
+            channel: dma_channel.degrade(),
             dma_peripheral,
         }
     }

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -12,21 +12,22 @@
 
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority},
+    dma::{Channel, Dma},
     dma_buffers,
     gpio::{AnyPin, NoPin, Pin},
     i2s::master::{DataFormat, I2s, I2sTx, Standard},
     peripherals::I2S0,
     prelude::*,
     Async,
+    Blocking,
 };
 use hil_test as _;
 
 cfg_if::cfg_if! {
     if #[cfg(any(esp32, esp32s2))] {
-        type DmaChannel0Creator = esp_hal::dma::I2s0DmaChannelCreator;
+        type DmaChannel0 = esp_hal::dma::I2s0DmaChannel;
     } else {
-        type DmaChannel0Creator = esp_hal::dma::ChannelCreator<0>;
+        type DmaChannel0 = esp_hal::dma::DmaChannel0;
     }
 }
 
@@ -104,7 +105,7 @@ mod tests {
 
     struct Context {
         dout: AnyPin,
-        dma_channel: DmaChannel0Creator,
+        dma_channel: Channel<'static, Blocking, DmaChannel0>,
         i2s: I2S0,
     }
 
@@ -143,7 +144,7 @@ mod tests {
             Standard::Philips,
             DataFormat::Data16Channel16,
             16000.Hz(),
-            ctx.dma_channel.configure(false, DmaPriority::Priority0),
+            ctx.dma_channel,
             rx_descriptors,
             tx_descriptors,
         )
@@ -196,7 +197,7 @@ mod tests {
             Standard::Philips,
             DataFormat::Data16Channel16,
             16000.Hz(),
-            ctx.dma_channel.configure(false, DmaPriority::Priority0),
+            ctx.dma_channel,
             rx_descriptors,
             tx_descriptors,
         );
@@ -305,7 +306,7 @@ mod tests {
             Standard::Philips,
             DataFormat::Data16Channel16,
             16000.Hz(),
-            ctx.dma_channel.configure(false, DmaPriority::Priority0),
+            ctx.dma_channel,
             rx_descriptors,
             tx_descriptors,
         );
@@ -335,7 +336,7 @@ mod tests {
             Standard::Philips,
             DataFormat::Data16Channel16,
             16000.Hz(),
-            ctx.dma_channel.configure(false, DmaPriority::Priority0),
+            ctx.dma_channel,
             rx_descriptors,
             tx_descriptors,
         );

--- a/hil-test/tests/lcd_cam.rs
+++ b/hil-test/tests/lcd_cam.rs
@@ -1,7 +1,6 @@
 //! LCD_CAM Camera and DPI tests
 
 //% CHIPS: esp32s3
-//% FEATURES: defmt
 
 #![no_std]
 #![no_main]
@@ -59,7 +58,7 @@ mod tests {
         let dma = Dma::new(peripherals.DMA);
         let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
 
-        let channel = dma.channel2.configure(false, DmaPriority::Priority0);
+        let channel = dma.channel2;
 
         let (vsync_in, vsync_out) = peripherals.GPIO6.split();
         let (hsync_in, hsync_out) = peripherals.GPIO7.split();

--- a/hil-test/tests/lcd_cam_i8080.rs
+++ b/hil-test/tests/lcd_cam_i8080.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{Dma, DmaPriority, DmaTxBuf},
+    dma::{Dma, DmaTxBuf},
     dma_buffers,
     gpio::{GpioPin, NoPin},
     lcd_cam::{
@@ -74,13 +74,11 @@ mod tests {
 
     #[test]
     fn test_i8080_8bit(ctx: Context<'static>) {
-        let channel = ctx.dma.channel0.configure(false, DmaPriority::Priority0);
-
         let pins = TxEightBits::new(NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin);
 
         let i8080 = I8080::new(
             ctx.lcd_cam.lcd,
-            channel.tx,
+            ctx.dma.channel0.tx,
             pins,
             20.MHz(),
             Config::default(),
@@ -130,7 +128,6 @@ mod tests {
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        let channel = ctx.dma.channel0.configure(false, DmaPriority::Priority0);
         let pins = TxEightBits::new(
             unit0_signal,
             unit1_signal,
@@ -144,7 +141,7 @@ mod tests {
 
         let mut i8080 = I8080::new(
             ctx.lcd_cam.lcd,
-            channel.tx,
+            ctx.dma.channel0.tx,
             pins,
             20.MHz(),
             Config::default(),
@@ -241,7 +238,7 @@ mod tests {
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        let channel = ctx.dma.channel0.configure(false, DmaPriority::Priority0);
+        let channel = ctx.dma.channel0;
         let pins = TxSixteenBits::new(
             NoPin,
             NoPin,

--- a/hil-test/tests/lcd_cam_i8080_async.rs
+++ b/hil-test/tests/lcd_cam_i8080_async.rs
@@ -7,7 +7,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{Dma, DmaPriority, DmaTxBuf},
+    dma::{Dma, DmaTxBuf},
     dma_buffers,
     gpio::NoPin,
     lcd_cam::{
@@ -50,12 +50,11 @@ mod tests {
 
     #[test]
     async fn test_i8080_8bit(ctx: Context<'static>) {
-        let channel = ctx.dma.channel0.configure(false, DmaPriority::Priority0);
         let pins = TxEightBits::new(NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin);
 
         let i8080 = I8080::new(
             ctx.lcd_cam.lcd,
-            channel.tx,
+            ctx.dma.channel0.tx,
             pins,
             20.MHz(),
             Config::default(),

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -7,7 +7,7 @@
 #[cfg(esp32c6)]
 use esp_hal::parl_io::{TxPinConfigWithValidPin, TxSixteenBits};
 use esp_hal::{
-    dma::{ChannelCreator, Dma, DmaPriority},
+    dma::{Channel, Dma, DmaChannel0},
     gpio::{
         interconnect::{InputSignal, OutputSignal},
         NoPin,
@@ -27,12 +27,13 @@ use esp_hal::{
     },
     peripherals::PARL_IO,
     prelude::*,
+    Blocking,
 };
 use hil_test as _;
 
 struct Context {
     parl_io: PARL_IO,
-    dma_channel: ChannelCreator<0>,
+    dma_channel: Channel<'static, Blocking, DmaChannel0>,
     clock: OutputSignal,
     valid: OutputSignal,
     clock_loopback: InputSignal,
@@ -88,13 +89,8 @@ mod tests {
         let mut pins = TxPinConfigIncludingValidPin::new(pins);
         let mut clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(
-            ctx.parl_io,
-            ctx.dma_channel.configure(false, DmaPriority::Priority0),
-            tx_descriptors,
-            10.MHz(),
-        )
-        .unwrap();
+        let pio =
+            ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, tx_descriptors, 10.MHz()).unwrap();
 
         let mut pio = pio
             .tx
@@ -155,13 +151,8 @@ mod tests {
 
         let mut clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(
-            ctx.parl_io,
-            ctx.dma_channel.configure(false, DmaPriority::Priority0),
-            tx_descriptors,
-            10.MHz(),
-        )
-        .unwrap();
+        let pio =
+            ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, tx_descriptors, 10.MHz()).unwrap();
 
         let mut pio = pio
             .tx

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -8,7 +8,7 @@
 #[cfg(pcnt)]
 use esp_hal::pcnt::{channel::EdgeMode, unit::Unit, Pcnt};
 use esp_hal::{
-    dma::{Channel, Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Channel, Dma, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     gpio::{AnyPin, Input, Level, Output, Pull},
     prelude::*,
@@ -202,7 +202,6 @@ mod tests {
             }
         }
 
-        let dma_channel = dma_channel.configure(false, DmaPriority::Priority0);
         let spi = Spi::new_with_config(
             peripherals.SPI2,
             Config {

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Dma, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     gpio::{Level, Output},
     prelude::*,
@@ -58,7 +58,7 @@ mod tests {
         )
         .with_sck(sclk)
         .with_miso(miso)
-        .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
+        .with_dma(dma_channel);
 
         Context { spi, miso_mirror }
     }

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Dma, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     gpio::interconnect::InputSignal,
     pcnt::{channel::EdgeMode, unit::Unit, Pcnt},
@@ -61,7 +61,7 @@ mod tests {
         )
         .with_sck(sclk)
         .with_mosi(mosi)
-        .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
+        .with_dma(dma_channel);
 
         Context {
             spi,

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -7,7 +7,7 @@
 use defmt::error;
 use esp_alloc as _;
 use esp_hal::{
-    dma::{Dma, DmaBufBlkSize, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Dma, DmaBufBlkSize, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     dma_descriptors_chunk_size,
     gpio::interconnect::InputSignal,
@@ -73,7 +73,7 @@ mod tests {
         )
         .with_sck(sclk)
         .with_mosi(mosi)
-        .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
+        .with_dma(dma_channel);
 
         Context {
             spi,

--- a/qa-test/src/bin/embassy_i2s_sound.rs
+++ b/qa-test/src/bin/embassy_i2s_sound.rs
@@ -34,7 +34,7 @@
 use embassy_executor::Spawner;
 use esp_backtrace as _;
 use esp_hal::{
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     i2s::master::{DataFormat, I2s, Standard},
     prelude::*,
@@ -71,7 +71,7 @@ async fn main(_spawner: Spawner) {
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100u32.Hz(),
-        dma_channel.configure(false, DmaPriority::Priority0),
+        dma_channel,
         rx_descriptors,
         tx_descriptors,
     )

--- a/qa-test/src/bin/i2s_sound.rs
+++ b/qa-test/src/bin/i2s_sound.rs
@@ -32,7 +32,7 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_buffers,
     i2s::master::{DataFormat, I2s, Standard},
     prelude::*,
@@ -63,7 +63,7 @@ fn main() -> ! {
         Standard::Philips,
         DataFormat::Data16Channel16,
         44100.Hz(),
-        dma_channel.configure(false, DmaPriority::Priority0),
+        dma_channel,
         rx_descriptors,
         tx_descriptors,
     );

--- a/qa-test/src/bin/lcd_cam_ov2640.rs
+++ b/qa-test/src/bin/lcd_cam_ov2640.rs
@@ -28,7 +28,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority},
+    dma::Dma,
     dma_rx_stream_buffer,
     i2c::{
         self,
@@ -48,11 +48,8 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     let dma = Dma::new(peripherals.DMA);
-    let channel = dma.channel0;
 
     let dma_rx_buf = dma_rx_stream_buffer!(20 * 1000, 1000);
-
-    let channel = channel.configure(false, DmaPriority::Priority0);
 
     let cam_siod = peripherals.GPIO4;
     let cam_sioc = peripherals.GPIO5;
@@ -72,7 +69,7 @@ fn main() -> ! {
     );
 
     let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
-    let camera = Camera::new(lcd_cam.cam, channel.rx, cam_data_pins, 20u32.MHz())
+    let camera = Camera::new(lcd_cam.cam, dma.channel0.rx, cam_data_pins, 20u32.MHz())
         .with_master_clock(cam_xclk)
         .with_pixel_clock(cam_pclk)
         .with_ctrl_pins(cam_vsync, cam_href);

--- a/qa-test/src/bin/lcd_i8080.rs
+++ b/qa-test/src/bin/lcd_i8080.rs
@@ -25,7 +25,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority, DmaTxBuf},
+    dma::{Dma, DmaTxBuf},
     dma_tx_buffer,
     gpio::{Input, Level, Output, Pull},
     lcd_cam::{
@@ -48,11 +48,8 @@ fn main() -> ! {
     let lcd_te = peripherals.GPIO48; // Frame sync
 
     let dma = Dma::new(peripherals.DMA);
-    let channel = dma.channel0;
 
     let dma_tx_buf = dma_tx_buffer!(4000).unwrap();
-
-    let channel = channel.configure(false, DmaPriority::Priority0);
 
     let delay = Delay::new();
 
@@ -74,7 +71,7 @@ fn main() -> ! {
     let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
     let i8080 = I8080::new(
         lcd_cam.lcd,
-        channel.tx,
+        dma.channel0.tx,
         tx_pins,
         20.MHz(),
         Config::default(),

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -30,7 +30,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{Dma, DmaPriority, DmaRxBuf, DmaTxBuf},
+    dma::{Dma, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     prelude::*,
     spi::{
@@ -91,7 +91,7 @@ fn main() -> ! {
     .with_sio2(sio2)
     .with_sio3(sio3)
     .with_cs(cs)
-    .with_dma(dma_channel.configure(false, DmaPriority::Priority0));
+    .with_dma(dma_channel);
 
     let delay = Delay::new();
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR removes the `ChannelCreator` types, and instead provides the initialized DMA channels immediately. The PR further removes the channel-wide burst mode setting, and pushes the responsibility to the DMA buffer APIs. As a consequence, some peripherals currently don't support burst DMA transfers.


