### PR TITLE
Add validation to `esp-config`

### DIFF
--- a/esp-config/src/lib.rs
+++ b/esp-config/src/lib.rs
@@ -3,17 +3,30 @@
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![cfg_attr(not(feature = "build"), no_std)]
+#![deny(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "build")]
 mod generate;
 #[cfg(feature = "build")]
-pub use generate::*;
+pub use generate::{generate_config, Error, Validator, Value};
 
+/// Parse the value of an environment variable as a [bool] at compile time.
 #[macro_export]
-// TODO from 1.82 we can use <$ty>::from_str_radix(env!($var), 10) instead
-/// Parse the value of a `env` variable as an integer at compile time
+macro_rules! esp_config_bool {
+    ( $var:expr ) => {
+        match env!($var).as_bytes() {
+            b"true" => true,
+            b"false" => false,
+            _ => ::core::panic!("boolean value must be either 'true' or 'false'"),
+        }
+    };
+}
+
+// TODO: From 1.82 on, we can use `<$ty>::from_str_radix(env!($var), 10)`
+/// Parse the value of an environment variable as an integer at compile time.
+#[macro_export]
 macro_rules! esp_config_int {
-    ($ty:ty, $var:expr) => {
+    ( $ty:ty, $var:expr ) => {
         const {
             const BYTES: &[u8] = env!($var).as_bytes();
             esp_config_int_parse!($ty, BYTES)
@@ -21,63 +34,53 @@ macro_rules! esp_config_int {
     };
 }
 
+/// Get the string value of an environment variable at compile time.
 #[macro_export]
-/// Get the string value of an `env` variable at compile time
 macro_rules! esp_config_str {
-    ($var:expr) => {
+    ( $var:expr ) => {
         env!($var)
     };
 }
 
-#[macro_export]
-/// Parse the value of a `env` variable as an bool at compile time
-macro_rules! esp_config_bool {
-    ($var:expr) => {
-        match env!($var).as_bytes() {
-            b"false" => false,
-            _ => true,
-        }
-    };
-}
-
-#[macro_export]
-#[doc(hidden)] // to avoid confusion with esp_config_int, let's hide this
 /// Parse a string like "777" into an integer, which _can_ be used in a `const`
 /// context
+#[doc(hidden)] // To avoid confusion with `esp_config_int`, hide this in the docs
+#[macro_export]
 macro_rules! esp_config_int_parse {
-    ($ty:ty, $bytes:expr) => {{
+    ( $ty:ty, $bytes:expr ) => {{
         let mut bytes = $bytes;
         let mut val: $ty = 0;
         let mut sign_seen = false;
         let mut is_negative = false;
+
         while let [byte, rest @ ..] = bytes {
             match *byte {
                 b'0'..=b'9' => {
                     val = val * 10 + (*byte - b'0') as $ty;
                 }
                 b'-' | b'+' if !sign_seen => {
-                    if *byte == b'-' {
-                        is_negative = true;
-                    }
+                    is_negative = *byte == b'-';
                     sign_seen = true;
                 }
-                _ => ::core::panic!("invalid digit"),
+                _ => ::core::panic!("invalid character encountered while parsing integer"),
             }
+
             bytes = rest;
         }
+
         if is_negative {
             let original = val;
-            // subtract twice to get the negative
+            // Subtract the value twice to get a negative:
             val -= original;
             val -= original;
         }
+
         val
     }};
 }
 
 #[cfg(test)]
 mod test {
-
     // We can only test success in the const context
     const _: () = {
         core::assert!(esp_config_int_parse!(i64, "-77777".as_bytes()) == -77777);
@@ -97,5 +100,11 @@ mod test {
     #[should_panic]
     fn test_expect_positive() {
         esp_config_int_parse!(u8, "-5".as_bytes());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_digit() {
+        esp_config_int_parse!(u32, "a".as_bytes());
     }
 }

--- a/esp-hal-embassy/build.rs
+++ b/esp-hal-embassy/build.rs
@@ -43,8 +43,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         "esp_hal_embassy",
         &[(
             "low-power-wait",
-            Value::Bool(true),
             "Enables the lower-power wait if no tasks are ready to run on the thread-mode executor. This allows the MCU to use less power if the workload allows. Recommended for battery-powered systems. May impact analog performance.",
+            Value::Bool(true),
+            None
         )],
         true,
     );

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -80,23 +80,27 @@ fn main() -> Result<(), Box<dyn Error>> {
         &[
             (
                 "place-spi-driver-in-ram",
-                Value::Bool(false),
                 "Places the SPI driver in RAM for better performance",
+                Value::Bool(false),
+                None
             ),
             (
                 "spi-address-workaround",
-                Value::Bool(true),
                 "(ESP32 only) Enables a workaround for the issue where SPI in half-duplex mode incorrectly transmits the address on a single line if the data buffer is empty.",
+                Value::Bool(true),
+                None
             ),
             (
                 "place-switch-tables-in-ram",
-                Value::Bool(true),
                 "Places switch-tables, some lookup tables and constants related to interrupt handling into RAM - resulting in better performance but slightly more RAM consumption.",
+                Value::Bool(true),
+                None
             ),
             (
                 "place-anon-in-ram",
-                Value::Bool(false),
                 "Places anonymous symbols into RAM - resulting in better performance at the cost of significant more RAM consumption. Best to be combined with `place-switch-tables-in-ram`.",
+                Value::Bool(false),
+                None
             ),
         ],
         true,

--- a/esp-ieee802154/build.rs
+++ b/esp-ieee802154/build.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf};
 
-use esp_config::{generate_config, Value};
+use esp_config::{generate_config, Validator, Value};
 
 fn main() {
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -11,8 +11,9 @@ fn main() {
         "esp_ieee802154",
         &[(
             "rx_queue_size",
-            Value::UnsignedInteger(50),
             "Size of the RX queue in frames",
+            Value::Integer(50),
+            Some(Validator::PositiveInteger),
         )],
         true,
     );

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -1,7 +1,7 @@
 use std::{error::Error, str::FromStr};
 
 use esp_build::assert_unique_used_features;
-use esp_config::{generate_config, Value};
+use esp_config::{generate_config, Validator, Value};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -99,37 +99,134 @@ fn main() -> Result<(), Box<dyn Error>> {
     generate_config(
         "esp_wifi",
         &[
-            ("rx_queue_size", Value::UnsignedInteger(5), "Size of the RX queue in frames"),
-            ("tx_queue_size", Value::UnsignedInteger(3), "Size of the TX queue in frames"),
-            ("static_rx_buf_num", Value::UnsignedInteger(10), "WiFi static RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("dynamic_rx_buf_num", Value::UnsignedInteger(32), "WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("static_tx_buf_num", Value::UnsignedInteger(0), "WiFi static TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("dynamic_tx_buf_num", Value::UnsignedInteger(32), "WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("csi_enable", Value::Bool(false), "WiFi channel state information enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("ampdu_rx_enable", Value::Bool(true), "WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("ampdu_tx_enable", Value::Bool(true), "WiFi AMPDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("amsdu_tx_enable", Value::Bool(false), "WiFi AMSDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("rx_ba_win", Value::UnsignedInteger(6), "WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)"),
-            ("max_burst_size", Value::UnsignedInteger(1), "See [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)"),
+            ("rx_queue_size", "Size of the RX queue in frames", Value::Integer(5), Some(Validator::PositiveInteger)),
+            ("tx_queue_size", "Size of the TX queue in frames", Value::Integer(3), Some(Validator::PositiveInteger)),
+            (
+                "static_rx_buf_num",
+                "WiFi static RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Integer(10),
+                None
+            ),
+            (
+                "dynamic_rx_buf_num",
+                "WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Integer(32),
+                None
+            ),
+            (
+                "static_tx_buf_num",
+                "WiFi static TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Integer(0),
+                None
+            ),
+            (
+                "dynamic_tx_buf_num",
+                "WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Integer(32),
+                None
+            ),
+            (
+                "csi_enable",
+                "WiFi channel state information enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Bool(false),
+                None
+            ),
+            (
+                "ampdu_rx_enable",
+                "WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Bool(true),
+                None
+            ),
+            (
+                "ampdu_tx_enable",
+                "WiFi AMPDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Bool(true),
+                None
+            ),
+            (
+                "amsdu_tx_enable",
+                "WiFi AMSDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Bool(false),
+                None
+            ),
+            (
+                "rx_ba_win",
+                "WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                Value::Integer(6),
+                None
+            ),
+            (
+                "max_burst_size",
+                "See [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)",
+                Value::Integer(1),
+                None
+            ),
             (
                 "country_code",
-                Value::String("CN".to_owned()),
                 "Country code. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
+                Value::String("CN".to_owned()),
+                None
             ),
             (
                 "country_code_operating_class",
-                Value::UnsignedInteger(0),
                 "If not 0: Operating Class table number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
+                Value::Integer(0),
+                None
             ),
-            ("mtu", Value::UnsignedInteger(1492), "MTU, see [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)"),
-            ("tick_rate_hz", Value::UnsignedInteger(100), "Tick rate of the internal task scheduler in hertz"),
-            ("listen_interval", Value::UnsignedInteger(3), "Interval for station to listen to beacon from AP. The unit of listen interval is one beacon interval. For example, if beacon interval is 100 ms and listen interval is 3, the interval for station to listen to beacon is 300 ms"),
-            ("beacon_timeout", Value::UnsignedInteger(6), "For Station, If the station does not receive a beacon frame from the connected SoftAP during the  inactive time, disconnect from SoftAP. Default 6s. Range 6-30"),
-            ("ap_beacon_timeout", Value::UnsignedInteger(300), "For SoftAP, If the SoftAP doesn’t receive any data from the connected STA during inactive time, the SoftAP will force deauth the STA. Default is 300s"),
-            ("failure_retry_cnt", Value::UnsignedInteger(1), "Number of connection retries station will do before moving to next AP. scan_method should be set as WIFI_ALL_CHANNEL_SCAN to use this config. Note: Enabling this may cause connection time to increase incase best AP doesn't behave properly. Defaults to 1"),
-            ("scan_method", Value::UnsignedInteger(0), "0 = WIFI_FAST_SCAN, 1 = WIFI_ALL_CHANNEL_SCAN, defaults to 0"),
-            ("dump_packets", Value::Bool(false), "Dump packets via an info log statement"),
-            ("phy_enable_usb", Value::Bool(true), "Keeps USB running when using WiFi. This allows debugging and log messages via USB Serial JTAG. Turn off for best WiFi performance."),
+            (
+                "mtu",
+                "MTU, see [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)",
+                Value::Integer(1492),
+                None
+            ),
+            (
+                "tick_rate_hz",
+                "Tick rate of the internal task scheduler in hertz",
+                Value::Integer(100),
+                None
+            ),
+            (
+                "listen_interval",
+                "Interval for station to listen to beacon from AP. The unit of listen interval is one beacon interval. For example, if beacon interval is 100 ms and listen interval is 3, the interval for station to listen to beacon is 300 ms",
+                Value::Integer(3),
+                None
+            ),
+            (
+                "beacon_timeout",
+                "For Station, If the station does not receive a beacon frame from the connected SoftAP during the  inactive time, disconnect from SoftAP. Default 6s. Range 6-30",
+                Value::Integer(6),
+                None
+            ),
+            (
+                "ap_beacon_timeout",
+                "For SoftAP, If the SoftAP doesn't receive any data from the connected STA during inactive time, the SoftAP will force deauth the STA. Default is 300s",
+                Value::Integer(300),
+                None
+            ),
+            (
+                "failure_retry_cnt",
+                "Number of connection retries station will do before moving to next AP. scan_method should be set as WIFI_ALL_CHANNEL_SCAN to use this config. Note: Enabling this may cause connection time to increase incase best AP doesn't behave properly. Defaults to 1",
+                Value::Integer(1),
+                None
+            ),
+            (
+                "scan_method",
+                "0 = WIFI_FAST_SCAN, 1 = WIFI_ALL_CHANNEL_SCAN, defaults to 0",
+                Value::Integer(0),
+                None
+            ),
+            (
+                "dump_packets",
+                "Dump packets via an info log statement",
+                Value::Bool(false),
+                None
+            ),
+            (
+                "phy_enable_usb",
+                "Keeps USB running when using WiFi. This allows debugging and log messages via USB Serial JTAG. Turn off for best WiFi performance.",
+                Value::Bool(true),
+                None
+            ),
         ],
         true
     );


### PR DESCRIPTION
Opening as a draft, as this will need rebasing and additional changes once #2422 and #2246 get merged.

I have not actually taken advantage of the validation in any of the packages depending on `esp-config`, not sure if that should be considered in-scope for this or be handled in a subsequent PR. Will take some time to do this.

`skip-changelog` added as the `esp-config` package does not have a `CHANGELOG.md`, and there are no user-facing changes here.

Closes #2206