### PR TITLE
Flatten Uart module, remove unnecessary data, replace methods with `apply_config`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow users to create DMA `Preparation`s (#2455) 
 - The `rmt::asynch::RxChannelAsync` and `rmt::asynch::TxChannelAsync` traits have been moved to `rmt` (#2430)
 - Calling `AnyPin::output_signals` on an input-only pin (ESP32 GPIO 34-39) will now result in a panic. (#2418)
+- UART configuration types have been moved to `esp_hal::uart` (#?)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -48,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow users to create DMA `Preparation`s (#2455) 
 - The `rmt::asynch::RxChannelAsync` and `rmt::asynch::TxChannelAsync` traits have been moved to `rmt` (#2430)
 - Calling `AnyPin::output_signals` on an input-only pin (ESP32 GPIO 34-39) will now result in a panic. (#2418)
-- UART configuration types have been moved to `esp_hal::uart` (#?)
 - UART configuration types have been moved to `esp_hal::uart` (#2449)
 
 ### Fixed

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gpio::{GpioPin, AnyPin, Flex, Output, OutputOpenDrain}::split()` to obtain peripheral interconnect signals. (#2418)
 - `gpio::Input::{split(), into_peripheral_output()}` when used with output pins. (#2418)
 - `gpio::Output::peripheral_input()` (#2418)
+- `{Uart, UartRx, UartTx}::apply_config()` (#2449)
+- `{Uart, UartRx, UartTx}` now implement `embassy_embedded_hal::SetConfig` (#2449)
 
 ### Changed
 
@@ -76,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the pin type parameters from `lcd_cam::cam::{RxEightBits, RxSixteenBits}` (#2388)
 - Most of the async-specific constructors (`new_async`, `new_async_no_transceiver`) have been removed. (#2430)
 - The `configure_for_async` DMA functions have been removed (#2430)
+- The `Uart::{change_baud, change_stop_bits}` functions have been removed (#2449)
 
 ## [0.21.1]
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `rmt::asynch::RxChannelAsync` and `rmt::asynch::TxChannelAsync` traits have been moved to `rmt` (#2430)
 - Calling `AnyPin::output_signals` on an input-only pin (ESP32 GPIO 34-39) will now result in a panic. (#2418)
 - UART configuration types have been moved to `esp_hal::uart` (#?)
+- UART configuration types have been moved to `esp_hal::uart` (#2449)
 
 ### Fixed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -25,6 +25,7 @@ defmt                    = { version = "0.3.8", optional = true }
 delegate                 = "0.12.0"
 digest                   = { version = "0.10.7", default-features = false, optional = true }
 document-features        = "0.2.10"
+embassy-embedded-hal     = "0.2.0"
 embassy-futures          = "0.1.1"
 embassy-sync             = "0.6.0"
 embassy-usb-driver       = { version = "0.1.0", optional = true }

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -230,3 +230,17 @@ The previous signal function have been replaced by `split`. This change affects 
 
 `into_peripheral_output`, `split` (for output pins only) and `peripheral_input` have been added to
 the GPIO drivers (`Input`, `Output`, `OutputOpenDrain` and `Flex`) instead.
+
+## Changes to peripheral configuration
+
+### The `uart::config` module has been removed
+
+The module's contents have been moved into `uart`.
+
+```diff
+-use esp_hal::uart::config::Config;
++use esp_hal::uart::Config;
+```
+
+If you work with multiple configurable peripherals, you may want to import the `uart` module and
+refer to the `Config` struct as `uart::Config`.

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1144,18 +1144,6 @@ where
         self
     }
 
-    fn change_data_bits(&mut self, data_bits: DataBits) -> &mut Self {
-        self.tx.uart.info().change_data_bits(data_bits);
-
-        self
-    }
-
-    fn change_parity(&mut self, parity: Parity) -> &mut Self {
-        self.tx.uart.info().change_parity(parity);
-
-        self
-    }
-
     /// Modify UART baud rate and reset TX/RX fifo.
     pub fn change_baud(&mut self, baudrate: u32, clock_source: ClockSource) {
         self.tx.uart.info().change_baud(baudrate, clock_source);

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1096,10 +1096,6 @@ where
         self.tx.uart.info().register_block()
     }
 
-    fn sync_regs(&self) {
-        sync_regs(self.register_block());
-    }
-
     /// Split the UART into a transmitter and receiver
     ///
     /// This is particularly useful when having two tasks correlating to
@@ -1155,7 +1151,7 @@ where
             .clk_conf()
             .modify(|_, w| w.sclk_en().set_bit());
 
-        self.sync_regs();
+        sync_regs(register_block);
     }
 
     /// Listen for the given interrupts
@@ -1240,7 +1236,7 @@ where
     }
 
     fn is_instance(&self, other: impl Instance) -> bool {
-        self.tx.uart.info() == other.info()
+        self.tx.uart.info().is_instance(other)
     }
 
     #[inline(always)]
@@ -2388,7 +2384,7 @@ impl Info {
         }
         reg_en.modify(|_, w| w.rx_tout_en().bit(timeout.is_some()));
 
-        sync_regs(register_block);
+        self.sync_regs();
 
         Ok(())
     }
@@ -2431,6 +2427,14 @@ impl Info {
         self.register_block()
             .clkdiv()
             .write(|w| unsafe { w.clkdiv().bits(divider_integer).frag().bits(divider_frag) });
+    }
+
+    fn is_instance(&self, other: impl Instance) -> bool {
+        self == other.info()
+    }
+
+    fn sync_regs(&self) {
+        sync_regs(self.register_block());
     }
 
     #[cfg(any(esp32c6, esp32h2))]

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -15,12 +15,7 @@ use esp_backtrace as _;
 use esp_hal::{
     gpio::Io,
     timer::timg::TimerGroup,
-    uart::{
-        config::{AtCmdConfig, Config},
-        Uart,
-        UartRx,
-        UartTx,
-    },
+    uart::{AtCmdConfig, Config, Uart, UartRx, UartTx},
     Async,
 };
 use static_cell::StaticCell;

--- a/examples/src/bin/lp_core_uart.rs
+++ b/examples/src/bin/lp_core_uart.rs
@@ -22,7 +22,7 @@ use esp_hal::{
     },
     lp_core::{LpCore, LpCoreWakeupSource},
     prelude::*,
-    uart::{config::Config, lp_uart::LpUart, Uart},
+    uart::{lp_uart::LpUart, Config, Uart},
 };
 use esp_println::println;
 

--- a/examples/src/bin/serial_interrupts.rs
+++ b/examples/src/bin/serial_interrupts.rs
@@ -15,11 +15,7 @@ use esp_hal::{
     delay::Delay,
     gpio::Io,
     prelude::*,
-    uart::{
-        config::{AtCmdConfig, Config},
-        Uart,
-        UartInterrupt,
-    },
+    uart::{AtCmdConfig, Config, Uart, UartInterrupt},
     Blocking,
 };
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -9,7 +9,7 @@ use embedded_hal_02::serial::{Read, Write};
 use esp_hal::{
     gpio::Io,
     prelude::*,
-    uart::{ClockSource, Uart},
+    uart::{self, ClockSource, Uart},
     Blocking,
 };
 use hil_test as _;
@@ -91,8 +91,14 @@ mod tests {
         ];
 
         let mut byte_to_write = 0xA5;
-        for (baud, clock_source) in &configs {
-            ctx.uart.change_baud(*baud, *clock_source);
+        for (baudrate, clock_source) in configs {
+            ctx.uart
+                .apply_config(&uart::Config {
+                    baudrate,
+                    clock_source,
+                    ..Default::default()
+                })
+                .unwrap();
             ctx.uart.write(byte_to_write).ok();
             let read = block!(ctx.uart.read());
             assert_eq!(read, Ok(byte_to_write));


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The main goal of this PR is to implement `apply_config`. This requires removing some internally tracked state, and moving some code around. cc #2416 and #1919

Some of the previous `change` methods weren't even public.

I'm also proposing flattening the module (i.e. removing `config`). When using multiple configurable peripherals, it's much neater to refer to the config struct as `uart::Config` than `uart::config::Config`. cc #2010 

I'm also implementing `embassy_embedded_hal::SetConfig` because why not (and we'll want to implement it for Spi anyway, so the dependency will be used even if it's not terribly useful for UART).