### PR TITLE
feat(uart): config option to disable the rx input checks

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BurstConfig`, a device-specific configuration for configuring DMA transfers in burst mode (#2543)
 - `{DmaRxBuf, DmaTxBuf, DmaRxTxBuf}::set_burst_config` (#2543)
 - ESP32-S2: DMA support for AES (#2699)
+- Added `disable_rx_input_checks` to `uart::Config` for cases like reading LIN Break (#2756)
 
 ### Changed
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2352,6 +2352,7 @@ impl Info {
         self.change_data_bits(config.data_bits);
         self.change_parity(config.parity);
         self.change_stop_bits(config.stop_bits);
+        self.change_disable_rx_input_checks(config.disable_rx_input_checks);
 
         // Reset Tx/Rx FIFOs
         self.rxfifo_reset();
@@ -2617,6 +2618,12 @@ impl Info {
         self.register_block()
             .conf0()
             .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8) });
+    }
+
+    fn change_disable_rx_input_checks(&self, disable: bool) {
+        self.register_block()
+            .conf0()
+            .modify(|_, w| w.rx_filter_en().bit(!disable));
     }
 
     fn rxfifo_reset(&self) {

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2623,7 +2623,7 @@ impl Info {
     fn change_disable_rx_input_checks(&self, disable: bool) {
         self.register_block()
             .conf0()
-            .modify(|_, w| w.rx_filter_en().bit(!disable));
+            .modify(|_, w| w.err_wr_mask().bit(!disable));
     }
 
     fn rxfifo_reset(&self) {

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -404,7 +404,7 @@ pub struct Config {
     pub rx_fifo_full_threshold: u16,
     /// Optional timeout value for RX operations.
     pub rx_timeout: Option<u8>,
-    /// Optionally disable forced checks on incoming RX inputs.
+    /// Optionally disable forced checks on incoming RX data.
     pub disable_rx_input_checks: bool,
 }
 


### PR DESCRIPTION
### Description
Aims to resolve #1580. Added a configuration to `uart::Config` for the ability to disabled forced input checks on incoming RX data. This is useful for cases like reading breaks.

### Testing
Still to be conducted.
