### PR TITLE
Fix WIFI_EVENT

### DIFF
--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -200,13 +200,7 @@ pub unsafe extern "C" fn puts(s: *const u8) {
 
 // #define ESP_EVENT_DEFINE_BASE(id) esp_event_base_t id = #id
 #[no_mangle]
-static mut WIFI_EVENT: esp_event_base_t = const {
-    if let Ok(str) = core::ffi::CStr::from_bytes_with_nul(b"WIFI_EVENT\0") {
-        str.as_ptr()
-    } else {
-        ::core::panic!()
-    }
-};
+static mut WIFI_EVENT: esp_event_base_t = c"WIFI_EVENT".as_ptr();
 
 // stuff needed by wpa-supplicant
 #[no_mangle]

--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -1,5 +1,3 @@
-use core::ptr::addr_of;
-
 use esp_wifi_sys::include::timeval;
 use hal::macros::ram;
 
@@ -201,10 +199,14 @@ pub unsafe extern "C" fn puts(s: *const u8) {
 }
 
 // #define ESP_EVENT_DEFINE_BASE(id) esp_event_base_t id = #id
-static mut EVT: i8 = 0;
 #[no_mangle]
-#[allow(unused_unsafe)]
-static mut WIFI_EVENT: esp_event_base_t = unsafe { addr_of!(EVT) };
+static mut WIFI_EVENT: esp_event_base_t = const {
+    if let Ok(str) = core::ffi::CStr::from_bytes_with_nul(b"WIFI_EVENT\0") {
+        str.as_ptr()
+    } else {
+        ::core::panic!()
+    }
+};
 
 // stuff needed by wpa-supplicant
 #[no_mangle]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/132975 changed Xtensa c_char to u8, which apparently breaks our builds. This PR properly reimplements what [esp-idf does](https://github.com/espressif/esp-idf/blob/cb3ac7429c73b6e7c6d79ae05de480d4b6706770/components/esp_event/include/esp_event_base.h#L17), instead of just adjusting the type of `EVT`.