### PR TITLE
Remove some unnecessary prelude reexports

### DIFF
--- a/esp-hal/src/prelude.rs
+++ b/esp-hal/src/prelude.rs
@@ -20,13 +20,7 @@ mod imp {
     #[cfg(any(dport, pcr, system))]
     pub use crate::clock::Clock as _esp_hal_clock_Clock;
     #[cfg(gpio)]
-    pub use crate::gpio::{
-        InputPin as _esp_hal_gpio_InputPin,
-        OutputPin as _esp_hal_gpio_OutputPin,
-        Pin as _esp_hal_gpio_Pin,
-    };
-    #[cfg(any(i2c0, i2c1))]
-    pub use crate::i2c::master::Instance as _esp_hal_i2c_master_Instance;
+    pub use crate::gpio::Pin as _esp_hal_gpio_Pin;
     #[cfg(ledc)]
     pub use crate::ledc::{
         channel::{
@@ -45,7 +39,5 @@ mod imp {
     };
     #[cfg(any(systimer, timg0, timg1))]
     pub use crate::timer::Timer as _esp_hal_timer_Timer;
-    #[cfg(any(uart0, uart1, uart2))]
-    pub use crate::uart::Instance as _esp_hal_uart_Instance;
     pub use crate::{clock::CpuClock, entry, macros::*, InterruptConfigurable};
 }

--- a/hil-test/tests/uart_regression.rs
+++ b/hil-test/tests/uart_regression.rs
@@ -9,6 +9,7 @@
 #[embedded_test::tests]
 mod tests {
     use esp_hal::{
+        gpio::OutputPin,
         prelude::*,
         uart::{UartRx, UartTx},
     };


### PR DESCRIPTION
I don't think peripheral Instances (at least where the Instance has been updated to only contain State/Info) are necessary to have in the prelude. They don't really provide anything users may need, and they can easily opt into using them explicitly.

Similarly, I think the public GPIO API should direct users to use the pin drivers, so I'm removing InputPin and OutputPin. Especially since they mostly contain `private::Internal` functions.