### PR TITLE
Add `Cpu::COUNT` and clean up in `esp-hal-embassy`

### DIFF
--- a/esp-hal-embassy/src/executor/interrupt.rs
+++ b/esp-hal-embassy/src/executor/interrupt.rs
@@ -99,7 +99,7 @@ impl<const SWI: u8> InterruptExecutor<SWI> {
         unsafe {
             (*self.executor.get())
                 .as_mut_ptr()
-                .write(raw::Executor::new(SWI as *mut ()));
+                .write(raw::Executor::new((SWI as usize) as *mut ()));
 
             EXECUTORS[SWI as usize].set((*self.executor.get()).as_mut_ptr());
         }

--- a/esp-hal-embassy/src/executor/mod.rs
+++ b/esp-hal-embassy/src/executor/mod.rs
@@ -7,19 +7,18 @@ mod thread;
 fn __pender(context: *mut ()) {
     use esp_hal::interrupt::software::SoftwareInterrupt;
 
-    let context = (context as usize).to_le_bytes();
-
-    match context[0] {
+    match context as usize {
         // For interrupt executors, the context value is the
         // software interrupt number
         0 => unsafe { SoftwareInterrupt::<0>::steal().raise() },
         1 => unsafe { SoftwareInterrupt::<1>::steal().raise() },
         2 => unsafe { SoftwareInterrupt::<2>::steal().raise() },
+        #[cfg(not(multi_core))]
         3 => unsafe { SoftwareInterrupt::<3>::steal().raise() },
-        other => {
-            assert_eq!(other, THREAD_MODE_CONTEXT);
-            // THREAD_MODE_CONTEXT id is reserved for thread mode executors
-            thread::pend_thread_mode(context[1] as usize)
-        }
+        // THREAD_MODE_CONTEXT + core ID
+        16 => thread::pend_thread_mode(0),
+        #[cfg(multi_core)]
+        17 => thread::pend_thread_mode(1),
+        _ => unreachable!(),
     }
 }

--- a/esp-hal-embassy/src/executor/thread.rs
+++ b/esp-hal-embassy/src/executor/thread.rs
@@ -3,7 +3,7 @@
 use core::marker::PhantomData;
 
 use embassy_executor::{raw, Spawner};
-use esp_hal::get_core;
+use esp_hal::{get_core, Cpu};
 #[cfg(multi_core)]
 use esp_hal::{interrupt::software::SoftwareInterrupt, macros::handler};
 use portable_atomic::{AtomicBool, Ordering};
@@ -12,10 +12,8 @@ pub(crate) const THREAD_MODE_CONTEXT: u8 = 16;
 
 /// global atomic used to keep track of whether there is work to do since sev()
 /// is not available on either Xtensa or RISC-V
-#[cfg(not(multi_core))]
-static SIGNAL_WORK_THREAD_MODE: [AtomicBool; 1] = [AtomicBool::new(false)];
-#[cfg(multi_core)]
-static SIGNAL_WORK_THREAD_MODE: [AtomicBool; 2] = [AtomicBool::new(false), AtomicBool::new(false)];
+static SIGNAL_WORK_THREAD_MODE: [AtomicBool; Cpu::COUNT] =
+    [const { AtomicBool::new(false) }; Cpu::COUNT];
 
 #[cfg(multi_core)]
 #[handler]

--- a/esp-hal-embassy/src/executor/thread.rs
+++ b/esp-hal-embassy/src/executor/thread.rs
@@ -8,7 +8,7 @@ use esp_hal::{get_core, Cpu};
 use esp_hal::{interrupt::software::SoftwareInterrupt, macros::handler};
 use portable_atomic::{AtomicBool, Ordering};
 
-pub(crate) const THREAD_MODE_CONTEXT: u8 = 16;
+pub(crate) const THREAD_MODE_CONTEXT: usize = 16;
 
 /// global atomic used to keep track of whether there is work to do since sev()
 /// is not available on either Xtensa or RISC-V
@@ -70,12 +70,7 @@ This will use software-interrupt 3 which isn't available for anything else to wa
         }
 
         Self {
-            inner: raw::Executor::new(usize::from_le_bytes([
-                THREAD_MODE_CONTEXT,
-                get_core() as u8,
-                0,
-                0,
-            ]) as *mut ()),
+            inner: raw::Executor::new((THREAD_MODE_CONTEXT + get_core() as usize) as *mut ()),
             not_send: PhantomData,
         }
     }

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Pins::steal()` to unsafely obtain GPIO. (#2335)
 - `I2c::with_timeout` (#2361)
 - `Spi::half_duplex_read` and `Spi::half_duplex_write` (#2373)
+- `Cpu::COUNT` and `Cpu::current()` (#?)
 
 ### Changed
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -363,6 +363,17 @@ pub enum Cpu {
     AppCpu = 1,
 }
 
+impl Cpu {
+    /// The number of available cores.
+    pub const COUNT: usize = 1 + cfg!(multi_core) as usize;
+
+    /// Returns the core the application is currently executing on
+    #[inline(always)]
+    pub fn current() -> Self {
+        get_core()
+    }
+}
+
 /// Which core the application is currently executing on
 #[inline(always)]
 pub fn get_core() -> Cpu {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The important bits in this PR is reworking the `context` to be a single `usize` instead of two `u8`s. This hopefully allows the compiler to avoid bounds checking the write to `SIGNAL_WORK_THREAD_MODE` (in `pend_thread_mode`).

skip-changelog added because I don't know if this actually needs to be logged in esp-hal-embassy.

#### Testing

Looking at the generated assembly, this PR generates simpler switch branches. The new thread-mode handler code is two branches of "write variable, read PRID, fire interrupt if not current core".