### PR TITLE
Hide most of the unstable peripherals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,10 @@ jobs:
 
       - name: msrv RISCV (esp-wifi)
         run: |
-          cargo xtask build-package --features=esp32c2,wifi,ble --target=riscv32imc-unknown-none-elf   esp-wifi
-          cargo xtask build-package --features=esp32c3,wifi,ble --target=riscv32imc-unknown-none-elf   esp-wifi
-          cargo xtask build-package --features=esp32c6,wifi,ble --target=riscv32imac-unknown-none-elf  esp-wifi
-          cargo xtask build-package --features=esp32h2,ble --target=riscv32imac-unknown-none-elf  esp-wifi
+          cargo xtask build-package --features=esp32c2,wifi,ble,esp-hal/unstable --target=riscv32imc-unknown-none-elf   esp-wifi
+          cargo xtask build-package --features=esp32c3,wifi,ble,esp-hal/unstable --target=riscv32imc-unknown-none-elf   esp-wifi
+          cargo xtask build-package --features=esp32c6,wifi,ble,esp-hal/unstable --target=riscv32imac-unknown-none-elf  esp-wifi
+          cargo xtask build-package --features=esp32h2,ble,esp-hal/unstable --target=riscv32imac-unknown-none-elf  esp-wifi
 
         # Verify the MSRV for all Xtensa chips:
       - name: msrv Xtensa (esp-hal)
@@ -151,9 +151,9 @@ jobs:
 
       - name: msrv Xtensa (esp-wifi)
         run: |
-          cargo xtask build-package --toolchain=esp --features=esp32,wifi,ble   --target=xtensa-esp32-none-elf   esp-wifi
-          cargo xtask build-package --toolchain=esp --features=esp32s2,wifi --target=xtensa-esp32s2-none-elf esp-wifi
-          cargo xtask build-package --toolchain=esp --features=esp32s3,wifi,ble --target=xtensa-esp32s3-none-elf esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32,wifi,ble,esp-hal/unstable   --target=xtensa-esp32-none-elf   esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32s2,wifi,esp-hal/unstable     --target=xtensa-esp32s2-none-elf esp-wifi
+          cargo xtask build-package --toolchain=esp --features=esp32s3,wifi,ble,esp-hal/unstable --target=xtensa-esp32s3-none-elf esp-wifi
 
       - name: msrv (esp-lp-hal)
         run: |

--- a/esp-hal-embassy/README.md
+++ b/esp-hal-embassy/README.md
@@ -8,6 +8,8 @@
 
 [Embassy] support for `esp-hal`.
 
+Note that this crate currently requires you to enable the `unstable` feature on `esp-hal`.
+
 [embassy]: https://github.com/embassy-rs/embassy
 
 ## [Documentation]
@@ -16,7 +18,7 @@
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_
+This crate is guaranteed to compile on stable Rust 1.79 and up. It _might_
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -4,6 +4,9 @@
 //! systems. This package provides support for building applications using
 //! Embassy with [esp-hal].
 //!
+//! Note that this crate currently requires you to enable the `unstable` feature
+//! on `esp-hal`.
+//!
 //! [esp-hal]: https://github.com/esp-rs/esp-hal
 //! [embassy]: https://github.com/embassy-rs/embassy
 //!

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -720,7 +720,7 @@ cfg_if::cfg_if! {
     }
 }
 
-crate::impl_dma_eligible! {
+crate::dma::impl_dma_eligible! {
     AnyGdmaChannel {
         #[cfg(spi2)]
         SPI2 => Spi2,
@@ -764,7 +764,7 @@ crate::impl_dma_eligible! {
 }
 
 #[cfg(any(esp32c6, esp32h2))]
-crate::impl_dma_eligible! {
+crate::dma::impl_dma_eligible! {
     AnyGdmaChannel {
         MEM2MEM4 => Mem2Mem4,
         MEM2MEM5 => Mem2Mem5,

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -556,6 +556,7 @@ macro_rules! as_mut_byte_array {
         unsafe { &mut *($name.as_mut_ptr() as *mut [u8; $size]) }
     };
 }
+pub use as_mut_byte_array; // TODO: can be removed as soon as DMA is stabilized
 
 /// Convenience macro to create DMA buffers and descriptors with specific chunk
 /// size.
@@ -670,7 +671,7 @@ macro_rules! dma_buffers_impl {
 
         unsafe {
             (
-                $crate::as_mut_byte_array!(BUFFER, $size),
+                $crate::dma::as_mut_byte_array!(BUFFER, $size),
                 $crate::dma_descriptors_impl!($size, $chunk_size, is_circular = $circular),
             )
         }
@@ -1558,7 +1559,6 @@ impl RxCircularState {
 }
 
 #[doc(hidden)]
-#[macro_export]
 macro_rules! impl_dma_eligible {
     ([$dma_ch:ident] $name:ident => $dma:ident) => {
         impl $crate::dma::DmaEligible for $crate::peripherals::$name {
@@ -1577,10 +1577,12 @@ macro_rules! impl_dma_eligible {
     ) => {
         $(
             $(#[$cfg])?
-            $crate::impl_dma_eligible!([$dma_ch] $name => $dma);
+            $crate::dma::impl_dma_eligible!([$dma_ch] $name => $dma);
         )*
     };
 }
+
+pub(crate) use impl_dma_eligible; // TODO: can be removed as soon as DMA is stabilized
 
 /// Helper type to get the DMA (Rx and Tx) channel for a peripheral.
 pub type PeripheralDmaChannel<T> = <T as DmaEligible>::Dma;

--- a/esp-hal/src/dma/pdma.rs
+++ b/esp-hal/src/dma/pdma.rs
@@ -870,11 +870,11 @@ ImplPdmaChannel!(AnyI2s, I2sRegisterBlock, I2s1, I2S1, [I2s1]);
 // Specific peripherals use specific channels. Note that this may be overly
 // restrictive (ESP32 allows configuring 2 SPI DMA channels between 3 different
 // peripherals), but for the current set of restrictions this is sufficient.
-crate::impl_dma_eligible!([Spi2DmaChannel] SPI2 => Spi2);
-crate::impl_dma_eligible!([Spi3DmaChannel] SPI3 => Spi3);
-crate::impl_dma_eligible!([I2s0DmaChannel] I2S0 => I2s0);
+crate::dma::impl_dma_eligible!([Spi2DmaChannel] SPI2 => Spi2);
+crate::dma::impl_dma_eligible!([Spi3DmaChannel] SPI3 => Spi3);
+crate::dma::impl_dma_eligible!([I2s0DmaChannel] I2S0 => I2s0);
 #[cfg(i2s1)]
-crate::impl_dma_eligible!([I2s1DmaChannel] I2S1 => I2s1);
+crate::dma::impl_dma_eligible!([I2s1DmaChannel] I2S1 => I2s1);
 
 pub(super) fn init_dma(_cs: CriticalSection<'_>) {
     #[cfg(esp32)]

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -204,10 +204,12 @@ macro_rules! unstable {
         $(
             $(#[$meta])*
             #[cfg(feature = "unstable")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
             pub mod $module;
 
             $(#[$meta])*
             #[cfg(not(feature = "unstable"))]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
             #[allow(unused)]
             pub(crate) mod $module;
         )*

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -151,6 +151,7 @@ pub use xtensa_lx;
 #[cfg(xtensa)]
 pub use xtensa_lx_rt::{self, entry};
 
+// TODO what should we reexport stably?
 #[cfg(any(esp32, esp32s3))]
 pub use self::soc::cpu_control;
 #[cfg(efuse)]
@@ -163,12 +164,6 @@ pub use self::soc::psram;
 #[cfg(ulp_riscv_core)]
 pub use self::soc::ulp_core;
 
-#[cfg(aes)]
-pub mod aes;
-#[cfg(any(adc, dac))]
-pub mod analog;
-#[cfg(assist_debug)]
-pub mod assist_debug;
 #[cfg(any(dport, hp_sys, pcr, system))]
 pub mod clock;
 
@@ -176,75 +171,103 @@ pub mod config;
 
 #[cfg(any(xtensa, all(riscv, systimer)))]
 pub mod delay;
-#[cfg(any(gdma, pdma))]
-pub mod dma;
-#[cfg(ecc)]
-pub mod ecc;
-#[cfg(soc_etm)]
-pub mod etm;
 #[cfg(gpio)]
 pub mod gpio;
-#[cfg(hmac)]
-pub mod hmac;
 #[cfg(any(i2c0, i2c1))]
 pub mod i2c;
-#[cfg(any(i2s0, i2s1))]
-pub mod i2s;
 #[cfg(any(dport, interrupt_core0, interrupt_core1))]
 pub mod interrupt;
-#[cfg(lcd_cam)]
-pub mod lcd_cam;
-#[cfg(ledc)]
-pub mod ledc;
-#[cfg(any(mcpwm0, mcpwm1))]
-pub mod mcpwm;
-#[cfg(usb0)]
-pub mod otg_fs;
-#[cfg(parl_io)]
-pub mod parl_io;
-#[cfg(pcnt)]
-pub mod pcnt;
 pub mod peripheral;
 pub mod prelude;
 #[cfg(any(hmac, sha))]
 mod reg_access;
-#[cfg(any(lp_clkrst, rtc_cntl))]
-pub mod reset;
-#[cfg(rmt)]
-pub mod rmt;
-#[cfg(rng)]
-pub mod rng;
-pub mod rom;
-#[cfg(rsa)]
-pub mod rsa;
-#[cfg(any(lp_clkrst, rtc_cntl))]
-pub mod rtc_cntl;
-#[cfg(sha)]
-pub mod sha;
 #[cfg(any(spi0, spi1, spi2, spi3))]
 pub mod spi;
-#[cfg(any(dport, hp_sys, pcr, system))]
-pub mod system;
-pub mod time;
-#[cfg(any(systimer, timg0, timg1))]
-pub mod timer;
-#[cfg(touch)]
-pub mod touch;
-#[cfg(trace0)]
-pub mod trace;
-#[cfg(any(twai0, twai1))]
-pub mod twai;
 #[cfg(any(uart0, uart1, uart2))]
 pub mod uart;
-#[cfg(usb_device)]
-pub mod usb_serial_jtag;
-
-pub mod debugger;
-
-#[doc(hidden)]
-pub mod sync;
 
 pub mod macros;
+pub mod rom;
+
+pub mod debugger;
+#[doc(hidden)]
+pub mod sync;
+pub mod time;
+
+// can't use instability on inline module definitions, see https://github.com/rust-lang/rust/issues/54727
+#[doc(hidden)]
+macro_rules! unstable {
+    ($(
+        $(#[$meta:meta])*
+        pub mod $module:ident;
+    )*) => {
+        $(
+            $(#[$meta])*
+            #[cfg(feature = "unstable")]
+            pub mod $module;
+
+            $(#[$meta])*
+            #[cfg(not(feature = "unstable"))]
+            #[allow(unused)]
+            pub(crate) mod $module;
+        )*
+    };
+}
+
+unstable! {
+    #[cfg(aes)]
+    pub mod aes;
+    #[cfg(any(adc, dac))]
+    pub mod analog;
+    #[cfg(assist_debug)]
+    pub mod assist_debug;
+    #[cfg(any(gdma, pdma))]
+    pub mod dma;
+    #[cfg(ecc)]
+    pub mod ecc;
+    #[cfg(soc_etm)]
+    pub mod etm;
+    #[cfg(hmac)]
+    pub mod hmac;
+    #[cfg(any(i2s0, i2s1))]
+    pub mod i2s;
+    #[cfg(lcd_cam)]
+    pub mod lcd_cam;
+    #[cfg(ledc)]
+    pub mod ledc;
+    #[cfg(any(mcpwm0, mcpwm1))]
+    pub mod mcpwm;
+    #[cfg(usb0)]
+    pub mod otg_fs;
+    #[cfg(parl_io)]
+    pub mod parl_io;
+    #[cfg(pcnt)]
+    pub mod pcnt;
+    #[cfg(any(lp_clkrst, rtc_cntl))]
+    pub mod reset;
+    #[cfg(rmt)]
+    pub mod rmt;
+    #[cfg(rng)]
+    pub mod rng;
+    #[cfg(rsa)]
+    pub mod rsa;
+    #[cfg(any(lp_clkrst, rtc_cntl))]
+    pub mod rtc_cntl;
+    #[cfg(sha)]
+    pub mod sha;
+    #[cfg(any(dport, hp_sys, pcr, system))]
+    pub mod system;
+    #[cfg(any(systimer, timg0, timg1))]
+    pub mod timer;
+    #[cfg(touch)]
+    pub mod touch;
+    #[cfg(trace0)]
+    pub mod trace;
+    #[cfg(any(twai0, twai1))]
+    pub mod twai;
+    #[cfg(usb_device)]
+    pub mod usb_serial_jtag;
+}
 
 /// State of the CPU saved when entering exception or interrupt
 pub mod trapframe {
@@ -309,6 +332,7 @@ pub(crate) mod private {
     }
 }
 
+#[cfg(feature = "unstable")]
 #[doc(hidden)]
 pub use private::Internal;
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -969,7 +969,7 @@ mod dma {
 
                 unwrap!(DmaTxBuf::new(
                     unsafe { &mut DESCRIPTORS[id] },
-                    crate::as_mut_byte_array!(BUFFERS[id], 4)
+                    crate::dma::as_mut_byte_array!(BUFFERS[id], 4)
                 ))
             };
 

--- a/esp-ieee802154/src/lib.rs
+++ b/esp-ieee802154/src/lib.rs
@@ -6,6 +6,9 @@
 //! This library is intended to be used to implement support for higher-level
 //! communication protocols, for example [esp-openthread].
 //!
+//! Note that this crate currently requires you to enable the `unstable` feature
+//! on `esp-hal`.
+//!
 //! [IEEE 802.15.4]: https://en.wikipedia.org/wiki/IEEE_802.15.4
 //! [esp-openthread]: https://github.com/esp-rs/esp-openthread
 //!

--- a/esp-wifi/README.md
+++ b/esp-wifi/README.md
@@ -8,6 +8,8 @@
 
 A WiFi, BLE and ESP-NOW driver for Espressif microcontrollers.
 
+Note that this crate currently requires you to enable the `unstable` feature on `esp-hal`.
+
 ## Current support
 
 If a cell contains an em dash (&mdash;) this means that the particular feature is not present for a chip. A check mark (✓) means that some driver implementation exists. A Tilde (&tilde;) means it is implemented but buggy. An empty cell means that the feature is present in the chip but not implemented yet.

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -17,6 +17,9 @@
 //!
 //! ### Importing
 //!
+//! Note that this crate currently requires you to enable the `unstable` feature
+//! on `esp-hal`.
+//!
 //! Ensure that the right features are enabled for your chip. See [Examples](https://github.com/esp-rs/esp-hal/tree/main/examples#examples) for more examples.
 //!
 //! ```toml

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -52,8 +52,8 @@ usbd-serial         = "0.2.2"
 esp32   = ["esp-hal/esp32",   "esp-backtrace/esp32",   "esp-hal-embassy?/esp32",   "esp-println/esp32",   "esp-storage?/esp32",   "esp-wifi?/esp32"]
 esp32c2 = ["esp-hal/esp32c2", "esp-backtrace/esp32c2", "esp-hal-embassy?/esp32c2", "esp-println/esp32c2", "esp-storage?/esp32c2", "esp-wifi?/esp32c2", ]
 esp32c3 = ["esp-hal/esp32c3", "esp-backtrace/esp32c3", "esp-hal-embassy?/esp32c3", "esp-println/esp32c3", "esp-storage?/esp32c3", "esp-wifi?/esp32c3"]
-esp32c6 = ["esp-hal/esp32c6", "esp-backtrace/esp32c6", "esp-hal-embassy?/esp32c6", "esp-println/esp32c6", "esp-storage?/esp32c6", "esp-wifi?/esp32c6", "esp-ieee802154/esp32c6"]
-esp32h2 = ["esp-hal/esp32h2", "esp-backtrace/esp32h2", "esp-hal-embassy?/esp32h2", "esp-println/esp32h2", "esp-storage?/esp32h2", "esp-wifi?/esp32h2", "esp-ieee802154/esp32h2"]
+esp32c6 = ["esp-hal/esp32c6", "esp-backtrace/esp32c6", "esp-hal-embassy?/esp32c6", "esp-println/esp32c6", "esp-storage?/esp32c6", "esp-wifi?/esp32c6", "esp-ieee802154?/esp32c6"]
+esp32h2 = ["esp-hal/esp32h2", "esp-backtrace/esp32h2", "esp-hal-embassy?/esp32h2", "esp-println/esp32h2", "esp-storage?/esp32h2", "esp-wifi?/esp32h2", "esp-ieee802154?/esp32h2"]
 esp32s2 = ["esp-hal/esp32s2", "esp-backtrace/esp32s2", "esp-hal-embassy?/esp32s2", "esp-println/esp32s2", "esp-storage?/esp32s2", "esp-wifi?/esp32s2"]
 esp32s3 = ["esp-hal/esp32s3", "esp-backtrace/esp32s3", "esp-hal-embassy?/esp32s3", "esp-println/esp32s3", "esp-storage?/esp32s3", "esp-wifi?/esp32s3"]
 

--- a/examples/src/bin/debug_assist.rs
+++ b/examples/src/bin/debug_assist.rs
@@ -3,6 +3,7 @@
 //! Uncomment the functionality you want to test
 
 //% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/dma_extmem2mem.rs
+++ b/examples/src/bin/dma_extmem2mem.rs
@@ -1,6 +1,6 @@
 //! Uses DMA to copy psram to internal memory.
 
-//% FEATURES: esp-hal/log esp-hal/octal-psram aligned
+//% FEATURES: esp-hal/log esp-hal/octal-psram aligned esp-hal/unstable
 //% CHIPS: esp32s3
 
 #![no_std]

--- a/examples/src/bin/dma_mem2mem.rs
+++ b/examples/src/bin/dma_mem2mem.rs
@@ -1,6 +1,6 @@
 //! Uses DMA to copy memory to memory.
 
-//% FEATURES: esp-hal/log
+//% FEATURES: esp-hal/log esp-hal/unstable
 //% CHIPS: esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
 
 #![no_std]

--- a/examples/src/bin/embassy_hello_world.rs
+++ b/examples/src/bin/embassy_hello_world.rs
@@ -4,7 +4,7 @@
 //! concurrently.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embassy esp-hal-embassy/integrated-timers
+//% FEATURES: embassy esp-hal-embassy/integrated-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -7,7 +7,7 @@
 //! - LED => GPIO0
 
 //% CHIPS: esp32 esp32s3
-//% FEATURES: embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -7,7 +7,7 @@
 //! - LED => GPIO0
 
 //% CHIPS: esp32 esp32s3
-//% FEATURES: embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -15,7 +15,7 @@
 // The interrupt-executor is created in `main` and is used to spawn `high_prio`.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embassy esp-hal-embassy/log esp-hal-embassy/integrated-timers
+//% FEATURES: embassy esp-hal-embassy/log esp-hal-embassy/integrated-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -4,7 +4,7 @@
 //! - Connect GPIO4 and GPIO5
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -6,7 +6,7 @@
 //! - generated pulses => GPIO4
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -13,7 +13,7 @@
 //! CS   => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -7,7 +7,7 @@
 //! - DM => GPIO19
 
 //% CHIPS: esp32s2 esp32s3
-//% FEATURES: embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/etm_timer.rs
+++ b/examples/src/bin/etm_timer.rs
@@ -4,6 +4,7 @@
 //! - LED => GPIO2
 
 //% CHIPS: esp32c6 esp32h2
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/hmac.rs
+++ b/examples/src/bin/hmac.rs
@@ -53,6 +53,7 @@
 //! ```
 
 //% CHIPS: esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_receive_all_frames.rs
+++ b/examples/src/bin/ieee802154_receive_all_frames.rs
@@ -1,4 +1,5 @@
 //% CHIPS: esp32c6 esp32h2
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_receive_all_frames.rs
+++ b/examples/src/bin/ieee802154_receive_all_frames.rs
@@ -1,5 +1,5 @@
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: esp-hal/unstable
+//% FEATURES: esp-ieee802154 esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_receive_frame.rs
+++ b/examples/src/bin/ieee802154_receive_frame.rs
@@ -1,4 +1,5 @@
 //% CHIPS: esp32c6 esp32h2
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_receive_frame.rs
+++ b/examples/src/bin/ieee802154_receive_frame.rs
@@ -1,5 +1,5 @@
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: esp-hal/unstable
+//% FEATURES: esp-ieee802154 esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_send_broadcast_frame.rs
+++ b/examples/src/bin/ieee802154_send_broadcast_frame.rs
@@ -1,4 +1,5 @@
 //% CHIPS: esp32c6 esp32h2
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_send_broadcast_frame.rs
+++ b/examples/src/bin/ieee802154_send_broadcast_frame.rs
@@ -1,5 +1,5 @@
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: esp-hal/unstable
+//% FEATURES: esp-ieee802154 esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_send_frame.rs
+++ b/examples/src/bin/ieee802154_send_frame.rs
@@ -1,4 +1,5 @@
 //% CHIPS: esp32c6 esp32h2
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_send_frame.rs
+++ b/examples/src/bin/ieee802154_send_frame.rs
@@ -1,5 +1,5 @@
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: esp-hal/unstable
+//% FEATURES: esp-ieee802154 esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_sniffer.rs
+++ b/examples/src/bin/ieee802154_sniffer.rs
@@ -3,6 +3,7 @@
 //! Besides the runtime changeable channel and the output format it's almost identical to ieee802154_receive_all_frames
 
 //% CHIPS: esp32c6 esp32h2
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/ieee802154_sniffer.rs
+++ b/examples/src/bin/ieee802154_sniffer.rs
@@ -3,7 +3,7 @@
 //! Besides the runtime changeable channel and the output format it's almost identical to ieee802154_receive_all_frames
 
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: esp-hal/unstable
+//% FEATURES: esp-ieee802154 esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/lp_core_basic.rs
+++ b/examples/src/bin/lp_core_basic.rs
@@ -9,6 +9,7 @@
 //! - LED => GPIO1
 
 //% CHIPS: esp32c6
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -16,7 +16,7 @@
 //! If your module is quad PSRAM then you need to change the `psram` feature in the
 //! in the features line below to `quad-psram`.
 
-//% FEATURES: esp-hal/log esp-hal/octal-psram
+//% FEATURES: esp-hal/log esp-hal/octal-psram esp-hal/unstable
 //% CHIPS: esp32s3
 
 #![no_std]

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -25,6 +25,7 @@
 //! so no immediate neighbor is available.
 
 //% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/touch.rs
+++ b/examples/src/bin/touch.rs
@@ -7,6 +7,7 @@
 //! pad on a PCB).
 
 //% CHIPS: esp32
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/twai.rs
+++ b/examples/src/bin/twai.rs
@@ -20,6 +20,7 @@
 //! * change the `tx_pin` and `rx_pin` to the appropriate pins for your boards.
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/usb_serial.rs
+++ b/examples/src/bin/usb_serial.rs
@@ -7,6 +7,7 @@
 //! - DM => GPIO19
 
 //% CHIPS: esp32s2 esp32s3
+//% FEATURES: esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/wifi_80211_tx.rs
+++ b/examples/src/bin/wifi_80211_tx.rs
@@ -3,7 +3,7 @@
 //! Periodically transmits a beacon frame.
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/sniffer
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/sniffer esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_access_point.rs
+++ b/examples/src/bin/wifi_access_point.rs
@@ -8,7 +8,7 @@
 //! On Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_access_point_with_sta.rs
@@ -9,7 +9,7 @@
 //! On Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_bench.rs
+++ b/examples/src/bin/wifi_bench.rs
@@ -8,7 +8,7 @@
 //! Ensure you have set the IP of your local machine in the `HOST_IP` env variable. E.g `HOST_IP="192.168.0.24"` and also set SSID and PASSWORD env variable before running this example.
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_ble.rs
+++ b/examples/src/bin/wifi_ble.rs
@@ -4,7 +4,7 @@
 //! - offers one service with three characteristics (one is read/write, one is write only, one is read/write/notify)
 //! - pressing the boot-button on a dev-board will send a notification if it is subscribed
 
-//% FEATURES: esp-wifi esp-wifi/ble
+//% FEATURES: esp-wifi esp-wifi/ble esp-hal/unstable
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
 
 #![no_std]

--- a/examples/src/bin/wifi_coex.rs
+++ b/examples/src/bin/wifi_coex.rs
@@ -8,7 +8,7 @@
 //! Note: On ESP32-C2 and ESP32-C3 you need a wifi-heap size of 70000, on ESP32-C6 you need 80000 and a tx_queue_size of 10
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/ble esp-wifi/coex
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/ble esp-wifi/coex esp-hal/unstable
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![allow(static_mut_refs)]

--- a/examples/src/bin/wifi_csi.rs
+++ b/examples/src/bin/wifi_csi.rs
@@ -4,7 +4,7 @@
 //! Set SSID and PASSWORD env variable before running this example.
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/log
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/log esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_dhcp.rs
+++ b/examples/src/bin/wifi_dhcp.rs
@@ -6,7 +6,7 @@
 //! This gets an ip address via DHCP then performs an HTTP get request to some "random" server
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_dhcp_smoltcp_nal.rs
+++ b/examples/src/bin/wifi_dhcp_smoltcp_nal.rs
@@ -6,7 +6,7 @@
 //! This gets an ip address via DHCP then performs an HTTP get request to some "random" server
 //! When using USB-SERIAL-JTAG you may have to activate the feature `phy-enable-usb` in the esp-wifi crate.
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -9,7 +9,7 @@
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 //!
 
-//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/sniffer
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/sniffer esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -12,7 +12,7 @@
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 //!
 
-//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -10,7 +10,7 @@
 //! Because of the huge task-arena size configured this won't work on ESP32-S2 and ESP32-C2
 //!
 
-//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c3 esp32c6
 
 #![allow(static_mut_refs)]

--- a/examples/src/bin/wifi_embassy_ble.rs
+++ b/examples/src/bin/wifi_embassy_ble.rs
@@ -4,7 +4,7 @@
 //! - offers one service with three characteristics (one is read/write, one is write only, one is read/write/notify)
 //! - pressing the boot-button on a dev-board will send a notification if it is subscribed
 
-//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/ble
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/ble esp-hal/unstable
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -7,7 +7,7 @@
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 
-//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_esp_now.rs
+++ b/examples/src/bin/wifi_embassy_esp_now.rs
@@ -4,7 +4,7 @@
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 
-//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/wifi_embassy_esp_now_duplex.rs
@@ -4,7 +4,7 @@
 //!
 //! Because of the huge task-arena size configured this won't work on ESP32-S2
 
-//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_embassy_trouble.rs
+++ b/examples/src/bin/wifi_embassy_trouble.rs
@@ -5,7 +5,7 @@
 //! - automatically notifies subscribers every second
 //!
 
-//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/ble
+//% FEATURES: embassy embassy-generic-timers esp-wifi esp-wifi/ble esp-hal/unstable
 //% CHIPS: esp32 esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
 
 #![no_std]

--- a/examples/src/bin/wifi_esp_now.rs
+++ b/examples/src/bin/wifi_esp_now.rs
@@ -2,7 +2,7 @@
 //!
 //! Broadcasts, receives and sends messages via esp-now
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/esp-now esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_sniffer.rs
+++ b/examples/src/bin/wifi_sniffer.rs
@@ -3,7 +3,7 @@
 //! Sniffs for beacon frames.
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/sniffer
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-wifi/sniffer esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/examples/src/bin/wifi_static_ip.rs
+++ b/examples/src/bin/wifi_static_ip.rs
@@ -7,7 +7,7 @@
 //! - responds with some HTML content when connecting to port 8080
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/utils esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -773,10 +773,15 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
 fn lint_package(chip: &Chip, path: &Path, args: &[&str], fix: bool) -> Result<()> {
     log::info!("Linting package: {}", path.display());
 
-    let mut builder = CargoArgsBuilder::default().subcommand("clippy");
+    let builder = CargoArgsBuilder::default().subcommand("clippy");
 
-    let toolchain = if chip.is_xtensa() { "esp" } else { "nightly" };
-    builder = builder.toolchain(toolchain);
+    let mut builder = if chip.is_xtensa() {
+        // We only overwrite Xtensas so that externally set nightly/stable toolchains
+        // are not overwritten.
+        builder.toolchain("esp")
+    } else {
+        builder
+    };
 
     for arg in args {
         builder = builder.arg(arg.to_string());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -644,7 +644,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                         &[
                             "-Zbuild-std=core",
                             &format!("--target={}", chip.target()),
-                            &format!("--features={chip},executors,defmt,integrated-timers"),
+                            &format!("--features={chip},executors,defmt,integrated-timers,esp-hal/unstable"),
                         ],
                         args.fix,
                     )?;
@@ -718,7 +718,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                 }
 
                 Package::EspWifi => {
-                    let mut features = format!("--features={chip},defmt,sys-logs");
+                    let mut features = format!("--features={chip},defmt,sys-logs,esp-hal/unstable");
 
                     if device.contains("wifi") {
                         features.push_str(",esp-now,sniffer")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -652,7 +652,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
 
                 Package::EspIeee802154 => {
                     if device.contains("ieee802154") {
-                        let features = format!("--features={chip},sys-logs");
+                        let features = format!("--features={chip},sys-logs,esp-hal/unstable");
                         lint_package(
                             chip,
                             &path,


### PR DESCRIPTION
There are a few annoying details, like how `#[macro_export]` refuses to work ([workaround](https://github.com/rust-lang/rust/pull/52234#issuecomment-2462493217)), and satellite crates, as well as examples will require `unstable`.

I guess we also want to hide `peripherals.UNSTABLE_PERIPHERAL` as well

This PR edits the xtask to enable the unstable feature where needed, and adds notes to esp-hal-embassy and esp-wifi (becaus they don't compile without timers, and maybe rng and more). We should also probably lint the stable subset of esp-hal. Be warned that it currently triggers weird clippy lints that we should have seen before.

cc #2499