### PR TITLE
Mark State/Info as `#[non_exhaustive]`

### DIFF
--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2165,6 +2165,7 @@ pub trait Instance:
 pub trait QspiInstance: Instance {}
 
 /// Peripheral data describing a particular SPI instance.
+#[non_exhaustive]
 pub struct Info {
     /// Pointer to the register block for this SPI instance.
     ///

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2174,6 +2174,7 @@ pub trait Instance: Peripheral<P = Self> + PeripheralMarker + Into<AnyUart> + 's
 }
 
 /// Peripheral data describing a particular UART instance.
+#[non_exhaustive]
 pub struct Info {
     /// Pointer to the register block for this UART instance.
     ///
@@ -2200,6 +2201,7 @@ pub struct Info {
 }
 
 /// Peripheral state for a UART instance.
+#[non_exhaustive]
 pub struct State {
     /// Waker for the asynchronous RX operations.
     pub rx_waker: AtomicWaker,


### PR DESCRIPTION
While these are public, users shouldn't be able to create new instances.