### PR TITLE
Fix qa-test build.rs

### DIFF
--- a/qa-test/build.rs
+++ b/qa-test/build.rs
@@ -2,8 +2,12 @@ fn main() {
     // Allow building QA tests in CI in debug mode
     println!("cargo:rustc-check-cfg=cfg(is_not_release)");
     println!("cargo:rerun-if-env-changed=CI");
-    #[cfg(debug_assertions)]
+    println!("cargo:rerun-if-env-changed=CI");
     if std::env::var("CI").is_err() {
-        println!("cargo::rustc-cfg=is_not_release");
+        if let Ok(level) = std::env::var("OPT_LEVEL") {
+            if level == "0" || level == "1" {
+                println!("cargo::rustc-cfg=is_not_release");
+            }
+        }
     }
 }

--- a/qa-test/build.rs
+++ b/qa-test/build.rs
@@ -2,7 +2,6 @@ fn main() {
     // Allow building QA tests in CI in debug mode
     println!("cargo:rustc-check-cfg=cfg(is_not_release)");
     println!("cargo:rerun-if-env-changed=CI");
-    println!("cargo:rerun-if-env-changed=CI");
     if std::env::var("CI").is_err() {
         if let Ok(level) = std::env::var("OPT_LEVEL") {
             if level == "0" || level == "1" {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
We enable debug assertions for release builds but the qa-test/build.rs wasn't changed to honor that change - i.e. the psram examples/tests didn't work when run locally

#### Testing
Run `psram_octal` / `psram_quad`
