### PR TITLE
Mark some dependencies as unstable

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -25,17 +25,17 @@ defmt                    = { version = "0.3.8", optional = true }
 delegate                 = "0.13.1"
 digest                   = { version = "0.10.7", default-features = false, optional = true }
 document-features        = "0.2.10"
-embassy-embedded-hal     = "0.2.0"
+embassy-embedded-hal     = { version = "0.2.0", optional = true }
 embassy-futures          = "0.1.1"
 embassy-sync             = "0.6.1"
 embassy-usb-driver       = { version = "0.1.0", optional = true }
 embassy-usb-synopsys-otg = { version = "0.1.0", optional = true }
-embedded-can             = "0.4.1"
+embedded-can             = { version = "0.4.1", optional = true }
 embedded-hal             = "1.0.0"
 embedded-hal-async       = "1.0.0"
 embedded-hal-nb          = "1.0.0"
-embedded-io              = "0.6.1"
-embedded-io-async        = "0.6.1"
+embedded-io              = { version = "0.6.1", optional = true }
+embedded-io-async        = { version = "0.6.1", optional = true }
 enumset                  = "1.1.5"
 esp-build                = { version = "0.1.0", path = "../esp-build" }
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
@@ -154,7 +154,12 @@ octal-psram = []
 ci = ["defmt", "bluetooth"]
 
 # Enables APIs that are not stable and thus come with no stability guarantees.
-unstable = []
+unstable = [
+    "dep:embassy-embedded-hal",
+    "dep:embedded-can",
+    "dep:embedded-io",
+    "dep:embedded-io-async",
+]
 
 [lints.clippy]
 mixed_attributes_style = "allow"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -153,7 +153,12 @@ octal-psram = []
 # This feature is intended for testing; you probably don't want to enable it:
 ci = ["defmt", "bluetooth"]
 
-# Enables APIs that are not stable and thus come with no stability guarantees.
+#! ### Unstable APIs
+#! Unstable APIs are drivers and features that are not yet ready for general use.
+#! They may be incomplete, have bugs, or be subject to change without notice.
+#! Unstable APIs are not covered by semver guarantees.
+
+## Enables APIs that are not stable and thus come with no stability guarantees.
 unstable = [
     "dep:embassy-embedded-hal",
     "dep:embedded-can",

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -44,7 +44,7 @@ use core::{
     task::{Context, Poll},
 };
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
 use embassy_embedded_hal::SetConfig;
 use embedded_hal::i2c::Operation as EhalOperation;
 use fugit::HertzU32;
@@ -281,7 +281,8 @@ pub struct I2c<'d, DM: Mode, T = AnyI2c> {
     guard: PeripheralGuard,
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T: Instance, DM: Mode> SetConfig for I2c<'_, DM, T> {
     type Config = Config;
     type ConfigError = ConfigError;

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -44,6 +44,7 @@ use core::{
     task::{Context, Poll},
 };
 
+#[cfg(feature = "unstable")]
 use embassy_embedded_hal::SetConfig;
 use embedded_hal::i2c::Operation as EhalOperation;
 use fugit::HertzU32;
@@ -280,6 +281,7 @@ pub struct I2c<'d, DM: Mode, T = AnyI2c> {
     guard: PeripheralGuard,
 }
 
+#[cfg(feature = "unstable")]
 impl<T: Instance, DM: Mode> SetConfig for I2c<'_, DM, T> {
     type Config = Config;
     type ConfigError = ConfigError;

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -61,7 +61,7 @@
 use core::marker::PhantomData;
 
 pub use dma::*;
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
 use embassy_embedded_hal::SetConfig;
 #[cfg(gdma)]
 use enumset::EnumSet;
@@ -649,7 +649,9 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M, T> SetConfig for Spi<'_, M, T>
 where
     T: Instance,
@@ -1167,7 +1169,9 @@ mod dma {
         }
     }
 
-    #[cfg(feature = "unstable")]
+    #[cfg(any(doc, feature = "unstable"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     impl<M, T> SetConfig for SpiDma<'_, M, T>
     where
         T: Instance,
@@ -1744,7 +1748,8 @@ mod dma {
         }
     }
 
-    #[cfg(feature = "unstable")]
+    #[cfg(any(doc, feature = "unstable"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     impl<M, T> SetConfig for SpiDmaBus<'_, M, T>
     where
         T: Instance,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -651,7 +651,6 @@ where
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M, T> SetConfig for Spi<'_, M, T>
 where
     T: Instance,
@@ -1170,7 +1169,6 @@ mod dma {
     }
 
     #[cfg(any(doc, feature = "unstable"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     impl<M, T> SetConfig for SpiDma<'_, M, T>
     where

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -61,6 +61,7 @@
 use core::marker::PhantomData;
 
 pub use dma::*;
+#[cfg(feature = "unstable")]
 use embassy_embedded_hal::SetConfig;
 #[cfg(gdma)]
 use enumset::EnumSet;
@@ -648,6 +649,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<M, T> SetConfig for Spi<'_, M, T>
 where
     T: Instance,
@@ -1165,6 +1167,7 @@ mod dma {
         }
     }
 
+    #[cfg(feature = "unstable")]
     impl<M, T> SetConfig for SpiDma<'_, M, T>
     where
         T: Instance,
@@ -1741,6 +1744,7 @@ mod dma {
         }
     }
 
+    #[cfg(feature = "unstable")]
     impl<M, T> SetConfig for SpiDmaBus<'_, M, T>
     where
         T: Instance,

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -201,7 +201,8 @@ impl_display! {
     Other => "A different error occurred. The original error may contain more information",
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl From<ErrorKind> for embedded_can::ErrorKind {
     fn from(value: ErrorKind) -> Self {
         match value {
@@ -216,7 +217,8 @@ impl From<ErrorKind> for embedded_can::ErrorKind {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl embedded_can::Error for ErrorKind {
     fn kind(&self) -> embedded_can::ErrorKind {
         (*self).into()
@@ -278,14 +280,16 @@ impl StandardId {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl From<StandardId> for embedded_can::StandardId {
     fn from(value: StandardId) -> Self {
         embedded_can::StandardId::new(value.as_raw()).unwrap()
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl From<embedded_can::StandardId> for StandardId {
     fn from(value: embedded_can::StandardId) -> Self {
         StandardId::new(value.as_raw()).unwrap()
@@ -340,14 +344,16 @@ impl ExtendedId {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl From<ExtendedId> for embedded_can::ExtendedId {
     fn from(value: ExtendedId) -> Self {
         embedded_can::ExtendedId::new(value.0).unwrap()
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl From<embedded_can::ExtendedId> for ExtendedId {
     fn from(value: embedded_can::ExtendedId) -> Self {
         ExtendedId::new(value.as_raw()).unwrap()
@@ -378,7 +384,8 @@ impl From<ExtendedId> for Id {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl From<Id> for embedded_can::Id {
     fn from(value: Id) -> Self {
         match value {
@@ -388,7 +395,8 @@ impl From<Id> for embedded_can::Id {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl From<embedded_can::Id> for Id {
     fn from(value: embedded_can::Id) -> Self {
         match value {
@@ -490,7 +498,8 @@ impl EspTwaiFrame {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl embedded_can::Frame for EspTwaiFrame {
     fn new(id: impl Into<embedded_can::Id>, data: &[u8]) -> Option<Self> {
         Self::new(id.into(), data)
@@ -1281,7 +1290,8 @@ pub enum EspTwaiError {
     EmbeddedHAL(ErrorKind),
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl embedded_can::Error for EspTwaiError {
     fn kind(&self) -> embedded_can::ErrorKind {
         if let Self::EmbeddedHAL(kind) = self {
@@ -1324,7 +1334,7 @@ unsafe fn copy_to_data_register(dest: *mut u32, src: &[u8]) {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
 impl<DM, T> embedded_can::nb::Can for Twai<'_, DM, T>
 where
     T: Instance,

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -25,14 +25,12 @@
 //!
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use embedded_can::Id;
 //! # use esp_hal::twai;
 //! # use esp_hal::twai::filter;
 //! # use esp_hal::twai::filter::SingleStandardFilter;
 //! # use esp_hal::twai::TwaiConfiguration;
 //! # use esp_hal::twai::BaudRate;
 //! # use esp_hal::twai::TwaiMode;
-//! # use embedded_can::Frame;
 //! # use nb::block;
 //! // Use GPIO pins 2 and 3 to connect to the respective pins on the TWAI
 //! // transceiver.
@@ -75,7 +73,6 @@
 //! ### Self-testing (self reception of transmitted messages)
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use embedded_can::Id;
 //! # use esp_hal::twai;
 //! # use esp_hal::twai::filter;
 //! # use esp_hal::twai::filter::SingleStandardFilter;
@@ -84,7 +81,6 @@
 //! # use esp_hal::twai::EspTwaiFrame;
 //! # use esp_hal::twai::StandardId;
 //! # use esp_hal::twai::TwaiMode;
-//! # use embedded_can::Frame;
 //! # use nb::block;
 //! // Use GPIO pins 2 and 3 to connect to the respective pins on the TWAI
 //! // transceiver.
@@ -205,6 +201,7 @@ impl_display! {
     Other => "A different error occurred. The original error may contain more information",
 }
 
+#[cfg(feature = "unstable")]
 impl From<ErrorKind> for embedded_can::ErrorKind {
     fn from(value: ErrorKind) -> Self {
         match value {
@@ -219,6 +216,7 @@ impl From<ErrorKind> for embedded_can::ErrorKind {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl embedded_can::Error for ErrorKind {
     fn kind(&self) -> embedded_can::ErrorKind {
         (*self).into()
@@ -280,12 +278,14 @@ impl StandardId {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl From<StandardId> for embedded_can::StandardId {
     fn from(value: StandardId) -> Self {
         embedded_can::StandardId::new(value.as_raw()).unwrap()
     }
 }
 
+#[cfg(feature = "unstable")]
 impl From<embedded_can::StandardId> for StandardId {
     fn from(value: embedded_can::StandardId) -> Self {
         StandardId::new(value.as_raw()).unwrap()
@@ -340,12 +340,14 @@ impl ExtendedId {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl From<ExtendedId> for embedded_can::ExtendedId {
     fn from(value: ExtendedId) -> Self {
         embedded_can::ExtendedId::new(value.0).unwrap()
     }
 }
 
+#[cfg(feature = "unstable")]
 impl From<embedded_can::ExtendedId> for ExtendedId {
     fn from(value: embedded_can::ExtendedId) -> Self {
         ExtendedId::new(value.as_raw()).unwrap()
@@ -376,6 +378,7 @@ impl From<ExtendedId> for Id {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl From<Id> for embedded_can::Id {
     fn from(value: Id) -> Self {
         match value {
@@ -385,6 +388,7 @@ impl From<Id> for embedded_can::Id {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl From<embedded_can::Id> for Id {
     fn from(value: embedded_can::Id) -> Self {
         match value {
@@ -394,7 +398,7 @@ impl From<embedded_can::Id> for Id {
     }
 }
 
-/// Structure backing the `embedded_can::Frame` trait.
+/// A TWAI Frame.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct EspTwaiFrame {
@@ -486,6 +490,7 @@ impl EspTwaiFrame {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl embedded_can::Frame for EspTwaiFrame {
     fn new(id: impl Into<embedded_can::Id>, data: &[u8]) -> Option<Self> {
         Self::new(id.into(), data)
@@ -1276,6 +1281,7 @@ pub enum EspTwaiError {
     EmbeddedHAL(ErrorKind),
 }
 
+#[cfg(feature = "unstable")]
 impl embedded_can::Error for EspTwaiError {
     fn kind(&self) -> embedded_can::ErrorKind {
         if let Self::EmbeddedHAL(kind) = self {
@@ -1318,6 +1324,7 @@ unsafe fn copy_to_data_register(dest: *mut u32, src: &[u8]) {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<DM, T> embedded_can::nb::Can for Twai<'_, DM, T>
 where
     T: Instance,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -42,8 +42,8 @@
 //! The UART driver implements a number of third-party traits, with the
 //! intention of making the HAL inter-compatible with various device drivers
 //! from the community. This includes, but is not limited to, the [embedded-hal]
-//! and [embedded-io] (`unstable`) blocking traits, and the [embedded-hal-async] and
-//! [embedded-io-async] (`unstable`) asynchronous traits.
+//! and [embedded-io] blocking traits, and the [embedded-hal-async] and
+//! [embedded-io-async] asynchronous traits.
 //!
 //! In addition to the interfaces provided by these traits, native APIs are also
 //! available. See the examples below for more information on how to interact
@@ -226,7 +226,7 @@
 
 use core::{marker::PhantomData, sync::atomic::Ordering, task::Poll};
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
 use embassy_embedded_hal::SetConfig;
 use enumset::{EnumSet, EnumSetType};
 use portable_atomic::AtomicBool;
@@ -293,7 +293,8 @@ impl embedded_hal_nb::serial::Error for Error {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl embedded_io::Error for Error {
     fn kind(&self) -> embedded_io::ErrorKind {
         embedded_io::ErrorKind::Other
@@ -624,7 +625,9 @@ pub enum ConfigError {
     UnsupportedFifoThreshold,
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M, T> SetConfig for Uart<'_, M, T>
 where
     T: Instance,
@@ -638,7 +641,9 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M, T> SetConfig for UartRx<'_, M, T>
 where
     T: Instance,
@@ -652,7 +657,9 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M, T> SetConfig for UartTx<'_, M, T>
 where
     T: Instance,
@@ -1465,22 +1472,30 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ErrorType for Uart<'_, M, T> {
     type Error = Error;
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ErrorType for UartTx<'_, M, T> {
     type Error = Error;
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ErrorType for UartRx<'_, M, T> {
     type Error = Error;
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::Read for Uart<'_, M, T>
 where
     T: Instance,
@@ -1491,7 +1506,9 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::Read for UartRx<'_, M, T>
 where
     T: Instance,
@@ -1510,7 +1527,9 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ReadReady for Uart<'_, M, T>
 where
     T: Instance,
@@ -1521,7 +1540,9 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ReadReady for UartRx<'_, M, T>
 where
     T: Instance,
@@ -1532,7 +1553,9 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::Write for Uart<'_, M, T>
 where
     T: Instance,
@@ -1547,7 +1570,9 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::Write for UartTx<'_, M, T>
 where
     T: Instance,
@@ -1905,7 +1930,8 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T> embedded_io_async::Read for Uart<'_, Async, T>
 where
     T: Instance,
@@ -1918,7 +1944,8 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T> embedded_io_async::Read for UartRx<'_, Async, T>
 where
     T: Instance,
@@ -1931,7 +1958,8 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T> embedded_io_async::Write for Uart<'_, Async, T>
 where
     T: Instance,
@@ -1945,7 +1973,8 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T> embedded_io_async::Write for UartTx<'_, Async, T>
 where
     T: Instance,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -42,8 +42,8 @@
 //! The UART driver implements a number of third-party traits, with the
 //! intention of making the HAL inter-compatible with various device drivers
 //! from the community. This includes, but is not limited to, the [embedded-hal]
-//! and [embedded-io] blocking traits, and the [embedded-hal-async] and
-//! [embedded-io-async] asynchronous traits.
+//! and [embedded-io] (`unstable`) blocking traits, and the [embedded-hal-async] and
+//! [embedded-io-async] (`unstable`) asynchronous traits.
 //!
 //! In addition to the interfaces provided by these traits, native APIs are also
 //! available. See the examples below for more information on how to interact
@@ -226,6 +226,7 @@
 
 use core::{marker::PhantomData, sync::atomic::Ordering, task::Poll};
 
+#[cfg(feature = "unstable")]
 use embassy_embedded_hal::SetConfig;
 use enumset::{EnumSet, EnumSetType};
 use portable_atomic::AtomicBool;
@@ -292,6 +293,7 @@ impl embedded_hal_nb::serial::Error for Error {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl embedded_io::Error for Error {
     fn kind(&self) -> embedded_io::ErrorKind {
         embedded_io::ErrorKind::Other
@@ -622,6 +624,7 @@ pub enum ConfigError {
     UnsupportedFifoThreshold,
 }
 
+#[cfg(feature = "unstable")]
 impl<M, T> SetConfig for Uart<'_, M, T>
 where
     T: Instance,
@@ -635,6 +638,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<M, T> SetConfig for UartRx<'_, M, T>
 where
     T: Instance,
@@ -648,6 +652,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<M, T> SetConfig for UartTx<'_, M, T>
 where
     T: Instance,
@@ -1460,18 +1465,22 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::ErrorType for Uart<'_, M, T> {
     type Error = Error;
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::ErrorType for UartTx<'_, M, T> {
     type Error = Error;
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::ErrorType for UartRx<'_, M, T> {
     type Error = Error;
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::Read for Uart<'_, M, T>
 where
     T: Instance,
@@ -1482,6 +1491,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::Read for UartRx<'_, M, T>
 where
     T: Instance,
@@ -1500,6 +1510,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::ReadReady for Uart<'_, M, T>
 where
     T: Instance,
@@ -1510,6 +1521,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::ReadReady for UartRx<'_, M, T>
 where
     T: Instance,
@@ -1520,6 +1532,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::Write for Uart<'_, M, T>
 where
     T: Instance,
@@ -1534,6 +1547,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T, M> embedded_io::Write for UartTx<'_, M, T>
 where
     T: Instance,
@@ -1891,6 +1905,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T> embedded_io_async::Read for Uart<'_, Async, T>
 where
     T: Instance,
@@ -1903,6 +1918,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T> embedded_io_async::Read for UartRx<'_, Async, T>
 where
     T: Instance,
@@ -1915,6 +1931,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T> embedded_io_async::Write for Uart<'_, Async, T>
 where
     T: Instance,
@@ -1928,6 +1945,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T> embedded_io_async::Write for UartTx<'_, Async, T>
 where
     T: Instance,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -627,7 +627,6 @@ pub enum ConfigError {
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M, T> SetConfig for Uart<'_, M, T>
 where
     T: Instance,
@@ -643,7 +642,6 @@ where
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M, T> SetConfig for UartRx<'_, M, T>
 where
     T: Instance,
@@ -658,7 +656,6 @@ where
 }
 
 #[cfg(any(doc, feature = "unstable"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M, T> SetConfig for UartTx<'_, M, T>
 where
@@ -1474,13 +1471,11 @@ where
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ErrorType for Uart<'_, M, T> {
     type Error = Error;
 }
 
 #[cfg(any(doc, feature = "unstable"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ErrorType for UartTx<'_, M, T> {
     type Error = Error;
@@ -1488,13 +1483,11 @@ impl<T, M> embedded_io::ErrorType for UartTx<'_, M, T> {
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ErrorType for UartRx<'_, M, T> {
     type Error = Error;
 }
 
 #[cfg(any(doc, feature = "unstable"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::Read for Uart<'_, M, T>
 where
@@ -1507,7 +1500,6 @@ where
 }
 
 #[cfg(any(doc, feature = "unstable"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::Read for UartRx<'_, M, T>
 where
@@ -1529,7 +1521,6 @@ where
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ReadReady for Uart<'_, M, T>
 where
     T: Instance,
@@ -1542,7 +1533,6 @@ where
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::ReadReady for UartRx<'_, M, T>
 where
     T: Instance,
@@ -1554,7 +1544,6 @@ where
 }
 
 #[cfg(any(doc, feature = "unstable"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::Write for Uart<'_, M, T>
 where
@@ -1571,7 +1560,6 @@ where
 }
 
 #[cfg(any(doc, feature = "unstable"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<T, M> embedded_io::Write for UartTx<'_, M, T>
 where

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -32,8 +32,8 @@
 //! The USB Serial/JTAG driver implements a number of third-party traits, with
 //! the intention of making the HAL inter-compatible with various device drivers
 //! from the community. This includes, but is not limited to, the [embedded-hal]
-//! and [embedded-io] blocking traits, and the [embedded-hal-async] and
-//! [embedded-io-async] asynchronous traits.
+//! and [embedded-io] (`unstable`) blocking traits, and the [embedded-hal-async]
+//! and [embedded-io-async] (`unstable`) asynchronous traits.
 //!
 //! In addition to the interfaces provided by these traits, native APIs are also
 //! available. See the examples below for more information on how to interact
@@ -126,7 +126,9 @@
 //! [embedded-hal-async]: https://docs.rs/embedded-hal-async/latest/embedded_hal_async/
 //! [embedded-io-async]: https://docs.rs/embedded-io-async/latest/embedded_io_async/
 
-use core::{convert::Infallible, marker::PhantomData, task::Poll};
+#[cfg(feature = "unstable")]
+use core::task::Poll;
+use core::{convert::Infallible, marker::PhantomData};
 
 use procmacros::handler;
 
@@ -604,6 +606,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<M> embedded_io::ErrorType for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -611,6 +614,7 @@ where
     type Error = Error;
 }
 
+#[cfg(feature = "unstable")]
 impl<M> embedded_io::ErrorType for UsbSerialJtagTx<'_, M>
 where
     M: Mode,
@@ -618,6 +622,7 @@ where
     type Error = Error;
 }
 
+#[cfg(feature = "unstable")]
 impl<M> embedded_io::ErrorType for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -625,6 +630,7 @@ where
     type Error = Error;
 }
 
+#[cfg(feature = "unstable")]
 impl<M> embedded_io::Read for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -634,6 +640,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<M> embedded_io::Read for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -648,6 +655,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<M> embedded_io::Write for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -661,6 +669,7 @@ where
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<M> embedded_io::Write for UsbSerialJtagTx<'_, M>
 where
     M: Mode,
@@ -680,11 +689,13 @@ where
 static WAKER_TX: AtomicWaker = AtomicWaker::new();
 static WAKER_RX: AtomicWaker = AtomicWaker::new();
 
+#[cfg(feature = "unstable")]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 struct UsbSerialJtagWriteFuture<'d> {
     _peripheral: PeripheralRef<'d, USB_DEVICE>,
 }
 
+#[cfg(feature = "unstable")]
 impl<'d> UsbSerialJtagWriteFuture<'d> {
     fn new(_peripheral: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         crate::into_ref!(_peripheral);
@@ -706,6 +717,7 @@ impl<'d> UsbSerialJtagWriteFuture<'d> {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl core::future::Future for UsbSerialJtagWriteFuture<'_> {
     type Output = ();
 
@@ -723,10 +735,12 @@ impl core::future::Future for UsbSerialJtagWriteFuture<'_> {
 }
 
 #[must_use = "futures do nothing unless you `.await` or poll them"]
+#[cfg(feature = "unstable")]
 struct UsbSerialJtagReadFuture<'d> {
     _peripheral: PeripheralRef<'d, USB_DEVICE>,
 }
 
+#[cfg(feature = "unstable")]
 impl<'d> UsbSerialJtagReadFuture<'d> {
     fn new(_peripheral: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         crate::into_ref!(_peripheral);
@@ -748,6 +762,7 @@ impl<'d> UsbSerialJtagReadFuture<'d> {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl core::future::Future for UsbSerialJtagReadFuture<'_> {
     type Output = ();
 
@@ -783,6 +798,7 @@ impl<'d> UsbSerialJtag<'d, Async> {
 }
 
 impl UsbSerialJtagTx<'_, Async> {
+    #[cfg(feature = "unstable")]
     async fn write_bytes_async(&mut self, words: &[u8]) -> Result<(), Error> {
         let reg_block = USB_DEVICE::register_block();
 
@@ -800,6 +816,7 @@ impl UsbSerialJtagTx<'_, Async> {
         Ok(())
     }
 
+    #[cfg(feature = "unstable")]
     async fn flush_tx_async(&mut self) -> Result<(), Error> {
         if USB_DEVICE::register_block()
             .jfifo_st()
@@ -815,6 +832,7 @@ impl UsbSerialJtagTx<'_, Async> {
 }
 
 impl UsbSerialJtagRx<'_, Async> {
+    #[cfg(feature = "unstable")]
     async fn read_bytes_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         if buf.is_empty() {
             return Ok(0);
@@ -830,6 +848,7 @@ impl UsbSerialJtagRx<'_, Async> {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl embedded_io_async::Write for UsbSerialJtag<'_, Async> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         embedded_io_async::Write::write(&mut self.tx, buf).await
@@ -840,6 +859,7 @@ impl embedded_io_async::Write for UsbSerialJtag<'_, Async> {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl embedded_io_async::Write for UsbSerialJtagTx<'_, Async> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.write_bytes_async(buf).await?;
@@ -852,12 +872,14 @@ impl embedded_io_async::Write for UsbSerialJtagTx<'_, Async> {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl embedded_io_async::Read for UsbSerialJtag<'_, Async> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         embedded_io_async::Read::read(&mut self.rx, buf).await
     }
 }
 
+#[cfg(feature = "unstable")]
 impl embedded_io_async::Read for UsbSerialJtagRx<'_, Async> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         self.read_bytes_async(buf).await

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -32,8 +32,8 @@
 //! The USB Serial/JTAG driver implements a number of third-party traits, with
 //! the intention of making the HAL inter-compatible with various device drivers
 //! from the community. This includes, but is not limited to, the [embedded-hal]
-//! and [embedded-io] (`unstable`) blocking traits, and the [embedded-hal-async]
-//! and [embedded-io-async] (`unstable`) asynchronous traits.
+//! and [embedded-io] blocking traits, and the [embedded-hal-async]
+//! and [embedded-io-async] asynchronous traits.
 //!
 //! In addition to the interfaces provided by these traits, native APIs are also
 //! available. See the examples below for more information on how to interact
@@ -126,7 +126,8 @@
 //! [embedded-hal-async]: https://docs.rs/embedded-hal-async/latest/embedded_hal_async/
 //! [embedded-io-async]: https://docs.rs/embedded-io-async/latest/embedded_io_async/
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 use core::task::Poll;
 use core::{convert::Infallible, marker::PhantomData};
 
@@ -606,7 +607,8 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M> embedded_io::ErrorType for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -614,7 +616,8 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M> embedded_io::ErrorType for UsbSerialJtagTx<'_, M>
 where
     M: Mode,
@@ -622,7 +625,8 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M> embedded_io::ErrorType for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -630,7 +634,8 @@ where
     type Error = Error;
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M> embedded_io::Read for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -640,7 +645,8 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M> embedded_io::Read for UsbSerialJtagRx<'_, M>
 where
     M: Mode,
@@ -655,7 +661,8 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M> embedded_io::Write for UsbSerialJtag<'_, M>
 where
     M: Mode,
@@ -669,7 +676,8 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<M> embedded_io::Write for UsbSerialJtagTx<'_, M>
 where
     M: Mode,
@@ -689,13 +697,15 @@ where
 static WAKER_TX: AtomicWaker = AtomicWaker::new();
 static WAKER_RX: AtomicWaker = AtomicWaker::new();
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 struct UsbSerialJtagWriteFuture<'d> {
     _peripheral: PeripheralRef<'d, USB_DEVICE>,
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<'d> UsbSerialJtagWriteFuture<'d> {
     fn new(_peripheral: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         crate::into_ref!(_peripheral);
@@ -717,7 +727,8 @@ impl<'d> UsbSerialJtagWriteFuture<'d> {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl core::future::Future for UsbSerialJtagWriteFuture<'_> {
     type Output = ();
 
@@ -735,12 +746,14 @@ impl core::future::Future for UsbSerialJtagWriteFuture<'_> {
 }
 
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 struct UsbSerialJtagReadFuture<'d> {
     _peripheral: PeripheralRef<'d, USB_DEVICE>,
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<'d> UsbSerialJtagReadFuture<'d> {
     fn new(_peripheral: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         crate::into_ref!(_peripheral);
@@ -762,7 +775,8 @@ impl<'d> UsbSerialJtagReadFuture<'d> {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl core::future::Future for UsbSerialJtagReadFuture<'_> {
     type Output = ();
 
@@ -798,7 +812,8 @@ impl<'d> UsbSerialJtag<'d, Async> {
 }
 
 impl UsbSerialJtagTx<'_, Async> {
-    #[cfg(feature = "unstable")]
+    #[cfg(any(doc, feature = "unstable"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     async fn write_bytes_async(&mut self, words: &[u8]) -> Result<(), Error> {
         let reg_block = USB_DEVICE::register_block();
 
@@ -816,7 +831,8 @@ impl UsbSerialJtagTx<'_, Async> {
         Ok(())
     }
 
-    #[cfg(feature = "unstable")]
+    #[cfg(any(doc, feature = "unstable"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     async fn flush_tx_async(&mut self) -> Result<(), Error> {
         if USB_DEVICE::register_block()
             .jfifo_st()
@@ -832,7 +848,8 @@ impl UsbSerialJtagTx<'_, Async> {
 }
 
 impl UsbSerialJtagRx<'_, Async> {
-    #[cfg(feature = "unstable")]
+    #[cfg(any(doc, feature = "unstable"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     async fn read_bytes_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         if buf.is_empty() {
             return Ok(0);
@@ -848,7 +865,8 @@ impl UsbSerialJtagRx<'_, Async> {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl embedded_io_async::Write for UsbSerialJtag<'_, Async> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         embedded_io_async::Write::write(&mut self.tx, buf).await
@@ -859,7 +877,8 @@ impl embedded_io_async::Write for UsbSerialJtag<'_, Async> {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl embedded_io_async::Write for UsbSerialJtagTx<'_, Async> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.write_bytes_async(buf).await?;
@@ -872,14 +891,16 @@ impl embedded_io_async::Write for UsbSerialJtagTx<'_, Async> {
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl embedded_io_async::Read for UsbSerialJtag<'_, Async> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         embedded_io_async::Read::read(&mut self.rx, buf).await
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(any(doc, feature = "unstable"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl embedded_io_async::Read for UsbSerialJtagRx<'_, Async> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         self.read_bytes_async(buf).await

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -4,7 +4,7 @@
 //! writing to and reading from UART.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_usb_serial_jtag.rs
+++ b/examples/src/bin/embassy_usb_serial_jtag.rs
@@ -3,7 +3,7 @@
 //! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
 
 //% CHIPS: esp32c3 esp32c6 esp32h2 esp32s3
-//% FEATURES: embassy embassy-generic-timers
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -157,13 +157,19 @@ pub fn build_documentation(workspace: &Path, package: Package, chip: Chip) -> Re
 fn apply_feature_rules(package: &Package, config: &Config) -> Vec<String> {
     let chip_name = &config.name();
 
-    match (package, chip_name.as_str()) {
-        (Package::EspHal, "esp32") => vec!["quad-psram".to_owned(), "ci".to_owned()],
-        (Package::EspHal, "esp32s2") => vec!["quad-psram".to_owned(), "ci".to_owned()],
-        (Package::EspHal, "esp32s3") => vec!["quad-psram".to_owned(), "ci".to_owned()],
-        (Package::EspHal, _) => vec!["ci".to_owned()],
-        (Package::EspWifi, _) => {
-            let mut features = vec![];
+    let mut features = vec![];
+    match package {
+        Package::EspHal => {
+            features.push("unstable".to_owned());
+            features.push("ci".to_owned());
+            match chip_name.as_str() {
+                "esp32" => features.push("quad-psram".to_owned()),
+                "esp32s2" => features.push("quad-psram".to_owned()),
+                "esp32s3" => features.push("quad-psram".to_owned()),
+                _ => {}
+            };
+        }
+        Package::EspWifi => {
             if config.contains("wifi") {
                 features.push("wifi".to_owned());
                 features.push("esp-now".to_owned());
@@ -178,10 +184,10 @@ fn apply_feature_rules(package: &Package, config: &Config) -> Vec<String> {
             if config.contains("wifi") && config.contains("ble") {
                 features.push("coex".to_owned());
             }
-            features
         }
-        _ => vec![],
+        _ => {}
     }
+    features
 }
 
 /// Load all examples at the given path, and parse their metadata.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -870,7 +870,7 @@ fn run_doc_tests(workspace: &Path, args: ExampleArgs) -> Result<()> {
     // Determine the appropriate build target, and cargo features for the given
     // package and chip:
     let target = target_triple(args.package, &chip)?;
-    let features = vec![chip.to_string()];
+    let features = vec![chip.to_string(), "unstable".to_string()];
 
     // We need `nightly` for building the doc tests, unfortunately:
     let toolchain = if chip.is_xtensa() { "esp" } else { "nightly" };


### PR DESCRIPTION
Even though the TWAI and USB serial drivers are unstable, marking the trait impls separately has some future compatibility benefit as we'll not have to do it when we stabilize the peripheral driver.

I guess we could try and upstream a `instability::unstable_trait_impl` macro, and maybe an `unstable_use`.

Please generate documentation and see if it looks right to you.

cc #2499