### PR TITLE
Remove unnecessary features from `esp-hal-procmacros`, enable `rtc-slow` feature for Xtensa devices

### DIFF
--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the `enum-dispatch`, `interrupt`, and `ram` features (#2594)
+
 ## [0.15.0] - 2024-11-20
 
 ### Changed

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -17,24 +17,18 @@ proc-macro = true
 darling           = "0.20.10"
 document-features = "0.2.10"
 litrs             = "0.4.1"
-object            = { version = "0.36.5", optional = true, default-features = false, features = ["read_core", "elf"] }
+object            = { version = "0.36.5", default-features = false, features = ["read_core", "elf"], optional = true }
 proc-macro-crate  = "3.2.0"
 proc-macro-error2 = "2.0.1"
-proc-macro2       = "1.0.89"
+proc-macro2       = "1.0.92"
 quote             = "1.0.37"
-syn               = { version = "2.0.87", features = ["extra-traits", "full"] }
+syn               = { version = "2.0.89", features = ["extra-traits", "full"] }
 
 [features]
 ## Provide a `#[main]` procmacro to mark the entry point for Embassy applications.
 embassy = []
-## Provide enum dispatch helpers.
-enum-dispatch = []
-## Provide an `#[interrupt]` procmacro for defining interrupt service routines.
-interrupt = []
-## Provide a `#[ram]` procmacro to place functions in RAM instead of flash.
-ram = []
 ## Indicates the target device has RTC slow memory available.
-rtc_slow = []
+rtc-slow = []
 
 #! ### Low-power Core Feature Flags
 ## Indicate that the SoC contains an LP core.

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -39,9 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-### Removed
-- Remove more examples. Update doctests. (#2547)
+- Xtensa devices now correctly enable the `esp-hal-procmacros/rtc-slow` feature (#2594)
 
+### Removed
+
+- Remove more examples. Update doctests. (#2547)
 - The `configure` and `configure_for_async` DMA channel functions has been removed (#2403)
 - The DMA channel objects no longer have `tx` and `rx` fields. (#2526)
 - `SysTimerAlarms` has been removed, alarms are now part of the `SystemTimer` struct (#2576)

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -44,7 +44,7 @@ log                      = { version = "0.4.22", optional = true }
 nb                       = "1.1.0"
 paste                    = "1.0.15"
 portable-atomic          = { version = "1.9.0", default-features = false }
-procmacros               = { version = "0.15.0", features = ["enum-dispatch", "interrupt", "ram"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+procmacros               = { version = "0.15.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 strum                    = { version = "0.26.3", default-features = false, features = ["derive"] }
 void                     = { version = "1.0.2", default-features = false }
 usb-device               = { version = "0.3.2", optional = true }
@@ -104,19 +104,19 @@ log = ["dep:log"]
 
 # Chip Support Feature Flags
 # Target the ESP32.
-esp32   = ["dep:esp32",   "xtensa-lx-rt/esp32"]
+esp32   = ["dep:esp32", "procmacros/rtc-slow", "xtensa-lx-rt/esp32"]
 # Target the ESP32-C2.
 esp32c2 = ["dep:esp32c2", "portable-atomic/unsafe-assume-single-core"]
 # Target the ESP32-C3.
-esp32c3 = ["dep:esp32c3", "portable-atomic/unsafe-assume-single-core", "esp-riscv-rt/rtc-ram"]
+esp32c3 = ["dep:esp32c3", "esp-riscv-rt/rtc-ram", "portable-atomic/unsafe-assume-single-core"]
 # Target the ESP32-C6.
-esp32c6 = ["dep:esp32c6", "procmacros/has-lp-core", "esp-riscv-rt/rtc-ram"]
+esp32c6 = ["dep:esp32c6", "esp-riscv-rt/rtc-ram", "procmacros/has-lp-core"]
 # Target the ESP32-H2.
 esp32h2 = ["dep:esp32h2", "esp-riscv-rt/rtc-ram"]
 # Target the ESP32-S2.
-esp32s2 = ["dep:esp32s2", "portable-atomic/critical-section", "procmacros/has-ulp-core", "xtensa-lx-rt/esp32s2", "usb-otg"]
+esp32s2 = ["dep:esp32s2", "portable-atomic/critical-section", "procmacros/has-ulp-core", "procmacros/rtc-slow", "usb-otg", "xtensa-lx-rt/esp32s2"]
 # Target the ESP32-S3.
-esp32s3 = ["dep:esp32s3", "procmacros/has-ulp-core", "xtensa-lx-rt/esp32s3", "usb-otg"]
+esp32s3 = ["dep:esp32s3", "procmacros/has-ulp-core", "procmacros/rtc-slow", "usb-otg", "xtensa-lx-rt/esp32s3"]
 
 #! ### RISC-V Exclusive Feature Flags
 ## Move the stack to start of RAM to get zero-cost stack overflow protection


### PR DESCRIPTION
These features were not really necessary, so just removed them and cleaned up the imports, etc.

Additionally noticed that the `rtc-slow` feature was not being enabled anywhere, so Xtensa devices now enable this in the HAL. Also renamed this feature from `rtc_slow` to be consistent with other features.