### PR TITLE
Add priority-limited locks

### DIFF
--- a/esp-hal-embassy/src/executor/thread.rs
+++ b/esp-hal-embassy/src/executor/thread.rs
@@ -138,7 +138,15 @@ This will use software-interrupt 3 which isn't available for anything else to wa
             // sections in Xtensa are implemented via increasing `PS.INTLEVEL`.
             // The critical section ends here. Take care not add code after
             // `waiti` if it needs to be inside the CS.
-            unsafe { core::arch::asm!("waiti 0") };
+            // Do not lower INTLEVEL below the current value.
+            match token & 0x0F {
+                0 => unsafe { core::arch::asm!("waiti 0") },
+                1 => unsafe { core::arch::asm!("waiti 1") },
+                2 => unsafe { core::arch::asm!("waiti 2") },
+                3 => unsafe { core::arch::asm!("waiti 3") },
+                4 => unsafe { core::arch::asm!("waiti 4") },
+                _ => unsafe { core::arch::asm!("waiti 5") },
+            }
         }
         // If this races and some waker sets the signal, we'll reset it, but still poll.
         SIGNAL_WORK_THREAD_MODE[cpu].store(false, Ordering::Relaxed);

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped GPIO futures stop listening for interrupts (#2625)
 - UART driver's `StopBits` enum variants now correctly use UpperCamelCase (#2669)
 - The `PeripheralInput` and `PeripheralOutput` traits are now sealed (#2690)
+- `esp_hal::sync::Lock` has been renamed to RawMutex (#2684)
 
 ### Fixed
 

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -117,7 +117,7 @@ pub enum CpuInterrupt {
 }
 
 /// Interrupt priority levels.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum Priority {
@@ -164,6 +164,32 @@ impl Priority {
     /// Minimum interrupt priority
     pub const fn min() -> Priority {
         Priority::Priority1
+    }
+}
+
+impl TryFrom<u8> for Priority {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Priority::None),
+            1 => Ok(Priority::Priority1),
+            2 => Ok(Priority::Priority2),
+            3 => Ok(Priority::Priority3),
+            4 => Ok(Priority::Priority4),
+            5 => Ok(Priority::Priority5),
+            6 => Ok(Priority::Priority6),
+            7 => Ok(Priority::Priority7),
+            8 => Ok(Priority::Priority8),
+            9 => Ok(Priority::Priority9),
+            10 => Ok(Priority::Priority10),
+            11 => Ok(Priority::Priority11),
+            12 => Ok(Priority::Priority12),
+            13 => Ok(Priority::Priority13),
+            14 => Ok(Priority::Priority14),
+            15 => Ok(Priority::Priority15),
+            _ => Err(Error::InvalidInterruptPriority),
+        }
     }
 }
 

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -340,7 +340,7 @@ mod vectored {
     use super::*;
 
     /// Interrupt priority levels.
-    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[repr(u8)]
     pub enum Priority {
@@ -363,6 +363,20 @@ mod vectored {
         /// Minimum interrupt priority
         pub const fn min() -> Priority {
             Priority::Priority1
+        }
+    }
+
+    impl TryFrom<u8> for Priority {
+        type Error = Error;
+
+        fn try_from(value: u8) -> Result<Self, Self::Error> {
+            match value {
+                0 => Ok(Priority::None),
+                1 => Ok(Priority::Priority1),
+                2 => Ok(Priority::Priority2),
+                3 => Ok(Priority::Priority3),
+                _ => Err(Error::InvalidInterrupt),
+            }
         }
     }
 

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -26,7 +26,7 @@ use crate::{
     interrupt::{self, InterruptConfigurable, InterruptHandler},
     peripheral::Peripheral,
     peripherals::{Interrupt, SYSTIMER},
-    sync::{lock, Lock},
+    sync::{lock, RawMutex},
     system::{Peripheral as PeripheralEnable, PeripheralClockControl},
     Cpu,
 };
@@ -628,8 +628,8 @@ impl Peripheral for Alarm {
 
 impl crate::private::Sealed for Alarm {}
 
-static CONF_LOCK: Lock = Lock::new();
-static INT_ENA_LOCK: Lock = Lock::new();
+static CONF_LOCK: RawMutex = RawMutex::new();
+static INT_ENA_LOCK: RawMutex = RawMutex::new();
 
 // Async functionality of the system timer.
 mod asynch {

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -76,13 +76,13 @@ use crate::{
     peripheral::Peripheral,
     peripherals::{timg0::RegisterBlock, Interrupt, TIMG0},
     private::Sealed,
-    sync::{lock, Lock},
+    sync::{lock, RawMutex},
     system::PeripheralClockControl,
 };
 
 const NUM_TIMG: usize = 1 + cfg!(timg1) as usize;
 
-static INT_ENA_LOCK: [Lock; NUM_TIMG] = [const { Lock::new() }; NUM_TIMG];
+static INT_ENA_LOCK: [RawMutex; NUM_TIMG] = [const { RawMutex::new() }; NUM_TIMG];
 
 /// A timer group consisting of
 #[cfg_attr(not(timg_timer1), doc = "a general purpose timer")]

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -10,7 +10,7 @@ pub(crate) mod os_adapter_chip_specific;
 use core::{cell::RefCell, ptr::addr_of_mut};
 
 use enumset::EnumSet;
-use esp_hal::sync::{Lock, Locked};
+use esp_hal::sync::{Locked, RawMutex};
 
 use super::WifiEvent;
 use crate::{
@@ -35,7 +35,7 @@ use crate::{
     timer::yield_task,
 };
 
-static WIFI_LOCK: Lock = Lock::new();
+static WIFI_LOCK: RawMutex = RawMutex::new();
 
 static mut QUEUE_HANDLE: *mut ConcurrentQueue = core::ptr::null_mut();
 


### PR DESCRIPTION
However, when it does, we can use it in embassy-executor to lock certain resources without affecting higher priority levels. This will come in handy once we manage our own timer queue, which is only ever accessed from the executor's priority level, and the alarm's level (which we'll be able to reduce to executor+1). Priority-limiting access to the queue will result in less jitter in higher priority executors. Hopefully :)

skip-changelog is purposeful. `sync` is a hidden module, which needs to be public because embassy/wifi build on it, but this new addition is pretty experimental - API, documentation or functionality may still change I think.