### PR TITLE
GPIO: do not overwrite interrupt handler

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `GpioEtmEventRising`, `GpioEtmEventFalling`, `GpioEtmEventAny` types have been replaced with `Event` (#2427)
 - The `TaskSet`, `TaskClear`, `TaskToggle` types have been replaced with `Task` (#2427)
 - `{Spi, SpiDma, SpiDmaBus}` configuration methods (#2448)
+- `Io::new_with_priority` and `Io::new_no_bind_interrupt`.
 
 ## [0.21.1]
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `GpioEtmEventRising`, `GpioEtmEventFalling`, `GpioEtmEventAny` types have been replaced with `Event` (#2427)
 - The `TaskSet`, `TaskClear`, `TaskToggle` types have been replaced with `Task` (#2427)
 - `{Spi, SpiDma, SpiDmaBus}` configuration methods (#2448)
-- `Io::new_with_priority` and `Io::new_no_bind_interrupt`.
+- `Io::new_with_priority` and `Io::new_no_bind_interrupt`. (#2486)
 
 ## [0.21.1]
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -785,50 +785,20 @@ where
 
 impl<const GPIONUM: u8> private::Sealed for GpioPin<GPIONUM> {}
 
-fn ensure_interrupt_handler_bound() {
-    #[cfg(multi_core)]
-    {
-        use portable_atomic::AtomicUsize;
-
-        use crate::Cpu;
-        // On multi-core, we need to call `interrupt::enable` on each core.
-        // However, we don't want to call it on a core where the handler is already
-        // bound, otherwise we'd overwrite the priority set for that handler.
-
-        // FIXME: handling GPIO interrupts on multiple cores may not be what the users
-        // want. Only ESP32 can handle a different set of pins on each core. Do
-        // we want to support this?
-        static BOUND: AtomicUsize = AtomicUsize::new(0);
-
-        let bound = BOUND.load(Ordering::Relaxed);
-
-        let cpu_bit = 1 << Cpu::current() as usize;
-        if bound & cpu_bit != 0 {
-            // Nothing to do.
-            return;
-        }
-
-        // A tiny optimization to avoid a CAS in the common case.
-        if BOUND.fetch_or(cpu_bit, Ordering::Relaxed) & cpu_bit != 0 {
-            // We have raced with something and lost.
-            return;
-        }
-    }
-
+pub(crate) fn bind_default_interrupt_handler() {
     // We check this by looking up the handler in the vector table.
     if let Some(handler) = interrupt::bound_handler(Interrupt::GPIO) {
         let handler = handler as *const unsafe extern "C" fn();
 
         // We only allow binding the default handler if nothing else is bound.
         // This prevents silently overwriting RTIC's interrupt handler, if using GPIO.
-        if core::ptr::eq(handler, DEFAULT_INTERRUPT_HANDLER.handler() as _) {
-            unsafe { interrupt::bind_interrupt(Interrupt::GPIO, gpio_interrupt_handler) };
-        } else if core::ptr::eq(handler, gpio_interrupt_handler as _) {
-            warn!("GPIO interrupt handler already bound to a function other than `gpio_interrupt_handler`");
+        if !core::ptr::eq(handler, DEFAULT_INTERRUPT_HANDLER.handler() as _) {
+            info!("Not using default GPIO interrupt handler: already bound");
             return;
         }
     }
 
+    unsafe { interrupt::bind_interrupt(Interrupt::GPIO, gpio_interrupt_handler) };
     // By default, we use lowest priority
     unwrap!(interrupt::enable(Interrupt::GPIO, Priority::min()));
 }
@@ -851,7 +821,6 @@ impl Io {
 
     /// Set the interrupt priority for GPIO interrupts.
     pub fn set_interrupt_priority(&self, prio: Priority) {
-        ensure_interrupt_handler_bound();
         unwrap!(interrupt::enable(crate::peripherals::Interrupt::GPIO, prio));
     }
 }
@@ -870,21 +839,6 @@ impl InterruptConfigurable for Io {
     ///   async driver from detecting the interrupt, silently disabling the
     ///   corresponding pin's async API.
     /// - You will not be notified if you make a mistake.
-    #[cfg_attr(multi_core, doc = "")]
-    #[cfg_attr(
-        multi_core,
-        doc = " ⚠️ Be careful when using GPIO interrupts on multiple cores:"
-    )]
-    #[cfg_attr(multi_core, doc = "")]
-    #[cfg_attr(
-        multi_core,
-        doc = " - This function only enables interrupts for the current core. To enable interrupts for other cores, call this function or [`Io::set_interrupt_priority`] on those cores."
-    )]
-    #[cfg_attr(multi_core, doc = " - Both cores will use the same interrupt handler.")]
-    #[cfg_attr(
-        all(multi_core, esp32s3),
-        doc = " - Both cores will handle the interrupt requests, possibly at the same time."
-    )]
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         self.set_interrupt_priority(handler.priority());
         USER_INTERRUPT_HANDLER.store(handler.handler());
@@ -1624,7 +1578,6 @@ where
         nmi_enable: bool,
         wake_up_from_light_sleep: bool,
     ) {
-        ensure_interrupt_handler_bound();
         if wake_up_from_light_sleep {
             match event {
                 Event::AnyEdge | Event::RisingEdge | Event::FallingEdge => {

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -806,7 +806,10 @@ impl Io {
         prio: crate::interrupt::Priority,
     ) -> Self {
         gpio.bind_gpio_interrupt(gpio_interrupt_handler);
-        crate::interrupt::enable(crate::peripherals::Interrupt::GPIO, prio).unwrap();
+        unwrap!(crate::interrupt::enable(
+            crate::peripherals::Interrupt::GPIO,
+            prio
+        ));
 
         Self::new_no_bind_interrupt(gpio, io_mux)
     }
@@ -840,7 +843,10 @@ impl InterruptConfigurable for Io {
     ///   corresponding pin's async API.
     /// - You will not be notified if you make a mistake.
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
-        crate::interrupt::enable(crate::peripherals::Interrupt::GPIO, handler.priority()).unwrap();
+        unwrap!(crate::interrupt::enable(
+            crate::peripherals::Interrupt::GPIO,
+            handler.priority()
+        ));
         USER_INTERRUPT_HANDLER.store(handler.handler());
     }
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -793,7 +793,16 @@ pub(crate) fn bind_default_interrupt_handler() {
         // We only allow binding the default handler if nothing else is bound.
         // This prevents silently overwriting RTIC's interrupt handler, if using GPIO.
         if !core::ptr::eq(handler, DEFAULT_INTERRUPT_HANDLER.handler() as _) {
-            info!("Not using default GPIO interrupt handler: already bound");
+            // The user has configured an interrupt handler they wish to use.
+            info!("Not using default GPIO interrupt handler: already bound in vector table");
+            return;
+        } else if interrupt::bound_cpu_interrupt_for(crate::Cpu::current(), Interrupt::GPIO)
+            .is_some()
+        {
+            // The vector table doesn't contain a custom entry. Still, the
+            // peripheral interrupt may already be bound to
+            // something else.
+            info!("Not using default GPIO interrupt handler: peripheral interrupt already in use");
             return;
         }
     }

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -423,15 +423,27 @@ mod vectored {
         Ok(())
     }
 
-    /// Bind the given interrupt to the given handler
+    /// Binds the given interrupt to the given handler.
     ///
     /// # Safety
     ///
     /// This will replace any previously bound interrupt handler
-    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn() -> ()) {
+    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn()) {
         let ptr = &peripherals::__EXTERNAL_INTERRUPTS[interrupt as usize]._handler as *const _
-            as *mut unsafe extern "C" fn() -> ();
+            as *mut unsafe extern "C" fn();
         ptr.write_volatile(handler);
+    }
+
+    /// Returns the currently bound interrupt handler.
+    pub fn bound_handler(interrupt: Interrupt) -> Option<unsafe extern "C" fn()> {
+        unsafe {
+            let addr = peripherals::__EXTERNAL_INTERRUPTS[interrupt as usize]._handler;
+            if addr as usize == 0 {
+                return None;
+            }
+
+            Some(addr)
+        }
     }
 
     #[no_mangle]

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -346,13 +346,17 @@ unsafe fn get_assigned_cpu_interrupt(interrupt: Interrupt) -> Option<CpuInterrup
     let intr_map_base = crate::soc::registers::INTERRUPT_MAP_BASE as *mut u32;
 
     let cpu_intr = intr_map_base.offset(interrupt_number).read_volatile();
-    if cpu_intr > 0 {
+    if cpu_intr > 0 && cpu_intr != DISABLED_CPU_INTERRUPT {
         Some(core::mem::transmute::<u32, CpuInterrupt>(
             cpu_intr - EXTERNAL_INTERRUPT_OFFSET,
         ))
     } else {
         None
     }
+}
+
+pub(crate) fn bound_cpu_interrupt_for(_cpu: Cpu, interrupt: Interrupt) -> Option<CpuInterrupt> {
+    unsafe { get_assigned_cpu_interrupt(interrupt) }
 }
 
 mod vectored {

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -106,7 +106,8 @@ impl CpuInterrupt {
     fn is_internal(self) -> bool {
         matches!(
             self,
-            |Self::Interrupt6Timer0Priority1| Self::Interrupt7SoftwarePriority1
+            Self::Interrupt6Timer0Priority1
+                | Self::Interrupt7SoftwarePriority1
                 | Self::Interrupt11ProfilingPriority3
                 | Self::Interrupt15Timer1Priority3
                 | Self::Interrupt16Timer2Priority5

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -415,15 +415,27 @@ mod vectored {
         Ok(())
     }
 
-    /// Bind the given interrupt to the given handler
+    /// Binds the given interrupt to the given handler.
     ///
     /// # Safety
     ///
     /// This will replace any previously bound interrupt handler
-    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn() -> ()) {
+    pub unsafe fn bind_interrupt(interrupt: Interrupt, handler: unsafe extern "C" fn()) {
         let ptr = &peripherals::__INTERRUPTS[interrupt as usize]._handler as *const _
-            as *mut unsafe extern "C" fn() -> ();
+            as *mut unsafe extern "C" fn();
         ptr.write_volatile(handler);
+    }
+
+    /// Returns the currently bound interrupt handler.
+    pub fn bound_handler(interrupt: Interrupt) -> Option<unsafe extern "C" fn()> {
+        unsafe {
+            let addr = peripherals::__INTERRUPTS[interrupt as usize]._handler;
+            if addr as usize == 0 {
+                return None;
+            }
+
+            Some(addr)
+        }
     }
 
     fn interrupt_level_to_cpu_interrupt(

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -560,5 +560,7 @@ pub fn init(config: Config) -> Peripherals {
     #[cfg(esp32)]
     crate::time::time_init();
 
+    crate::gpio::bind_default_interrupt_handler();
+
     peripherals
 }

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -56,6 +56,10 @@ name    = "gpio"
 harness = false
 
 [[test]]
+name    = "gpio_custom_handler"
+harness = false
+
+[[test]]
 name    = "interrupt"
 harness = false
 

--- a/hil-test/tests/gpio_custom_handler.rs
+++ b/hil-test/tests/gpio_custom_handler.rs
@@ -1,0 +1,99 @@
+//! GPIO interrupt handler tests
+//!
+//! This test checks that during HAL initialization we do not overwrite custom
+//! GPIO interrupt handlers. We also check that binding a custom interrupt
+//! handler explicitly overwrites the handler set by the user, as well as the
+//! async API works for user handlers automatically.
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: integrated-timers
+
+#![no_std]
+#![no_main]
+
+use embassy_time::{Duration, Timer};
+use esp_hal::{
+    gpio::{AnyPin, Input, Io, Level, Output, Pull},
+    macros::handler,
+    timer::timg::TimerGroup,
+    InterruptConfigurable,
+};
+use hil_test as _;
+use portable_atomic::{AtomicUsize, Ordering};
+
+#[no_mangle]
+unsafe extern "C" fn GPIO() {
+    // do nothing, prevents binding the default handler
+}
+
+#[handler]
+pub fn interrupt_handler() {
+    // Do nothing
+}
+
+async fn drive_pins(gpio1: impl Into<AnyPin>, gpio2: impl Into<AnyPin>) -> usize {
+    let counter = AtomicUsize::new(0);
+    let mut test_gpio1 = Input::new(gpio1.into(), Pull::Down);
+    let mut test_gpio2 = Output::new(gpio2.into(), Level::Low);
+    embassy_futures::select::select(
+        async {
+            loop {
+                test_gpio1.wait_for_rising_edge().await;
+                counter.fetch_add(1, Ordering::SeqCst);
+            }
+        },
+        async {
+            for _ in 0..5 {
+                test_gpio2.set_high();
+                Timer::after(Duration::from_millis(25)).await;
+                test_gpio2.set_low();
+                Timer::after(Duration::from_millis(25)).await;
+            }
+        },
+    )
+    .await;
+
+    counter.load(Ordering::SeqCst)
+}
+
+#[cfg(test)]
+#[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    async fn default_handler_does_not_run_because_gpio_is_defined() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+
+        let (gpio1, gpio2) = hil_test::common_test_pins!(io);
+
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        esp_hal_embassy::init(timg0.timer0);
+
+        let counter = drive_pins(gpio1, gpio2).await;
+
+        // GPIO is bound to something else, so we don't expect the async API to work.
+        assert_eq!(counter, 0);
+    }
+
+    #[test]
+    async fn default_handler_runs_because_handler_is_set() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        let mut io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+        io.set_interrupt_handler(interrupt_handler);
+
+        let (gpio1, gpio2) = hil_test::common_test_pins!(io);
+
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        esp_hal_embassy::init(timg0.timer0);
+
+        let counter = drive_pins(gpio1, gpio2).await;
+
+        // GPIO is bound to something else, so we don't expect the async API to work.
+        assert_eq!(counter, 5);
+    }
+}

--- a/hil-test/tests/gpio_custom_handler.rs
+++ b/hil-test/tests/gpio_custom_handler.rs
@@ -93,7 +93,7 @@ mod tests {
 
         let counter = drive_pins(gpio1, gpio2).await;
 
-        // GPIO is bound to something else, so we don't expect the async API to work.
+        // We expect the async API to keep working even if a user handler is set.
         assert_eq!(counter, 5);
     }
 }


### PR DESCRIPTION
Another idea I'd want some feedback on. Closes #2009 I hope.

Why not keep this in `Io::new`? I intend to move the Pins out into Peripherals so that users don't need to create `Io` - unless they want to handle user interrupts. That is a bigger change, though.