### PR TITLE
Mention that config structs should derive `procmacros::BuilderLite` in the API guidelines

### DIFF
--- a/documentation/API-GUIDELINES.md
+++ b/documentation/API-GUIDELINES.md
@@ -35,6 +35,7 @@ In general, the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines
   - The `ConfigError` enum should be separate from other `Error` enums used by the driver.
   - The driver should implement `fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError>`.
   - In case the driver's configuration is infallible (all possible combinations of options are supported by the hardware), the `ConfigError` should be implemented as an empty `enum`.
+  - Configuration structs should derive `procmacros::BuilderLite` in order to automatically implement the Builder Lite pattern for them.
 - If a driver only supports a single peripheral instance, no instance type parameter is necessary.
 - If a driver implements both blocking and async operations, or only implements blocking operations, but may support asynchronous ones in the future, the driver's type signature must include a `crate::Mode` type parameter.
 - By default, constructors must configure the driver for blocking mode. The driver must implement `into_async` (and a matching `into_blocking`) function that reconfigures the driver.


### PR DESCRIPTION
Closes #2500