### PR TITLE
esp-backtrace: Add `coredump` feature

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Features `coredump` and `coredump-all`
+
 ### Changed
 
 ### Fixed

--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Features `coredump` and `coredump-all`
+- Features `coredump` and `coredump-all` (#2672)
 
 ### Changed
 

--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped MSRV to 1.79 (#2672)
+
 ### Fixed
 
 ### Removed

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -2,7 +2,7 @@
 name         = "esp-backtrace"
 version      = "0.14.2"
 edition      = "2021"
-rust-version = "1.76.0"
+rust-version = "1.79.0"
 description  = "Bare-metal backtrace support for Espressif devices"
 repository   = "https://github.com/esp-rs/esp-hal"
 license      = "MIT OR Apache-2.0"
@@ -18,7 +18,8 @@ semihosting = { version = "0.1.17", optional = true }
 embedded-io = { version = "0.6.1", optional = true }
 
 [build-dependencies]
-esp-build = { version = "0.1.0", path = "../esp-build" }
+esp-build       = { version = "0.1.0", path = "../esp-build" }
+esp-metadata    = { version = "0.4.0", path = "../esp-metadata" }
 
 [features]
 default = ["colors"]

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -12,9 +12,9 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["esp32c3", "panic-handler", "exception-handler", "println", "esp-println/uart"]
 
 [dependencies]
-defmt       = { version = "0.3.8",  optional = true }
+defmt       = { version = "0.3.10",  optional = true }
 esp-println = { version = "0.12.0", optional = true, default-features = false, path = "../esp-println" }
-semihosting = { version = "0.1.15", optional = true }
+semihosting = { version = "0.1.17", optional = true }
 embedded-io = { version = "0.6.1", optional = true }
 
 [build-dependencies]

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -15,6 +15,7 @@ features       = ["esp32c3", "panic-handler", "exception-handler", "println", "e
 defmt       = { version = "0.3.8",  optional = true }
 esp-println = { version = "0.12.0", optional = true, default-features = false, path = "../esp-println" }
 semihosting = { version = "0.1.15", optional = true }
+embedded-io = { version = "0.6.1", optional = true }
 
 [build-dependencies]
 esp-build = { version = "0.1.0", path = "../esp-build" }
@@ -43,8 +44,8 @@ print-float-registers = [] # TODO support esp32p4
 # You may optionally enable one or more of the below features to provide
 # additional functionality:
 colors               = []
-coredump             = []
-coredump-all         = []
+coredump             = [ "dep:embedded-io" ]
+coredump-all         = [ "dep:embedded-io" ]
 custom-halt          = []
 custom-pre-backtrace = []
 exception-handler    = []

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -43,6 +43,7 @@ print-float-registers = [] # TODO support esp32p4
 # You may optionally enable one or more of the below features to provide
 # additional functionality:
 colors               = []
+coredump             = []
 custom-halt          = []
 custom-pre-backtrace = []
 exception-handler    = []

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -44,6 +44,7 @@ print-float-registers = [] # TODO support esp32p4
 # additional functionality:
 colors               = []
 coredump             = []
+coredump-all         = []
 custom-halt          = []
 custom-pre-backtrace = []
 exception-handler    = []

--- a/esp-backtrace/README.md
+++ b/esp-backtrace/README.md
@@ -31,6 +31,8 @@ When using the panic and/or exception handler make sure to include `use esp_back
 | exception-handler    | Include an exception handler, will add `esp-println` as a dependency                                               |
 | println              | Use `esp-println` to print messages                                                                                |
 | defmt                | Use `defmt` logging to print messages\* (check [example](https://github.com/playfulFence/backtrace-defmt-example)) |
+| coredump             | Create a coredump file, need `exception-handler` feature                                                           |
+| coredump-all         | Create a coredump file containing the whole SRAM memory, need `exception-handler` feature                          |
 | colors               | Print messages in red\*                                                                                            |
 | halt-cores           | Halt both CPUs on ESP32 / ESP32-S3 instead of doing a `loop {}` in case of a panic or exception                    |
 | semihosting          | Call `semihosting::process::abort()` on panic.                                                                     |

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -13,7 +13,9 @@ fn main() {
         panic!("Only one of `custom-halt` and `halt-cores` can be enabled");
     }
 
-    if cfg!(feature = "coredump") && !cfg!(feature = "exception-handler") {
+    if (cfg!(feature = "coredump") || cfg!(feature = "coredump-all"))
+        && !cfg!(feature = "exception-handler")
+    {
         panic!("coredumps need the `exception-handler` feature");
     }
 }

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -1,6 +1,9 @@
-use esp_build::assert_unique_used_features;
+use std::{error::Error, str::FromStr};
 
-fn main() {
+use esp_build::assert_unique_used_features;
+use esp_metadata::{Chip, Config};
+
+fn main() -> Result<(), Box<dyn Error>> {
     // Ensure that only a single chip is specified:
     assert_unique_used_features!(
         "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32p4", "esp32s2", "esp32s3"
@@ -18,4 +21,31 @@ fn main() {
     {
         panic!("coredumps need the `exception-handler` feature");
     }
+
+    // NOTE: update when adding new device support!
+    // Determine the name of the configured device:
+    let device_name = if cfg!(feature = "esp32") {
+        "esp32"
+    } else if cfg!(feature = "esp32c2") {
+        "esp32c2"
+    } else if cfg!(feature = "esp32c3") {
+        "esp32c3"
+    } else if cfg!(feature = "esp32c6") {
+        "esp32c6"
+    } else if cfg!(feature = "esp32h2") {
+        "esp32h2"
+    } else if cfg!(feature = "esp32s2") {
+        "esp32s2"
+    } else if cfg!(feature = "esp32s3") {
+        "esp32s3"
+    } else {
+        unreachable!() // We've confirmed exactly one known device was selected
+    };
+
+    // Load the configuration file for the configured device:
+    let chip = Chip::from_str(device_name)?;
+    let config = Config::for_chip(&chip);
+    config.define_symbols();
+
+    Ok(())
 }

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -12,4 +12,8 @@ fn main() {
     if cfg!(feature = "custom-halt") && cfg!(feature = "halt-cores") {
         panic!("Only one of `custom-halt` and `halt-cores` can be enabled");
     }
+
+    if cfg!(feature = "coredump") && !cfg!(feature = "exception-handler") {
+        panic!("coredumps need the `exception-handler` feature");
+    }
 }

--- a/esp-backtrace/src/coredump.rs
+++ b/esp-backtrace/src/coredump.rs
@@ -1,5 +1,3 @@
-use esp_println::print;
-
 const HEADER_SIZE: u32 = 0x34;
 const PROGRAM_HEADER_SIZE: u32 = 0x20;
 const REG_INFO_HEADER_SIZE: usize = 20;

--- a/esp-backtrace/src/coredump.rs
+++ b/esp-backtrace/src/coredump.rs
@@ -1,0 +1,351 @@
+use esp_println::print;
+
+const HEADER_SIZE: u32 = 0x34;
+const PROGRAM_HEADER_SIZE: u32 = 0x20;
+const REG_INFO_HEADER_SIZE: usize = 20;
+
+enum SegmentType {
+    Load = 1,
+    Note = 4,
+}
+
+#[cfg(target_arch = "xtensa")]
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct Registers {
+    pub pc: u32,
+    pub ps: u32,
+    pub lbeg: u32,
+    pub lend: u32,
+    pub lcount: u32,
+    pub sar: u32,
+    pub windowstart: u32,
+    pub windowbase: u32,
+    pub reserved: [u32; 8 + 48],
+    pub ar: [u32; 64],
+}
+
+#[cfg(target_arch = "xtensa")]
+impl Default for Registers {
+    fn default() -> Self {
+        Self {
+            pc: Default::default(),
+            ps: Default::default(),
+            lbeg: Default::default(),
+            lend: Default::default(),
+            lcount: Default::default(),
+            sar: Default::default(),
+            windowstart: Default::default(),
+            windowbase: Default::default(),
+            reserved: [0u32; 8 + 48],
+            ar: [0u32; 64],
+        }
+    }
+}
+
+#[cfg(target_arch = "riscv32")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Registers {
+    pub pc: u32,
+    pub x1: u32,
+    pub x2: u32,
+    pub x3: u32,
+    pub x4: u32,
+    pub x5: u32,
+    pub x6: u32,
+    pub x7: u32,
+    pub x8: u32,
+    pub x9: u32,
+    pub x10: u32,
+    pub x11: u32,
+    pub x12: u32,
+    pub x13: u32,
+    pub x14: u32,
+    pub x15: u32,
+    pub x16: u32,
+    pub x17: u32,
+    pub x18: u32,
+    pub x19: u32,
+    pub x20: u32,
+    pub x21: u32,
+    pub x22: u32,
+    pub x23: u32,
+    pub x24: u32,
+    pub x25: u32,
+    pub x26: u32,
+    pub x27: u32,
+    pub x28: u32,
+    pub x29: u32,
+    pub x30: u32,
+    pub x31: u32,
+}
+
+#[cfg(target_arch = "riscv32")]
+impl Default for Registers {
+    fn default() -> Self {
+        Self {
+            pc: Default::default(),
+            x1: Default::default(),
+            x2: Default::default(),
+            x3: Default::default(),
+            x4: Default::default(),
+            x5: Default::default(),
+            x6: Default::default(),
+            x7: Default::default(),
+            x8: Default::default(),
+            x9: Default::default(),
+            x10: Default::default(),
+            x11: Default::default(),
+            x12: Default::default(),
+            x13: Default::default(),
+            x14: Default::default(),
+            x15: Default::default(),
+            x16: Default::default(),
+            x17: Default::default(),
+            x18: Default::default(),
+            x19: Default::default(),
+            x20: Default::default(),
+            x21: Default::default(),
+            x22: Default::default(),
+            x23: Default::default(),
+            x24: Default::default(),
+            x25: Default::default(),
+            x26: Default::default(),
+            x27: Default::default(),
+            x28: Default::default(),
+            x29: Default::default(),
+            x30: Default::default(),
+            x31: Default::default(),
+        }
+    }
+}
+
+pub struct Memory<'a> {
+    pub start: u32,
+    pub slice: &'a [u8],
+}
+
+#[cfg(target_arch = "xtensa")]
+#[repr(C, packed)]
+struct RegisterInfo {
+    // PR status
+    si_signo: u32,
+    si_code: u32,
+    si_errno: u32,
+    pr_cursig: u16,
+    pr_pad0: u16,
+    pr_sigpend: u32,
+    pr_sighold: u32,
+    pr_pid: u32,
+    pr_ppid: u32,
+    pr_pgrp: u32,
+    pr_sid: u32,
+    pr_utime: u64,
+    pr_stime: u64,
+    pr_cutime: u64,
+    pr_cstime: u64,
+
+    registers: Registers,
+
+    reserved_: u32,
+}
+
+#[cfg(target_arch = "xtensa")]
+impl Default for RegisterInfo {
+    fn default() -> Self {
+        Self {
+            si_signo: 0,
+            si_code: 0,
+            si_errno: 0,
+            pr_cursig: 0,
+            pr_pad0: 0,
+            pr_sigpend: 0,
+            pr_sighold: 0,
+            pr_pid: 0,
+            pr_ppid: 0,
+            pr_pgrp: 0,
+            pr_sid: 0,
+            pr_utime: 0,
+            pr_stime: 0,
+            pr_cutime: 0,
+            pr_cstime: 0,
+
+            registers: Registers::default(),
+
+            reserved_: 0,
+        }
+    }
+}
+
+// see ESP-IDF for how this looks like for Xtensa
+// see components\espcoredump\src\port\xtensa\core_dump_port.c for
+#[cfg(target_arch = "riscv32")]
+#[repr(C)]
+struct RegisterInfo {
+    padding1: [u8; 12],
+    signal: u16,
+    padding2: [u8; 10],
+    pid: u32,
+    padding3: [u8; 44],
+
+    registers: Registers,
+
+    padding4: [u8; 4],
+}
+
+#[cfg(target_arch = "riscv32")]
+impl Default for RegisterInfo {
+    fn default() -> Self {
+        Self {
+            padding1: Default::default(),
+            signal: Default::default(),
+            padding2: Default::default(),
+            pid: Default::default(),
+            padding3: [0u8; 72 - 24 - 4],
+            registers: Default::default(),
+            padding4: Default::default(),
+        }
+    }
+}
+
+pub fn dump<W: Writer>(writer: &mut W, regs: &Registers, mem: Memory) {
+    let mut writer = CoreDumpWriter::new(writer);
+
+    let reg_info: RegisterInfo = {
+        let mut reg_info = RegisterInfo::default();
+        reg_info.registers = *regs;
+        reg_info
+    };
+
+    writer.elf_header();
+
+    // header for the memory region
+    writer.write_program_header(
+        SegmentType::Load,
+        HEADER_SIZE + 2 * PROGRAM_HEADER_SIZE, // we have 2 program header entries
+        mem.start,
+        mem.slice.len() as u32,
+        6,
+        0,
+    );
+
+    // header for the register info
+    writer.write_program_header(
+        SegmentType::Note,
+        HEADER_SIZE + 2 * PROGRAM_HEADER_SIZE + mem.slice.len() as u32, /* we have 2 program
+                                                                         * header entries and
+                                                                         * first data is the
+                                                                         * memory block */
+        0,
+        (core::mem::size_of::<RegisterInfo>() + REG_INFO_HEADER_SIZE) as u32,
+        6,
+        0,
+    );
+
+    // write memory contents
+    writer.writer.write(mem.slice);
+
+    // write register info
+    let mut reg_info_bytes = [0x0u8; core::mem::size_of::<RegisterInfo>() + REG_INFO_HEADER_SIZE];
+    unsafe {
+        (&reg_info as *const RegisterInfo)
+            .copy_to(reg_info_bytes.as_mut_ptr() as *mut RegisterInfo, 1);
+    }
+
+    // reg-info-header
+
+    // always like this so we can hardcode it
+    // slightly different for Xtensa b.c. the length of the register info (0xcc) is
+    // different
+    #[cfg(target_arch = "riscv32")]
+    writer.writer.write(&[
+        0x08, 0x00, 0x00, 0x00, 0xcc, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x43, 0x4f, 0x52,
+        0x45, 0x00, 0x00, 0x00, 0x00,
+    ]);
+
+    #[cfg(target_arch = "xtensa")]
+    writer.writer.write(&[
+        0x08, 0x00, 0x00, 0x00, 0x4c, 0x02, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x43, 0x4f, 0x52,
+        0x45, 0x00, 0x00, 0x00, 0x00,
+    ]);
+
+    writer.writer.write(&reg_info_bytes);
+}
+
+pub trait Writer {
+    fn write(&mut self, buffer: &[u8]);
+}
+
+struct CoreDumpWriter<'a, W: Writer> {
+    writer: &'a mut W,
+}
+
+impl<'a, W: Writer> CoreDumpWriter<'a, W> {
+    pub fn new(writer: &'a mut W) -> Self {
+        Self { writer }
+    }
+
+    fn elf_header(&mut self) {
+        self.writer.write(&[0x7f, b'E', b'L', b'F']);
+        self.writer.write(&[0x01]); // 32 bit
+        self.writer.write(&[0x01]); // little endian
+        self.writer.write(&[0x01]); // version
+        self.writer.write(&[0x00]); // ABI
+        self.writer.write(&[0x00]); // ABI version
+        self.writer
+            .write(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]); // padding
+        self.writer.write(&[0x04, 0x00]); // CORE file
+
+        #[cfg(target_arch = "riscv32")]
+        self.writer.write(&[0xf3, 0x00]); // machine (RISCV) !!!!
+
+        #[cfg(target_arch = "xtensa")]
+        self.writer.write(&[0x5e, 0x00]); // machine (Xtensa) !!!!
+
+        self.writer.write(&[0x01, 0x00, 0x00, 0x00]); // version
+        self.writer.write(&[0x00, 0x00, 0x00, 0x00]); // entry
+        self.writer.write(&[0x34, 0x00, 0x00, 0x00]); // start of program header
+        self.writer.write(&[0x00, 0x00, 0x00, 0x00]); // start of section header
+        self.writer.write(&[0x00, 0x00, 0x00, 0x00]); // flags
+        self.writer.write(&[0x34, 0x00]); // ehsize
+        self.writer.write(&[0x20, 0x00]); // size of a program header table entry.
+        self.writer.write(&[0x02, 0x00]); // number of entries in the program header table !!!! here 2: one memory block
+                                          // and the registers as a note
+        self.writer.write(&[0x28, 0x00]); // size of a section header table entry.
+        self.writer.write(&[0x00, 0x00]); // number of section headers
+        self.writer.write(&[0x00, 0x00]); // index of the section header table
+                                          // entry that contains the section
+                                          // names
+    }
+
+    fn write_program_header(
+        &mut self,
+        stype: SegmentType,
+        offset: u32,
+        addr: u32,
+        size: u32,
+        flags: u32,
+        align: u32,
+    ) {
+        self.writer.write(&(stype as u32).to_le_bytes()); // type
+        self.writer.write(&offset.to_le_bytes()); // offset in file
+        self.writer.write(&addr.to_le_bytes()); // vaddr
+        self.writer.write(&addr.to_le_bytes()); // paddr
+        self.writer.write(&size.to_le_bytes()); // file size
+        self.writer.write(&size.to_le_bytes()); // memory size
+        self.writer.write(&flags.to_le_bytes()); // flags
+        self.writer.write(&align.to_le_bytes()); // align
+    }
+}
+
+pub struct DumpWriter {}
+
+impl Writer for DumpWriter {
+    fn write(&mut self, buffer: &[u8]) {
+        for b in buffer.iter() {
+            #[cfg(feature = "println")]
+            esp_println::print!("{:02x}", b);
+        }
+    }
+}

--- a/esp-backtrace/src/coredump.rs
+++ b/esp-backtrace/src/coredump.rs
@@ -231,10 +231,8 @@ pub fn dump<W: Writer>(writer: &mut W, regs: &Registers, mem: Memory) {
     // header for the register info
     writer.write_program_header(
         SegmentType::Note,
-        HEADER_SIZE + 2 * PROGRAM_HEADER_SIZE + mem.slice.len() as u32, /* we have 2 program
-                                                                         * header entries and
-                                                                         * first data is the
-                                                                         * memory block */
+        // we have 2 program header entries and first data is the memory block
+        HEADER_SIZE + 2 * PROGRAM_HEADER_SIZE + mem.slice.len() as u32,
         0,
         (core::mem::size_of::<RegisterInfo>() + REG_INFO_HEADER_SIZE) as u32,
         6,
@@ -296,10 +294,10 @@ impl<'a, W: Writer> CoreDumpWriter<'a, W> {
         self.writer.write(&[0x04, 0x00]); // CORE file
 
         #[cfg(target_arch = "riscv32")]
-        self.writer.write(&[0xf3, 0x00]); // machine (RISCV) !!!!
+        self.writer.write(&[0xf3, 0x00]); // machine (RISCV)
 
         #[cfg(target_arch = "xtensa")]
-        self.writer.write(&[0x5e, 0x00]); // machine (Xtensa) !!!!
+        self.writer.write(&[0x5e, 0x00]); // machine (Xtensa)
 
         self.writer.write(&[0x01, 0x00, 0x00, 0x00]); // version
         self.writer.write(&[0x00, 0x00, 0x00, 0x00]); // entry

--- a/esp-backtrace/src/coredump.rs
+++ b/esp-backtrace/src/coredump.rs
@@ -355,9 +355,9 @@ impl embedded_io::ErrorType for DumpWriter {
 
 impl embedded_io::Write for DumpWriter {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        for b in buf.iter() {
+        for _b in buf.iter() {
             #[cfg(feature = "println")]
-            esp_println::print!("{:02x}", b);
+            esp_println::print!("{:02x}", _b);
         }
         Ok(buf.len())
     }

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -65,7 +65,7 @@ fn set_color_code(code: &str) {
     }
 }
 
-#[cfg(feature = "coredump")]
+#[cfg(any(feature = "coredump", feature = "coredump-all"))]
 pub(crate) mod coredump;
 
 #[cfg_attr(target_arch = "riscv32", path = "riscv.rs")]
@@ -77,7 +77,10 @@ extern "C" {
     static _stack_end: u32;
 }
 
-#[cfg(all(feature = "panic-handler", not(feature = "coredump")))]
+#[cfg(all(
+    feature = "panic-handler",
+    not(any(feature = "coredump", feature = "coredump-all"))
+))]
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     pre_backtrace();
@@ -121,7 +124,10 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     halt();
 }
 
-#[cfg(all(feature = "panic-handler", feature = "coredump"))]
+#[cfg(all(
+    feature = "panic-handler",
+    any(feature = "coredump", feature = "coredump-all")
+))]
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     #[cfg(feature = "colors")]

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -124,6 +124,9 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 #[cfg(all(feature = "panic-handler", feature = "coredump"))]
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+    #[cfg(feature = "colors")]
+    set_color_code(RED);
+
     println!("");
     println!("====================== PANIC ======================");
 
@@ -132,6 +135,9 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 
     #[cfg(feature = "defmt")]
     println!("{}", defmt::Display2Format(info));
+
+    #[cfg(feature = "colors")]
+    set_color_code(RESET);
 
     unsafe {
         #[cfg(target_arch = "riscv32")]

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -11,29 +11,28 @@ use esp_println as _;
 
 const MAX_BACKTRACE_ADDRESSES: usize = 10;
 
-#[cfg(feature = "esp32")]
-const RAM: (u32, u32) = (0x3FFA_E000, 0x4000_0000);
+const RAM: (u32, u32) = (
+    convert(env!("REGION-DRAM-START")),
+    convert(env!("REGION-DRAM-END")),
+);
 
-#[cfg(feature = "esp32c2")]
-const RAM: (u32, u32) = (0x3FCA_0000, 0x3FCE_0000);
+// We know esp-metadata already parsed the values and the env var contains
+// the expected format
+const fn convert(s: &str) -> u32 {
+    let mut r = 0u32;
+    let mut i = 0;
+    let bytes = s.as_bytes();
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c >= b'0' && c <= b'9' {
+            r *= 10;
+            r += (c - b'0') as u32;
+        }
 
-#[cfg(feature = "esp32c3")]
-const RAM: (u32, u32) = (0x3FC8_0000, 0x3FCE_0000);
-
-#[cfg(feature = "esp32c6")]
-const RAM: (u32, u32) = (0x4080_0000, 0x4088_0000);
-
-#[cfg(feature = "esp32h2")]
-const RAM: (u32, u32) = (0x4080_0000, 0x4085_0000);
-
-#[cfg(feature = "esp32p4")]
-const RAM: (u32, u32) = (0x4FF0_0000, 0x4FFC_0000);
-
-#[cfg(feature = "esp32s2")]
-const RAM: (u32, u32) = (0x3FFB_0000, 0x4000_0000);
-
-#[cfg(feature = "esp32s3")]
-const RAM: (u32, u32) = (0x3FC8_8000, 0x3FD0_0000);
+        i += 1;
+    }
+    r
+}
 
 #[cfg(feature = "colors")]
 const RESET: &str = "\u{001B}[0m";

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -90,13 +90,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 
     println!("");
     println!("====================== PANIC ======================");
-
-    #[cfg(not(feature = "defmt"))]
     println!("{}", info);
-
-    #[cfg(feature = "defmt")]
-    println!("{}", defmt::Display2Format(info));
-
     println!("");
     println!("Backtrace:");
     println!("");
@@ -135,12 +129,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 
     println!("");
     println!("====================== PANIC ======================");
-
-    #[cfg(not(feature = "defmt"))]
     println!("{}", info);
-
-    #[cfg(feature = "defmt")]
-    println!("{}", defmt::Display2Format(info));
 
     #[cfg(feature = "colors")]
     set_color_code(RESET);

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -263,22 +263,23 @@ fn exception_handler(context: TrapFrame) -> ! {
             "Exception '{}' mepc=0x{:08x}, mtval=0x{:08x}",
             code, mepc, mtval
         );
+
         #[cfg(not(feature = "defmt"))]
         println!("{:x?}", context);
 
         #[cfg(feature = "defmt")]
         println!("{:?}", context);
 
-        let backtrace = crate::arch::backtrace_internal(context.s0 as u32, 0);
+        let backtrace = backtrace_internal(context.s0 as u32, 0);
         if backtrace.iter().filter(|e| e.is_some()).count() == 0 {
             println!("No backtrace available - make sure to force frame-pointers. (see https://crates.io/crates/esp-backtrace)");
         }
         for addr in backtrace.into_iter().flatten() {
             #[cfg(all(feature = "colors", feature = "println"))]
-            println!("{}0x{:x}", RED, addr - crate::arch::RA_OFFSET);
+            println!("{}0x{:x}", RED, addr - RA_OFFSET);
 
             #[cfg(not(all(feature = "colors", feature = "println")))]
-            println!("0x{:x}", addr - crate::arch::RA_OFFSET);
+            println!("0x{:x}", addr - RA_OFFSET);
         }
     }
 
@@ -298,8 +299,51 @@ fn exception_handler(context: TrapFrame) -> ! {
 
 #[cfg(all(feature = "exception-handler", feature = "coredump"))]
 #[export_name = "ExceptionHandler"]
-fn exception_handler(context: &arch::TrapFrame) -> ! {
+fn exception_handler(context: &TrapFrame) -> ! {
     use core::ptr::addr_of;
+
+    let mepc = context.pc;
+    let code = context.mcause & 0xff;
+    let mtval = context.mtval;
+
+    #[cfg(feature = "colors")]
+    set_color_code(RED);
+
+    if code == 14 {
+        println!("");
+        println!(
+            "Stack overflow detected at 0x{:x} called by 0x{:x}",
+            mepc, context.ra
+        );
+        println!("");
+    } else if code != 11 {
+        let code = match code {
+            0 => "Instruction address misaligned",
+            1 => "Instruction access fault",
+            2 => "Illegal instruction",
+            3 => "Breakpoint",
+            4 => "Load address misaligned",
+            5 => "Load access fault",
+            6 => "Store/AMO address misaligned",
+            7 => "Store/AMO access fault",
+            8 => "Environment call from U-mode",
+            9 => "Environment call from S-mode",
+            10 => "Reserved",
+            11 => "Environment call from M-mode",
+            12 => "Instruction page fault",
+            13 => "Load page fault",
+            14 => "Reserved",
+            15 => "Store/AMO page fault",
+            _ => "UNKNOWN",
+        };
+
+        println!(
+            "Exception '{}' mepc=0x{:08x}, mtval=0x{:08x}",
+            code, mepc, mtval
+        );
+    }
+    #[cfg(feature = "colors")]
+    set_color_code(RESET);
 
     let regs = coredump::Registers {
         pc: context.pc as u32,

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -1,5 +1,6 @@
 use core::arch::asm;
 
+#[cfg(feature = "exception-handler")]
 use super::*;
 use crate::MAX_BACKTRACE_ADDRESSES;
 
@@ -300,8 +301,6 @@ fn exception_handler(context: TrapFrame) -> ! {
 #[cfg(all(feature = "exception-handler", feature = "coredump"))]
 #[export_name = "ExceptionHandler"]
 fn exception_handler(context: &TrapFrame) -> ! {
-    use core::ptr::addr_of;
-
     let mepc = context.pc;
     let code = context.mcause & 0xff;
     let mtval = context.mtval;
@@ -383,7 +382,7 @@ fn exception_handler(context: &TrapFrame) -> ! {
     let mut writer = crate::coredump::DumpWriter {};
 
     let start = regs.x2 - 256;
-    let end = addr_of!(_stack_start) as u32;
+    let end = core::ptr::addr_of!(_stack_start) as u32;
     let len = (end - start) as usize;
 
     let slice = unsafe { core::slice::from_raw_parts(start as *const u8, len) };

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -406,7 +406,7 @@ fn exception_handler(context: &TrapFrame) -> ! {
     };
 
     println!("@COREDUMP");
-    coredump::dump(&mut writer, &regs, mem);
+    coredump::dump(&mut writer, &regs, mem).ok();
     println!("@ENDCOREDUMP");
 
     #[cfg(feature = "semihosting")]

--- a/esp-backtrace/src/xtensa.rs
+++ b/esp-backtrace/src/xtensa.rs
@@ -1,5 +1,6 @@
-use core::{arch::asm, fmt::Display, ptr::addr_of};
+use core::{arch::asm, fmt::Display};
 
+#[cfg(feature = "exception-handler")]
 use super::*;
 use crate::MAX_BACKTRACE_ADDRESSES;
 
@@ -521,7 +522,7 @@ unsafe fn __user_exception(cause: ExceptionCause, context: Context) {
     let mut writer = crate::coredump::DumpWriter {};
 
     let start = regs.ar[1] - 256;
-    let end = addr_of!(_stack_start) as u32;
+    let end = core::ptr::addr_of!(_stack_start) as u32;
     let len = (end - start) as usize;
 
     let slice = unsafe { core::slice::from_raw_parts(start as *const u8, len) };

--- a/esp-backtrace/src/xtensa.rs
+++ b/esp-backtrace/src/xtensa.rs
@@ -543,7 +543,7 @@ unsafe fn __user_exception(cause: ExceptionCause, context: Context) {
     let mem = coredump::Memory { start, slice };
 
     println!("@COREDUMP");
-    coredump::dump(&mut writer, &regs, mem);
+    coredump::dump(&mut writer, &regs, mem).ok();
     println!("@ENDCOREDUMP");
 
     #[cfg(feature = "semihosting")]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -38,6 +38,7 @@ embedded-io              = { version = "0.6.1", optional = true }
 embedded-io-async        = { version = "0.6.1", optional = true }
 enumset                  = "1.1.5"
 esp-build                = { version = "0.1.0", path = "../esp-build" }
+esp-config               = { version = "0.2.0", path = "../esp-config" }
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                    = "0.3.7"
 instability              = "0.3"

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -45,9 +45,9 @@ pub(crate) mod constants {
     /// The size, in bytes, of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 64;
     /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: usize = 0x3FFA_E000;
+    pub const SOC_DRAM_LOW: usize = super::super::SOC_DRAM_LOW;
     /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: usize = 0x4000_0000;
+    pub const SOC_DRAM_HIGH: usize = super::super::SOC_DRAM_HIGH;
     /// A reference clock tick of 1 MHz.
     pub const REF_TICK: fugit::HertzU32 = fugit::HertzU32::MHz(1);
 }

--- a/esp-hal/src/soc/esp32c2/mod.rs
+++ b/esp-hal/src/soc/esp32c2/mod.rs
@@ -35,9 +35,9 @@ pub(crate) mod registers {
 
 pub(crate) mod constants {
     /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: usize = 0x3FCA_0000;
+    pub const SOC_DRAM_LOW: usize = super::super::SOC_DRAM_LOW;
     /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: usize = 0x3FCE_0000;
+    pub const SOC_DRAM_HIGH: usize = super::super::SOC_DRAM_HIGH;
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -53,9 +53,9 @@ pub(crate) mod constants {
     pub const RMT_CLOCK_SRC_FREQ: fugit::HertzU32 = fugit::HertzU32::MHz(80);
 
     /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: usize = 0x3FC8_0000;
+    pub const SOC_DRAM_LOW: usize = super::super::SOC_DRAM_LOW;
     /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: usize = 0x3FCE_0000;
+    pub const SOC_DRAM_HIGH: usize = super::super::SOC_DRAM_HIGH;
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -60,10 +60,10 @@ pub(crate) mod constants {
     /// The clock frequency for the Parallel IO peripheral in Hertz.
     pub const PARL_IO_SCLK: u32 = 240_000_000;
 
-    /// The lower address boundary for system DRAM.
-    pub const SOC_DRAM_LOW: usize = 0x4080_0000;
-    /// The upper address boundary for system DRAM.
-    pub const SOC_DRAM_HIGH: usize = 0x4088_0000;
+    /// The lower bound of the system's DRAM (Data RAM) address space.
+    pub const SOC_DRAM_LOW: usize = super::super::SOC_DRAM_LOW;
+    /// The upper bound of the system's DRAM (Data RAM) address space.
+    pub const SOC_DRAM_HIGH: usize = super::super::SOC_DRAM_HIGH;
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17_500);

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -60,10 +60,10 @@ pub(crate) mod constants {
     /// Hertz.
     pub const PARL_IO_SCLK: u32 = 96_000_000;
 
-    /// Start address of the system's DRAM (low range).
-    pub const SOC_DRAM_LOW: usize = 0x4080_0000;
-    /// End address of the system's DRAM (high range).
-    pub const SOC_DRAM_HIGH: usize = 0x4085_0000;
+    /// The lower bound of the system's DRAM (Data RAM) address space.
+    pub const SOC_DRAM_LOW: usize = super::super::SOC_DRAM_LOW;
+    /// The upper bound of the system's DRAM (Data RAM) address space.
+    pub const SOC_DRAM_HIGH: usize = super::super::SOC_DRAM_HIGH;
 
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -49,10 +49,10 @@ pub(crate) mod constants {
     pub const RMT_RAM_START: usize = 0x3f416400;
     /// Size of the RAM allocated per RMT channel, in bytes.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 64;
-    /// Start address of the system's DRAM (low range).
-    pub const SOC_DRAM_LOW: usize = 0x3FFB_0000;
-    /// End address of the system's DRAM (high range).
-    pub const SOC_DRAM_HIGH: usize = 0x4000_0000;
+    /// The lower bound of the system's DRAM (Data RAM) address space.
+    pub const SOC_DRAM_LOW: usize = super::super::SOC_DRAM_LOW;
+    /// The upper bound of the system's DRAM (Data RAM) address space.
+    pub const SOC_DRAM_HIGH: usize = super::super::SOC_DRAM_HIGH;
     /// Reference clock tick frequency, set to 1 MHz.
     pub const REF_TICK: fugit::HertzU32 = fugit::HertzU32::MHz(1);
 }

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -57,9 +57,9 @@ pub(crate) mod constants {
     pub const RMT_CLOCK_SRC_FREQ: fugit::HertzU32 = fugit::HertzU32::MHz(80);
 
     /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: usize = 0x3FC8_8000;
+    pub const SOC_DRAM_LOW: usize = super::super::SOC_DRAM_LOW;
     /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: usize = 0x3FD0_0000;
+    pub const SOC_DRAM_HIGH: usize = super::super::SOC_DRAM_HIGH;
 
     /// A reference clock tick of 1 MHz.
     pub const RC_FAST_CLK: fugit::HertzU32 = fugit::HertzU32::kHz(17500);

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -38,6 +38,11 @@ pub(crate) fn psram_range() -> Range<usize> {
     }
 }
 
+/// The lower bound of the system's DRAM (Data RAM) address space.
+const SOC_DRAM_LOW: usize = esp_config::esp_config_int!(usize, "REGION-DRAM-START");
+/// The upper bound of the system's DRAM (Data RAM) address space.
+const SOC_DRAM_HIGH: usize = esp_config::esp_config_int!(usize, "REGION-DRAM-END");
+
 const DRAM: Range<usize> = self::constants::SOC_DRAM_LOW..self::constants::SOC_DRAM_HIGH;
 
 #[cfg(any(feature = "quad-psram", feature = "octal-psram"))]

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -75,3 +75,5 @@ symbols = [
     "pm_support_touch_sensor_wakeup",
     "ulp_supported",
 ]
+
+memory = [{ name = "dram", start = 0x3FFA_E000, end = 0x4000_0000 }]

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -52,3 +52,5 @@ symbols = [
     "uart_support_wakeup_int",
     "gpio_support_deepsleep_wakeup",
 ]
+
+memory = [{ name = "dram", start = 0x3FCA_0000, end = 0x3FCE_0000 }]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -64,3 +64,5 @@ symbols = [
     "uart_support_wakeup_int",
     "gpio_support_deepsleep_wakeup",
 ]
+
+memory = [{ name = "dram", start = 0x3FC8_0000, end = 0x3FCE_0000 }]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -97,3 +97,5 @@ symbols = [
     "uart_support_wakeup_int",
     "pm_support_ext1_wakeup",
 ]
+
+memory = [{ name = "dram", start = 0x4080_0000, end = 0x4088_0000 }]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -77,3 +77,5 @@ symbols = [
     "rom_crc_be",
     "rom_md5_bsd",
 ]
+
+memory = [{ name = "dram", start = 0x4080_0000, end = 0x4085_0000 }]

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -98,3 +98,5 @@ symbols = [
     "gpio_bank_1",
     "spi_octal",
 ]
+
+memory = [{ name = "dram", start = 0x4FF0_0000, end = 0x4FFC_0000 }]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -77,3 +77,5 @@ symbols = [
     # Other capabilities
     "psram_dma",
 ]
+
+memory = [{ name = "dram", start = 0x3FFB_0000, end = 0x4000_0000 }]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -94,3 +94,5 @@ symbols = [
     # Other capabilities
     "psram_dma",
 ]
+
+memory = [{ name = "dram", start = 0x3FC8_8000, end = 0x3FD0_0000 }]

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -214,8 +214,9 @@ impl Config {
     }
 
     /// Memory regions.
-    /// 
-    /// Will be available as env-variables `REGION-<NAME>-START` / `REGION-<NAME>-END`
+    ///
+    /// Will be available as env-variables `REGION-<NAME>-START` /
+    /// `REGION-<NAME>-END`
     pub fn memory(&self) -> &[MemoryRegion] {
         &self.device.memory
     }

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -248,6 +248,8 @@ impl Config {
 
         // Define env-vars for all memory regions
         for memory in self.memory() {
+            println!("cargo:rustc-cfg=has_{}_region", memory.name.to_lowercase());
+
             println!(
                 "cargo::rustc-env=REGION-{}-START={}",
                 memory.name.to_uppercase(),
@@ -275,6 +277,12 @@ fn define_all_possible_symbols() {
         for symbol in config.all() {
             // https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-check-cfg
             println!("cargo:rustc-check-cfg=cfg({})", symbol);
+        }
+        for memory in config.memory() {
+            println!(
+                "cargo:rustc-check-cfg=cfg(has_{}_region)",
+                memory.name.to_lowercase()
+            );
         }
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds the features `coredump` and `coredump-all` which will make the panic handler to raise an exception (via `ecall`/`syscall`) and changes the exception handler to create a coredump.

#### Testing
Add the `coredump` feature to `esp-backtrace` in `examples`, change one of the examples to panic.

You can use https://github.com/bjoernQ/espflash-coredump and a recent espfalsh commit (or copy paste, convert from hex to binary)
