### PR TITLE
Add `--no-verify` for `esp-riscv-rt` to `xtask publish`

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -796,7 +796,7 @@ fn publish(workspace: &Path, args: PublishArgs) -> Result<()> {
         }
 
         EspBacktrace | EspHal | EspHalEmbassy | EspIeee802154 | EspLpHal | EspPrintln
-        | EspStorage | EspWifi | XtensaLxRt => vec!["--no-verify"],
+        | EspRiscvRt | EspStorage | EspWifi | XtensaLxRt => vec!["--no-verify"],
 
         _ => vec![],
     };


### PR DESCRIPTION
This is required as the RISC-V assembly results in `unknown directive` errors when building on a host system otherwise.