### PR TITLE
Add missing Sealed impl

### DIFF
--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -357,7 +357,7 @@ impl private::Sealed for Trng<'_> {}
 ///
 /// ```rust, no_run
 #[doc = esp_hal::before_snippet!()]
-/// use esp_hal::{rng::Rng, timg::TimerGroup};
+/// use esp_hal::{rng::Rng, timer::timg::TimerGroup};
 ///
 /// let timg0 = TimerGroup::new(peripherals.TIMG0);
 /// let init = esp_wifi::init(
@@ -409,7 +409,7 @@ pub fn init<'d, T: EspWifiTimerSource>(
 /// # Safety
 ///
 /// The user must ensure that any use of the radio via the WIFI/BLE/ESP-NOW
-/// drivers are complete, else undefined behavour may occur within those
+/// drivers are complete, else undefined behaviour may occur within those
 /// drivers.
 pub unsafe fn deinit_unchecked() -> Result<(), InitializationError> {
     // Disable coexistence

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -300,6 +300,7 @@ where
 {
 }
 
+impl private::Sealed for AnyTimer {}
 impl IntoAnyTimer for AnyTimer {}
 
 impl<T> EspWifiTimerSource for T

--- a/hil-test/tests/esp_wifi_floats.rs
+++ b/hil-test/tests/esp_wifi_floats.rs
@@ -173,3 +173,15 @@ mod tests {
         assert_eq!(result, 4.0);
     }
 }
+
+// Here is a random test that doesn't fit anywhere else - and since it's alone,
+// creating a new test suite is not necessary as we don't want to flash/run
+// anything.
+#[allow(unused)] // compile test
+fn esp_wifi_can_be_initialized_with_any_timer(
+    timer: esp_hal::timer::AnyTimer,
+    rng: esp_hal::rng::Rng,
+    radio_clocks: esp_hal::peripherals::RADIO_CLK,
+) {
+    esp_wifi::init(timer, rng, radio_clocks);
+}


### PR DESCRIPTION
I'm open to suggestions how we should test this. We can shove an "it_compiles" function into one of the test suites, or we can have it in source, although I'd not recommend that. Ideally I'd add a doctest, but we aren't running those for non-`esp-hal`.