### PR TITLE
Remove NoClkPin

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -104,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `TaskSet`, `TaskClear`, `TaskToggle` types have been replaced with `Task` (#2427)
 - `{Spi, SpiDma, SpiDmaBus}` configuration methods (#2448)
 - `Io::new_with_priority` and `Io::new_no_bind_interrupt`. (#2486)
+- `parl_io::{no_clk_pin(), NoClkPin}` (#2531)
 
 ## [0.21.1]
 

--- a/esp-hal/MIGRATING-0.21.md
+++ b/esp-hal/MIGRATING-0.21.md
@@ -396,3 +396,19 @@ When trying to send a one-shot transmission will fail if it doesn't end with an 
 -        let transaction = channel.transmit(&data);
 +        let transaction = channel.transmit(&data).unwrap();
 ```
+
+
+## The `parl_io::NoClkPin` and `no_clk_pin()` have been removed
+
+You can use `gpio::NoPin` instead.
+
+```diff
+ use esp_hal:: {
+-   parl_io::no_clk_pin,
++   gpio::NoPin,
+ }
+
+-parl_io.rx.with_config(&mut rx_pins, no_clk_pin(), BitPackOrder::Msb, Some(0xfff))
++let mut rx_clk_pin = NoPin;
++parl_io.rx.with_config(&mut rx_pins, &mut rx_clk_pin, BitPackOrder::Msb, Some(0xfff))
+```

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -49,7 +49,10 @@ use crate::{
         Tx,
         WriteBuffer,
     },
-    gpio::interconnect::{InputConnection, OutputConnection, PeripheralInput, PeripheralOutput},
+    gpio::{
+        interconnect::{InputConnection, OutputConnection, PeripheralInput, PeripheralOutput},
+        NoPin,
+    },
     interrupt::InterruptHandler,
     peripheral::{self, Peripheral},
     peripherals::{self, Interrupt, PARL_IO},
@@ -260,22 +263,15 @@ pub enum EofMode {
 }
 
 /// Used to configure no pin as clock output
-pub struct NoClkPin;
-impl TxClkPin for NoClkPin {
+impl TxClkPin for NoPin {
     fn configure(&mut self) {
-        // nothing
+        crate::gpio::OutputSignal::PARL_TX_CLK.connect_to(self);
     }
 }
-impl RxClkPin for NoClkPin {
+impl RxClkPin for NoPin {
     fn configure(&mut self) {
-        // nothing
+        crate::gpio::InputSignal::PARL_RX_CLK.connect_to(self);
     }
-}
-
-/// This can be used to pass to the `with_config` functions
-pub fn no_clk_pin() -> &'static mut NoClkPin {
-    static mut NO_CLK: NoClkPin = NoClkPin;
-    unsafe { &mut *core::ptr::addr_of_mut!(NO_CLK) }
 }
 
 /// Wraps a GPIO pin which will be used as the clock output signal

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -16,7 +16,8 @@ use esp_backtrace as _;
 use esp_hal::{
     dma::{Dma, DmaPriority},
     dma_buffers,
-    parl_io::{no_clk_pin, BitPackOrder, ParlIoRxOnly, RxFourBits},
+    gpio::NoPin,
+    parl_io::{BitPackOrder, ParlIoRxOnly, RxFourBits},
     prelude::*,
     timer::systimer::{SystemTimer, Target},
 };
@@ -41,6 +42,7 @@ async fn main(_spawner: Spawner) {
         peripherals.GPIO3,
         peripherals.GPIO4,
     );
+    let mut rx_clk_pin = NoPin;
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,
@@ -54,7 +56,12 @@ async fn main(_spawner: Spawner) {
 
     let mut parl_io_rx = parl_io
         .rx
-        .with_config(&mut rx_pins, no_clk_pin(), BitPackOrder::Msb, Some(0xfff))
+        .with_config(
+            &mut rx_pins,
+            &mut rx_clk_pin,
+            BitPackOrder::Msb,
+            Some(0xfff),
+        )
         .unwrap();
 
     let buffer = rx_buffer;

--- a/examples/src/bin/parl_io_rx.rs
+++ b/examples/src/bin/parl_io_rx.rs
@@ -14,7 +14,8 @@ use esp_hal::{
     delay::Delay,
     dma::{Dma, DmaPriority},
     dma_buffers,
-    parl_io::{no_clk_pin, BitPackOrder, ParlIoRxOnly, RxFourBits},
+    gpio::NoPin,
+    parl_io::{BitPackOrder, ParlIoRxOnly, RxFourBits},
     prelude::*,
 };
 use esp_println::println;
@@ -34,6 +35,7 @@ fn main() -> ! {
         peripherals.GPIO3,
         peripherals.GPIO4,
     );
+    let mut rx_clk_pin = NoPin;
 
     let parl_io = ParlIoRxOnly::new(
         peripherals.PARL_IO,
@@ -45,7 +47,12 @@ fn main() -> ! {
 
     let mut parl_io_rx = parl_io
         .rx
-        .with_config(&mut rx_pins, no_clk_pin(), BitPackOrder::Msb, Some(0xfff))
+        .with_config(
+            &mut rx_pins,
+            &mut rx_clk_pin,
+            BitPackOrder::Msb,
+            Some(0xfff),
+        )
         .unwrap();
 
     let mut buffer = rx_buffer;


### PR DESCRIPTION
I'm not turning these into `impl Peripheral` because I don't want to start overhauling the whole driver, but I don't think it's worth keeping a second no-pin.