### PR TITLE
Disable i2s test

### DIFF
--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -3,8 +3,9 @@
 //! This test uses I2S TX to transmit known data to I2S RX (forced to slave mode
 //! with loopback mode enabled).
 
-//% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: generic-queue
+// FIXME: re-enable on ESP32 when it no longer fails spuriously
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
HIL tests periodically fail with an error like:

```
assertion `left == right` failed: Sample #1 does not match (0 != 5)
  left: 0
 right: 5
```

The mismatch always occurs with the second sample (the first one on the wire I think). There are combinations of test code (only running the 2 loopback tests, removing the last 2) and test pin (anything not GPIO27) where the issue does not reproduce, making this hard to debug.