### PR TITLE
Fix I8080.set_byte_order()

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GPIO ETM tasks and events now accept `InputSignal` and `OutputSignal` (#2427)
 - `spi::master::Config` and `{Spi, SpiDma, SpiDmaBus}::apply_config` (#2448)
 - `embassy_embedded_hal::SetConfig` is now implemented for `{Spi, SpiDma, SpiDmaBus}` (#2448)
+- I8080: Added `set_8bits_order()` to set the byte order in 8-bit mode (#2487)
 
 ### Changed
 
@@ -64,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: added UART-specific workaround for https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/03-errata-description/esp32/cpu-subsequent-access-halted-when-get-interrupted.html (#2441)
 - Fixed some SysTimer race conditions and panics (#2451)
 - TWAI: accept all messages by default (#2467)
+- I8080: `set_byte_order()` now works correctly in 16-bit mode (#2487)
 
 ### Removed
 

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -285,3 +285,16 @@ refer to the `Config` struct as `uart::Config`.
 +    },
 +)
 ```
+
+## I8080 driver split `set_byte_order()` into `set_8bits_order()` and `set_byte_order()`.
+
+If you were using an 8-bit bus.
+```diff
+- i8080.set_byte_order(ByteOrder::default());
++ i8080.set_8bits_order(ByteOrder::default());
+```
+
+If you were using an 16-bit bus, you don't need to change anything, `set_byte_order()` now works correctly.
+
+If you were sharing the bus between an 8-bit and 16-bit device, you will have to call the corresponding method when
+you switch between devices. Be sure to read the documentation of the new methods.

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -217,13 +217,25 @@ impl<'d, DM: Mode> I8080<'d, DM> {
 }
 
 impl<'d, DM: Mode> I8080<'d, DM> {
-    /// Configures the byte order for data transmission.
+    /// Configures the byte order for data transmission in 16-bit mode.
+    /// This must be set to [ByteOrder::default()] when transmitting in 8-bit
+    /// mode.
     pub fn set_byte_order(&mut self, byte_order: ByteOrder) -> &mut Self {
         let is_inverted = byte_order != ByteOrder::default();
-        self.lcd_cam.lcd_user().modify(|_, w| {
-            w.lcd_byte_order().bit(is_inverted);
-            w.lcd_8bits_order().bit(is_inverted)
-        });
+        self.lcd_cam
+            .lcd_user()
+            .modify(|_, w| w.lcd_byte_order().bit(is_inverted));
+        self
+    }
+
+    /// Configures the byte order for data transmission in 8-bit mode.
+    /// This must be set to [ByteOrder::default()] when transmitting in 16-bit
+    /// mode.
+    pub fn set_8bits_order(&mut self, byte_order: ByteOrder) -> &mut Self {
+        let is_inverted = byte_order != ByteOrder::default();
+        self.lcd_cam
+            .lcd_user()
+            .modify(|_, w| w.lcd_8bits_order().bit(is_inverted));
         self
     }
 

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -108,7 +108,7 @@ pub enum BitOrder {
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ByteOrder {
-    /// Do not change bit order.
+    /// Do not change byte order.
     #[default]
     Native   = 0,
     /// Invert byte order.


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #2362 by splitting the `set_byte_order` into two functions.
The user is now responsible for calling the right one depending on the bus width, which will be straight forward for most users.
Those that share the bus between 8-bit and 16-bit devices will have to do a little more work. 

#### Testing
Works as expected on my Slint app.

@yanshay pls confirm this PR works for you too.
