### PR TITLE
Fixed triggering a debug-assertion during scan

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -37,6 +37,7 @@ embedded-hal-nb          = "1.0.0"
 embedded-io              = "0.6.1"
 embedded-io-async        = "0.6.1"
 enumset                  = "1.1.5"
+esp-build                = { version = "0.1.0", path = "../esp-build" }
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                    = "0.3.7"
 log                      = { version = "0.4.22", optional = true }

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -11,16 +11,14 @@ use esp_build::assert_unique_used_features;
 use esp_config::{generate_config, Value};
 use esp_metadata::{Chip, Config};
 
-#[cfg(debug_assertions)]
-esp_build::warning! {"
-WARNING: use --release
-  We *strongly* recommend using release profile when building esp-hal.
-  The dev profile can potentially be one or more orders of magnitude
-  slower than release, and may cause issues with timing-senstive
-  peripherals and/or devices.
-"}
-
 fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rustc-check-cfg=cfg(is_debug_build)");
+    if let Ok(level) = std::env::var("OPT_LEVEL") {
+        if level != "2" && level != "3" {
+            println!("cargo:rustc-cfg=is_debug_build");
+        }
+    }
+
     // NOTE: update when adding new device support!
     // Ensure that exactly one chip has been specified:
     assert_unique_used_features!(

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -14,7 +14,7 @@ use esp_metadata::{Chip, Config};
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-check-cfg=cfg(is_debug_build)");
     if let Ok(level) = std::env::var("OPT_LEVEL") {
-        if level != "2" && level != "3" {
+        if level == "0" || level == "1" {
             println!("cargo:rustc-cfg=is_debug_build");
         }
     }

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -261,6 +261,15 @@ pub mod trapframe {
 // be directly exposed.
 mod soc;
 
+#[cfg(is_debug_build)]
+esp_build::warning! {"
+WARNING: use --release
+  We *strongly* recommend using release profile when building esp-hal.
+  The dev profile can potentially be one or more orders of magnitude
+  slower than release, and may cause issues with timing-senstive
+  peripherals and/or devices.
+"}
+
 /// A marker trait for initializing drivers in a specific mode.
 pub trait Mode: crate::private::Sealed {}
 

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Introduced the `wifi6` symbol
+- Introduced the `wifi6` symbol (#2612)
 
 ### Fixed
 

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Introduced the `wifi6` symbol
 
 ### Fixed
 

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -80,6 +80,7 @@ symbols = [
     "phy",
     "bt",
     "wifi",
+    "wifi6",
     "ieee802154",
     "lp_core",
 

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed triggering a debug-assertion during scan
 
 ### Removed
 

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- Fixed triggering a debug-assertion during scan
+- Fixed triggering a debug-assertion during scan (#2612)
 
 ### Removed
 

--- a/esp-wifi/src/wifi/event.rs
+++ b/esp-wifi/src/wifi/event.rs
@@ -180,13 +180,11 @@ pub(crate) unsafe fn handle_raw<Event: EventExt>(
     event_data: *mut crate::binary::c_types::c_void,
     event_data_size: usize,
 ) -> bool {
-    if event_data_size != core::mem::size_of::<Event>() {
-        warn!(
-            "event data size doesn't match {} != {}",
-            event_data_size,
-            core::mem::size_of::<Event>()
-        );
-    }
+    debug_assert_eq!(
+        event_data_size,
+        core::mem::size_of::<Event>(),
+        "wrong size event data"
+    );
 
     handle::<Event>(unsafe { &Event::from_raw_event_data(event_data) })
 }

--- a/esp-wifi/src/wifi/event.rs
+++ b/esp-wifi/src/wifi/event.rs
@@ -104,7 +104,7 @@ macro_rules! impl_wifi_event {
 }
 
 impl_wifi_event!(WifiReady);
-impl_wifi_event!(ScanDone);
+impl_wifi_event!(ScanDone, wifi_event_sta_scan_done_t);
 impl_wifi_event!(StaStart);
 impl_wifi_event!(StaStop);
 impl_wifi_event!(StaConnected, wifi_event_sta_connected_t);
@@ -131,13 +131,25 @@ impl_wifi_event!(ApWpsRgFailed, wifi_event_ap_wps_rg_fail_reason_t);
 impl_wifi_event!(ApWpsRgTimeout);
 impl_wifi_event!(ApWpsRgPin, wifi_event_ap_wps_rg_pin_t);
 impl_wifi_event!(ApWpsRgPbcOverlap);
-impl_wifi_event!(ItwtSetup);
-impl_wifi_event!(ItwtTeardown);
-impl_wifi_event!(ItwtProbe);
-impl_wifi_event!(ItwtSuspend);
-impl_wifi_event!(TwtWakeup);
-impl_wifi_event!(BtwtSetup);
-impl_wifi_event!(BtwtTeardown);
+cfg_if::cfg_if! {
+    if #[cfg(wifi6)] {
+        impl_wifi_event!(ItwtSetup, wifi_event_sta_itwt_setup_t);
+        impl_wifi_event!(ItwtTeardown, wifi_event_sta_itwt_teardown_t);
+        impl_wifi_event!(ItwtProbe, wifi_event_sta_itwt_probe_t);
+        impl_wifi_event!(ItwtSuspend, wifi_event_sta_itwt_suspend_t);
+        impl_wifi_event!(TwtWakeup);
+        impl_wifi_event!(BtwtSetup, wifi_event_sta_btwt_setup_t);
+        impl_wifi_event!(BtwtTeardown, wifi_event_sta_btwt_teardown_t);
+    } else {
+        impl_wifi_event!(ItwtSetup);
+        impl_wifi_event!(ItwtTeardown);
+        impl_wifi_event!(ItwtProbe);
+        impl_wifi_event!(ItwtSuspend);
+        impl_wifi_event!(TwtWakeup);
+        impl_wifi_event!(BtwtSetup);
+        impl_wifi_event!(BtwtTeardown);
+    }
+}
 impl_wifi_event!(NanStarted);
 impl_wifi_event!(NanStopped);
 impl_wifi_event!(NanSvcMatch, wifi_event_nan_svc_match_t);

--- a/esp-wifi/src/wifi/event.rs
+++ b/esp-wifi/src/wifi/event.rs
@@ -180,11 +180,14 @@ pub(crate) unsafe fn handle_raw<Event: EventExt>(
     event_data: *mut crate::binary::c_types::c_void,
     event_data_size: usize,
 ) -> bool {
-    debug_assert_eq!(
-        event_data_size,
-        core::mem::size_of::<Event>(),
-        "wrong size event data"
-    );
+    if event_data_size != core::mem::size_of::<Event>() {
+        warn!(
+            "event data size doesn't match {} != {}",
+            event_data_size,
+            core::mem::size_of::<Event>()
+        );
+    }
+
     handle::<Event>(unsafe { &Event::from_raw_event_data(event_data) })
 }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -65,7 +65,7 @@ embassy-generic-timers = ["embassy-time/generic-queue-8"]
 [profile.release]
 codegen-units    = 1
 debug            = 2
-debug-assertions = false
+debug-assertions = true
 incremental      = false
 opt-level        = 3
 lto = 'fat'

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -298,7 +298,7 @@ overflow-checks  = true
 [profile.release]
 codegen-units    = 1
 debug            = 2
-debug-assertions = false
+debug-assertions = true
 incremental      = false
 opt-level        = 3
 lto              = false # LTO (thin or fat) miscompiles some tests on RISC-V

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -32,5 +32,6 @@ embassy-generic-timers = ["embassy-time/generic-queue-8"]
 
 [profile.release]
 debug         = 2
+debug-assertions = true
 lto           = "fat"
 codegen-units = 1


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #2611 

`skip-changelog` because of the change in `esp-hal`

#### Testing
Change that assert from `debug_assert_eq` to `assert_eq` and just run the `wifi-dhcp` example
