### PR TITLE
[DMA 1/N] Add mode to DMA channel drivers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `I2c` SCL timeout is now defined in bus clock cycles. (#2477)
 - Trying to send a single-shot RMT transmission will result in an error now, `RMT` deals with `u32` now, `PulseCode` is a convenience trait now (#2463)
 - Removed `get_` prefixes from functions (#2528)
+- The `Camera` and `I8080` drivers' constructors now only accepts blocking-mode DMA channels. (#2519)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -180,6 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The DMA channel types have been removed from peripherals (#2261)
 - `I2C` driver renamed to `I2c` (#2320)
 - The GPIO pins are now accessible via `Peripherals` and are no longer part of the `Io` struct (#2508)
+- `dma::{ChannelRx, ChannelTx}` now have a `Mode` type parameter (#2519)
 
 ### Fixed
 

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -324,7 +324,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportTx for AesDma<'d> {
-        type TX = ChannelTx<'d, <AES as DmaEligible>::Dma>;
+        type TX = ChannelTx<'d, <AES as DmaEligible>::Dma, Blocking>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -336,7 +336,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportRx for AesDma<'d> {
-        type RX = ChannelRx<'d, <AES as DmaEligible>::Dma>;
+        type RX = ChannelRx<'d, <AES as DmaEligible>::Dma, Blocking>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -276,21 +276,21 @@ pub mod dma {
         /// The underlying [`Aes`](super::Aes) driver
         pub aes: super::Aes<'d>,
 
-        channel: Channel<'d, <AES as DmaEligible>::Dma, Blocking>,
+        channel: Channel<'d, Blocking, <AES as DmaEligible>::Dma>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
     }
 
     impl<'d> crate::aes::Aes<'d> {
         /// Enable DMA for the current instance of the AES driver
-        pub fn with_dma<C>(
+        pub fn with_dma<CH>(
             self,
-            channel: Channel<'d, C, Blocking>,
+            channel: Channel<'d, Blocking, CH>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> AesDma<'d>
         where
-            C: DmaChannelConvert<<AES as DmaEligible>::Dma>,
+            CH: DmaChannelConvert<<AES as DmaEligible>::Dma>,
         {
             AesDma {
                 aes: self,
@@ -324,7 +324,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportTx for AesDma<'d> {
-        type TX = ChannelTx<'d, <AES as DmaEligible>::Dma, Blocking>;
+        type TX = ChannelTx<'d, Blocking, <AES as DmaEligible>::Dma>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -336,7 +336,7 @@ pub mod dma {
     }
 
     impl<'d> DmaSupportRx for AesDma<'d> {
-        type RX = ChannelRx<'d, <AES as DmaEligible>::Dma, Blocking>;
+        type RX = ChannelRx<'d, Blocking, <AES as DmaEligible>::Dma>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -519,7 +519,7 @@ impl<C: GdmaChannel> InterruptAccess<DmaRxInterrupt> for ChannelRxImpl<C> {
 #[non_exhaustive]
 pub struct ChannelCreator<const N: u8> {}
 
-impl<CH: DmaChannel, M: Mode> Channel<'_, CH, M> {
+impl<CH: DmaChannel, M: Mode> Channel<'_, M, CH> {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible<P: DmaEligible>(&self, _peripheral: &PeripheralRef<'_, P>) {
         // No runtime checks; GDMA channels are compatible with any peripheral
@@ -583,7 +583,7 @@ macro_rules! impl_channel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<DmaChannel $num>], Blocking> {
+                ) -> Channel<'a, Blocking, [<DmaChannel $num>]> {
                     let mut this = Channel {
                         tx: ChannelTx::new(ChannelTxImpl(SpecificGdmaChannel::<$num> {})),
                         rx: ChannelRx::new(ChannelRxImpl(SpecificGdmaChannel::<$num> {})),

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -25,6 +25,66 @@ use crate::{
 #[doc(hidden)]
 pub trait GdmaChannel {
     fn number(&self) -> u8;
+
+    fn async_handler_out(&self) -> Option<InterruptHandler> {
+        match self.number() {
+            0 => DmaChannel0::handler_out(),
+            #[cfg(not(esp32c2))]
+            1 => DmaChannel1::handler_out(),
+            #[cfg(not(esp32c2))]
+            2 => DmaChannel2::handler_out(),
+            #[cfg(esp32s3)]
+            3 => DmaChannel3::handler_out(),
+            #[cfg(esp32s3)]
+            4 => DmaChannel4::handler_out(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn peripheral_interrupt_out(&self) -> Option<Interrupt> {
+        match self.number() {
+            0 => DmaChannel0::isr_out(),
+            #[cfg(not(esp32c2))]
+            1 => DmaChannel1::isr_out(),
+            #[cfg(not(esp32c2))]
+            2 => DmaChannel2::isr_out(),
+            #[cfg(esp32s3)]
+            3 => DmaChannel3::isr_out(),
+            #[cfg(esp32s3)]
+            4 => DmaChannel4::isr_out(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn async_handler_in(&self) -> Option<InterruptHandler> {
+        match self.number() {
+            0 => DmaChannel0::handler_in(),
+            #[cfg(not(esp32c2))]
+            1 => DmaChannel1::handler_in(),
+            #[cfg(not(esp32c2))]
+            2 => DmaChannel2::handler_in(),
+            #[cfg(esp32s3)]
+            3 => DmaChannel3::handler_in(),
+            #[cfg(esp32s3)]
+            4 => DmaChannel4::handler_in(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn peripheral_interrupt_in(&self) -> Option<Interrupt> {
+        match self.number() {
+            0 => DmaChannel0::isr_in(),
+            #[cfg(not(esp32c2))]
+            1 => DmaChannel1::isr_in(),
+            #[cfg(not(esp32c2))]
+            2 => DmaChannel2::isr_in(),
+            #[cfg(esp32s3)]
+            3 => DmaChannel3::isr_in(),
+            #[cfg(esp32s3)]
+            4 => DmaChannel4::isr_in(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// An arbitrary GDMA channel
@@ -35,36 +95,6 @@ impl crate::private::Sealed for AnyGdmaChannel {}
 impl DmaChannel for AnyGdmaChannel {
     type Rx = ChannelRxImpl<Self>;
     type Tx = ChannelTxImpl<Self>;
-
-    fn async_handler<M: Mode>(ch: &Channel<'_, Self, M>) -> InterruptHandler {
-        match ch.tx.tx_impl.0.number() {
-            0 => DmaChannel0::handler(),
-            #[cfg(not(esp32c2))]
-            1 => DmaChannel1::handler(),
-            #[cfg(not(esp32c2))]
-            2 => DmaChannel2::handler(),
-            #[cfg(esp32s3)]
-            3 => DmaChannel3::handler(),
-            #[cfg(esp32s3)]
-            4 => DmaChannel4::handler(),
-            _ => unreachable!(),
-        }
-    }
-
-    fn interrupts<M: Mode>(ch: &Channel<'_, Self, M>) -> &'static [Interrupt] {
-        match ch.tx.tx_impl.0.number() {
-            0 => DmaChannel0::isrs(),
-            #[cfg(not(esp32c2))]
-            1 => DmaChannel1::isrs(),
-            #[cfg(not(esp32c2))]
-            2 => DmaChannel2::isrs(),
-            #[cfg(esp32s3)]
-            3 => DmaChannel3::isrs(),
-            #[cfg(esp32s3)]
-            4 => DmaChannel4::isrs(),
-            _ => unreachable!(),
-        }
-    }
 }
 
 #[non_exhaustive]
@@ -201,6 +231,14 @@ impl<C: GdmaChannel> TxRegisterAccess for ChannelTxImpl<C> {
             .read()
             .out_eof_des_addr()
             .bits() as _
+    }
+
+    fn async_handler(&self) -> Option<InterruptHandler> {
+        self.0.async_handler_out()
+    }
+
+    fn peripheral_interrupt(&self) -> Option<Interrupt> {
+        self.0.peripheral_interrupt_out()
     }
 }
 
@@ -385,6 +423,14 @@ impl<C: GdmaChannel> RxRegisterAccess for ChannelRxImpl<C> {
             .in_conf0()
             .modify(|_, w| w.mem_trans_en().bit(value));
     }
+
+    fn async_handler(&self) -> Option<InterruptHandler> {
+        self.0.async_handler_in()
+    }
+
+    fn peripheral_interrupt(&self) -> Option<Interrupt> {
+        self.0.peripheral_interrupt_in()
+    }
 }
 
 impl<C: GdmaChannel> InterruptAccess<DmaRxInterrupt> for ChannelRxImpl<C> {
@@ -481,7 +527,7 @@ impl<CH: DmaChannel, M: Mode> Channel<'_, CH, M> {
 }
 
 macro_rules! impl_channel {
-    ($num: literal, $async_handler: path, $($interrupt: ident),* ) => {
+    ($num:literal, $interrupt_in:ident, $async_handler:path $(, $interrupt_out:ident , $async_handler_out:path)? ) => {
         paste::paste! {
             /// A description of a specific GDMA channel
             #[non_exhaustive]
@@ -490,26 +536,26 @@ macro_rules! impl_channel {
             impl crate::private::Sealed for [<DmaChannel $num>] {}
 
             impl [<DmaChannel $num>] {
-                fn handler() -> InterruptHandler {
-                    $async_handler
+                fn handler_in() -> Option<InterruptHandler> {
+                    Some($async_handler)
                 }
 
-                fn isrs() -> &'static [Interrupt] {
-                    &[$(Interrupt::$interrupt),*]
+                fn isr_in() -> Option<Interrupt> {
+                    Some(Interrupt::$interrupt_in)
+                }
+
+                fn handler_out() -> Option<InterruptHandler> {
+                    $crate::if_set! { $(Some($async_handler_out))?, None }
+                }
+
+                fn isr_out() -> Option<Interrupt> {
+                    $crate::if_set! { $(Some(Interrupt::$interrupt_out))?, None }
                 }
             }
 
             impl DmaChannel for [<DmaChannel $num>] {
                 type Rx = ChannelRxImpl<SpecificGdmaChannel<$num>>;
                 type Tx = ChannelTxImpl<SpecificGdmaChannel<$num>>;
-
-                fn async_handler<M: Mode>(_ch: &Channel<'_, Self, M>) -> InterruptHandler {
-                    Self::handler()
-                }
-
-                fn interrupts<M: Mode>(_ch: &Channel<'_, Self, M>,) -> &'static [Interrupt] {
-                    Self::isrs()
-                }
             }
 
             impl DmaChannelConvert<AnyGdmaChannel> for [<DmaChannel $num>] {
@@ -541,7 +587,6 @@ macro_rules! impl_channel {
                     let mut this = Channel {
                         tx: ChannelTx::new(ChannelTxImpl(SpecificGdmaChannel::<$num> {})),
                         rx: ChannelRx::new(ChannelRxImpl(SpecificGdmaChannel::<$num> {})),
-                        phantom: PhantomData,
                     };
 
                     this.configure(burst_mode, priority);
@@ -553,27 +598,29 @@ macro_rules! impl_channel {
     };
 }
 
+use super::asynch::interrupt as asynch_handler;
+
 cfg_if::cfg_if! {
     if #[cfg(esp32c2)] {
         const CHANNEL_COUNT: usize = 1;
-        impl_channel!(0, super::asynch::interrupt::interrupt_handler_ch0, DMA_CH0);
+        impl_channel!(0, DMA_CH0, asynch_handler::interrupt_handler_ch0);
     } else if #[cfg(esp32c3)] {
         const CHANNEL_COUNT: usize = 3;
-        impl_channel!(0, super::asynch::interrupt::interrupt_handler_ch0, DMA_CH0);
-        impl_channel!(1, super::asynch::interrupt::interrupt_handler_ch1, DMA_CH1);
-        impl_channel!(2, super::asynch::interrupt::interrupt_handler_ch2, DMA_CH2);
+        impl_channel!(0, DMA_CH0, asynch_handler::interrupt_handler_ch0);
+        impl_channel!(1, DMA_CH1, asynch_handler::interrupt_handler_ch1);
+        impl_channel!(2, DMA_CH2, asynch_handler::interrupt_handler_ch2);
     } else if #[cfg(any(esp32c6, esp32h2))] {
         const CHANNEL_COUNT: usize = 3;
-        impl_channel!(0, super::asynch::interrupt::interrupt_handler_ch0, DMA_IN_CH0, DMA_OUT_CH0);
-        impl_channel!(1, super::asynch::interrupt::interrupt_handler_ch1, DMA_IN_CH1, DMA_OUT_CH1);
-        impl_channel!(2, super::asynch::interrupt::interrupt_handler_ch2, DMA_IN_CH2, DMA_OUT_CH2);
+        impl_channel!(0, DMA_IN_CH0, asynch_handler::interrupt_handler_ch0, DMA_OUT_CH0, asynch_handler::interrupt_handler_ch0);
+        impl_channel!(1, DMA_IN_CH1, asynch_handler::interrupt_handler_ch1, DMA_OUT_CH1, asynch_handler::interrupt_handler_ch1);
+        impl_channel!(2, DMA_IN_CH2, asynch_handler::interrupt_handler_ch2, DMA_OUT_CH2, asynch_handler::interrupt_handler_ch2);
     } else if #[cfg(esp32s3)] {
         const CHANNEL_COUNT: usize = 5;
-        impl_channel!(0, super::asynch::interrupt::interrupt_handler_ch0, DMA_IN_CH0, DMA_OUT_CH0);
-        impl_channel!(1, super::asynch::interrupt::interrupt_handler_ch1, DMA_IN_CH1, DMA_OUT_CH1);
-        impl_channel!(2, super::asynch::interrupt::interrupt_handler_ch2, DMA_IN_CH2, DMA_OUT_CH2);
-        impl_channel!(3, super::asynch::interrupt::interrupt_handler_ch3, DMA_IN_CH3, DMA_OUT_CH3);
-        impl_channel!(4, super::asynch::interrupt::interrupt_handler_ch4, DMA_IN_CH4, DMA_OUT_CH4);
+        impl_channel!(0, DMA_IN_CH0, asynch_handler::interrupt_handler_ch0, DMA_OUT_CH0, asynch_handler::interrupt_handler_ch0);
+        impl_channel!(1, DMA_IN_CH1, asynch_handler::interrupt_handler_ch1, DMA_OUT_CH1, asynch_handler::interrupt_handler_ch1);
+        impl_channel!(2, DMA_IN_CH2, asynch_handler::interrupt_handler_ch2, DMA_OUT_CH2, asynch_handler::interrupt_handler_ch2);
+        impl_channel!(3, DMA_IN_CH3, asynch_handler::interrupt_handler_ch3, DMA_OUT_CH3, asynch_handler::interrupt_handler_ch3);
+        impl_channel!(4, DMA_IN_CH4, asynch_handler::interrupt_handler_ch4, DMA_OUT_CH4, asynch_handler::interrupt_handler_ch4);
     }
 }
 

--- a/esp-hal/src/dma/m2m.rs
+++ b/esp-hal/src/dma/m2m.rs
@@ -190,11 +190,11 @@ where
     }
 }
 
-impl<'d, MODE> DmaSupportRx for Mem2Mem<'d, MODE>
+impl<'d, M> DmaSupportRx for Mem2Mem<'d, M>
 where
-    MODE: Mode,
+    M: Mode,
 {
-    type RX = ChannelRx<'d, AnyGdmaChannel>;
+    type RX = ChannelRx<'d, AnyGdmaChannel, M>;
 
     fn rx(&mut self) -> &mut Self::RX {
         &mut self.channel.rx

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1692,7 +1692,7 @@ where
             self.set_interrupt_handler(handler);
         }
         ChannelRx {
-            burst_mode: false,
+            burst_mode: self.burst_mode,
             rx_impl: self.rx_impl,
             _phantom: PhantomData,
         }
@@ -1725,7 +1725,7 @@ where
             crate::interrupt::disable(Cpu::current(), interrupt);
         }
         ChannelRx {
-            burst_mode: false,
+            burst_mode: self.burst_mode,
             rx_impl: self.rx_impl,
             _phantom: PhantomData,
         }
@@ -1973,7 +1973,7 @@ where
             self.set_interrupt_handler(handler);
         }
         ChannelTx {
-            burst_mode: false,
+            burst_mode: self.burst_mode,
             tx_impl: self.tx_impl,
             _phantom: PhantomData,
         }
@@ -2006,7 +2006,7 @@ where
             crate::interrupt::disable(Cpu::current(), interrupt);
         }
         ChannelTx {
-            burst_mode: false,
+            burst_mode: self.burst_mode,
             tx_impl: self.tx_impl,
             _phantom: PhantomData,
         }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1571,12 +1571,6 @@ pub trait DmaChannel: crate::private::Sealed + Sized {
 
     /// A description of the TX half of a DMA Channel.
     type Tx: TxRegisterAccess + InterruptAccess<DmaTxInterrupt>;
-
-    /// Returns the async interrupt handler.
-    fn async_handler<M: Mode>(ch: &Channel<'_, Self, M>) -> InterruptHandler;
-
-    /// Returns the interrupt.
-    fn interrupts<M: Mode>(ch: &Channel<'_, Self, M>) -> &'static [Interrupt];
 }
 
 #[doc(hidden)]
@@ -1666,16 +1660,17 @@ pub trait Rx: crate::private::Sealed {
 // DMA receive channel
 #[non_exhaustive]
 #[doc(hidden)]
-pub struct ChannelRx<'a, CH>
+pub struct ChannelRx<'a, CH, M>
 where
     CH: DmaChannel,
 {
     pub(crate) burst_mode: bool,
     pub(crate) rx_impl: CH::Rx,
+    pub(crate) mode: PhantomData<M>,
     pub(crate) _phantom: PhantomData<(&'a (), CH)>,
 }
 
-impl<'a, CH> ChannelRx<'a, CH>
+impl<'a, CH> ChannelRx<'a, CH, Blocking>
 where
     CH: DmaChannel,
 {
@@ -1688,19 +1683,74 @@ where
         Self {
             burst_mode: false,
             rx_impl,
+            mode: PhantomData,
             _phantom: PhantomData,
         }
     }
 
+    /// Converts a blocking channel to an async channel.
+    pub(crate) fn into_async(mut self) -> ChannelRx<'a, CH, Async> {
+        if let Some(handler) = self.rx_impl.async_handler() {
+            self.set_interrupt_handler(handler);
+        }
+        ChannelRx {
+            burst_mode: false,
+            rx_impl: self.rx_impl,
+            mode: PhantomData,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn set_interrupt_handler(&mut self, handler: InterruptHandler)
+    where
+        CH: DmaChannel,
+    {
+        self.unlisten_in(EnumSet::all());
+        self.clear_in(EnumSet::all());
+
+        if let Some(interrupt) = self.rx_impl.peripheral_interrupt() {
+            for core in crate::Cpu::other() {
+                crate::interrupt::disable(core, interrupt);
+            }
+            unsafe { crate::interrupt::bind_interrupt(interrupt, handler.handler()) };
+            unwrap!(crate::interrupt::enable(interrupt, handler.priority()));
+        }
+    }
+}
+
+impl<'a, CH> ChannelRx<'a, CH, Async>
+where
+    CH: DmaChannel,
+{
+    /// Converts an async channel into a blocking channel.
+    pub(crate) fn into_blocking(self) -> ChannelRx<'a, CH, Blocking> {
+        if let Some(interrupt) = self.rx_impl.peripheral_interrupt() {
+            crate::interrupt::disable(Cpu::current(), interrupt);
+        }
+        ChannelRx {
+            burst_mode: false,
+            rx_impl: self.rx_impl,
+            mode: PhantomData,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, CH, M> ChannelRx<'a, CH, M>
+where
+    CH: DmaChannel,
+    M: Mode,
+{
     /// Return a less specific (degraded) version of this channel.
     #[doc(hidden)]
-    pub fn degrade<DEG: DmaChannel>(self) -> ChannelRx<'a, DEG>
+    pub fn degrade<DEG: DmaChannel>(self) -> ChannelRx<'a, DEG, M>
     where
         CH: DmaChannelConvert<DEG>,
     {
         ChannelRx {
             burst_mode: self.burst_mode,
             rx_impl: CH::degrade_rx(self.rx_impl),
+            mode: PhantomData,
             _phantom: PhantomData,
         }
     }
@@ -1712,11 +1762,17 @@ where
     }
 }
 
-impl<CH> crate::private::Sealed for ChannelRx<'_, CH> where CH: DmaChannel {}
-
-impl<CH> Rx for ChannelRx<'_, CH>
+impl<CH, M> crate::private::Sealed for ChannelRx<'_, CH, M>
 where
     CH: DmaChannel,
+    M: Mode,
+{
+}
+
+impl<CH, M> Rx for ChannelRx<'_, CH, M>
+where
+    CH: DmaChannel,
+    M: Mode,
 {
     unsafe fn prepare_transfer_without_start(
         &mut self,
@@ -1894,17 +1950,18 @@ pub trait Tx: crate::private::Sealed {
 
 /// DMA transmit channel
 #[doc(hidden)]
-pub struct ChannelTx<'a, CH>
+pub struct ChannelTx<'a, CH, M>
 where
     CH: DmaChannel,
 {
     #[allow(unused)]
     pub(crate) burst_mode: bool,
     pub(crate) tx_impl: CH::Tx,
+    pub(crate) mode: PhantomData<M>,
     pub(crate) _phantom: PhantomData<(&'a (), CH)>,
 }
 
-impl<'a, CH> ChannelTx<'a, CH>
+impl<'a, CH> ChannelTx<'a, CH, Blocking>
 where
     CH: DmaChannel,
 {
@@ -1912,19 +1969,74 @@ where
         Self {
             burst_mode: false,
             tx_impl,
+            mode: PhantomData,
             _phantom: PhantomData,
         }
     }
 
+    /// Converts a blocking channel to an async channel.
+    pub(crate) fn into_async(mut self) -> ChannelTx<'a, CH, Async> {
+        if let Some(handler) = self.tx_impl.async_handler() {
+            self.set_interrupt_handler(handler);
+        }
+        ChannelTx {
+            burst_mode: false,
+            tx_impl: self.tx_impl,
+            mode: PhantomData,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn set_interrupt_handler(&mut self, handler: InterruptHandler)
+    where
+        CH: DmaChannel,
+    {
+        self.unlisten_out(EnumSet::all());
+        self.clear_out(EnumSet::all());
+
+        if let Some(interrupt) = self.tx_impl.peripheral_interrupt() {
+            for core in crate::Cpu::other() {
+                crate::interrupt::disable(core, interrupt);
+            }
+            unsafe { crate::interrupt::bind_interrupt(interrupt, handler.handler()) };
+            unwrap!(crate::interrupt::enable(interrupt, handler.priority()));
+        }
+    }
+}
+
+impl<'a, CH> ChannelTx<'a, CH, Async>
+where
+    CH: DmaChannel,
+{
+    /// Converts an async channel into a blocking channel.
+    pub(crate) fn into_blocking(self) -> ChannelTx<'a, CH, Blocking> {
+        if let Some(interrupt) = self.tx_impl.peripheral_interrupt() {
+            crate::interrupt::disable(Cpu::current(), interrupt);
+        }
+        ChannelTx {
+            burst_mode: false,
+            tx_impl: self.tx_impl,
+            mode: PhantomData,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, CH, M> ChannelTx<'a, CH, M>
+where
+    CH: DmaChannel,
+    M: Mode,
+{
     /// Return a less specific (degraded) version of this channel.
     #[doc(hidden)]
-    pub fn degrade<DEG: DmaChannel>(self) -> ChannelTx<'a, DEG>
+    pub fn degrade<DEG: DmaChannel>(self) -> ChannelTx<'a, DEG, M>
     where
         CH: DmaChannelConvert<DEG>,
     {
         ChannelTx {
             burst_mode: self.burst_mode,
             tx_impl: CH::degrade_tx(self.tx_impl),
+            mode: PhantomData,
             _phantom: PhantomData,
         }
     }
@@ -1936,11 +2048,17 @@ where
     }
 }
 
-impl<CH> crate::private::Sealed for ChannelTx<'_, CH> where CH: DmaChannel {}
-
-impl<CH> Tx for ChannelTx<'_, CH>
+impl<CH, M> crate::private::Sealed for ChannelTx<'_, CH, M>
 where
     CH: DmaChannel,
+    M: Mode,
+{
+}
+
+impl<CH, M> Tx for ChannelTx<'_, CH, M>
+where
+    CH: DmaChannel,
+    M: Mode,
 {
     unsafe fn prepare_transfer_without_start(
         &mut self,
@@ -2116,6 +2234,9 @@ pub trait RegisterAccess: crate::private::Sealed {
 pub trait RxRegisterAccess: RegisterAccess {
     #[cfg(gdma)]
     fn set_mem2mem_mode(&self, value: bool);
+
+    fn peripheral_interrupt(&self) -> Option<Interrupt>;
+    fn async_handler(&self) -> Option<InterruptHandler>;
 }
 
 #[doc(hidden)]
@@ -2125,6 +2246,9 @@ pub trait TxRegisterAccess: RegisterAccess {
 
     /// Outlink descriptor address when EOF occurs of Tx channel.
     fn last_dscr_address(&self) -> usize;
+
+    fn peripheral_interrupt(&self) -> Option<Interrupt>;
+    fn async_handler(&self) -> Option<InterruptHandler>;
 }
 
 #[doc(hidden)]
@@ -2154,10 +2278,9 @@ where
     M: Mode,
 {
     /// RX half of the channel
-    pub rx: ChannelRx<'d, CH>,
+    pub rx: ChannelRx<'d, CH, M>,
     /// TX half of the channel
-    pub tx: ChannelTx<'d, CH>,
-    pub(crate) phantom: PhantomData<M>,
+    pub tx: ChannelTx<'d, CH, M>,
 }
 
 impl<'d, C> Channel<'d, C, Blocking>
@@ -2171,15 +2294,8 @@ where
     where
         C: DmaChannel,
     {
-        self.unlisten(EnumSet::all());
-        self.clear_interrupts(EnumSet::all());
-        for interrupt in C::interrupts(self).iter().copied() {
-            for core in crate::Cpu::other() {
-                crate::interrupt::disable(core, interrupt);
-            }
-            unsafe { crate::interrupt::bind_interrupt(interrupt, handler.handler()) };
-            unwrap!(crate::interrupt::enable(interrupt, handler.priority()));
-        }
+        self.rx.set_interrupt_handler(handler);
+        self.tx.set_interrupt_handler(handler);
     }
 
     /// Listen for the given interrupts
@@ -2226,18 +2342,15 @@ where
 
     /// Configure the channel.
     pub fn configure(&mut self, burst_mode: bool, priority: DmaPriority) {
-        self.tx.configure(burst_mode, priority);
         self.rx.configure(burst_mode, priority);
+        self.tx.configure(burst_mode, priority);
     }
 
     /// Converts a blocking channel to an async channel.
-    pub fn into_async(mut self) -> Channel<'d, C, Async> {
-        self.set_interrupt_handler(C::async_handler(&self));
-
+    pub fn into_async(self) -> Channel<'d, C, Async> {
         Channel {
-            tx: self.tx,
-            rx: self.rx,
-            phantom: PhantomData,
+            rx: self.rx.into_async(),
+            tx: self.tx.into_async(),
         }
     }
 }
@@ -2248,14 +2361,9 @@ where
 {
     /// Converts an async channel to a blocking channel.
     pub fn into_blocking(self) -> Channel<'d, C, Blocking> {
-        for interrupt in C::interrupts(&self).iter().copied() {
-            crate::interrupt::disable(Cpu::current(), interrupt);
-        }
-
         Channel {
-            tx: self.tx,
-            rx: self.rx,
-            phantom: PhantomData,
+            rx: self.rx.into_blocking(),
+            tx: self.tx.into_blocking(),
         }
     }
 }
@@ -2286,7 +2394,6 @@ where
         Channel {
             rx: self.rx.degrade(),
             tx: self.tx.degrade(),
-            phantom: PhantomData,
         }
     }
 }

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -32,6 +32,9 @@ pub trait PdmaChannel: crate::private::Sealed {
     fn tx_waker(&self) -> &'static AtomicWaker;
     fn rx_waker(&self) -> &'static AtomicWaker;
     fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool;
+
+    fn peripheral_interrupt(&self) -> Interrupt;
+    fn async_handler(&self) -> InterruptHandler;
 }
 
 #[doc(hidden)]
@@ -106,6 +109,14 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> TxRegisterAccess for SpiD
     fn last_dscr_address(&self) -> usize {
         let spi = self.0.register_block();
         spi.out_eof_des_addr().read().dma_out_eof_des_addr().bits() as usize
+    }
+
+    fn peripheral_interrupt(&self) -> Option<Interrupt> {
+        None
+    }
+
+    fn async_handler(&self) -> Option<InterruptHandler> {
+        None
     }
 }
 
@@ -241,7 +252,15 @@ impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RegisterAccess for SpiDma
     }
 }
 
-impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RxRegisterAccess for SpiDmaRxChannelImpl<C> {}
+impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> RxRegisterAccess for SpiDmaRxChannelImpl<C> {
+    fn peripheral_interrupt(&self) -> Option<Interrupt> {
+        Some(self.0.peripheral_interrupt())
+    }
+
+    fn async_handler(&self) -> Option<InterruptHandler> {
+        Some(self.0.async_handler())
+    }
+}
 
 impl<C: PdmaChannel<RegisterBlock = SpiRegisterBlock>> InterruptAccess<DmaRxInterrupt>
     for SpiDmaRxChannelImpl<C>
@@ -343,27 +362,9 @@ macro_rules! ImplSpiChannel {
             #[non_exhaustive]
             pub struct [<Spi $num DmaChannel>] {}
 
-            impl [<Spi $num DmaChannel>] {
-                fn handler() -> InterruptHandler {
-                    super::asynch::interrupt::[< interrupt_handler_spi $num _dma >]
-                }
-
-                fn isrs() -> &'static [Interrupt] {
-                    &[Interrupt::[< SPI $num _DMA >]]
-                }
-            }
-
             impl DmaChannel for [<Spi $num DmaChannel>] {
                 type Rx = SpiDmaRxChannelImpl<Self>;
                 type Tx = SpiDmaTxChannelImpl<Self>;
-
-                fn async_handler<M: Mode>(_ch: &Channel<'_, Self, M>) -> InterruptHandler {
-                    Self::handler()
-                }
-
-                fn interrupts<M: Mode>(_ch: &Channel<'_, Self, M>) -> &'static [Interrupt] {
-                    Self::isrs()
-                }
             }
 
             impl DmaChannelExt for [<Spi $num DmaChannel>] {
@@ -393,6 +394,14 @@ macro_rules! ImplSpiChannel {
                 fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
                     peripheral == DmaPeripheral::[<Spi $num>]
                 }
+
+                fn peripheral_interrupt(&self) -> Interrupt {
+                    Interrupt::[< SPI $num _DMA >]
+                }
+
+                fn async_handler(&self) -> InterruptHandler {
+                    super::asynch::interrupt::[< interrupt_handler_spi $num _dma >]
+                }
             }
 
             impl DmaChannelConvert<AnySpiDmaChannel> for [<Spi $num DmaChannel>] {
@@ -420,7 +429,6 @@ macro_rules! ImplSpiChannel {
                     let mut this = Channel {
                         tx: ChannelTx::new(SpiDmaTxChannelImpl([<Spi $num DmaChannel>] {})),
                         rx: ChannelRx::new(SpiDmaRxChannelImpl([<Spi $num DmaChannel>] {})),
-                        phantom: PhantomData,
                     };
 
                     this.configure(burst_mode, priority);
@@ -517,6 +525,14 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> TxRegisterAccess for I2sD
             .read()
             .out_eof_des_addr()
             .bits() as usize
+    }
+
+    fn peripheral_interrupt(&self) -> Option<Interrupt> {
+        None
+    }
+
+    fn async_handler(&self) -> Option<InterruptHandler> {
+        None
     }
 }
 
@@ -658,7 +674,15 @@ impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RegisterAccess for I2sDma
     }
 }
 
-impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RxRegisterAccess for I2sDmaRxChannelImpl<C> {}
+impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> RxRegisterAccess for I2sDmaRxChannelImpl<C> {
+    fn peripheral_interrupt(&self) -> Option<Interrupt> {
+        Some(self.0.peripheral_interrupt())
+    }
+
+    fn async_handler(&self) -> Option<InterruptHandler> {
+        Some(self.0.async_handler())
+    }
+}
 
 impl<C: PdmaChannel<RegisterBlock = I2sRegisterBlock>> InterruptAccess<DmaRxInterrupt>
     for I2sDmaRxChannelImpl<C>
@@ -756,27 +780,9 @@ macro_rules! ImplI2sChannel {
 
             impl $crate::private::Sealed for [<I2s $num DmaChannel>] {}
 
-            impl [<I2s $num DmaChannel>] {
-                fn handler() -> InterruptHandler {
-                    super::asynch::interrupt::[< interrupt_handler_i2s $num _dma >]
-                }
-
-                fn isrs() -> &'static [Interrupt] {
-                    &[Interrupt::[< I2S $num >]]
-                }
-            }
-
             impl DmaChannel for [<I2s $num DmaChannel>] {
                 type Rx = I2sDmaRxChannelImpl<Self>;
                 type Tx = I2sDmaTxChannelImpl<Self>;
-
-                fn async_handler<M: Mode>(_ch: &Channel<'_, Self, M>) -> InterruptHandler {
-                    Self::handler()
-                }
-
-                fn interrupts<M: Mode>(_ch: &Channel<'_, Self, M>) -> &'static [Interrupt] {
-                    Self::isrs()
-                }
             }
 
             impl DmaChannelExt for [<I2s $num DmaChannel>] {
@@ -805,6 +811,14 @@ macro_rules! ImplI2sChannel {
                 fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
                     peripheral == DmaPeripheral::[<I2s $num>]
                 }
+
+                fn peripheral_interrupt(&self) -> Interrupt {
+                    Interrupt::[< I2S $num >]
+                }
+
+                fn async_handler(&self) -> InterruptHandler {
+                    super::asynch::interrupt::[< interrupt_handler_i2s $num _dma >]
+                }
             }
 
             impl DmaChannelConvert<AnyI2sDmaChannel> for [<I2s $num DmaChannel>] {
@@ -829,7 +843,6 @@ macro_rules! ImplI2sChannel {
                     let mut this = Channel {
                         tx: ChannelTx::new(I2sDmaTxChannelImpl([<I2s $num DmaChannel>] {})),
                         rx: ChannelRx::new(I2sDmaRxChannelImpl([<I2s $num DmaChannel>] {})),
-                        phantom: PhantomData,
                     };
 
                     this.configure(burst_mode, priority);
@@ -928,20 +941,6 @@ impl crate::private::Sealed for AnySpiDmaChannel {}
 impl DmaChannel for AnySpiDmaChannel {
     type Rx = SpiDmaRxChannelImpl<AnySpiDmaChannelInner>;
     type Tx = SpiDmaTxChannelImpl<AnySpiDmaChannelInner>;
-
-    fn async_handler<M: Mode>(ch: &Channel<'_, Self, M>) -> InterruptHandler {
-        match &ch.tx.tx_impl.0 {
-            AnySpiDmaChannelInner::Spi2(_) => Spi2DmaChannel::handler(),
-            AnySpiDmaChannelInner::Spi3(_) => Spi3DmaChannel::handler(),
-        }
-    }
-
-    fn interrupts<M: Mode>(ch: &Channel<'_, Self, M>) -> &'static [Interrupt] {
-        match &ch.tx.tx_impl.0 {
-            AnySpiDmaChannelInner::Spi2(_) => Spi2DmaChannel::isrs(),
-            AnySpiDmaChannelInner::Spi3(_) => Spi3DmaChannel::isrs(),
-        }
-    }
 }
 
 crate::any_enum! {
@@ -966,6 +965,8 @@ impl PdmaChannel for AnySpiDmaChannelInner {
             fn tx_waker(&self) -> &'static AtomicWaker;
             fn rx_waker(&self) -> &'static AtomicWaker;
             fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool;
+            fn peripheral_interrupt(&self) -> Interrupt;
+            fn async_handler(&self) -> InterruptHandler;
         }
     }
 }
@@ -978,22 +979,6 @@ impl crate::private::Sealed for AnyI2sDmaChannel {}
 impl DmaChannel for AnyI2sDmaChannel {
     type Rx = I2sDmaRxChannelImpl<AnyI2sDmaChannelInner>;
     type Tx = I2sDmaTxChannelImpl<AnyI2sDmaChannelInner>;
-
-    fn async_handler<M: Mode>(ch: &Channel<'_, Self, M>) -> InterruptHandler {
-        match &ch.tx.tx_impl.0 {
-            AnyI2sDmaChannelInner::I2s0(_) => I2s0DmaChannel::handler(),
-            #[cfg(i2s1)]
-            AnyI2sDmaChannelInner::I2s1(_) => I2s1DmaChannel::handler(),
-        }
-    }
-
-    fn interrupts<M: Mode>(ch: &Channel<'_, Self, M>) -> &'static [Interrupt] {
-        match &ch.tx.tx_impl.0 {
-            AnyI2sDmaChannelInner::I2s0(_) => I2s0DmaChannel::isrs(),
-            #[cfg(i2s1)]
-            AnyI2sDmaChannelInner::I2s1(_) => I2s1DmaChannel::isrs(),
-        }
-    }
 }
 
 crate::any_enum! {
@@ -1020,6 +1005,8 @@ impl PdmaChannel for AnyI2sDmaChannelInner {
             fn tx_waker(&self) -> &'static AtomicWaker;
             fn rx_waker(&self) -> &'static AtomicWaker;
             fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool;
+            fn peripheral_interrupt(&self) -> Interrupt;
+            fn async_handler(&self) -> InterruptHandler;
         }
     }
 }

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -425,7 +425,7 @@ macro_rules! ImplSpiChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<Spi $num DmaChannel>], Blocking> {
+                ) -> Channel<'a, Blocking, [<Spi $num DmaChannel>]> {
                     let mut this = Channel {
                         tx: ChannelTx::new(SpiDmaTxChannelImpl([<Spi $num DmaChannel>] {})),
                         rx: ChannelRx::new(SpiDmaRxChannelImpl([<Spi $num DmaChannel>] {})),
@@ -839,7 +839,7 @@ macro_rules! ImplI2sChannel {
                     self,
                     burst_mode: bool,
                     priority: DmaPriority,
-                ) -> Channel<'a, [<I2s $num DmaChannel>], Blocking> {
+                ) -> Channel<'a, Blocking, [<I2s $num DmaChannel>]> {
                     let mut this = Channel {
                         tx: ChannelTx::new(I2sDmaTxChannelImpl([<I2s $num DmaChannel>] {})),
                         rx: ChannelRx::new(I2sDmaRxChannelImpl([<I2s $num DmaChannel>] {})),
@@ -917,9 +917,10 @@ impl<'d> Dma<'d> {
     }
 }
 
-impl<'d, C, M: Mode> Channel<'d, C, M>
+impl<'d, CH, M> Channel<'d, M, CH>
 where
-    C: DmaChannel,
+    CH: DmaChannel,
+    M: Mode,
 {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible(&self, peripheral: &PeripheralRef<'_, impl DmaEligible>) {

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -272,7 +272,7 @@ where
         standard: Standard,
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
-        channel: Channel<'d, CH, DmaMode>,
+        channel: Channel<'d, DmaMode, CH>,
         rx_descriptors: &'static mut [DmaDescriptor],
         tx_descriptors: &'static mut [DmaDescriptor],
     ) -> Self
@@ -371,14 +371,14 @@ impl<'d> I2s<'d, Blocking> {
         standard: Standard,
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
-        channel: Channel<'d, CH, DM>,
+        channel: Channel<'d, DM, CH>,
         rx_descriptors: &'static mut [DmaDescriptor],
         tx_descriptors: &'static mut [DmaDescriptor],
     ) -> Self
     where
         CH: DmaChannelConvert<<AnyI2s as DmaEligible>::Dma>,
         DM: Mode,
-        Channel<'d, CH, Blocking>: From<Channel<'d, CH, DM>>,
+        Channel<'d, Blocking, CH>: From<Channel<'d, DM, CH>>,
     {
         Self::new_typed(
             i2s.map_into(),
@@ -404,14 +404,14 @@ where
         standard: Standard,
         data_format: DataFormat,
         sample_rate: impl Into<fugit::HertzU32>,
-        channel: Channel<'d, CH, DM>,
+        channel: Channel<'d, DM, CH>,
         rx_descriptors: &'static mut [DmaDescriptor],
         tx_descriptors: &'static mut [DmaDescriptor],
     ) -> Self
     where
         CH: DmaChannelConvert<T::Dma>,
         DM: Mode,
-        Channel<'d, CH, Blocking>: From<Channel<'d, CH, DM>>,
+        Channel<'d, Blocking, CH>: From<Channel<'d, DM, CH>>,
     {
         crate::into_ref!(i2s);
         Self::new_internal(
@@ -463,7 +463,7 @@ where
     T: RegisterAccess,
 {
     i2s: PeripheralRef<'d, T>,
-    tx_channel: ChannelTx<'d, T::Dma, DmaMode>,
+    tx_channel: ChannelTx<'d, DmaMode, T::Dma>,
     tx_chain: DescriptorChain,
 }
 
@@ -496,7 +496,7 @@ where
     T: RegisterAccess,
     DmaMode: Mode,
 {
-    type TX = ChannelTx<'d, T::Dma, DmaMode>;
+    type TX = ChannelTx<'d, DmaMode, T::Dma>;
 
     fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
@@ -595,7 +595,7 @@ where
     DmaMode: Mode,
 {
     i2s: PeripheralRef<'d, T>,
-    rx_channel: ChannelRx<'d, T::Dma, DmaMode>,
+    rx_channel: ChannelRx<'d, DmaMode, T::Dma>,
     rx_chain: DescriptorChain,
 }
 
@@ -628,7 +628,7 @@ where
     T: RegisterAccess,
     DmaMode: Mode,
 {
-    type RX = ChannelRx<'d, T::Dma, DmaMode>;
+    type RX = ChannelRx<'d, DmaMode, T::Dma>;
 
     fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
@@ -772,7 +772,7 @@ mod private {
         M: Mode,
     {
         pub i2s: PeripheralRef<'d, T>,
-        pub tx_channel: ChannelTx<'d, T::Dma, M>,
+        pub tx_channel: ChannelTx<'d, M, T::Dma>,
         pub descriptors: &'static mut [DmaDescriptor],
     }
 
@@ -829,7 +829,7 @@ mod private {
         M: Mode,
     {
         pub i2s: PeripheralRef<'d, T>,
-        pub rx_channel: ChannelRx<'d, T::Dma, M>,
+        pub rx_channel: ChannelRx<'d, M, T::Dma>,
         pub descriptors: &'static mut [DmaDescriptor],
     }
 

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -176,7 +176,7 @@ where
     I: Instance,
 {
     instance: PeripheralRef<'d, I>,
-    tx_channel: ChannelTx<'d, I::Dma, DM>,
+    tx_channel: ChannelTx<'d, DM, I::Dma>,
 }
 
 impl<'d, DM> I2sParallel<'d, DM>
@@ -186,7 +186,7 @@ where
     /// Create a new I2S Parallel Interface
     pub fn new<CH>(
         i2s: impl Peripheral<P = impl Instance> + 'd,
-        channel: Channel<'d, CH, DM>,
+        channel: Channel<'d, DM, CH>,
         frequency: impl Into<fugit::HertzU32>,
         pins: impl TxPins<'d>,
         clock_pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
@@ -206,7 +206,7 @@ where
     /// Create a new I2S Parallel Interface
     pub fn new_typed<CH>(
         i2s: impl Peripheral<P = I> + 'd,
-        channel: Channel<'d, CH, DM>,
+        channel: Channel<'d, DM, CH>,
         frequency: impl Into<fugit::HertzU32>,
         mut pins: impl TxPins<'d>,
         clock_pin: impl Peripheral<P = impl PeripheralOutput> + 'd,

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -35,7 +35,6 @@
 //!   - `DMA`
 //!   - `system` (to configure and enable the I2S peripheral)
 use core::{
-    marker::PhantomData,
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
 };
@@ -177,8 +176,7 @@ where
     I: Instance,
 {
     instance: PeripheralRef<'d, I>,
-    tx_channel: ChannelTx<'d, I::Dma>,
-    mode: PhantomData<DM>,
+    tx_channel: ChannelTx<'d, I::Dma, DM>,
 }
 
 impl<'d, DM> I2sParallel<'d, DM>
@@ -234,7 +232,6 @@ where
         Self {
             instance: i2s,
             tx_channel: channel.tx,
-            mode: PhantomData,
         }
     }
 

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -126,14 +126,14 @@ pub struct Cam<'d> {
 /// Represents the camera interface with DMA support.
 pub struct Camera<'d> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
-    rx_channel: ChannelRx<'d, <LCD_CAM as DmaEligible>::Dma, Blocking>,
+    rx_channel: ChannelRx<'d, Blocking, <LCD_CAM as DmaEligible>::Dma>,
 }
 
 impl<'d> Camera<'d> {
     /// Creates a new `Camera` instance with DMA support.
     pub fn new<P, CH>(
         cam: Cam<'d>,
-        channel: ChannelRx<'d, CH, Blocking>,
+        channel: ChannelRx<'d, Blocking, CH>,
         _pins: P,
         frequency: HertzU32,
     ) -> Self

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -82,6 +82,7 @@ use crate::{
     lcd_cam::{calculate_clkm, BitOrder, ByteOrder},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
+    Blocking,
 };
 
 /// Generation of GDMA SUC EOF
@@ -125,14 +126,14 @@ pub struct Cam<'d> {
 /// Represents the camera interface with DMA support.
 pub struct Camera<'d> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
-    rx_channel: ChannelRx<'d, <LCD_CAM as DmaEligible>::Dma>,
+    rx_channel: ChannelRx<'d, <LCD_CAM as DmaEligible>::Dma, Blocking>,
 }
 
 impl<'d> Camera<'d> {
     /// Creates a new `Camera` instance with DMA support.
     pub fn new<P, CH>(
         cam: Cam<'d>,
-        channel: ChannelRx<'d, CH>,
+        channel: ChannelRx<'d, CH, Blocking>,
         _pins: P,
         frequency: HertzU32,
     ) -> Self

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -83,21 +83,25 @@ use crate::{
     },
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
+    Blocking,
     Mode,
 };
 
 /// Represents the I8080 LCD interface.
 pub struct I8080<'d, DM: Mode> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
-    tx_channel: ChannelTx<'d, <LCD_CAM as DmaEligible>::Dma>,
-    _phantom: PhantomData<DM>,
+    tx_channel: ChannelTx<'d, <LCD_CAM as DmaEligible>::Dma, Blocking>,
+    _mode: PhantomData<DM>,
 }
 
-impl<'d, DM: Mode> I8080<'d, DM> {
+impl<'d, DM> I8080<'d, DM>
+where
+    DM: Mode,
+{
     /// Creates a new instance of the I8080 LCD interface.
     pub fn new<P, CH>(
         lcd: Lcd<'d, DM>,
-        channel: ChannelTx<'d, CH>,
+        channel: ChannelTx<'d, CH, Blocking>,
         mut pins: P,
         frequency: HertzU32,
         config: Config,
@@ -209,12 +213,10 @@ impl<'d, DM: Mode> I8080<'d, DM> {
         Self {
             lcd_cam,
             tx_channel: channel.degrade(),
-            _phantom: PhantomData,
+            _mode: PhantomData,
         }
     }
-}
 
-impl<'d, DM: Mode> I8080<'d, DM> {
     /// Configures the byte order for data transmission in 16-bit mode.
     /// This must be set to [ByteOrder::default()] when transmitting in 8-bit
     /// mode.

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -90,7 +90,7 @@ use crate::{
 /// Represents the I8080 LCD interface.
 pub struct I8080<'d, DM: Mode> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
-    tx_channel: ChannelTx<'d, <LCD_CAM as DmaEligible>::Dma, Blocking>,
+    tx_channel: ChannelTx<'d, Blocking, <LCD_CAM as DmaEligible>::Dma>,
     _mode: PhantomData<DM>,
 }
 
@@ -101,7 +101,7 @@ where
     /// Creates a new instance of the I8080 LCD interface.
     pub fn new<P, CH>(
         lcd: Lcd<'d, DM>,
-        channel: ChannelTx<'d, CH, Blocking>,
+        channel: ChannelTx<'d, Blocking, CH>,
         mut pins: P,
         frequency: HertzU32,
         config: Config,

--- a/esp-hal/src/macros.rs
+++ b/esp-hal/src/macros.rs
@@ -118,3 +118,16 @@ macro_rules! any_peripheral {
         }
     };
 }
+
+/// Macro to choose between two expressions. Useful for implementing "else" for
+/// `$()?` macro syntax.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! if_set {
+    (, $not_set:expr) => {
+        $not_set
+    };
+    ($set:expr, $not_set:expr) => {
+        $set
+    };
+}

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -811,7 +811,7 @@ pub struct ParlIoTx<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d, <PARL_IO as DmaEligible>::Dma>,
+    tx_channel: ChannelTx<'d, <PARL_IO as DmaEligible>::Dma, DM>,
     tx_chain: DescriptorChain,
     phantom: PhantomData<DM>,
 }
@@ -890,7 +890,7 @@ pub struct ParlIoRx<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d, <PARL_IO as DmaEligible>::Dma>,
+    rx_channel: ChannelRx<'d, <PARL_IO as DmaEligible>::Dma, DM>,
     rx_chain: DescriptorChain,
     phantom: PhantomData<DM>,
 }
@@ -1034,20 +1034,14 @@ impl<'d> ParlIoFullDuplex<'d, Blocking> {
 
     /// Convert to an async version.
     pub fn into_async(self) -> ParlIoFullDuplex<'d, Async> {
-        let channel = Channel {
-            tx: self.tx.tx_channel,
-            rx: self.rx.rx_channel,
-            phantom: PhantomData::<Blocking>,
-        };
-        let channel = channel.into_async();
         ParlIoFullDuplex {
             tx: TxCreatorFullDuplex {
-                tx_channel: channel.tx,
+                tx_channel: self.tx.tx_channel.into_async(),
                 descriptors: self.tx.descriptors,
                 phantom: PhantomData,
             },
             rx: RxCreatorFullDuplex {
-                rx_channel: channel.rx,
+                rx_channel: self.rx.rx_channel.into_async(),
                 descriptors: self.rx.descriptors,
                 phantom: PhantomData,
             },
@@ -1094,20 +1088,14 @@ impl InterruptConfigurable for ParlIoFullDuplex<'_, Blocking> {
 impl<'d> ParlIoFullDuplex<'d, Async> {
     /// Convert to a blocking version.
     pub fn into_blocking(self) -> ParlIoFullDuplex<'d, Blocking> {
-        let channel = Channel {
-            tx: self.tx.tx_channel,
-            rx: self.rx.rx_channel,
-            phantom: PhantomData::<Async>,
-        };
-        let channel = channel.into_blocking();
         ParlIoFullDuplex {
             tx: TxCreatorFullDuplex {
-                tx_channel: channel.tx,
+                tx_channel: self.tx.tx_channel.into_blocking(),
                 descriptors: self.tx.descriptors,
                 phantom: PhantomData,
             },
             rx: RxCreatorFullDuplex {
-                rx_channel: channel.rx,
+                rx_channel: self.rx.rx_channel.into_blocking(),
                 descriptors: self.rx.descriptors,
                 phantom: PhantomData,
             },
@@ -1372,7 +1360,7 @@ impl<'d, DM> DmaSupportTx for ParlIoTx<'d, DM>
 where
     DM: Mode,
 {
-    type TX = ChannelTx<'d, <PARL_IO as DmaEligible>::Dma>;
+    type TX = ChannelTx<'d, <PARL_IO as DmaEligible>::Dma, DM>;
 
     fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
@@ -1414,7 +1402,7 @@ where
     }
 
     fn start_receive_bytes_dma(
-        rx_channel: &mut ChannelRx<'d, <PARL_IO as DmaEligible>::Dma>,
+        rx_channel: &mut ChannelRx<'d, <PARL_IO as DmaEligible>::Dma, DM>,
         rx_chain: &mut DescriptorChain,
         ptr: *mut u8,
         len: usize,
@@ -1468,7 +1456,7 @@ impl<'d, DM> DmaSupportRx for ParlIoRx<'d, DM>
 where
     DM: Mode,
 {
-    type RX = ChannelRx<'d, <PARL_IO as DmaEligible>::Dma>;
+    type RX = ChannelRx<'d, <PARL_IO as DmaEligible>::Dma, DM>;
 
     fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
@@ -1484,7 +1472,7 @@ pub struct TxCreator<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d, <PARL_IO as DmaEligible>::Dma>,
+    tx_channel: ChannelTx<'d, <PARL_IO as DmaEligible>::Dma, DM>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1494,7 +1482,7 @@ pub struct RxCreator<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d, <PARL_IO as DmaEligible>::Dma>,
+    rx_channel: ChannelRx<'d, <PARL_IO as DmaEligible>::Dma, DM>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1504,7 +1492,7 @@ pub struct TxCreatorFullDuplex<'d, DM>
 where
     DM: Mode,
 {
-    tx_channel: ChannelTx<'d, <PARL_IO as DmaEligible>::Dma>,
+    tx_channel: ChannelTx<'d, <PARL_IO as DmaEligible>::Dma, DM>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }
@@ -1514,7 +1502,7 @@ pub struct RxCreatorFullDuplex<'d, DM>
 where
     DM: Mode,
 {
-    rx_channel: ChannelRx<'d, <PARL_IO as DmaEligible>::Dma>,
+    rx_channel: ChannelRx<'d, <PARL_IO as DmaEligible>::Dma, DM>,
     descriptors: &'static mut [DmaDescriptor],
     phantom: PhantomData<DM>,
 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -474,11 +474,11 @@ where
     /// This method prepares the SPI instance for DMA transfers using SPI
     /// and returns an instance of `SpiDma` that supports DMA
     /// operations.
-    pub fn with_dma<CH, DM>(self, channel: Channel<'d, CH, DM>) -> SpiDma<'d, M, T>
+    pub fn with_dma<CH, DM>(self, channel: Channel<'d, DM, CH>) -> SpiDma<'d, M, T>
     where
         CH: DmaChannelConvert<T::Dma>,
         DM: Mode,
-        Channel<'d, CH, M>: From<Channel<'d, CH, DM>>,
+        Channel<'d, M, CH>: From<Channel<'d, DM, CH>>,
     {
         SpiDma::new(self.spi, channel.into())
     }
@@ -880,7 +880,7 @@ mod dma {
         M: Mode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
-        pub(crate) channel: Channel<'d, T::Dma, M>,
+        pub(crate) channel: Channel<'d, M, T::Dma>,
         tx_transfer_in_progress: bool,
         rx_transfer_in_progress: bool,
         #[cfg(all(esp32, spi_address_workaround))]
@@ -990,7 +990,7 @@ mod dma {
         T: Instance,
         M: Mode,
     {
-        pub(super) fn new<CH>(spi: PeripheralRef<'d, T>, channel: Channel<'d, CH, M>) -> Self
+        pub(super) fn new<CH>(spi: PeripheralRef<'d, T>, channel: Channel<'d, M, CH>) -> Self
         where
             CH: DmaChannelConvert<T::Dma>,
         {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -3003,10 +3003,10 @@ macro_rules! spi_instance {
                         cs: OutputSignal::$cs,
                         sio0_input: InputSignal::$mosi,
                         sio1_output: OutputSignal::$miso,
-                        sio2_output: if_set!($(Some(OutputSignal::$sio2))?, None),
-                        sio2_input: if_set!($(Some(InputSignal::$sio2))?, None),
-                        sio3_output: if_set!($(Some(OutputSignal::$sio3))?, None),
-                        sio3_input: if_set!($(Some(InputSignal::$sio3))?, None),
+                        sio2_output: $crate::if_set!($(Some(OutputSignal::$sio2))?, None),
+                        sio2_input: $crate::if_set!($(Some(InputSignal::$sio2))?, None),
+                        sio3_output: $crate::if_set!($(Some(OutputSignal::$sio3))?, None),
+                        sio3_input: $crate::if_set!($(Some(InputSignal::$sio3))?, None),
                     };
 
                     &INFO
@@ -3020,17 +3020,6 @@ macro_rules! spi_instance {
             )?
         }
     }
-}
-
-/// Macro to choose between two expressions. Useful for implementing "else" for
-/// `$()?` macro syntax.
-macro_rules! if_set {
-    (, $not_set:expr) => {
-        $not_set
-    };
-    ($set:expr, $not_set:expr) => {
-        $set
-    };
 }
 
 #[cfg(spi2)]

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -202,14 +202,14 @@ pub mod dma {
         #[cfg_attr(esp32, doc = "\n\n**Note**: ESP32 only supports Mode 1 and 3.")]
         pub fn with_dma<CH, DM>(
             self,
-            channel: Channel<'d, CH, DM>,
+            channel: Channel<'d, DM, CH>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> SpiDma<'d, M, T>
         where
             CH: DmaChannelConvert<T::Dma>,
             DM: Mode,
-            Channel<'d, CH, M>: From<Channel<'d, CH, DM>>,
+            Channel<'d, M, CH>: From<Channel<'d, DM, CH>>,
         {
             self.spi.info().set_data_mode(self.data_mode, true);
             SpiDma::new(self.spi, channel.into(), rx_descriptors, tx_descriptors)
@@ -223,7 +223,7 @@ pub mod dma {
         M: Mode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
-        pub(crate) channel: Channel<'d, T::Dma, M>,
+        pub(crate) channel: Channel<'d, M, T::Dma>,
         rx_chain: DescriptorChain,
         tx_chain: DescriptorChain,
     }
@@ -262,7 +262,7 @@ pub mod dma {
         T: InstanceDma,
         DmaMode: Mode,
     {
-        type TX = ChannelTx<'d, T::Dma, DmaMode>;
+        type TX = ChannelTx<'d, DmaMode, T::Dma>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -278,7 +278,7 @@ pub mod dma {
         T: InstanceDma,
         DmaMode: Mode,
     {
-        type RX = ChannelRx<'d, T::Dma, DmaMode>;
+        type RX = ChannelRx<'d, DmaMode, T::Dma>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx
@@ -296,7 +296,7 @@ pub mod dma {
     {
         fn new<CH>(
             spi: PeripheralRef<'d, T>,
-            channel: Channel<'d, CH, DmaMode>,
+            channel: Channel<'d, DmaMode, CH>,
             rx_descriptors: &'static mut [DmaDescriptor],
             tx_descriptors: &'static mut [DmaDescriptor],
         ) -> Self

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -262,7 +262,7 @@ pub mod dma {
         T: InstanceDma,
         DmaMode: Mode,
     {
-        type TX = ChannelTx<'d, T::Dma>;
+        type TX = ChannelTx<'d, T::Dma, DmaMode>;
 
         fn tx(&mut self) -> &mut Self::TX {
             &mut self.channel.tx
@@ -278,7 +278,7 @@ pub mod dma {
         T: InstanceDma,
         DmaMode: Mode,
     {
-        type RX = ChannelRx<'d, T::Dma>;
+        type RX = ChannelRx<'d, T::Dma, DmaMode>;
 
         fn rx(&mut self) -> &mut Self::RX {
             &mut self.channel.rx

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -25,7 +25,7 @@ cfg_if::cfg_if! {
 }
 
 struct Context {
-    channel: Channel<'static, AnyGdmaChannel, Blocking>,
+    channel: Channel<'static, Blocking, AnyGdmaChannel>,
     dma_peripheral: DmaPeripheralType,
 }
 

--- a/hil-test/tests/lcd_cam_i8080.rs
+++ b/hil-test/tests/lcd_cam_i8080.rs
@@ -91,27 +91,6 @@ mod tests {
     }
 
     #[test]
-    fn test_i8080_8bit_async_channel(ctx: Context<'static>) {
-        let channel = ctx
-            .dma
-            .channel0
-            .configure(false, DmaPriority::Priority0)
-            .into_async();
-        let pins = TxEightBits::new(NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin);
-
-        let i8080 = I8080::new(
-            ctx.lcd_cam.lcd,
-            channel.tx,
-            pins,
-            20.MHz(),
-            Config::default(),
-        );
-
-        let xfer = i8080.send(Command::<u8>::None, 0, ctx.dma_buf).unwrap();
-        xfer.wait().0.unwrap();
-    }
-
-    #[test]
     fn test_i8080_8bit_is_seen_by_pcnt(ctx: Context<'static>) {
         // FIXME: Update this test to exercise all the I8080 output signals once the
         // issue with configuring pins as outputs after inputs have been sorted

--- a/hil-test/tests/lcd_cam_i8080_async.rs
+++ b/hil-test/tests/lcd_cam_i8080_async.rs
@@ -70,31 +70,4 @@ mod tests {
 
         transfer.wait().0.unwrap();
     }
-
-    #[test]
-    async fn test_i8080_8bit_async_channel(ctx: Context<'static>) {
-        let channel = ctx
-            .dma
-            .channel0
-            .configure(false, DmaPriority::Priority0)
-            .into_async();
-        let pins = TxEightBits::new(NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin);
-
-        let i8080 = I8080::new(
-            ctx.lcd_cam.lcd,
-            channel.tx,
-            pins,
-            20.MHz(),
-            Config::default(),
-        );
-
-        let mut transfer = i8080.send(Command::<u8>::None, 0, ctx.dma_buf).unwrap();
-
-        transfer.wait_for_done().await;
-
-        // This should not block forever and should immediately return.
-        transfer.wait_for_done().await;
-
-        transfer.wait().0.unwrap();
-    }
 }

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -43,7 +43,7 @@ struct Context {
     spi: Spi<'static, Blocking>,
     #[cfg(pcnt)]
     pcnt: esp_hal::peripherals::PCNT,
-    dma_channel: Channel<'static, DmaChannel0, Blocking>,
+    dma_channel: Channel<'static, Blocking, DmaChannel0>,
     gpios: [AnyPin; 3],
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR adds `Mode` type parameters to `ChannelRx` and `ChannelTx`, so that in the future we can independently configure them between blocking and async modes. The PR also swaps the Mode and DMA chanel type params of `Channel`, so that it is consistent with other peripherals - even if we apply different rules to DMA instance typing.