### PR TITLE
[DMA 2/N] Split DMA IN/OUT handlers

### DIFF
--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -611,16 +611,16 @@ cfg_if::cfg_if! {
         impl_channel!(2, DMA_CH2, asynch_handler::interrupt_handler_ch2);
     } else if #[cfg(any(esp32c6, esp32h2))] {
         const CHANNEL_COUNT: usize = 3;
-        impl_channel!(0, DMA_IN_CH0, asynch_handler::interrupt_handler_ch0, DMA_OUT_CH0, asynch_handler::interrupt_handler_ch0);
-        impl_channel!(1, DMA_IN_CH1, asynch_handler::interrupt_handler_ch1, DMA_OUT_CH1, asynch_handler::interrupt_handler_ch1);
-        impl_channel!(2, DMA_IN_CH2, asynch_handler::interrupt_handler_ch2, DMA_OUT_CH2, asynch_handler::interrupt_handler_ch2);
+        impl_channel!(0, DMA_IN_CH0, asynch_handler::interrupt_handler_in_ch0, DMA_OUT_CH0, asynch_handler::interrupt_handler_out_ch0);
+        impl_channel!(1, DMA_IN_CH1, asynch_handler::interrupt_handler_in_ch1, DMA_OUT_CH1, asynch_handler::interrupt_handler_out_ch1);
+        impl_channel!(2, DMA_IN_CH2, asynch_handler::interrupt_handler_in_ch2, DMA_OUT_CH2, asynch_handler::interrupt_handler_out_ch2);
     } else if #[cfg(esp32s3)] {
         const CHANNEL_COUNT: usize = 5;
-        impl_channel!(0, DMA_IN_CH0, asynch_handler::interrupt_handler_ch0, DMA_OUT_CH0, asynch_handler::interrupt_handler_ch0);
-        impl_channel!(1, DMA_IN_CH1, asynch_handler::interrupt_handler_ch1, DMA_OUT_CH1, asynch_handler::interrupt_handler_ch1);
-        impl_channel!(2, DMA_IN_CH2, asynch_handler::interrupt_handler_ch2, DMA_OUT_CH2, asynch_handler::interrupt_handler_ch2);
-        impl_channel!(3, DMA_IN_CH3, asynch_handler::interrupt_handler_ch3, DMA_OUT_CH3, asynch_handler::interrupt_handler_ch3);
-        impl_channel!(4, DMA_IN_CH4, asynch_handler::interrupt_handler_ch4, DMA_OUT_CH4, asynch_handler::interrupt_handler_ch4);
+        impl_channel!(0, DMA_IN_CH0, asynch_handler::interrupt_handler_in_ch0, DMA_OUT_CH0, asynch_handler::interrupt_handler_out_ch0);
+        impl_channel!(1, DMA_IN_CH1, asynch_handler::interrupt_handler_in_ch1, DMA_OUT_CH1, asynch_handler::interrupt_handler_out_ch1);
+        impl_channel!(2, DMA_IN_CH2, asynch_handler::interrupt_handler_in_ch2, DMA_OUT_CH2, asynch_handler::interrupt_handler_out_ch2);
+        impl_channel!(3, DMA_IN_CH3, asynch_handler::interrupt_handler_in_ch3, DMA_OUT_CH3, asynch_handler::interrupt_handler_out_ch3);
+        impl_channel!(4, DMA_IN_CH4, asynch_handler::interrupt_handler_in_ch4, DMA_OUT_CH4, asynch_handler::interrupt_handler_out_ch4);
     }
 }
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2982,9 +2982,8 @@ pub(crate) mod asynch {
         }
     }
 
-    fn handle_interrupt<CH: DmaChannelExt>() {
+    fn handle_in_interrupt<CH: DmaChannelExt>() {
         let rx = CH::rx_interrupts();
-        let tx = CH::tx_interrupts();
 
         if rx.pending_interrupts().is_disjoint(
             DmaRxInterrupt::DescriptorError
@@ -3001,16 +3000,6 @@ pub(crate) mod asynch {
             rx.waker().wake()
         }
 
-        if tx
-            .pending_interrupts()
-            .contains(DmaTxInterrupt::DescriptorError)
-        {
-            tx.unlisten(
-                DmaTxInterrupt::DescriptorError | DmaTxInterrupt::TotalEof | DmaTxInterrupt::Done,
-            );
-            tx.waker().wake()
-        }
-
         if rx
             .pending_interrupts()
             .contains(DmaRxInterrupt::SuccessfulEof)
@@ -3022,6 +3011,20 @@ pub(crate) mod asynch {
         if rx.pending_interrupts().contains(DmaRxInterrupt::Done) {
             rx.unlisten(DmaRxInterrupt::Done);
             rx.waker().wake()
+        }
+    }
+
+    fn handle_out_interrupt<CH: DmaChannelExt>() {
+        let tx = CH::tx_interrupts();
+
+        if tx
+            .pending_interrupts()
+            .contains(DmaTxInterrupt::DescriptorError)
+        {
+            tx.unlisten(
+                DmaTxInterrupt::DescriptorError | DmaTxInterrupt::TotalEof | DmaTxInterrupt::Done,
+            );
+            tx.waker().wake()
         }
 
         if tx.pending_interrupts().contains(DmaTxInterrupt::TotalEof)
@@ -3037,69 +3040,80 @@ pub(crate) mod asynch {
         }
     }
 
-    #[cfg(not(any(esp32, esp32s2)))]
+    #[cfg(gdma)]
     pub(crate) mod interrupt {
-        use procmacros::handler;
-
         use super::*;
+        use crate::{interrupt::Priority, macros::handler};
 
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_ch0() {
-            handle_interrupt::<DmaChannel0>();
+        // Single interrupt handler for IN and OUT
+        // TODO: add a global flag to only call the half that is configured for async
+        #[cfg(any(esp32c2, esp32c3))]
+        macro_rules! interrupt_handler {
+            ($ch:literal) => {
+                paste::paste! {
+                    #[handler(priority = Priority::max())]
+                    pub(crate) fn [<interrupt_handler_ch $ch>]() {
+                        handle_in_interrupt::<[< DmaChannel $ch >]>();
+                        handle_out_interrupt::<[< DmaChannel $ch >]>();
+                    }
+                }
+            };
         }
 
+        #[cfg(not(any(esp32c2, esp32c3)))]
+        macro_rules! interrupt_handler {
+            ($ch:literal) => {
+                paste::paste! {
+                    #[handler(priority = Priority::max())]
+                    pub(crate) fn [<interrupt_handler_in_ch $ch>]() {
+                        handle_in_interrupt::<[< DmaChannel $ch >]>();
+                    }
+
+                    #[handler(priority = Priority::max())]
+                    pub(crate) fn [<interrupt_handler_out_ch $ch>]() {
+                        handle_out_interrupt::<[< DmaChannel $ch >]>();
+                    }
+                }
+            };
+        }
+
+        interrupt_handler!(0);
         #[cfg(not(esp32c2))]
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_ch1() {
-            handle_interrupt::<DmaChannel1>();
-        }
-
+        interrupt_handler!(1);
         #[cfg(not(esp32c2))]
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_ch2() {
-            handle_interrupt::<DmaChannel2>();
-        }
-
+        interrupt_handler!(2);
         #[cfg(esp32s3)]
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_ch3() {
-            handle_interrupt::<DmaChannel3>();
-        }
-
+        interrupt_handler!(3);
         #[cfg(esp32s3)]
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_ch4() {
-            handle_interrupt::<DmaChannel4>();
-        }
+        interrupt_handler!(4);
     }
 
-    #[cfg(any(esp32, esp32s2))]
+    #[cfg(pdma)]
     pub(crate) mod interrupt {
-        use procmacros::handler;
-
         use super::*;
+        use crate::{interrupt::Priority, macros::handler};
 
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_spi2_dma() {
-            handle_interrupt::<Spi2DmaChannel>();
+        // Single interrupt handler for IN and OUT
+        // TODO: add a global flag to only call the half that is configured for async
+        macro_rules! interrupt_handler {
+            ($ch:ident) => {
+                paste::paste! {
+                    #[handler(priority = Priority::max())]
+                    pub(crate) fn [<interrupt_handler_ $ch:lower _dma>]() {
+                        handle_in_interrupt::<[< $ch DmaChannel >]>();
+                        handle_out_interrupt::<[< $ch DmaChannel >]>();
+                    }
+                }
+            };
         }
 
+        interrupt_handler!(Spi2);
         #[cfg(spi3)]
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_spi3_dma() {
-            handle_interrupt::<Spi3DmaChannel>();
-        }
+        interrupt_handler!(Spi3);
 
         #[cfg(i2s0)]
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_i2s0_dma() {
-            handle_interrupt::<I2s0DmaChannel>();
-        }
-
+        interrupt_handler!(I2s0);
         #[cfg(i2s1)]
-        #[handler(priority = crate::interrupt::Priority::max())]
-        pub(crate) fn interrupt_handler_i2s1_dma() {
-            handle_interrupt::<I2s1DmaChannel>();
-        }
+        interrupt_handler!(I2s1);
     }
 }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1679,6 +1679,13 @@ where
         // channel was previously used for a mem2mem transfer.
         rx_impl.set_mem2mem_mode(false);
 
+        if let Some(interrupt) = rx_impl.peripheral_interrupt() {
+            for cpu in Cpu::all() {
+                crate::interrupt::disable(cpu, interrupt);
+            }
+        }
+        rx_impl.set_async(false);
+
         Self {
             burst_mode: false,
             rx_impl,
@@ -1962,6 +1969,13 @@ where
     CH: DmaChannel,
 {
     fn new(tx_impl: CH::Tx) -> Self {
+        if let Some(interrupt) = tx_impl.peripheral_interrupt() {
+            for cpu in Cpu::all() {
+                crate::interrupt::disable(cpu, interrupt);
+            }
+        }
+        tx_impl.set_async(false);
+
         Self {
             burst_mode: false,
             tx_impl,

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -3075,7 +3075,6 @@ pub(crate) mod asynch {
         use crate::{interrupt::Priority, macros::handler};
 
         // Single interrupt handler for IN and OUT
-        // TODO: add a global flag to only call the half that is configured for async
         #[cfg(any(esp32c2, esp32c3))]
         macro_rules! interrupt_handler {
             ($ch:literal) => {
@@ -3123,7 +3122,6 @@ pub(crate) mod asynch {
         use crate::{interrupt::Priority, macros::handler};
 
         // Single interrupt handler for IN and OUT
-        // TODO: add a global flag to only call the half that is configured for async
         macro_rules! interrupt_handler {
             ($ch:ident) => {
                 paste::paste! {

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -398,6 +398,18 @@ impl Cpu {
             }
         }
     }
+
+    /// Returns an iterator over all cores.
+    #[inline(always)]
+    pub fn all() -> impl Iterator<Item = Self> {
+        cfg_if::cfg_if! {
+            if #[cfg(multi_core)] {
+                [Cpu::ProCpu, Cpu::AppCpu].into_iter()
+            } else {
+                [Cpu::ProCpu].into_iter()
+            }
+        }
+    }
 }
 
 /// Returns the raw value of the mhartid register.

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -386,7 +386,7 @@ impl Cpu {
 
     /// Returns an iterator over the "other" cores.
     #[inline(always)]
-    pub fn other() -> impl Iterator<Item = Self> {
+    pub(crate) fn other() -> impl Iterator<Item = Self> {
         cfg_if::cfg_if! {
             if #[cfg(multi_core)] {
                 match Self::current() {
@@ -401,7 +401,7 @@ impl Cpu {
 
     /// Returns an iterator over all cores.
     #[inline(always)]
-    pub fn all() -> impl Iterator<Item = Self> {
+    pub(crate) fn all() -> impl Iterator<Item = Self> {
         cfg_if::cfg_if! {
             if #[cfg(multi_core)] {
                 [Cpu::ProCpu, Cpu::AppCpu].into_iter()


### PR DESCRIPTION
This PR uses separate interrupts where available (C6, H2, S3), and adds a global flag where there is a single handler for the two DMA halves. This means that if a DMA channel's halves are configured differently, only the async halfs bits are cleared.

This is currently a bit of a half measure (we don't handle blocking-async mixtures yet), but it is impossible to register a user handler for a half DMA channel currently. In the future, in case the user registers a custom handler, we can swap out the handler function to one that supports two separate callbacks.