### PR TITLE
[DMA 5/8]: Clean up macros

### DIFF
--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -16,6 +16,8 @@ use portable_atomic::{AtomicBool, Ordering};
 
 use crate::{
     dma::*,
+    interrupt::Priority,
+    macros::handler,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::Interrupt,
     system::{self, PeripheralClockControl},
@@ -819,7 +821,13 @@ macro_rules! ImplPdmaChannel {
                 }
 
                 fn async_handler(&self) -> InterruptHandler {
-                    super::asynch::interrupt::[< interrupt_handler_ $peri:lower $num _dma >]
+                    #[handler(priority = Priority::max())]
+                    pub(crate) fn interrupt_handler() {
+                        super::asynch::handle_in_interrupt::<[< $instance DmaChannel >]>();
+                        super::asynch::handle_out_interrupt::<[< $instance DmaChannel >]>();
+                    }
+
+                    interrupt_handler
                 }
                 fn rx_async_flag(&self) -> &'static AtomicBool {
                     static FLAG: AtomicBool = AtomicBool::new(false);

--- a/esp-hal/src/macros.rs
+++ b/esp-hal/src/macros.rs
@@ -134,3 +134,13 @@ macro_rules! if_set {
         $set
     };
 }
+
+/// Macro to ignore tokens.
+///
+/// This is useful when we need existence of a metavariable (to expand a
+/// repetition), but we don't need to use it.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! ignore {
+    ($($item:tt)*) => {};
+}

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -531,8 +531,6 @@ pub enum OutputSignal {
 }
 
 macro_rules! rtcio_analog {
-    ( @ignore $rue:literal ) => {};
-
     (
         $pin_num:expr, $rtc_pin:expr, $pin_reg:expr, $prefix:pat, $hold:ident $(, $rue:literal)?
     ) => {
@@ -564,7 +562,7 @@ macro_rules! rtcio_analog {
 
         $(
             // FIXME: replace with $(ignore($rue)) once stable
-            rtcio_analog!(@ignore $rue);
+            $crate::ignore!($rue);
             impl $crate::gpio::RtcPinWithResistors for $crate::gpio::GpioPin<$pin_num> {
                 fn rtcio_pullup(&mut self, enable: bool) {
                     paste::paste! {
@@ -610,7 +608,7 @@ macro_rules! rtcio_analog {
                         // Disable pull-up and pull-down resistors on the pin, if it has them
                         $(
                             // FIXME: replace with $(ignore($rue)) once stable
-                            rtcio_analog!( @ignore $rue );
+                            $crate::ignore!($rue);
                             w.[<$prefix rue>]().bit(false);
                             w.[<$prefix rde>]().bit(false);
                         )?

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -318,8 +318,6 @@ pub enum OutputSignal {
 }
 
 macro_rules! rtcio_analog {
-    ( @ignore $rue:literal ) => {};
-
     (
         $pin_num:expr, $pin_reg:expr, $prefix:pat, $hold:ident
     ) => {

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -395,8 +395,6 @@ pub enum OutputSignal {
 }
 
 macro_rules! rtcio_analog {
-    ( @ignore $rue:literal ) => {};
-
     (
         $pin_num:expr, $pin_reg:expr, $prefix:pat, $hold:ident
     ) => {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -3001,8 +3001,6 @@ impl PartialEq for Info {
 unsafe impl Sync for Info {}
 
 macro_rules! spi_instance {
-    (@ignore $sio2:ident) => {};
-
     ($num:literal, $sclk:ident, $mosi:ident, $miso:ident, $cs:ident $(, $sio2:ident, $sio3:ident)?) => {
         paste::paste! {
             impl Instance for crate::peripherals::[<SPI $num>] {
@@ -3030,7 +3028,7 @@ macro_rules! spi_instance {
 
             $(
                 // If the extra pins are set, implement QspiInstance
-                spi_instance!(@ignore $sio2);
+                $crate::ignore!($sio2);
                 impl QspiInstance for crate::peripherals::[<SPI $num>] {}
             )?
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR mostly cleans up macros and interrupt handlers (reducing the number of locations we need to edit), but also refactors the PDMA macro a bit in preparation for CryptoDMA support.

#### Testing
Describe how you tested your changes.
