### PR TITLE
Fix signal fn recommendation

### DIFF
--- a/documentation/API-GUIDELINES.md
+++ b/documentation/API-GUIDELINES.md
@@ -24,7 +24,7 @@ In general, the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines
 ## Construction and Destruction of Drivers
 
 - Drivers must take peripherals via the `PeripheralRef` pattern - they don't consume peripherals directly.
-- If a driver requires pins, those pins must be configured using `fn with_signal_name(self, pin: impl Peripheral<P = InputConnection> + 'd) -> Self)` or `fn with_signal_name(self, pin: impl Peripheral<P = OutputConnection> + 'd) -> Self)`
+- If a driver requires pins, those pins should be configured using `fn with_signal_name(self, pin: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self` or `fn with_signal_name(self, pin: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self`
 - If a driver supports multiple peripheral instances (for example, I2C0 is one such instance):
   - The peripheral instance type must be positioned as the last type parameter of the driver type.
   - The peripheral instance type must default to a type that supports any of the peripheral instances.


### PR DESCRIPTION
I've also relaxed the wording from "must" to "should" because there is a chance SPI chip select is going to end up being an exception. Maybe not, but just in case the peripheral needs an extra param, or returns an error, we should allow some deviation.

Let's say this fixes https://github.com/esp-rs/esp-hal/issues/2658 - that issue seems to have been opened based on the incorrect recommendation.