### PR TITLE
DHCP support added to wifi embassy access point example

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added DHCP support to wifi embassy access point example.
 - In addition to taking by value, peripheral drivers can now mutably borrow DMA channel objects. (#2526)
 - DMA channel objects are no longer wrapped in `Channel`. The `Channel` drivers are now managed by DMA enabled peripheral drivers. (#2526)
 - The `Dpi` driver and `DpiTransfer` now have a `Mode` type parameter. The driver's asyncness is determined by the asyncness of the `Lcd` used to create it. (#2526)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added DHCP support to wifi embassy access point example.
 - In addition to taking by value, peripheral drivers can now mutably borrow DMA channel objects. (#2526)
 - DMA channel objects are no longer wrapped in `Channel`. The `Channel` drivers are now managed by DMA enabled peripheral drivers. (#2526)
 - The `Dpi` driver and `DpiTransfer` now have a `Mode` type parameter. The driver's asyncness is determined by the asyncness of the `Lcd` used to create it. (#2526)

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@ blocking-network-stack = { git = "https://github.com/bjoernQ/blocking-network-st
 bt-hci              = "0.1.1"
 cfg-if              = "1.0.0"
 critical-section    = "1.1.3"
-embassy-executor    = { version = "0.6.0", features = ["task-arena-size-12288"] }
+embassy-executor    = { version = "0.6.0", features = ["task-arena-size-20480"] }
 embassy-futures     = "0.1.1"
 embassy-net = { version = "0.4.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 embassy-sync        = "0.6.0"
@@ -47,6 +47,10 @@ static_cell         = { version = "2.1.0", features = ["nightly"] }
 trouble-host        = { git = "https://github.com/embassy-rs/trouble", package = "trouble-host", rev = "4f1114ce58e96fe54f5ed7e726f66e1ad8d9ce54", features = [ "log", "gatt" ] }
 usb-device          = "0.3.2"
 usbd-serial         = "0.2.2"
+edge-dhcp = "0.3.0"
+edge-raw = "0.3.0"
+edge-nal = "0.3.0"
+edge-nal-embassy = "0.3.0"
 
 [features]
 esp32   = ["esp-hal/esp32",   "esp-backtrace/esp32",   "esp-hal-embassy?/esp32",   "esp-println/esp32",   "esp-storage?/esp32",   "esp-wifi?/esp32"]

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -243,14 +243,17 @@ async fn run_dhcp(
         .await
         .unwrap();
 
-    _ = io::server::run(
-        &mut Server::<64>::new(ip),
-        &ServerOptions::new(ip, Some(&mut gw_buf)),
-        &mut bound_socket,
-        &mut buf,
-    )
-    .await
-    .inspect_err(|e| log::warn!("DHCP server failed: {e:?}"));
+    loop {
+        _ = io::server::run(
+            &mut Server::<64>::new(ip),
+            &ServerOptions::new(ip, Some(&mut gw_buf)),
+            &mut bound_socket,
+            &mut buf,
+        )
+        .await
+        .inspect_err(|e| log::warn!("DHCP server error: {e:?}"));
+        Timer::after(Duration::from_millis(500)).await;
+    }
 }
 
 #[embassy_executor::task]

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -15,6 +15,8 @@
 #![no_std]
 #![no_main]
 
+use core::str::FromStr;
+
 use embassy_executor::Spawner;
 use embassy_net::{
     tcp::TcpSocket,
@@ -54,6 +56,8 @@ macro_rules! mk_static {
     }};
 }
 
+const GW_IP_ADDR: &str = env!("GATEWAY_IP");
+
 #[esp_hal_embassy::main]
 async fn main(spawner: Spawner) -> ! {
     esp_println::logger::init_logger_from_env();
@@ -89,9 +93,11 @@ async fn main(spawner: Spawner) -> ! {
         }
     }
 
+    let gw_ip_addr = Ipv4Address::from_str(GW_IP_ADDR).expect("failed to parse gateway ip");
+
     let config = embassy_net::Config::ipv4_static(StaticConfigV4 {
-        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
-        gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
+        address: Ipv4Cidr::new(gw_ip_addr, 24),
+        gateway: Some(gw_ip_addr),
         dns_servers: Default::default(),
     });
 
@@ -110,6 +116,7 @@ async fn main(spawner: Spawner) -> ! {
 
     spawner.spawn(connection(controller)).ok();
     spawner.spawn(net_task(&stack)).ok();
+    spawner.spawn(run_dhcp(&stack, GW_IP_ADDR)).ok();
 
     let mut rx_buffer = [0; 1536];
     let mut tx_buffer = [0; 1536];
@@ -120,8 +127,14 @@ async fn main(spawner: Spawner) -> ! {
         }
         Timer::after(Duration::from_millis(500)).await;
     }
-    println!("Connect to the AP `esp-wifi` and point your browser to http://192.168.2.1:8080/");
-    println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
+    println!("Connect to the AP `esp-wifi` and point your browser to http://{GW_IP_ADDR}:8080/");
+    println!("DHCP is enabled so there's no need to configure a static IP, just in case:");
+    while !stack.is_config_up() {
+        Timer::after(Duration::from_millis(100)).await
+    }
+    stack
+        .config_v4()
+        .inspect(|c| println!("ipv4 config: {c:?}"));
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
     socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
@@ -195,6 +208,46 @@ async fn main(spawner: Spawner) -> ! {
 
         socket.abort();
     }
+}
+
+#[embassy_executor::task]
+async fn run_dhcp(
+    stack: &'static Stack<WifiDevice<'static, WifiApDevice>>,
+    gw_ip_addr: &'static str,
+) {
+    use core::net::{Ipv4Addr, SocketAddrV4};
+
+    use edge_dhcp::{
+        io::{self, DEFAULT_SERVER_PORT},
+        server::{Server, ServerOptions},
+    };
+    use edge_nal::UdpBind;
+    use edge_nal_embassy::{Udp, UdpBuffers};
+
+    let ip = Ipv4Addr::from_str(gw_ip_addr).expect("dhcp task failed to parse gw ip");
+
+    let mut buf = [0u8; 1500];
+
+    let mut gw_buf = [Ipv4Addr::UNSPECIFIED];
+
+    let buffers = UdpBuffers::<3, 1024, 1024, 10>::new();
+    let unbound_socket = Udp::new(stack, &buffers);
+    let mut bound_socket = unbound_socket
+        .bind(core::net::SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::UNSPECIFIED,
+            DEFAULT_SERVER_PORT,
+        )))
+        .await
+        .unwrap();
+
+    _ = io::server::run(
+        &mut Server::<64>::new(ip),
+        &ServerOptions::new(ip, Some(&mut gw_buf)),
+        &mut bound_socket,
+        &mut buf,
+    )
+    .await
+    .inspect_err(|e| log::warn!("DHCP server failed: {e:?}"));
 }
 
 #[embassy_executor::task]


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Related to https://github.com/esp-rs/esp-hal/issues/1626.
Add DHCP to wifi ap example, it uses edge net for the protocol, some tweaks regarding the number and size of buffers needed are needed.
Also, the Gateway IP address used is now the one configured in the environment.

#### Testing
I uploaded the app to my esp32-s3-devkitc board, I successfully connected to the board wifi ap with my phone, without any configuration on the android side, I was able to connect to the HTTP server.
