### PR TITLE
Remove `embedded-hal 0.2.x` impls and dependency from `esp-lp-hal` package

### DIFF
--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Removed
+- Remove embedded-hal 0.2.x impls and dependency from esp-lp-hal package (#2609)
 
 ## 0.1.0 - 2024-07-15
 

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -28,7 +28,6 @@ test  = false
 cfg-if            = "1.0.0"
 document-features = "0.2.10"
 embedded-hal      = { version = "1.0.0",  optional = true }
-embedded-hal-02   = { version = "0.2.7",  optional = true, features = ["unproven"], package = "embedded-hal" }
 embedded-hal-nb   = { version = "1.0.0",  optional = true }
 embedded-io       = { version = "0.6.1",  optional = true }
 esp32c6-lp        = { version = "0.3.0", features = ["critical-section"], optional = true }
@@ -63,8 +62,6 @@ esp32s2 = ["dep:esp32s2-ulp", "procmacros/is-ulp-core"]
 esp32s3 = ["dep:esp32s3-ulp", "procmacros/is-ulp-core"]
 
 #! ### Trait Implementation Feature Flags
-## Implement the traits defined in the `0.2.x` release of `embedded-hal`.
-embedded-hal-02 = ["dep:embedded-hal-02"]
 ## Implement the traits defined in the `1.0.0` releases of `embedded-hal` and
 ## `embedded-hal-nb` for the relevant peripherals.
 embedded-hal = ["dep:embedded-hal", "dep:embedded-hal-nb"]
@@ -73,15 +70,15 @@ embedded-io = ["dep:embedded-io"]
 
 [[example]]
 name              = "blinky"
-required-features = ["embedded-hal-02"]
+required-features = []
 
 [[example]]
 name              = "i2c"
-required-features = ["embedded-hal-02", "esp32c6"]
+required-features = ["esp32c6"]
 
 [[example]]
 name              = "uart"
-required-features = ["embedded-hal-02", "esp32c6"]
+required-features = ["esp32c6"]
 
 [lints.rust]
 unexpected_cfgs = "allow"

--- a/esp-lp-hal/README.md
+++ b/esp-lp-hal/README.md
@@ -12,7 +12,7 @@ Implements a number of blocking and, where applicable, async traits from the var
 
 For help getting started with this HAL, please refer to [The Rust on ESP Book] and the [documentation].
 
-[embedded-hal]: https://github.com/rust-embedded/embedded-hal
+[embedded-hal]: https://docs.rs/embedded-hal/latest/embedded_hal/
 [the rust on esp book]: https://docs.esp-rs.org/book/
 
 ## [Documentation]

--- a/esp-lp-hal/examples/blinky.rs
+++ b/esp-lp-hal/examples/blinky.rs
@@ -7,12 +7,10 @@
 //!
 //! Make sure the LP RAM is cleared before loading the code.
 
-//% FEATURES: embedded-hal-02
-
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::{blocking::delay::DelayMs, digital::v2::OutputPin};
+use embedded_hal::{delay::DelayNs, digital::OutputPin};
 use esp_lp_hal::{delay::Delay, gpio::Output, prelude::*};
 use panic_halt as _;
 

--- a/esp-lp-hal/examples/i2c.rs
+++ b/esp-lp-hal/examples/i2c.rs
@@ -12,7 +12,6 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::i2c::I2c;
 use esp_lp_hal::{i2c::LpI2c, prelude::*};
 use panic_halt as _;
 

--- a/esp-lp-hal/examples/i2c.rs
+++ b/esp-lp-hal/examples/i2c.rs
@@ -8,12 +8,11 @@
 //! - SCL => GPIO7
 
 //% CHIPS: esp32c6
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
-use embedded_hal_02::blocking::i2c::WriteRead;
+use embedded_hal::i2c::I2c;
 use esp_lp_hal::{i2c::LpI2c, prelude::*};
 use panic_halt as _;
 

--- a/esp-lp-hal/examples/uart.rs
+++ b/esp-lp-hal/examples/uart.rs
@@ -6,14 +6,13 @@
 //! logs from LP_UART. Make sure the LP RAM is cleared before loading the code.
 
 //% CHIPS: esp32c6
-//% FEATURES: embedded-hal-02
 
 #![no_std]
 #![no_main]
 
 use core::fmt::Write;
 
-use embedded_hal_02::blocking::delay::DelayMs;
+use embedded_hal::delay::DelayNs;
 use esp_lp_hal::{delay::Delay, prelude::*, uart::LpUart};
 use panic_halt as _;
 

--- a/esp-lp-hal/src/delay.rs
+++ b/esp-lp-hal/src/delay.rs
@@ -74,30 +74,6 @@ fn cycles() -> u64 {
     cycles as u64
 }
 
-#[cfg(feature = "embedded-hal-02")]
-impl embedded_hal_02::blocking::delay::DelayUs<u64> for Delay {
-    #[inline(always)]
-    fn delay_us(&mut self, us: u64) {
-        self.delay_micros(us as u32);
-    }
-}
-
-#[cfg(feature = "embedded-hal-02")]
-impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
-    #[inline(always)]
-    fn delay_us(&mut self, us: u32) {
-        self.delay_micros(us);
-    }
-}
-
-#[cfg(feature = "embedded-hal-02")]
-impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
-    #[inline(always)]
-    fn delay_ms(&mut self, ms: u32) {
-        self.delay_millis(ms);
-    }
-}
-
 #[cfg(feature = "embedded-hal")]
 impl embedded_hal::delay::DelayNs for Delay {
     #[inline(always)]

--- a/esp-lp-hal/src/gpio.rs
+++ b/esp-lp-hal/src/gpio.rs
@@ -86,48 +86,6 @@ pub unsafe fn conjure_input<const PIN: u8>() -> Option<Input<PIN>> {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
-impl<const PIN: u8> embedded_hal_02::digital::v2::InputPin for Input<PIN> {
-    type Error = core::convert::Infallible;
-
-    fn is_high(&self) -> Result<bool, Self::Error> {
-        Ok(self.input_state())
-    }
-
-    fn is_low(&self) -> Result<bool, Self::Error> {
-        Ok(!self.is_high()?)
-    }
-}
-
-#[cfg(feature = "embedded-hal-02")]
-impl<const PIN: u8> embedded_hal_02::digital::v2::OutputPin for Output<PIN> {
-    type Error = core::convert::Infallible;
-
-    fn set_low(&mut self) -> Result<(), Self::Error> {
-        self.set_output(false);
-        Ok(())
-    }
-
-    fn set_high(&mut self) -> Result<(), Self::Error> {
-        self.set_output(true);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "embedded-hal-02")]
-impl<const PIN: u8> embedded_hal_02::digital::v2::StatefulOutputPin for Output<PIN> {
-    fn is_set_high(&self) -> Result<bool, Self::Error> {
-        Ok(self.output_state())
-    }
-
-    fn is_set_low(&self) -> Result<bool, Self::Error> {
-        Ok(!self.is_set_high()?)
-    }
-}
-
-#[cfg(feature = "embedded-hal-02")]
-impl<const PIN: u8> embedded_hal_02::digital::v2::toggleable::Default for Output<PIN> {}
-
 #[cfg(feature = "embedded-hal")]
 impl<const PIN: u8> embedded_hal::digital::ErrorType for Input<PIN> {
     type Error = core::convert::Infallible;

--- a/esp-lp-hal/src/uart.rs
+++ b/esp-lp-hal/src/uart.rs
@@ -231,28 +231,6 @@ impl core::fmt::Write for LpUart {
     }
 }
 
-#[cfg(feature = "embedded-hal-02")]
-impl embedded_hal_02::serial::Read<u8> for LpUart {
-    type Error = Error;
-
-    fn read(&mut self) -> nb::Result<u8, Self::Error> {
-        self.read_byte()
-    }
-}
-
-#[cfg(feature = "embedded-hal-02")]
-impl embedded_hal_02::serial::Write<u8> for LpUart {
-    type Error = Error;
-
-    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
-        self.write_byte(word)
-    }
-
-    fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        self.flush_tx()
-    }
-}
-
 #[cfg(feature = "embedded-hal")]
 impl embedded_hal_nb::serial::ErrorType for LpUart {
     type Error = Error;


### PR DESCRIPTION
### Pull Request Details 📖

#### Description
closes https://github.com/esp-rs/esp-hal/issues/2597

For `LpI2c` we need to implement the `embedded_hal::i2c:I2c` trait instead of `embedded-hal 0.2.7` ones. 

But for now, let's just rename current methods to match common "write"/"read" format and make them public

#### Testing
examples
