### PR TITLE
Disable peripherals when unused

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Trying to send a single-shot RMT transmission will result in an error now, `RMT` deals with `u32` now, `PulseCode` is a convenience trait now (#2463)
 - Removed `get_` prefixes from functions (#2528)
 - The `Camera` and `I8080` drivers' constructors now only accepts blocking-mode DMA channels. (#2519)
+- Many peripherals are now disabled by default and also get disabled when the driver is dropped (#2544)
 
 ### Fixed
 

--- a/esp-hal/src/aes/esp32.rs
+++ b/esp-hal/src/aes/esp32.rs
@@ -1,11 +1,7 @@
-use crate::{
-    aes::{Aes, Aes128, Aes192, Aes256, AesFlavour, Endianness, ALIGN_SIZE},
-    system::{Peripheral as PeripheralEnable, PeripheralClockControl},
-};
+use crate::aes::{Aes, Aes128, Aes192, Aes256, AesFlavour, Endianness, ALIGN_SIZE};
 
 impl<'d> Aes<'d> {
     pub(super) fn init(&mut self) {
-        PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_endianness(
             Endianness::BigEndian,
             Endianness::BigEndian,

--- a/esp-hal/src/aes/esp32cX.rs
+++ b/esp-hal/src/aes/esp32cX.rs
@@ -1,11 +1,7 @@
-use crate::{
-    aes::{Aes, Aes128, Aes256, AesFlavour, ALIGN_SIZE},
-    system::{Peripheral as PeripheralEnable, PeripheralClockControl},
-};
+use crate::aes::{Aes, Aes128, Aes256, AesFlavour, ALIGN_SIZE};
 
 impl Aes<'_> {
     pub(super) fn init(&mut self) {
-        PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_dma(false);
     }
 

--- a/esp-hal/src/aes/esp32s2.rs
+++ b/esp-hal/src/aes/esp32s2.rs
@@ -1,11 +1,7 @@
-use crate::{
-    aes::{Aes, Aes128, Aes192, Aes256, AesFlavour, Endianness, ALIGN_SIZE},
-    system::{Peripheral as PeripheralEnable, PeripheralClockControl},
-};
+use crate::aes::{Aes, Aes128, Aes192, Aes256, AesFlavour, Endianness, ALIGN_SIZE};
 
 impl<'d> Aes<'d> {
     pub(super) fn init(&mut self) {
-        PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_dma(false);
         self.write_endianness(
             Endianness::BigEndian,

--- a/esp-hal/src/aes/esp32s3.rs
+++ b/esp-hal/src/aes/esp32s3.rs
@@ -1,11 +1,7 @@
-use crate::{
-    aes::{Aes, Aes128, Aes256, AesFlavour, ALIGN_SIZE},
-    system::{Peripheral as PeripheralEnable, PeripheralClockControl},
-};
+use crate::aes::{Aes, Aes128, Aes256, AesFlavour, ALIGN_SIZE};
 
 impl<'d> Aes<'d> {
     pub(super) fn init(&mut self) {
-        PeripheralClockControl::enable(PeripheralEnable::Aes);
         self.write_dma(false);
     }
 

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -143,8 +143,9 @@ impl<'d> Aes<'d> {
     pub fn new(aes: impl Peripheral<P = AES> + 'd) -> Self {
         crate::into_ref!(aes);
 
-        crate::system::PeripheralClockControl::reset(crate::system::Peripheral::Aes);
-        crate::system::PeripheralClockControl::enable(crate::system::Peripheral::Aes);
+        if crate::system::PeripheralClockControl::enable(crate::system::Peripheral::Aes, true) {
+            crate::system::PeripheralClockControl::reset(crate::system::Peripheral::Aes);
+        }
 
         let mut ret = Self {
             aes,
@@ -187,6 +188,12 @@ impl<'d> Aes<'d> {
 
     fn start(&mut self) {
         self.write_start();
+    }
+}
+
+impl Drop for Aes<'_> {
+    fn drop(&mut self) {
+        crate::system::PeripheralClockControl::enable(crate::system::Peripheral::Aes, false);
     }
 }
 

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -408,8 +408,9 @@ where
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
     ) -> Self {
-        PeripheralClockControl::reset(Peripheral::ApbSarAdc);
-        PeripheralClockControl::enable(Peripheral::ApbSarAdc);
+        if PeripheralClockControl::enable(Peripheral::ApbSarAdc, true) {
+            PeripheralClockControl::reset(Peripheral::ApbSarAdc);
+        }
 
         unsafe { &*APB_SARADC::PTR }.ctrl().modify(|_, w| unsafe {
             w.start_force().set_bit();
@@ -497,6 +498,12 @@ where
         self.active_channel = None;
 
         Ok(converted_value)
+    }
+}
+
+impl<ADCI> Drop for Adc<'_, ADCI> {
+    fn drop(&mut self) {
+        PeripheralClockControl::enable(Peripheral::ApbSarAdc, false);
     }
 }
 

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -401,8 +401,9 @@ where
         adc_instance: impl crate::peripheral::Peripheral<P = ADCI> + 'd,
         config: AdcConfig<ADCI>,
     ) -> Self {
-        PeripheralClockControl::reset(Peripheral::ApbSarAdc);
-        PeripheralClockControl::enable(Peripheral::ApbSarAdc);
+        if PeripheralClockControl::enable(Peripheral::ApbSarAdc, true) {
+            PeripheralClockControl::reset(Peripheral::ApbSarAdc);
+        }
 
         let sensors = unsafe { &*SENS::ptr() };
 
@@ -557,6 +558,12 @@ where
 
         ADCI::clear_start_sample();
         ADCI::start_sample();
+    }
+}
+
+impl<ADCI> Drop for Adc<'_, ADCI> {
+    fn drop(&mut self) {
+        PeripheralClockControl::enable(Peripheral::ApbSarAdc, false);
     }
 }
 

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -753,7 +753,9 @@ impl<'d> Dma<'d> {
     ) -> Dma<'d> {
         crate::into_ref!(dma);
 
-        PeripheralClockControl::enable(Peripheral::Gdma);
+        if PeripheralClockControl::enable(Peripheral::Gdma, true) {
+            PeripheralClockControl::reset(Peripheral::Gdma);
+        }
         dma.misc_conf().modify(|_, w| w.ahbm_rst_inter().set_bit());
         dma.misc_conf()
             .modify(|_, w| w.ahbm_rst_inter().clear_bit());

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -753,7 +753,7 @@ impl<'d> Dma<'d> {
     ) -> Dma<'d> {
         crate::into_ref!(dma);
 
-        if PeripheralClockControl::enable(Peripheral::Gdma, true) {
+        if PeripheralClockControl::enable(Peripheral::Gdma) {
             PeripheralClockControl::reset(Peripheral::Gdma);
         }
         dma.misc_conf().modify(|_, w| w.ahbm_rst_inter().set_bit());

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -942,7 +942,7 @@ impl<'d> Dma<'d> {
     pub fn new(
         dma: impl crate::peripheral::Peripheral<P = crate::peripherals::DMA> + 'd,
     ) -> Dma<'d> {
-        if PeripheralClockControl::enable(Peripheral::Dma, true) {
+        if PeripheralClockControl::enable(Peripheral::Dma) {
             PeripheralClockControl::reset(Peripheral::Dma);
         }
 

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -942,7 +942,9 @@ impl<'d> Dma<'d> {
     pub fn new(
         dma: impl crate::peripheral::Peripheral<P = crate::peripherals::DMA> + 'd,
     ) -> Dma<'d> {
-        PeripheralClockControl::enable(Peripheral::Dma);
+        if PeripheralClockControl::enable(Peripheral::Dma, true) {
+            PeripheralClockControl::reset(Peripheral::Dma);
+        }
 
         #[cfg(esp32)]
         {

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -102,8 +102,9 @@ impl<'d> Ecc<'d, crate::Blocking> {
     pub fn new(ecc: impl Peripheral<P = ECC> + 'd) -> Self {
         crate::into_ref!(ecc);
 
-        PeripheralClockControl::reset(PeripheralEnable::Ecc);
-        PeripheralClockControl::enable(PeripheralEnable::Ecc);
+        if PeripheralClockControl::enable(PeripheralEnable::Ecc, true) {
+            PeripheralClockControl::reset(PeripheralEnable::Ecc);
+        }
 
         Self {
             ecc,
@@ -962,5 +963,11 @@ impl<DM: crate::Mode> Ecc<'_, DM> {
         for (a, b) in nsrc.chunks_exact(4).zip(ndst.rchunks_exact_mut(4)) {
             b.copy_from_slice(&u32::from_be_bytes(a.try_into().unwrap()).to_ne_bytes());
         }
+    }
+}
+
+impl<DM: crate::Mode> Drop for Ecc<'_, DM> {
+    fn drop(&mut self) {
+        PeripheralClockControl::enable(PeripheralEnable::Ecc, false);
     }
 }

--- a/esp-hal/src/hmac.rs
+++ b/esp-hal/src/hmac.rs
@@ -349,6 +349,6 @@ impl<'d> Hmac<'d> {
 
 impl Drop for Hmac<'_> {
     fn drop(&mut self) {
-        PeripheralClockControl::enable(PeripheralEnable::Hmac, true);
+        PeripheralClockControl::enable(PeripheralEnable::Hmac, false);
     }
 }

--- a/esp-hal/src/hmac.rs
+++ b/esp-hal/src/hmac.rs
@@ -107,8 +107,9 @@ impl<'d> Hmac<'d> {
     pub fn new(hmac: impl Peripheral<P = HMAC> + 'd) -> Self {
         crate::into_ref!(hmac);
 
-        PeripheralClockControl::reset(PeripheralEnable::Hmac);
-        PeripheralClockControl::enable(PeripheralEnable::Hmac);
+        if PeripheralClockControl::enable(PeripheralEnable::Hmac, true) {
+            PeripheralClockControl::reset(PeripheralEnable::Hmac);
+        }
 
         Self {
             hmac,
@@ -343,5 +344,11 @@ impl<'d> Hmac<'d> {
             .write(|w| w.set_text_one().set_bit());
 
         while self.is_busy() {}
+    }
+}
+
+impl Drop for Hmac<'_> {
+    fn drop(&mut self) {
+        PeripheralClockControl::enable(PeripheralEnable::Hmac, true);
     }
 }

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -353,8 +353,8 @@ where
     }
 
     fn internal_recover(&self) {
-        PeripheralClockControl::enable(self.driver().info.peripheral, false);
-        PeripheralClockControl::enable(self.driver().info.peripheral, true);
+        PeripheralClockControl::disable(self.driver().info.peripheral);
+        PeripheralClockControl::enable(self.driver().info.peripheral);
         PeripheralClockControl::reset(self.driver().info.peripheral);
 
         // We know the configuration is valid, we can ignore the result.

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -259,7 +259,6 @@ where
     pub i2s_rx: RxCreator<'d, M, T>,
     /// Handles the transmission (TX) side of the I2S peripheral.
     pub i2s_tx: TxCreator<'d, M, T>,
-    guard: PeripheralGuard,
 }
 
 impl<'d, DmaMode, T> I2s<'d, DmaMode, T>
@@ -287,7 +286,8 @@ where
 
         // make sure the peripheral is enabled before configuring it
         let peripheral = i2s.peripheral();
-        let guard = PeripheralGuard::new(peripheral);
+        let rx_guard = PeripheralGuard::new(peripheral);
+        let tx_guard = PeripheralGuard::new(peripheral);
 
         i2s.set_clock(calculate_clock(sample_rate, 2, data_format.channel_bits()));
         i2s.configure(&standard, &data_format);
@@ -300,15 +300,14 @@ where
                 i2s: unsafe { i2s.clone_unchecked() },
                 rx_channel: channel.rx,
                 descriptors: rx_descriptors,
-                guard,
+                guard: rx_guard,
             },
             i2s_tx: TxCreator {
                 i2s,
                 tx_channel: channel.tx,
                 descriptors: tx_descriptors,
-                guard: PeripheralGuard::new(peripheral),
+                guard: tx_guard,
             },
-            guard: PeripheralGuard::new(peripheral),
         }
     }
 }
@@ -446,7 +445,6 @@ where
                 descriptors: self.i2s_tx.descriptors,
                 guard: self.i2s_tx.guard,
             },
-            guard: self.guard,
         }
     }
 }

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -60,7 +60,7 @@ use crate::{
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{i2s0::RegisterBlock, I2S0, I2S1},
     private::Internal,
-    system::PeripheralClockControl,
+    system::PeripheralGuard,
     Async,
     Mode,
 };
@@ -177,6 +177,7 @@ where
 {
     instance: PeripheralRef<'d, I>,
     tx_channel: ChannelTx<'d, DM, I::Dma>,
+    _guard: PeripheralGuard,
 }
 
 impl<'d, DM> I2sParallel<'d, DM>
@@ -220,8 +221,8 @@ where
         channel.runtime_ensure_compatible(&i2s);
         let channel = channel.degrade();
 
-        PeripheralClockControl::reset(i2s.peripheral());
-        PeripheralClockControl::enable(i2s.peripheral());
+        let guard = PeripheralGuard::new(i2s.peripheral());
+
         // configure the I2S peripheral for parallel mode
         i2s.setup(frequency, pins.bus_width());
         // setup the clock pin
@@ -232,6 +233,7 @@ where
         Self {
             instance: i2s,
             tx_channel: channel.tx,
+            _guard: guard,
         }
     }
 

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -82,7 +82,7 @@ use crate::{
     lcd_cam::{calculate_clkm, BitOrder, ByteOrder},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
-    system::PeripheralGuard,
+    system::{self, GenericPeripheralGuard},
     Blocking,
 };
 
@@ -122,14 +122,14 @@ pub enum VsyncFilterThreshold {
 pub struct Cam<'d> {
     /// The LCD_CAM peripheral reference for managing the camera functionality.
     pub(crate) lcd_cam: PeripheralRef<'d, LCD_CAM>,
-    pub(super) _guard: PeripheralGuard,
+    pub(super) _guard: GenericPeripheralGuard<{ system::Peripheral::LcdCam as u8 }>,
 }
 
 /// Represents the camera interface with DMA support.
 pub struct Camera<'d> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
     rx_channel: ChannelRx<'d, Blocking, <LCD_CAM as DmaEligible>::Dma>,
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ system::Peripheral::LcdCam as u8 }>,
 }
 
 impl<'d> Camera<'d> {

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -144,8 +144,6 @@ impl<'d> Camera<'d> {
         CH: DmaChannelConvert<<LCD_CAM as DmaEligible>::Dma>,
         P: RxPins,
     {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::LcdCam);
-
         let lcd_cam = cam.lcd_cam;
 
         let clocks = Clocks::get();
@@ -192,7 +190,7 @@ impl<'d> Camera<'d> {
         Self {
             lcd_cam,
             rx_channel: channel.degrade(),
-            _guard: guard,
+            _guard: cam._guard,
         }
     }
 }

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -82,6 +82,7 @@ use crate::{
     lcd_cam::{calculate_clkm, BitOrder, ByteOrder},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
+    system::PeripheralGuard,
     Blocking,
 };
 
@@ -121,12 +122,14 @@ pub enum VsyncFilterThreshold {
 pub struct Cam<'d> {
     /// The LCD_CAM peripheral reference for managing the camera functionality.
     pub(crate) lcd_cam: PeripheralRef<'d, LCD_CAM>,
+    pub(super) _guard: PeripheralGuard,
 }
 
 /// Represents the camera interface with DMA support.
 pub struct Camera<'d> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
     rx_channel: ChannelRx<'d, Blocking, <LCD_CAM as DmaEligible>::Dma>,
+    _guard: PeripheralGuard,
 }
 
 impl<'d> Camera<'d> {
@@ -141,6 +144,8 @@ impl<'d> Camera<'d> {
         CH: DmaChannelConvert<<LCD_CAM as DmaEligible>::Dma>,
         P: RxPins,
     {
+        let guard = PeripheralGuard::new(crate::system::Peripheral::LcdCam);
+
         let lcd_cam = cam.lcd_cam;
 
         let clocks = Clocks::get();
@@ -187,6 +192,7 @@ impl<'d> Camera<'d> {
         Self {
             lcd_cam,
             rx_channel: channel.degrade(),
+            _guard: guard,
         }
     }
 }

--- a/esp-hal/src/lcd_cam/lcd/mod.rs
+++ b/esp-hal/src/lcd_cam/lcd/mod.rs
@@ -10,7 +10,12 @@
 //! ## Implementation State
 //! - RGB is not supported yet
 
-use crate::{peripheral::PeripheralRef, peripherals::LCD_CAM, system::PeripheralGuard};
+use super::GenericPeripheralGuard;
+use crate::{
+    peripheral::PeripheralRef,
+    peripherals::LCD_CAM,
+    system::{self},
+};
 
 pub mod dpi;
 pub mod i8080;
@@ -23,7 +28,7 @@ pub struct Lcd<'d, DM: crate::Mode> {
     /// A marker for the mode of operation (blocking or asynchronous).
     pub(crate) _mode: core::marker::PhantomData<DM>,
 
-    pub(super) _guard: PeripheralGuard,
+    pub(super) _guard: GenericPeripheralGuard<{ system::Peripheral::LcdCam as u8 }>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/esp-hal/src/lcd_cam/lcd/mod.rs
+++ b/esp-hal/src/lcd_cam/lcd/mod.rs
@@ -10,7 +10,7 @@
 //! ## Implementation State
 //! - RGB is not supported yet
 
-use crate::{peripheral::PeripheralRef, peripherals::LCD_CAM};
+use crate::{peripheral::PeripheralRef, peripherals::LCD_CAM, system::PeripheralGuard};
 
 pub mod dpi;
 pub mod i8080;
@@ -22,6 +22,8 @@ pub struct Lcd<'d, DM: crate::Mode> {
 
     /// A marker for the mode of operation (blocking or asynchronous).
     pub(crate) _mode: core::marker::PhantomData<DM>,
+
+    pub(super) _guard: PeripheralGuard,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -31,8 +31,6 @@ pub struct LcdCam<'d, DM: crate::Mode> {
     pub lcd: Lcd<'d, DM>,
     /// The Camera interface.
     pub cam: Cam<'d>,
-
-    _guard: PeripheralGuard,
 }
 
 impl<'d> LcdCam<'d, Blocking> {
@@ -40,15 +38,19 @@ impl<'d> LcdCam<'d, Blocking> {
     pub fn new(lcd_cam: impl Peripheral<P = LCD_CAM> + 'd) -> Self {
         crate::into_ref!(lcd_cam);
 
-        let guard = PeripheralGuard::new(system::Peripheral::LcdCam);
+        let lcd_guard = PeripheralGuard::new(system::Peripheral::LcdCam);
+        let cam_guard = PeripheralGuard::new(system::Peripheral::LcdCam);
 
         Self {
             lcd: Lcd {
                 lcd_cam: unsafe { lcd_cam.clone_unchecked() },
                 _mode: PhantomData,
+                _guard: lcd_guard,
             },
-            cam: Cam { lcd_cam },
-            _guard: guard,
+            cam: Cam {
+                lcd_cam,
+                _guard: cam_guard,
+            },
         }
     }
 
@@ -59,9 +61,9 @@ impl<'d> LcdCam<'d, Blocking> {
             lcd: Lcd {
                 lcd_cam: self.lcd.lcd_cam,
                 _mode: PhantomData,
+                _guard: self.lcd._guard,
             },
             cam: self.cam,
-            _guard: self._guard,
         }
     }
 }
@@ -90,9 +92,9 @@ impl<'d> LcdCam<'d, Async> {
             lcd: Lcd {
                 lcd_cam: self.lcd.lcd_cam,
                 _mode: PhantomData,
+                _guard: self.lcd._guard,
             },
             cam: self.cam,
-            _guard: self._guard,
         }
     }
 }

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     macros::handler,
     peripheral::Peripheral,
     peripherals::{Interrupt, LCD_CAM},
-    system::{self, PeripheralClockControl},
+    system::{self, PeripheralGuard},
     Async,
     Blocking,
     Cpu,
@@ -31,6 +31,8 @@ pub struct LcdCam<'d, DM: crate::Mode> {
     pub lcd: Lcd<'d, DM>,
     /// The Camera interface.
     pub cam: Cam<'d>,
+
+    _guard: PeripheralGuard,
 }
 
 impl<'d> LcdCam<'d, Blocking> {
@@ -38,8 +40,7 @@ impl<'d> LcdCam<'d, Blocking> {
     pub fn new(lcd_cam: impl Peripheral<P = LCD_CAM> + 'd) -> Self {
         crate::into_ref!(lcd_cam);
 
-        PeripheralClockControl::reset(system::Peripheral::LcdCam);
-        PeripheralClockControl::enable(system::Peripheral::LcdCam);
+        let guard = PeripheralGuard::new(system::Peripheral::LcdCam);
 
         Self {
             lcd: Lcd {
@@ -47,6 +48,7 @@ impl<'d> LcdCam<'d, Blocking> {
                 _mode: PhantomData,
             },
             cam: Cam { lcd_cam },
+            _guard: guard,
         }
     }
 
@@ -59,6 +61,7 @@ impl<'d> LcdCam<'d, Blocking> {
                 _mode: PhantomData,
             },
             cam: self.cam,
+            _guard: self._guard,
         }
     }
 }
@@ -89,6 +92,7 @@ impl<'d> LcdCam<'d, Async> {
                 _mode: PhantomData,
             },
             cam: self.cam,
+            _guard: self._guard,
         }
     }
 }

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     macros::handler,
     peripheral::Peripheral,
     peripherals::{Interrupt, LCD_CAM},
-    system::{self, PeripheralGuard},
+    system::GenericPeripheralGuard,
     Async,
     Blocking,
     Cpu,
@@ -38,8 +38,8 @@ impl<'d> LcdCam<'d, Blocking> {
     pub fn new(lcd_cam: impl Peripheral<P = LCD_CAM> + 'd) -> Self {
         crate::into_ref!(lcd_cam);
 
-        let lcd_guard = PeripheralGuard::new(system::Peripheral::LcdCam);
-        let cam_guard = PeripheralGuard::new(system::Peripheral::LcdCam);
+        let lcd_guard = GenericPeripheralGuard::new();
+        let cam_guard = GenericPeripheralGuard::new();
 
         Self {
             lcd: Lcd {

--- a/esp-hal/src/ledc/mod.rs
+++ b/esp-hal/src/ledc/mod.rs
@@ -111,7 +111,7 @@ impl<'d> Ledc<'d> {
     pub fn new(_instance: impl Peripheral<P = crate::peripherals::LEDC> + 'd) -> Self {
         crate::into_ref!(_instance);
 
-        if PeripheralClockControl::enable(PeripheralEnable::Ledc, true) {
+        if PeripheralClockControl::enable(PeripheralEnable::Ledc) {
             PeripheralClockControl::reset(PeripheralEnable::Ledc);
         }
 

--- a/esp-hal/src/ledc/mod.rs
+++ b/esp-hal/src/ledc/mod.rs
@@ -111,8 +111,9 @@ impl<'d> Ledc<'d> {
     pub fn new(_instance: impl Peripheral<P = crate::peripherals::LEDC> + 'd) -> Self {
         crate::into_ref!(_instance);
 
-        PeripheralClockControl::reset(PeripheralEnable::Ledc);
-        PeripheralClockControl::enable(PeripheralEnable::Ledc);
+        if PeripheralClockControl::enable(PeripheralEnable::Ledc, true) {
+            PeripheralClockControl::reset(PeripheralEnable::Ledc);
+        }
 
         let ledc = unsafe { &*crate::peripherals::LEDC::ptr() };
         Ledc { _instance, ledc }

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -515,6 +515,8 @@ pub struct Config {
 /// This function sets up the CPU clock and watchdog, then, returns the
 /// peripherals and clocks.
 pub fn init(config: Config) -> Peripherals {
+    system::disable_peripherals();
+
     let mut peripherals = Peripherals::take();
 
     // RTC domain must be enabled before we try to disable

--- a/esp-hal/src/mcpwm/timer.rs
+++ b/esp-hal/src/mcpwm/timer.rs
@@ -8,6 +8,7 @@ use core::marker::PhantomData;
 
 use fugit::HertzU32;
 
+use super::PeripheralGuard;
 use crate::mcpwm::{FrequencyError, PeripheralClockConfig, PwmPeripheral};
 
 /// A MCPWM timer
@@ -17,12 +18,15 @@ use crate::mcpwm::{FrequencyError, PeripheralClockConfig, PwmPeripheral};
 /// [`Operator`](super::operator::Operator) of that peripheral
 pub struct Timer<const TIM: u8, PWM> {
     pub(super) phantom: PhantomData<PWM>,
+    _guard: PeripheralGuard,
 }
 
 impl<const TIM: u8, PWM: PwmPeripheral> Timer<TIM, PWM> {
     pub(super) fn new() -> Self {
+        let guard = PeripheralGuard::new(PWM::peripheral());
         Timer {
             phantom: PhantomData,
+            _guard: guard,
         }
     }
 

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -70,8 +70,9 @@ impl<'d> Usb<'d> {
         P: UsbDp + Send + Sync,
         M: UsbDm + Send + Sync,
     {
-        PeripheralClockControl::reset(PeripheralEnable::Usb);
-        PeripheralClockControl::enable(PeripheralEnable::Usb);
+        if PeripheralClockControl::enable(PeripheralEnable::Usb, true) {
+            PeripheralClockControl::reset(PeripheralEnable::Usb);
+        }
 
         Self {
             _usb0: usb0.into_ref(),
@@ -107,6 +108,12 @@ impl<'d> Usb<'d> {
 
     fn _disable() {
         // TODO
+    }
+}
+
+impl Drop for Usb<'_> {
+    fn drop(&mut self) {
+        PeripheralClockControl::enable(PeripheralEnable::Usb, false);
     }
 }
 

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -43,7 +43,7 @@ use crate::{
     gpio::InputSignal,
     peripheral::{Peripheral, PeripheralRef},
     peripherals,
-    system::{Peripheral as PeripheralEnable, PeripheralClockControl},
+    system::{GenericPeripheralGuard, Peripheral as PeripheralEnable},
 };
 
 #[doc(hidden)]
@@ -57,6 +57,7 @@ pub trait UsbDm: crate::private::Sealed {}
 /// USB peripheral.
 pub struct Usb<'d> {
     _usb0: PeripheralRef<'d, peripherals::USB0>,
+    _guard: GenericPeripheralGuard<{ PeripheralEnable::Usb as u8 }>,
 }
 
 impl<'d> Usb<'d> {
@@ -70,12 +71,11 @@ impl<'d> Usb<'d> {
         P: UsbDp + Send + Sync,
         M: UsbDm + Send + Sync,
     {
-        if PeripheralClockControl::enable(PeripheralEnable::Usb, true) {
-            PeripheralClockControl::reset(PeripheralEnable::Usb);
-        }
+        let guard = GenericPeripheralGuard::new();
 
         Self {
             _usb0: usb0.into_ref(),
+            _guard: guard,
         }
     }
 
@@ -108,12 +108,6 @@ impl<'d> Usb<'d> {
 
     fn _disable() {
         // TODO
-    }
-}
-
-impl Drop for Usb<'_> {
-    fn drop(&mut self) {
-        PeripheralClockControl::enable(PeripheralEnable::Usb, false);
     }
 }
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -54,7 +54,7 @@ use crate::{
     interrupt::InterruptHandler,
     peripheral::{self, Peripheral},
     peripherals::{self, Interrupt, PARL_IO},
-    system::PeripheralGuard,
+    system::{self, GenericPeripheralGuard},
     Async,
     Blocking,
     InterruptConfigurable,
@@ -757,8 +757,6 @@ where
         P: FullDuplex + TxPins + ConfigurePins,
         CP: TxClkPin,
     {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
-
         tx_pins.configure()?;
         clk_pin.configure();
 
@@ -769,7 +767,7 @@ where
         Ok(ParlIoTx {
             tx_channel: self.tx_channel,
             tx_chain: DescriptorChain::new(self.descriptors),
-            _guard: guard,
+            _guard: self._guard,
         })
     }
 }
@@ -791,8 +789,6 @@ where
         P: TxPins + ConfigurePins,
         CP: TxClkPin,
     {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
-
         tx_pins.configure()?;
         clk_pin.configure();
 
@@ -803,7 +799,7 @@ where
         Ok(ParlIoTx {
             tx_channel: self.tx_channel,
             tx_chain: DescriptorChain::new(self.descriptors),
-            _guard: guard,
+            _guard: self._guard,
         })
     }
 }
@@ -815,7 +811,7 @@ where
 {
     tx_channel: ChannelTx<'d, DM, <PARL_IO as DmaEligible>::Dma>,
     tx_chain: DescriptorChain,
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ crate::system::Peripheral::ParlIo as u8 }>,
 }
 
 impl<DM> core::fmt::Debug for ParlIoTx<'_, DM>
@@ -843,7 +839,7 @@ where
         P: FullDuplex + RxPins + ConfigurePins,
         CP: RxClkPin,
     {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
+        let guard = GenericPeripheralGuard::new();
 
         rx_pins.configure()?;
         clk_pin.configure();
@@ -875,8 +871,6 @@ where
         P: RxPins + ConfigurePins,
         CP: RxClkPin,
     {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
-
         rx_pins.configure()?;
         clk_pin.configure();
 
@@ -886,7 +880,7 @@ where
         Ok(ParlIoRx {
             rx_channel: self.rx_channel,
             rx_chain: DescriptorChain::new(self.descriptors),
-            _guard: guard,
+            _guard: self._guard,
         })
     }
 }
@@ -898,7 +892,7 @@ where
 {
     rx_channel: ChannelRx<'d, DM, <PARL_IO as DmaEligible>::Dma>,
     rx_chain: DescriptorChain,
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ crate::system::Peripheral::ParlIo as u8 }>,
 }
 
 impl<DM> core::fmt::Debug for ParlIoRx<'_, DM>
@@ -1021,8 +1015,8 @@ impl<'d> ParlIoFullDuplex<'d, Blocking> {
         CH: DmaChannelConvert<<PARL_IO as DmaEligible>::Dma>,
         Channel<'d, Blocking, CH>: From<Channel<'d, DM, CH>>,
     {
-        let tx_guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
-        let rx_guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
+        let tx_guard = GenericPeripheralGuard::new();
+        let rx_guard = GenericPeripheralGuard::new();
         let dma_channel = Channel::<Blocking, CH>::from(dma_channel);
         internal_init(frequency)?;
 
@@ -1136,7 +1130,7 @@ where
     where
         CH: DmaChannelConvert<<PARL_IO as DmaEligible>::Dma>,
     {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
+        let guard = GenericPeripheralGuard::new();
         internal_init(frequency)?;
 
         Ok(Self {
@@ -1212,7 +1206,7 @@ where
     where
         CH: DmaChannelConvert<<PARL_IO as DmaEligible>::Dma>,
     {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
+        let guard = GenericPeripheralGuard::new();
         internal_init(frequency)?;
 
         Ok(Self {
@@ -1481,7 +1475,7 @@ where
 {
     tx_channel: ChannelTx<'d, DM, <PARL_IO as DmaEligible>::Dma>,
     descriptors: &'static mut [DmaDescriptor],
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ system::Peripheral::ParlIo as u8 }>,
 }
 
 /// Creates a RX channel
@@ -1491,7 +1485,7 @@ where
 {
     rx_channel: ChannelRx<'d, DM, <PARL_IO as DmaEligible>::Dma>,
     descriptors: &'static mut [DmaDescriptor],
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ system::Peripheral::ParlIo as u8 }>,
 }
 
 /// Creates a TX channel
@@ -1501,7 +1495,7 @@ where
 {
     tx_channel: ChannelTx<'d, DM, <PARL_IO as DmaEligible>::Dma>,
     descriptors: &'static mut [DmaDescriptor],
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ system::Peripheral::ParlIo as u8 }>,
 }
 
 /// Creates a RX channel
@@ -1511,7 +1505,7 @@ where
 {
     rx_channel: ChannelRx<'d, DM, <PARL_IO as DmaEligible>::Dma>,
     descriptors: &'static mut [DmaDescriptor],
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ system::Peripheral::ParlIo as u8 }>,
 }
 
 #[doc(hidden)]

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1005,8 +1005,6 @@ where
     /// The receiver (RX) channel responsible for handling DMA transfers in the
     /// parallel I/O full-duplex operation.
     pub rx: RxCreatorFullDuplex<'d, DM>,
-
-    _guard: PeripheralGuard,
 }
 
 impl<'d> ParlIoFullDuplex<'d, Blocking> {
@@ -1023,7 +1021,8 @@ impl<'d> ParlIoFullDuplex<'d, Blocking> {
         CH: DmaChannelConvert<<PARL_IO as DmaEligible>::Dma>,
         Channel<'d, Blocking, CH>: From<Channel<'d, DM, CH>>,
     {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
+        let tx_guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
+        let rx_guard = PeripheralGuard::new(crate::system::Peripheral::ParlIo);
         let dma_channel = Channel::<Blocking, CH>::from(dma_channel);
         internal_init(frequency)?;
 
@@ -1031,14 +1030,13 @@ impl<'d> ParlIoFullDuplex<'d, Blocking> {
             tx: TxCreatorFullDuplex {
                 tx_channel: dma_channel.tx.degrade(),
                 descriptors: tx_descriptors,
-                _guard: PeripheralGuard::new(crate::system::Peripheral::ParlIo),
+                _guard: tx_guard,
             },
             rx: RxCreatorFullDuplex {
                 rx_channel: dma_channel.rx.degrade(),
                 descriptors: rx_descriptors,
-                _guard: PeripheralGuard::new(crate::system::Peripheral::ParlIo),
+                _guard: rx_guard,
             },
-            _guard: guard,
         })
     }
 
@@ -1055,7 +1053,6 @@ impl<'d> ParlIoFullDuplex<'d, Blocking> {
                 descriptors: self.rx.descriptors,
                 _guard: self.rx._guard,
             },
-            _guard: self._guard,
         }
     }
 
@@ -1110,7 +1107,6 @@ impl<'d> ParlIoFullDuplex<'d, Async> {
                 descriptors: self.rx.descriptors,
                 _guard: self.rx._guard,
             },
-            _guard: self._guard,
         }
     }
 }
@@ -1123,7 +1119,6 @@ where
     /// The transmitter (TX) channel responsible for handling DMA transfers in
     /// the parallel I/O operation.
     pub tx: TxCreator<'d, DM>,
-    _guard: PeripheralGuard,
 }
 
 impl<'d, DM> ParlIoTxOnly<'d, DM>
@@ -1148,8 +1143,8 @@ where
             tx: TxCreator {
                 tx_channel: dma_channel.tx.degrade(),
                 descriptors,
+                _guard: guard,
             },
-            _guard: guard,
         })
     }
 }
@@ -1200,8 +1195,6 @@ where
     /// The receiver (RX) channel responsible for handling DMA transfers in the
     /// parallel I/O operation.
     pub rx: RxCreator<'d, DM>,
-
-    _guard: PeripheralGuard,
 }
 
 impl<'d, DM> ParlIoRxOnly<'d, DM>
@@ -1226,8 +1219,8 @@ where
             rx: RxCreator {
                 rx_channel: dma_channel.rx.degrade(),
                 descriptors,
+                _guard: guard,
             },
-            _guard: guard,
         })
     }
 }
@@ -1488,6 +1481,7 @@ where
 {
     tx_channel: ChannelTx<'d, DM, <PARL_IO as DmaEligible>::Dma>,
     descriptors: &'static mut [DmaDescriptor],
+    _guard: PeripheralGuard,
 }
 
 /// Creates a RX channel
@@ -1497,6 +1491,7 @@ where
 {
     rx_channel: ChannelRx<'d, DM, <PARL_IO as DmaEligible>::Dma>,
     descriptors: &'static mut [DmaDescriptor],
+    _guard: PeripheralGuard,
 }
 
 /// Creates a TX channel

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -13,7 +13,7 @@ pub use crate::peripherals::pcnt::unit::conf0::{CTRL_MODE as CtrlMode, EDGE_MODE
 use crate::{
     gpio::{interconnect::PeripheralInput, InputSignal},
     peripheral::Peripheral,
-    system::PeripheralGuard,
+    system::GenericPeripheralGuard,
 };
 
 /// Represents a channel within a pulse counter unit.
@@ -21,13 +21,13 @@ pub struct Channel<'d, const UNIT: usize, const NUM: usize> {
     _phantom: PhantomData<&'d ()>,
     // Individual channels are not Send, since they share registers.
     _not_send: PhantomData<*const ()>,
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Pcnt as u8 }>,
 }
 
 impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
     /// return a new Channel
     pub(super) fn new() -> Self {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::Pcnt);
+        let guard = GenericPeripheralGuard::new();
 
         Self {
             _phantom: PhantomData,

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -13,6 +13,7 @@ pub use crate::peripherals::pcnt::unit::conf0::{CTRL_MODE as CtrlMode, EDGE_MODE
 use crate::{
     gpio::{interconnect::PeripheralInput, InputSignal},
     peripheral::Peripheral,
+    system::PeripheralGuard,
 };
 
 /// Represents a channel within a pulse counter unit.
@@ -20,14 +21,18 @@ pub struct Channel<'d, const UNIT: usize, const NUM: usize> {
     _phantom: PhantomData<&'d ()>,
     // Individual channels are not Send, since they share registers.
     _not_send: PhantomData<*const ()>,
+    _guard: PeripheralGuard,
 }
 
 impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
     /// return a new Channel
     pub(super) fn new() -> Self {
+        let guard = PeripheralGuard::new(crate::system::Peripheral::Pcnt);
+
         Self {
             _phantom: PhantomData,
             _not_send: PhantomData,
+            _guard: guard,
         }
     }
 

--- a/esp-hal/src/pcnt/mod.rs
+++ b/esp-hal/src/pcnt/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     interrupt::{self, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{self, Interrupt},
-    system::PeripheralClockControl,
+    system::PeripheralGuard,
     InterruptConfigurable,
 };
 
@@ -56,6 +56,8 @@ pub struct Pcnt<'d> {
     #[cfg(esp32)]
     /// Unit 7
     pub unit7: Unit<'d, 7>,
+
+    _guard: PeripheralGuard,
 }
 
 impl<'d> Pcnt<'d> {
@@ -63,10 +65,7 @@ impl<'d> Pcnt<'d> {
     pub fn new(_instance: impl Peripheral<P = peripherals::PCNT> + 'd) -> Self {
         crate::into_ref!(_instance);
 
-        // Enable the PCNT peripherals clock in the system peripheral
-        PeripheralClockControl::reset(crate::system::Peripheral::Pcnt);
-        PeripheralClockControl::enable(crate::system::Peripheral::Pcnt);
-
+        let guard = PeripheralGuard::new(crate::system::Peripheral::Pcnt);
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
 
         // disable filter, all events, and channel settings
@@ -105,6 +104,7 @@ impl<'d> Pcnt<'d> {
             unit6: Unit::new(),
             #[cfg(esp32)]
             unit7: Unit::new(),
+            _guard: guard,
         }
     }
 }

--- a/esp-hal/src/pcnt/mod.rs
+++ b/esp-hal/src/pcnt/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     interrupt::{self, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{self, Interrupt},
-    system::PeripheralGuard,
+    system::GenericPeripheralGuard,
     InterruptConfigurable,
 };
 
@@ -57,7 +57,7 @@ pub struct Pcnt<'d> {
     /// Unit 7
     pub unit7: Unit<'d, 7>,
 
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Pcnt as u8 }>,
 }
 
 impl<'d> Pcnt<'d> {
@@ -65,7 +65,7 @@ impl<'d> Pcnt<'d> {
     pub fn new(_instance: impl Peripheral<P = peripherals::PCNT> + 'd) -> Self {
         crate::into_ref!(_instance);
 
-        let guard = PeripheralGuard::new(crate::system::Peripheral::Pcnt);
+        let guard = GenericPeripheralGuard::new();
         let pcnt = unsafe { &*crate::peripherals::PCNT::ptr() };
 
         // disable filter, all events, and channel settings

--- a/esp-hal/src/pcnt/unit.rs
+++ b/esp-hal/src/pcnt/unit.rs
@@ -13,7 +13,7 @@ use core::marker::PhantomData;
 
 use critical_section::CriticalSection;
 
-use crate::{pcnt::channel::Channel, system::PeripheralGuard};
+use crate::{pcnt::channel::Channel, system::GenericPeripheralGuard};
 
 /// Invalid filter threshold value
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -83,13 +83,13 @@ pub struct Unit<'d, const NUM: usize> {
     /// The second channel in PCNT unit.
     pub channel1: Channel<'d, NUM, 1>,
 
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Pcnt as u8 }>,
 }
 
 impl<const NUM: usize> Unit<'_, NUM> {
     /// return a new Unit
     pub(super) fn new() -> Self {
-        let guard = PeripheralGuard::new(crate::system::Peripheral::Pcnt);
+        let guard = GenericPeripheralGuard::new();
 
         Self {
             counter: Counter::new(),

--- a/esp-hal/src/pcnt/unit.rs
+++ b/esp-hal/src/pcnt/unit.rs
@@ -13,7 +13,7 @@ use core::marker::PhantomData;
 
 use critical_section::CriticalSection;
 
-use crate::pcnt::channel::Channel;
+use crate::{pcnt::channel::Channel, system::PeripheralGuard};
 
 /// Invalid filter threshold value
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -82,15 +82,20 @@ pub struct Unit<'d, const NUM: usize> {
     pub channel0: Channel<'d, NUM, 0>,
     /// The second channel in PCNT unit.
     pub channel1: Channel<'d, NUM, 1>,
+
+    _guard: PeripheralGuard,
 }
 
 impl<const NUM: usize> Unit<'_, NUM> {
     /// return a new Unit
     pub(super) fn new() -> Self {
+        let guard = PeripheralGuard::new(crate::system::Peripheral::Pcnt);
+
         Self {
             counter: Counter::new(),
             channel0: Channel::new(),
             channel1: Channel::new(),
+            _guard: guard,
         }
     }
 

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -94,7 +94,7 @@ use crate::{
     peripheral::Peripheral,
     peripherals::Interrupt,
     soc::constants,
-    system::PeripheralGuard,
+    system::{self, GenericPeripheralGuard},
     Async,
     Blocking,
     InterruptConfigurable,
@@ -602,7 +602,7 @@ mod impl_for_chip {
 
     use crate::{
         peripheral::{Peripheral, PeripheralRef},
-        system::PeripheralGuard,
+        system::GenericPeripheralGuard,
     };
 
     /// RMT Instance
@@ -635,19 +635,19 @@ mod impl_for_chip {
                 peripheral,
                 channel0: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel1: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel2: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel3: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 phantom: PhantomData,
             }
@@ -660,7 +660,7 @@ mod impl_for_chip {
         M: crate::Mode,
     {
         phantom: PhantomData<M>,
-        _guard: PeripheralGuard,
+        _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
     }
 
     impl_tx_channel_creator!(0);
@@ -682,7 +682,7 @@ mod impl_for_chip {
 
     use crate::{
         peripheral::{Peripheral, PeripheralRef},
-        system::PeripheralGuard,
+        system::GenericPeripheralGuard,
     };
 
     /// RMT Instance
@@ -722,35 +722,35 @@ mod impl_for_chip {
                 peripheral,
                 channel0: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel1: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel2: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel3: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel4: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel5: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel6: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel7: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 phantom: PhantomData,
             }
@@ -763,7 +763,7 @@ mod impl_for_chip {
         M: crate::Mode,
     {
         phantom: PhantomData<M>,
-        _guard: PeripheralGuard,
+        _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
     }
 
     impl_tx_channel_creator!(0);
@@ -809,7 +809,7 @@ mod impl_for_chip {
 
     use crate::{
         peripheral::{Peripheral, PeripheralRef},
-        system::PeripheralGuard,
+        system::GenericPeripheralGuard,
     };
 
     /// RMT Instance
@@ -842,19 +842,19 @@ mod impl_for_chip {
                 peripheral,
                 channel0: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel1: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel2: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel3: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 phantom: PhantomData,
             }
@@ -867,7 +867,7 @@ mod impl_for_chip {
         M: crate::Mode,
     {
         phantom: PhantomData<M>,
-        _guard: PeripheralGuard,
+        _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
     }
 
     impl_tx_channel_creator!(0);
@@ -897,7 +897,7 @@ mod impl_for_chip {
 
     use crate::{
         peripheral::{Peripheral, PeripheralRef},
-        system::PeripheralGuard,
+        system::GenericPeripheralGuard,
     };
 
     /// RMT Instance
@@ -938,35 +938,35 @@ mod impl_for_chip {
                 peripheral,
                 channel0: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel1: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel2: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel3: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel4: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel5: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel6: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 channel7: ChannelCreator {
                     phantom: PhantomData,
-                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
+                    _guard: GenericPeripheralGuard::new(),
                 },
                 phantom: PhantomData,
             }
@@ -979,7 +979,7 @@ mod impl_for_chip {
         M: crate::Mode,
     {
         phantom: PhantomData<M>,
-        _guard: PeripheralGuard,
+        _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
     }
 
     impl_tx_channel_creator!(0);
@@ -1011,7 +1011,7 @@ where
     M: crate::Mode,
 {
     phantom: PhantomData<M>,
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ system::Peripheral::Rmt as u8 }>,
 }
 
 /// Channel in TX mode
@@ -1631,7 +1631,7 @@ mod chip_specific {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
-                        let guard = PeripheralGuard::new(crate::system::Peripheral::Rmt);
+                        let guard = GenericPeripheralGuard::new();
                         Self {
                             phantom: core::marker::PhantomData,
                             _guard: guard,
@@ -1794,7 +1794,7 @@ mod chip_specific {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
-                        let guard = PeripheralGuard::new(crate::system::Peripheral::Rmt);
+                        let guard = GenericPeripheralGuard::new();
                         Self {
                             phantom: core::marker::PhantomData,
                             _guard: guard,
@@ -1985,7 +1985,7 @@ mod chip_specific {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
-                        let guard = PeripheralGuard::new(crate::system::Peripheral::Rmt);
+                        let guard = GenericPeripheralGuard::new();
                         Self {
                             phantom: core::marker::PhantomData,
                             _guard: guard,
@@ -2138,7 +2138,7 @@ mod chip_specific {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
-                        let guard = PeripheralGuard::new(crate::system::Peripheral::Rmt);
+                        let guard = GenericPeripheralGuard::new();
                         Self {
                             phantom: core::marker::PhantomData,
                             _guard: guard,

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -620,7 +620,6 @@ mod impl_for_chip {
         /// RMT Channel 3.
         pub channel3: ChannelCreator<M, 3>,
         phantom: PhantomData<M>,
-        _guard: PeripheralGuard,
     }
 
     impl<'d, M> Rmt<'d, M>
@@ -631,8 +630,6 @@ mod impl_for_chip {
             peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
         ) -> Self {
             crate::into_ref!(peripheral);
-
-            let guard = PeripheralGuard::new(crate::system::Peripheral::Rmt);
 
             Self {
                 peripheral,
@@ -653,7 +650,6 @@ mod impl_for_chip {
                     _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 phantom: PhantomData,
-                _guard: guard,
             }
         }
     }
@@ -712,7 +708,6 @@ mod impl_for_chip {
         /// RMT Channel 7.
         pub channel7: ChannelCreator<M, 7>,
         phantom: PhantomData<M>,
-        _guard: PeripheralGuard,
     }
 
     impl<'d, M> Rmt<'d, M>
@@ -723,8 +718,6 @@ mod impl_for_chip {
             peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
         ) -> Self {
             crate::into_ref!(peripheral);
-            let guard = PeripheralGuard::new(crate::system::Peripheral::Rmt);
-
             Self {
                 peripheral,
                 channel0: ChannelCreator {
@@ -760,7 +753,6 @@ mod impl_for_chip {
                     _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 phantom: PhantomData,
-                _guard: guard,
             }
         }
     }
@@ -835,7 +827,6 @@ mod impl_for_chip {
         /// RMT Channel 3.
         pub channel3: ChannelCreator<M, 3>,
         phantom: PhantomData<M>,
-        _guard: PeripheralGuard,
     }
 
     impl<'d, M> Rmt<'d, M>
@@ -866,7 +857,6 @@ mod impl_for_chip {
                     _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 phantom: PhantomData,
-                _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
             }
         }
     }
@@ -933,7 +923,6 @@ mod impl_for_chip {
         /// RMT Channel 7.
         pub channel7: ChannelCreator<M, 7>,
         phantom: PhantomData<M>,
-        _guard: PeripheralGuard,
     }
 
     impl<'d, M> Rmt<'d, M>
@@ -980,7 +969,6 @@ mod impl_for_chip {
                     _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 phantom: PhantomData,
-                _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
             }
         }
     }

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1016,6 +1016,7 @@ mod impl_for_chip {
 }
 
 /// RMT Channel
+#[derive(Debug)]
 #[non_exhaustive]
 pub struct Channel<M, const CHANNEL: u8>
 where
@@ -1023,12 +1024,6 @@ where
 {
     phantom: PhantomData<M>,
     _guard: PeripheralGuard,
-}
-
-impl<M: crate::Mode, const CHANNEL: u8> core::fmt::Debug for Channel<M, CHANNEL> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Rmt Channel {}", CHANNEL)
-    }
 }
 
 /// Channel in TX mode

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -712,6 +712,7 @@ mod impl_for_chip {
         /// RMT Channel 7.
         pub channel7: ChannelCreator<M, 7>,
         phantom: PhantomData<M>,
+        _guard: PeripheralGuard,
     }
 
     impl<'d, M> Rmt<'d, M>
@@ -770,6 +771,7 @@ mod impl_for_chip {
         M: crate::Mode,
     {
         phantom: PhantomData<M>,
+        _guard: PeripheralGuard,
     }
 
     impl_tx_channel_creator!(0);
@@ -833,6 +835,7 @@ mod impl_for_chip {
         /// RMT Channel 3.
         pub channel3: ChannelCreator<M, 3>,
         phantom: PhantomData<M>,
+        _guard: PeripheralGuard,
     }
 
     impl<'d, M> Rmt<'d, M>
@@ -848,17 +851,22 @@ mod impl_for_chip {
                 peripheral,
                 channel0: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel1: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel2: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel3: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 phantom: PhantomData,
+                _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
             }
         }
     }
@@ -869,6 +877,7 @@ mod impl_for_chip {
         M: crate::Mode,
     {
         phantom: PhantomData<M>,
+        _guard: PeripheralGuard,
     }
 
     impl_tx_channel_creator!(0);
@@ -924,6 +933,7 @@ mod impl_for_chip {
         /// RMT Channel 7.
         pub channel7: ChannelCreator<M, 7>,
         phantom: PhantomData<M>,
+        _guard: PeripheralGuard,
     }
 
     impl<'d, M> Rmt<'d, M>
@@ -939,29 +949,38 @@ mod impl_for_chip {
                 peripheral,
                 channel0: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel1: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel2: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel3: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel4: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel5: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel6: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 channel7: ChannelCreator {
                     phantom: PhantomData,
+                    _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
                 },
                 phantom: PhantomData,
+                _guard: PeripheralGuard::new(crate::system::Peripheral::Rmt),
             }
         }
     }
@@ -972,6 +991,7 @@ mod impl_for_chip {
         M: crate::Mode,
     {
         phantom: PhantomData<M>,
+        _guard: PeripheralGuard,
     }
 
     impl_tx_channel_creator!(0);
@@ -1982,8 +2002,10 @@ mod chip_specific {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
+                        let guard = PeripheralGuard::new(crate::system::Peripheral::Rmt);
                         Self {
                             phantom: core::marker::PhantomData,
+                            _guard: guard,
                         }
                     }
 
@@ -2133,8 +2155,10 @@ mod chip_specific {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
+                        let guard = PeripheralGuard::new(crate::system::Peripheral::Rmt);
                         Self {
                             phantom: core::marker::PhantomData,
+                            _guard: guard,
                         }
                     }
 

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     interrupt::InterruptHandler,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{Interrupt, RSA},
-    system::{Peripheral as PeripheralEnable, PeripheralGuard},
+    system::{GenericPeripheralGuard, Peripheral as PeripheralEnable},
     Async,
     Blocking,
     Cpu,
@@ -48,7 +48,7 @@ pub use rsa_spec_impl::operand_sizes;
 pub struct Rsa<'d, DM: crate::Mode> {
     rsa: PeripheralRef<'d, RSA>,
     phantom: PhantomData<DM>,
-    _guard: PeripheralGuard,
+    _guard: GenericPeripheralGuard<{ PeripheralEnable::Rsa as u8 }>,
 }
 
 impl<'d> Rsa<'d, Blocking> {
@@ -98,7 +98,7 @@ impl<'d, DM: crate::Mode> Rsa<'d, DM> {
     fn new_internal(rsa: impl Peripheral<P = RSA> + 'd) -> Self {
         crate::into_ref!(rsa);
 
-        let guard = PeripheralGuard::new(PeripheralEnable::Rsa);
+        let guard = GenericPeripheralGuard::new();
 
         Self {
             rsa,

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     interrupt::InterruptHandler,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{Interrupt, RSA},
-    system::{Peripheral as PeripheralEnable, PeripheralClockControl},
+    system::{Peripheral as PeripheralEnable, PeripheralGuard},
     Async,
     Blocking,
     Cpu,
@@ -48,6 +48,7 @@ pub use rsa_spec_impl::operand_sizes;
 pub struct Rsa<'d, DM: crate::Mode> {
     rsa: PeripheralRef<'d, RSA>,
     phantom: PhantomData<DM>,
+    _guard: PeripheralGuard,
 }
 
 impl<'d> Rsa<'d, Blocking> {
@@ -64,6 +65,7 @@ impl<'d> Rsa<'d, Blocking> {
         Rsa {
             rsa: self.rsa,
             phantom: PhantomData,
+            _guard: self._guard,
         }
     }
 }
@@ -87,6 +89,7 @@ impl<'d> Rsa<'d, Async> {
         Rsa {
             rsa: self.rsa,
             phantom: PhantomData,
+            _guard: self._guard,
         }
     }
 }
@@ -95,12 +98,12 @@ impl<'d, DM: crate::Mode> Rsa<'d, DM> {
     fn new_internal(rsa: impl Peripheral<P = RSA> + 'd) -> Self {
         crate::into_ref!(rsa);
 
-        PeripheralClockControl::reset(PeripheralEnable::Rsa);
-        PeripheralClockControl::enable(PeripheralEnable::Rsa);
+        let guard = PeripheralGuard::new(PeripheralEnable::Rsa);
 
         Self {
             rsa,
             phantom: PhantomData,
+            _guard: guard,
         }
     }
 

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -81,8 +81,9 @@ impl<'d> Sha<'d> {
     pub fn new(sha: impl Peripheral<P = SHA> + 'd) -> Self {
         crate::into_ref!(sha);
 
-        PeripheralClockControl::reset(crate::system::Peripheral::Sha);
-        PeripheralClockControl::enable(crate::system::Peripheral::Sha);
+        if PeripheralClockControl::enable(crate::system::Peripheral::Sha, true) {
+            PeripheralClockControl::reset(crate::system::Peripheral::Sha);
+        }
 
         Self { sha }
     }
@@ -101,6 +102,12 @@ impl<'d> Sha<'d> {
 }
 
 impl crate::private::Sealed for Sha<'_> {}
+
+impl Drop for Sha<'_> {
+    fn drop(&mut self) {
+        PeripheralClockControl::enable(crate::system::Peripheral::Sha, false);
+    }
+}
 
 #[cfg(not(esp32))]
 impl crate::InterruptConfigurable for Sha<'_> {

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -176,7 +176,6 @@ pub(crate) struct PeripheralClockControl;
 
 #[cfg(not(any(esp32c6, esp32h2)))]
 impl PeripheralClockControl {
-
     fn enable_internal(peripheral: Peripheral, enable: bool) {
         debug!("Enable {:?} {}", peripheral, enable);
 

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -5,7 +5,21 @@
 //! This `system` module defines the available radio peripherals and provides an
 //! interface to control and configure radio clocks.
 
+use core::sync::atomic::Ordering;
+
+use portable_atomic::AtomicUsize;
+use strum::{EnumCount, EnumIter, IntoEnumIterator};
+
 use crate::peripherals::SYSTEM;
+
+pub(crate) const KEEP_ENABLED: &[Peripheral] = &[
+    Peripheral::Uart0,
+    #[cfg(usb_device)]
+    Peripheral::UsbDevice,
+    #[cfg(systimer)]
+    Peripheral::Systimer,
+    Peripheral::Timg0,
+];
 
 /// Peripherals which can be enabled via `PeripheralClockControl`.
 ///
@@ -15,7 +29,8 @@ use crate::peripherals::SYSTEM;
 // FIXME: This enum needs to be public because it's exposed via a bunch of traits, but it's not
 // useful to users.
 #[doc(hidden)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, EnumCount, EnumIter)]
+#[repr(u8)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Peripheral {
     /// SPI2 peripheral.
@@ -78,9 +93,6 @@ pub enum Peripheral {
     /// Timer Group 1 peripheral.
     #[cfg(timg1)]
     Timg1,
-    /// Low-power watchdog timer (WDT) peripheral.
-    #[cfg(lp_wdt)]
-    Wdt,
     /// SHA peripheral (Secure Hash Algorithm).
     #[cfg(sha)]
     Sha,
@@ -122,234 +134,247 @@ pub enum Peripheral {
     Systimer,
 }
 
+static PERIPHERAL_REF_COUNT: [AtomicUsize; Peripheral::COUNT] =
+    [const { AtomicUsize::new(0) }; Peripheral::COUNT];
+
+/// Disable all peripherals.
+///
+/// Peripherals listed in [KEEP_ENABLED] are NOT disabled.
+pub(crate) fn disable_peripherals() {
+    for p in Peripheral::iter() {
+        if KEEP_ENABLED.contains(&p) {
+            continue;
+        }
+        PeripheralClockControl::enable_forced(p, false, true);
+    }
+}
+
+pub(crate) struct PeripheralGuard {
+    peripheral: Peripheral,
+}
+
+impl PeripheralGuard {
+    pub(crate) fn new(p: Peripheral) -> Self {
+        if !KEEP_ENABLED.contains(&p) {
+            if PeripheralClockControl::enable(p, true) {
+                PeripheralClockControl::reset(p);
+            }
+        }
+
+        Self { peripheral: p }
+    }
+}
+
+impl Drop for PeripheralGuard {
+    fn drop(&mut self) {
+        if !KEEP_ENABLED.contains(&self.peripheral) {
+            PeripheralClockControl::enable(self.peripheral, false);
+        }
+    }
+}
+
 /// Controls the enablement of peripheral clocks.
 pub(crate) struct PeripheralClockControl;
 
 #[cfg(not(any(esp32c6, esp32h2)))]
 impl PeripheralClockControl {
-    /// Enables and resets the given peripheral
-    pub(crate) fn enable(peripheral: Peripheral) {
-        let system = unsafe { &*SYSTEM::PTR };
+    pub(crate) fn enable_forced(peripheral: Peripheral, enable: bool, force: bool) -> bool {
+        debug!("Enable {:?} {} {}", peripheral, enable, force);
+        critical_section::with(|_cs| {
+            if !force {
+                if enable {
+                    let prev =
+                        PERIPHERAL_REF_COUNT[peripheral as usize].fetch_add(1, Ordering::Relaxed);
+                    if prev > 0 {
+                        return false;
+                    }
+                } else {
+                    let prev =
+                        PERIPHERAL_REF_COUNT[peripheral as usize].fetch_sub(1, Ordering::Relaxed);
+                    if prev > 1 {
+                        return false;
+                    }
+                };
+            }
 
-        #[cfg(esp32)]
-        let (perip_clk_en0, perip_rst_en0, peri_clk_en, peri_rst_en) = {
-            (
-                &system.perip_clk_en(),
-                &system.perip_rst_en(),
-                &system.peri_clk_en(),
-                &system.peri_rst_en(),
-            )
-        };
-        #[cfg(not(esp32))]
-        let (perip_clk_en0, perip_rst_en0) = { (&system.perip_clk_en0(), &system.perip_rst_en0()) };
+            if !enable {
+                Self::reset(peripheral);
+            }
+            
+            let system = unsafe { &*SYSTEM::PTR };
 
-        #[cfg(any(esp32c2, esp32c3, esp32s2, esp32s3))]
-        let (perip_clk_en1, perip_rst_en1) = { (&system.perip_clk_en1(), &system.perip_rst_en1()) };
-
-        critical_section::with(|_cs| match peripheral {
-            #[cfg(spi2)]
-            Peripheral::Spi2 => {
-                perip_clk_en0.modify(|_, w| w.spi2_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.spi2_rst().clear_bit());
-            }
-            #[cfg(spi3)]
-            Peripheral::Spi3 => {
-                perip_clk_en0.modify(|_, w| w.spi3_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.spi3_rst().clear_bit());
-            }
-            #[cfg(all(i2c0, esp32))]
-            Peripheral::I2cExt0 => {
-                perip_clk_en0.modify(|_, w| w.i2c0_ext0_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.i2c0_ext0_rst().clear_bit());
-            }
-            #[cfg(all(i2c0, not(esp32)))]
-            Peripheral::I2cExt0 => {
-                perip_clk_en0.modify(|_, w| w.i2c_ext0_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.i2c_ext0_rst().clear_bit());
-            }
-            #[cfg(i2c1)]
-            Peripheral::I2cExt1 => {
-                perip_clk_en0.modify(|_, w| w.i2c_ext1_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.i2c_ext1_rst().clear_bit());
-            }
-            #[cfg(rmt)]
-            Peripheral::Rmt => {
-                perip_clk_en0.modify(|_, w| w.rmt_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.rmt_rst().clear_bit());
-            }
-            #[cfg(ledc)]
-            Peripheral::Ledc => {
-                perip_clk_en0.modify(|_, w| w.ledc_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.ledc_rst().clear_bit());
-            }
-            #[cfg(mcpwm0)]
-            Peripheral::Mcpwm0 => {
-                perip_clk_en0.modify(|_, w| w.pwm0_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.pwm0_rst().clear_bit());
-            }
-            #[cfg(mcpwm1)]
-            Peripheral::Mcpwm1 => {
-                perip_clk_en0.modify(|_, w| w.pwm1_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.pwm1_rst().clear_bit());
-            }
-            #[cfg(pcnt)]
-            Peripheral::Pcnt => {
-                perip_clk_en0.modify(|_, w| w.pcnt_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.pcnt_rst().clear_bit());
-            }
-            #[cfg(apb_saradc)]
-            Peripheral::ApbSarAdc => {
-                perip_clk_en0.modify(|_, w| w.apb_saradc_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.apb_saradc_rst().clear_bit());
-            }
-            #[cfg(gdma)]
-            Peripheral::Gdma => {
-                perip_clk_en1.modify(|_, w| w.dma_clk_en().set_bit());
-                perip_rst_en1.modify(|_, w| w.dma_rst().clear_bit());
-            }
             #[cfg(esp32)]
-            Peripheral::Dma => {
-                perip_clk_en0.modify(|_, w| w.spi_dma_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.spi_dma_rst().clear_bit());
-            }
-            #[cfg(esp32s2)]
-            Peripheral::Dma => {
-                perip_clk_en0.modify(|_, w| w.spi2_dma_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.spi2_dma_rst().clear_bit());
-                perip_clk_en0.modify(|_, w| w.spi3_dma_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.spi3_dma_rst().clear_bit());
-            }
-            #[cfg(esp32c3)]
-            Peripheral::I2s0 => {
-                // on ESP32-C3 note that i2s1_clk_en / rst is really I2s0
-                perip_clk_en0.modify(|_, w| w.i2s1_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.i2s1_rst().clear_bit());
-            }
-            #[cfg(any(esp32s3, esp32, esp32s2))]
-            Peripheral::I2s0 => {
-                perip_clk_en0.modify(|_, w| w.i2s0_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.i2s0_rst().clear_bit());
-            }
-            #[cfg(any(esp32s3, esp32))]
-            Peripheral::I2s1 => {
-                perip_clk_en0.modify(|_, w| w.i2s1_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.i2s1_rst().clear_bit());
-            }
-            #[cfg(usb0)]
-            Peripheral::Usb => {
-                perip_clk_en0.modify(|_, w| w.usb_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.usb_rst().clear_bit());
-            }
-            #[cfg(twai0)]
-            Peripheral::Twai0 => {
-                perip_clk_en0.modify(|_, w| w.twai_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.twai_rst().clear_bit());
-            }
-            #[cfg(esp32)]
-            Peripheral::Aes => {
-                peri_clk_en.modify(|r, w| unsafe { w.bits(r.bits() | 1) });
-                peri_rst_en.modify(|r, w| unsafe { w.bits(r.bits() & (!1)) });
-            }
-            #[cfg(any(esp32c3, esp32s2, esp32s3))]
-            Peripheral::Aes => {
-                perip_clk_en1.modify(|_, w| w.crypto_aes_clk_en().set_bit());
-                perip_rst_en1.modify(|_, w| w.crypto_aes_rst().clear_bit());
-            }
-            #[cfg(timg0)]
-            Peripheral::Timg0 => {
-                #[cfg(any(esp32c3, esp32s2, esp32s3))]
-                perip_clk_en0.modify(|_, w| w.timers_clk_en().set_bit());
-                perip_clk_en0.modify(|_, w| w.timergroup_clk_en().set_bit());
+            let (perip_clk_en0, peri_clk_en) = { (&system.perip_clk_en(), &system.peri_clk_en()) };
+            #[cfg(not(esp32))]
+            let perip_clk_en0 = &system.perip_clk_en0();
 
-                #[cfg(any(esp32c3, esp32s2, esp32s3))]
-                perip_rst_en0.modify(|_, w| w.timers_rst().clear_bit());
-                perip_rst_en0.modify(|_, w| w.timergroup_rst().clear_bit());
-            }
-            #[cfg(timg1)]
-            Peripheral::Timg1 => {
-                #[cfg(any(esp32c3, esp32s2, esp32s3))]
-                perip_clk_en0.modify(|_, w| w.timers_clk_en().set_bit());
-                perip_clk_en0.modify(|_, w| w.timergroup1_clk_en().set_bit());
+            #[cfg(any(esp32c2, esp32c3, esp32s2, esp32s3))]
+            let perip_clk_en1 = &system.perip_clk_en1();
 
+            match peripheral {
+                #[cfg(spi2)]
+                Peripheral::Spi2 => {
+                    perip_clk_en0.modify(|_, w| w.spi2_clk_en().bit(enable));
+                }
+                #[cfg(spi3)]
+                Peripheral::Spi3 => {
+                    perip_clk_en0.modify(|_, w| w.spi3_clk_en().bit(enable));
+                }
+                #[cfg(all(i2c0, esp32))]
+                Peripheral::I2cExt0 => {
+                    perip_clk_en0.modify(|_, w| w.i2c0_ext0_clk_en().bit(enable));
+                }
+                #[cfg(all(i2c0, not(esp32)))]
+                Peripheral::I2cExt0 => {
+                    perip_clk_en0.modify(|_, w| w.i2c_ext0_clk_en().bit(enable));
+                }
+                #[cfg(i2c1)]
+                Peripheral::I2cExt1 => {
+                    perip_clk_en0.modify(|_, w| w.i2c_ext1_clk_en().bit(enable));
+                }
+                #[cfg(rmt)]
+                Peripheral::Rmt => {
+                    perip_clk_en0.modify(|_, w| w.rmt_clk_en().bit(enable));
+                }
+                #[cfg(ledc)]
+                Peripheral::Ledc => {
+                    perip_clk_en0.modify(|_, w| w.ledc_clk_en().bit(enable));
+                }
+                #[cfg(mcpwm0)]
+                Peripheral::Mcpwm0 => {
+                    perip_clk_en0.modify(|_, w| w.pwm0_clk_en().bit(enable));
+                }
+                #[cfg(mcpwm1)]
+                Peripheral::Mcpwm1 => {
+                    perip_clk_en0.modify(|_, w| w.pwm1_clk_en().bit(enable));
+                }
+                #[cfg(pcnt)]
+                Peripheral::Pcnt => {
+                    perip_clk_en0.modify(|_, w| w.pcnt_clk_en().bit(enable));
+                }
+                #[cfg(apb_saradc)]
+                Peripheral::ApbSarAdc => {
+                    perip_clk_en0.modify(|_, w| w.apb_saradc_clk_en().bit(enable));
+                }
+                #[cfg(gdma)]
+                Peripheral::Gdma => {
+                    perip_clk_en1.modify(|_, w| w.dma_clk_en().bit(enable));
+                }
+                #[cfg(esp32)]
+                Peripheral::Dma => {
+                    perip_clk_en0.modify(|_, w| w.spi_dma_clk_en().bit(enable));
+                }
+                #[cfg(esp32s2)]
+                Peripheral::Dma => {
+                    perip_clk_en0.modify(|_, w| w.spi2_dma_clk_en().bit(enable));
+                    perip_clk_en0.modify(|_, w| w.spi3_dma_clk_en().bit(enable));
+                }
+                #[cfg(esp32c3)]
+                Peripheral::I2s0 => {
+                    // on ESP32-C3 note that i2s1_clk_en / rst is really I2s0
+                    perip_clk_en0.modify(|_, w| w.i2s1_clk_en().bit(enable));
+                }
+                #[cfg(any(esp32s3, esp32, esp32s2))]
+                Peripheral::I2s0 => {
+                    perip_clk_en0.modify(|_, w| w.i2s0_clk_en().bit(enable));
+                }
+                #[cfg(any(esp32s3, esp32))]
+                Peripheral::I2s1 => {
+                    perip_clk_en0.modify(|_, w| w.i2s1_clk_en().bit(enable));
+                }
+                #[cfg(usb0)]
+                Peripheral::Usb => {
+                    perip_clk_en0.modify(|_, w| w.usb_clk_en().bit(enable));
+                }
+                #[cfg(twai0)]
+                Peripheral::Twai0 => {
+                    perip_clk_en0.modify(|_, w| w.twai_clk_en().bit(enable));
+                }
+                #[cfg(esp32)]
+                Peripheral::Aes => {
+                    peri_clk_en.modify(|r, w| unsafe { w.bits(r.bits() | enable as u32) });
+                }
                 #[cfg(any(esp32c3, esp32s2, esp32s3))]
-                perip_rst_en0.modify(|_, w| w.timers_rst().clear_bit());
-                perip_rst_en0.modify(|_, w| w.timergroup1_rst().clear_bit());
+                Peripheral::Aes => {
+                    perip_clk_en1.modify(|_, w| w.crypto_aes_clk_en().bit(enable));
+                }
+                #[cfg(timg0)]
+                Peripheral::Timg0 => {
+                    #[cfg(any(esp32c3, esp32s2, esp32s3))]
+                    perip_clk_en0.modify(|_, w| w.timers_clk_en().bit(enable));
+                    perip_clk_en0.modify(|_, w| w.timergroup_clk_en().bit(enable));
+                }
+                #[cfg(timg1)]
+                Peripheral::Timg1 => {
+                    #[cfg(any(esp32c3, esp32s2, esp32s3))]
+                    perip_clk_en0.modify(|_, w| w.timers_clk_en().bit(enable));
+                    perip_clk_en0.modify(|_, w| w.timergroup1_clk_en().bit(enable));
+                }
+                #[cfg(sha)]
+                Peripheral::Sha => {
+                    #[cfg(not(esp32))]
+                    perip_clk_en1.modify(|_, w| w.crypto_sha_clk_en().bit(enable));
+                }
+                #[cfg(esp32c3)]
+                Peripheral::UsbDevice => {
+                    perip_clk_en0.modify(|_, w| w.usb_device_clk_en().bit(enable));
+                }
+                #[cfg(esp32s3)]
+                Peripheral::UsbDevice => {
+                    perip_clk_en1.modify(|_, w| w.usb_device_clk_en().bit(enable));
+                }
+                #[cfg(uart0)]
+                Peripheral::Uart0 => {
+                    perip_clk_en0.modify(|_, w| w.uart_clk_en().bit(enable));
+                }
+                #[cfg(uart1)]
+                Peripheral::Uart1 => {
+                    perip_clk_en0.modify(|_, w| w.uart1_clk_en().bit(enable));
+                }
+                #[cfg(all(uart2, esp32s3))]
+                Peripheral::Uart2 => {
+                    perip_clk_en1.modify(|_, w| w.uart2_clk_en().set_bit());
+                }
+                #[cfg(all(uart2, esp32))]
+                Peripheral::Uart2 => {
+                    perip_clk_en0.modify(|_, w| w.uart2_clk_en().bit(enable));
+                }
+                #[cfg(all(rsa, esp32))]
+                Peripheral::Rsa => {
+                    peri_clk_en.modify(|r, w| unsafe { w.bits(r.bits() | (enable as u32) << 2) });
+                }
+                #[cfg(all(rsa, any(esp32c3, esp32s2, esp32s3)))]
+                Peripheral::Rsa => {
+                    perip_clk_en1.modify(|_, w| w.crypto_rsa_clk_en().bit(enable));
+                    system
+                        .rsa_pd_ctrl()
+                        .modify(|_, w| w.rsa_mem_pd().bit(!enable));
+                }
+                #[cfg(hmac)]
+                Peripheral::Hmac => {
+                    perip_clk_en1.modify(|_, w| w.crypto_hmac_clk_en().bit(enable));
+                }
+                #[cfg(ecc)]
+                Peripheral::Ecc => {
+                    perip_clk_en1.modify(|_, w| w.crypto_ecc_clk_en().bit(enable));
+                }
+                #[cfg(lcd_cam)]
+                Peripheral::LcdCam => {
+                    perip_clk_en1.modify(|_, w| w.lcd_cam_clk_en().bit(enable));
+                }
+                #[cfg(systimer)]
+                Peripheral::Systimer => {
+                    perip_clk_en0.modify(|_, w| w.systimer_clk_en().bit(enable));
+                }
             }
-            #[cfg(sha)]
-            Peripheral::Sha => {
-                #[cfg(not(esp32))]
-                perip_clk_en1.modify(|_, w| w.crypto_sha_clk_en().set_bit());
-                #[cfg(not(esp32))]
-                perip_rst_en1.modify(|_, w| w.crypto_sha_rst().clear_bit());
-            }
-            #[cfg(esp32c3)]
-            Peripheral::UsbDevice => {
-                perip_clk_en0.modify(|_, w| w.usb_device_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.usb_device_rst().clear_bit());
-            }
-            #[cfg(esp32s3)]
-            Peripheral::UsbDevice => {
-                perip_clk_en1.modify(|_, w| w.usb_device_clk_en().set_bit());
-                perip_rst_en1.modify(|_, w| w.usb_device_rst().clear_bit());
-            }
-            #[cfg(uart0)]
-            Peripheral::Uart0 => {
-                perip_clk_en0.modify(|_, w| w.uart_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.uart_rst().clear_bit());
-            }
-            #[cfg(uart1)]
-            Peripheral::Uart1 => {
-                perip_clk_en0.modify(|_, w| w.uart1_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.uart1_rst().clear_bit());
-            }
-            #[cfg(all(uart2, esp32s3))]
-            Peripheral::Uart2 => {
-                perip_clk_en1.modify(|_, w| w.uart2_clk_en().set_bit());
-                perip_rst_en1.modify(|_, w| w.uart2_rst().clear_bit());
-            }
-            #[cfg(all(uart2, esp32))]
-            Peripheral::Uart2 => {
-                perip_clk_en0.modify(|_, w| w.uart2_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.uart2_rst().clear_bit());
-            }
-            #[cfg(all(rsa, esp32))]
-            Peripheral::Rsa => {
-                peri_clk_en.modify(|r, w| unsafe { w.bits(r.bits() | 1 << 2) });
-                peri_rst_en.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << 2)) });
-            }
-            #[cfg(all(rsa, any(esp32c3, esp32s2, esp32s3)))]
-            Peripheral::Rsa => {
-                perip_clk_en1.modify(|_, w| w.crypto_rsa_clk_en().set_bit());
-                perip_rst_en1.modify(|_, w| w.crypto_rsa_rst().clear_bit());
-                system
-                    .rsa_pd_ctrl()
-                    .modify(|_, w| w.rsa_mem_pd().clear_bit());
-            }
-            #[cfg(hmac)]
-            Peripheral::Hmac => {
-                perip_clk_en1.modify(|_, w| w.crypto_hmac_clk_en().set_bit());
-                perip_rst_en1.modify(|_, w| w.crypto_hmac_rst().clear_bit());
-            }
-            #[cfg(ecc)]
-            Peripheral::Ecc => {
-                perip_clk_en1.modify(|_, w| w.crypto_ecc_clk_en().set_bit());
-                perip_rst_en1.modify(|_, w| w.crypto_ecc_rst().clear_bit());
-            }
-            #[cfg(lcd_cam)]
-            Peripheral::LcdCam => {
-                perip_clk_en1.modify(|_, w| w.lcd_cam_clk_en().set_bit());
-                perip_rst_en1.modify(|_, w| w.lcd_cam_rst().clear_bit());
-            }
-            #[cfg(systimer)]
-            Peripheral::Systimer => {
-                perip_clk_en0.modify(|_, w| w.systimer_clk_en().set_bit());
-                perip_rst_en0.modify(|_, w| w.systimer_rst().clear_bit());
-            }
-        });
+
+            true
+        })
     }
 
     /// Resets the given peripheral
     pub(crate) fn reset(peripheral: Peripheral) {
+        debug!("Reset {:?}", peripheral);
         let system = unsafe { &*SYSTEM::PTR };
 
         #[cfg(esp32)]
@@ -560,232 +585,198 @@ impl PeripheralClockControl {
 
 #[cfg(any(esp32c6, esp32h2))]
 impl PeripheralClockControl {
-    /// Enables and resets the given peripheral
-    pub(crate) fn enable(peripheral: Peripheral) {
-        let system = unsafe { &*SYSTEM::PTR };
-
-        match peripheral {
-            #[cfg(spi2)]
-            Peripheral::Spi2 => {
-                system.spi2_conf().modify(|_, w| w.spi2_clk_en().set_bit());
-                system
-                    .spi2_conf()
-                    .modify(|_, w| w.spi2_rst_en().clear_bit());
+    pub(crate) fn enable_forced(peripheral: Peripheral, enable: bool, force: bool) -> bool {
+        debug!("Enable {:?} {} {}", peripheral, enable, force);
+        critical_section::with(|_| {
+            if !force {
+                if enable {
+                    let prev =
+                        PERIPHERAL_REF_COUNT[peripheral as usize].fetch_add(1, Ordering::Relaxed);
+                    if prev > 0 {
+                        return false;
+                    }
+                } else {
+                    let prev =
+                        PERIPHERAL_REF_COUNT[peripheral as usize].fetch_sub(1, Ordering::Relaxed);
+                    if prev > 1 {
+                        return false;
+                    }
+                };
             }
-            #[cfg(i2c0)]
-            Peripheral::I2cExt0 => {
-                #[cfg(any(esp32c6, esp32h2))]
-                {
-                    system.i2c0_conf().modify(|_, w| w.i2c0_clk_en().set_bit());
+
+            if !enable {
+                Self::reset(peripheral);
+            }
+
+            let system = unsafe { &*SYSTEM::PTR };
+
+            match peripheral {
+                #[cfg(spi2)]
+                Peripheral::Spi2 => {
+                    system
+                        .spi2_conf()
+                        .modify(|_, w| w.spi2_clk_en().bit(enable));
+                }
+                #[cfg(i2c0)]
+                Peripheral::I2cExt0 => {
                     system
                         .i2c0_conf()
-                        .modify(|_, w| w.i2c0_rst_en().clear_bit());
+                        .modify(|_, w| w.i2c0_clk_en().bit(enable));
                 }
-            }
-            #[cfg(i2c1)]
-            Peripheral::I2cExt1 => {
-                #[cfg(esp32h2)]
-                {
-                    system.i2c1_conf().modify(|_, w| w.i2c1_clk_en().set_bit());
+                #[cfg(i2c1)]
+                Peripheral::I2cExt1 => {
                     system
                         .i2c1_conf()
-                        .modify(|_, w| w.i2c1_rst_en().clear_bit());
+                        .modify(|_, w| w.i2c1_clk_en().bit(enable));
+                }
+                #[cfg(rmt)]
+                Peripheral::Rmt => {
+                    system.rmt_conf().modify(|_, w| w.rmt_clk_en().bit(enable));
+                }
+                #[cfg(ledc)]
+                Peripheral::Ledc => {
+                    system
+                        .ledc_conf()
+                        .modify(|_, w| w.ledc_clk_en().bit(enable));
+                }
+                #[cfg(mcpwm0)]
+                Peripheral::Mcpwm0 => {
+                    system.pwm_conf().modify(|_, w| w.pwm_clk_en().bit(enable));
+                }
+                #[cfg(mcpwm1)]
+                Peripheral::Mcpwm1 => {
+                    system.pwm_conf.modify(|_, w| w.pwm_clk_en().bit(enable));
+                }
+                #[cfg(apb_saradc)]
+                Peripheral::ApbSarAdc => {
+                    system
+                        .saradc_conf()
+                        .modify(|_, w| w.saradc_reg_clk_en().bit(enable));
+                }
+                #[cfg(gdma)]
+                Peripheral::Gdma => {
+                    system
+                        .gdma_conf()
+                        .modify(|_, w| w.gdma_clk_en().bit(enable));
+                }
+                #[cfg(i2s0)]
+                Peripheral::I2s0 => {
+                    system.i2s_conf().modify(|_, w| w.i2s_clk_en().bit(enable));
+                }
+                #[cfg(twai0)]
+                Peripheral::Twai0 => {
+                    system
+                        .twai0_conf()
+                        .modify(|_, w| w.twai0_clk_en().bit(enable));
+
+                    if enable {
+                        // use Xtal clk-src
+                        system.twai0_func_clk_conf().modify(|_, w| {
+                            w.twai0_func_clk_en()
+                                .set_bit()
+                                .twai0_func_clk_sel()
+                                .variant(false)
+                        });
+                    }
+                }
+                #[cfg(twai1)]
+                Peripheral::Twai1 => {
+                    system
+                        .twai1_conf()
+                        .modify(|_, w| w.twai1_clk_en().bit(enable));
+                }
+                #[cfg(aes)]
+                Peripheral::Aes => {
+                    system.aes_conf().modify(|_, w| w.aes_clk_en().bit(enable));
+                }
+                #[cfg(pcnt)]
+                Peripheral::Pcnt => {
+                    system
+                        .pcnt_conf()
+                        .modify(|_, w| w.pcnt_clk_en().bit(enable));
+                }
+                #[cfg(timg0)]
+                Peripheral::Timg0 => {
+                    system
+                        .timergroup0_timer_clk_conf()
+                        .modify(|_, w| w.tg0_timer_clk_en().bit(enable));
+                }
+                #[cfg(timg1)]
+                Peripheral::Timg1 => {
+                    system
+                        .timergroup1_timer_clk_conf()
+                        .modify(|_, w| w.tg1_timer_clk_en().bit(enable));
+                }
+                #[cfg(sha)]
+                Peripheral::Sha => {
+                    system.sha_conf().modify(|_, w| w.sha_clk_en().bit(enable));
+                }
+                #[cfg(usb_device)]
+                Peripheral::UsbDevice => {
+                    system
+                        .usb_device_conf()
+                        .modify(|_, w| w.usb_device_clk_en().bit(enable));
+                }
+                #[cfg(uart0)]
+                Peripheral::Uart0 => {
+                    system
+                        .uart0_conf()
+                        .modify(|_, w| w.uart0_clk_en().bit(enable));
+                }
+                #[cfg(uart1)]
+                Peripheral::Uart1 => {
+                    system
+                        .uart1_conf()
+                        .modify(|_, w| w.uart1_clk_en().bit(enable));
+                }
+                #[cfg(rsa)]
+                Peripheral::Rsa => {
+                    system.rsa_conf().modify(|_, w| w.rsa_clk_en().bit(enable));
+                    system
+                        .rsa_pd_ctrl()
+                        .modify(|_, w| w.rsa_mem_pd().clear_bit());
+                }
+                #[cfg(parl_io)]
+                Peripheral::ParlIo => {
+                    system
+                        .parl_io_conf()
+                        .modify(|_, w| w.parl_clk_en().bit(enable));
+                }
+                #[cfg(hmac)]
+                Peripheral::Hmac => {
+                    system
+                        .hmac_conf()
+                        .modify(|_, w| w.hmac_clk_en().bit(enable));
+                }
+                #[cfg(ecc)]
+                Peripheral::Ecc => {
+                    system.ecc_conf().modify(|_, w| w.ecc_clk_en().bit(enable));
+                }
+                #[cfg(soc_etm)]
+                Peripheral::Etm => {
+                    system.etm_conf().modify(|_, w| w.etm_clk_en().bit(enable));
+                }
+                #[cfg(trace0)]
+                Peripheral::Trace0 => {
+                    system
+                        .trace_conf()
+                        .modify(|_, w| w.trace_clk_en().bit(enable));
+                }
+                #[cfg(systimer)]
+                Peripheral::Systimer => {
+                    system
+                        .systimer_conf()
+                        .modify(|_, w| w.systimer_clk_en().bit(enable));
                 }
             }
-            #[cfg(rmt)]
-            Peripheral::Rmt => {
-                system.rmt_conf().modify(|_, w| w.rmt_clk_en().set_bit());
-                system.rmt_conf().modify(|_, w| w.rmt_rst_en().clear_bit());
-            }
-            #[cfg(ledc)]
-            Peripheral::Ledc => {
-                system.ledc_conf().modify(|_, w| w.ledc_clk_en().set_bit());
-                system
-                    .ledc_conf()
-                    .modify(|_, w| w.ledc_rst_en().clear_bit());
-            }
-            #[cfg(mcpwm0)]
-            Peripheral::Mcpwm0 => {
-                system.pwm_conf().modify(|_, w| w.pwm_clk_en().set_bit());
-                system.pwm_conf().modify(|_, w| w.pwm_rst_en().clear_bit());
-            }
-            #[cfg(mcpwm1)]
-            Peripheral::Mcpwm1 => {
-                system.pwm_conf.modify(|_, w| w.pwm_clk_en().set_bit());
-                system.pwm_conf.modify(|_, w| w.pwm_rst_en().clear_bit());
-            }
-            #[cfg(apb_saradc)]
-            Peripheral::ApbSarAdc => {
-                system
-                    .saradc_conf()
-                    .modify(|_, w| w.saradc_reg_clk_en().set_bit());
-                system
-                    .saradc_conf()
-                    .modify(|_, w| w.saradc_reg_rst_en().clear_bit());
-            }
-            #[cfg(gdma)]
-            Peripheral::Gdma => {
-                system.gdma_conf().modify(|_, w| w.gdma_clk_en().set_bit());
-                system
-                    .gdma_conf()
-                    .modify(|_, w| w.gdma_rst_en().clear_bit());
-            }
-            #[cfg(i2s0)]
-            Peripheral::I2s0 => {
-                system.i2s_conf().modify(|_, w| w.i2s_clk_en().set_bit());
-                system.i2s_conf().modify(|_, w| w.i2s_rst_en().clear_bit());
-            }
-            #[cfg(twai0)]
-            Peripheral::Twai0 => {
-                system
-                    .twai0_conf()
-                    .modify(|_, w| w.twai0_clk_en().set_bit());
-                system
-                    .twai0_conf()
-                    .modify(|_, w| w.twai0_rst_en().clear_bit());
-
-                // use Xtal clk-src
-                system.twai0_func_clk_conf().modify(|_, w| {
-                    w.twai0_func_clk_en()
-                        .set_bit()
-                        .twai0_func_clk_sel()
-                        .variant(false)
-                });
-            }
-            #[cfg(twai1)]
-            Peripheral::Twai1 => {
-                system
-                    .twai1_conf()
-                    .modify(|_, w| w.twai1_clk_en().set_bit());
-                system
-                    .twai1_conf()
-                    .modify(|_, w| w.twai1_rst_en().clear_bit());
-            }
-            #[cfg(aes)]
-            Peripheral::Aes => {
-                system.aes_conf().modify(|_, w| w.aes_clk_en().set_bit());
-                system.aes_conf().modify(|_, w| w.aes_rst_en().clear_bit());
-            }
-            #[cfg(pcnt)]
-            Peripheral::Pcnt => {
-                system.pcnt_conf().modify(|_, w| w.pcnt_clk_en().set_bit());
-                system
-                    .pcnt_conf()
-                    .modify(|_, w| w.pcnt_rst_en().clear_bit());
-            }
-            #[cfg(timg0)]
-            Peripheral::Timg0 => {
-                system
-                    .timergroup0_timer_clk_conf()
-                    .modify(|_, w| w.tg0_timer_clk_en().set_bit());
-            }
-            #[cfg(timg1)]
-            Peripheral::Timg1 => {
-                system
-                    .timergroup1_timer_clk_conf()
-                    .modify(|_, w| w.tg1_timer_clk_en().set_bit());
-            }
-            #[cfg(lp_wdt)]
-            Peripheral::Wdt => {
-                system
-                    .timergroup0_wdt_clk_conf()
-                    .modify(|_, w| w.tg0_wdt_clk_en().set_bit());
-                system
-                    .timergroup1_timer_clk_conf()
-                    .modify(|_, w| w.tg1_timer_clk_en().set_bit());
-            }
-            #[cfg(sha)]
-            Peripheral::Sha => {
-                system.sha_conf().modify(|_, w| w.sha_clk_en().set_bit());
-                system.sha_conf().modify(|_, w| w.sha_rst_en().clear_bit());
-            }
-            #[cfg(usb_device)]
-            Peripheral::UsbDevice => {
-                system
-                    .usb_device_conf()
-                    .modify(|_, w| w.usb_device_clk_en().set_bit());
-                system
-                    .usb_device_conf()
-                    .modify(|_, w| w.usb_device_rst_en().clear_bit());
-            }
-            #[cfg(uart0)]
-            Peripheral::Uart0 => {
-                system
-                    .uart0_conf()
-                    .modify(|_, w| w.uart0_clk_en().set_bit());
-                system
-                    .uart0_conf()
-                    .modify(|_, w| w.uart0_rst_en().clear_bit());
-            }
-            #[cfg(uart1)]
-            Peripheral::Uart1 => {
-                system
-                    .uart1_conf()
-                    .modify(|_, w| w.uart1_clk_en().set_bit());
-                system
-                    .uart1_conf()
-                    .modify(|_, w| w.uart1_rst_en().clear_bit());
-            }
-            #[cfg(rsa)]
-            Peripheral::Rsa => {
-                system.rsa_conf().modify(|_, w| w.rsa_clk_en().set_bit());
-                system.rsa_conf().modify(|_, w| w.rsa_rst_en().clear_bit());
-                system
-                    .rsa_pd_ctrl()
-                    .modify(|_, w| w.rsa_mem_pd().clear_bit());
-            }
-            #[cfg(parl_io)]
-            Peripheral::ParlIo => {
-                system
-                    .parl_io_conf()
-                    .modify(|_, w| w.parl_clk_en().set_bit());
-                system
-                    .parl_io_conf()
-                    .modify(|_, w| w.parl_rst_en().set_bit());
-                system
-                    .parl_io_conf()
-                    .modify(|_, w| w.parl_rst_en().clear_bit());
-            }
-            #[cfg(hmac)]
-            Peripheral::Hmac => {
-                system.hmac_conf().modify(|_, w| w.hmac_clk_en().set_bit());
-                system
-                    .hmac_conf()
-                    .modify(|_, w| w.hmac_rst_en().clear_bit());
-            }
-            #[cfg(ecc)]
-            Peripheral::Ecc => {
-                system.ecc_conf().modify(|_, w| w.ecc_clk_en().set_bit());
-                system.ecc_conf().modify(|_, w| w.ecc_rst_en().clear_bit());
-            }
-            #[cfg(soc_etm)]
-            Peripheral::Etm => {
-                system.etm_conf().modify(|_, w| w.etm_clk_en().set_bit());
-                system.etm_conf().modify(|_, w| w.etm_rst_en().clear_bit());
-            }
-            #[cfg(trace0)]
-            Peripheral::Trace0 => {
-                system
-                    .trace_conf()
-                    .modify(|_, w| w.trace_clk_en().set_bit());
-                system
-                    .trace_conf()
-                    .modify(|_, w| w.trace_rst_en().clear_bit());
-            }
-            #[cfg(systimer)]
-            Peripheral::Systimer => {
-                system
-                    .systimer_conf()
-                    .modify(|_, w| w.systimer_clk_en().set_bit());
-                system
-                    .systimer_conf()
-                    .modify(|_, w| w.systimer_rst_en().clear_bit());
-            }
-        }
+            true
+        })
     }
 
     /// Resets the given peripheral
     pub(crate) fn reset(peripheral: Peripheral) {
+        debug!("Reset {:?}", peripheral);
+
         let system = unsafe { &*SYSTEM::PTR };
 
         match peripheral {
@@ -897,10 +888,6 @@ impl PeripheralClockControl {
             Peripheral::Timg1 => {
                 // no reset?
             }
-            #[cfg(lp_wdt)]
-            Peripheral::Wdt => {
-                // no reset?
-            }
             #[cfg(sha)]
             Peripheral::Sha => {
                 system.sha_conf().modify(|_, w| w.sha_rst_en().set_bit());
@@ -983,6 +970,22 @@ impl PeripheralClockControl {
                     .modify(|_, w| w.systimer_rst_en().clear_bit());
             }
         }
+    }
+}
+
+
+impl PeripheralClockControl {
+    /// Enables/disables the given peripheral.
+    ///
+    /// This keeps track of enabling/disabling a peripheral - i.e. a peripheral
+    /// is only enabled with the first call attempt to enable it. It only
+    /// gets disabled when the number of enable/disable attempts is balanced.
+    ///
+    /// Returns `true` if it actually enabled/disabled the peripheral.
+    /// 
+    /// Before disabling a peripheral it will also get reset
+    pub(crate) fn enable(peripheral: Peripheral, enable: bool) -> bool {
+        Self::enable_forced(peripheral, enable, false)
     }
 }
 

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -150,6 +150,7 @@ pub(crate) fn disable_peripherals() {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct PeripheralGuard {
     peripheral: Peripheral,
 }

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -193,6 +193,8 @@ impl PeripheralClockControl {
                         return false;
                     }
                 };
+            } else if !enable {
+                PERIPHERAL_REF_COUNT[peripheral as usize].store(0, Ordering::Relaxed);
             }
 
             if !enable {
@@ -600,6 +602,8 @@ impl PeripheralClockControl {
                         return false;
                     }
                 };
+            } else if !enable {
+                PERIPHERAL_REF_COUNT[peripheral as usize].store(0, Ordering::Relaxed);
             }
 
             if !enable {

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -155,10 +155,8 @@ pub(crate) struct PeripheralGuard {
 
 impl PeripheralGuard {
     pub(crate) fn new(p: Peripheral) -> Self {
-        if !KEEP_ENABLED.contains(&p) {
-            if PeripheralClockControl::enable(p, true) {
-                PeripheralClockControl::reset(p);
-            }
+        if !KEEP_ENABLED.contains(&p) && PeripheralClockControl::enable(p, true) {
+            PeripheralClockControl::reset(p);
         }
 
         Self { peripheral: p }
@@ -200,7 +198,7 @@ impl PeripheralClockControl {
             if !enable {
                 Self::reset(peripheral);
             }
-            
+
             let system = unsafe { &*SYSTEM::PTR };
 
             #[cfg(esp32)]
@@ -973,7 +971,6 @@ impl PeripheralClockControl {
     }
 }
 
-
 impl PeripheralClockControl {
     /// Enables/disables the given peripheral.
     ///
@@ -982,7 +979,7 @@ impl PeripheralClockControl {
     /// gets disabled when the number of enable/disable attempts is balanced.
     ///
     /// Returns `true` if it actually enabled/disabled the peripheral.
-    /// 
+    ///
     /// Before disabling a peripheral it will also get reset
     pub(crate) fn enable(peripheral: Peripheral, enable: bool) -> bool {
         Self::enable_forced(peripheral, enable, false)

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -148,7 +148,7 @@ impl<'d> SystemTimer<'d> {
     /// Create a new instance.
     pub fn new(_systimer: impl Peripheral<P = SYSTIMER> + 'd) -> Self {
         // Don't reset Systimer as it will break `time::now`, only enable it
-        PeripheralClockControl::enable(PeripheralEnable::Systimer, true);
+        PeripheralClockControl::enable(PeripheralEnable::Systimer);
 
         #[cfg(soc_etm)]
         etm::enable_etm();

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -148,7 +148,7 @@ impl<'d> SystemTimer<'d> {
     /// Create a new instance.
     pub fn new(_systimer: impl Peripheral<P = SYSTIMER> + 'd) -> Self {
         // Don't reset Systimer as it will break `time::now`, only enable it
-        PeripheralClockControl::enable(PeripheralEnable::Systimer);
+        PeripheralClockControl::enable(PeripheralEnable::Systimer, true);
 
         #[cfg(soc_etm)]
         etm::enable_etm();

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -152,7 +152,7 @@ impl TimerGroupInstance for TIMG0 {
     }
 
     fn enable_peripheral() {
-        PeripheralClockControl::enable(crate::system::Peripheral::Timg0)
+        PeripheralClockControl::enable(crate::system::Peripheral::Timg0, true);
     }
 
     fn reset_peripheral() {
@@ -215,7 +215,7 @@ impl TimerGroupInstance for crate::peripherals::TIMG1 {
     }
 
     fn enable_peripheral() {
-        PeripheralClockControl::enable(crate::system::Peripheral::Timg1)
+        PeripheralClockControl::enable(crate::system::Peripheral::Timg1, true);
     }
 
     fn reset_peripheral() {
@@ -929,9 +929,6 @@ where
 {
     /// Construct a new instance of [`Wdt`]
     pub fn new() -> Self {
-        #[cfg(lp_wdt)]
-        PeripheralClockControl::enable(crate::system::Peripheral::Wdt);
-
         TG::configure_wdt_src_clk();
 
         Self {

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -152,7 +152,7 @@ impl TimerGroupInstance for TIMG0 {
     }
 
     fn enable_peripheral() {
-        PeripheralClockControl::enable(crate::system::Peripheral::Timg0, true);
+        PeripheralClockControl::enable(crate::system::Peripheral::Timg0);
     }
 
     fn reset_peripheral() {
@@ -215,7 +215,7 @@ impl TimerGroupInstance for crate::peripherals::TIMG1 {
     }
 
     fn enable_peripheral() {
-        PeripheralClockControl::enable(crate::system::Peripheral::Timg1, true);
+        PeripheralClockControl::enable(crate::system::Peripheral::Timg1);
     }
 
     fn reset_peripheral() {

--- a/esp-hal/src/trace.rs
+++ b/esp-hal/src/trace.rs
@@ -22,8 +22,8 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::trace::Trace;
-//! let mut trace = Trace::new(peripherals.TRACE0);
 //! let mut buffer = [0_u8; 1024];
+//! let mut trace = Trace::new(peripherals.TRACE0);
 //! trace.start_trace(&mut buffer);
 //! // traced code
 //!

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -314,7 +314,7 @@ where
     fn new_inner(usb_device: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         // Do NOT reset the peripheral. Doing so will result in a broken USB JTAG
         // connection.
-        PeripheralClockControl::enable(crate::system::Peripheral::UsbDevice, true);
+        PeripheralClockControl::enable(crate::system::Peripheral::UsbDevice);
 
         USB_DEVICE::disable_tx_interrupts();
         USB_DEVICE::disable_rx_interrupts();

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -314,7 +314,7 @@ where
     fn new_inner(usb_device: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         // Do NOT reset the peripheral. Doing so will result in a broken USB JTAG
         // connection.
-        PeripheralClockControl::enable(crate::system::Peripheral::UsbDevice);
+        PeripheralClockControl::enable(crate::system::Peripheral::UsbDevice, true);
 
         USB_DEVICE::disable_tx_interrupts();
         USB_DEVICE::disable_rx_interrupts();

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -46,8 +46,8 @@ fn main() -> ! {
         },
     )
     .with_sck(sclk)
-    .with_mosi(miso_mosi)
-    .with_miso(miso)
+    .with_miso(miso) // order matters
+    .with_mosi(miso_mosi) // order matters
     .with_cs(cs);
 
     let delay = Delay::new();

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -113,7 +113,7 @@ mod tests {
             .map_err(|e| e.0)
             .unwrap();
         // dropping SPI would make us see an additional edge - so let's keep SPI alive
-        let (_spi,_) = transfer.wait();
+        let (_spi, _) = transfer.wait();
 
         assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -112,7 +112,8 @@ mod tests {
             )
             .map_err(|e| e.0)
             .unwrap();
-        transfer.wait();
+        // dropping SPI would make us see an additional edge - so let's keep SPI alive
+        let (_spi,_) = transfer.wait();
 
         assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Closes #1382 
Supercedes #2484 

This disables most peripherals when their driver gets fully dropped.

There are some peripherals which don't get touched
- UART0 (console logging would break)
- serial-jtag (console logging would break)
- systimer (we use it to get the time since boot)
- TIMG (we use TIMG0-LACT to get the time on ESP32)
- DMA (should be fine to do - but lets do it in a separate PR)
- LEDC (that driver will see a refactoring or rewrite)

others which we currently don't explicitly enable (some of them for reasons, but not all)

Additionally, peripherals are disabled in `init` - gives us a ~ 5mA advantage when not using them

#### Testing
- HIL-tests
- manual testing with logging enabled
