### PR TITLE
Add `CHANGELOG.md` for remaining packages which do not have one

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,16 +2,13 @@ name: Changelog check
 
 on:
   pull_request:
-    # We will not track changes for the following packages.
+    # We will not track changes for the following packages/directories.
     paths-ignore:
-      - "/xtask/"
-      - "/esp-build/"
-      - "/esp-hal-procmacros/"
-      - "/esp-metadata/"
       - "/examples/"
-      - "/hil-tests/"
       - "/extras/"
+      - "/hil-tests/"
       - "/resources/"
+      - "/xtask/"
     # Run on labeled/unlabeled in addition to defaults to detect
     # adding/removing skip-changelog labels.
     types: [opened, reopened, labeled, unlabeled, synchronize]
@@ -33,24 +30,34 @@ jobs:
               - 'esp-alloc/**'
             esp-backtrace:
               - 'esp-backtrace/**'
+            esp-build:
+              - 'esp-build/**'
+            esp-config:
+              - 'esp-config/**'
             esp-hal:
               - 'esp-hal/**'
             esp-hal-embassy:
               - 'esp-hal-embassy/**'
+            esp-hal-procmacros:
+              - 'esp-hal-procmacros/**'
             esp-ieee802154:
               - 'esp-ieee802154/**'
             esp-lp-hal:
               - 'esp-lp-hal/**'
+            esp-metadata:
+              - 'esp-metadata/**'
             esp-println:
               - 'esp-println/**'
             esp-riscv-rt:
               - 'esp-riscv-rt/**'
-            xtensa-lx-rt:
-              - 'xtensa-lx-rt/**'
             esp-storage:
               - 'esp-storage/**'
             esp-wifi:
               - 'esp-wifi/**'
+            xtensa-lx:
+              - 'xtensa-lx/**'
+            xtensa-lx-rt:
+              - 'xtensa-lx-rt/**'
 
       - name: Check that changelog updated (esp-alloc)
         if: steps.changes.outputs.esp-alloc == 'true'
@@ -68,6 +75,22 @@ jobs:
           skipLabels: "skip-changelog"
           missingUpdateErrorMessage: "Please add a changelog entry in the esp-backtrace/CHANGELOG.md file."
 
+      - name: Check that changelog updated (esp-build)
+        if: steps.changes.outputs.esp-build == 'true'
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: esp-build/CHANGELOG.md
+          skipLabels: "skip-changelog"
+          missingUpdateErrorMessage: "Please add a changelog entry in the esp-build/CHANGELOG.md file."
+
+      - name: Check that changelog updated (esp-config)
+        if: steps.changes.outputs.esp-config == 'true'
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: esp-config/CHANGELOG.md
+          skipLabels: "skip-changelog"
+          missingUpdateErrorMessage: "Please add a changelog entry in the esp-config/CHANGELOG.md file."
+
       - name: Check that changelog updated (esp-hal)
         if: steps.changes.outputs.esp-hal == 'true'
         uses: dangoslen/changelog-enforcer@v3
@@ -83,6 +106,14 @@ jobs:
           changeLogPath: esp-hal-embassy/CHANGELOG.md
           skipLabels: "skip-changelog"
           missingUpdateErrorMessage: "Please add a changelog entry in the esp-hal-embassy/CHANGELOG.md file."
+
+      - name: Check that changelog updated (esp-hal-procmacros)
+        if: steps.changes.outputs.esp-hal-procmacros == 'true'
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: esp-hal-procmacros/CHANGELOG.md
+          skipLabels: "skip-changelog"
+          missingUpdateErrorMessage: "Please add a changelog entry in the esp-hal-procmacros/CHANGELOG.md file."
 
       - name: Check that changelog updated (esp-ieee802154)
         if: steps.changes.outputs.esp-ieee802154 == 'true'
@@ -131,3 +162,19 @@ jobs:
           changeLogPath: esp-wifi/CHANGELOG.md
           skipLabels: "skip-changelog"
           missingUpdateErrorMessage: "Please add a changelog entry in the esp-wifi/CHANGELOG.md file."
+
+      - name: Check that changelog updated (xtensa-lx)
+        if: steps.changes.outputs.xtensa-lx == 'true'
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: xtensa-lx/CHANGELOG.md
+          skipLabels: "skip-changelog"
+          missingUpdateErrorMessage: "Please add a changelog entry in the xtensa-lx/CHANGELOG.md file."
+
+      - name: Check that changelog updated (xtensa-lx-rt)
+        if: steps.changes.outputs.xtensa-lx-rt == 'true'
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: xtensa-lx-rt/CHANGELOG.md
+          skipLabels: "skip-changelog"
+          missingUpdateErrorMessage: "Please add a changelog entry in the xtensa-lx-rt/CHANGELOG.md file."

--- a/esp-build/CHANGELOG.md
+++ b/esp-build/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+- Use `panic` instead of `process::exit` in esp-build (#2402 )
+
+### Removed
+
+## [0.1.0] - 2024-04-17
+
+- Initial release
+
+[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/esp-build?since=2024-04-17

--- a/esp-config/CHANGELOG.md
+++ b/esp-config/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [0.1.0] - 2024-10-10
+
+- Initial release
+
+[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/esp-config?since=2024-10-10

--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [0.14.0] - 2024-10-10
+
+## [0.13.0] - 2024-08-29
+
+## [0.12.0] - 2024-07-15
+
+## [0.11.0] - 2024-06-04
+
+## [0.10.0] - 2024-04-18
+
+## [0.9.0] - 2024-03-18
+
+## [0.8.0] - 2023-12-12
+
+## [0.7.0] - 2023-10-31
+
+## [0.6.1] - 2023-09-05
+
+## [0.6.0] - 2023-07-04
+
+## [0.5.0] - 2023-03-27
+
+## [0.4.0] - 2023-02-21
+
+## [0.2.0] - 2023-01-26
+
+## [0.1.0] - 2022-08-25
+
+- Initial release
+
+[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/esp-hal-procmacros?since=2024-10-10

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [0.4.0] - 2024-10-10
+
+## [0.3.0] - 2024-08-29
+
+## [0.2.0] - 2024-07-15
+
+## [0.1.1] - 2024-06-04
+
+## [0.1.0] - 2024-04-17
+
+- Initial release
+
+[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/esp-metadata?since=2024-10-10

--- a/xtensa-lx/CHANGELOG.md
+++ b/xtensa-lx/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [0.9.0] - 2024-02-21
+
+## [0.8.0] - 2023-02-23
+
+## [0.7.0] - 2022-04-20
+
+## [0.6.0] - 2022-01-16
+
+## [0.5.0] - 2022-01-15
+
+## [0.4.0] - 2021-08-11
+
+## [0.3.0] - 2020-09-19
+
+[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/xtensa-lx?since=2024-02-21


### PR DESCRIPTION
I will extract the changelog check into a local action in a separate PR when I get  a chance, to reduce the duplication in this workflow a bit.

Not going to bother populating the older releases' entries.