### PR TITLE
SPI PDMA: Don't read to clear interrupts

### DIFF
--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -333,7 +333,7 @@ impl InterruptAccess<DmaRxInterrupt> for AnySpiDmaRxChannel {
 
     fn clear(&self, interrupts: impl Into<EnumSet<DmaRxInterrupt>>) {
         let spi = self.0.register_block();
-        spi.dma_int_clr().modify(|_, w| {
+        spi.dma_int_clr().write(|w| {
             for interrupt in interrupts.into() {
                 match interrupt {
                     DmaRxInterrupt::SuccessfulEof => w.in_suc_eof().clear_bit_by_one(),


### PR DESCRIPTION
This is the only place where we use `modify` instead of `write` and the hardware is write-1-to-clear so not reading should be safe.