### PR TITLE
C6/H2 Make higher LEDC frequencies work

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed some SysTimer race conditions and panics (#2451)
 - TWAI: accept all messages by default (#2467)
 - I8080: `set_byte_order()` now works correctly in 16-bit mode (#2487)
+- ESP32-C6/ESP32-H2: Make higher LEDC frequencies work (#2520)
 
 ### Removed
 

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -369,6 +369,11 @@ impl<S: crate::ledc::timer::TimerSpeed> Channel<'_, S> {
                 unsafe { w.timer_sel().bits(timer_number) }
             });
         }
+
+        // this is needed to make low duty-resolutions / high frequencies work
+        #[cfg(any(esp32h2, esp32c6))]
+        self.ledc.ch_gamma_wr_addr(self.number as usize).write(|w| unsafe { w.bits(0)} );
+
         self.start_duty_without_fading();
     }
 

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -372,7 +372,9 @@ impl<S: crate::ledc::timer::TimerSpeed> Channel<'_, S> {
 
         // this is needed to make low duty-resolutions / high frequencies work
         #[cfg(any(esp32h2, esp32c6))]
-        self.ledc.ch_gamma_wr_addr(self.number as usize).write(|w| unsafe { w.bits(0)} );
+        self.ledc
+            .ch_gamma_wr_addr(self.number as usize)
+            .write(|w| unsafe { w.bits(0) });
 
         self.start_duty_without_fading();
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #1867

(Note: On H2 we are using a fixed 32 MHz source-clock which means we can't get more than 16 MHz)

#### Testing
Change the example to generate e.g. 20 MHz on C6
