### PR TITLE
SPI: Implement missing traits

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HAL configuration structs now implement the Builder Lite pattern (#2645)
 - Added `OutputOpenDrain::unlisten` (#2625)
 - Added `{Input, Flex}::wait_for` (#2625)
-- Peripheral singletons now implement `Debug` and `defmt::Format` (except AnyPeripherals) (#2682, #2834)
+- Peripheral singletons now implement `Debug` and `defmt::Format` (#2682, #2834)
 - `BurstConfig`, a device-specific configuration for configuring DMA transfers in burst mode (#2543)
 - `{DmaRxBuf, DmaTxBuf, DmaRxTxBuf}::set_burst_config` (#2543)
 - ESP32-S2: DMA support for AES (#2699)
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `i2c::master::Config` now implements `PartialEq`, `Eq`, ans `Hash` (#2825)
 - `i2c::master::I2c` now implements `Debug`, `PartialEq`, and `Eq` (#2825)
 - `i2c::master::Info` now implements `Debug` (#2825)
+- `spi::master::Config` now implements `Hash` (#2823)
+- `spi::master` drivers now implement `Debug` and `defmt::Format` (#2823)
+- `DmaRxBuf`, `DmaTxBuf` and `DmaRxTxBuf` now implement `Debug` and `defmt::Format` (#2823)
+- DMA channels (`AnyGdmaChannel`, `SpiDmaChannel`, `I2sDmaChannel`, `CryptoDmaChannel`) and their RX/TX halves now implement `Debug` and `defmt::Format` (#2823)
+- `DmaDescriptor` and `DmaDescriptorFlags` now implement `PartialEq` and `Eq` (#2823)
 
 ### Changed
 

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -650,6 +650,8 @@ unsafe impl DmaTxBuffer for DmaTxBuf {
 /// This is a contiguous buffer linked together by DMA descriptors of length
 /// 4092. It can only be used for receiving data from a peripheral's FIFO.
 /// See [DmaTxBuf] for transmitting data.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DmaRxBuf {
     descriptors: DescriptorSet<'static>,
     buffer: &'static mut [u8],
@@ -841,6 +843,8 @@ unsafe impl DmaRxBuffer for DmaRxBuf {
 /// descriptors of length 4092 each.
 /// It can be used for simultaneously transmitting to and receiving from a
 /// peripheral's FIFO. These are typically full-duplex transfers.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DmaRxTxBuf {
     rx_descriptors: DescriptorSet<'static>,
     tx_descriptors: DescriptorSet<'static>,

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -25,6 +25,8 @@ use crate::{
 };
 
 /// An arbitrary GDMA channel
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaChannel(u8);
 
 impl Peripheral for AnyGdmaChannel {
@@ -51,6 +53,8 @@ impl DmaChannel for AnyGdmaChannel {
 }
 
 /// An arbitrary GDMA RX channel
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaRxChannel(u8);
 
 impl Peripheral for AnyGdmaRxChannel {
@@ -68,6 +72,8 @@ impl DmaChannelConvert<AnyGdmaRxChannel> for AnyGdmaRxChannel {
 }
 
 /// An arbitrary GDMA TX channel
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaTxChannel(u8);
 
 impl Peripheral for AnyGdmaTxChannel {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -215,7 +215,7 @@ where
 
 bitfield::bitfield! {
     /// DMA descriptor flags.
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct DmaDescriptorFlags(u32);
 
     u16;
@@ -272,7 +272,7 @@ impl defmt::Format for DmaDescriptorFlags {
 }
 
 /// A DMA transfer descriptor.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DmaDescriptor {
     /// Descriptor flags.

--- a/esp-hal/src/dma/pdma/crypto.rs
+++ b/esp-hal/src/dma/pdma/crypto.rs
@@ -11,6 +11,8 @@ use crate::{
 pub(super) type CryptoRegisterBlock = crate::peripherals::crypto_dma::RegisterBlock;
 
 /// The RX half of a Crypto DMA channel.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CryptoDmaRxChannel(pub(crate) CryptoDmaChannel);
 
 impl crate::private::Sealed for CryptoDmaRxChannel {}
@@ -24,6 +26,8 @@ impl Peripheral for CryptoDmaRxChannel {
 }
 
 /// The TX half of a Crypto DMA channel.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CryptoDmaTxChannel(pub(crate) CryptoDmaChannel);
 
 impl crate::private::Sealed for CryptoDmaTxChannel {}
@@ -437,6 +441,8 @@ impl InterruptAccess<DmaRxInterrupt> for CryptoDmaRxChannel {
 
 #[doc = "DMA channel suitable for CRYPTO"]
 #[non_exhaustive]
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CryptoDmaChannel {}
 
 impl crate::private::Sealed for CryptoDmaChannel {}

--- a/esp-hal/src/dma/pdma/i2s.rs
+++ b/esp-hal/src/dma/pdma/i2s.rs
@@ -5,6 +5,8 @@ use crate::{asynch::AtomicWaker, dma::*, peripheral::Peripheral, peripherals::In
 pub(super) type I2sRegisterBlock = crate::peripherals::i2s0::RegisterBlock;
 
 /// The RX half of an arbitrary I2S DMA channel.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyI2sDmaRxChannel(pub(crate) AnyI2sDmaChannel);
 
 impl crate::private::Sealed for AnyI2sDmaRxChannel {}
@@ -18,6 +20,8 @@ impl Peripheral for AnyI2sDmaRxChannel {
 }
 
 /// The TX half of an arbitrary I2S DMA channel.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyI2sDmaTxChannel(pub(crate) AnyI2sDmaChannel);
 
 impl crate::private::Sealed for AnyI2sDmaTxChannel {}

--- a/esp-hal/src/dma/pdma/mod.rs
+++ b/esp-hal/src/dma/pdma/mod.rs
@@ -53,7 +53,7 @@ macro_rules! impl_pdma_channel {
         paste::paste! {
             #[doc = concat!("DMA channel suitable for ", stringify!([< $instance:upper >]))]
             #[non_exhaustive]
-            #[derive(Debug, PartialEq, Eq)]
+            #[derive(Debug)]
             #[cfg_attr(feature = "defmt", derive(defmt::Format))]
             pub struct [<$instance DmaChannel>] {}
 

--- a/esp-hal/src/dma/pdma/spi.rs
+++ b/esp-hal/src/dma/pdma/spi.rs
@@ -5,6 +5,8 @@ use crate::{asynch::AtomicWaker, dma::*, peripheral::Peripheral, peripherals::In
 pub(super) type SpiRegisterBlock = crate::peripherals::spi2::RegisterBlock;
 
 /// The RX half of an arbitrary SPI DMA channel.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnySpiDmaRxChannel(pub(crate) AnySpiDmaChannel);
 
 impl crate::private::Sealed for AnySpiDmaRxChannel {}
@@ -18,6 +20,8 @@ impl Peripheral for AnySpiDmaRxChannel {
 }
 
 /// The TX half of an arbitrary SPI DMA channel.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnySpiDmaTxChannel(pub(crate) AnySpiDmaChannel);
 
 impl crate::private::Sealed for AnySpiDmaTxChannel {}

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -440,6 +440,15 @@ pub struct Config {
     pub write_bit_order: BitOrder,
 }
 
+impl core::hash::Hash for Config {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.frequency.to_Hz().hash(state); // HertzU32 doesn't implement Hash
+        self.mode.hash(state);
+        self.read_bit_order.hash(state);
+        self.write_bit_order.hash(state);
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         use fugit::RateExtU32;
@@ -884,6 +893,7 @@ mod dma {
     /// [`SpiDmaBus`] via `with_buffers` to get access
     /// to a DMA capable SPI bus that implements the
     /// embedded-hal traits.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct SpiDma<'d, Dm, T = AnySpi>
     where
         T: Instance,
@@ -943,7 +953,7 @@ mod dma {
 
     impl<Dm, T> core::fmt::Debug for SpiDma<'_, Dm, T>
     where
-        T: Instance,
+        T: Instance + core::fmt::Debug,
         Dm: DriverMode,
     {
         /// Formats the `SpiDma` instance for debugging purposes.
@@ -951,7 +961,7 @@ mod dma {
         /// This method returns a debug struct with the name "SpiDma" without
         /// exposing internal details.
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            f.debug_struct("SpiDma").finish()
+            f.debug_struct("SpiDma").field("spi", &self.spi).finish()
         }
     }
 
@@ -1575,6 +1585,8 @@ mod dma {
     ///
     /// This structure is responsible for managing SPI transfers using DMA
     /// buffers.
+    #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct SpiDmaBus<'d, Dm, T = AnySpi>
     where
         T: Instance,

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -192,6 +192,7 @@ impl Drop for PeripheralGuard {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct GenericPeripheralGuard<const P: u8> {}
 
 impl<const P: u8> GenericPeripheralGuard<P> {


### PR DESCRIPTION
Closes #2791
Closes #2792

This also touches some other places because `any_peripheral` now derives more traits