### PR TITLE
Don't require importing macro for esp-config

### DIFF
--- a/esp-config/CHANGELOG.md
+++ b/esp-config/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Users no longer have to manually import `esp_config_int_parse`. (#2630)
+
 ### Changed
 
 ### Removed

--- a/esp-config/src/lib.rs
+++ b/esp-config/src/lib.rs
@@ -29,7 +29,7 @@ macro_rules! esp_config_int {
     ( $ty:ty, $var:expr ) => {
         const {
             const BYTES: &[u8] = env!($var).as_bytes();
-            esp_config_int_parse!($ty, BYTES)
+            $crate::esp_config_int_parse!($ty, BYTES)
         }
     };
 }


### PR DESCRIPTION
Fixes this:

```
error: cannot find macro `esp_config_int_parse` in this scope
   --> C:\_Espressif\esp-hal\esp-hal-embassy\src\executor\mod.rs:176:11
    |
176 |         { esp_config::esp_config_int!(usize, "ESP_HAL_EMBASSY_GENERIC_QUEUE_SIZE") },
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `esp_config::esp_config_int` (in Nightly builds, run with -Z macro-backtrace for more info)
```