### PR TITLE
[DMA 8/8] Burst configuration

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -77,7 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Dma` structure has been removed. (#2545)
 - Removed `embedded-hal 0.2.x` impls and deps from `esp-hal` (#2593)
 - Removed `Camera::set_` functions (#2610)
-- Remove `embedded-hal 0.2.x` impls and deps from `esp-hal` (#2593)
 - `DmaTxBuf::{compute_chunk_size, compute_descriptor_count, new_with_block_size}` (#2543)
 
 ## [0.22.0] - 2024-11-20

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `OutputOpenDrain::unlisten` (#2625)
 - Added `{Input, Flex}::wait_for` (#2625)
 - Peripheral singletons now implement `Debug`, `PartialEq`, `defmt::Format` and `Eq` (except AnyPeripherals) (#2682)
+- `BurstConfig`, a device-specific configuration for configuring DMA transfers in burst mode (#2543)
+- `{DmaRxBuf, DmaTxBuf, DmaRxTxBuf}::set_burst_config` (#2543)
 
 ### Changed
 
@@ -75,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Dma` structure has been removed. (#2545)
 - Removed `embedded-hal 0.2.x` impls and deps from `esp-hal` (#2593)
 - Removed `Camera::set_` functions (#2610)
+- Remove `embedded-hal 0.2.x` impls and deps from `esp-hal` (#2593)
+- `DmaTxBuf::{compute_chunk_size, compute_descriptor_count, new_with_block_size}` (#2543)
 
 ## [0.22.0] - 2024-11-20
 

--- a/esp-hal/MIGRATING-0.22.md
+++ b/esp-hal/MIGRATING-0.22.md
@@ -22,10 +22,10 @@ by `esp_hal::init()`. The channels themselves have been renamed to match other p
 +let channel = peripherals.DMA_CH2;
 ```
 
-### Configuration changes
+### Channel configuration changes
 
 - `configure_for_async` and `configure` have been removed
-- PDMA devices (ESP32, ESP32-S2) provide no configurability
+- PDMA devices (ESP32, ESP32-S2) provide no channel configurability
 - GDMA devices provide `set_priority` to change DMA in/out channel priority
 
 ```diff
@@ -48,6 +48,12 @@ by `esp_hal::init()`. The channels themselves have been renamed to match other p
 -.with_dma(dma_channel.configure(false, DmaPriority::Priority1));
 +.with_dma(dma_channel);
 ```
+
+### Burst mode configuration
+
+Burst mode is now a property of buffers, instead of DMA channels. Configuration can be done by
+calling `set_burst_config` on buffers that support it. The configuration options and the
+corresponding `BurstConfig` type are device specfic.
 
 ### Usability changes affecting applications
 

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -28,6 +28,7 @@ pub enum DmaBufError {
     InvalidChunkSize,
 }
 
+/// DMA buffer alignment errors.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaAlignmentError {

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -10,7 +10,7 @@ use crate::soc::{is_valid_psram_address, is_valid_ram_address};
 
 cfg_if::cfg_if! {
     if #[cfg(psram_dma)] {
-        /// PSRAM access burst size.
+        /// Burst size used when transferring to and from external memory.
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExternalBurstSize {
@@ -459,7 +459,7 @@ impl DmaTxBuf {
     /// Note that the hardware is allowed to ignore this setting. If you attempt
     /// to use burst transfers with improperly aligned buffers, starting the
     /// transfer will result in [`DmaError::InvalidAlignment`].
-    pub fn set_burst_transfer(&mut self, burst: BurstConfig) -> Result<(), DmaBufError> {
+    pub fn set_burst_config(&mut self, burst: BurstConfig) -> Result<(), DmaBufError> {
         let len = self.len();
         self.configure(burst, len)
     }
@@ -618,7 +618,7 @@ impl DmaRxBuf {
     /// Note that the hardware is allowed to ignore this setting. If you attempt
     /// to use burst transfers with improperly aligned buffers, starting the
     /// transfer will result in [`DmaError::InvalidAlignment`].
-    pub fn set_burst_transfer(&mut self, burst: BurstConfig) -> Result<(), DmaBufError> {
+    pub fn set_burst_config(&mut self, burst: BurstConfig) -> Result<(), DmaBufError> {
         let len = self.len();
         self.configure(burst, len)
     }
@@ -816,7 +816,7 @@ impl DmaRxTxBuf {
     /// Note that the hardware is allowed to ignore this setting. If you attempt
     /// to use burst transfers with improperly aligned buffers, starting the
     /// transfer will result in [`DmaError::InvalidAlignment`].
-    pub fn set_burst_transfer(&mut self, burst: BurstConfig) -> Result<(), DmaBufError> {
+    pub fn set_burst_config(&mut self, burst: BurstConfig) -> Result<(), DmaBufError> {
         let len = self.len();
         self.configure(burst, len)
     }

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -12,6 +12,9 @@ use crate::soc::{is_valid_psram_address, is_valid_ram_address};
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaBufError {
+    /// The buffer is smaller than the requested size.
+    BufferTooSmall,
+
     /// More descriptors are needed for the buffer size.
     InsufficientDescriptors,
 
@@ -511,6 +514,9 @@ impl DmaTxBuf {
     }
 
     fn set_length_fallible(&mut self, len: usize, burst: BurstConfig) -> Result<(), DmaBufError> {
+        if len > self.capacity() {
+            return Err(DmaBufError::BufferTooSmall);
+        }
         burst.ensure_buffer_compatible(&self.buffer[..len], TransferDirection::Out)?;
 
         self.descriptors.set_tx_length(
@@ -665,6 +671,9 @@ impl DmaRxBuf {
     }
 
     fn set_length_fallible(&mut self, len: usize, burst: BurstConfig) -> Result<(), DmaBufError> {
+        if len > self.capacity() {
+            return Err(DmaBufError::BufferTooSmall);
+        }
         burst.ensure_buffer_compatible(&self.buffer[..len], TransferDirection::In)?;
 
         self.descriptors.set_rx_length(
@@ -877,6 +886,9 @@ impl DmaRxTxBuf {
     }
 
     fn set_length_fallible(&mut self, len: usize, burst: BurstConfig) -> Result<(), DmaBufError> {
+        if len > self.capacity() {
+            return Err(DmaBufError::BufferTooSmall);
+        }
         burst.ensure_buffer_compatible(&self.buffer[..len], TransferDirection::In)?;
         burst.ensure_buffer_compatible(&self.buffer[..len], TransferDirection::Out)?;
 

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -345,6 +345,8 @@ pub enum TransferDirection {
 }
 
 /// Holds all the information needed to configure a DMA channel for a transfer.
+#[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Preparation {
     /// The descriptor the DMA will start from.
     pub start: *mut DmaDescriptor,

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -194,6 +194,11 @@ impl RegisterAccess for AnyGdmaTxChannel {
             .out_conf1()
             .modify(|_, w| unsafe { w.out_ext_mem_bk_size().bits(size as u8) });
     }
+
+    #[cfg(psram_dma)]
+    fn can_access_psram(&self) -> bool {
+        true
+    }
 }
 
 impl TxRegisterAccess for AnyGdmaTxChannel {
@@ -430,6 +435,11 @@ impl RegisterAccess for AnyGdmaRxChannel {
         self.ch()
             .in_conf1()
             .modify(|_, w| unsafe { w.in_ext_mem_bk_size().bits(size as u8) });
+    }
+
+    #[cfg(psram_dma)]
+    fn can_access_psram(&self) -> bool {
+        true
     }
 }
 

--- a/esp-hal/src/dma/m2m.rs
+++ b/esp-hal/src/dma/m2m.rs
@@ -1,5 +1,3 @@
-#[cfg(esp32s3)]
-use crate::dma::DmaExtMemBKSize;
 use crate::{
     dma::{
         dma_private::{DmaSupport, DmaSupportRx},
@@ -151,21 +149,6 @@ where
                 .rx
                 .prepare_transfer_without_start(self.peripheral, &self.rx_chain)?;
             self.channel.rx.set_mem2mem_mode(true);
-        }
-        #[cfg(esp32s3)]
-        {
-            let align = match unsafe { crate::soc::cache_get_dcache_line_size() } {
-                16 => DmaExtMemBKSize::Size16,
-                32 => DmaExtMemBKSize::Size32,
-                64 => DmaExtMemBKSize::Size64,
-                _ => panic!("unsupported cache line size"),
-            };
-            if crate::soc::is_valid_psram_address(tx_ptr as usize) {
-                self.channel.tx.set_ext_mem_block_size(align);
-            }
-            if crate::soc::is_valid_psram_address(rx_ptr as usize) {
-                self.channel.rx.set_ext_mem_block_size(align);
-            }
         }
         self.channel.tx.start_transfer()?;
         self.channel.rx.start_transfer()?;

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -797,11 +797,11 @@ macro_rules! dma_loop_buffer {
 }
 
 /// DMA Errors
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaError {
     /// The alignment of data is invalid
-    InvalidAlignment,
+    InvalidAlignment(DmaAlignmentError),
     /// More descriptors are needed for the buffer size
     OutOfDescriptors,
     /// DescriptorError the DMA rejected the descriptor configuration. This
@@ -827,7 +827,7 @@ impl From<DmaBufError> for DmaError {
         match error {
             DmaBufError::InsufficientDescriptors => DmaError::OutOfDescriptors,
             DmaBufError::UnsupportedMemoryRegion => DmaError::UnsupportedMemoryRegion,
-            DmaBufError::InvalidAlignment => DmaError::InvalidAlignment,
+            DmaBufError::InvalidAlignment(err) => DmaError::InvalidAlignment(err),
             DmaBufError::InvalidChunkSize => DmaError::InvalidChunkSize,
         }
     }
@@ -1914,7 +1914,7 @@ where
 
         #[cfg(psram_dma)]
         self.rx_impl
-            .set_ext_mem_block_size(preparation.burst_transfer.external.into());
+            .set_ext_mem_block_size(preparation.burst_transfer.external_memory.into());
         self.rx_impl.set_burst_mode(preparation.burst_transfer);
         self.rx_impl.set_descr_burst_mode(true);
         self.rx_impl.set_check_owner(preparation.check_owner);
@@ -2202,7 +2202,7 @@ where
 
         #[cfg(psram_dma)]
         self.tx_impl
-            .set_ext_mem_block_size(preparation.burst_transfer.external.into());
+            .set_ext_mem_block_size(preparation.burst_transfer.external_memory.into());
         self.tx_impl.set_burst_mode(preparation.burst_transfer);
         self.tx_impl.set_descr_burst_mode(true);
         self.tx_impl.set_check_owner(preparation.check_owner);

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1966,8 +1966,11 @@ where
                     if crate::soc::addr_in_range(des.buffer as usize, psram_range.clone()) {
                         uses_psram = true;
                         // both the size and address of the buffer must be aligned
-                        if des.buffer as usize % alignment != 0 && des.size() % alignment != 0 {
-                            return Err(DmaError::InvalidAlignment);
+                        if des.buffer as usize % alignment != 0 {
+                            return Err(DmaError::InvalidAlignment(DmaAlignmentError::Address));
+                        }
+                        if des.size() % alignment != 0 {
+                            return Err(DmaError::InvalidAlignment(DmaAlignmentError::Size));
                         }
                         crate::soc::cache_invalidate_addr(des.buffer as u32, des.size() as u32);
                     }
@@ -2255,8 +2258,11 @@ where
                     if crate::soc::addr_in_range(des.buffer as usize, psram_range.clone()) {
                         uses_psram = true;
                         // both the size and address of the buffer must be aligned
-                        if des.buffer as usize % alignment != 0 && des.size() % alignment != 0 {
-                            return Err(DmaError::InvalidAlignment);
+                        if des.buffer as usize % alignment != 0 {
+                            return Err(DmaError::InvalidAlignment(DmaAlignmentError::Address));
+                        }
+                        if des.size() % alignment != 0 {
+                            return Err(DmaError::InvalidAlignment(DmaAlignmentError::Size));
                         }
                         crate::soc::cache_writeback_addr(des.buffer as u32, des.size() as u32);
                     }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -829,6 +829,7 @@ impl From<DmaBufError> for DmaError {
             DmaBufError::UnsupportedMemoryRegion => DmaError::UnsupportedMemoryRegion,
             DmaBufError::InvalidAlignment(err) => DmaError::InvalidAlignment(err),
             DmaBufError::InvalidChunkSize => DmaError::InvalidChunkSize,
+            DmaBufError::BufferTooSmall => DmaError::BufferTooSmall,
         }
     }
 }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1908,6 +1908,9 @@ where
     ) -> Result<(), DmaError> {
         debug_assert_eq!(preparation.direction, TransferDirection::In);
 
+        debug!("Preparing RX transfer {:?}", preparation);
+        trace!("First descriptor {:?}", unsafe { &*preparation.start });
+
         #[cfg(psram_dma)]
         if preparation.accesses_psram && !self.rx_impl.can_access_psram() {
             return Err(DmaError::UnsupportedMemoryRegion);
@@ -2198,6 +2201,9 @@ where
         peri: DmaPeripheral,
     ) -> Result<(), DmaError> {
         debug_assert_eq!(preparation.direction, TransferDirection::Out);
+
+        debug!("Preparing TX transfer {:?}", preparation);
+        trace!("First descriptor {:?}", unsafe { &*preparation.start });
 
         #[cfg(psram_dma)]
         if preparation.accesses_psram && !self.tx_impl.can_access_psram() {

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -122,6 +122,18 @@ impl RegisterAccess for AnySpiDmaTxChannel {
     fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
         self.0.is_compatible_with(peripheral)
     }
+
+    #[cfg(psram_dma)]
+    fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize) {
+        let spi = self.0.register_block();
+        spi.dma_conf()
+            .modify(|_, w| unsafe { w.ext_mem_bk_size().bits(size as u8) });
+    }
+
+    #[cfg(psram_dma)]
+    fn can_access_psram(&self) -> bool {
+        matches!(self.0, AnySpiDmaChannel(AnySpiDmaChannelInner::Spi2(_)))
+    }
 }
 
 impl TxRegisterAccess for AnySpiDmaTxChannel {
@@ -279,6 +291,18 @@ impl RegisterAccess for AnySpiDmaRxChannel {
 
     fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
         self.0.is_compatible_with(peripheral)
+    }
+
+    #[cfg(psram_dma)]
+    fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize) {
+        let spi = self.0.register_block();
+        spi.dma_conf()
+            .modify(|_, w| unsafe { w.ext_mem_bk_size().bits(size as u8) });
+    }
+
+    #[cfg(psram_dma)]
+    fn can_access_psram(&self) -> bool {
+        matches!(self.0, AnySpiDmaChannel(AnySpiDmaChannelInner::Spi2(_)))
     }
 }
 
@@ -475,6 +499,18 @@ impl RegisterAccess for AnyI2sDmaTxChannel {
     fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
         self.0.is_compatible_with(peripheral)
     }
+
+    #[cfg(psram_dma)]
+    fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize) {
+        let spi = self.0.register_block();
+        spi.lc_conf()
+            .modify(|_, w| unsafe { w.ext_mem_bk_size().bits(size as u8) });
+    }
+
+    #[cfg(psram_dma)]
+    fn can_access_psram(&self) -> bool {
+        matches!(self.0, AnyI2sDmaChannel(AnyI2sDmaChannelInner::I2s0(_)))
+    }
 }
 
 impl TxRegisterAccess for AnyI2sDmaTxChannel {
@@ -644,6 +680,18 @@ impl RegisterAccess for AnyI2sDmaRxChannel {
 
     fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
         self.0.is_compatible_with(peripheral)
+    }
+
+    #[cfg(psram_dma)]
+    fn set_ext_mem_block_size(&self, size: DmaExtMemBKSize) {
+        let spi = self.0.register_block();
+        spi.lc_conf()
+            .modify(|_, w| unsafe { w.ext_mem_bk_size().bits(size as u8) });
+    }
+
+    #[cfg(psram_dma)]
+    fn can_access_psram(&self) -> bool {
+        matches!(self.0, AnyI2sDmaChannel(AnyI2sDmaChannelInner::I2s0(_)))
     }
 }
 

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -133,3 +133,33 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 pub extern "Rust" fn __init_data() -> bool {
     false
 }
+
+/// Write back a specific range of data in the cache.
+#[doc(hidden)]
+#[link_section = ".rwtext"]
+pub unsafe fn cache_writeback_addr(addr: u32, size: u32) {
+    extern "C" {
+        fn Cache_WriteBack_Addr(addr: u32, size: u32);
+    }
+    Cache_WriteBack_Addr(addr, size);
+}
+
+/// Invalidate a specific range of addresses in the cache.
+#[doc(hidden)]
+#[link_section = ".rwtext"]
+pub unsafe fn cache_invalidate_addr(addr: u32, size: u32) {
+    extern "C" {
+        fn Cache_Invalidate_Addr(addr: u32, size: u32);
+    }
+    Cache_Invalidate_Addr(addr, size);
+}
+
+/// Get the size of a cache line in the DCache.
+#[doc(hidden)]
+#[link_section = ".rwtext"]
+pub unsafe fn cache_get_dcache_line_size() -> u32 {
+    extern "C" {
+        fn Cache_Get_DCache_Line_Size() -> u32;
+    }
+    Cache_Get_DCache_Line_Size()
+}

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -27,7 +27,7 @@ mod psram_common;
 #[cfg(any(feature = "quad-psram", feature = "octal-psram"))]
 static mut MAPPED_PSRAM: MappedPsram = MappedPsram { memory_range: 0..0 };
 
-fn psram_range_internal() -> Range<usize> {
+pub(crate) fn psram_range() -> Range<usize> {
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "quad-psram", feature = "octal-psram"))] {
             unsafe { MAPPED_PSRAM.memory_range.clone() }
@@ -112,12 +112,12 @@ pub(crate) fn is_slice_in_dram<T>(slice: &[T]) -> bool {
 
 #[allow(unused)]
 pub(crate) fn is_valid_psram_address(address: usize) -> bool {
-    addr_in_range(address, psram_range_internal())
+    addr_in_range(address, psram_range())
 }
 
 #[allow(unused)]
 pub(crate) fn is_slice_in_psram<T>(slice: &[T]) -> bool {
-    slice_in_range(slice, psram_range_internal())
+    slice_in_range(slice, psram_range())
 }
 
 #[allow(unused)]
@@ -135,6 +135,6 @@ fn slice_in_range<T>(slice: &[T], range: Range<usize>) -> bool {
     addr_in_range(start, range.clone()) && end <= range.end
 }
 
-fn addr_in_range(addr: usize, range: Range<usize>) -> bool {
+pub(crate) fn addr_in_range(addr: usize, range: Range<usize>) -> bool {
     range.contains(&addr)
 }

--- a/esp-hal/src/soc/psram_common.rs
+++ b/esp-hal/src/soc/psram_common.rs
@@ -26,12 +26,6 @@ impl PsramSize {
     }
 }
 
-/// Returns the address range available in external memory.
-#[cfg(any(feature = "quad-psram", feature = "octal-psram"))]
-pub(crate) fn psram_range(_psram: &crate::peripherals::PSRAM) -> Range<usize> {
-    unsafe { super::MAPPED_PSRAM.memory_range.clone() }
-}
-
 /// Returns the address and size of the available in external memory.
 #[cfg(any(feature = "quad-psram", feature = "octal-psram"))]
 pub fn psram_raw_parts(psram: &crate::peripherals::PSRAM) -> (*mut u8, usize) {

--- a/esp-hal/src/soc/psram_common.rs
+++ b/esp-hal/src/soc/psram_common.rs
@@ -1,5 +1,3 @@
-use core::ops::Range;
-
 /// Size of PSRAM
 ///
 /// [PsramSize::AutoDetect] will try to detect the size of PSRAM
@@ -28,7 +26,7 @@ impl PsramSize {
 
 /// Returns the address and size of the available in external memory.
 #[cfg(any(feature = "quad-psram", feature = "octal-psram"))]
-pub fn psram_raw_parts(psram: &crate::peripherals::PSRAM) -> (*mut u8, usize) {
-    let range = psram_range(psram);
+pub fn psram_raw_parts(_psram: &crate::peripherals::PSRAM) -> (*mut u8, usize) {
+    let range = crate::soc::psram_range();
     (range.start as *mut u8, range.end - range.start)
 }

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -72,4 +72,7 @@ symbols = [
     "uart_support_wakeup_int",
     "ulp_supported",
     "riscv_coproc_supported",
+
+    # Other capabilities
+    "psram_dma",
 ]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -68,6 +68,7 @@ symbols = [
     "bt",
     "wifi",
     "psram",
+    "psram_dma",
     "octal_psram",
     "ulp_riscv_core",
     "timg_timer1",
@@ -88,4 +89,7 @@ symbols = [
     "uart_support_wakeup_int",
     "ulp_supported",
     "riscv_coproc_supported",
+
+    # Other capabilities
+    "psram_dma",
 ]

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -25,7 +25,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{DmaBufBlkSize, DmaRxBuf, DmaTxBuf},
+    dma::{BurstConfig, DmaRxBuf, DmaTxBuf, ExternalBurstSize},
     peripheral::Peripheral,
     prelude::*,
     spi::{
@@ -51,7 +51,7 @@ macro_rules! dma_alloc_buffer {
 }
 
 const DMA_BUFFER_SIZE: usize = 8192;
-const DMA_ALIGNMENT: DmaBufBlkSize = DmaBufBlkSize::Size64;
+const DMA_ALIGNMENT: ExternalBurstSize = ExternalBurstSize::Size64;
 const DMA_CHUNK_SIZE: usize = 4096 - DMA_ALIGNMENT as usize;
 
 #[entry]
@@ -76,8 +76,15 @@ fn main() -> ! {
         tx_buffer.len(),
         tx_descriptors.len()
     );
-    let mut dma_tx_buf =
-        DmaTxBuf::new_with_block_size(tx_descriptors, tx_buffer, Some(DMA_ALIGNMENT)).unwrap();
+    let mut dma_tx_buf = DmaTxBuf::new_with_config(
+        tx_descriptors,
+        tx_buffer,
+        BurstConfig {
+            external: DMA_ALIGNMENT,
+            ..BurstConfig::default()
+        },
+    )
+    .unwrap();
     let (rx_buffer, rx_descriptors, _, _) = esp_hal::dma_buffers!(DMA_BUFFER_SIZE, 0);
     info!(
         "RX: {:p} len {} ({} descripters)",

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -25,7 +25,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{BurstConfig, DmaRxBuf, DmaTxBuf, ExternalBurstSize},
+    dma::{BurstConfig, DmaRxBuf, DmaTxBuf, ExternalBurstConfig},
     peripheral::Peripheral,
     prelude::*,
     spi::{
@@ -51,7 +51,7 @@ macro_rules! dma_alloc_buffer {
 }
 
 const DMA_BUFFER_SIZE: usize = 8192;
-const DMA_ALIGNMENT: ExternalBurstSize = ExternalBurstSize::Size64;
+const DMA_ALIGNMENT: ExternalBurstConfig = ExternalBurstConfig::Size64;
 const DMA_CHUNK_SIZE: usize = 4096 - DMA_ALIGNMENT as usize;
 
 #[entry]

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -25,7 +25,7 @@
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::{BurstConfig, DmaRxBuf, DmaTxBuf, ExternalBurstConfig},
+    dma::{DmaRxBuf, DmaTxBuf, ExternalBurstConfig},
     peripheral::Peripheral,
     prelude::*,
     spi::{
@@ -76,15 +76,8 @@ fn main() -> ! {
         tx_buffer.len(),
         tx_descriptors.len()
     );
-    let mut dma_tx_buf = DmaTxBuf::new_with_config(
-        tx_descriptors,
-        tx_buffer,
-        BurstConfig {
-            external: DMA_ALIGNMENT,
-            ..BurstConfig::default()
-        },
-    )
-    .unwrap();
+    let mut dma_tx_buf =
+        DmaTxBuf::new_with_config(tx_descriptors, tx_buffer, DMA_ALIGNMENT).unwrap();
     let (rx_buffer, rx_descriptors, _, _) = esp_hal::dma_buffers!(DMA_BUFFER_SIZE, 0);
     info!(
         "RX: {:p} len {} ({} descripters)",

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -197,6 +197,9 @@ mod tests {
         unit.channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
+        dma_rx_buf.set_length(TRANSFER_SIZE);
+        dma_tx_buf.set_length(TRANSFER_SIZE);
+
         // Fill the buffer where each byte has 3 pos edges.
         dma_tx_buf.as_mut_slice().fill(0b0110_1010);
 
@@ -233,6 +236,9 @@ mod tests {
         unit.channel0.set_edge_signal(ctx.pcnt_source);
         unit.channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
+
+        dma_rx_buf.set_length(TRANSFER_SIZE);
+        dma_tx_buf.set_length(TRANSFER_SIZE);
 
         // Fill the buffer where each byte has 3 pos edges.
         dma_tx_buf.as_mut_slice().fill(0b0110_1010);

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -7,7 +7,7 @@
 use defmt::error;
 use esp_alloc as _;
 use esp_hal::{
-    dma::{BurstConfig, DmaRxBuf, DmaTxBuf, ExternalBurstConfig, InternalBurstConfig},
+    dma::{DmaRxBuf, DmaTxBuf, ExternalBurstConfig},
     dma_buffers,
     dma_descriptors_chunk_size,
     gpio::interconnect::InputSignal,
@@ -88,15 +88,7 @@ mod tests {
 
         let (_, descriptors) = dma_descriptors_chunk_size!(0, DMA_BUFFER_SIZE, DMA_CHUNK_SIZE);
         let buffer = dma_alloc_buffer!(DMA_BUFFER_SIZE, DMA_ALIGNMENT as usize);
-        let mut dma_tx_buf = DmaTxBuf::new_with_config(
-            descriptors,
-            buffer,
-            BurstConfig {
-                internal: InternalBurstConfig::default(),
-                external: ExternalBurstConfig::Size32,
-            },
-        )
-        .unwrap();
+        let mut dma_tx_buf = DmaTxBuf::new_with_config(descriptors, buffer, DMA_ALIGNMENT).unwrap();
 
         let unit = ctx.pcnt_unit;
         let mut spi = ctx.spi;
@@ -146,15 +138,7 @@ mod tests {
 
         let (_, descriptors) = dma_descriptors_chunk_size!(0, DMA_BUFFER_SIZE, DMA_CHUNK_SIZE);
         let buffer = dma_alloc_buffer!(DMA_BUFFER_SIZE, DMA_ALIGNMENT as usize);
-        let dma_tx_buf = DmaTxBuf::new_with_config(
-            descriptors,
-            buffer,
-            BurstConfig {
-                internal: InternalBurstConfig::default(),
-                external: ExternalBurstConfig::Size32,
-            },
-        )
-        .unwrap();
+        let dma_tx_buf = DmaTxBuf::new_with_config(descriptors, buffer, DMA_ALIGNMENT).unwrap();
 
         let (rx, rxd, _, _) = dma_buffers!(1, 0);
         let dma_rx_buf = DmaRxBuf::new(rxd, rx).unwrap();

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -7,7 +7,7 @@
 use defmt::error;
 use esp_alloc as _;
 use esp_hal::{
-    dma::{BurstConfig, DmaRxBuf, DmaTxBuf, ExternalBurstSize, InternalBurstTransfer},
+    dma::{BurstConfig, DmaRxBuf, DmaTxBuf, ExternalBurstConfig, InternalBurstConfig},
     dma_buffers,
     dma_descriptors_chunk_size,
     gpio::interconnect::InputSignal,
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn test_spi_writes_are_correctly_by_pcnt(ctx: Context) {
         const DMA_BUFFER_SIZE: usize = 4;
-        const DMA_ALIGNMENT: ExternalBurstSize = ExternalBurstSize::Size32;
+        const DMA_ALIGNMENT: ExternalBurstConfig = ExternalBurstConfig::Size32;
         const DMA_CHUNK_SIZE: usize = 4096 - DMA_ALIGNMENT as usize;
 
         let (_, descriptors) = dma_descriptors_chunk_size!(0, DMA_BUFFER_SIZE, DMA_CHUNK_SIZE);
@@ -92,8 +92,8 @@ mod tests {
             descriptors,
             buffer,
             BurstConfig {
-                internal: InternalBurstTransfer::default(),
-                external: ExternalBurstSize::Size32,
+                internal: InternalBurstConfig::default(),
+                external: ExternalBurstConfig::Size32,
             },
         )
         .unwrap();
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn test_spidmabus_writes_are_correctly_by_pcnt(ctx: Context) {
         const DMA_BUFFER_SIZE: usize = 4;
-        const DMA_ALIGNMENT: ExternalBurstSize = ExternalBurstSize::Size32; // matches dcache line size
+        const DMA_ALIGNMENT: ExternalBurstConfig = ExternalBurstConfig::Size32; // matches dcache line size
         const DMA_CHUNK_SIZE: usize = 4096 - DMA_ALIGNMENT as usize; // 64 byte aligned
 
         let (_, descriptors) = dma_descriptors_chunk_size!(0, DMA_BUFFER_SIZE, DMA_CHUNK_SIZE);
@@ -150,8 +150,8 @@ mod tests {
             descriptors,
             buffer,
             BurstConfig {
-                internal: InternalBurstTransfer::default(),
-                external: ExternalBurstSize::Size32,
+                internal: InternalBurstConfig::default(),
+                external: ExternalBurstConfig::Size32,
             },
         )
         .unwrap();

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -7,7 +7,7 @@
 use defmt::error;
 use esp_alloc as _;
 use esp_hal::{
-    dma::{DmaBufBlkSize, DmaRxBuf, DmaTxBuf},
+    dma::{BurstConfig, DmaRxBuf, DmaTxBuf, ExternalBurstSize, InternalBurstTransfer},
     dma_buffers,
     dma_descriptors_chunk_size,
     gpio::interconnect::InputSignal,
@@ -83,13 +83,20 @@ mod tests {
     #[test]
     fn test_spi_writes_are_correctly_by_pcnt(ctx: Context) {
         const DMA_BUFFER_SIZE: usize = 4;
-        const DMA_ALIGNMENT: DmaBufBlkSize = DmaBufBlkSize::Size32;
+        const DMA_ALIGNMENT: ExternalBurstSize = ExternalBurstSize::Size32;
         const DMA_CHUNK_SIZE: usize = 4096 - DMA_ALIGNMENT as usize;
 
         let (_, descriptors) = dma_descriptors_chunk_size!(0, DMA_BUFFER_SIZE, DMA_CHUNK_SIZE);
         let buffer = dma_alloc_buffer!(DMA_BUFFER_SIZE, DMA_ALIGNMENT as usize);
-        let mut dma_tx_buf =
-            DmaTxBuf::new_with_block_size(descriptors, buffer, Some(DMA_ALIGNMENT)).unwrap();
+        let mut dma_tx_buf = DmaTxBuf::new_with_config(
+            descriptors,
+            buffer,
+            BurstConfig {
+                internal: InternalBurstTransfer::default(),
+                external: ExternalBurstSize::Size32,
+            },
+        )
+        .unwrap();
 
         let unit = ctx.pcnt_unit;
         let mut spi = ctx.spi;
@@ -134,13 +141,20 @@ mod tests {
     #[test]
     fn test_spidmabus_writes_are_correctly_by_pcnt(ctx: Context) {
         const DMA_BUFFER_SIZE: usize = 4;
-        const DMA_ALIGNMENT: DmaBufBlkSize = DmaBufBlkSize::Size32; // matches dcache line size
+        const DMA_ALIGNMENT: ExternalBurstSize = ExternalBurstSize::Size32; // matches dcache line size
         const DMA_CHUNK_SIZE: usize = 4096 - DMA_ALIGNMENT as usize; // 64 byte aligned
 
         let (_, descriptors) = dma_descriptors_chunk_size!(0, DMA_BUFFER_SIZE, DMA_CHUNK_SIZE);
         let buffer = dma_alloc_buffer!(DMA_BUFFER_SIZE, DMA_ALIGNMENT as usize);
-        let dma_tx_buf =
-            DmaTxBuf::new_with_block_size(descriptors, buffer, Some(DMA_ALIGNMENT)).unwrap();
+        let dma_tx_buf = DmaTxBuf::new_with_config(
+            descriptors,
+            buffer,
+            BurstConfig {
+                internal: InternalBurstTransfer::default(),
+                external: ExternalBurstSize::Size32,
+            },
+        )
+        .unwrap();
 
         let (rx, rxd, _, _) = dma_buffers!(1, 0);
         let dma_rx_buf = DmaRxBuf::new(rxd, rx).unwrap();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR adds burst mode configuration to the DMA buffers. This is somewhat out of their scope, but I believe they may be a slight overcomplication anyway. The PR also describes burst mode constraints for both internal and PSRAM accesses, where applicable.