### PR TITLE
Add new function `esp_hal::try_init`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `esp_hal::psram::psram_raw_parts` (#2546)
 - The timer drivers `OneShotTimer` & `PeriodicTimer` have `into_async` and `new_typed` methods (#2586)
 - `timer::Timer` trait has three new methods, `wait`, `async_interrupt_handler` and `peripheral_interrupt` (#2586)
+- Configuration structs in the I2C, SPI, and UART drivers now implement the Builder Lite pattern (#2614)
+- Improve safety for verifying `init` is only called once, 
+  add `try_init` function for safely initializing peripheral when they may already have been (#2618)
 
 ### Changed
 
@@ -42,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The timer drivers `OneShotTimer` & `PeriodicTimer` now have a `Mode` parameter and type erase the underlying driver by default (#2586)
 - `timer::Timer` has new trait requirements of `Into<AnyTimer>`, `'static` and `InterruptConfigurable` (#2586)
 - `systimer::etm::Event` no longer borrows the alarm indefinitely (#2586)
+- A number of public enums and structs in the I2C, SPI, and UART drivers have been marked with `#[non_exhaustive]` (#2614)
 
 ### Fixed
 

--- a/hil-test/tests/init.rs
+++ b/hil-test/tests/init.rs
@@ -107,4 +107,19 @@ mod tests {
         let delay = Delay::new();
         delay.delay(2000.millis());
     }
+
+    #[test]
+    #[timeout(3)]
+    fn test_init_then_try_init() {
+        esp_hal::init(Config::default());
+
+        esp_hal::try_init(Config::default());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_try_init_then_init() {
+        esp_hal::try_init(Config::default());
+        esp_hal::init(Config::default());
+    }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [X] I have updated existing examples or added new ones (if applicable).
- [X] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [X] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.22.md).
- [X] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [X] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds a new function `esp_hal::try_init`. This function initializes the system *only if it hasn't been already*, then steals the peripherals and returns them.

The main use case for this functionality is for panic handlers that require peripheral access (e.g. to notify the user that a panic has occurred on a hardware display). The panic handler should not rely on the prior initialization of the system. However, if it has not yet been initialized, `steal`ing the peripherals is insufficient. In contrast, trying to re-initialize the system from inside the panic handler causes the panic handler to get caught in a death loop if the main program has already called `init`. The `try_init` function will check if the system has already been initialized and, if not, will call `init_internal` (where I have moved the implementation of `init`, aside from the taking of the peripherals). The output is always the stolen peripherals, and as such the function is marked as `unsafe`.

Previously, [`Peripherals::take()`](https://github.com/esp-rs/esp-hal/blob/bdfec3781fd59c4d51173706e3cbee3760bbf8b6/esp-hal/src/peripheral.rs#L269) would unsafely check an unmangled `static mut bool`. This PR replaces that with an [`AtomicBool`](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicBool.html) to ensure (attempt) safety. 

#### Testing
[Some simple tests](https://github.com/esp-rs/esp-hal/commit/45cb1615a907052e8e616031a3386d1967cf2621#diff-7c56a29dfbafd9b41963b6998cfcd1c77646d61e69b5ea0296d225a37c9973d7R113) have been added to [`hil-test`](https://github.com/esp-rs/esp-hal/blob/main/hil-test/), but I cannot verify its success as I do not own a JTAG-compatible board.

In lieu of this, I wrote a small crate to verify my changes worked as expected. The board used is the Wemos LOLIN32 with a built-in [SSD1306](https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf) OLED display (unofficial info about the board can be found [here](https://makeradvisor.com/tools/wemos-lolin32-esp32-oled/), I cannot find any reference to it from [Wemos](https://www.wemos.cc) themselves). The ESP module on the board is an [ESP32-WROOM-32](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32_datasheet_en.pdf).

The `src/main.rs` (contents below) file contains several commented-out `main` functions with explanations as to what each one is for. Each one was flashed to the board and executed separately and successfully. I will continue to try to implement similar tests to the main functions above in `hil-test`, but I'm still working out how I could do so in a board-agnostic fashion.

```rust
#![no_std]
#![no_main]
#![allow(unused)]
#![feature(future_join)]

use core::{fmt::Write, future::join};
use embassy_time::Delay;
use embedded_hal_async::delay::DelayNs;
use esp_backtrace as _;
use esp_hal::{entry, gpio::GpioPin, i2c::master::I2c, peripherals::I2C0, timer::timg::TimerGroup};
use esp_println::println;
use ssd1306::{
    mode::{DisplayConfig, DisplayConfigAsync},
    rotation::DisplayRotation,
    size::DisplaySize128x64,
    I2CDisplayInterface, Ssd1306, Ssd1306Async,
};

// This is the use case for the API proposed in this PR.
#[no_mangle]
fn custom_pre_backtrace() {
    let mut display = {
        let peripherals = unsafe { esp_hal::try_init(Default::default()) };

        Ssd1306::new(
            I2CDisplayInterface::new(
                I2c::new(peripherals.I2C0, Default::default())
                    .with_sda(peripherals.GPIO5)
                    .with_scl(peripherals.GPIO4),
            ),
            DisplaySize128x64,
            DisplayRotation::Rotate0,
        )
        .into_terminal_mode()
    };

    _ = display.init();
    _ = display.clear();

    _ = display.write_str("PANICKED\nConnect USB for details");
}

/*
Used between executions of other `main` functions in this file, otherwise display state may persist between flashings.

#[entry]
fn main() -> ! {
    let peripherals = esp_hal::init(Default::default());
    let mut display = Ssd1306::new(
        I2CDisplayInterface::new(
            I2c::new(peripherals.I2C0, Default::default())
                .with_sda(peripherals.GPIO5)
                .with_scl(peripherals.GPIO4),
        ),
        DisplaySize128x64,
        DisplayRotation::Rotate0,
    )
    .into_terminal_mode();
    display.init().unwrap();
    display.clear().unwrap();

    println!("done");

    loop {}
}
*/

/*
Panic after initialization

#[entry]
fn main() -> ! {
    const MESSAGE: &'static str = "Hello, World!";

    let peripherals = esp_hal::init(Default::default());
    let delay = esp_hal::delay::Delay::new();

    let mut display = Ssd1306::new(
        I2CDisplayInterface::new(
            I2c::new(peripherals.I2C0, Default::default())
                .with_sda(peripherals.GPIO5)
                .with_scl(peripherals.GPIO4),
        ),
        DisplaySize128x64,
        DisplayRotation::Rotate0,
    )
    .into_terminal_mode();
    display.init().unwrap();

    display.clear().unwrap();
    for character in MESSAGE.chars() {
        display.print_char(character).unwrap();
        delay.delay_millis(100);
    }

    panic!("A panic message");
}
*/

/*
Panic without initialization

#[entry]
fn main() -> ! {
    panic!("A panic message")
}
*/

/*
Demonstrates that:
- `init` still behaves the same as it did before (i.e. panics if you try to call it more than once)
- When the second call to `init` panics, the panic handler still operates as expected

#[entry]
fn main() -> ! {
    esp_hal::init(Default::default());
    esp_hal::init(Default::default());
    unreachable!()
}
*/

/*
Panic after initialization in an asynchronous context

#[esp_hal_embassy::main]
async fn main(_spawner: embassy_executor::Spawner) {
    const MESSAGE: &'static str = "Hello, World!";

    let peripherals = esp_hal::init(Default::default());

    esp_hal_embassy::init(TimerGroup::new(peripherals.TIMG0).timer0);

    let mut delay = Delay;

    let mut display = Ssd1306Async::new(
        I2CDisplayInterface::new(
            I2c::new(peripherals.I2C0, Default::default())
                .with_sda(peripherals.GPIO5)
                .with_scl(peripherals.GPIO4)
                .into_async(),
        ),
        DisplaySize128x64,
        DisplayRotation::Rotate0,
    )
    .into_terminal_mode();
    display.init().await.unwrap();

    display.clear().await.unwrap();
    for character in MESSAGE.chars() {
        display.print_char(character).await.unwrap();
        delay.delay_ms(100).await;
    }

    panic!("A panic message");
}
*/

/*
Panic without initialization in an asynchronous context

#[esp_hal_embassy::main]
async fn main(_spawner: embassy_executor::Spawner) {
    panic!("A panic message")
}
*/
```