### PR TITLE
Peripheral interconnect redo, vol 2 (`split()`)

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DmaDescriptor` is now `Send` (#2456)
 - `into_async` and `into_blocking` functions for most peripherals (#2430)
 - API mode type parameter (currently always `Blocking`) to `master::Spi` and `slave::Spi` (#2430)
+- `gpio::{GpioPin, AnyPin, Flex, Output, OutputOpenDrain}::split()` to obtain peripheral interconnect signals. (#2418)
+- `gpio::Input::{split(), into_peripheral_output()}` when used with output pins. (#2418)
+- `gpio::Output::peripheral_input()` (#2418)
 
 ### Changed
 
@@ -42,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI interrupt listening is now only available in Blocking mode. The `set_interrupt_handler` is available via `InterruptConfigurable` (#2442)
 - Allow users to create DMA `Preparation`s (#2455) 
 - The `rmt::asynch::RxChannelAsync` and `rmt::asynch::TxChannelAsync` traits have been moved to `rmt` (#2430)
+- Calling `AnyPin::output_signals` on an input-only pin (ESP32 GPIO 34-39) will now result in a panic. (#2418)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -194,7 +194,8 @@ You can now listen/unlisten multiple interrupt bits at once:
 -uart0.listen_at_cmd();
 -uart0.listen_rx_fifo_full();
 +uart0.listen(UartInterrupt::AtCmd | UartConterrupt::RxFifoFull);
-```˛
+```
+
 ## Circular DMA transfer's `available` returns `Result<usize, DmaError>` now
 
 In case of any error you should drop the transfer and restart it.
@@ -210,4 +211,19 @@ In case of any error you should drop the transfer and restart it.
 +                continue;
 +            },
 +        };
+```
+
+## Removed `peripheral_input` and `into_peripheral_output` from GPIO pin types
+
+Creating peripheral interconnect signals now consume the GPIO pin used for the connection.
+
+The previous signal function have been replaced by `split`. This change affects the following APIs:
+
+- `GpioPin`
+- `AnyPin`
+
+```diff
+-let input_signal = gpioN.peripheral_input();
+-let output_signal = gpioN.into_peripheral_output();
++let (input_signal, output_signal) = gpioN.split();
 ```

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -227,3 +227,6 @@ The previous signal function have been replaced by `split`. This change affects 
 -let output_signal = gpioN.into_peripheral_output();
 +let (input_signal, output_signal) = gpioN.split();
 ```
+
+`into_peripheral_output`, `split` (for output pins only) and `peripheral_input` have been added to
+the GPIO drivers (`Input`, `Output`, `OutputOpenDrain` and `Flex`) instead.

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -54,9 +54,6 @@ impl PeripheralOutput for OutputConnection {}
 
 /// A configurable input signal between a peripheral and a GPIO pin.
 ///
-/// Obtained by calling [`super::GpioPin::peripheral_input()`],
-/// [`super::Flex::peripheral_input()`] or [`super::Input::peripheral_input()`].
-///
 /// Multiple input signals can be connected to one pin.
 pub struct InputSignal {
     pin: AnyPin,
@@ -187,10 +184,6 @@ impl InputSignal {
 }
 
 /// A configurable output signal between a peripheral and a GPIO pin.
-///
-/// Obtained by calling [`super::GpioPin::into_peripheral_output()`],
-/// [`super::Flex::into_peripheral_output()`] or
-/// [`super::Output::into_peripheral_output()`].
 ///
 /// Multiple pins can be connected to one output signal.
 pub struct OutputSignal {
@@ -441,9 +434,9 @@ where
     P: InputPin,
 {
     fn from(input: P) -> Self {
-        Self(InputConnectionInner::Input(
-            input.degrade().peripheral_input(),
-        ))
+        Self(InputConnectionInner::Input(InputSignal::new(
+            input.degrade(),
+        )))
     }
 }
 
@@ -534,9 +527,9 @@ where
     P: OutputPin,
 {
     fn from(input: P) -> Self {
-        Self(OutputConnectionInner::Output(
-            input.degrade().into_peripheral_output(),
-        ))
+        Self(OutputConnectionInner::Output(OutputSignal::new(
+            input.degrade(),
+        )))
     }
 }
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1526,14 +1526,6 @@ where
         Self { pin }
     }
 
-    /// Split the pin into an input and output signal.
-    ///
-    /// Peripheral signals allow connecting peripherals together without using
-    /// external hardware.
-    pub fn split(self) -> (interconnect::InputSignal, interconnect::OutputSignal) {
-        self.pin.degrade_pin(private::Internal).split()
-    }
-
     /// Returns a peripheral [input][interconnect::InputSignal] connected to
     /// this pin.
     ///
@@ -1541,16 +1533,6 @@ where
     #[inline]
     pub fn peripheral_input(&self) -> interconnect::InputSignal {
         self.pin.degrade_pin(private::Internal).split().0
-    }
-
-    /// Turns the pin object into a peripheral
-    /// [output][interconnect::OutputSignal].
-    ///
-    /// The output signal can be passed to peripherals in place of an output
-    /// pin.
-    #[inline]
-    pub fn into_peripheral_output(self) -> interconnect::OutputSignal {
-        self.split().1
     }
 }
 
@@ -1701,16 +1683,29 @@ where
     pub fn set_drive_strength(&mut self, strength: DriveStrength) {
         self.pin.set_drive_strength(strength, private::Internal);
     }
-}
 
-impl<P> Flex<'_, P>
-where
-    P: InputPin + OutputPin,
-{
     /// Set the GPIO to open-drain mode.
     pub fn set_as_open_drain(&mut self, pull: Pull) {
         self.pin.set_to_open_drain_output(private::Internal);
         self.pin.pull_direction(pull, private::Internal);
+    }
+
+    /// Split the pin into an input and output signal.
+    ///
+    /// Peripheral signals allow connecting peripherals together without using
+    /// external hardware.
+    pub fn split(self) -> (interconnect::InputSignal, interconnect::OutputSignal) {
+        self.pin.degrade_pin(private::Internal).split()
+    }
+
+    /// Turns the pin object into a peripheral
+    /// [output][interconnect::OutputSignal].
+    ///
+    /// The output signal can be passed to peripherals in place of an output
+    /// pin.
+    #[inline]
+    pub fn into_peripheral_output(self) -> interconnect::OutputSignal {
+        self.split().1
     }
 }
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -98,12 +98,12 @@
 //!
 //! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 //!
-//! let rx = io.pins.gpio2.peripheral_input().inverted();
-//! let tx = io.pins.gpio1.into_peripheral_output().inverted();
+//! let (rx, _) = io.pins.gpio2.split();
+//! let (_, tx) = io.pins.gpio1.split();
 //! let mut uart1 = Uart::new(
 //!     peripherals.UART1,
-//!     rx,
-//!     tx,
+//!     rx.inverted(),
+//!     tx.inverted(),
 //! ).unwrap();
 //! # }
 //! ```

--- a/examples/src/bin/embassy_twai.rs
+++ b/examples/src/bin/embassy_twai.rs
@@ -94,11 +94,11 @@ async fn main(spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let tx_pin = io.pins.gpio2;
-    // let rx_pin = io.pins.gpio0; // Uncomment if you want to use an external transceiver.
-
     // Without an external transceiver, we only need a single line between the two MCUs.
-    let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transceiver.
+    let (rx_pin, tx_pin) = io.pins.gpio2.split();
+    // Use these if you want to use an external transceiver:
+    // let tx_pin = io.pins.gpio2;
+    // let rx_pin = io.pins.gpio0;
 
     // The speed of the bus.
     const TWAI_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;

--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -49,18 +49,22 @@ fn main() -> ! {
 
     println!("setup channel 0");
     let ch0 = &u0.channel0;
+
     let pin_a = Input::new(io.pins.gpio4, Pull::Up);
     let pin_b = Input::new(io.pins.gpio5, Pull::Up);
 
-    ch0.set_ctrl_signal(pin_a.peripheral_input());
-    ch0.set_edge_signal(pin_b.peripheral_input());
+    let (input_a, _) = pin_a.split();
+    let (input_b, _) = pin_b.split();
+
+    ch0.set_ctrl_signal(input_a.clone());
+    ch0.set_edge_signal(input_b.clone());
     ch0.set_ctrl_mode(channel::CtrlMode::Reverse, channel::CtrlMode::Keep);
     ch0.set_input_mode(channel::EdgeMode::Increment, channel::EdgeMode::Decrement);
 
     println!("setup channel 1");
     let ch1 = &u0.channel1;
-    ch1.set_ctrl_signal(pin_b.peripheral_input());
-    ch1.set_edge_signal(pin_a.peripheral_input());
+    ch1.set_ctrl_signal(input_b);
+    ch1.set_edge_signal(input_a);
     ch1.set_ctrl_mode(channel::CtrlMode::Reverse, channel::CtrlMode::Keep);
     ch1.set_input_mode(channel::EdgeMode::Decrement, channel::EdgeMode::Increment);
 

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -42,11 +42,11 @@ fn main() -> ! {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let tx_pin = io.pins.gpio2;
-    // let rx_pin = io.pins.gpio0; // Uncomment if you want to use an external transceiver.
-
     // Without an external transceiver, we only need a single line between the two MCUs.
-    let rx_pin = tx_pin.peripheral_input(); // Comment this line if you want to use an external transceiver.
+    let (rx_pin, tx_pin) = io.pins.gpio2.split();
+    // Use these if you want to use an external transceiver:
+    // let tx_pin = io.pins.gpio2;
+    // let rx_pin = io.pins.gpio0;
 
     // The speed of the bus.
     const TWAI_BAUDRATE: twai::BaudRate = twai::BaudRate::B125K;

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -151,7 +151,7 @@ mod tests {
 
         let (_, dout) = hil_test::common_test_pins!(ctx.io);
 
-        let din = dout.peripheral_input();
+        let (din, dout) = dout.split();
 
         let i2s_tx = i2s
             .i2s_tx
@@ -205,7 +205,7 @@ mod tests {
 
         let (_, dout) = hil_test::common_test_pins!(ctx.io);
 
-        let din = dout.peripheral_input();
+        let (din, dout) = dout.split();
 
         let mut i2s_tx = i2s
             .i2s_tx
@@ -347,7 +347,8 @@ mod tests {
         );
 
         let (_, dout) = hil_test::common_test_pins!(ctx.io);
-        let din = dout.peripheral_input();
+
+        let (din, dout) = dout.split();
 
         let mut i2s_rx = i2s
             .i2s_rx

--- a/hil-test/tests/lcd_cam_i8080.rs
+++ b/hil-test/tests/lcd_cam_i8080.rs
@@ -102,19 +102,13 @@ mod tests {
         // issue with configuring pins as outputs after inputs have been sorted
         // out. See https://github.com/esp-rs/esp-hal/pull/2173#issue-2529323702
 
-        let cs_signal = ctx.io.pins.gpio8;
-        let unit0_signal = ctx.io.pins.gpio11;
-        let unit1_signal = ctx.io.pins.gpio12;
-        let unit2_signal = ctx.io.pins.gpio16;
-        let unit3_signal = ctx.io.pins.gpio17;
+        let (unit_ctrl, cs_signal) = ctx.io.pins.gpio8.split();
+        let (unit0_input, unit0_signal) = ctx.io.pins.gpio11.split();
+        let (unit1_input, unit1_signal) = ctx.io.pins.gpio12.split();
+        let (unit2_input, unit2_signal) = ctx.io.pins.gpio16.split();
+        let (unit3_input, unit3_signal) = ctx.io.pins.gpio17.split();
 
         let pcnt = ctx.pcnt;
-
-        let unit_ctrl = cs_signal.peripheral_input();
-        let unit0_input = unit0_signal.peripheral_input();
-        let unit1_input = unit1_signal.peripheral_input();
-        let unit2_input = unit2_signal.peripheral_input();
-        let unit3_input = unit3_signal.peripheral_input();
 
         pcnt.unit0
             .channel0
@@ -219,19 +213,13 @@ mod tests {
         // issue with configuring pins as outputs after inputs have been sorted
         // out. See https://github.com/esp-rs/esp-hal/pull/2173#issue-2529323702
 
-        let cs_signal = ctx.io.pins.gpio8;
-        let unit0_signal = ctx.io.pins.gpio11;
-        let unit1_signal = ctx.io.pins.gpio12;
-        let unit2_signal = ctx.io.pins.gpio16;
-        let unit3_signal = ctx.io.pins.gpio17;
+        let (unit_ctrl, cs_signal) = ctx.io.pins.gpio8.split();
+        let (unit0_input, unit0_signal) = ctx.io.pins.gpio11.split();
+        let (unit1_input, unit1_signal) = ctx.io.pins.gpio12.split();
+        let (unit2_input, unit2_signal) = ctx.io.pins.gpio16.split();
+        let (unit3_input, unit3_signal) = ctx.io.pins.gpio17.split();
 
         let pcnt = ctx.pcnt;
-
-        let unit_ctrl = cs_signal.peripheral_input();
-        let unit0_input = unit0_signal.peripheral_input();
-        let unit1_input = unit1_signal.peripheral_input();
-        let unit2_input = unit2_signal.peripheral_input();
-        let unit3_input = unit3_signal.peripheral_input();
 
         pcnt.unit0
             .channel0

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -8,7 +8,11 @@
 use esp_hal::parl_io::{TxPinConfigWithValidPin, TxSixteenBits};
 use esp_hal::{
     dma::{ChannelCreator, Dma, DmaPriority},
-    gpio::{interconnect::InputSignal, AnyPin, Io, NoPin},
+    gpio::{
+        interconnect::{InputSignal, OutputSignal},
+        Io,
+        NoPin,
+    },
     parl_io::{
         BitPackOrder,
         ClkOutPin,
@@ -30,8 +34,8 @@ use hil_test as _;
 struct Context {
     parl_io: PARL_IO,
     dma_channel: ChannelCreator<0>,
-    clock: AnyPin,
-    valid: AnyPin,
+    clock: OutputSignal,
+    valid: OutputSignal,
     clock_loopback: InputSignal,
     valid_loopback: InputSignal,
     pcnt_unit: Unit<'static, 0>,
@@ -50,10 +54,9 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let (clock, _) = hil_test::common_test_pins!(io);
-        let valid = io.pins.gpio0.degrade();
-        let clock_loopback = clock.peripheral_input();
-        let valid_loopback = valid.peripheral_input();
-        let clock = clock.degrade();
+        let valid = hil_test::unconnected_pin!(io);
+        let (clock_loopback, clock) = clock.split();
+        let (valid_loopback, valid) = valid.split();
         let pcnt = Pcnt::new(peripherals.PCNT);
         let pcnt_unit = pcnt.unit0;
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/parl_io_tx_async.rs
+++ b/hil-test/tests/parl_io_tx_async.rs
@@ -10,7 +10,11 @@
 use esp_hal::parl_io::{TxPinConfigWithValidPin, TxSixteenBits};
 use esp_hal::{
     dma::{ChannelCreator, Dma, DmaPriority},
-    gpio::{interconnect::InputSignal, AnyPin, Io, NoPin},
+    gpio::{
+        interconnect::{InputSignal, OutputSignal},
+        Io,
+        NoPin,
+    },
     parl_io::{
         BitPackOrder,
         ClkOutPin,
@@ -32,8 +36,8 @@ use hil_test as _;
 struct Context {
     parl_io: PARL_IO,
     dma_channel: ChannelCreator<0>,
-    clock: AnyPin,
-    valid: AnyPin,
+    clock: OutputSignal,
+    valid: OutputSignal,
     clock_loopback: InputSignal,
     valid_loopback: InputSignal,
     pcnt_unit: Unit<'static, 0>,
@@ -52,10 +56,9 @@ mod tests {
 
         let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
         let (clock, _) = hil_test::common_test_pins!(io);
-        let valid = io.pins.gpio0.degrade();
-        let clock_loopback = clock.peripheral_input();
-        let valid_loopback = valid.peripheral_input();
-        let clock = clock.degrade();
+        let valid = hil_test::unconnected_pin!(io);
+        let (clock_loopback, clock) = clock.split();
+        let (valid_loopback, valid) = valid.split();
         let pcnt = Pcnt::new(peripherals.PCNT);
         let pcnt_unit = pcnt.unit0;
         let dma = Dma::new(peripherals.DMA);

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -335,7 +335,9 @@ mod tests {
         let unit0 = pcnt.unit0;
         let unit1 = pcnt.unit1;
 
-        unit0.channel0.set_edge_signal(mosi.peripheral_input());
+        let (mosi_loopback, mosi) = mosi.split();
+
+        unit0.channel0.set_edge_signal(mosi_loopback);
         unit0
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
@@ -359,12 +361,15 @@ mod tests {
         let unit0 = pcnt.unit0;
         let unit1 = pcnt.unit1;
 
-        unit0.channel0.set_edge_signal(mosi.peripheral_input());
+        let (mosi_loopback, mosi) = mosi.split();
+        let (gpio_loopback, gpio) = gpio.split();
+
+        unit0.channel0.set_edge_signal(mosi_loopback);
         unit0
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        unit1.channel0.set_edge_signal(gpio.peripheral_input());
+        unit1.channel0.set_edge_signal(gpio_loopback);
         unit1
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
@@ -389,12 +394,15 @@ mod tests {
         let unit0 = pcnt.unit0;
         let unit1 = pcnt.unit1;
 
-        unit0.channel0.set_edge_signal(mosi.peripheral_input());
+        let (mosi_loopback, mosi) = mosi.split();
+        let (gpio_loopback, gpio) = gpio.split();
+
+        unit0.channel0.set_edge_signal(mosi_loopback);
         unit0
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        unit1.channel0.set_edge_signal(gpio.peripheral_input());
+        unit1.channel0.set_edge_signal(gpio_loopback);
         unit1
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
@@ -419,12 +427,15 @@ mod tests {
         let unit0 = pcnt.unit0;
         let unit1 = pcnt.unit1;
 
-        unit0.channel0.set_edge_signal(mosi.peripheral_input());
+        let (mosi_loopback, mosi) = mosi.split();
+        let (gpio_loopback, gpio) = gpio.split();
+
+        unit0.channel0.set_edge_signal(mosi_loopback);
         unit0
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        unit1.channel0.set_edge_signal(gpio.peripheral_input());
+        unit1.channel0.set_edge_signal(gpio_loopback);
         unit1
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -73,7 +73,7 @@ mod tests {
         }
 
         #[cfg(pcnt)]
-        let mosi_loopback_pcnt = mosi.peripheral_input();
+        let (mosi_loopback_pcnt, mosi) = mosi.split();
         // Need to set miso first so that mosi can overwrite the
         // output connection (because we are using the same pin to loop back)
         let spi = Spi::new(peripherals.SPI2, 10000.kHz(), SpiMode::Mode0)

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -50,7 +50,7 @@ mod tests {
             }
         }
 
-        let mosi_loopback = mosi.peripheral_input();
+        let (mosi_loopback, mosi) = mosi.split();
 
         let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
             .with_sck(sclk)

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -62,7 +62,7 @@ mod tests {
 
         let dma_channel = dma.channel0;
 
-        let mosi_loopback = mosi.peripheral_input();
+        let (mosi_loopback, mosi) = mosi.split();
 
         let spi = Spi::new(peripherals.SPI2, 100.kHz(), SpiMode::Mode0)
             .with_sck(sclk)

--- a/hil-test/tests/twai.rs
+++ b/hil-test/tests/twai.rs
@@ -32,10 +32,12 @@ mod tests {
 
         let (loopback_pin, _) = hil_test::common_test_pins!(io);
 
+        let (rx, tx) = loopback_pin.split();
+
         let mut config = twai::TwaiConfiguration::new(
             peripherals.TWAI0,
-            loopback_pin.peripheral_input(),
-            loopback_pin,
+            rx,
+            tx,
             twai::BaudRate::B1000K,
             TwaiMode::SelfTest,
         );

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -32,12 +32,9 @@ mod tests {
 
         let (_, pin) = hil_test::common_test_pins!(io);
 
-        let uart = Uart::new(
-            peripherals.UART1,
-            pin.peripheral_input(),
-            pin.into_peripheral_output(),
-        )
-        .unwrap();
+        let (rx, tx) = pin.split();
+
+        let uart = Uart::new(peripherals.UART1, rx, tx).unwrap();
 
         Context { uart }
     }


### PR DESCRIPTION
This PR replaces the previous getters with a `split` function. This will allow eventually resolving #2273 by introducing different variants for when the GPIO is split, vs when the GPIO is passed wholly to a peripheral. This also allows us to remove a few hacks around input/output initialization - if a pin was split, `enable_output` shouldn't disable input, for example.

Pin drivers retain their getters and instead convert into signals that (will) force GPIO matrix use.