### PR TITLE
Add heap usage stats with defmt

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `esp_alloc::HEAP.stats()` can now be used to get heap usage informations (#2137)
+
 ### Changed
 
 ### Fixed

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -27,14 +27,16 @@ cfg-if                = "1.0.0"
 critical-section      = "1.1.3"
 enumset               = "1.1.5"
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
+document-features = "0.2.10"
 
 [features]
 default = []
 nightly = []
 
-# Enable this feature if you want to keep stats about the internal heap usage such as:
-# - Max memory usage since initialization of the heap
-# - Total allocated memory since initialization of the heap
-# - Total freed memory since initialization of the heap
-# Note: Enabling this feature will require extra computation every time alloc/dealloc is called.
+## Enable this feature if you want to keep stats about the internal heap usage such as:
+## - Max memory usage since initialization of the heap
+## - Total allocated memory since initialization of the heap
+## - Total freed memory since initialization of the heap
+##
+## ⚠️ Note: Enabling this feature will require extra computation every time alloc/dealloc is called.
 internal-heap-stats = []

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -23,6 +23,7 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["nightly"]
 
 [dependencies]
+cfg-if                = "1.0.0"
 critical-section      = "1.1.3"
 enumset               = "1.1.5"
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
@@ -30,3 +31,10 @@ linked_list_allocator = { version = "0.10.5", default-features = false, features
 [features]
 default = []
 nightly = []
+
+# Enable this feature if you want to keep stats about the internal heap usage such as:
+# - Max memory usage since initialization of the heap
+# - Total allocated memory since initialization of the heap
+# - Total freed memory since initialization of the heap
+# Note: Enabling this feature will require extra computation every time alloc/dealloc is called.
+internal-heap-stats = []

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -23,6 +23,7 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["nightly"]
 
 [dependencies]
+defmt = { version = "0.3.8", optional = true }
 cfg-if                = "1.0.0"
 critical-section      = "1.1.3"
 enumset               = "1.1.5"
@@ -32,6 +33,9 @@ document-features = "0.2.10"
 [features]
 default = []
 nightly = []
+
+## Implement `defmt::Format` on certain types.
+defmt = ["dep:defmt"]
 
 ## Enable this feature if you want to keep stats about the internal heap usage such as:
 ## - Max memory usage since initialization of the heap

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -23,12 +23,12 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["nightly"]
 
 [dependencies]
-defmt = { version = "0.3.8", optional = true }
+defmt                 = { version = "0.3.8", optional = true }
 cfg-if                = "1.0.0"
 critical-section      = "1.1.3"
 enumset               = "1.1.5"
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
-document-features = "0.2.10"
+document-features     = "0.2.10"
 
 [features]
 default = []

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -52,7 +52,7 @@
 //! let large_buffer: Vec<u8, _> = Vec::with_capacity_in(1048576, &PSRAM_ALLOCATOR);
 //! ```
 //!
-//! You can also gets stats about the heap usage at anytime with:
+//! You can also get stats about the heap usage at anytime with:
 //! ```rust
 //! let stats: HeapStats = esp_alloc::HEAP.stats();
 //! // HeapStats implements the Display and defmt::Format traits, so you can pretty print the heap stats.

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -561,8 +561,9 @@ unsafe impl GlobalAlloc for EspHeap {
             {
                 let mut internal_heap_stats = self.internal_heap_stats.borrow_ref_mut(cs);
                 drop(regions);
-                // We need to call `used()` because [linked_list_allocator::Heap] does internal size
-                // alignment so we cannot use the size provided by the layout.
+                // We need to call `used()` because [linked_list_allocator::Heap] does internal
+                // size alignment so we cannot use the size provided by the
+                // layout.
                 internal_heap_stats.total_freed += before - self.used();
             }
         })

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -55,19 +55,19 @@
 //! You can also gets stats about the heap usage at anytime with:
 //! ```rust
 //! let stats: HeapStats = esp_alloc::HEAP.stats();
-//! // HeapStats implements the Display trait, so you can pretty print the heap stats.
+//! // HeapStats implements the Display and defmt::Format traits, so you can pretty print the heap stats.
 //! println!("{}", stats);
 //! ```
 //!
 //! ```txt
 //! HEAP INFO
-//! Size: 2097152
-//! Current usage: 512028
-//! Max usage: 512028
+//! Size: 131068
+//! Current usage: 46148
+//! Max usage: 46148
 //! Total freed: 0
-//! Total allocated: 512028
+//! Total allocated: 46148
 //! Memory Layout:
-//! External | ████████░░░░░░░░░░░░░░░░░░░░░░░░░░░ | Used: 512028 / Total: 2097152 (Free: 1585124)
+//! Internal | ████████████░░░░░░░░░░░░░░░░░░░░░░░ | Used: 35% (Used 46148 of 131068, free: 84920)
 //! Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |
 //! Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |
 //! ```

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -561,7 +561,7 @@ unsafe impl GlobalAlloc for EspHeap {
             {
                 let mut internal_heap_stats = self.internal_heap_stats.borrow_ref_mut(cs);
                 drop(regions);
-                // We need to call used because [linked_list_allocator::Heap] does internal size
+                // We need to call `used()` because [linked_list_allocator::Heap] does internal size
                 // alignment so we cannot use the size provided by the layout.
                 internal_heap_stats.total_freed += before - self.used();
             }

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -103,14 +103,14 @@ const BAR_WIDTH: usize = 35;
 fn write_bar(f: &mut core::fmt::Formatter<'_>, usage_percent: usize) -> core::fmt::Result {
     let used_blocks = BAR_WIDTH * usage_percent / 100;
     (0..used_blocks).try_for_each(|_| write!(f, "█"))?;
-    (0..BAR_WIDTH - used_blocks).try_for_each(|_| write!(f, "░"))
+    (used_blocks..BAR_WIDTH).try_for_each(|_| write!(f, "░"))
 }
 
 #[cfg(feature = "defmt")]
 fn write_bar_defmt(fmt: defmt::Formatter, usage_percent: usize) {
     let used_blocks = BAR_WIDTH * usage_percent / 100;
     (0..used_blocks).for_each(|_| defmt::write!(fmt, "█"));
-    (0..BAR_WIDTH - used_blocks).for_each(|_| defmt::write!(fmt, "░"));
+    (used_blocks..BAR_WIDTH).for_each(|_| defmt::write!(fmt, "░"));
 }
 
 #[derive(EnumSetType, Debug)]

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -191,7 +191,6 @@ impl defmt::Format for RegionStats {
     }
 }
 
-
 /// A memory region to be used as heap memory
 pub struct HeapRegion {
     heap: Heap,

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -55,7 +55,7 @@
 //! You can also get stats about the heap usage at anytime with:
 //! ```rust
 //! let stats: HeapStats = esp_alloc::HEAP.stats();
-//! // HeapStats implements the Display and defmt::Format traits, so you can pretty print the heap stats.
+//! // HeapStats implements the Display and defmt::Format traits, so you can pretty-print the heap stats.
 //! println!("{}", stats);
 //! ```
 //!

--- a/esp-alloc/src/macros.rs
+++ b/esp-alloc/src/macros.rs
@@ -41,3 +41,16 @@ macro_rules! psram_allocator {
         }
     }};
 }
+
+/// Gets the usage stats for the current memory heap
+///
+/// # Usage
+/// ```rust, no_run
+/// esp_alloc::get_info!();
+/// ```
+#[macro_export]
+macro_rules! get_info {
+    () => {{
+        $crate::HEAP.stats()
+    }};
+}

--- a/esp-alloc/src/macros.rs
+++ b/esp-alloc/src/macros.rs
@@ -41,16 +41,3 @@ macro_rules! psram_allocator {
         }
     }};
 }
-
-/// Gets the usage stats for the current memory heap
-///
-/// # Usage
-/// ```rust, no_run
-/// esp_alloc::get_info!();
-/// ```
-#[macro_export]
-macro_rules! get_info {
-    () => {{
-        $crate::HEAP.stats()
-    }};
-}

--- a/qa-test/src/bin/psram_quad.rs
+++ b/qa-test/src/bin/psram_quad.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
     let string = String::from("A string allocated in PSRAM");
     println!("'{}' allocated at {:p}", &string, string.as_ptr());
 
-    println!("{}", esp_alloc::get_info!());
+    println!("{}", esp_alloc::HEAP.stats());
 
     println!("done");
 

--- a/qa-test/src/bin/psram_quad.rs
+++ b/qa-test/src/bin/psram_quad.rs
@@ -2,8 +2,8 @@
 //!
 //! You need an ESP32, ESP32-S2 or ESP32-S3 with at least 2 MB of PSRAM memory.
 
-//% CHIPS: esp32 esp32s2 esp32s3
-//% FEATURES: esp-hal/quad-psram
+//% CHIPS: esp32 esp32s2 sp32s3
+//% FEATURES: esp-hal/quad-psram esp-alloc/internal-heap-stats
 
 #![no_std]
 #![no_main]
@@ -51,6 +51,8 @@ fn main() -> ! {
 
     let string = String::from("A string allocated in PSRAM");
     println!("'{}' allocated at {:p}", &string, string.as_ptr());
+
+    println!("{}", esp_alloc::get_info!());
 
     println!("done");
 

--- a/qa-test/src/bin/psram_quad.rs
+++ b/qa-test/src/bin/psram_quad.rs
@@ -2,7 +2,7 @@
 //!
 //! You need an ESP32, ESP32-S2 or ESP32-S3 with at least 2 MB of PSRAM memory.
 
-//% CHIPS: esp32 esp32s2 sp32s3
+//% CHIPS: esp32 esp32s2 esp32s3
 //% FEATURES: esp-hal/quad-psram esp-alloc/internal-heap-stats
 
 #![no_std]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

This is based on https://github.com/esp-rs/esp-hal/pull/2137 with defmt::Format trait properly implemented and minor changes in format of heap stats, tested with defmt on esp32-c3