### PR TITLE
ESP32 PSRAM: Clean the correct bit

### DIFF
--- a/esp-hal/src/soc/esp32/psram.rs
+++ b/esp-hal/src/soc/esp32/psram.rs
@@ -702,7 +702,7 @@ pub(crate) mod utils {
         unsafe {
             let spi = &*crate::peripherals::SPI1::PTR;
             // We need to clear last bit of INT_EN field here.
-            spi.slave().modify(|_, w| w.trans_done().clear_bit());
+            spi.slave().modify(|_, w| w.trans_inten().clear_bit());
             // SPI_CPOL & SPI_CPHA
             spi.pin().modify(|_, w| w.ck_idle_edge().clear_bit());
             spi.user().modify(|_, w| w.ck_out_edge().clear_bit());


### PR DESCRIPTION
A mistake in https://github.com/esp-rs/esp-hal/pull/2719

In esp-idf, the corresponding line is 

```c
CLEAR_PERI_REG_MASK(SPI_SLAVE_REG(spi_num), SPI_TRANS_DONE << 5);
```

Where

`#define SPI_TRANS_DONE  (BIT(4))`

This is a weird way to formulate things, but the end result is that bit 9 gets cleared, which is `SPI_TRANS_INTEN`