### PR TITLE
esp-hal: otg_fs: drop obsolete late cnak quirk

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -29,7 +29,7 @@ embassy-embedded-hal     = { version = "0.2.0", optional = true }
 embassy-futures          = "0.1.1"
 embassy-sync             = "0.6.1"
 embassy-usb-driver       = { version = "0.1.0", optional = true }
-embassy-usb-synopsys-otg = { version = "0.1.0", optional = true }
+embassy-usb-synopsys-otg = { version = "0.2.0", optional = true }
 embedded-can             = { version = "0.4.1", optional = true }
 embedded-hal             = "1.0.0"
 embedded-hal-async       = "1.0.0"


### PR DESCRIPTION
## Thank you for your contribution!



We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Current embassy main [dropped](https://github.com/embassy-rs/embassy/pull/3565) this quirk. I needed this commit to get it to compile again.

Opening as draft as some checkboxes are missing, I didn't actually test this and also there's no version change upstream. (This will fail CI unless somehow a patch.crates-io points to a current embassy branch).

#### Testing
Describe how you tested your changes.
