### PR TITLE
RISC-V: Fix interrupt stack alignment

### DIFF
--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -721,12 +721,12 @@ r#"
     "#,
     // store current priority, set threshold, enable interrupts
     r#"
-    addi sp, sp, -4 #build stack
+    addi sp, sp, -16 #build stack
     sw ra, 0(sp)
     jal ra, _handle_priority
     lw ra, 0(sp)
     sw a0, 0(sp) #reuse old stack, a0 is return of _handle_priority
-    addi a0, sp, 4 #the proper stack pointer is an argument to the HAL handler
+    addi a0, sp, 16 #the proper stack pointer is an argument to the HAL handler
     "#,
     // jump to handler loaded in direct handler
     r#"
@@ -736,7 +736,7 @@ r#"
     r#"
     lw a0, 0(sp) #load stored priority
     jal ra, _restore_priority
-    addi sp, sp, 4 #pop
+    addi sp, sp, 16 #pop
     "#,
     r#"
     lw t1, 31*4(sp)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Closes #2270 

`skip-changelog` since it's not really a user-facing change

#### Testing
Examples still work

