### PR TITLE
Allow users to create DMA `Preparation`s

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Circular DMA transfers now correctly error, `available` returns `Result<usize,DmaError>` now (#2409)
 - Interrupt listen/unlisten/clear functions now accept any type that converts into `EnumSet` (i.e. single interrupt flags). (#2442)
 - SPI interrupt listening is now only available in Blocking mode. The `set_interrupt_handler` is available via `InterruptConfigurable` (#2442)
+- Allow users to create DMA `Preparation`s (#2455) 
 
 ### Fixed
 

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -7,11 +7,12 @@ use crate::soc::is_slice_in_psram;
 
 /// Holds all the information needed to configure a DMA channel for a transfer.
 pub struct Preparation {
-    pub(super) start: *mut DmaDescriptor,
+    /// The descriptor the DMA will start from.
+    pub start: *mut DmaDescriptor,
 
-    /// block size for PSRAM transfers
+    /// Block size for PSRAM transfers
     #[cfg_attr(not(esp32s3), allow(dead_code))]
-    pub(super) block_size: Option<DmaBufBlkSize>,
+    pub block_size: Option<DmaBufBlkSize>,
 
     /// Specifies whether descriptor linked list specified in `start` conforms
     /// to the alignment requirements required to enable burst transfers.
@@ -22,7 +23,7 @@ pub struct Preparation {
     /// There are no additional alignment requirements for TX burst transfers,
     /// but RX transfers require all descriptors to have buffer pointers and
     /// sizes that are a multiple of 4 (word aligned).
-    pub(super) is_burstable: bool,
+    pub is_burstable: bool,
 
     /// Configures the "check owner" feature of the DMA channel.
     ///
@@ -50,7 +51,7 @@ pub struct Preparation {
     ///
     /// Note: If the DMA channel doesn't support the provided option,
     /// preparation will fail.
-    pub(super) check_owner: Option<bool>,
+    pub check_owner: Option<bool>,
 }
 
 /// [DmaTxBuffer] is a DMA descriptor + memory combo that can be used for


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This will let people implement their own `DmaTxBuffer`/`DmaRxBuffer` implementations.
I'm making this public now as I don't anticipate any breaking changes to the type in the near future.

#### Testing
It builds
