### PR TITLE
Systimer improvements

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Alarm interrupts are now handled on the core that allocated them. (For executors created on the second core after calling `esp_hal_embassy::init`) (#2451)
+
 ### Removed
 
 ## 0.4.0 - 2024-10-10

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -149,6 +149,9 @@ impl_array!(4);
 /// - A mutable static array of `OneShotTimer` instances
 /// - A 2, 3, 4 element array of `AnyTimer` instances
 ///
+/// Note that if you use the `integrated-timers` feature,
+/// you need to pass as many timers as you start executors.
+///
 /// # Examples
 ///
 /// ```rust, no_run

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where interrupts enabled before `esp_hal::init` were disabled. This issue caused the executor created by `#[esp_hal_embassy::main]` to behave incorrectly in multi-core applications. (#2377)
 - Fixed `TWAI::transmit_async`: bus-off state is not reached when CANH and CANL are shorted. (#2421)
 - ESP32: added UART-specific workaround for https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/03-errata-description/esp32/cpu-subsequent-access-halted-when-get-interrupted.html (#2441)
+- Fixed some SysTimer race conditions and panics (#2451)
 
 ### Removed
 

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -242,37 +242,29 @@ pub trait Unit {
                     _ => unreachable!(),
                 },
                 UnitConfig::DisabledIfCpuIsStalled(cpu) => match self.channel() {
-                    0 => w
-                        .timer_unit0_work_en()
-                        .set_bit()
-                        .timer_unit0_core0_stall_en()
-                        .bit(cpu == Cpu::ProCpu)
-                        .timer_unit0_core1_stall_en()
-                        .bit(cpu != Cpu::ProCpu),
-                    1 => w
-                        .timer_unit1_work_en()
-                        .set_bit()
-                        .timer_unit1_core0_stall_en()
-                        .bit(cpu == Cpu::ProCpu)
-                        .timer_unit1_core1_stall_en()
-                        .bit(cpu != Cpu::ProCpu),
+                    0 => {
+                        w.timer_unit0_work_en().set_bit();
+                        w.timer_unit0_core0_stall_en().bit(cpu == Cpu::ProCpu);
+                        w.timer_unit0_core1_stall_en().bit(cpu != Cpu::ProCpu)
+                    }
+                    1 => {
+                        w.timer_unit1_work_en().set_bit();
+                        w.timer_unit1_core0_stall_en().bit(cpu == Cpu::ProCpu);
+                        w.timer_unit1_core1_stall_en().bit(cpu != Cpu::ProCpu)
+                    }
                     _ => unreachable!(),
                 },
                 UnitConfig::Enabled => match self.channel() {
-                    0 => w
-                        .timer_unit0_work_en()
-                        .set_bit()
-                        .timer_unit0_core0_stall_en()
-                        .clear_bit()
-                        .timer_unit0_core1_stall_en()
-                        .clear_bit(),
-                    1 => w
-                        .timer_unit1_work_en()
-                        .set_bit()
-                        .timer_unit1_core0_stall_en()
-                        .clear_bit()
-                        .timer_unit1_core1_stall_en()
-                        .clear_bit(),
+                    0 => {
+                        w.timer_unit0_work_en().set_bit();
+                        w.timer_unit0_core0_stall_en().clear_bit();
+                        w.timer_unit0_core1_stall_en().clear_bit()
+                    }
+                    1 => {
+                        w.timer_unit1_work_en().set_bit();
+                        w.timer_unit1_core0_stall_en().clear_bit();
+                        w.timer_unit1_core1_stall_en().clear_bit()
+                    }
                     _ => unreachable!(),
                 },
             });

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -367,7 +367,7 @@ impl<const CHANNEL: u8> SpecificUnit<'_, CHANNEL> {
     }
 }
 
-const CHANNEL_COUNT: usize = 3;
+const CHANNEL_COUNT: usize = 1 + cfg!(not(esp32s2)) as usize;
 static UPDATING: [AtomicBool; CHANNEL_COUNT] = [const { AtomicBool::new(false) }; CHANNEL_COUNT];
 impl<const CHANNEL: u8> Unit for SpecificUnit<'_, CHANNEL> {
     fn channel(&self) -> u8 {

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -325,7 +325,7 @@ pub trait Unit {
         let systimer = unsafe { &*SYSTIMER::ptr() };
         systimer
             .unit_op(self.channel() as _)
-            .modify(|_, w| w.update().set_bit());
+            .write(|w| w.update().set_bit());
     }
 
     /// Return the count value at the time of the last call to [Self::update].

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -311,7 +311,7 @@ pub trait Unit {
         }
     }
 
-    /// Convenience method to call [Self::update] and [Self::poll_count].
+    /// Reads the current counter value.
     fn read_count(&self) -> u64 {
         // This can be a shared reference as long as this type isn't Sync.
 

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -17,7 +17,7 @@ use esp_hal::{
         master::{Spi, SpiDma},
         SpiMode,
     },
-    timer::{timg::TimerGroup, AnyTimer},
+    timer::AnyTimer,
     Async,
 };
 use esp_hal_embassy::InterruptExecutor;
@@ -60,11 +60,25 @@ mod test {
     #[timeout(3)]
     async fn dma_does_not_lock_up_when_used_in_different_executors() {
         let peripherals = esp_hal::init(esp_hal::Config::default());
-
-        let timg0 = TimerGroup::new(peripherals.TIMG0);
-        esp_hal_embassy::init([AnyTimer::from(timg0.timer0), AnyTimer::from(timg0.timer1)]);
-
         let dma = Dma::new(peripherals.DMA);
+
+        cfg_if::cfg_if! {
+            if #[cfg(systimer)] {
+                use esp_hal::timer::systimer::{SystemTimer, Target};
+                let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
+                esp_hal_embassy::init([
+                    AnyTimer::from(systimer.alarm0),
+                    AnyTimer::from(systimer.alarm1),
+                ]);
+            } else {
+                use esp_hal::timer::timg::TimerGroup;
+                let timg0 = TimerGroup::new(peripherals.TIMG0);
+                esp_hal_embassy::init([
+                    AnyTimer::from(timg0.timer0),
+                    AnyTimer::from(timg0.timer1),
+                ]);
+            }
+        }
 
         cfg_if::cfg_if! {
             if #[cfg(pdma)] {
@@ -161,8 +175,23 @@ mod test {
         let peripherals = esp_hal::init(esp_hal::Config::default());
         let dma = Dma::new(peripherals.DMA);
 
-        let timg0 = TimerGroup::new(peripherals.TIMG0);
-        esp_hal_embassy::init(timg0.timer0);
+        cfg_if::cfg_if! {
+            if #[cfg(systimer)] {
+                use esp_hal::timer::systimer::{SystemTimer, Target};
+                let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
+                esp_hal_embassy::init([
+                    AnyTimer::from(systimer.alarm0),
+                    AnyTimer::from(systimer.alarm1),
+                ]);
+            } else {
+                use esp_hal::timer::timg::TimerGroup;
+                let timg0 = TimerGroup::new(peripherals.TIMG0);
+                esp_hal_embassy::init([
+                    AnyTimer::from(timg0.timer0),
+                    AnyTimer::from(timg0.timer1),
+                ]);
+            }
+        }
 
         cfg_if::cfg_if! {
             if #[cfg(pdma)] {


### PR DESCRIPTION
- Optimize register access
- Clean up duplicate code - this might be enough to prevent the panics seen in #2431
- Improve panic message for #2432
- Ensure consistency when reading the counter.

Closes #2431
Closes #2432

At least in theory, I did not spend time reproducing the race issue. I do not think we can test the race condition easily so I didn't add a test case.