### PR TITLE
implement wifi event handling with data

### DIFF
--- a/esp-wifi/src/wifi/event.rs
+++ b/esp-wifi/src/wifi/event.rs
@@ -1,0 +1,52 @@
+use core::cell::RefCell;
+
+use critical_section::Mutex;
+
+mod sealed {
+    pub trait Sealed {}
+}
+/// The type of handlers of events.
+pub type Handler<T> = dyn FnMut(&T) + Sync + Send;
+// fn default_handler<'a, T>(_: &'a T) {}
+/// Data for a wifi event which can be handled by an event handler.
+pub trait WifiEventData: sealed::Sealed + Sized + 'static {
+    /// Get the static reference to the handler for this event.
+    fn get_handler() -> &'static Mutex<RefCell<Option<&'static mut Handler<Self>>>>;
+
+    /// Get the handler for this event, replacing it with the default handler.
+    fn take_handler() -> Option<&'static mut Handler<Self>> {
+        critical_section::with(|cs| Self::get_handler().borrow_ref_mut(cs).take())
+    }
+    /// Set the handler for this event.
+    fn set_handler(f: &'static mut Handler<Self>) {
+        critical_section::with(|cs| Self::get_handler().borrow_ref_mut(cs).replace(f));
+    }
+    /// Atomic combination of `set_handler` and `get_handler`. Use this to add a
+    /// new handler while preserving the previous.
+    fn update_handler(
+        f: impl FnOnce(Option<&'static mut Handler<Self>>) -> &'static mut Handler<Self>,
+    ) {
+        critical_section::with(|cs| {
+            let handler = Self::take_handler();
+            Self::get_handler().borrow_ref_mut(cs).replace(f(handler))
+        });
+    }
+}
+
+macro_rules! impl_wifi_event_data {
+    ($ty:path) => {
+        pub use $ty;
+        impl sealed::Sealed for $ty {}
+        impl WifiEventData for $ty {
+            fn get_handler() -> &'static Mutex<RefCell<Option<&'static mut Handler<Self>>>> {
+                static HANDLE: Mutex<RefCell<Option<&'static mut Handler<$ty>>>> =
+                    Mutex::new(RefCell::new(None));
+                &HANDLE
+            }
+        }
+    };
+}
+
+impl_wifi_event_data!(esp_wifi_sys::include::wifi_event_ap_probe_req_rx_t);
+impl_wifi_event_data!(esp_wifi_sys::include::wifi_event_ap_staconnected_t);
+impl_wifi_event_data!(esp_wifi_sys::include::wifi_event_ap_stadisconnected_t);

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1,5 +1,6 @@
 //! WiFi
 
+pub mod event;
 pub(crate) mod os_adapter;
 pub(crate) mod state;
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes: https://github.com/esp-rs/esp-hal/issues/2412

Implement event handling for apsta{,dis}connect and probe

I kind of guessed which events are associated with which data. Is there a better place for this?

Added to wifi_access_point example, I don't know it would be preferred to copy-paste it as a new example.

Currently requires `Box`ing and somewhat ugly `update` function. I'm going to work on this a bit more before undrafting the request, but would like feedback on:

If the approach should be modified completely instead of following the `std::panic::hook` apis. The implementation here doesn't support removing a single handler, but I'm not sure when that would be preferred over checking a flag in the handler itself.

#### Testing
Ran the modified example on `esp32` and connected to it. Got `printlns` for the `sta` connected and disconnected events as expected. Didn't test probe event.
