### PR TITLE
Fix async USB OTG-FS driver

### DIFF
--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -231,13 +231,11 @@ pub mod asynch {
         fn start(self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe) {
             let (bus, cp) = self.inner.start(control_max_packet_size);
 
-            (
-                Bus {
-                    inner: bus,
-                    inited: false,
-                },
-                cp,
-            )
+            let mut bus = Bus { inner: bus };
+
+            bus.init();
+
+            (bus, cp)
         }
     }
 
@@ -245,7 +243,6 @@ pub mod asynch {
     // We need a custom wrapper implementation to handle custom initialization.
     pub struct Bus<'d> {
         inner: OtgBus<'d, MAX_EP_COUNT>,
-        inited: bool,
     }
 
     impl<'d> Bus<'d> {
@@ -298,11 +295,6 @@ pub mod asynch {
 
     impl<'d> embassy_usb_driver::Bus for Bus<'d> {
         async fn poll(&mut self) -> Event {
-            if !self.inited {
-                self.init();
-                self.inited = true;
-            }
-
             self.inner.poll().await
         }
 

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -284,10 +284,10 @@ pub mod asynch {
         }
 
         fn disable(&mut self) {
-            crate::interrupt::disable(Cpu::ProCpu, crate::peripherals::Interrupt::USB);
+            crate::interrupt::disable(Cpu::ProCpu, peripherals::Interrupt::USB);
 
             #[cfg(multi_core)]
-            crate::interrupt::disable(Cpu::AppCpu, crate::peripherals::Interrupt::USB);
+            crate::interrupt::disable(Cpu::AppCpu, peripherals::Interrupt::USB);
 
             Usb::_disable();
         }

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -62,15 +62,11 @@ pub struct Usb<'d> {
 
 impl<'d> Usb<'d> {
     /// Creates a new `Usb` instance.
-    pub fn new<P, M>(
+    pub fn new(
         usb0: impl Peripheral<P = peripherals::USB0> + 'd,
-        _usb_dp: impl Peripheral<P = P> + 'd,
-        _usb_dm: impl Peripheral<P = M> + 'd,
-    ) -> Self
-    where
-        P: UsbDp + Send + Sync,
-        M: UsbDm + Send + Sync,
-    {
+        _usb_dp: impl Peripheral<P = impl UsbDp> + 'd,
+        _usb_dm: impl Peripheral<P = impl UsbDm> + 'd,
+    ) -> Self {
         let guard = GenericPeripheralGuard::new();
 
         Self {

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -283,12 +283,11 @@ pub mod asynch {
                     crate::peripherals::Interrupt::USB,
                     interrupt_handler.handler(),
                 );
-                crate::interrupt::enable(
-                    crate::peripherals::Interrupt::USB,
-                    interrupt_handler.priority(),
-                )
-                .unwrap();
             }
+            unwrap!(crate::interrupt::enable(
+                crate::peripherals::Interrupt::USB,
+                interrupt_handler.priority(),
+            ));
         }
 
         fn disable(&mut self) {

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -403,15 +403,15 @@ impl PeripheralClockControl {
     /// Resets the given peripheral
     pub(crate) fn reset(peripheral: Peripheral) {
         debug!("Reset {:?}", peripheral);
-        let system = unsafe { &*SYSTEM::PTR };
+        let system = unsafe { SYSTEM::steal() };
 
         #[cfg(esp32)]
-        let (perip_rst_en0, peri_rst_en) = { (&system.perip_rst_en(), &system.peri_rst_en()) };
+        let (perip_rst_en0, peri_rst_en) = (system.perip_rst_en(), system.peri_rst_en());
         #[cfg(not(esp32))]
-        let perip_rst_en0 = { &system.perip_rst_en0() };
+        let perip_rst_en0 = system.perip_rst_en0();
 
         #[cfg(any(esp32c2, esp32c3, esp32s2, esp32s3))]
-        let perip_rst_en1 = { &system.perip_rst_en1() };
+        let perip_rst_en1 = system.perip_rst_en1();
 
         critical_section::with(|_cs| match peripheral {
             #[cfg(spi2)]

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -30,6 +30,7 @@ use esp_hal::{
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
+    esp_println::logger::init_logger(log::LevelFilter::Info);
     esp_println::println!("Init!");
     let peripherals = esp_hal::init(esp_hal::Config::default());
 

--- a/examples/src/bin/embassy_usb_serial.rs
+++ b/examples/src/bin/embassy_usb_serial.rs
@@ -30,7 +30,6 @@ use esp_hal::{
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
-    esp_println::logger::init_logger(log::LevelFilter::Info);
     esp_println::println!("Init!");
     let peripherals = esp_hal::init(esp_hal::Config::default());
 


### PR DESCRIPTION
#2544 made a reasonable effort to update USB OTG, but we did not keep the `Usb` struct alive long enough, so starting the driver ended up dropping it and disabled clocks.

This PR fixes the issue, and applies some drive-by cleanups, as well as aligns init code with esp-usb-synopsys-otg. Changelog entry skipped because the bug was introduced in this cycle.