### PR TITLE
Add derive macro for `BuilderLite`, add `#[non_exhaustive]` to some enums and structs

### DIFF
--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the `BuilderLite` derive macro which implements the Builder Lite pattern for a struct (#2614)
+
 ### Fixed
 
 ### Changed

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -468,6 +468,17 @@ pub fn builder_lite_derive(item: TokenStream) -> TokenStream {
                     self
                 }
             });
+
+            if maybe_path_type.is_some() {
+                let function_ident = format_ident!("with_{}_none", field_ident);
+                fns.push(quote! {
+                    #[doc = concat!(" Set the value of `", stringify!(#field_ident), "` to `None`.")]
+                    pub fn #function_ident(mut self) -> Self {
+                        self.#field_ident = None;
+                        self
+                    }
+                });
+            }
         }
     } else {
         return ParseError::new(

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -460,7 +460,7 @@ pub fn builder_lite_derive(item: TokenStream) -> TokenStream {
             };
 
             fns.push(quote! {
-                /// Assign the given value to the `#field_ident` field.
+                #[doc = concat!(" Assign the given value to the `", stringify!(#field_ident) ,"` field.")]
                 pub fn #function_ident(mut self, #field_ident: #field_type) -> Self {
                     self.#field_ident = #field_assigns;
                     self

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -52,7 +52,22 @@ use proc_macro::{Span, TokenStream};
 use proc_macro2::Ident;
 use proc_macro_crate::{crate_name, FoundCrate};
 use proc_macro_error2::abort;
-use syn::{parse, parse::Error as ParseError, spanned::Spanned, Item, ItemFn, ReturnType, Type};
+use quote::{format_ident, quote};
+use syn::{
+    parse,
+    parse::Error as ParseError,
+    spanned::Spanned,
+    Data,
+    DataStruct,
+    GenericArgument,
+    Item,
+    ItemFn,
+    Path,
+    PathArguments,
+    PathSegment,
+    ReturnType,
+    Type,
+};
 
 use self::interrupt::{check_attr_whitelist, WhiteListCaller};
 
@@ -238,8 +253,8 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
 /// esp_hal::interrupt::Priority::Priority2)]`.
 ///
 /// If no priority is given, `Priority::min()` is assumed
-#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
+#[proc_macro_error2::proc_macro_error]
 pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
     #[derive(Debug, FromMeta)]
     struct MacroArgs {
@@ -341,8 +356,8 @@ pub fn load_lp_code(input: TokenStream) -> TokenStream {
 
 /// Marks the entry function of a LP core / ULP program.
 #[cfg(any(feature = "is-lp-core", feature = "is-ulp-core"))]
-#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
+#[proc_macro_error2::proc_macro_error]
 pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     lp_core::entry(args, input)
 }
@@ -380,4 +395,110 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
     let f = syn::parse_macro_input!(item as syn::ItemFn);
 
     run(&args.meta, f, main()).unwrap_or_else(|x| x).into()
+}
+
+/// Automatically implement the [Builder Lite] pattern for a struct.
+///
+/// This will create an `impl` which contains methods for each field of a
+/// struct, allowing users to easily set the values. The generated methods will
+/// be the field name prefixed with `with_`, and calls to these methods can be
+/// chained as needed.
+///
+/// ## Example
+///
+/// ```rust, no_run
+/// #[derive(Default)]
+/// enum MyEnum {
+///     #[default]
+///     A,
+///     B,
+/// }
+///
+/// #[derive(Default, BuilderLite)]
+/// #[non_exhaustive]
+/// struct MyStruct {
+///     enum_field: MyEnum,
+///     bool_field: bool,
+///     option_field: Option<i32>,
+/// }
+///
+/// MyStruct::default()
+///     .with_enum_field(MyEnum::B)
+///     .with_bool_field(true)
+///     .with_option_field(-5);
+/// ```
+///
+/// [Builder Lite]: https://matklad.github.io/2022/05/29/builder-lite.html
+#[proc_macro_derive(BuilderLite)]
+pub fn builder_lite_derive(item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::DeriveInput);
+    let ident = input.ident;
+
+    let mut fns = Vec::new();
+    if let Data::Struct(DataStruct { fields, .. }) = &input.data {
+        for field in fields {
+            let field_ident = field.ident.as_ref().unwrap();
+            let field_type = &field.ty;
+
+            let function_ident = format_ident!("with_{}", field_ident);
+
+            let maybe_path_type = extract_type_path(field_type)
+                .and_then(|path| extract_option_segment(path))
+                .and_then(|path_seg| match path_seg.arguments {
+                    PathArguments::AngleBracketed(ref params) => params.args.first(),
+                    _ => None,
+                })
+                .and_then(|generic_arg| match *generic_arg {
+                    GenericArgument::Type(ref ty) => Some(ty),
+                    _ => None,
+                });
+
+            let (field_type, field_assigns) = if let Some(inner_type) = maybe_path_type {
+                (inner_type, quote! { Some(#field_ident) })
+            } else {
+                (field_type, quote! { #field_ident })
+            };
+
+            fns.push(quote! {
+                /// Assign the given value to the `#field_ident` field.
+                pub fn #function_ident(mut self, #field_ident: #field_type) -> Self {
+                    self.#field_ident = #field_assigns;
+                    self
+                }
+            });
+        }
+    } else {
+        panic!("#[derive(Builder)] is only defined for structs, not for enums or unions!");
+    }
+
+    let implementation = quote! {
+        #[automatically_derived]
+        impl #ident {
+            #(#fns)*
+        }
+    };
+
+    implementation.into()
+}
+
+// https://stackoverflow.com/a/56264023
+fn extract_type_path(ty: &Type) -> Option<&Path> {
+    match *ty {
+        Type::Path(ref typepath) if typepath.qself.is_none() => Some(&typepath.path),
+        _ => None,
+    }
+}
+
+// https://stackoverflow.com/a/56264023
+fn extract_option_segment(path: &Path) -> Option<&PathSegment> {
+    let idents_of_path = path.segments.iter().fold(String::new(), |mut acc, v| {
+        acc.push_str(&v.ident.to_string());
+        acc.push('|');
+        acc
+    });
+
+    vec!["Option|", "std|option|Option|", "core|option|Option|"]
+        .into_iter()
+        .find(|s| idents_of_path == *s)
+        .and_then(|_| path.segments.last())
 }

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -432,6 +432,8 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_derive(BuilderLite)]
 pub fn builder_lite_derive(item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::DeriveInput);
+
+    let span = input.span();
     let ident = input.ident;
 
     let mut fns = Vec::new();
@@ -468,7 +470,12 @@ pub fn builder_lite_derive(item: TokenStream) -> TokenStream {
             });
         }
     } else {
-        panic!("#[derive(Builder)] is only defined for structs, not for enums or unions!");
+        return ParseError::new(
+            span,
+            "#[derive(Builder)] is only defined for structs, not for enums or unions!",
+        )
+        .to_compile_error()
+        .into();
     }
 
     let implementation = quote! {

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `esp_hal::psram::psram_raw_parts` (#2546)
 - The timer drivers `OneShotTimer` & `PeriodicTimer` have `into_async` and `new_typed` methods (#2586)
 - `timer::Timer` trait has three new methods, `wait`, `async_interrupt_handler` and `peripheral_interrupt` (#2586)
+- Configuration structs in the I2C, SPI, and UART drivers now implement the Builder Lite pattern (#2614)
 
 ### Changed
 
@@ -42,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The timer drivers `OneShotTimer` & `PeriodicTimer` now have a `Mode` parameter and type erase the underlying driver by default (#2586)
 - `timer::Timer` has new trait requirements of `Into<AnyTimer>`, `'static` and `InterruptConfigurable` (#2586)
 - `systimer::etm::Event` no longer borrows the alarm indefinitely (#2586)
+- A number of public enums and structs in the I2C, SPI, and UART drivers have been marked with `#[non_exhaustive]` (#2614)
 
 ### Fixed
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -28,11 +28,7 @@
 //!
 //! let mut spi = Spi::new_with_config(
 //!     peripherals.SPI2,
-//!     Config {
-//!         frequency: 100.kHz(),
-//!         mode: SpiMode::Mode0,
-//!         ..Config::default()
-//!     },
+//!     Config::default().with_frequency(100.kHz()).with_mode(SpiMode::Mode0)
 //! )
 //! .with_sck(sclk)
 //! .with_mosi(mosi)

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -86,6 +86,7 @@ const MAX_ITERATIONS: u32 = 1_000_000;
 /// I2C-specific transmission errors
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Error {
     /// The transmission exceeded the FIFO size.
     ExceedingFifo,
@@ -106,14 +107,15 @@ pub enum Error {
 /// I2C-specific configuration errors
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ConfigError {}
 
-#[derive(PartialEq)]
 // This enum is used to keep track of the last/next operation that was/will be
 // performed in an embedded-hal(-async) I2c::transaction. It is used to
 // determine whether a START condition should be issued at the start of the
 // current operation and whether a read needs an ack or a nack for the final
 // byte.
+#[derive(PartialEq)]
 enum OpKind {
     Write,
     Read,
@@ -217,6 +219,7 @@ enum Ack {
     Ack  = 0,
     Nack = 1,
 }
+
 impl From<u32> for Ack {
     fn from(ack: u32) -> Self {
         match ack {
@@ -226,6 +229,7 @@ impl From<u32> for Ack {
         }
     }
 }
+
 impl From<Ack> for u32 {
     fn from(ack: Ack) -> u32 {
         ack as u32
@@ -233,8 +237,9 @@ impl From<Ack> for u32 {
 }
 
 /// I2C driver configuration
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, procmacros::BuilderLite)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub struct Config {
     /// The I2C clock frequency.
     pub frequency: HertzU32,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -45,11 +45,7 @@
 //!
 //! let mut spi = Spi::new_with_config(
 //!     peripherals.SPI2,
-//!     Config {
-//!         frequency: 100.kHz(),
-//!         mode: SpiMode::Mode0,
-//!         ..Config::default()
-//!     },
+//!     Config::default().with_frequency(100.kHz()).with_mode(SpiMode::Mode0)
 //! )
 //! .with_sck(sclk)
 //! .with_mosi(mosi)
@@ -93,6 +89,7 @@ use crate::{
 #[cfg(gdma)]
 #[derive(Debug, EnumSetType)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum SpiInterrupt {
     /// Indicates that the SPI transaction has completed successfully.
     ///
@@ -423,8 +420,9 @@ impl Address {
 }
 
 /// SPI peripheral configuration
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, procmacros::BuilderLite)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub struct Config {
     /// SPI clock frequency
     pub frequency: HertzU32,

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -17,6 +17,7 @@ pub mod slave;
 /// SPI errors
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Error {
     /// Error occurred due to a DMA-related issue.
     DmaError(DmaError),

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -59,11 +59,9 @@ async fn main(_spawner: Spawner) {
 
     let mut spi = Spi::new_with_config(
         peripherals.SPI2,
-        Config {
-            frequency: 100.kHz(),
-            mode: SpiMode::Mode0,
-            ..Config::default()
-        },
+        Config::default()
+            .with_frequency(100.kHz())
+            .with_mode(SpiMode::Mode0),
     )
     .with_sck(sclk)
     .with_mosi(mosi)

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -39,11 +39,9 @@ fn main() -> ! {
 
     let mut spi = Spi::new_with_config(
         peripherals.SPI2,
-        Config {
-            frequency: 100.kHz(),
-            mode: SpiMode::Mode0,
-            ..Config::default()
-        },
+        Config::default()
+            .with_frequency(100.kHz())
+            .with_mode(SpiMode::Mode0),
     )
     .with_sck(sclk)
     .with_miso(miso) // order matters

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -90,11 +90,9 @@ fn main() -> ! {
     // output connection (because we are using the same pin to loop back)
     let mut spi = Spi::new_with_config(
         peripherals.SPI2,
-        Config {
-            frequency: 100.kHz(),
-            mode: SpiMode::Mode0,
-            ..Config::default()
-        },
+        Config::default()
+            .with_frequency(100.kHz())
+            .with_mode(SpiMode::Mode0),
     )
     .with_sck(sclk)
     .with_miso(miso)

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -120,11 +120,9 @@ mod test {
 
         let mut spi = Spi::new_with_config(
             peripherals.SPI2,
-            Config {
-                frequency: 10000.kHz(),
-                mode: SpiMode::Mode0,
-                ..Config::default()
-            },
+            Config::default()
+                .with_frequency(10000.kHz())
+                .with_mode(SpiMode::Mode0),
         )
         .with_miso(unsafe { mosi.clone_unchecked() })
         .with_mosi(mosi)
@@ -135,11 +133,9 @@ mod test {
         #[cfg(any(esp32, esp32s2, esp32s3))]
         let other_peripheral = Spi::new_with_config(
             peripherals.SPI3,
-            Config {
-                frequency: 10000.kHz(),
-                mode: SpiMode::Mode0,
-                ..Config::default()
-            },
+            Config::default()
+                .with_frequency(10000.kHz())
+                .with_mode(SpiMode::Mode0),
         )
         .with_dma(dma_channel2)
         .into_async();
@@ -231,11 +227,9 @@ mod test {
 
             let mut spi = Spi::new_with_config(
                 peripherals.spi,
-                Config {
-                    frequency: 100.kHz(),
-                    mode: SpiMode::Mode0,
-                    ..Config::default()
-                },
+                Config::default()
+                    .with_frequency(100.kHz())
+                    .with_mode(SpiMode::Mode0),
             )
             .with_dma(peripherals.dma_channel)
             .with_buffers(dma_rx_buf, dma_tx_buf)

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -202,11 +202,9 @@ mod tests {
 
         let spi = Spi::new_with_config(
             peripherals.SPI2,
-            Config {
-                frequency: 100.kHz(),
-                mode: SpiMode::Mode0,
-                ..Config::default()
-            },
+            Config::default()
+                .with_frequency(100.kHz())
+                .with_mode(SpiMode::Mode0),
         );
 
         Context {

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -73,15 +73,11 @@ mod tests {
         let (mosi_loopback_pcnt, mosi) = mosi.split();
         // Need to set miso first so that mosi can overwrite the
         // output connection (because we are using the same pin to loop back)
-        let spi = Spi::new_with_config(
-            peripherals.SPI2,
-            Config::default()
-                .with_frequency(10.MHz())
-                .with_mode(SpiMode::Mode0),
-        )
-        .with_sck(sclk)
-        .with_miso(unsafe { mosi.clone_unchecked() })
-        .with_mosi(mosi);
+        let spi =
+            Spi::new_with_config(peripherals.SPI2, Config::default().with_frequency(10.MHz()))
+                .with_sck(sclk)
+                .with_miso(unsafe { mosi.clone_unchecked() })
+                .with_mosi(mosi);
 
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -75,10 +75,9 @@ mod tests {
         // output connection (because we are using the same pin to loop back)
         let spi = Spi::new_with_config(
             peripherals.SPI2,
-            Config {
-                frequency: 10.MHz(),
-                ..Config::default()
-            },
+            Config::default()
+                .with_frequency(10.MHz())
+                .with_mode(SpiMode::Mode0),
         )
         .with_sck(sclk)
         .with_miso(unsafe { mosi.clone_unchecked() })
@@ -487,10 +486,7 @@ mod tests {
         // This means that without working cancellation, the test case should
         // fail.
         ctx.spi
-            .apply_config(&Config {
-                frequency: 80.kHz(),
-                ..Config::default()
-            })
+            .apply_config(&Config::default().with_frequency(80.kHz()))
             .unwrap();
 
         // Set up a large buffer that would trigger a timeout
@@ -513,10 +509,7 @@ mod tests {
     fn can_transmit_after_cancel(mut ctx: Context) {
         // Slow down. At 80kHz, the transfer is supposed to take a bit over 3 seconds.
         ctx.spi
-            .apply_config(&Config {
-                frequency: 80.kHz(),
-                ..Config::default()
-            })
+            .apply_config(&Config::default().with_frequency(80.kHz()))
             .unwrap();
 
         // Set up a large buffer that would trigger a timeout
@@ -533,11 +526,8 @@ mod tests {
         transfer.cancel();
         (spi, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
 
-        spi.apply_config(&Config {
-            frequency: 10.MHz(),
-            ..Config::default()
-        })
-        .unwrap();
+        spi.apply_config(&Config::default().with_frequency(10.MHz()))
+            .unwrap();
 
         let transfer = spi
             .transfer(dma_rx_buf, dma_tx_buf)

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -48,11 +48,9 @@ mod tests {
 
         let spi = Spi::new_with_config(
             peripherals.SPI2,
-            Config {
-                frequency: 100.kHz(),
-                mode: SpiMode::Mode0,
-                ..Config::default()
-            },
+            Config::default()
+                .with_frequency(100.kHz())
+                .with_mode(SpiMode::Mode0),
         )
         .with_sck(sclk)
         .with_miso(miso)

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -52,11 +52,9 @@ mod tests {
 
         let spi = Spi::new_with_config(
             peripherals.SPI2,
-            Config {
-                frequency: 100.kHz(),
-                mode: SpiMode::Mode0,
-                ..Config::default()
-            },
+            Config::default()
+                .with_frequency(100.kHz())
+                .with_mode(SpiMode::Mode0),
         )
         .with_sck(sclk)
         .with_mosi(mosi)

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -64,11 +64,9 @@ mod tests {
 
         let spi = Spi::new_with_config(
             peripherals.SPI2,
-            Config {
-                frequency: 100.kHz(),
-                mode: SpiMode::Mode0,
-                ..Config::default()
-            },
+            Config::default()
+                .with_frequency(100.kHz())
+                .with_mode(SpiMode::Mode0),
         )
         .with_sck(sclk)
         .with_mosi(mosi)

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -91,7 +91,7 @@ mod tests {
         for (baudrate, clock_source) in configs {
             ctx.uart
                 .apply_config(
-                    &Config::default()
+                    &uart::Config::default()
                         .with_baudrate(baudrate)
                         .with_clock_source(clock_source),
                 )

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -90,11 +90,11 @@ mod tests {
         let mut byte_to_write = 0xA5;
         for (baudrate, clock_source) in configs {
             ctx.uart
-                .apply_config(&uart::Config {
-                    baudrate,
-                    clock_source,
-                    ..Default::default()
-                })
+                .apply_config(
+                    &Config::default()
+                        .with_baudrate(baudrate)
+                        .with_clock_source(clock_source),
+                )
                 .unwrap();
             ctx.uart.write(byte_to_write).ok();
             let read = block!(ctx.uart.read());

--- a/qa-test/src/bin/lcd_dpi.rs
+++ b/qa-test/src/bin/lcd_dpi.rs
@@ -36,8 +36,7 @@ use esp_hal::{
     delay::Delay,
     dma_loop_buffer,
     gpio::{Level, Output},
-    i2c,
-    i2c::master::I2c,
+    i2c::{self, master::I2c},
     lcd_cam::{
         lcd::{
             dpi::{Config, Dpi, Format, FrameTiming},
@@ -61,10 +60,7 @@ fn main() -> ! {
 
     let i2c = I2c::new(
         peripherals.I2C0,
-        i2c::master::Config {
-            frequency: 400.kHz(),
-            ..Default::default()
-        },
+        i2c::master::Config::default().with_frequency(400.kHz()),
     )
     .with_sda(peripherals.GPIO47)
     .with_scl(peripherals.GPIO48);

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -77,11 +77,9 @@ fn main() -> ! {
 
     let mut spi = Spi::new_with_config(
         peripherals.SPI2,
-        Config {
-            frequency: 100.kHz(),
-            mode: SpiMode::Mode0,
-            ..Config::default()
-        },
+        Config::default()
+            .with_frequency(100.kHz())
+            .with_mode(SpiMode::Mode0),
     )
     .with_sck(sclk)
     .with_mosi(mosi)

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -63,11 +63,9 @@ fn main() -> ! {
 
     let mut spi = Spi::new_with_config(
         peripherals.SPI2,
-        Config {
-            frequency: 100.kHz(),
-            mode: SpiMode::Mode0,
-            ..Config::default()
-        },
+        Config::default()
+            .with_frequency(100.kHz())
+            .with_mode(SpiMode::Mode0),
     )
     .with_sck(sclk)
     .with_mosi(mosi)


### PR DESCRIPTION
This is working towards #2500.

First, I've created a derive procmacro to implement the Builder Lite pattern on a struct automatically. Definitely not an expert on procmacros, so welcome to hear any feedback here, but seems to be working at least.

Additionally, I've started adding `#[non_exhaustive]` to  public enums and structs where necessary, starting with the core peripherals which we are looking to stabilize in our `1.x.x.` release. Based on comments in the GPIO analysis issue, it is not clear that any of these are currently required there, but let me know if this is incorrect. Additionally, if you feel any of these attributes are missing in the included drivers, or that any which I've added are not necessary, please let me know.

Once this is merged I will continue to work on adding these to other drivers, just wanted to prove this out first with a limited subset.