### PR TITLE
Remove `get_` prefix from functions

### DIFF
--- a/esp-hal-embassy/src/executor/interrupt.rs
+++ b/esp-hal-embassy/src/executor/interrupt.rs
@@ -4,7 +4,7 @@ use core::{cell::UnsafeCell, mem::MaybeUninit};
 
 use embassy_executor::{raw, SendSpawner};
 use esp_hal::{
-    get_core,
+    core,
     interrupt::{self, software::SoftwareInterrupt, InterruptHandler},
 };
 use portable_atomic::{AtomicUsize, Ordering};
@@ -87,7 +87,7 @@ impl<const SWI: u8> InterruptExecutor<SWI> {
             .core
             .compare_exchange(
                 usize::MAX,
-                get_core() as usize,
+                core() as usize,
                 Ordering::Acquire,
                 Ordering::Relaxed,
             )

--- a/esp-hal-embassy/src/executor/thread.rs
+++ b/esp-hal-embassy/src/executor/thread.rs
@@ -3,7 +3,7 @@
 use core::marker::PhantomData;
 
 use embassy_executor::{raw, Spawner};
-use esp_hal::{get_core, Cpu};
+use esp_hal::{core, Cpu};
 #[cfg(multi_core)]
 use esp_hal::{interrupt::software::SoftwareInterrupt, macros::handler};
 #[cfg(low_power_wait)]
@@ -35,7 +35,7 @@ pub(crate) fn pend_thread_mode(_core: usize) {
         // If we are pending a task on the current core, we're done. Otherwise, we
         // need to make sure the other core wakes up.
         #[cfg(multi_core)]
-        if _core != get_core() as usize {
+        if _core != core() as usize {
             // We need to clear the interrupt from software. We don't actually
             // need it to trigger and run the interrupt handler, we just need to
             // kick waiti to return.
@@ -74,7 +74,7 @@ This will use software-interrupt 3 which isn't available for anything else to wa
         }
 
         Self {
-            inner: raw::Executor::new((THREAD_MODE_CONTEXT + get_core() as usize) as *mut ()),
+            inner: raw::Executor::new((THREAD_MODE_CONTEXT + core() as usize) as *mut ()),
             not_send: PhantomData,
         }
     }
@@ -103,7 +103,7 @@ This will use software-interrupt 3 which isn't available for anything else to wa
         init(self.inner.spawner());
 
         #[cfg(low_power_wait)]
-        let cpu = get_core() as usize;
+        let cpu = core() as usize;
 
         loop {
             unsafe { self.inner.poll() };

--- a/esp-hal-procmacros/src/lp_core.rs
+++ b/esp-hal-procmacros/src/lp_core.rs
@@ -31,7 +31,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         res
     }
 
-    pub(crate) fn get_simplename(t: &Type) -> String {
+    pub(crate) fn simplename(t: &Type) -> String {
         match t {
             Type::Path(p) => p.path.segments.last().unwrap().ident.to_string(),
             _ => String::new(),
@@ -125,7 +125,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
                     .into();
             }
             FnArg::Typed(t) => {
-                match get_simplename(&t.ty).as_str() {
+                match simplename(&t.ty).as_str() {
                     "Output" => {
                         let pin = extract_pin(&t.ty);
                         if used_pins.contains(&pin) {

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - A new config option `PLACE_SWITCH_TABLES_IN_RAM` to improve performance (especially for interrupts) at the cost of slightly more RAM usage (#2331)
 - A new config option `PLACE_ANON_IN_RAM` to improve performance (especially for interrupts) at the cost of RAM usage (#2331)
 - Add burst transfer support to DMA buffers (#2336)
@@ -63,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `I2c` master driver has been moved from `esp_hal::i2c` to `esp_hal::i2c::master`. (#2476)
 - `I2c` SCL timeout is now defined in bus clock cycles. (#2477)
 - Trying to send a single-shot RMT transmission will result in an error now, `RMT` deals with `u32` now, `PulseCode` is a convenience trait now (#2463)
+- Removed `get_` prefixes from functions (#2528)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -223,6 +223,7 @@ You can now use the `UartInterrupt` enum and the corresponding `listen`, `unlist
 Use `interrupts` in place of `<INTERRUPT>_interrupt_set` and `clear_interrupts` in place of the old `reset_` functions.
 
 `UartInterrupt`:
+
 - `AtCmd`
 - `TxDone`
 - `RxFifoFull`
@@ -359,6 +360,7 @@ refer to the `Config` struct as `uart::Config`.
 ## I8080 driver split `set_byte_order()` into `set_8bits_order()` and `set_byte_order()`.
 
 If you were using an 8-bit bus.
+
 ```diff
 - i8080.set_byte_order(ByteOrder::default());
 + i8080.set_8bits_order(ByteOrder::default());
@@ -368,7 +370,6 @@ If you were using an 16-bit bus, you don't need to change anything, `set_byte_or
 
 If you were sharing the bus between an 8-bit and 16-bit device, you will have to call the corresponding method when
 you switch between devices. Be sure to read the documentation of the new methods.
-
 
 ## `rmt::Channel::transmit` now returns `Result`, `PulseCode` is now `u32`
 
@@ -412,3 +413,9 @@ You can use `gpio::NoPin` instead.
 +let mut rx_clk_pin = NoPin;
 +parl_io.rx.with_config(&mut rx_pins, &mut rx_clk_pin, BitPackOrder::Msb, Some(0xfff))
 ```
+
+## `get_` prefixes have been removed from functions
+
+In order to better comply with the Rust API Guidelines [getter names convention], we have removed the `get_` prefixes from all functions which previously had it. Due to the number of changes it's not practical to list all changes here, however if a function previous began with `get_`, you can simply remove this prefix.
+
+[getter names convention]: https://rust-lang.github.io/api-guidelines/naming.html#c-getter

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -166,7 +166,7 @@ impl<'d> Aes<'d> {
         self.set_block(block);
         self.start();
         while !(self.is_idle()) {}
-        self.get_block(block);
+        self.block(block);
     }
 
     fn set_mode(&mut self, mode: u8) {
@@ -181,7 +181,7 @@ impl<'d> Aes<'d> {
         self.write_block(block);
     }
 
-    fn get_block(&self, block: &mut [u8; 16]) {
+    fn block(&self, block: &mut [u8; 16]) {
         self.read_block(block);
     }
 

--- a/esp-hal/src/analog/adc/calibration/basic.rs
+++ b/esp-hal/src/analog/adc/calibration/basic.rs
@@ -36,7 +36,7 @@ where
     fn new_cal(atten: Attenuation) -> Self {
         // Try to get init code (Dout0) from efuse
         // Dout0 means mean raw ADC value when zero voltage applied to input.
-        let cal_val = ADCI::get_init_code(atten).unwrap_or_else(|| {
+        let cal_val = ADCI::init_code(atten).unwrap_or_else(|| {
             // As a fallback try to calibrate via connecting input to ground internally.
             AdcConfig::<ADCI>::adc_calibrate(atten, AdcCalSource::Gnd)
         });

--- a/esp-hal/src/analog/adc/calibration/line.rs
+++ b/esp-hal/src/analog/adc/calibration/line.rs
@@ -59,8 +59,8 @@ where
 
         // Try get the reference point (Dout, Vin) from efuse
         // Dout means mean raw ADC value when specified Vin applied to input.
-        let (code, mv) = ADCI::get_cal_code(atten)
-            .map(|code| (code, ADCI::get_cal_mv(atten)))
+        let (code, mv) = ADCI::cal_code(atten)
+            .map(|code| (code, ADCI::cal_mv(atten)))
             .unwrap_or_else(|| {
                 // As a fallback try to calibrate using reference voltage source.
                 // This method is not too good because actual reference voltage may varies

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -235,17 +235,17 @@ trait AdcCalEfuse {
     /// Get ADC calibration init code
     ///
     /// Returns digital value for zero voltage for a given attenuation
-    fn get_init_code(atten: Attenuation) -> Option<u16>;
+    fn init_code(atten: Attenuation) -> Option<u16>;
 
     /// Get ADC calibration reference point voltage
     ///
     /// Returns reference voltage (millivolts) for a given attenuation
-    fn get_cal_mv(atten: Attenuation) -> u16;
+    fn cal_mv(atten: Attenuation) -> u16;
 
     /// Get ADC calibration reference point digital value
     ///
     /// Returns digital value for reference voltage for a given attenuation
-    fn get_cal_code(atten: Attenuation) -> Option<u16>;
+    fn cal_code(atten: Attenuation) -> Option<u16>;
 }
 
 macro_rules! impl_adc_interface {

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -502,31 +502,31 @@ where
 
 #[cfg(any(esp32c2, esp32c3, esp32c6))]
 impl super::AdcCalEfuse for crate::peripherals::ADC1 {
-    fn get_init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::get_rtc_calib_init_code(1, atten)
+    fn init_code(atten: Attenuation) -> Option<u16> {
+        Efuse::rtc_calib_init_code(1, atten)
     }
 
-    fn get_cal_mv(atten: Attenuation) -> u16 {
-        Efuse::get_rtc_calib_cal_mv(1, atten)
+    fn cal_mv(atten: Attenuation) -> u16 {
+        Efuse::rtc_calib_cal_mv(1, atten)
     }
 
-    fn get_cal_code(atten: Attenuation) -> Option<u16> {
-        Efuse::get_rtc_calib_cal_code(1, atten)
+    fn cal_code(atten: Attenuation) -> Option<u16> {
+        Efuse::rtc_calib_cal_code(1, atten)
     }
 }
 
 #[cfg(esp32c3)]
 impl super::AdcCalEfuse for crate::peripherals::ADC2 {
-    fn get_init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::get_rtc_calib_init_code(2, atten)
+    fn init_code(atten: Attenuation) -> Option<u16> {
+        Efuse::rtc_calib_init_code(2, atten)
     }
 
-    fn get_cal_mv(atten: Attenuation) -> u16 {
-        Efuse::get_rtc_calib_cal_mv(2, atten)
+    fn cal_mv(atten: Attenuation) -> u16 {
+        Efuse::rtc_calib_cal_mv(2, atten)
     }
 
-    fn get_cal_code(atten: Attenuation) -> Option<u16> {
-        Efuse::get_rtc_calib_cal_code(2, atten)
+    fn cal_code(atten: Attenuation) -> Option<u16> {
+        Efuse::rtc_calib_cal_code(2, atten)
     }
 }
 

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -562,31 +562,31 @@ where
 
 #[cfg(esp32s3)]
 impl super::AdcCalEfuse for crate::peripherals::ADC1 {
-    fn get_init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::get_rtc_calib_init_code(1, atten)
+    fn init_code(atten: Attenuation) -> Option<u16> {
+        Efuse::rtc_calib_init_code(1, atten)
     }
 
-    fn get_cal_mv(atten: Attenuation) -> u16 {
-        Efuse::get_rtc_calib_cal_mv(1, atten)
+    fn cal_mv(atten: Attenuation) -> u16 {
+        Efuse::rtc_calib_cal_mv(1, atten)
     }
 
-    fn get_cal_code(atten: Attenuation) -> Option<u16> {
-        Efuse::get_rtc_calib_cal_code(1, atten)
+    fn cal_code(atten: Attenuation) -> Option<u16> {
+        Efuse::rtc_calib_cal_code(1, atten)
     }
 }
 
 #[cfg(esp32s3)]
 impl super::AdcCalEfuse for crate::peripherals::ADC2 {
-    fn get_init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::get_rtc_calib_init_code(2, atten)
+    fn init_code(atten: Attenuation) -> Option<u16> {
+        Efuse::rtc_calib_init_code(2, atten)
     }
 
-    fn get_cal_mv(atten: Attenuation) -> u16 {
-        Efuse::get_rtc_calib_cal_mv(2, atten)
+    fn cal_mv(atten: Attenuation) -> u16 {
+        Efuse::rtc_calib_cal_mv(2, atten)
     }
 
-    fn get_cal_code(atten: Attenuation) -> Option<u16> {
-        Efuse::get_rtc_calib_cal_code(2, atten)
+    fn cal_code(atten: Attenuation) -> Option<u16> {
+        Efuse::rtc_calib_cal_code(2, atten)
     }
 }
 

--- a/esp-hal/src/assist_debug.rs
+++ b/esp-hal/src/assist_debug.rs
@@ -136,7 +136,7 @@ impl DebugAssist<'_> {
     }
 
     /// Get SP monitoring PC value on main core.
-    pub fn get_sp_monitor_pc(&self) -> u32 {
+    pub fn sp_monitor_pc(&self) -> u32 {
         self.debug_assist
             .core_0_sp_pc()
             .read()
@@ -219,7 +219,7 @@ impl<'d> DebugAssist<'d> {
     }
 
     /// Get SP monitoring PC value on secondary core.
-    pub fn get_core1_sp_monitor_pc(&self) -> u32 {
+    pub fn core1_sp_monitor_pc(&self) -> u32 {
         self.debug_assist.core_1_sp_pc.read().core_1_sp_pc().bits()
     }
 }
@@ -382,7 +382,7 @@ impl DebugAssist<'_> {
     }
 
     /// Get region monitoring PC value on main core.
-    pub fn get_region_monitor_pc(&self) -> u32 {
+    pub fn region_monitor_pc(&self) -> u32 {
         self.debug_assist
             .core_0_area_pc()
             .read()
@@ -548,7 +548,7 @@ impl<'d> DebugAssist<'d> {
     }
 
     /// Get region monitoring PC value on secondary core.
-    pub fn get_core1_region_monitor_pc(&self) -> u32 {
+    pub fn core1_region_monitor_pc(&self) -> u32 {
         self.debug_assist
             .core_1_area_pc()
             .read()

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -522,11 +522,11 @@ macro_rules! impl_channel {
             }
 
             impl DmaChannelExt for [<DmaChannel $num>] {
-                fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
+                fn rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     ChannelRxImpl(SpecificGdmaChannel::<$num> {})
                 }
 
-                fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
+                fn tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     ChannelTxImpl(SpecificGdmaChannel::<$num> {})
                 }
             }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1581,8 +1581,8 @@ pub trait DmaChannel: crate::private::Sealed + Sized {
 
 #[doc(hidden)]
 pub trait DmaChannelExt: DmaChannel {
-    fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt>;
-    fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt>;
+    fn rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt>;
+    fn tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt>;
 }
 
 #[diagnostic::on_unimplemented(
@@ -2885,8 +2885,8 @@ pub(crate) mod asynch {
     }
 
     fn handle_interrupt<CH: DmaChannelExt>() {
-        let rx = CH::get_rx_interrupts();
-        let tx = CH::get_tx_interrupts();
+        let rx = CH::rx_interrupts();
+        let tx = CH::tx_interrupts();
 
         if rx.pending_interrupts().is_disjoint(
             DmaRxInterrupt::DescriptorError

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -367,10 +367,10 @@ macro_rules! ImplSpiChannel {
             }
 
             impl DmaChannelExt for [<Spi $num DmaChannel>] {
-                fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
+                fn rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     SpiDmaRxChannelImpl(Self {})
                 }
-                fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
+                fn tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     SpiDmaTxChannelImpl(Self {})
                 }
             }
@@ -780,10 +780,10 @@ macro_rules! ImplI2sChannel {
             }
 
             impl DmaChannelExt for [<I2s $num DmaChannel>] {
-                fn get_rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
+                fn rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     I2sDmaRxChannelImpl(Self {})
                 }
-                fn get_tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
+                fn tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     I2sDmaTxChannelImpl(Self {})
                 }
             }

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -268,7 +268,7 @@ impl InputSignal {
     }
 
     /// Returns the current signal level.
-    pub fn get_level(&self) -> Level {
+    pub fn level(&self) -> Level {
         self.is_input_high(private::Internal).into()
     }
 

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -239,8 +239,8 @@ pub fn enable_direct(
         return Err(Error::InvalidInterruptPriority);
     }
     unsafe {
-        map(crate::get_core(), interrupt, cpu_interrupt);
-        set_priority(crate::get_core(), cpu_interrupt, level);
+        map(crate::core(), interrupt, cpu_interrupt);
+        set_priority(crate::core(), cpu_interrupt, level);
         enable_cpu_interrupt(cpu_interrupt);
     }
     Ok(())
@@ -262,7 +262,7 @@ pub fn disable(_core: Cpu, interrupt: Interrupt) {
 
 /// Get status of peripheral interrupts
 #[inline]
-pub fn get_status(_core: Cpu) -> InterruptStatus {
+pub fn status(_core: Cpu) -> InterruptStatus {
     #[cfg(large_intr_status)]
     unsafe {
         InterruptStatus::from(
@@ -341,7 +341,7 @@ pub unsafe fn map(_core: Cpu, interrupt: Interrupt, which: CpuInterrupt) {
 
 /// Get cpu interrupt assigned to peripheral interrupt
 #[inline]
-unsafe fn get_assigned_cpu_interrupt(interrupt: Interrupt) -> Option<CpuInterrupt> {
+unsafe fn assigned_cpu_interrupt(interrupt: Interrupt) -> Option<CpuInterrupt> {
     let interrupt_number = interrupt as isize;
     let intr_map_base = crate::soc::registers::INTERRUPT_MAP_BASE as *mut u32;
 
@@ -356,7 +356,7 @@ unsafe fn get_assigned_cpu_interrupt(interrupt: Interrupt) -> Option<CpuInterrup
 }
 
 pub(crate) fn bound_cpu_interrupt_for(_cpu: Cpu, interrupt: Interrupt) -> Option<CpuInterrupt> {
-    unsafe { get_assigned_cpu_interrupt(interrupt) }
+    unsafe { assigned_cpu_interrupt(interrupt) }
 }
 
 mod vectored {
@@ -369,12 +369,12 @@ mod vectored {
     pub(crate) unsafe fn init_vectoring() {
         for (prio, num) in PRIORITY_TO_INTERRUPT.iter().enumerate() {
             set_kind(
-                crate::get_core(),
+                crate::core(),
                 core::mem::transmute::<u32, CpuInterrupt>(*num as u32),
                 InterruptKind::Level,
             );
             set_priority(
-                crate::get_core(),
+                crate::core(),
                 core::mem::transmute::<u32, CpuInterrupt>(*num as u32),
                 core::mem::transmute::<u8, Priority>((prio as u8) + 1),
             );
@@ -385,7 +385,7 @@ mod vectored {
     /// Get the interrupts configured for the core at the given priority
     /// matching the given status
     #[inline]
-    fn get_configured_interrupts(
+    fn configured_interrupts(
         core: Cpu,
         status: InterruptStatus,
         priority: Priority,
@@ -396,11 +396,11 @@ mod vectored {
             for interrupt_nr in status.iterator() {
                 // safety: cast is safe because of repr(u16)
                 if let Some(cpu_interrupt) =
-                    get_assigned_cpu_interrupt(core::mem::transmute::<u16, Interrupt>(
+                    assigned_cpu_interrupt(core::mem::transmute::<u16, Interrupt>(
                         interrupt_nr as u16,
                     ))
                 {
-                    if get_priority_by_core(core, cpu_interrupt) == priority {
+                    if priority_by_core(core, cpu_interrupt) == priority {
                         res.set(interrupt_nr as u16);
                     }
                 }
@@ -421,7 +421,7 @@ mod vectored {
             let cpu_interrupt = core::mem::transmute::<u32, CpuInterrupt>(
                 PRIORITY_TO_INTERRUPT[(level as usize) - 1] as u32,
             );
-            map(crate::get_core(), interrupt, cpu_interrupt);
+            map(crate::core(), interrupt, cpu_interrupt);
             enable_cpu_interrupt(cpu_interrupt);
         }
         Ok(())
@@ -453,15 +453,15 @@ mod vectored {
     #[no_mangle]
     #[ram]
     unsafe fn handle_interrupts(cpu_intr: CpuInterrupt, context: &mut TrapFrame) {
-        let core = crate::get_core();
-        let status = get_status(core);
+        let core = crate::core();
+        let status = status(core);
 
         // this has no effect on level interrupts, but the interrupt may be an edge one
         // so we clear it anyway
         clear(core, cpu_intr);
         let prio: Priority =
             unsafe { core::mem::transmute(INTERRUPT_TO_PRIORITY[cpu_intr as usize - 1] as u8) };
-        let configured_interrupts = get_configured_interrupts(core, status, prio);
+        let configured_interrupts = configured_interrupts(core, status, prio);
 
         for interrupt_nr in configured_interrupts.iterator() {
             // Don't use `Interrupt::try_from`. It's slower and placed in flash
@@ -639,13 +639,13 @@ mod classic {
 
     /// Get interrupt priority
     #[inline]
-    pub(super) fn get_priority_by_core(_core: Cpu, cpu_interrupt: CpuInterrupt) -> Priority {
-        unsafe { get_priority(cpu_interrupt) }
+    pub(super) fn priority_by_core(_core: Cpu, cpu_interrupt: CpuInterrupt) -> Priority {
+        unsafe { priority(cpu_interrupt) }
     }
 
     /// Get interrupt priority - called by assembly code
     #[inline]
-    pub(super) unsafe extern "C" fn get_priority(cpu_interrupt: CpuInterrupt) -> Priority {
+    pub(super) unsafe extern "C" fn priority(cpu_interrupt: CpuInterrupt) -> Priority {
         let intr = &*crate::peripherals::INTERRUPT_CORE0::PTR;
         core::mem::transmute::<u8, Priority>(
             intr.cpu_int_pri(cpu_interrupt as usize).read().map().bits(),
@@ -771,16 +771,16 @@ mod plic {
 
     /// Get interrupt priority
     #[inline]
-    pub(super) unsafe extern "C" fn get_priority_by_core(
+    pub(super) unsafe extern "C" fn priority_by_core(
         _core: Cpu,
         cpu_interrupt: CpuInterrupt,
     ) -> Priority {
-        unsafe { get_priority(cpu_interrupt) }
+        unsafe { priority(cpu_interrupt) }
     }
 
     /// Get interrupt priority - called by assembly code
     #[inline]
-    pub(super) unsafe extern "C" fn get_priority(cpu_interrupt: CpuInterrupt) -> Priority {
+    pub(super) unsafe extern "C" fn priority(cpu_interrupt: CpuInterrupt) -> Priority {
         let plic = &*crate::peripherals::PLIC_MX::PTR;
         let prio = plic
             .mxint_pri(cpu_interrupt as usize)

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -189,7 +189,7 @@ where
     fn set_duty(&self, duty_pct: u8) -> Result<(), Error> {
         let duty_exp;
         if let Some(timer) = self.timer {
-            if let Some(timer_duty) = timer.get_duty() {
+            if let Some(timer_duty) = timer.duty() {
                 duty_exp = timer_duty as u32;
             } else {
                 return Err(Error::Timer);
@@ -238,10 +238,10 @@ where
             return Err(Error::Fade(FadeError::EndDuty));
         }
         if let Some(timer) = self.timer {
-            if let Some(timer_duty) = timer.get_duty() {
-                if timer.get_frequency() > 0 {
+            if let Some(timer_duty) = timer.duty() {
+                if timer.frequency() > 0 {
                     duty_exp = timer_duty as u32;
-                    frequency = timer.get_frequency();
+                    frequency = timer.frequency();
                 } else {
                     return Err(Error::Timer);
                 }
@@ -323,7 +323,7 @@ mod ehal1 {
         fn max_duty_cycle(&self) -> u16 {
             let duty_exp;
 
-            if let Some(timer_duty) = self.timer.and_then(|timer| timer.get_duty()) {
+            if let Some(timer_duty) = self.timer.and_then(|timer| timer.duty()) {
                 duty_exp = timer_duty as u32;
             } else {
                 return 0;
@@ -571,7 +571,7 @@ where
                     .set_to_open_drain_output(crate::private::Internal),
             };
 
-            let timer_number = timer.get_number() as u8;
+            let timer_number = timer.number() as u8;
 
             self.set_channel(timer_number);
             self.update_channel();

--- a/esp-hal/src/ledc/mod.rs
+++ b/esp-hal/src/ledc/mod.rs
@@ -34,7 +34,7 @@
 //! let mut ledc = Ledc::new(peripherals.LEDC);
 //! ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 //!
-//! let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer0);
+//! let mut lstimer0 = ledc.timer::<LowSpeed>(timer::Number::Timer0);
 //! lstimer0
 //!     .configure(timer::config::Config {
 //!         duty: timer::config::Duty::Duty5Bit,
@@ -43,7 +43,7 @@
 //!     })
 //!     .unwrap();
 //!
-//! let mut channel0 = ledc.get_channel(channel::Number::Channel0, led);
+//! let mut channel0 = ledc.channel(channel::Number::Channel0, led);
 //! channel0
 //!     .configure(channel::config::Config {
 //!         timer: &lstimer0,
@@ -158,12 +158,12 @@ impl<'d> Ledc<'d> {
     }
 
     /// Return a new timer
-    pub fn get_timer<S: TimerSpeed>(&self, number: timer::Number) -> Timer<'d, S> {
+    pub fn timer<S: TimerSpeed>(&self, number: timer::Number) -> Timer<'d, S> {
         Timer::new(self.ledc, number)
     }
 
     /// Return a new channel
-    pub fn get_channel<S: TimerSpeed>(
+    pub fn channel<S: TimerSpeed>(
         &self,
         number: channel::Number,
         output_pin: impl Peripheral<P = impl PeripheralOutput> + 'd,

--- a/esp-hal/src/ledc/timer.rs
+++ b/esp-hal/src/ledc/timer.rs
@@ -187,7 +187,7 @@ impl TimerSpeed for HighSpeed {
 /// Interface for Timers
 pub trait TimerIFace<S: TimerSpeed> {
     /// Return the frequency of the timer
-    fn get_freq(&self) -> Option<HertzU32>;
+    fn freq(&self) -> Option<HertzU32>;
 
     /// Configure the timer
     fn configure(&mut self, config: config::Config<S::ClockSourceType>) -> Result<(), Error>;
@@ -196,19 +196,19 @@ pub trait TimerIFace<S: TimerSpeed> {
     fn is_configured(&self) -> bool;
 
     /// Return the duty resolution of the timer
-    fn get_duty(&self) -> Option<config::Duty>;
+    fn duty(&self) -> Option<config::Duty>;
 
     /// Return the timer number
-    fn get_number(&self) -> Number;
+    fn number(&self) -> Number;
 
     /// Return the timer frequency, or 0 if not configured
-    fn get_frequency(&self) -> u32;
+    fn frequency(&self) -> u32;
 }
 
 /// Interface for HW configuration of timer
 pub trait TimerHW<S: TimerSpeed> {
     /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<HertzU32>;
+    fn freq_hw(&self) -> Option<HertzU32>;
 
     /// Configure the HW for the timer
     fn configure_hw(&self, divisor: u32);
@@ -233,8 +233,8 @@ where
     Timer<'a, S>: TimerHW<S>,
 {
     /// Return the frequency of the timer
-    fn get_freq(&self) -> Option<HertzU32> {
-        self.get_freq_hw()
+    fn freq(&self) -> Option<HertzU32> {
+        self.freq_hw()
     }
 
     /// Configure the timer
@@ -243,7 +243,7 @@ where
         self.clock_source = Some(config.clock_source);
 
         // TODO: we should return some error here if `unwrap()` fails
-        let src_freq: u32 = self.get_freq().unwrap().to_Hz();
+        let src_freq: u32 = self.freq().unwrap().to_Hz();
         let precision = 1 << config.duty as u32;
         let frequency: u32 = config.frequency.raw();
         self.frequency = frequency;
@@ -275,17 +275,17 @@ where
     }
 
     /// Return the duty resolution of the timer
-    fn get_duty(&self) -> Option<config::Duty> {
+    fn duty(&self) -> Option<config::Duty> {
         self.duty
     }
 
     /// Return the timer number
-    fn get_number(&self) -> Number {
+    fn number(&self) -> Number {
         self.number
     }
 
     /// Return the timer frequency
-    fn get_frequency(&self) -> u32 {
+    fn frequency(&self) -> u32 {
         self.frequency
     }
 }
@@ -308,7 +308,7 @@ impl<'a, S: TimerSpeed> Timer<'a, S> {
 /// Timer HW implementation for LowSpeed timers
 impl TimerHW<LowSpeed> for Timer<'_, LowSpeed> {
     /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<HertzU32> {
+    fn freq_hw(&self) -> Option<HertzU32> {
         self.clock_source.map(|source| match source {
             LSClockSource::APBClk => {
                 let clocks = Clocks::get();
@@ -371,7 +371,7 @@ impl TimerHW<LowSpeed> for Timer<'_, LowSpeed> {
 /// Timer HW implementation for HighSpeed timers
 impl<'a> TimerHW<HighSpeed> for Timer<'a, HighSpeed> {
     /// Get the current source timer frequency from the HW
-    fn get_freq_hw(&self) -> Option<HertzU32> {
+    fn freq_hw(&self) -> Option<HertzU32> {
         self.clock_source.map(|source| match source {
             HSClockSource::APBClk => {
                 let clocks = Clocks::get();

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -369,7 +369,7 @@ impl Cpu {
     /// Returns the core the application is currently executing on
     #[inline(always)]
     pub fn current() -> Self {
-        get_core()
+        core()
     }
 
     /// Returns an iterator over the "other" cores.
@@ -377,7 +377,7 @@ impl Cpu {
     pub fn other() -> impl Iterator<Item = Self> {
         cfg_if::cfg_if! {
             if #[cfg(multi_core)] {
-                match get_core() {
+                match core() {
                     Cpu::ProCpu => [Cpu::AppCpu].into_iter(),
                     Cpu::AppCpu => [Cpu::ProCpu].into_iter(),
                 }
@@ -390,12 +390,12 @@ impl Cpu {
 
 /// Which core the application is currently executing on
 #[inline(always)]
-pub fn get_core() -> Cpu {
+pub fn core() -> Cpu {
     // This works for both RISCV and Xtensa because both
-    // get_raw_core functions return zero, _or_ something
+    // raw_core functions return zero, _or_ something
     // greater than zero; 1 in the case of RISCV and 0x2000
     // in the case of Xtensa.
-    match get_raw_core() {
+    match raw_core() {
         0 => Cpu::ProCpu,
         #[cfg(all(multi_core, riscv))]
         1 => Cpu::AppCpu,
@@ -410,7 +410,7 @@ pub fn get_core() -> Cpu {
 /// Safety: This method should never return UNUSED_THREAD_ID_VALUE
 #[cfg(riscv)]
 #[inline(always)]
-fn get_raw_core() -> usize {
+fn raw_core() -> usize {
     #[cfg(multi_core)]
     {
         riscv::register::mhartid::read()
@@ -429,7 +429,7 @@ fn get_raw_core() -> usize {
 /// Safety: This method should never return UNUSED_THREAD_ID_VALUE
 #[cfg(xtensa)]
 #[inline(always)]
-fn get_raw_core() -> usize {
+fn raw_core() -> usize {
     (xtensa_lx::get_processor_id() & 0x2000) as usize
 }
 

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -363,7 +363,7 @@ impl<'d, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<'d, PWM, OP,
     /// Get the old timestamp.
     /// The value of the timestamp will take effect according to the set
     /// [`PwmUpdateMethod`].
-    pub fn get_timestamp(&self) -> u16 {
+    pub fn timestamp(&self) -> u16 {
         // SAFETY:
         // We only read to our GENx_TSTMP_x register
         let ch = unsafe { Self::ch() };
@@ -384,7 +384,7 @@ impl<'d, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<'d, PWM, OP,
     }
 
     /// Get the period of the timer.
-    pub fn get_period(&self) -> u16 {
+    pub fn period(&self) -> u16 {
         // SAFETY:
         // We only grant access to our CFG0 register with the lifetime of &mut self
         let block = unsafe { &*PWM::block() };
@@ -430,12 +430,12 @@ impl<PWM: PwmPeripheral, const OP: u8, const IS_A: bool> embedded_hal_02::PwmPin
 
     /// Get the duty of the pin
     fn get_duty(&self) -> Self::Duty {
-        self.get_timestamp()
+        self.timestamp()
     }
 
     /// Get the max duty of the pin
     fn get_max_duty(&self) -> Self::Duty {
-        self.get_period()
+        self.period()
     }
 
     /// Set the duty of the pin
@@ -457,7 +457,7 @@ impl<PWM: PwmPeripheral, const OP: u8, const IS_A: bool> embedded_hal::pwm::SetD
 {
     /// Get the max duty of the PwmPin
     fn max_duty_cycle(&self) -> u16 {
-        self.get_period()
+        self.period()
     }
 
     /// Set the max duty of the PwmPin

--- a/esp-hal/src/pcnt/unit.rs
+++ b/esp-hal/src/pcnt/unit.rs
@@ -243,7 +243,7 @@ impl<const NUM: usize> Unit<'_, NUM> {
     }
 
     /// Get the latest events for this unit.
-    pub fn get_events(&self) -> Events {
+    pub fn events(&self) -> Events {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         let status = pcnt.u_status(NUM).read();
 
@@ -257,7 +257,7 @@ impl<const NUM: usize> Unit<'_, NUM> {
     }
 
     /// Get the mode of the last zero crossing
-    pub fn get_zero_mode(&self) -> ZeroMode {
+    pub fn zero_mode(&self) -> ZeroMode {
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
         pcnt.u_status(NUM).read().zero_mode().bits().into()
     }
@@ -296,7 +296,7 @@ impl<const NUM: usize> Unit<'_, NUM> {
     }
 
     /// Get the current counter value.
-    pub fn get_value(&self) -> i16 {
+    pub fn value(&self) -> i16 {
         self.counter.get()
     }
 }

--- a/esp-hal/src/reset.rs
+++ b/esp-hal/src/reset.rs
@@ -102,11 +102,11 @@ pub fn software_reset_cpu() {
 
 /// Retrieves the reason for the last reset as a SocResetReason enum value.
 /// Returns `None` if the reset reason cannot be determined.
-pub fn get_reset_reason() -> Option<SocResetReason> {
-    crate::rtc_cntl::get_reset_reason(crate::get_core())
+pub fn reset_reason() -> Option<SocResetReason> {
+    crate::rtc_cntl::reset_reason(crate::core())
 }
 
 /// Retrieves the cause of the last wakeup event as a SleepSource enum value.
-pub fn get_wakeup_cause() -> SleepSource {
-    crate::rtc_cntl::get_wakeup_cause()
+pub fn wakeup_cause() -> SleepSource {
+    crate::rtc_cntl::wakeup_cause()
 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c3.rs
@@ -86,10 +86,7 @@ pub(crate) fn init() {
 }
 
 pub(crate) fn configure_clock() {
-    assert!(matches!(
-        RtcClock::get_xtal_freq(),
-        XtalClock::RtcXtalFreq40M
-    ));
+    assert!(matches!(RtcClock::xtal_freq(), XtalClock::RtcXtalFreq40M));
 
     unsafe {
         // from esp_clk_init:

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -1200,10 +1200,7 @@ pub(crate) fn init() {
 }
 
 pub(crate) fn configure_clock() {
-    assert!(matches!(
-        RtcClock::get_xtal_freq(),
-        XtalClock::RtcXtalFreq40M
-    ));
+    assert!(matches!(RtcClock::xtal_freq(), XtalClock::RtcXtalFreq40M));
 
     RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
 
@@ -1423,22 +1420,22 @@ pub(crate) enum RtcCaliClkSel {
 /// RTC Watchdog Timer driver
 impl RtcClock {
     // rtc_clk_xtal_freq_get
-    pub(crate) fn get_xtal_freq_mhz() -> u32 {
+    pub(crate) fn xtal_freq_mhz() -> u32 {
         Self::read_xtal_freq_mhz().unwrap_or(40)
     }
 
     /// Get main XTAL frequency
     /// This is the value stored in RTC register RTC_XTAL_FREQ_REG by the
     /// bootloader, as passed to rtc_clk_init function.
-    pub fn get_xtal_freq() -> XtalClock {
-        match Self::get_xtal_freq_mhz() {
+    pub fn xtal_freq() -> XtalClock {
+        match Self::xtal_freq_mhz() {
             40 => XtalClock::RtcXtalFreq40M,
             other => XtalClock::RtcXtalFreqOther(other),
         }
     }
 
     /// Get the RTC_SLOW_CLK source
-    pub fn get_slow_freq() -> RtcSlowClock {
+    pub fn slow_freq() -> RtcSlowClock {
         let lp_clrst = unsafe { lp_clkrst() };
 
         let slow_freq = lp_clrst.lp_clk_conf().read().slow_clk_sel().bits();
@@ -1492,7 +1489,7 @@ impl RtcClock {
 
         if cal_clk == RtcCalSel::RtcCalRtcMux {
             cal_clk = match cal_clk {
-                RtcCalSel::RtcCalRtcMux => match RtcClock::get_slow_freq() {
+                RtcCalSel::RtcCalRtcMux => match RtcClock::slow_freq() {
                     RtcSlowClock::RtcSlowClock32kXtal => RtcCalSel::RtcCal32kXtal,
                     RtcSlowClock::RtcSlowClock32kRc => RtcCalSel::RtcCal32kRc,
                     _ => cal_clk,
@@ -1506,7 +1503,7 @@ impl RtcClock {
         let pcr = unsafe { pcr() };
         let pmu = unsafe { pmu() };
 
-        let clk_src = RtcClock::get_slow_freq();
+        let clk_src = RtcClock::slow_freq();
 
         if cal_clk == RtcCalSel::RtcCalRtcMux {
             cal_clk = match clk_src {
@@ -1756,7 +1753,7 @@ impl RtcClock {
     /// not started up (due to incorrect loading capacitance, board design
     /// issue, or lack of 32 XTAL on board).
     fn calibrate(cal_clk: RtcCalSel, slowclk_cycles: u32) -> u32 {
-        let xtal_freq = RtcClock::get_xtal_freq();
+        let xtal_freq = RtcClock::xtal_freq();
 
         let mut slowclk_cycles = slowclk_cycles;
 
@@ -1777,7 +1774,7 @@ impl RtcClock {
     /// Calculate the necessary RTC_SLOW_CLK cycles to complete 1 millisecond.
     pub(crate) fn cycles_to_1ms() -> u16 {
         let period_13q19 = RtcClock::calibrate(
-            match RtcClock::get_slow_freq() {
+            match RtcClock::slow_freq() {
                 RtcSlowClock::RtcSlowClockRcSlow => RtcCalSel::RtcCalRtcMux,
                 RtcSlowClock::RtcSlowClock32kXtal => RtcCalSel::RtcCal32kXtal,
                 RtcSlowClock::RtcSlowClock32kRc => RtcCalSel::RtcCal32kRc,
@@ -1821,7 +1818,7 @@ impl RtcClock {
 
 pub(crate) fn rtc_clk_cpu_freq_set_xtal() {
     // rtc_clk_cpu_set_to_default_config
-    let freq = RtcClock::get_xtal_freq_mhz();
+    let freq = RtcClock::xtal_freq_mhz();
 
     esp32c6_rtc_update_to_xtal_raw(freq, 1);
 
@@ -1889,7 +1886,7 @@ impl SavedClockConfig {
         match source {
             CpuClockSource::Xtal => {
                 div = esp32c6_cpu_get_ls_divider();
-                source_freq_mhz = RtcClock::get_xtal_freq_mhz();
+                source_freq_mhz = RtcClock::xtal_freq_mhz();
             }
             CpuClockSource::Pll => {
                 div = esp32c6_cpu_get_hs_divider();
@@ -1923,7 +1920,7 @@ impl SavedClockConfig {
                 if old_source != CpuClockSource::Pll {
                     rtc_clk_bbpll_enable();
                     esp32c6_rtc_bbpll_configure_raw(
-                        RtcClock::get_xtal_freq_mhz(),
+                        RtcClock::xtal_freq_mhz(),
                         self.source_freq_mhz,
                     );
                 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -120,10 +120,7 @@ pub(crate) fn init() {
 }
 
 pub(crate) fn configure_clock() {
-    assert!(matches!(
-        RtcClock::get_xtal_freq(),
-        XtalClock::RtcXtalFreq32M
-    ));
+    assert!(matches!(RtcClock::xtal_freq(), XtalClock::RtcXtalFreq32M));
 
     RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
 
@@ -270,7 +267,7 @@ impl RtcClock {
     /// Get main XTAL frequency.
     /// This is the value stored in RTC register RTC_XTAL_FREQ_REG by the
     /// bootloader, as passed to rtc_clk_init function.
-    pub fn get_xtal_freq() -> XtalClock {
+    pub fn xtal_freq() -> XtalClock {
         match Self::read_xtal_freq_mhz() {
             None | Some(32) => XtalClock::RtcXtalFreq32M,
             Some(other) => XtalClock::RtcXtalFreqOther(other),
@@ -309,7 +306,7 @@ impl RtcClock {
     }
 
     /// Get the RTC_SLOW_CLK source
-    pub fn get_slow_freq() -> RtcSlowClock {
+    pub fn slow_freq() -> RtcSlowClock {
         let lp_clrst = unsafe { &*LPWR::ptr() };
 
         let slow_freq = lp_clrst.lp_clk_conf().read().slow_clk_sel().bits();
@@ -323,7 +320,7 @@ impl RtcClock {
     }
 
     fn calibrate(cal_clk: RtcCalSel, slowclk_cycles: u32) -> u32 {
-        let xtal_freq = RtcClock::get_xtal_freq();
+        let xtal_freq = RtcClock::xtal_freq();
         let xtal_cycles = RtcClock::calibrate_internal(cal_clk, slowclk_cycles) as u64;
         let divider = xtal_freq.mhz() as u64 * slowclk_cycles as u64;
         let period_64 = ((xtal_cycles << RtcClock::CAL_FRACT) + divider / 2u64 - 1u64) / divider;
@@ -341,7 +338,7 @@ impl RtcClock {
 
         if cal_clk == RtcCalSel::RtcCalRtcMux {
             cal_clk = match cal_clk {
-                RtcCalSel::RtcCalRtcMux => match RtcClock::get_slow_freq() {
+                RtcCalSel::RtcCalRtcMux => match RtcClock::slow_freq() {
                     RtcSlowClock::RtcSlowClock32kXtal => RtcCalSel::RtcCal32kXtal,
                     RtcSlowClock::RtcSlowClock32kRc => RtcCalSel::RtcCal32kRc,
                     _ => cal_clk,
@@ -355,7 +352,7 @@ impl RtcClock {
         let pcr = unsafe { &*PCR::ptr() };
         let pmu = unsafe { &*PMU::ptr() };
 
-        let clk_src = RtcClock::get_slow_freq();
+        let clk_src = RtcClock::slow_freq();
 
         if cal_clk == RtcCalSel::RtcCalRtcMux {
             cal_clk = match clk_src {
@@ -587,7 +584,7 @@ impl RtcClock {
 
     pub(crate) fn cycles_to_1ms() -> u16 {
         let period_13q19 = RtcClock::calibrate(
-            match RtcClock::get_slow_freq() {
+            match RtcClock::slow_freq() {
                 RtcSlowClock::RtcSlowClockRcSlow => RtcCalSel::RtcCalRtcMux,
                 RtcSlowClock::RtcSlowClock32kXtal => RtcCalSel::RtcCal32kXtal,
                 RtcSlowClock::RtcSlowClock32kRc => RtcCalSel::RtcCal32kRc,

--- a/esp-hal/src/rtc_cntl/rtc/esp32s2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32s2.rs
@@ -9,10 +9,7 @@ use crate::{
 pub(crate) fn init() {}
 
 pub(crate) fn configure_clock() {
-    assert!(matches!(
-        RtcClock::get_xtal_freq(),
-        XtalClock::RtcXtalFreq40M
-    ));
+    assert!(matches!(RtcClock::xtal_freq(), XtalClock::RtcXtalFreq40M));
 
     RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
 

--- a/esp-hal/src/rtc_cntl/rtc/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32s3.rs
@@ -9,10 +9,7 @@ use crate::{
 pub(crate) fn init() {}
 
 pub(crate) fn configure_clock() {
-    assert!(matches!(
-        RtcClock::get_xtal_freq(),
-        XtalClock::RtcXtalFreq40M
-    ));
+    assert!(matches!(RtcClock::xtal_freq(), XtalClock::RtcXtalFreq40M));
 
     RtcClock::set_fast_freq(RtcFastClock::RtcFastClock8m);
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32.rs
@@ -76,7 +76,7 @@ impl WakeSource for TimerWakeupSource {
     ) {
         triggers.set_timer(true);
         let rtc_cntl = unsafe { &*esp32::RTC_CNTL::ptr() };
-        let clock_freq = RtcClock::get_slow_freq();
+        let clock_freq = RtcClock::slow_freq();
         // TODO: maybe add sleep time adjustlemnt like idf
         // TODO: maybe add check to prevent overflow?
         let clock_hz = clock_freq.frequency().to_Hz() as u64;

--- a/esp-hal/src/rtc_cntl/sleep/esp32c2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c2.rs
@@ -130,7 +130,7 @@ impl WakeSource for TimerWakeupSource {
     ) {
         triggers.set_timer(true);
         let rtc_cntl = unsafe { &*esp32c2::RTC_CNTL::ptr() };
-        let clock_freq = RtcClock::get_slow_freq();
+        let clock_freq = RtcClock::slow_freq();
         // TODO: maybe add sleep time adjustlemnt like idf
         // TODO: maybe add check to prevent overflow?
         let clock_hz = clock_freq.frequency().to_Hz() as u64;

--- a/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
@@ -130,7 +130,7 @@ impl WakeSource for TimerWakeupSource {
     ) {
         triggers.set_timer(true);
         let rtc_cntl = unsafe { &*esp32c3::RTC_CNTL::ptr() };
-        let clock_freq = RtcClock::get_slow_freq();
+        let clock_freq = RtcClock::slow_freq();
         // TODO: maybe add sleep time adjustlemnt like idf
         // TODO: maybe add check to prevent overflow?
         let clock_hz = clock_freq.frequency().to_Hz() as u64;

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -38,7 +38,7 @@ impl WakeSource for TimerWakeupSource {
         triggers.set_timer(true);
 
         let lp_timer = unsafe { &*esp32c6::LP_TIMER::ptr() };
-        let clock_freq = RtcClock::get_slow_freq();
+        let clock_freq = RtcClock::slow_freq();
         // TODO: maybe add sleep time adjustment like idf
         // TODO: maybe add check to prevent overflow?
         let clock_hz = clock_freq.frequency().to_Hz() as u64;

--- a/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
@@ -116,7 +116,7 @@ impl WakeSource for TimerWakeupSource {
     ) {
         triggers.set_timer(true);
         let rtc_cntl = unsafe { &*esp32s3::RTC_CNTL::ptr() };
-        let clock_freq = RtcClock::get_slow_freq();
+        let clock_freq = RtcClock::slow_freq();
         // TODO: maybe add sleep time adjustlemnt like idf
         // TODO: maybe add check to prevent overflow?
         let clock_hz = clock_freq.frequency().to_Hz() as u64;

--- a/esp-hal/src/soc/esp32/cpu_control.rs
+++ b/esp-hal/src/soc/esp32/cpu_control.rs
@@ -328,7 +328,7 @@ impl<'d> CpuControl<'d> {
                 let entry = unsafe { ManuallyDrop::take(&mut *entry.cast::<ManuallyDrop<F>>()) };
                 entry();
                 loop {
-                    unsafe { internal_park_core(crate::get_core()) };
+                    unsafe { internal_park_core(crate::core()) };
                 }
             }
             None => panic!("No start function set"),

--- a/esp-hal/src/soc/esp32/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32/efuse/mod.rs
@@ -82,7 +82,7 @@ impl Efuse {
     /// While ESP32 chips usually come with two mostly equivalent CPUs (protocol
     /// CPU and application CPU), the application CPU is unavailable on
     /// some.
-    pub fn get_core_count() -> u32 {
+    pub fn core_count() -> u32 {
         if Self::read_bit(DISABLE_APP_CPU) {
             1
         } else {
@@ -94,7 +94,7 @@ impl Efuse {
     ///
     /// Note that the actual clock may be lower, depending on the current power
     /// configuration of the chip, clock source, and other settings.
-    pub fn get_max_cpu_frequency() -> HertzU32 {
+    pub fn max_cpu_frequency() -> HertzU32 {
         let has_rating = Self::read_bit(CHIP_CPU_FREQ_RATED);
         let has_low_rating = Self::read_bit(CHIP_CPU_FREQ_LOW);
 
@@ -111,7 +111,7 @@ impl Efuse {
     }
 
     /// Returns the CHIP_VER_PKG eFuse value.
-    pub fn get_chip_type() -> ChipType {
+    pub fn chip_type() -> ChipType {
         let chip_ver = Self::read_field_le::<u8>(CHIP_PACKAGE)
             | Self::read_field_le::<u8>(CHIP_PACKAGE_4BIT) << 4;
 
@@ -127,7 +127,7 @@ impl Efuse {
     }
 
     /// Get status of SPI boot encryption.
-    pub fn get_flash_encryption() -> bool {
+    pub fn flash_encryption() -> bool {
         (Self::read_field_le::<u8>(FLASH_CRYPT_CNT).count_ones() % 2) != 0
     }
 }

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -8,7 +8,7 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `get_io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0:`:
+//!   - `io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0:`:
 //!       * This function returns a reference to the GPIO register associated
 //!         with the given GPIO number. It uses unsafe code and transmutation to
 //!         access the GPIO registers based on the provided GPIO number.
@@ -63,7 +63,7 @@ pub(crate) const ZERO_INPUT: u8 = 0x30;
 
 pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function2;
 
-pub(crate) fn get_io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
+pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
     unsafe {
         let iomux = &*IO_MUX::PTR;
 
@@ -110,7 +110,7 @@ pub(crate) fn get_io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
 }
 
 pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    match crate::get_core() {
+    match crate::core() {
         Cpu::AppCpu => int_enable as u8 | ((nmi_enable as u8) << 1),
         // this should be bits 3 & 4 respectively, according to the TRM, but it doesn't seem to
         // work. This does though.
@@ -719,7 +719,7 @@ macro_rules! touch {
                 }
             }
 
-            fn get_touch_measurement(&self, _: $crate::private::Internal) -> u16 {
+            fn touch_measurement(&self, _: $crate::private::Internal) -> u16 {
                 paste::paste! {
                     unsafe { $crate::peripherals::SENS::steal() }
                         . $touch_out_reg ().read()
@@ -727,7 +727,7 @@ macro_rules! touch {
                 }
             }
 
-            fn get_touch_nr(&self, _: $crate::private::Internal) -> u8 {
+            fn touch_nr(&self, _: $crate::private::Internal) -> u8 {
                 $touch_num
             }
 
@@ -789,11 +789,11 @@ pub(crate) enum InterruptStatusRegisterAccess {
 impl InterruptStatusRegisterAccess {
     pub(crate) fn interrupt_status_read(self) -> u32 {
         match self {
-            Self::Bank0 => match crate::get_core() {
+            Self::Bank0 => match crate::core() {
                 crate::Cpu::ProCpu => unsafe { GPIO::steal() }.pcpu_int().read().bits(),
                 crate::Cpu::AppCpu => unsafe { GPIO::steal() }.acpu_int().read().bits(),
             },
-            Self::Bank1 => match crate::get_core() {
+            Self::Bank1 => match crate::core() {
                 crate::Cpu::ProCpu => unsafe { GPIO::steal() }.pcpu_int1().read().bits(),
                 crate::Cpu::AppCpu => unsafe { GPIO::steal() }.acpu_int1().read().bits(),
             },

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         addr_of_mut!(_rtc_slow_bss_end),
     );
     if matches!(
-        crate::reset::get_reset_reason(),
+        crate::reset::reset_reason(),
         None | Some(SocResetReason::ChipPowerOn)
     ) {
         xtensa_lx_rt::zero_bss(

--- a/esp-hal/src/soc/esp32/psram.rs
+++ b/esp-hal/src/soc/esp32/psram.rs
@@ -304,7 +304,7 @@ pub(crate) mod utils {
 
     #[ram]
     pub(crate) fn psram_init(config: &PsramConfig) {
-        let chip = crate::efuse::Efuse::get_chip_type();
+        let chip = crate::efuse::Efuse::chip_type();
 
         let mode = config.cache_speed;
         let mut psram_io = PsramIo::default();
@@ -1061,7 +1061,7 @@ pub(crate) mod utils {
 
             fn configure_gpio(gpio: u8, field: Field, bits: u8) {
                 unsafe {
-                    let ptr = crate::gpio::get_io_mux_reg(gpio);
+                    let ptr = crate::gpio::io_mux_reg(gpio);
                     ptr.modify(|_, w| apply_to_field!(w, field, bits));
                 }
             }

--- a/esp-hal/src/soc/esp32c2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c2/efuse/mod.rs
@@ -54,19 +54,19 @@ impl Efuse {
     }
 
     /// Get status of SPI boot encryption.
-    pub fn get_flash_encryption() -> bool {
+    pub fn flash_encryption() -> bool {
         (Self::read_field_le::<u8>(SPI_BOOT_CRYPT_CNT).count_ones() % 2) != 0
     }
 
     /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
-    pub fn get_rwdt_multiplier() -> u8 {
+    pub fn rwdt_multiplier() -> u8 {
         Self::read_field_le::<u8>(WDT_DELAY_SEL)
     }
 
     /// Get efuse block version
     ///
     /// see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30>
-    pub fn get_block_version() -> (u8, u8) {
+    pub fn block_version() -> (u8, u8) {
         // see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c2/include/hal/efuse_ll.h#L65-L73>
         // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_table.csv#L90-L91>
         (
@@ -78,8 +78,8 @@ impl Efuse {
     /// Get version of RTC calibration block
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L14>
-    pub fn get_rtc_calib_version() -> u8 {
-        let (major, _minor) = Self::get_block_version();
+    pub fn rtc_calib_version() -> u8 {
+        let (major, _minor) = Self::block_version();
         if major == 0 {
             1
         } else {
@@ -90,8 +90,8 @@ impl Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L27>
-    pub fn get_rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
-        let version = Self::get_rtc_calib_version();
+    pub fn rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+        let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;
@@ -119,7 +119,7 @@ impl Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L65>
-    pub fn get_rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::Attenuation0dB => 400,
             Attenuation::Attenuation11dB => 1370,
@@ -129,8 +129,8 @@ impl Efuse {
     /// Get ADC reference point digital code for specified attenuation
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L65>
-    pub fn get_rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
-        let version = Self::get_rtc_calib_version();
+    pub fn rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+        let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;

--- a/esp-hal/src/soc/esp32c2/gpio.rs
+++ b/esp-hal/src/soc/esp32c2/gpio.rs
@@ -8,8 +8,7 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `get_io_mux_reg(gpio_num: u8) -> &'static
-//!     crate::peripherals::io_mux::GPIO`:
+//!   - `io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
 //!       * This function enables or disables GPIO interrupts and Non-Maskable
@@ -55,7 +54,7 @@ pub(crate) const ZERO_INPUT: u8 = 0x1f;
 
 pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
 
-pub(crate) const fn get_io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
+pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }
 }
 

--- a/esp-hal/src/soc/esp32c3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c3/efuse/mod.rs
@@ -55,19 +55,19 @@ impl Efuse {
     }
 
     /// Get status of SPI boot encryption.
-    pub fn get_flash_encryption() -> bool {
+    pub fn flash_encryption() -> bool {
         (Self::read_field_le::<u8>(SPI_BOOT_CRYPT_CNT).count_ones() % 2) != 0
     }
 
     /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
-    pub fn get_rwdt_multiplier() -> u8 {
+    pub fn rwdt_multiplier() -> u8 {
         Self::read_field_le::<u8>(WDT_DELAY_SEL)
     }
 
     /// Get efuse block version
     ///
     /// see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30>
-    pub fn get_block_version() -> (u8, u8) {
+    pub fn block_version() -> (u8, u8) {
         // see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c3/include/hal/efuse_ll.h#L70-L78>
         // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L163>
         // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_table.csv#L173>
@@ -80,8 +80,8 @@ impl Efuse {
     /// Get version of RTC calibration block
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L12>
-    pub fn get_rtc_calib_version() -> u8 {
-        let (major, _minor) = Self::get_block_version();
+    pub fn rtc_calib_version() -> u8 {
+        let (major, _minor) = Self::block_version();
         if major == 1 {
             1
         } else {
@@ -92,8 +92,8 @@ impl Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L25>
-    pub fn get_rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
-        let version = Self::get_rtc_calib_version();
+    pub fn rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+        let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;
@@ -113,7 +113,7 @@ impl Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L49>
-    pub fn get_rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::Attenuation0dB => 400,
             Attenuation::Attenuation2p5dB => 550,
@@ -125,8 +125,8 @@ impl Efuse {
     /// Get ADC reference point digital code for specified attenuation
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L49>
-    pub fn get_rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
-        let version = Self::get_rtc_calib_version();
+    pub fn rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+        let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;

--- a/esp-hal/src/soc/esp32c3/gpio.rs
+++ b/esp-hal/src/soc/esp32c3/gpio.rs
@@ -8,7 +8,7 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `get_io_mux_reg(gpio_num: u8) -> &'static
+//!   - `io_mux_reg(gpio_num: u8) -> &'static
 //!     crate::peripherals::io_mux::GPIO0:`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
@@ -56,7 +56,7 @@ pub(crate) const ZERO_INPUT: u8 = 0x1f;
 
 pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
 
-pub(crate) const fn get_io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
+pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }
 }
 

--- a/esp-hal/src/soc/esp32c6/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32c6/efuse/mod.rs
@@ -55,19 +55,19 @@ impl Efuse {
     }
 
     /// Get status of SPI boot encryption.
-    pub fn get_flash_encryption() -> bool {
+    pub fn flash_encryption() -> bool {
         (Self::read_field_le::<u8>(SPI_BOOT_CRYPT_CNT).count_ones() % 2) != 0
     }
 
     /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
-    pub fn get_rwdt_multiplier() -> u8 {
+    pub fn rwdt_multiplier() -> u8 {
         Self::read_field_le::<u8>(WDT_DELAY_SEL)
     }
 
     /// Get efuse block version
     ///
     /// see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30>
-    pub fn get_block_version() -> (u8, u8) {
+    pub fn block_version() -> (u8, u8) {
         // see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32c6/include/hal/efuse_ll.h#L65-L73>
         // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L156>
         (
@@ -79,8 +79,8 @@ impl Efuse {
     /// Get version of RTC calibration block
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L20>
-    pub fn get_rtc_calib_version() -> u8 {
-        let (_major, minor) = Self::get_block_version();
+    pub fn rtc_calib_version() -> u8 {
+        let (_major, minor) = Self::block_version();
         if minor >= 1 {
             1
         } else {
@@ -91,8 +91,8 @@ impl Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L32>
-    pub fn get_rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
-        let version = Self::get_rtc_calib_version();
+    pub fn rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+        let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;
@@ -112,7 +112,7 @@ impl Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42>
-    pub fn get_rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::Attenuation0dB => 400,
             Attenuation::Attenuation2p5dB => 550,
@@ -124,8 +124,8 @@ impl Efuse {
     /// Get ADC reference point digital code for specified attenuation
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42>
-    pub fn get_rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
-        let version = Self::get_rtc_calib_version();
+    pub fn rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+        let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;

--- a/esp-hal/src/soc/esp32c6/gpio.rs
+++ b/esp-hal/src/soc/esp32c6/gpio.rs
@@ -8,7 +8,7 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `get_io_mux_reg(gpio_num: u8) -> &'static
+//!   - `io_mux_reg(gpio_num: u8) -> &'static
 //!     crate::peripherals::io_mux::GPIO0:`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
@@ -56,7 +56,7 @@ pub(crate) const ZERO_INPUT: u8 = 0x3c;
 
 pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
 
-pub(crate) const fn get_io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
+pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }
 }
 

--- a/esp-hal/src/soc/esp32h2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32h2/efuse/mod.rs
@@ -55,12 +55,12 @@ impl Efuse {
     }
 
     /// Get status of SPI boot encryption.
-    pub fn get_flash_encryption() -> bool {
+    pub fn flash_encryption() -> bool {
         (Self::read_field_le::<u8>(SPI_BOOT_CRYPT_CNT).count_ones() % 2) != 0
     }
 
     /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
-    pub fn get_rwdt_multiplier() -> u8 {
+    pub fn rwdt_multiplier() -> u8 {
         Self::read_field_le::<u8>(WDT_DELAY_SEL)
     }
 }

--- a/esp-hal/src/soc/esp32h2/gpio.rs
+++ b/esp-hal/src/soc/esp32h2/gpio.rs
@@ -8,7 +8,7 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `get_io_mux_reg(gpio_num: u8) -> &'static
+//!   - `io_mux_reg(gpio_num: u8) -> &'static
 //!     crate::peripherals::io_mux::GPIO0:`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
@@ -54,7 +54,7 @@ pub(crate) const ZERO_INPUT: u8 = 0x3c;
 
 pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
 
-pub(crate) const fn get_io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
+pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }
 }
 

--- a/esp-hal/src/soc/esp32s2/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32s2/efuse/mod.rs
@@ -57,12 +57,12 @@ impl Efuse {
     }
 
     /// Get status of SPI boot encryption.
-    pub fn get_flash_encryption() -> bool {
+    pub fn flash_encryption() -> bool {
         (Self::read_field_le::<u8>(SPI_BOOT_CRYPT_CNT).count_ones() % 2) != 0
     }
 
     /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
-    pub fn get_rwdt_multiplier() -> u8 {
+    pub fn rwdt_multiplier() -> u8 {
         Self::read_field_le::<u8>(WDT_DELAY_SEL)
     }
 }

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -8,7 +8,7 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `get_io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0:`:
+//!   - `io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0:`:
 //!       * This function returns a reference to the GPIO register associated
 //!         with the given GPIO number. It uses unsafe code and transmutation to
 //!         access the GPIO registers based on the provided GPIO number.
@@ -69,7 +69,7 @@ pub(crate) const ZERO_INPUT: u8 = 0x3c;
 
 pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
 
-pub(crate) const fn get_io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
+pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
     unsafe {
         let iomux = &*IO_MUX::PTR;
 

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         addr_of_mut!(_rtc_slow_bss_end),
     );
     if matches!(
-        crate::reset::get_reset_reason(),
+        crate::reset::reset_reason(),
         None | Some(SocResetReason::ChipPowerOn)
     ) {
         xtensa_lx_rt::zero_bss(

--- a/esp-hal/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal/src/soc/esp32s3/cpu_control.rs
@@ -264,7 +264,7 @@ impl<'d> CpuControl<'d> {
                 let entry = unsafe { ManuallyDrop::take(&mut *entry.cast::<ManuallyDrop<F>>()) };
                 entry();
                 loop {
-                    unsafe { internal_park_core(crate::get_core()) };
+                    unsafe { internal_park_core(crate::core()) };
                 }
             }
             None => panic!("No start function set"),

--- a/esp-hal/src/soc/esp32s3/efuse/mod.rs
+++ b/esp-hal/src/soc/esp32s3/efuse/mod.rs
@@ -55,19 +55,19 @@ impl Efuse {
     }
 
     /// Get status of SPI boot encryption.
-    pub fn get_flash_encryption() -> bool {
+    pub fn flash_encryption() -> bool {
         (Self::read_field_le::<u8>(SPI_BOOT_CRYPT_CNT).count_ones() % 2) != 0
     }
 
     /// Get the multiplier for the timeout value of the RWDT STAGE 0 register.
-    pub fn get_rwdt_multiplier() -> u8 {
+    pub fn rwdt_multiplier() -> u8 {
         Self::read_field_le::<u8>(WDT_DELAY_SEL)
     }
 
     /// Get efuse block version
     ///
     /// see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/efuse_hal.c#L27-L30>
-    pub fn get_block_version() -> (u8, u8) {
+    pub fn block_version() -> (u8, u8) {
         // see <https://github.com/espressif/esp-idf/blob/dc016f5987/components/hal/esp32s3/include/hal/efuse_ll.h#L65-L73>
         // <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32s3/esp_efuse_table.csv#L196>
         (
@@ -79,8 +79,8 @@ impl Efuse {
     /// Get version of RTC calibration block
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32s3/esp_efuse_rtc_calib.c#L15>
-    pub fn get_rtc_calib_version() -> u8 {
-        let (major, _minor) = Self::get_block_version();
+    pub fn rtc_calib_version() -> u8 {
+        let (major, _minor) = Self::block_version();
 
         if major == 1 {
             1
@@ -92,8 +92,8 @@ impl Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32s3/esp_efuse_rtc_calib.c#L28>
-    pub fn get_rtc_calib_init_code(unit: u8, atten: Attenuation) -> Option<u16> {
-        let version = Self::get_rtc_calib_version();
+    pub fn rtc_calib_init_code(unit: u8, atten: Attenuation) -> Option<u16> {
+        let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;
@@ -143,15 +143,15 @@ impl Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32s3/esp_efuse_rtc_calib.c#L63>
-    pub fn get_rtc_calib_cal_mv(_unit: u8, _atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: u8, _atten: Attenuation) -> u16 {
         850
     }
 
     /// Get ADC reference point digital code for specified attenuation
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32s3/esp_efuse_rtc_calib.c#L63>
-    pub fn get_rtc_calib_cal_code(unit: u8, atten: Attenuation) -> Option<u16> {
-        let version = Self::get_rtc_calib_version();
+    pub fn rtc_calib_cal_code(unit: u8, atten: Attenuation) -> Option<u16> {
+        let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -8,7 +8,7 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `get_io_mux_reg(gpio_num: u8) -> &'static
+//!   - `io_mux_reg(gpio_num: u8) -> &'static
 //!     crate::peripherals::io_mux::GPIO0:`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
@@ -56,7 +56,7 @@ pub(crate) const ZERO_INPUT: u8 = 0x3c;
 
 pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
 
-pub(crate) const fn get_io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
+pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }
 }
 

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         addr_of_mut!(_rtc_slow_bss_end),
     );
     if matches!(
-        crate::reset::get_reset_reason(),
+        crate::reset::reset_reason(),
         None | Some(SocResetReason::ChipPowerOn)
     ) {
         xtensa_lx_rt::zero_bss(

--- a/esp-hal/src/soc/esp32s3/psram.rs
+++ b/esp-hal/src/soc/esp32s3/psram.rs
@@ -379,9 +379,9 @@ pub(crate) mod utils {
     /// or `calculate_best_flash_tuning_config`
     #[ram]
     fn mspi_timing_enter_high_speed_mode(control_spi1: bool, config: &PsramConfig) {
-        let core_clock: SpiTimingConfigCoreClock = get_mspi_core_clock(config);
-        let flash_div: u32 = get_flash_clock_divider(config);
-        let psram_div: u32 = get_psram_clock_divider(config);
+        let core_clock: SpiTimingConfigCoreClock = mspi_core_clock(config);
+        let flash_div: u32 = flash_clock_divider(config);
+        let psram_div: u32 = psram_clock_divider(config);
 
         info!(
             "PSRAM core_clock {:?}, flash_div = {}, psram_div = {}",
@@ -466,17 +466,17 @@ pub(crate) mod utils {
     }
 
     #[ram]
-    fn get_mspi_core_clock(config: &PsramConfig) -> SpiTimingConfigCoreClock {
+    fn mspi_core_clock(config: &PsramConfig) -> SpiTimingConfigCoreClock {
         config.core_clock
     }
 
     #[ram]
-    fn get_flash_clock_divider(config: &PsramConfig) -> u32 {
+    fn flash_clock_divider(config: &PsramConfig) -> u32 {
         config.core_clock as u32 / config.flash_frequency as u32
     }
 
     #[ram]
-    fn get_psram_clock_divider(config: &PsramConfig) -> u32 {
+    fn psram_clock_divider(config: &PsramConfig) -> u32 {
         config.core_clock as u32 / config.ram_frequency as u32
     }
 
@@ -1058,7 +1058,7 @@ pub(crate) mod utils {
 
         init_psram_mode_reg(1, &mode_reg);
         // Print PSRAM info
-        get_psram_mode_reg(1, &mut mode_reg);
+        psram_mode_reg(1, &mut mode_reg);
 
         print_psram_info(&mode_reg);
 
@@ -1238,11 +1238,11 @@ pub(crate) mod utils {
     // This function should always be called after `spi_timing_flash_tuning` or
     // `calculate_best_flash_tuning_config`
     fn spi_timing_enter_mspi_high_speed_mode(control_spi1: bool, config: &PsramConfig) {
-        // spi_timing_config_core_clock_t core_clock = get_mspi_core_clock();
+        // spi_timing_config_core_clock_t core_clock = mspi_core_clock();
         let core_clock = SpiTimingConfigCoreClock::SpiTimingConfigCoreClock80m;
 
-        let flash_div: u32 = get_flash_clock_divider(config);
-        let psram_div: u32 = get_psram_clock_divider(config);
+        let flash_div: u32 = flash_clock_divider(config);
+        let psram_div: u32 = psram_clock_divider(config);
 
         // Set SPI01 core clock
         spi0_timing_config_set_core_clock(core_clock); // SPI0 and SPI1 share the register for core clock. So we only set SPI0 here.
@@ -1306,7 +1306,7 @@ pub(crate) mod utils {
         }
     }
 
-    fn get_psram_mode_reg(spi_num: u32, out_reg: &mut OpiPsramModeReg) {
+    fn psram_mode_reg(spi_num: u32, out_reg: &mut OpiPsramModeReg) {
         let mode = ESP_ROM_SPIFLASH_OPI_DTR_MODE;
         let cmd_len: u32 = 16;
         let addr_bit_len: u32 = 32;
@@ -1601,12 +1601,12 @@ pub(crate) mod utils {
     }
 
     #[ram]
-    fn get_flash_clock_divider(config: &PsramConfig) -> u32 {
+    fn flash_clock_divider(config: &PsramConfig) -> u32 {
         config.core_clock as u32 / config.flash_frequency as u32
     }
 
     #[ram]
-    fn get_psram_clock_divider(config: &PsramConfig) -> u32 {
+    fn psram_clock_divider(config: &PsramConfig) -> u32 {
         config.core_clock as u32 / config.ram_frequency as u32
     }
 }

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -87,7 +87,7 @@ impl self::efuse::Efuse {
     ///
     /// By default this reads the base mac address from eFuse, but it can be
     /// overridden by `set_mac_address`.
-    pub fn get_mac_address() -> [u8; 6] {
+    pub fn mac_address() -> [u8; 6] {
         if MAC_OVERRIDE_STATE.load(Ordering::Relaxed) == 2 {
             unsafe { MAC_OVERRIDE }
         } else {

--- a/esp-hal/src/sync.rs
+++ b/esp-hal/src/sync.rs
@@ -56,13 +56,13 @@ mod single_core {
 mod multicore {
     use portable_atomic::{AtomicUsize, Ordering};
 
-    // Safety: Ensure that when adding new chips `get_raw_core` doesn't return this
+    // Safety: Ensure that when adding new chips `raw_core` doesn't return this
     // value.
     // FIXME: ensure in HIL tests this is the case!
     const UNUSED_THREAD_ID_VALUE: usize = 0x100;
 
     pub fn thread_id() -> usize {
-        crate::get_raw_core()
+        crate::raw_core()
     }
 
     pub(super) struct AtomicLock {

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -454,7 +454,7 @@ pub trait Comparator {
 
     /// Get the current mode of the comparator, which is either target or
     /// periodic.
-    fn get_mode(&self) -> ComparatorMode {
+    fn mode(&self) -> ComparatorMode {
         let tconf = unsafe {
             let systimer = &*SYSTIMER::ptr();
             systimer.target_conf(self.channel() as usize)
@@ -497,7 +497,7 @@ pub trait Comparator {
     }
 
     /// Get the actual target value of the comparator.
-    fn get_actual_target(&self) -> u64 {
+    fn actual_target(&self) -> u64 {
         let target = unsafe {
             let systimer = &*SYSTIMER::ptr();
             systimer.trgt(self.channel() as usize)
@@ -871,7 +871,7 @@ where
     }
 
     fn load_value(&self, value: MicrosDurationU64) -> Result<(), Error> {
-        let mode = self.comparator.get_mode();
+        let mode = self.comparator.mode();
 
         let us = value.ticks();
         let ticks = us * (SystemTimer::ticks_per_second() / 1_000_000);

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -394,7 +394,7 @@ impl<P: TouchPin, TOUCHMODE: TouchMode, MODE: Mode> TouchPad<P, TOUCHMODE, MODE>
             .touch_meas_done()
             .bit_is_set()
         {
-            Some(self.pin.get_touch_measurement(Internal))
+            Some(self.pin.touch_measurement(Internal))
         } else {
             None
         }
@@ -420,7 +420,7 @@ impl<P: TouchPin, TOUCHMODE: TouchMode> TouchPad<P, TOUCHMODE, Blocking> {
             .touch_meas_done()
             .bit_is_clear()
         {}
-        self.pin.get_touch_measurement(Internal)
+        self.pin.touch_measurement(Internal)
     }
 
     /// Enables the touch_pad interrupt.
@@ -439,7 +439,7 @@ impl<P: TouchPin, TOUCHMODE: TouchMode> TouchPad<P, TOUCHMODE, Blocking> {
     /// ## Example
     pub fn enable_interrupt(&mut self, threshold: u16) {
         self.pin.set_threshold(threshold, Internal);
-        internal_enable_interrupt(self.pin.get_touch_nr(Internal))
+        internal_enable_interrupt(self.pin.touch_nr(Internal))
     }
 
     /// Disables the touch pad's interrupt.
@@ -447,7 +447,7 @@ impl<P: TouchPin, TOUCHMODE: TouchMode> TouchPad<P, TOUCHMODE, Blocking> {
     /// If no other touch pad interrupts are active, the touch interrupt is
     /// disabled completely.
     pub fn disable_interrupt(&mut self) {
-        internal_disable_interrupt(self.pin.get_touch_nr(Internal))
+        internal_disable_interrupt(self.pin.touch_nr(Internal))
     }
 
     /// Clears a pending touch interrupt.
@@ -464,7 +464,7 @@ impl<P: TouchPin, TOUCHMODE: TouchMode> TouchPad<P, TOUCHMODE, Blocking> {
 
     /// Checks if the pad is touched, based on the configured threshold value.
     pub fn is_interrupt_set(&mut self) -> bool {
-        internal_is_interrupt_set(self.pin.get_touch_nr(Internal))
+        internal_is_interrupt_set(self.pin.touch_nr(Internal))
     }
 }
 
@@ -587,7 +587,7 @@ mod asynch {
         /// Wait for the pad to be touched.
         pub async fn wait_for_touch(&mut self, threshold: u16) {
             self.pin.set_threshold(threshold, Internal);
-            let touch_nr = self.pin.get_touch_nr(Internal);
+            let touch_nr = self.pin.touch_nr(Internal);
             internal_enable_interrupt(touch_nr);
             TouchFuture::new(touch_nr).await;
         }

--- a/esp-ieee802154/CHANGELOG.md
+++ b/esp-ieee802154/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed `get_` prefixes from functions (#2528)
+
 ### Fixed
 
 ### Removed

--- a/esp-ieee802154/src/hal.rs
+++ b/esp-ieee802154/src/hal.rs
@@ -255,7 +255,7 @@ pub(crate) fn set_freq(freq: u8) {
 }
 
 #[inline(always)]
-pub(crate) fn get_freq() -> u8 {
+pub(crate) fn freq() -> u8 {
     unsafe { &*IEEE802154::PTR }.channel().read().hop().bits()
 }
 
@@ -344,7 +344,7 @@ pub(crate) fn set_tx_auto_ack(enable: bool) {
 }
 
 #[inline(always)]
-pub(crate) fn get_tx_auto_ack() -> bool {
+pub(crate) fn tx_auto_ack() -> bool {
     unsafe { &*IEEE802154::PTR }
         .ctrl_cfg()
         .read()
@@ -367,7 +367,7 @@ pub(crate) fn set_tx_enhance_ack(enable: bool) {
 }
 
 #[inline(always)]
-pub(crate) fn get_tx_enhance_ack() -> bool {
+pub(crate) fn tx_enhance_ack() -> bool {
     unsafe { &*IEEE802154::PTR }
         .ctrl_cfg()
         .read()
@@ -397,7 +397,7 @@ pub(crate) fn set_pending_mode(enable: bool) {
 }
 
 #[inline(always)]
-pub(crate) fn get_events() -> u16 {
+pub(crate) fn events() -> u16 {
     unsafe { &*IEEE802154::PTR }.event_status().read().bits() as u16
 }
 

--- a/esp-ieee802154/src/lib.rs
+++ b/esp-ieee802154/src/lib.rs
@@ -160,12 +160,12 @@ impl<'a> Ieee802154<'a> {
     }
 
     /// Return the raw data of a received frame
-    pub fn get_raw_received(&mut self) -> Option<RawReceived> {
+    pub fn raw_received(&mut self) -> Option<RawReceived> {
         ieee802154_poll()
     }
 
     /// Get a received frame, if available
-    pub fn get_received(&mut self) -> Option<Result<ReceivedFrame, Error>> {
+    pub fn received(&mut self) -> Option<Result<ReceivedFrame, Error>> {
         if let Some(raw) = ieee802154_poll() {
             let maybe_decoded = if raw.data[0] as usize > raw.data.len() {
                 // try to decode up to data.len()

--- a/esp-ieee802154/src/raw.rs
+++ b/esp-ieee802154/src/raw.rs
@@ -252,7 +252,7 @@ fn enable_rx() {
 }
 
 fn stop_current_operation() {
-    let events = get_events();
+    let events = events();
     set_cmd(Command::Stop);
     clear_events(events);
 }
@@ -359,7 +359,7 @@ fn next_operation() {
 fn ZB_MAC() {
     trace!("ZB_MAC interrupt");
 
-    let events = get_events();
+    let events = events();
     clear_events(events);
 
     trace!("events = {:032b}", events);
@@ -390,7 +390,7 @@ fn ZB_MAC() {
                 if !queue.is_full() {
                     let item = RawReceived {
                         data: RX_BUFFER,
-                        channel: freq_to_channel(get_freq()),
+                        channel: freq_to_channel(freq()),
                     };
                     queue.enqueue(item).ok();
                 } else {
@@ -440,11 +440,9 @@ fn freq_to_channel(freq: u8) -> u8 {
 }
 
 fn will_auto_send_ack(frame: &[u8]) -> bool {
-    frame_is_ack_required(frame) && frame_get_version(frame) <= FRAME_VERSION_1 && get_tx_auto_ack()
+    frame_is_ack_required(frame) && frame_get_version(frame) <= FRAME_VERSION_1 && tx_auto_ack()
 }
 
 fn should_send_enhanced_ack(frame: &[u8]) -> bool {
-    frame_is_ack_required(frame)
-        && frame_get_version(frame) <= FRAME_VERSION_2
-        && get_tx_enhance_ack()
+    frame_is_ack_required(frame) && frame_get_version(frame) <= FRAME_VERSION_2 && tx_enhance_ack()
 }

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - esp-now: Data is now private in `ReceivedData` - use `data()`(#2396)
 - Changed the async APIs to have a `_async` postfix to avoid name collisions (#2446)
 - `phy_enable_usb` is enabled by default (#2446)
+- Removed `get_` prefixes from functions (#2528)
 
 ### Fixed
 

--- a/esp-wifi/MIGRATING-0.10.md
+++ b/esp-wifi/MIGRATING-0.10.md
@@ -61,7 +61,7 @@ use esp_wifi::{
 +    let mut rng = Rng::new(peripherals.RNG);
 -    let init = init(timg0.timer0, rng, peripherals.RADIO_CLK).unwrap();
 +    let init = init(timg0.timer0, rng.clone(), peripherals.RADIO_CLK).unwrap();
- 
+
      let mut wifi = peripherals.WIFI;
      let mut socket_set_entries: [SocketStorage; 3] = Default::default();
 +    let (iface, device, mut controller) =
@@ -76,3 +76,9 @@ use esp_wifi::{
 ```
 
 The related features are removed from `esp-wifi`: wifi-default, ipv6, ipv4, tcp, udp, icmp, igmp, dns, dhcpv4
+
+## `get_` prefixes have been removed from functions
+
+In order to better comply with the Rust API Guidelines [getter names convention], we have removed the `get_` prefixes from all functions which previously had it. Due to the number of changes it's not practical to list all changes here, however if a function previous began with `get_`, you can simply remove this prefix.
+
+[getter names convention]: https://rust-lang.github.io/api-guidelines/naming.html#c-getter

--- a/esp-wifi/src/ble/controller/mod.rs
+++ b/esp-wifi/src/ble/controller/mod.rs
@@ -29,7 +29,7 @@ impl<'d> BleConnector<'d> {
         }
     }
 
-    pub fn get_next(&mut self, buf: &mut [u8]) -> Result<usize, BleConnectorError> {
+    pub fn next(&mut self, buf: &mut [u8]) -> Result<usize, BleConnectorError> {
         Ok(read_next(buf))
     }
 }

--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -209,8 +209,9 @@ unsafe extern "C" fn phy_exit_critical(level: u32) {
 #[ram]
 #[no_mangle]
 unsafe extern "C" fn rtc_get_xtal() -> u32 {
-    use crate::hal::clock::Clock;
-    let xtal = crate::hal::rtc_cntl::RtcClock::get_xtal_freq();
+    use esp_hal::clock::Clock;
+
+    let xtal = crate::hal::rtc_cntl::RtcClock::xtal_freq();
     xtal.mhz()
 }
 

--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn random() -> crate::binary::c_types::c_ulong {
 pub unsafe extern "C" fn read_mac(mac: *mut u8, type_: u32) -> crate::binary::c_types::c_int {
     trace!("read_mac {:?} {}", mac, type_);
 
-    let base_mac = crate::hal::efuse::Efuse::get_mac_address();
+    let base_mac = crate::hal::efuse::Efuse::mac_address();
 
     for (i, &byte) in base_mac.iter().enumerate() {
         mac.add(i).write_volatile(byte);

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -207,7 +207,7 @@ pub(crate) fn sem_take(semphr: *mut c_void, tick: u32) -> i32 {
 
     let forever = tick == OSI_FUNCS_TIME_BLOCKING;
     let timeout = tick as u64;
-    let start = crate::timer::get_systimer_count();
+    let start = crate::timer::systimer_count();
 
     let sem = semphr as *mut u32;
 
@@ -377,7 +377,7 @@ pub(crate) fn receive_queued(
 
     let forever = block_time_tick == OSI_FUNCS_TIME_BLOCKING;
     let timeout = block_time_tick as u64;
-    let start = crate::timer::get_systimer_count();
+    let start = crate::timer::systimer_count();
 
     loop {
         if unsafe { (*queue).try_dequeue(item) } {

--- a/esp-wifi/src/compat/timer_compat.rs
+++ b/esp-wifi/src/compat/timer_compat.rs
@@ -145,7 +145,7 @@ pub(crate) fn compat_timer_arm(ets_timer: *mut ets_timer, tmout: u32, repeat: bo
 }
 
 pub(crate) fn compat_timer_arm_us(ets_timer: *mut ets_timer, us: u32, repeat: bool) {
-    let systick = crate::timer::get_systimer_count();
+    let systick = crate::timer::systimer_count();
     let ticks = crate::timer::micros_to_ticks(us as u64);
 
     trace!(

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -352,7 +352,7 @@ impl EspNowManager<'_> {
     }
 
     /// Get the version of ESP-NOW.
-    pub fn get_version(&self) -> Result<u32, EspNowError> {
+    pub fn version(&self) -> Result<u32, EspNowError> {
         let mut version = 0u32;
         check_error!({ esp_now_get_version(&mut version as *mut u32) })?;
         Ok(version)
@@ -404,7 +404,7 @@ impl EspNowManager<'_> {
     }
 
     /// Get peer by MAC address.
-    pub fn get_peer(&self, peer_address: &[u8; 6]) -> Result<PeerInfo, EspNowError> {
+    pub fn peer(&self, peer_address: &[u8; 6]) -> Result<PeerInfo, EspNowError> {
         let mut raw_peer = esp_now_peer_info_t {
             peer_addr: [0u8; 6],
             lmk: [0u8; 16],
@@ -744,8 +744,8 @@ impl<'d> EspNow<'d> {
     }
 
     /// Get the version of ESP-NOW.
-    pub fn get_version(&self) -> Result<u32, EspNowError> {
-        self.manager.get_version()
+    pub fn version(&self) -> Result<u32, EspNowError> {
+        self.manager.version()
     }
 
     /// Add a peer to the list of known peers.
@@ -764,8 +764,8 @@ impl<'d> EspNow<'d> {
     }
 
     /// Get peer by MAC address.
-    pub fn get_peer(&self, peer_address: &[u8; 6]) -> Result<PeerInfo, EspNowError> {
-        self.manager.get_peer(peer_address)
+    pub fn peer(&self, peer_address: &[u8; 6]) -> Result<PeerInfo, EspNowError> {
+        self.manager.peer(peer_address)
     }
 
     /// Fetch a peer from peer list.

--- a/esp-wifi/src/tasks.rs
+++ b/esp-wifi/src/tasks.rs
@@ -1,7 +1,7 @@
 use crate::{
     compat::timer_compat::TIMERS,
     preempt::arch_specific::task_create,
-    timer::{get_systimer_count, yield_task},
+    timer::{systimer_count, yield_task},
 };
 
 /// Initializes the `main` and `timer` tasks for the Wi-Fi driver.
@@ -17,7 +17,7 @@ pub(crate) fn init_tasks() {
 /// events.
 pub(crate) extern "C" fn timer_task(_param: *mut esp_wifi_sys::c_types::c_void) {
     loop {
-        let current_timestamp = get_systimer_count();
+        let current_timestamp = systimer_count();
         let to_run = critical_section::with(|cs| unsafe {
             let mut timers = TIMERS.borrow_ref_mut(cs);
             let to_run = timers.find_next_due(current_timestamp);

--- a/esp-wifi/src/timer/mod.rs
+++ b/esp-wifi/src/timer/mod.rs
@@ -62,6 +62,6 @@ pub(crate) fn ticks_to_millis(ticks: u64) -> u64 {
 
 /// Do not call this in a critical section!
 pub(crate) fn elapsed_time_since(start: u64) -> u64 {
-    let now = get_systimer_count();
+    let now = systimer_count();
     time_diff(start, now)
 }

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -95,7 +95,7 @@ pub(crate) fn yield_task() {
 
 /// Current systimer count value
 /// A tick is 1 / 1_000_000 seconds
-pub(crate) fn get_systimer_count() -> u64 {
+pub(crate) fn systimer_count() -> u64 {
     esp_hal::time::now().ticks()
 }
 

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -17,7 +17,7 @@ pub const TICKS_PER_SECOND: u64 = 1_000_000;
 
 /// This function must not be called in a critical section. Doing so may return
 /// an incorrect value.
-pub(crate) fn get_systimer_count() -> u64 {
+pub(crate) fn systimer_count() -> u64 {
     esp_hal::time::now().ticks()
 }
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1465,14 +1465,14 @@ static mut G_CONFIG: wifi_init_config_t = wifi_init_config_t {
 };
 
 /// Get the STA MAC address
-pub fn get_sta_mac(mac: &mut [u8; 6]) {
+pub fn sta_mac(mac: &mut [u8; 6]) {
     unsafe {
         read_mac(mac as *mut u8, 0);
     }
 }
 
 /// Get the AP MAC address
-pub fn get_ap_mac(mac: &mut [u8; 6]) {
+pub fn ap_mac(mac: &mut [u8; 6]) {
     unsafe {
         read_mac(mac as *mut u8, 1);
     }
@@ -1984,7 +1984,7 @@ mod sealed {
         }
 
         fn link_state(self) -> embassy_net_driver::LinkState {
-            if matches!(get_sta_state(), WifiState::StaConnected) {
+            if matches!(sta_state(), WifiState::StaConnected) {
                 embassy_net_driver::LinkState::Up
             } else {
                 embassy_net_driver::LinkState::Down
@@ -2020,7 +2020,7 @@ mod sealed {
         }
 
         fn link_state(self) -> embassy_net_driver::LinkState {
-            if matches!(get_ap_state(), WifiState::ApStarted) {
+            if matches!(ap_state(), WifiState::ApStarted) {
                 embassy_net_driver::LinkState::Up
             } else {
                 embassy_net_driver::LinkState::Down
@@ -2052,7 +2052,7 @@ impl WifiDeviceMode for WifiStaDevice {
 
     fn mac_address(self) -> [u8; 6] {
         let mut mac = [0; 6];
-        get_sta_mac(&mut mac);
+        sta_mac(&mut mac);
         mac
     }
 }
@@ -2069,7 +2069,7 @@ impl WifiDeviceMode for WifiApDevice {
 
     fn mac_address(self) -> [u8; 6] {
         let mut mac = [0; 6];
-        get_ap_mac(&mut mac);
+        ap_mac(&mut mac);
         mac
     }
 }
@@ -2986,7 +2986,7 @@ fn apply_sta_eap_config(config: &EapClientConfiguration) -> Result<(), WifiError
 
 impl WifiController<'_> {
     /// Get the supported capabilities of the controller.
-    pub fn get_capabilities(&self) -> Result<EnumSet<crate::wifi::Capability>, WifiError> {
+    pub fn capabilities(&self) -> Result<EnumSet<crate::wifi::Capability>, WifiError> {
         let caps = match self.config {
             Configuration::None => unreachable!(),
             Configuration::Client(_) => enumset::enum_set! { Capability::Client },
@@ -3001,7 +3001,7 @@ impl WifiController<'_> {
     }
 
     /// Get the currently used configuration.
-    pub fn get_configuration(&self) -> Result<Configuration, WifiError> {
+    pub fn configuration(&self) -> Result<Configuration, WifiError> {
         Ok(self.config.clone())
     }
 
@@ -3071,12 +3071,12 @@ impl WifiController<'_> {
     /// WiFi has started successfully.
     pub fn is_started(&self) -> Result<bool, WifiError> {
         if matches!(
-            crate::wifi::get_sta_state(),
+            crate::wifi::sta_state(),
             WifiState::StaStarted | WifiState::StaConnected | WifiState::StaDisconnected
         ) {
             return Ok(true);
         }
-        if matches!(crate::wifi::get_ap_state(), WifiState::ApStarted) {
+        if matches!(crate::wifi::ap_state(), WifiState::ApStarted) {
             return Ok(true);
         }
         Ok(false)
@@ -3087,7 +3087,7 @@ impl WifiController<'_> {
     /// This function should be called after the `connect` method to verify if
     /// the connection was successful.
     pub fn is_connected(&self) -> Result<bool, WifiError> {
-        match crate::wifi::get_sta_state() {
+        match crate::wifi::sta_state() {
             crate::wifi::WifiState::StaConnected => Ok(true),
             crate::wifi::WifiState::StaDisconnected => Err(WifiError::Disconnected),
             // FIXME: Should any other enum value trigger an error instead of returning false?

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -734,7 +734,7 @@ pub unsafe extern "C" fn task_delete(task_handle: *mut crate::binary::c_types::c
 /// *************************************************************************
 pub unsafe extern "C" fn task_delay(tick: u32) {
     trace!("task_delay tick {}", tick);
-    let start_time = crate::timer::get_systimer_count();
+    let start_time = crate::timer::systimer_count();
     while crate::timer::elapsed_time_since(start_time) < tick as u64 {
         yield_task();
     }
@@ -1126,7 +1126,7 @@ pub unsafe extern "C" fn wifi_rtc_disable_iso() {
 #[no_mangle]
 pub unsafe extern "C" fn esp_timer_get_time() -> i64 {
     trace!("esp_timer_get_time");
-    crate::timer::ticks_to_micros(crate::timer::get_systimer_count()) as i64
+    crate::timer::ticks_to_micros(crate::timer::systimer_count()) as i64
 }
 
 /// **************************************************************************

--- a/esp-wifi/src/wifi/state.rs
+++ b/esp-wifi/src/wifi/state.rs
@@ -38,12 +38,12 @@ pub(crate) static STA_STATE: AtomicWifiState = AtomicWifiState::new(WifiState::I
 pub(crate) static AP_STATE: AtomicWifiState = AtomicWifiState::new(WifiState::Invalid);
 
 /// Get the current state of the AP
-pub fn get_ap_state() -> WifiState {
+pub fn ap_state() -> WifiState {
     AP_STATE.load(Ordering::Relaxed)
 }
 
 /// Get the current state of the STA
-pub fn get_sta_state() -> WifiState {
+pub fn sta_state() -> WifiState {
     STA_STATE.load(Ordering::Relaxed)
 }
 
@@ -76,13 +76,13 @@ pub(crate) fn reset_sta_state() {
 
 /// Returns the current state of the WiFi stack.
 ///
-/// This does not support AP-STA mode. Use one of `get_sta_state` or
-/// `get_ap_state` instead.
-pub fn get_wifi_state() -> WifiState {
+/// This does not support AP-STA mode. Use one of `sta_state` or
+/// `ap_state` instead.
+pub fn wifi_state() -> WifiState {
     use super::WifiMode;
     match WifiMode::current() {
-        Ok(WifiMode::Sta) => get_sta_state(),
-        Ok(WifiMode::Ap) => get_ap_state(),
+        Ok(WifiMode::Sta) => sta_state(),
+        Ok(WifiMode::Ap) => ap_state(),
         _ => WifiState::Invalid,
     }
 }

--- a/examples/src/bin/debug_assist.rs
+++ b/examples/src/bin/debug_assist.rs
@@ -87,7 +87,7 @@ fn interrupt_handler() {
         if da.is_sp_monitor_interrupt_set() {
             println!("SP MONITOR TRIGGERED");
             da.clear_sp_monitor_interrupt();
-            let pc = da.get_sp_monitor_pc();
+            let pc = da.sp_monitor_pc();
             println!("PC = 0x{:x}", pc);
         }
 
@@ -95,7 +95,7 @@ fn interrupt_handler() {
         if da.is_region0_monitor_interrupt_set() {
             println!("REGION0 MONITOR TRIGGERED");
             da.clear_region0_monitor_interrupt();
-            let pc = da.get_region_monitor_pc();
+            let pc = da.region_monitor_pc();
             println!("PC = 0x{:x}", pc);
         }
 
@@ -103,7 +103,7 @@ fn interrupt_handler() {
         if da.is_region1_monitor_interrupt_set() {
             println!("REGION1 MONITOR TRIGGERED");
             da.clear_region1_monitor_interrupt();
-            let pc = da.get_region_monitor_pc();
+            let pc = da.region_monitor_pc();
             println!("PC = 0x{:x}", pc);
         }
 

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -19,8 +19,8 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal}
 use embassy_time::{Duration, Ticker};
 use esp_backtrace as _;
 use esp_hal::{
+    core,
     cpu_control::{CpuControl, Stack},
-    get_core,
     gpio::{Level, Output},
     timer::{timg::TimerGroup, AnyTimer},
 };
@@ -37,7 +37,7 @@ async fn control_led(
     mut led: Output<'static>,
     control: &'static Signal<CriticalSectionRawMutex, bool>,
 ) {
-    println!("Starting control_led() on core {}", get_core() as usize);
+    println!("Starting control_led() on core {}", core() as usize);
     loop {
         if control.wait().await {
             esp_println::println!("LED on");
@@ -76,10 +76,7 @@ async fn main(_spawner: Spawner) {
         .unwrap();
 
     // Sends periodic messages to control_led, enabling or disabling it.
-    println!(
-        "Starting enable_disable_led() on core {}",
-        get_core() as usize
-    );
+    println!("Starting enable_disable_led() on core {}", core() as usize);
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {
         esp_println::println!("Sending LED on");

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -18,8 +18,8 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal}
 use embassy_time::{Duration, Ticker};
 use esp_backtrace as _;
 use esp_hal::{
+    core,
     cpu_control::{CpuControl, Stack},
-    get_core,
     gpio::{Level, Output},
     interrupt::{software::SoftwareInterruptControl, Priority},
     prelude::*,
@@ -38,7 +38,7 @@ async fn control_led(
     mut led: Output<'static>,
     control: &'static Signal<CriticalSectionRawMutex, bool>,
 ) {
-    println!("Starting control_led() on core {}", get_core() as usize);
+    println!("Starting control_led() on core {}", core() as usize);
     loop {
         if control.wait().await {
             esp_println::println!("LED on");
@@ -53,10 +53,7 @@ async fn control_led(
 /// Sends periodic messages to control_led, enabling or disabling it.
 #[embassy_executor::task]
 async fn enable_disable_led(control: &'static Signal<CriticalSectionRawMutex, bool>) {
-    println!(
-        "Starting enable_disable_led() on core {}",
-        get_core() as usize
-    );
+    println!("Starting enable_disable_led() on core {}", core() as usize);
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {
         esp_println::println!("Sending LED on");

--- a/examples/src/bin/ieee802154_receive_all_frames.rs
+++ b/examples/src/bin/ieee802154_receive_all_frames.rs
@@ -26,7 +26,7 @@ fn main() -> ! {
     ieee802154.start_receive();
 
     loop {
-        if let Some(frame) = ieee802154.get_received() {
+        if let Some(frame) = ieee802154.received() {
             println!("Received {:?}\n", &frame);
         }
     }

--- a/examples/src/bin/ieee802154_receive_frame.rs
+++ b/examples/src/bin/ieee802154_receive_frame.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     ieee802154.start_receive();
 
     loop {
-        if let Some(frame) = ieee802154.get_received() {
+        if let Some(frame) = ieee802154.received() {
             println!("Received {:?}\n", &frame);
         }
     }

--- a/examples/src/bin/ieee802154_sniffer.rs
+++ b/examples/src/bin/ieee802154_sniffer.rs
@@ -62,7 +62,7 @@ fn main() -> ! {
     ieee802154.start_receive();
 
     loop {
-        if let Some(frame) = ieee802154.get_raw_received() {
+        if let Some(frame) = ieee802154.raw_received() {
             println!("@RAW {:02x?}", &frame.data);
         }
 

--- a/examples/src/bin/ledc.rs
+++ b/examples/src/bin/ledc.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
 
     ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 
-    let mut lstimer0 = ledc.get_timer::<LowSpeed>(timer::Number::Timer0);
+    let mut lstimer0 = ledc.timer::<LowSpeed>(timer::Number::Timer0);
 
     lstimer0
         .configure(timer::config::Config {
@@ -41,7 +41,7 @@ fn main() -> ! {
         })
         .unwrap();
 
-    let mut channel0 = ledc.get_channel(channel::Number::Channel0, led);
+    let mut channel0 = ledc.channel(channel::Number::Channel0, led);
     channel0
         .configure(channel::config::Config {
             timer: &lstimer0,

--- a/examples/src/bin/pcnt_encoder.rs
+++ b/examples/src/bin/pcnt_encoder.rs
@@ -91,7 +91,7 @@ fn interrupt_handler() {
         let mut u0 = UNIT0.borrow_ref_mut(cs);
         let u0 = u0.as_mut().unwrap();
         if u0.interrupt_is_set() {
-            let events = u0.get_events();
+            let events = u0.events();
             if events.high_limit {
                 VALUE.fetch_add(100, Ordering::SeqCst);
             } else if events.low_limit {

--- a/examples/src/bin/read_efuse.rs
+++ b/examples/src/bin/read_efuse.rs
@@ -14,15 +14,15 @@ use esp_println::println;
 
 #[entry]
 fn main() -> ! {
-    println!("MAC address {:02x?}", Efuse::get_mac_address());
-    println!("Flash Encryption {:?}", Efuse::get_flash_encryption());
+    println!("MAC address {:02x?}", Efuse::mac_address());
+    println!("Flash Encryption {:?}", Efuse::flash_encryption());
 
     #[cfg(feature = "esp32")]
     {
-        println!("Core Count {}", Efuse::get_core_count());
+        println!("Core Count {}", Efuse::core_count());
         println!("Bluetooth enabled {}", Efuse::is_bluetooth_enabled());
-        println!("Chip type {:?}", Efuse::get_chip_type());
-        println!("Max CPU clock {:?}", Efuse::get_max_cpu_frequency());
+        println!("Chip type {:?}", Efuse::chip_type());
+        println!("Max CPU clock {:?}", Efuse::max_cpu_frequency());
     }
 
     loop {}

--- a/examples/src/bin/sleep_timer.rs
+++ b/examples/src/bin/sleep_timer.rs
@@ -11,7 +11,7 @@ use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
     entry,
-    rtc_cntl::{get_reset_reason, get_wakeup_cause, sleep::TimerWakeupSource, Rtc, SocResetReason},
+    rtc_cntl::{reset_reason, sleep::TimerWakeupSource, wakeup_cause, Rtc, SocResetReason},
     Cpu,
 };
 use esp_println::println;
@@ -24,9 +24,9 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.LPWR);
 
     println!("up and runnning!");
-    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
-    let wake_reason = get_wakeup_cause();
+    let wake_reason = wakeup_cause();
     println!("wake reason: {:?}", wake_reason);
 
     let timer = TimerWakeupSource::new(Duration::from_secs(5));

--- a/examples/src/bin/sleep_timer_ext0.rs
+++ b/examples/src/bin/sleep_timer_ext0.rs
@@ -16,9 +16,9 @@ use esp_hal::{
     entry,
     gpio::{Input, Pull},
     rtc_cntl::{
-        get_reset_reason,
-        get_wakeup_cause,
+        reset_reason,
         sleep::{Ext0WakeupSource, TimerWakeupSource, WakeupLevel},
+        wakeup_cause,
         Rtc,
         SocResetReason,
     },
@@ -35,9 +35,9 @@ fn main() -> ! {
     let ext0_pin = Input::new(peripherals.GPIO4, Pull::None);
 
     println!("up and runnning!");
-    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
-    let wake_reason = get_wakeup_cause();
+    let wake_reason = wakeup_cause();
     println!("wake reason: {:?}", wake_reason);
 
     let delay = Delay::new();

--- a/examples/src/bin/sleep_timer_ext1.rs
+++ b/examples/src/bin/sleep_timer_ext1.rs
@@ -17,9 +17,9 @@ use esp_hal::{
     gpio::{Input, Pull, RtcPin},
     peripheral::Peripheral,
     rtc_cntl::{
-        get_reset_reason,
-        get_wakeup_cause,
+        reset_reason,
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
+        wakeup_cause,
         Rtc,
         SocResetReason,
     },
@@ -37,9 +37,9 @@ fn main() -> ! {
     let mut pin_2 = peripherals.GPIO2;
 
     println!("up and runnning!");
-    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
-    let wake_reason = get_wakeup_cause();
+    let wake_reason = wakeup_cause();
     println!("wake reason: {:?}", wake_reason);
 
     let delay = Delay::new();

--- a/examples/src/bin/sleep_timer_lpio.rs
+++ b/examples/src/bin/sleep_timer_lpio.rs
@@ -18,9 +18,9 @@ use esp_hal::{
     gpio::{Input, Pull, RtcPinWithResistors},
     peripheral::Peripheral,
     rtc_cntl::{
-        get_reset_reason,
-        get_wakeup_cause,
+        reset_reason,
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
+        wakeup_cause,
         Rtc,
         SocResetReason,
     },
@@ -38,9 +38,9 @@ fn main() -> ! {
     let mut pin3 = peripherals.GPIO3;
 
     println!("up and runnning!");
-    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
-    let wake_reason = get_wakeup_cause();
+    let wake_reason = wakeup_cause();
     println!("wake reason: {:?}", wake_reason);
 
     let delay = Delay::new();

--- a/examples/src/bin/sleep_timer_rtcio.rs
+++ b/examples/src/bin/sleep_timer_rtcio.rs
@@ -22,9 +22,9 @@ use esp_hal::{
     gpio::{Input, Pull},
     peripheral::Peripheral,
     rtc_cntl::{
-        get_reset_reason,
-        get_wakeup_cause,
+        reset_reason,
         sleep::{RtcioWakeupSource, TimerWakeupSource, WakeupLevel},
+        wakeup_cause,
         Rtc,
         SocResetReason,
     },
@@ -39,9 +39,9 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.LPWR);
 
     println!("up and runnning!");
-    let reason = get_reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+    let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
     println!("reset reason: {:?}", reason);
-    let wake_reason = get_wakeup_cause();
+    let wake_reason = wakeup_cause();
     println!("wake reason: {:?}", wake_reason);
 
     let delay = Delay::new();

--- a/examples/src/bin/wifi_access_point.rs
+++ b/examples/src/bin/wifi_access_point.rs
@@ -91,7 +91,7 @@ fn main() -> ! {
     controller.start().unwrap();
     println!("is wifi started: {:?}", controller.is_started());
 
-    println!("{:?}", controller.get_capabilities());
+    println!("{:?}", controller.capabilities());
 
     stack
         .set_iface_configuration(&blocking_network_stack::ipv4::Configuration::Client(

--- a/examples/src/bin/wifi_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_access_point_with_sta.rs
@@ -97,7 +97,7 @@ fn main() -> ! {
     controller.start().unwrap();
     println!("is wifi started: {:?}", controller.is_started());
 
-    println!("{:?}", controller.get_capabilities());
+    println!("{:?}", controller.capabilities());
 
     ap_stack
         .set_iface_configuration(&blocking_network_stack::ipv4::Configuration::Client(

--- a/examples/src/bin/wifi_bench.rs
+++ b/examples/src/bin/wifi_bench.rs
@@ -109,7 +109,7 @@ fn main() -> ! {
         }
     }
 
-    println!("{:?}", controller.get_capabilities());
+    println!("{:?}", controller.capabilities());
     println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected

--- a/examples/src/bin/wifi_coex.rs
+++ b/examples/src/bin/wifi_coex.rs
@@ -114,7 +114,7 @@ fn main() -> ! {
 
     controller.start().unwrap();
     println!("is wifi started: {:?}", controller.is_started());
-    println!("{:?}", controller.get_capabilities());
+    println!("{:?}", controller.capabilities());
     println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected

--- a/examples/src/bin/wifi_csi.rs
+++ b/examples/src/bin/wifi_csi.rs
@@ -109,7 +109,7 @@ fn main() -> ! {
         }
     }
 
-    println!("{:?}", controller.get_capabilities());
+    println!("{:?}", controller.capabilities());
     println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected

--- a/examples/src/bin/wifi_dhcp.rs
+++ b/examples/src/bin/wifi_dhcp.rs
@@ -97,7 +97,7 @@ fn main() -> ! {
         }
     }
 
-    println!("{:?}", controller.get_capabilities());
+    println!("{:?}", controller.capabilities());
     println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected

--- a/examples/src/bin/wifi_dhcp_smoltcp_nal.rs
+++ b/examples/src/bin/wifi_dhcp_smoltcp_nal.rs
@@ -107,7 +107,7 @@ fn main() -> ! {
         }
     }
 
-    println!("{:?}", controller.get_capabilities());
+    println!("{:?}", controller.capabilities());
     println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -203,9 +203,9 @@ async fn main(spawner: Spawner) -> ! {
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
     println!("start connection task");
-    println!("Device capabilities: {:?}", controller.get_capabilities());
+    println!("Device capabilities: {:?}", controller.capabilities());
     loop {
-        match esp_wifi::wifi::get_wifi_state() {
+        match esp_wifi::wifi::wifi_state() {
             WifiState::ApStarted => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::ApStop).await;

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -312,14 +312,14 @@ async fn main(spawner: Spawner) -> ! {
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
     println!("start connection task");
-    println!("Device capabilities: {:?}", controller.get_capabilities());
+    println!("Device capabilities: {:?}", controller.capabilities());
 
     println!("Starting wifi");
     controller.start_async().await.unwrap();
     println!("Wifi started!");
 
     loop {
-        match esp_wifi::wifi::get_ap_state() {
+        match esp_wifi::wifi::ap_state() {
             WifiState::ApStarted => {
                 println!("About to connect...");
 

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -175,9 +175,9 @@ async fn main(spawner: Spawner) -> ! {
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
     println!("start connection task");
-    println!("Device capabilities: {:?}", controller.get_capabilities());
+    println!("Device capabilities: {:?}", controller.capabilities());
     loop {
-        match esp_wifi::wifi::get_wifi_state() {
+        match esp_wifi::wifi::wifi_state() {
             WifiState::StaConnected => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::StaDisconnected).await;

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -167,9 +167,9 @@ async fn main(spawner: Spawner) -> ! {
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
     println!("start connection task");
-    println!("Device capabilities: {:?}", controller.get_capabilities());
+    println!("Device capabilities: {:?}", controller.capabilities());
     loop {
-        match esp_wifi::wifi::get_wifi_state() {
+        match esp_wifi::wifi::wifi_state() {
             WifiState::StaConnected => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::StaDisconnected).await;

--- a/examples/src/bin/wifi_embassy_esp_now.rs
+++ b/examples/src/bin/wifi_embassy_esp_now.rs
@@ -58,7 +58,7 @@ async fn main(_spawner: Spawner) -> ! {
 
     let wifi = peripherals.WIFI;
     let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
-    println!("esp-now version {}", esp_now.get_version().unwrap());
+    println!("esp-now version {}", esp_now.version().unwrap());
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {

--- a/examples/src/bin/wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/wifi_embassy_esp_now_duplex.rs
@@ -58,7 +58,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let wifi = peripherals.WIFI;
     let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
-    println!("esp-now version {}", esp_now.get_version().unwrap());
+    println!("esp-now version {}", esp_now.version().unwrap());
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {

--- a/examples/src/bin/wifi_esp_now.rs
+++ b/examples/src/bin/wifi_esp_now.rs
@@ -45,7 +45,7 @@ fn main() -> ! {
     let wifi = peripherals.WIFI;
     let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
-    println!("esp-now version {}", esp_now.get_version().unwrap());
+    println!("esp-now version {}", esp_now.version().unwrap());
 
     let mut next_send_time = time::now() + Duration::secs(5);
     loop {

--- a/examples/src/bin/wifi_static_ip.rs
+++ b/examples/src/bin/wifi_static_ip.rs
@@ -88,7 +88,7 @@ fn main() -> ! {
         }
     }
 
-    println!("{:?}", controller.get_capabilities());
+    println!("{:?}", controller.capabilities());
     println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected

--- a/hil-test/tests/lcd_cam_i8080.rs
+++ b/hil-test/tests/lcd_cam_i8080.rs
@@ -212,10 +212,10 @@ mod tests {
         xfer.wait().0.unwrap();
 
         let actual = [
-            pcnt.unit0.get_value(),
-            pcnt.unit1.get_value(),
-            pcnt.unit2.get_value(),
-            pcnt.unit3.get_value(),
+            pcnt.unit0.value(),
+            pcnt.unit1.value(),
+            pcnt.unit2.value(),
+            pcnt.unit3.value(),
         ];
         let expected = [5, 3, 2, 1];
 
@@ -339,10 +339,10 @@ mod tests {
         xfer.wait().0.unwrap();
 
         let actual = [
-            pcnt.unit0.get_value(),
-            pcnt.unit1.get_value(),
-            pcnt.unit2.get_value(),
-            pcnt.unit3.get_value(),
+            pcnt.unit0.value(),
+            pcnt.unit1.value(),
+            pcnt.unit2.value(),
+            pcnt.unit3.value(),
         ];
         let expected = [5, 3, 2, 1];
 

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -122,8 +122,8 @@ mod tests {
             clock_unit.clear();
             let xfer = pio.write_dma(&tx_buffer).unwrap();
             xfer.wait().unwrap();
-            info!("clock count: {}", clock_unit.get_value());
-            assert_eq!(clock_unit.get_value(), BUFFER_SIZE as _);
+            info!("clock count: {}", clock_unit.value());
+            assert_eq!(clock_unit.value(), BUFFER_SIZE as _);
         }
     }
 
@@ -189,8 +189,8 @@ mod tests {
             clock_unit.clear();
             let xfer = pio.write_dma(&tx_buffer).unwrap();
             xfer.wait().unwrap();
-            info!("clock count: {}", clock_unit.get_value());
-            assert_eq!(clock_unit.get_value(), BUFFER_SIZE as _);
+            info!("clock count: {}", clock_unit.value());
+            assert_eq!(clock_unit.value(), BUFFER_SIZE as _);
         }
     }
 }

--- a/hil-test/tests/parl_io_tx_async.rs
+++ b/hil-test/tests/parl_io_tx_async.rs
@@ -125,8 +125,8 @@ mod tests {
         for _ in 0..100 {
             clock_unit.clear();
             pio.write_dma_async(&tx_buffer).await.unwrap();
-            info!("clock count: {}", clock_unit.get_value());
-            assert_eq!(clock_unit.get_value(), BUFFER_SIZE as _);
+            info!("clock count: {}", clock_unit.value());
+            assert_eq!(clock_unit.value(), BUFFER_SIZE as _);
         }
     }
 
@@ -193,8 +193,8 @@ mod tests {
         for _ in 0..100 {
             clock_unit.clear();
             pio.write_dma_async(&tx_buffer).await.unwrap();
-            info!("clock count: {}", clock_unit.get_value());
-            assert_eq!(clock_unit.get_value(), BUFFER_SIZE as _);
+            info!("clock count: {}", clock_unit.value());
+            assert_eq!(clock_unit.value(), BUFFER_SIZE as _);
         }
     }
 }

--- a/hil-test/tests/pcnt.rs
+++ b/hil-test/tests/pcnt.rs
@@ -55,27 +55,27 @@ mod tests {
 
         unit.resume();
 
-        assert_eq!(0, unit.get_value());
+        assert_eq!(0, unit.value());
 
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(1, unit.get_value());
+        assert_eq!(1, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(1, unit.get_value());
+        assert_eq!(1, unit.value());
 
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(2, unit.get_value());
+        assert_eq!(2, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(2, unit.get_value());
+        assert_eq!(2, unit.value());
     }
 
     #[test]
@@ -92,27 +92,27 @@ mod tests {
 
         unit.resume();
 
-        assert_eq!(0, unit.get_value());
+        assert_eq!(0, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(1, unit.get_value());
+        assert_eq!(1, unit.value());
 
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(1, unit.get_value());
+        assert_eq!(1, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(2, unit.get_value());
+        assert_eq!(2, unit.value());
 
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(2, unit.get_value());
+        assert_eq!(2, unit.value());
     }
 
     #[test]
@@ -131,29 +131,29 @@ mod tests {
 
         unit.resume();
 
-        assert_eq!(0, unit.get_value());
+        assert_eq!(0, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(1, unit.get_value());
+        assert_eq!(1, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(2, unit.get_value());
+        assert_eq!(2, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(0, unit.get_value());
-        assert!(unit.get_events().high_limit);
+        assert_eq!(0, unit.value());
+        assert!(unit.events().high_limit);
         assert!(unit.interrupt_is_set());
 
         output.set_low();
@@ -161,16 +161,16 @@ mod tests {
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(1, unit.get_value());
+        assert_eq!(1, unit.value());
 
         // high limit event remains after next increment.
-        assert!(unit.get_events().high_limit);
+        assert!(unit.events().high_limit);
 
         unit.reset_interrupt();
         assert!(!unit.interrupt_is_set());
 
         // high limit event remains after interrupt is cleared.
-        assert!(unit.get_events().high_limit);
+        assert!(unit.events().high_limit);
     }
 
     #[test]
@@ -192,27 +192,27 @@ mod tests {
 
         unit.resume();
 
-        assert_eq!(0, unit.get_value());
+        assert_eq!(0, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(1, unit.get_value());
+        assert_eq!(1, unit.value());
         assert!(!unit.interrupt_is_set());
-        assert!(!unit.get_events().threshold0);
-        assert!(!unit.get_events().threshold1);
+        assert!(!unit.events().threshold0);
+        assert!(!unit.events().threshold1);
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(2, unit.get_value());
+        assert_eq!(2, unit.value());
         assert!(unit.interrupt_is_set());
-        assert!(unit.get_events().threshold0);
-        assert!(!unit.get_events().threshold1);
+        assert!(unit.events().threshold0);
+        assert!(!unit.events().threshold1);
 
         unit.reset_interrupt();
 
@@ -221,22 +221,22 @@ mod tests {
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(3, unit.get_value());
+        assert_eq!(3, unit.value());
         assert!(!unit.interrupt_is_set());
         // threshold event remains after next increment and after interrupt is cleared.
-        assert!(unit.get_events().threshold0);
-        assert!(!unit.get_events().threshold1);
+        assert!(unit.events().threshold0);
+        assert!(!unit.events().threshold1);
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(4, unit.get_value());
+        assert_eq!(4, unit.value());
         assert!(unit.interrupt_is_set());
         // threshold event cleared after new event occurs.
-        assert!(!unit.get_events().threshold0);
-        assert!(unit.get_events().threshold1);
+        assert!(!unit.events().threshold0);
+        assert!(unit.events().threshold1);
     }
 
     #[test]
@@ -257,29 +257,29 @@ mod tests {
 
         unit.resume();
 
-        assert_eq!(0, unit.get_value());
+        assert_eq!(0, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(-1, unit.get_value());
+        assert_eq!(-1, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(-2, unit.get_value());
+        assert_eq!(-2, unit.value());
 
         output.set_low();
         ctx.delay.delay_micros(1);
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(0, unit.get_value());
-        assert!(unit.get_events().low_limit);
+        assert_eq!(0, unit.value());
+        assert!(unit.events().low_limit);
         assert!(unit.interrupt_is_set());
 
         output.set_low();
@@ -287,16 +287,16 @@ mod tests {
         output.set_high();
         ctx.delay.delay_micros(1);
 
-        assert_eq!(-1, unit.get_value());
+        assert_eq!(-1, unit.value());
 
         // low limit event remains after next increment.
-        assert!(unit.get_events().low_limit);
+        assert!(unit.events().low_limit);
 
         unit.reset_interrupt();
         assert!(!unit.interrupt_is_set());
 
         // low limit event remains after interrupt is cleared.
-        assert!(unit.get_events().low_limit);
+        assert!(unit.events().low_limit);
     }
 
     #[test]
@@ -313,10 +313,10 @@ mod tests {
 
         unit.resume();
 
-        assert_eq!(0, unit.get_value());
+        assert_eq!(0, unit.value());
 
         for i in (0..=i16::MAX).chain(i16::MIN..0) {
-            assert_eq!(i, unit.get_value());
+            assert_eq!(i, unit.value());
 
             output.set_low();
             ctx.delay.delay_micros(1);
@@ -324,14 +324,14 @@ mod tests {
             ctx.delay.delay_micros(1);
         }
 
-        assert_eq!(0, unit.get_value());
+        assert_eq!(0, unit.value());
 
         // Channel 1 should now decrement.
         unit.channel1
             .set_input_mode(EdgeMode::Decrement, EdgeMode::Hold);
 
         for i in (0..=i16::MAX).chain(i16::MIN..=0).rev() {
-            assert_eq!(i, unit.get_value());
+            assert_eq!(i, unit.value());
 
             output.set_low();
             ctx.delay.delay_micros(1);

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -143,15 +143,15 @@ fn execute_write(
         unit0.clear();
         unit1.clear();
         (spi, dma_tx_buf) = transfer_write(spi, dma_tx_buf, write, command_data_mode);
-        assert_eq!(unit0.get_value() + unit1.get_value(), 8);
+        assert_eq!(unit0.value() + unit1.value(), 8);
 
         if data_on_multiple_pins {
             if command_data_mode == SpiDataMode::Single {
-                assert_eq!(unit0.get_value(), 1);
-                assert_eq!(unit1.get_value(), 7);
+                assert_eq!(unit0.value(), 1);
+                assert_eq!(unit1.value(), 7);
             } else {
-                assert_eq!(unit0.get_value(), 0);
-                assert_eq!(unit1.get_value(), 8);
+                assert_eq!(unit0.value(), 0);
+                assert_eq!(unit1.value(), 8);
             }
         }
 
@@ -161,15 +161,15 @@ fn execute_write(
         unit0.clear();
         unit1.clear();
         (spi, dma_tx_buf) = transfer_write(spi, dma_tx_buf, write, command_data_mode);
-        assert_eq!(unit0.get_value() + unit1.get_value(), 4);
+        assert_eq!(unit0.value() + unit1.value(), 4);
 
         if data_on_multiple_pins {
             if command_data_mode == SpiDataMode::Single {
-                assert_eq!(unit0.get_value(), 1);
-                assert_eq!(unit1.get_value(), 3);
+                assert_eq!(unit0.value(), 1);
+                assert_eq!(unit1.value(), 3);
             } else {
-                assert_eq!(unit0.get_value(), 0);
-                assert_eq!(unit1.get_value(), 4);
+                assert_eq!(unit0.value(), 0);
+                assert_eq!(unit1.value(), 4);
             }
         }
     }

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -143,7 +143,7 @@ mod tests {
         // Flush because we're not reading, so the write may happen in the background
         ctx.spi.flush().expect("Flush failed");
 
-        assert_eq!(unit.get_value(), 9);
+        assert_eq!(unit.value(), 9);
     }
 
     #[test]
@@ -162,7 +162,7 @@ mod tests {
         // Flush because we're not reading, so the write may happen in the background
         ctx.spi.flush().expect("Flush failed");
 
-        assert_eq!(unit.get_value(), 9);
+        assert_eq!(unit.value(), 9);
     }
 
     #[test]
@@ -223,7 +223,7 @@ mod tests {
 
             let transfer = spi.write(dma_tx_buf).map_err(|e| e.0).unwrap();
             (spi, dma_tx_buf) = transfer.wait();
-            assert_eq!(unit.get_value(), (i * 3 * DMA_BUFFER_SIZE) as _);
+            assert_eq!(unit.value(), (i * 3 * DMA_BUFFER_SIZE) as _);
         }
     }
 
@@ -259,7 +259,7 @@ mod tests {
                 .map_err(|e| e.0)
                 .unwrap();
             (spi, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
-            assert_eq!(unit.get_value(), (i * 3 * DMA_BUFFER_SIZE) as _);
+            assert_eq!(unit.value(), (i * 3 * DMA_BUFFER_SIZE) as _);
         }
     }
 
@@ -418,7 +418,7 @@ mod tests {
             assert_eq!(receive, [0, 0, 0, 0, 0]);
 
             SpiBusAsync::write(&mut spi, &transmit).await.unwrap();
-            assert_eq!(ctx.pcnt_unit.get_value(), (i * 3 * DMA_BUFFER_SIZE) as _);
+            assert_eq!(ctx.pcnt_unit.value(), (i * 3 * DMA_BUFFER_SIZE) as _);
         }
     }
 
@@ -454,7 +454,7 @@ mod tests {
             SpiBusAsync::transfer(&mut spi, &mut receive, &transmit)
                 .await
                 .unwrap();
-            assert_eq!(ctx.pcnt_unit.get_value(), (i * 3 * DMA_BUFFER_SIZE) as _);
+            assert_eq!(ctx.pcnt_unit.value(), (i * 3 * DMA_BUFFER_SIZE) as _);
         }
     }
 

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -100,7 +100,7 @@ mod tests {
             .unwrap();
         (spi, dma_tx_buf) = transfer.wait();
 
-        assert_eq!(unit.get_value(), (3 * DMA_BUFFER_SIZE) as _);
+        assert_eq!(unit.value(), (3 * DMA_BUFFER_SIZE) as _);
 
         let transfer = spi
             .half_duplex_write(
@@ -114,7 +114,7 @@ mod tests {
             .unwrap();
         transfer.wait();
 
-        assert_eq!(unit.get_value(), (6 * DMA_BUFFER_SIZE) as _);
+        assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }
 
     #[test]
@@ -144,7 +144,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(unit.get_value(), (3 * DMA_BUFFER_SIZE) as _);
+        assert_eq!(unit.value(), (3 * DMA_BUFFER_SIZE) as _);
 
         spi.half_duplex_write(
             SpiDataMode::Single,
@@ -155,6 +155,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(unit.get_value(), (6 * DMA_BUFFER_SIZE) as _);
+        assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }
 }

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -115,7 +115,7 @@ mod tests {
             .unwrap();
         (spi, dma_tx_buf) = transfer.wait();
 
-        assert_eq!(unit.get_value(), (3 * DMA_BUFFER_SIZE) as _);
+        assert_eq!(unit.value(), (3 * DMA_BUFFER_SIZE) as _);
 
         let transfer = spi
             .half_duplex_write(
@@ -129,7 +129,7 @@ mod tests {
             .unwrap();
         transfer.wait();
 
-        assert_eq!(unit.get_value(), (6 * DMA_BUFFER_SIZE) as _);
+        assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }
 
     #[test]
@@ -165,7 +165,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(unit.get_value(), (3 * DMA_BUFFER_SIZE) as _);
+        assert_eq!(unit.value(), (3 * DMA_BUFFER_SIZE) as _);
 
         spi.half_duplex_write(
             SpiDataMode::Single,
@@ -176,6 +176,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(unit.get_value(), (6 * DMA_BUFFER_SIZE) as _);
+        assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }
 }

--- a/hil-test/tests/spi_slave.rs
+++ b/hil-test/tests/spi_slave.rs
@@ -69,7 +69,7 @@ impl BitbangSpi {
         self.mosi.set_level(Level::from(bit));
         self.sclk.set_level(Level::High);
 
-        let miso = self.miso.get_level().into();
+        let miso = self.miso.level().into();
         self.sclk.set_level(Level::Low);
 
         miso


### PR DESCRIPTION
I've skipped `xtensa-lx` as I don't think we really have any reason to publish a new version of that currently, but can update it as well if requested. Otherwise, I think I got them all (or most of them, at least 😅). Unfortunately had to touch a ton of files in the process, but oh well.

Closes #2524