### PR TITLE
Use `diagnostic` on `DmaChannelConvert`

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1593,6 +1593,11 @@ pub trait DmaChannelExt: DmaChannel {
     fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt>;
 }
 
+#[diagnostic::on_unimplemented(
+    message = "The DMA channel isn't suitable for this peripheral`",
+    label = "This DMA channel",
+    note = "Not all channels are useable with all peripherals"
+)]
 #[doc(hidden)]
 pub trait DmaChannelConvert<DEG: DmaChannel>: DmaChannel {
     fn degrade_rx(rx: Self::Rx) -> DEG::Rx;

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1594,7 +1594,7 @@ pub trait DmaChannelExt: DmaChannel {
 }
 
 #[diagnostic::on_unimplemented(
-    message = "The DMA channel isn't suitable for this peripheral`",
+    message = "The DMA channel isn't suitable for this peripheral",
     label = "This DMA channel",
     note = "Not all channels are useable with all peripherals"
 )]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
While I don't expect many users to run into this (currently), we can do better in reporting an unsuitable dma-channel

This PR turns this
![image](https://github.com/user-attachments/assets/ff800ed9-efb8-43ea-8d5f-1a3b5f4f0a85)

into this
![image](https://github.com/user-attachments/assets/7d163a88-6ff7-4900-a8b2-b7590008533b)

`skip-changelog` - while it's more or less user-facing I don't think this deserves a changelog entry

#### Testing
Use a wrong DMA channel and see the compiler output
