### PR TITLE
I2C: add `apply_config`, implement `SetConfig`, add `with_sda` and `with_scl`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -36,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `embassy_embedded_hal::SetConfig` is now implemented for `{Spi, SpiDma, SpiDmaBus}` (#2448)
 - `slave::Spi::{with_mosi(), with_miso(), with_sclk(), with_cs()}` functions (#2485)
 - I8080: Added `set_8bits_order()` to set the byte order in 8-bit mode (#2487)
-- `embassy_embedded_hal::SetConfig` is now implemented for `spi::master::{Spi, SpiDma, SpiDmaBus}`, `i2c::master::I2c` (#2448, #?)
+- `embassy_embedded_hal::SetConfig` is now implemented for `spi::master::{Spi, SpiDma, SpiDmaBus}`, `i2c::master::I2c` (#2448, #2477)
+- `I2c::{apply_config(), with_sda(), with_scl()}` (#2477)
 
 ### Changed
 
@@ -76,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `i2s::{I2sWrite, I2sWriteDma, I2sRead, I2sReadDma, I2sWriteDmaAsync, I2sReadDmaAsync}` traits have been removed. (#2316)
 - The `ledc::ChannelHW` trait is no longer generic. (#2387)
 - The `I2c::new_with_timeout` constructors have been removed (#2361)
+- `I2c::new()` no longer takes `frequency` and pins as parameters. (#?)
 - The `spi::master::HalfDuplexReadWrite` trait has been removed. (#2373)
 - The `Spi::with_pins` methods have been removed. (#2373)
 - The `Spi::new_half_duplex` constructor have been removed. (#2373)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -33,10 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `{Uart, UartRx, UartTx}` now implement `embassy_embedded_hal::SetConfig` (#2449)
 - GPIO ETM tasks and events now accept `InputSignal` and `OutputSignal` (#2427)
 - `spi::master::Config` and `{Spi, SpiDma, SpiDmaBus}::apply_config` (#2448)
-- `embassy_embedded_hal::SetConfig` is now implemented for `{Spi, SpiDma, SpiDmaBus}` (#2448)
+- `embassy_embedded_hal::SetConfig` is now implemented for `spi::master::{Spi, SpiDma, SpiDmaBus}`, `i2c::master::I2c` (#2448, #2477)
 - `slave::Spi::{with_mosi(), with_miso(), with_sclk(), with_cs()}` functions (#2485)
 - I8080: Added `set_8bits_order()` to set the byte order in 8-bit mode (#2487)
-- `embassy_embedded_hal::SetConfig` is now implemented for `spi::master::{Spi, SpiDma, SpiDmaBus}`, `i2c::master::I2c` (#2448, #2477)
 - `I2c::{apply_config(), with_sda(), with_scl()}` (#2477)
 
 ### Changed
@@ -61,7 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The I2S driver has been moved to `i2s::master` (#2472)
 - `slave::Spi` constructors no longer take pins (#2485)
 - The `I2c` master driver has been moved from `esp_hal::i2c` to `esp_hal::i2c::master`. (#2476)
-- The `I2c` master driver has been moved to `esp_hal::i2c::master`. (#2476)
 - `I2c` SCL timeout is now defined in bus clock cycles. (#2477)
 
 ### Fixed
@@ -79,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `i2s::{I2sWrite, I2sWriteDma, I2sRead, I2sReadDma, I2sWriteDmaAsync, I2sReadDmaAsync}` traits have been removed. (#2316)
 - The `ledc::ChannelHW` trait is no longer generic. (#2387)
 - The `I2c::new_with_timeout` constructors have been removed (#2361)
-- `I2c::new()` no longer takes `frequency` and pins as parameters. (#?)
+- `I2c::new()` no longer takes `frequency` and pins as parameters. (#2477)
 - The `spi::master::HalfDuplexReadWrite` trait has been removed. (#2373)
 - The `Spi::with_pins` methods have been removed. (#2373)
 - The `Spi::new_half_duplex` constructor have been removed. (#2373)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The I2S driver has been moved to `i2s::master` (#2472)
 - `slave::Spi` constructors no longer take pins (#2485)
 - The `I2c` master driver has been moved from `esp_hal::i2c` to `esp_hal::i2c::master`. (#2476)
+- The `I2c` master driver has been moved to `esp_hal::i2c::master`. (#2476)
+- `I2c` SCL timeout is now defined in bus clock cycles. (#2477)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `embassy_embedded_hal::SetConfig` is now implemented for `{Spi, SpiDma, SpiDmaBus}` (#2448)
 - `slave::Spi::{with_mosi(), with_miso(), with_sclk(), with_cs()}` functions (#2485)
 - I8080: Added `set_8bits_order()` to set the byte order in 8-bit mode (#2487)
+- `embassy_embedded_hal::SetConfig` is now implemented for `spi::master::{Spi, SpiDma, SpiDmaBus}`, `i2c::master::I2c` (#2448, #?)
 
 ### Changed
 

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -72,14 +72,23 @@ The I2C master driver and related types have been moved to `esp_hal::i2c::master
 The `with_timeout` constructors have been removed. `new` and `new_typed` now take a `Config` struct
 with the available configuration options.
 
+The constructors no longer take pins. Use `with_sda` and `with_scl` instead.
+
 ```diff
+-use esp_hal::i2c::I2c;
++use esp_hal::i2c::{Config, I2c};
 -let i2c = I2c::new_with_timeout(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 100.kHz(), timeout);
-+let i2c = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, {
-+    let mut config = Config::default();
-+    config.frequency = 100.kHz();
-+    config.timeout = timeout;
-+    config
-+});
++I2c::new_with_config(
++    peripherals.I2C0,
++    {
++        let mut config = Config::default();
++        config.frequency = 100.kHz();
++        config.timeout = timeout;
++        config
++    },
++)
++.with_sda(io.pins.gpio4)
++.with_scl(io.pins.gpio5);
 ```
 
 ## Changes to half-duplex SPI

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -69,11 +69,17 @@ let spi: Spi<'static, FullDuplexMode, SPI2> = Spi::new_typed(peripherals.SPI2, 1
 
 The I2C master driver and related types have been moved to `esp_hal::i2c::master`.
 
-The `with_timeout` constructors have been removed in favour of `set_timeout` or `with_timeout`.
+The `with_timeout` constructors have been removed. `new` and `new_typed` now take a `Config` struct
+with the available configuration options.
 
 ```diff
 -let i2c = I2c::new_with_timeout(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 100.kHz(), timeout);
-+let i2c = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 100.kHz()).with_timeout(timeout);
++let i2c = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, {
++    let mut config = Config::default();
++    config.frequency = 100.kHz();
++    config.timeout = timeout;
++    config
++});
 ```
 
 ## Changes to half-duplex SPI

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -72,6 +72,10 @@ The I2C master driver and related types have been moved to `esp_hal::i2c::master
 The `with_timeout` constructors have been removed. `new` and `new_typed` now take a `Config` struct
 with the available configuration options.
 
+- The default configuration is now:
+  - bus frequency: 100 kHz
+  - timeout: about 10 bus clock cycles
+
 The constructors no longer take pins. Use `with_sda` and `with_scl` instead.
 
 ```diff
@@ -90,6 +94,16 @@ The constructors no longer take pins. Use `with_sda` and `with_scl` instead.
 +.with_sda(io.pins.gpio4)
 +.with_scl(io.pins.gpio5);
 ```
+
+### The calculation of I2C timeout has changed
+
+Previously, I2C timeouts were counted in increments of I2C peripheral clock cycles. This meant that
+the configure value meant different lengths of time depending on the device. With this update, the
+I2C configuration now expects the timeout value in number of bus clock cycles, which is consistent
+between devices.
+
+ESP32 and ESP32-S2 use an exact number of clock cycles for its timeout. Other MCUs, however, use
+the `2^timeout` value internally, and the HAL rounds up the timeout to the next appropriate value.
 
 ## Changes to half-duplex SPI
 

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::i2c::master::I2c;
+//! # use esp_hal::i2c::master::{Config, I2c};
 //! # use esp_hal::gpio::Io;
 //! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 //!
@@ -28,7 +28,7 @@
 //!     peripherals.I2C0,
 //!     io.pins.gpio1,
 //!     io.pins.gpio2,
-//!     100.kHz(),
+//!     Config::default(),
 //! );
 //!
 //! loop {
@@ -46,6 +46,7 @@ use core::{
     task::{Context, Poll},
 };
 
+use embassy_embedded_hal::SetConfig;
 use embassy_sync::waitqueue::AtomicWaker;
 use embedded_hal::i2c::Operation as EhalOperation;
 use fugit::HertzU32;
@@ -105,6 +106,11 @@ pub enum Error {
     /// Zero length read or write operation.
     InvalidZeroLength,
 }
+
+/// I2C-specific configuration errors
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ConfigError {}
 
 #[derive(PartialEq)]
 // This enum is used to keep track of the last/next operation that was/will be
@@ -230,12 +236,54 @@ impl From<Ack> for u32 {
     }
 }
 
+/// I2C driver configuration
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// The I2C clock frequency.
+    pub frequency: HertzU32,
+
+    /// I2C SCL timeout period.
+    ///
+    /// When the level of SCL remains unchanged for more than `timeout` bus
+    /// clock cycles, the bus goes to idle state.
+    ///
+    /// The default value is about 10 bus clock cycles.
+    #[doc = ""]
+    #[cfg_attr(
+        not(esp32),
+        doc = "Note that the effective timeout may be longer than the value configured here."
+    )]
+    #[cfg_attr(not(esp32), doc = "Configuring `None` disables timeout control.")]
+    #[cfg_attr(esp32, doc = "Configuring `None` equals to the maximum timeout value.")]
+    // TODO: when supporting interrupts, document that SCL = high also triggers an interrupt.
+    pub timeout: Option<u32>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        use fugit::RateExtU32;
+        Config {
+            frequency: 100.kHz(),
+            timeout: Some(10),
+        }
+    }
+}
+
 /// I2C driver
 pub struct I2c<'d, DM: Mode, T = AnyI2c> {
     i2c: PeripheralRef<'d, T>,
     phantom: PhantomData<DM>,
-    frequency: HertzU32,
-    timeout: Option<u32>,
+    config: Config,
+}
+
+impl<T: Instance, DM: Mode> SetConfig for I2c<'_, DM, T> {
+    type Config = Config;
+    type ConfigError = ConfigError;
+
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.apply_config(config)
+    }
 }
 
 impl<T> embedded_hal_02::blocking::i2c::Read for I2c<'_, Blocking, T>
@@ -301,7 +349,7 @@ where
         i2c: impl Peripheral<P = T> + 'd,
         sda: impl Peripheral<P = impl PeripheralOutput> + 'd,
         scl: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        frequency: HertzU32,
+        config: Config,
     ) -> Self {
         crate::into_ref!(i2c);
         crate::into_mapped_ref!(sda, scl);
@@ -309,8 +357,7 @@ where
         let i2c = I2c {
             i2c,
             phantom: PhantomData,
-            frequency,
-            timeout: None,
+            config,
         };
 
         PeripheralClockControl::reset(i2c.info().peripheral);
@@ -318,7 +365,7 @@ where
 
         let i2c = i2c.with_sda(sda).with_scl(scl);
 
-        i2c.info().setup(frequency, None);
+        unwrap!(i2c.info().setup(&i2c.config));
         i2c
     }
 
@@ -330,16 +377,15 @@ where
         PeripheralClockControl::reset(self.info().peripheral);
         PeripheralClockControl::enable(self.info().peripheral);
 
-        self.info().setup(self.frequency, self.timeout);
+        // We know the configuration is valid, we can ignore the result.
+        _ = self.info().setup(&self.config);
     }
 
-    /// Set the I2C timeout.
-    // TODO: explain this function better - what's the unit, what happens on
-    // timeout, and just what exactly is a timeout in this context?
-    pub fn with_timeout(mut self, timeout: Option<u32>) -> Self {
-        self.timeout = timeout;
-        self.info().setup(self.frequency, self.timeout);
-        self
+    /// Applies a new configuration.
+    pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
+        self.info().setup(config)?;
+        self.config = *config;
+        Ok(())
     }
 
     fn transaction_impl<'a>(
@@ -442,9 +488,9 @@ impl<'d> I2c<'d, Blocking> {
         i2c: impl Peripheral<P = impl Instance> + 'd,
         sda: impl Peripheral<P = impl PeripheralOutput> + 'd,
         scl: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        frequency: HertzU32,
+        config: Config,
     ) -> Self {
-        Self::new_typed(i2c.map_into(), sda, scl, frequency)
+        Self::new_typed(i2c.map_into(), sda, scl, config)
     }
 }
 
@@ -459,9 +505,9 @@ where
         i2c: impl Peripheral<P = T> + 'd,
         sda: impl Peripheral<P = impl PeripheralOutput> + 'd,
         scl: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        frequency: HertzU32,
+        config: Config,
     ) -> Self {
-        Self::new_internal(i2c, sda, scl, frequency)
+        Self::new_internal(i2c, sda, scl, config)
     }
 
     // TODO: missing interrupt APIs
@@ -473,8 +519,7 @@ where
         I2c {
             i2c: self.i2c,
             phantom: PhantomData,
-            frequency: self.frequency,
-            timeout: self.timeout,
+            config: self.config,
         }
     }
 
@@ -743,8 +788,7 @@ where
         I2c {
             i2c: self.i2c,
             phantom: PhantomData,
-            frequency: self.frequency,
-            timeout: self.timeout,
+            config: self.config,
         }
     }
 
@@ -1324,7 +1368,7 @@ impl Info {
 
     /// Configures the I2C peripheral with the specified frequency, clocks, and
     /// optional timeout.
-    fn setup(&self, frequency: HertzU32, timeout: Option<u32>) {
+    fn setup(&self, config: &Config) -> Result<(), ConfigError> {
         self.register_block().ctr().write(|w| {
             // Set I2C controller to master mode
             w.ms_mode().set_bit();
@@ -1358,12 +1402,14 @@ impl Info {
                 let clock = clocks.xtal_clock.convert();
             }
         }
-        self.set_frequency(clock, frequency, timeout);
+        self.set_frequency(clock, config.frequency, config.timeout);
 
         self.update_config();
 
         // Reset entire peripheral (also resets fifo)
         self.reset();
+
+        Ok(())
     }
 
     /// Resets the I2C controller (FIFO + FSM + command list)

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -36,11 +36,13 @@ async fn main(_spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let i2c0 = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, {
+    let i2c0 = I2c::new(peripherals.I2C0, {
         let mut config = Config::default();
         config.frequency = 400.kHz();
         config
     })
+    .with_sda(io.pins.gpio4)
+    .with_scl(io.pins.gpio5)
     .into_async();
 
     let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -19,7 +19,12 @@
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
-use esp_hal::{gpio::Io, i2c::master::I2c, prelude::*, timer::timg::TimerGroup};
+use esp_hal::{
+    gpio::Io,
+    i2c::master::{Config, I2c},
+    prelude::*,
+    timer::timg::TimerGroup,
+};
 use lis3dh_async::{Lis3dh, Range, SlaveAddr};
 
 #[esp_hal_embassy::main]
@@ -31,7 +36,12 @@ async fn main(_spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let i2c0 = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 400.kHz()).into_async();
+    let i2c0 = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, {
+        let mut config = Config::default();
+        config.frequency = 400.kHz();
+        config
+    })
+    .into_async();
 
     let mut lis3dh = Lis3dh::new_i2c(i2c0, SlaveAddr::Alternate).await.unwrap();
     lis3dh.set_range(Range::G8).await.unwrap();

--- a/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -20,7 +20,12 @@
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
-use esp_hal::{gpio::Io, i2c::master::I2c, prelude::*, timer::timg::TimerGroup};
+use esp_hal::{
+    gpio::Io,
+    i2c::master::{Config, I2c},
+    prelude::*,
+    timer::timg::TimerGroup,
+};
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
@@ -31,7 +36,12 @@ async fn main(_spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut i2c = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 400.kHz()).into_async();
+    let mut i2c = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, {
+        let mut config = Config::default();
+        config.frequency = 400.kHz();
+        config
+    })
+    .into_async();
 
     loop {
         let mut data = [0u8; 22];

--- a/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -36,11 +36,13 @@ async fn main(_spawner: Spawner) {
 
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let mut i2c = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, {
+    let mut i2c = I2c::new(peripherals.I2C0, {
         let mut config = Config::default();
         config.frequency = 400.kHz();
         config
     })
+    .with_sda(io.pins.gpio4)
+    .with_scl(io.pins.gpio5)
     .into_async();
 
     loop {

--- a/examples/src/bin/i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/i2c_bmp180_calibration_data.rs
@@ -27,12 +27,9 @@ fn main() -> ! {
 
     // Create a new peripheral object with the described wiring and standard
     // I2C clock speed:
-    let mut i2c = I2c::new(
-        peripherals.I2C0,
-        io.pins.gpio4,
-        io.pins.gpio5,
-        Config::default(),
-    );
+    let mut i2c = I2c::new(peripherals.I2C0, Config::default())
+        .with_sda(io.pins.gpio4)
+        .with_scl(io.pins.gpio5);
 
     loop {
         let mut data = [0u8; 22];

--- a/examples/src/bin/i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/i2c_bmp180_calibration_data.rs
@@ -12,7 +12,11 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{gpio::Io, i2c::master::I2c, prelude::*};
+use esp_hal::{
+    gpio::Io,
+    i2c::master::{Config, I2c},
+    prelude::*,
+};
 use esp_println::println;
 
 #[entry]
@@ -23,7 +27,12 @@ fn main() -> ! {
 
     // Create a new peripheral object with the described wiring and standard
     // I2C clock speed:
-    let mut i2c = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 100.kHz());
+    let mut i2c = I2c::new(
+        peripherals.I2C0,
+        io.pins.gpio4,
+        io.pins.gpio5,
+        Config::default(),
+    );
 
     loop {
         let mut data = [0u8; 22];

--- a/examples/src/bin/i2c_display.rs
+++ b/examples/src/bin/i2c_display.rs
@@ -22,7 +22,12 @@ use embedded_graphics::{
     text::{Alignment, Text},
 };
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, gpio::Io, i2c::master::I2c, prelude::*};
+use esp_hal::{
+    delay::Delay,
+    gpio::Io,
+    i2c::master::{Config, I2c},
+    prelude::*,
+};
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 
 #[entry]
@@ -34,7 +39,12 @@ fn main() -> ! {
 
     // Create a new peripheral object with the described wiring
     // and standard I2C clock speed
-    let i2c = I2c::new(peripherals.I2C0, io.pins.gpio4, io.pins.gpio5, 100.kHz());
+    let i2c = I2c::new(
+        peripherals.I2C0,
+        io.pins.gpio4,
+        io.pins.gpio5,
+        Config::default(),
+    );
 
     // Initialize display
     let interface = I2CDisplayInterface::new(i2c);

--- a/examples/src/bin/i2c_display.rs
+++ b/examples/src/bin/i2c_display.rs
@@ -39,12 +39,9 @@ fn main() -> ! {
 
     // Create a new peripheral object with the described wiring
     // and standard I2C clock speed
-    let i2c = I2c::new(
-        peripherals.I2C0,
-        io.pins.gpio4,
-        io.pins.gpio5,
-        Config::default(),
-    );
+    let i2c = I2c::new(peripherals.I2C0, Config::default())
+        .with_sda(io.pins.gpio4)
+        .with_scl(io.pins.gpio5);
 
     // Initialize display
     let interface = I2CDisplayInterface::new(i2c);

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -82,7 +82,9 @@ fn main() -> ! {
 
     delay.delay_millis(500u32);
 
-    let i2c = I2c::new(peripherals.I2C0, cam_siod, cam_sioc, Config::default());
+    let i2c = I2c::new(peripherals.I2C0, Config::default())
+        .with_sda(cam_siod)
+        .with_scl(cam_sioc);
 
     let mut sccb = Sccb::new(i2c);
 

--- a/examples/src/bin/lcd_cam_ov2640.rs
+++ b/examples/src/bin/lcd_cam_ov2640.rs
@@ -29,7 +29,10 @@ use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_rx_stream_buffer,
     gpio::Io,
-    i2c::{self, master::I2c},
+    i2c::{
+        self,
+        master::{Config, I2c},
+    },
     lcd_cam::{
         cam::{Camera, RxEightBits},
         LcdCam,
@@ -79,7 +82,7 @@ fn main() -> ! {
 
     delay.delay_millis(500u32);
 
-    let i2c = I2c::new(peripherals.I2C0, cam_siod, cam_sioc, 100u32.kHz());
+    let i2c = I2c::new(peripherals.I2C0, cam_siod, cam_sioc, Config::default());
 
     let mut sccb = Sccb::new(i2c);
 

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -39,7 +39,9 @@ mod tests {
 
         // Create a new peripheral object with the described wiring and standard
         // I2C clock speed:
-        let i2c = I2c::new(peripherals.I2C0, sda, scl, Config::default());
+        let i2c = I2c::new(peripherals.I2C0, Config::default())
+            .with_sda(sda)
+            .with_scl(scl);
 
         Context { i2c }
     }

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -7,8 +7,7 @@
 
 use esp_hal::{
     gpio::Io,
-    i2c::master::{I2c, Operation},
-    prelude::*,
+    i2c::master::{Config, I2c, Operation},
     Async,
     Blocking,
 };
@@ -40,7 +39,7 @@ mod tests {
 
         // Create a new peripheral object with the described wiring and standard
         // I2C clock speed:
-        let i2c = I2c::new(peripherals.I2C0, sda, scl, 100.kHz());
+        let i2c = I2c::new(peripherals.I2C0, sda, scl, Config::default());
 
         Context { i2c }
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Part 3 of #2437

cc https://github.com/esp-rs/esp-hal/issues/2416 and closes https://github.com/esp-rs/esp-hal/issues/1919

`with_sda` and `with_scl` are now consistent with SPI and allow reconfiguring the bus (though a bit of a replace_with hackery may be needed).

This PR also aims to clarify the meaning of the `timeout` configuration.