### PR TITLE
Move interrupt related bits out of lib.rs and into the interrupt module

### DIFF
--- a/esp-hal/src/assist_debug.rs
+++ b/esp-hal/src/assist_debug.rs
@@ -24,10 +24,9 @@
 //! - This driver has only blocking API
 
 use crate::{
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{Interrupt, ASSIST_DEBUG},
-    InterruptConfigurable,
 };
 
 /// The debug assist driver instance.

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -28,12 +28,11 @@
 use core::marker::PhantomData;
 
 use crate::{
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{Interrupt, ECC},
     reg_access::{AlignmentHelper, SocDependentEndianess},
     system::{self, GenericPeripheralGuard},
-    InterruptConfigurable,
 };
 
 /// The ECC Accelerator driver instance

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -62,7 +62,13 @@ use procmacros::ram;
 use crate::peripherals::gpio::{handle_rtcio, handle_rtcio_with_resistors};
 pub use crate::soc::gpio::*;
 use crate::{
-    interrupt::{self, InterruptHandler, Priority},
+    interrupt::{
+        self,
+        InterruptConfigurable,
+        InterruptHandler,
+        Priority,
+        DEFAULT_INTERRUPT_HANDLER,
+    },
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{
         gpio::{handle_gpio_input, handle_gpio_output, AnyPinInner},
@@ -71,8 +77,6 @@ use crate::{
         IO_MUX,
     },
     private::{self, Sealed},
-    InterruptConfigurable,
-    DEFAULT_INTERRUPT_HANDLER,
 };
 
 pub mod interconnect;

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     asynch::AtomicWaker,
     clock::Clocks,
     gpio::{interconnect::PeripheralOutput, InputSignal, OutputSignal, Pull},
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{
         i2c0::{RegisterBlock, COMD},
@@ -62,7 +62,6 @@ use crate::{
     Async,
     Blocking,
     Cpu,
-    InterruptConfigurable,
     Mode,
 };
 

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -99,12 +99,11 @@ use crate::{
         WriteBuffer,
     },
     gpio::interconnect::PeripheralOutput,
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     system::PeripheralGuard,
     Async,
     Blocking,
-    InterruptConfigurable,
     Mode,
 };
 

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -81,6 +81,38 @@ mod xtensa;
 
 pub mod software;
 
+#[cfg(xtensa)]
+#[no_mangle]
+extern "C" fn EspDefaultHandler(_level: u32, _interrupt: crate::peripherals::Interrupt) {
+    panic!("Unhandled level {} interrupt: {:?}", _level, _interrupt);
+}
+
+#[cfg(riscv)]
+#[no_mangle]
+extern "C" fn EspDefaultHandler(_interrupt: crate::peripherals::Interrupt) {
+    panic!("Unhandled interrupt: {:?}", _interrupt);
+}
+
+/// Default (unhandled) interrupt handler
+pub const DEFAULT_INTERRUPT_HANDLER: InterruptHandler = InterruptHandler::new(
+    unsafe { core::mem::transmute::<*const (), extern "C" fn()>(EspDefaultHandler as *const ()) },
+    Priority::min(),
+);
+
+/// Trait implemented by drivers which allow the user to set an
+/// [interrupt::InterruptHandler]
+pub trait InterruptConfigurable: crate::private::Sealed {
+    /// Set the interrupt handler
+    ///
+    /// Note that this will replace any previously registered interrupt handler.
+    /// Some peripherals offer a shared interrupt handler for multiple purposes.
+    /// It's the users duty to honor this.
+    ///
+    /// You can restore the default/unhandled interrupt handler by using
+    /// [DEFAULT_INTERRUPT_HANDLER]
+    fn set_interrupt_handler(&mut self, handler: InterruptHandler);
+}
+
 /// An interrupt handler
 #[cfg_attr(
     multi_core,

--- a/esp-hal/src/interrupt/software.rs
+++ b/esp-hal/src/interrupt/software.rs
@@ -45,7 +45,7 @@
 //! }
 //! ```
 
-use crate::{interrupt::InterruptHandler, InterruptConfigurable};
+use crate::interrupt::{InterruptConfigurable, InterruptHandler};
 
 /// A software interrupt can be triggered by software.
 #[non_exhaustive]

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -12,7 +12,7 @@ use core::marker::PhantomData;
 
 use crate::{
     asynch::AtomicWaker,
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     lcd_cam::{cam::Cam, lcd::Lcd},
     macros::handler,
     peripheral::Peripheral,
@@ -21,7 +21,6 @@ use crate::{
     Async,
     Blocking,
     Cpu,
-    InterruptConfigurable,
 };
 
 /// Represents a combined LCD and Camera interface.

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -261,18 +261,6 @@ pub mod trapframe {
 // be directly exposed.
 mod soc;
 
-#[cfg(xtensa)]
-#[no_mangle]
-extern "C" fn EspDefaultHandler(_level: u32, _interrupt: peripherals::Interrupt) {
-    panic!("Unhandled level {} interrupt: {:?}", _level, _interrupt);
-}
-
-#[cfg(riscv)]
-#[no_mangle]
-extern "C" fn EspDefaultHandler(_interrupt: peripherals::Interrupt) {
-    panic!("Unhandled interrupt: {:?}", _interrupt);
-}
-
 /// A marker trait for initializing drivers in a specific mode.
 pub trait Mode: crate::private::Sealed {}
 
@@ -440,26 +428,6 @@ fn raw_core() -> usize {
 #[inline(always)]
 fn raw_core() -> usize {
     (xtensa_lx::get_processor_id() & 0x2000) as usize
-}
-
-/// Default (unhandled) interrupt handler
-pub const DEFAULT_INTERRUPT_HANDLER: interrupt::InterruptHandler = interrupt::InterruptHandler::new(
-    unsafe { core::mem::transmute::<*const (), extern "C" fn()>(EspDefaultHandler as *const ()) },
-    crate::interrupt::Priority::min(),
-);
-
-/// Trait implemented by drivers which allow the user to set an
-/// [interrupt::InterruptHandler]
-pub trait InterruptConfigurable: private::Sealed {
-    /// Set the interrupt handler
-    ///
-    /// Note that this will replace any previously registered interrupt handler.
-    /// Some peripherals offer a shared interrupt handler for multiple purposes.
-    /// It's the users duty to honor this.
-    ///
-    /// You can restore the default/unhandled interrupt handler by using
-    /// [DEFAULT_INTERRUPT_HANDLER]
-    fn set_interrupt_handler(&mut self, handler: interrupt::InterruptHandler);
 }
 
 #[cfg(riscv)]

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -156,13 +156,12 @@ use crate::{
         interconnect::{InputConnection, OutputConnection, PeripheralInput, PeripheralOutput},
         NoPin,
     },
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{self, Peripheral},
     peripherals::{Interrupt, PARL_IO},
     system::{self, GenericPeripheralGuard},
     Async,
     Blocking,
-    InterruptConfigurable,
     Mode,
 };
 

--- a/esp-hal/src/pcnt/mod.rs
+++ b/esp-hal/src/pcnt/mod.rs
@@ -95,11 +95,10 @@
 
 use self::unit::Unit;
 use crate::{
-    interrupt::{self, InterruptHandler},
+    interrupt::{self, InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{self, Interrupt},
     system::GenericPeripheralGuard,
-    InterruptConfigurable,
 };
 
 pub mod channel;

--- a/esp-hal/src/prelude.rs
+++ b/esp-hal/src/prelude.rs
@@ -36,5 +36,5 @@ mod imp {
     pub use crate::timer::timg::TimerGroupInstance as _esp_hal_timer_timg_TimerGroupInstance;
     #[cfg(any(systimer, timg0, timg1))]
     pub use crate::timer::Timer as _esp_hal_timer_Timer;
-    pub use crate::{clock::CpuClock, entry, macros::*, InterruptConfigurable};
+    pub use crate::{clock::CpuClock, entry, interrupt::InterruptConfigurable, macros::*};
 }

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -228,6 +228,7 @@ use fugit::HertzU32;
 use crate::{
     asynch::AtomicWaker,
     gpio::interconnect::{PeripheralInput, PeripheralOutput},
+    interrupt::InterruptConfigurable,
     macros::handler,
     peripheral::Peripheral,
     peripherals::Interrupt,
@@ -235,7 +236,6 @@ use crate::{
     system::{self, GenericPeripheralGuard},
     Async,
     Blocking,
-    InterruptConfigurable,
 };
 
 /// Errors

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -24,14 +24,13 @@
 use core::{marker::PhantomData, ptr::copy_nonoverlapping};
 
 use crate::{
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{Interrupt, RSA},
     system::{GenericPeripheralGuard, Peripheral as PeripheralEnable},
     Async,
     Blocking,
     Cpu,
-    InterruptConfigurable,
 };
 
 #[cfg_attr(esp32s2, path = "esp32sX.rs")]

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -49,7 +49,6 @@
 //! # use esp_hal::rtc_cntl::Rtc;
 //! # use esp_hal::rtc_cntl::Rwdt;
 //! # use esp_hal::rtc_cntl::RwdtStage;
-//! # use crate::esp_hal::InterruptConfigurable;
 //! static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 //!
 //! let mut delay = Delay::new();
@@ -126,12 +125,11 @@ use crate::peripherals::{LP_AON, LP_TIMER, LP_WDT};
 use crate::rtc_cntl::sleep::{RtcSleepConfig, WakeSource, WakeTriggers};
 use crate::{
     clock::Clock,
-    interrupt::{self, InterruptHandler},
+    interrupt::{self, InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::Interrupt,
     reset::{SleepSource, WakeupReason},
     Cpu,
-    InterruptConfigurable,
 };
 // only include sleep where it's been implemented
 #[cfg(any(esp32, esp32s3, esp32c3, esp32c6, esp32c2))]

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -102,7 +102,7 @@ impl<'d> Sha<'d> {
 impl crate::private::Sealed for Sha<'_> {}
 
 #[cfg(not(esp32))]
-impl crate::InterruptConfigurable for Sha<'_> {
+impl crate::interrupt::InterruptConfigurable for Sha<'_> {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         for core in crate::Cpu::other() {
             crate::interrupt::disable(core, Interrupt::SHA);

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -825,9 +825,9 @@ mod dma {
             Rx,
             Tx,
         },
+        interrupt::InterruptConfigurable,
         Async,
         Blocking,
-        InterruptConfigurable,
     };
 
     /// A DMA capable SPI instance.

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -43,9 +43,8 @@
 use fugit::{ExtU64, Instant, MicrosDurationU64};
 
 use crate::{
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
-    InterruptConfigurable,
 };
 
 #[cfg(systimer)]

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -72,13 +72,12 @@ use super::Error;
 use crate::soc::constants::TIMG_DEFAULT_CLK_SRC;
 use crate::{
     clock::Clocks,
-    interrupt::{self, InterruptHandler},
+    interrupt::{self, InterruptConfigurable, InterruptHandler},
     peripheral::Peripheral,
     peripherals::{timg0::RegisterBlock, Interrupt, TIMG0},
     private::Sealed,
     sync::{lock, Lock},
     system::PeripheralClockControl,
-    InterruptConfigurable,
 };
 
 const NUM_TIMG: usize = 1 + cfg!(timg1) as usize;

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -29,13 +29,13 @@ use core::marker::PhantomData;
 
 use crate::{
     gpio::TouchPin,
+    interrupt::InterruptConfigurable,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{RTC_CNTL, SENS, TOUCH},
     private::{Internal, Sealed},
     rtc_cntl::Rtc,
     Async,
     Blocking,
-    InterruptConfigurable,
     Mode,
 };
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -131,14 +131,13 @@ use crate::{
         OutputSignal,
         Pull,
     },
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::twai0::RegisterBlock,
     system::PeripheralGuard,
     twai::filter::SingleStandardFilter,
     Async,
     Blocking,
-    InterruptConfigurable,
 };
 
 pub mod filter;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -229,14 +229,13 @@ use crate::{
         OutputSignal,
         Pull,
     },
-    interrupt::InterruptHandler,
+    interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{uart0::RegisterBlock, Interrupt},
     private::Internal,
     system::{PeripheralClockControl, PeripheralGuard},
     Async,
     Blocking,
-    InterruptConfigurable,
     Mode,
 };
 

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -132,13 +132,13 @@ use procmacros::handler;
 
 use crate::{
     asynch::AtomicWaker,
+    interrupt::InterruptConfigurable,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{usb_device::RegisterBlock, Interrupt, USB_DEVICE},
     system::PeripheralClockControl,
     Async,
     Blocking,
     Cpu,
-    InterruptConfigurable,
     Mode,
 };
 

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -12,9 +12,9 @@ use critical_section::Mutex;
 use esp_hal::{
     delay::Delay,
     gpio::{AnyPin, Input, Io, Level, Output, Pin, Pull},
+    interrupt::InterruptConfigurable,
     macros::handler,
     timer::timg::TimerGroup,
-    InterruptConfigurable,
 };
 use hil_test as _;
 

--- a/hil-test/tests/gpio_custom_handler.rs
+++ b/hil-test/tests/gpio_custom_handler.rs
@@ -14,9 +14,9 @@
 use embassy_time::{Duration, Timer};
 use esp_hal::{
     gpio::{AnyPin, Input, Io, Level, Output, Pull},
+    interrupt::InterruptConfigurable,
     macros::handler,
     timer::timg::TimerGroup,
-    InterruptConfigurable,
 };
 use hil_test as _;
 use portable_atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

