### PR TITLE
Reduce UART Instance trait to the bare minimum

### DIFF
--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1423,7 +1423,7 @@ where
         // already enough to make this a no-go. (i.e. one needs to mute the ROM
         // code via efuse / strapping pin AND use a silent bootloader)
         //
-        // Ideally this should be configurable once we have a solution for https://github.com/esp-rs/esp-hal/issues/1111
+        // TODO: make this configurable
         // see https://github.com/espressif/esp-idf/blob/5f4249357372f209fdd57288265741aaba21a2b1/components/esp_driver_uart/src/uart.c#L179
         if self.is_instance(unsafe { crate::peripherals::UART0::steal() }) {
             return;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1027,7 +1027,10 @@ where
         // `self.tx.uart` and `self.rx.uart` are the same
         unsafe {
             crate::interrupt::bind_interrupt(self.tx.uart.interrupt(), handler.handler());
-            crate::interrupt::enable(self.tx.uart.interrupt(), handler.priority()).unwrap();
+            unwrap!(crate::interrupt::enable(
+                self.tx.uart.interrupt(),
+                handler.priority()
+            ));
         }
     }
 


### PR DESCRIPTION
A bit of an experimental change, that allows (though doesn't fully implements) erasing the UART types completely in internal code.

At this point we can make UART's Instance completely public, allowing third parties to write their own drivers without relying on hidden code. Because there is no public, but hidden code :)

The driver itself is a bit of a mess, still, and I guess I'll need to write at least a changelog entry.