### PR TITLE
[TWAI] bus-off error is never reached when using `transmit_async`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix conflict between `RtcClock::get_xtal_freq` and `Rtc::disable_rom_message_printing` (#2360)
 - Fixed an issue where interrupts enabled before `esp_hal::init` were disabled. This issue caused the executor created by `#[esp_hal_embassy::main]` to behave incorrectly in multi-core applications. (#2377)
+- Fixed `TWAI::transmit_async`: bus-off state is not reached when CANH and CANL are shorted. (#2421)
 
 ### Removed
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1943,6 +1943,24 @@ mod asynch {
         }
 
         if intr_status.bits() & 0b11111100 > 0 {
+            let err_capture = register_block.err_code_cap().read();
+            let status = register_block.status().read();
+
+            // Read error code direction (transmitting or receiving)
+            cfg_if::cfg_if! {
+                if #[cfg(any(esp32, esp32c3, esp32s2, esp32s3))] {
+                    let ecc_direction = err_capture.ecc_direction().bit_is_set();
+                } else {
+                    let ecc_direction = err_capture.err_capture_code_direction().bit_is_set();
+                }
+            }
+            // If the error comes from Tx and Tx request is pending
+            if !ecc_direction && !status.tx_buf_st().bit_is_set() {
+                // Cancel a pending transmission request
+                register_block.cmd().write(|w| {
+                    w.abort_tx().set_bit()
+                });
+            }
             async_state.err_waker.wake();
         }
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1957,9 +1957,7 @@ mod asynch {
             // If the error comes from Tx and Tx request is pending
             if !ecc_direction && !status.tx_buf_st().bit_is_set() {
                 // Cancel a pending transmission request
-                register_block.cmd().write(|w| {
-                    w.abort_tx().set_bit()
-                });
+                register_block.cmd().write(|w| w.abort_tx().set_bit());
             }
             async_state.err_waker.wake();
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
#### Description
![image](https://github.com/user-attachments/assets/c0a04999-24ed-4e88-a9e8-e151d980a57e)
When `CANH` and `CANL` are shorted during packet transmission, the `Transmit Error Counter (TEC)` may increase but remain below 255, which prevents entering the `Bus-Off` state. Since `transmit_async` currently only checks for `Bus-Off`, the system doesn’t detect or handle lower-level transmit errors, causing it to remain in `Poll::Pending` indefinitely, with no further wake-ups to resume transmission.

This PR introduces a new step for handling error interrupts:
- On receiving an error interrupt, the system now checks whether the error is due to a transmit error.
- If a TX error is identified and there’s a pending transmission, the pending transmission is canceled to allow the TWAI bus to recover, providing a clean state for the next transmission attempt.

#### Testing
Tested with esp32s3
![image](https://github.com/user-attachments/assets/1e04be61-0236-4a19-855a-e05abcfaf74a)
