### PR TITLE
Fix typo in migration guide

### DIFF
--- a/esp-hal/MIGRATING-0.20.md
+++ b/esp-hal/MIGRATING-0.20.md
@@ -230,7 +230,7 @@ We've replaced some usage of features with [esp-config](https://docs.rs/esp-conf
 # feature in Cargo.toml
 - esp-hal = { version = "0.20", features = ["place-spi-driver-in-ram"] }
 # key in .cargo/config.toml [env] section
-+ ESP_HAL_PLACE_SPI_DRIVER_IN_RAM=true
++ ESP_HAL_PLACE_SPI_DRIVER_IN_RAM="true"
 ```
 
 ## `Camera` driver now uses `DmaRxBuffer` and moves the driver into the transfer object.


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The config.toml needs quotes around the `true`. I've run into this twice after copy/pasting.

#### Testing
Tried it in a project
