### PR TITLE
Add xtask subcommand to determine version change required based on `CHANGELOG.md`

### DIFF
--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9.1 - 2024-11-20
 
-## Fixed
+### Fixed
 
 - Fix interrupt stack alignment (#2425)
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,16 +5,18 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow       = "1.0.93"
-basic-toml   = "0.1.9"
-chrono       = "0.4.38"
-clap         = { version = "4.5.20",  features = ["derive", "wrap_help"] }
-csv          = "1.3.1"
-env_logger   = "0.11.5"
-esp-metadata = { path = "../esp-metadata", features = ["clap"] }
-log          = "0.4.22"
-minijinja    = "2.5.0"
-semver       = { version = "1.0.23",  features = ["serde"] }
-serde        = { version = "1.0.215", features = ["derive"] }
-strum        = { version = "0.26.3",  features = ["derive"] }
-toml_edit    = "0.22.22"
+anyhow          = "1.0.93"
+basic-toml      = "0.1.9"
+chrono          = "0.4.38"
+clap            = { version = "4.5.21", features = ["derive", "wrap_help"] }
+csv             = "1.3.1"
+env_logger      = "0.11.5"
+esp-metadata    = { path = "../esp-metadata", features = ["clap"] }
+log             = "0.4.22"
+markdown        = "1.0.0-alpha.21"
+minijinja       = "2.5.0"
+parse-changelog = "0.6.10"
+semver          = { version = "1.0.23",  features = ["serde"] }
+serde           = { version = "1.0.215", features = ["derive"] }
+strum           = { version = "0.26.3",  features = ["derive"] }
+toml_edit       = "0.22.22"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -95,12 +95,12 @@ impl Metadata {
     }
 }
 
-#[derive(Debug, Clone, Copy, Display, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Display, ValueEnum)]
 #[strum(serialize_all = "lowercase")]
 pub enum Version {
-    Major,
-    Minor,
     Patch,
+    Minor,
+    Major,
 }
 
 /// Build the documentation for the specified package and device.


### PR DESCRIPTION
Example output (hardcoded to previous release to generate this, just as an example):

```
esp-alloc: minor
esp-backtrace: patch
esp-config: minor
esp-hal: minor
esp-hal-embassy: minor
esp-hal-procmacros: minor
esp-ieee802154: minor
esp-lp-hal: minor
esp-println: minor
esp-riscv-rt: patch
esp-storage: minor
esp-wifi: minor
xtensa-lx-rt: patch
```

Will require updating once we move to `1.x.x` (maybe it makes sense to just do this now?), but otherwise seems to be functioning as expected, as far as I can tell at least 😅 