### PR TITLE
Use opt-level to detect debug profile

### DIFF
--- a/examples/build.rs
+++ b/examples/build.rs
@@ -2,8 +2,11 @@ fn main() {
     // Allow building examples in CI in debug mode
     println!("cargo:rustc-check-cfg=cfg(is_not_release)");
     println!("cargo:rerun-if-env-changed=CI");
-    #[cfg(debug_assertions)]
     if std::env::var("CI").is_err() {
-        println!("cargo::rustc-cfg=is_not_release");
+        if let Ok(level) = std::env::var("OPT_LEVEL") {
+            if level == "0" || level == "1" {
+                println!("cargo::rustc-cfg=is_not_release");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Aligns debug profile detection in examples with what esp-hal is doing

#### Testing
`cargo xtask run-example esp-hal esp32c6 embassy_rmt_rx --debug`
 