### PR TITLE
Add `SpiDmaBus::split` for moving between manual & automatic DMA buffers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Peripheral singletons now implement `Debug` and `defmt::Format` (#2682, #2834)
 - `BurstConfig`, a device-specific configuration for configuring DMA transfers in burst mode (#2543)
 - `{DmaRxBuf, DmaTxBuf, DmaRxTxBuf}::set_burst_config` (#2543)
+- Added `SpiDmaBus::deconstruct` for moving between manual & automatic DMA buffers (#2823)
 - ESP32-S2: DMA support for AES (#2699)
 - Added `transfer_in_place_async` and embedded-hal-async implementation to `Spi` (#2691)
 - `InterruptHandler` now implements `Hash` and `defmt::Format` (#2830)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Peripheral singletons now implement `Debug` and `defmt::Format` (#2682, #2834)
 - `BurstConfig`, a device-specific configuration for configuring DMA transfers in burst mode (#2543)
 - `{DmaRxBuf, DmaTxBuf, DmaRxTxBuf}::set_burst_config` (#2543)
-- Added `SpiDmaBus::deconstruct` for moving between manual & automatic DMA buffers (#2824)
+- Added `SpiDmaBus::split` for moving between manual & automatic DMA buffers (#2824)
 - ESP32-S2: DMA support for AES (#2699)
 - Added `transfer_in_place_async` and embedded-hal-async implementation to `Spi` (#2691)
 - `InterruptHandler` now implements `Hash` and `defmt::Format` (#2830)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Peripheral singletons now implement `Debug` and `defmt::Format` (#2682, #2834)
 - `BurstConfig`, a device-specific configuration for configuring DMA transfers in burst mode (#2543)
 - `{DmaRxBuf, DmaTxBuf, DmaRxTxBuf}::set_burst_config` (#2543)
-- Added `SpiDmaBus::deconstruct` for moving between manual & automatic DMA buffers (#2823)
+- Added `SpiDmaBus::deconstruct` for moving between manual & automatic DMA buffers (#2824)
 - ESP32-S2: DMA support for AES (#2699)
 - Added `transfer_in_place_async` and embedded-hal-async implementation to `Spi` (#2691)
 - `InterruptHandler` now implements `Hash` and `defmt::Format` (#2830)

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1653,6 +1653,13 @@ mod dma {
                 tx_buf,
             }
         }
+
+        /// Swap dma buffers
+        pub fn swap_buffers(&mut self, rx_buf: DmaRxBuf, tx_buf: DmaTxBuf) -> (DmaRxBuf, DmaTxBuf) {
+            self.wait_for_idle();
+            core::mem::swap(self.rx_buf, rx_buf);
+            core::mem::swap(self.tx_buf, tx_buf);
+        }
     }
 
     impl<T> InterruptConfigurable for SpiDmaBus<'_, Blocking, T>

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1654,9 +1654,9 @@ mod dma {
             }
         }
 
-        /// Splits `SpiDmaBus` back into `SpiDma` to allow for manual
-        /// buffer control
+        /// Splits [SpiDmaBus] back into [SpiDma], [DmaRxBuf] and [DmaTxBuf].
         pub fn split(self) -> (SpiDma<'d, M, T>, DmaRxBuf, DmaTxBuf) {
+            self.wait_for_idle();
             (self.spi_dma, self.rx_buf, self.tx_buf)
         }
     }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1654,11 +1654,9 @@ mod dma {
             }
         }
 
-        /// Swap dma buffers
-        pub fn swap_buffers(&mut self, rx_buf: DmaRxBuf, tx_buf: DmaTxBuf) -> (DmaRxBuf, DmaTxBuf) {
-            self.wait_for_idle();
-            core::mem::swap(self.rx_buf, rx_buf);
-            core::mem::swap(self.tx_buf, tx_buf);
+        /// Deconstruct `SpiDmaBus` back into `SpiDma` to allow for manual buffer control
+        pub fn deconstruct(self) -> (SpiDma<'d, M, T>, DmaRxBuf, DmaTxBuf) {
+            (self.spi_dma, self.rx_buf, self.tx_buf)
         }
     }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1654,7 +1654,8 @@ mod dma {
             }
         }
 
-        /// Deconstruct `SpiDmaBus` back into `SpiDma` to allow for manual buffer control
+        /// Deconstruct `SpiDmaBus` back into `SpiDma` to allow for manual
+        /// buffer control
         pub fn deconstruct(self) -> (SpiDma<'d, M, T>, DmaRxBuf, DmaTxBuf) {
             (self.spi_dma, self.rx_buf, self.tx_buf)
         }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1655,7 +1655,7 @@ mod dma {
         }
 
         /// Splits [SpiDmaBus] back into [SpiDma], [DmaRxBuf] and [DmaTxBuf].
-        pub fn split(mut self) -> (SpiDma<'d, M, T>, DmaRxBuf, DmaTxBuf) {
+        pub fn split(mut self) -> (SpiDma<'d, Dm, T>, DmaRxBuf, DmaTxBuf) {
             self.wait_for_idle();
             (self.spi_dma, self.rx_buf, self.tx_buf)
         }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1655,7 +1655,7 @@ mod dma {
         }
 
         /// Splits [SpiDmaBus] back into [SpiDma], [DmaRxBuf] and [DmaTxBuf].
-        pub fn split(self) -> (SpiDma<'d, M, T>, DmaRxBuf, DmaTxBuf) {
+        pub fn split(mut self) -> (SpiDma<'d, M, T>, DmaRxBuf, DmaTxBuf) {
             self.wait_for_idle();
             (self.spi_dma, self.rx_buf, self.tx_buf)
         }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1654,9 +1654,9 @@ mod dma {
             }
         }
 
-        /// Deconstruct `SpiDmaBus` back into `SpiDma` to allow for manual
+        /// Splits `SpiDmaBus` back into `SpiDma` to allow for manual
         /// buffer control
-        pub fn deconstruct(self) -> (SpiDma<'d, M, T>, DmaRxBuf, DmaTxBuf) {
+        pub fn split(self) -> (SpiDma<'d, M, T>, DmaRxBuf, DmaTxBuf) {
             (self.spi_dma, self.rx_buf, self.tx_buf)
         }
     }


### PR DESCRIPTION
#### Description
This pull-request adds `SpiDmaBus::deconstruct` for moving between manual & automatic DMA buffers.
If an SpiDmaBus is made you are stuck with automatic buffer handling (unless drop, steal & re-init the SPI peripheral again).

Here is an example snippet (for the FT8xx series display driver series) of it's usage:
```rust
  pub fn new(inner: SpiDma<'static, Blocking, esp_hal::spi::AnySpi>) -> Self {
    let (_, tx_desc) = esp_hal::dma_descriptors_chunk_size!(1, DMA_BUFFER_SIZE, DMA_CHUNK_SIZE);

    let tx_buffer = dma_alloc_buffer!(DMA_BUFFER_SIZE, DMA_ALIGNMENT as usize);
    let display_buf = DmaTxBuf::new_with_config(tx_desc, tx_buffer, DMA_ALIGNMENT).unwrap();

    let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = esp_hal::dma_buffers!(128, 128);
    let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
    let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();

    Self {
      inner: Some(inner.with_buffers(dma_rx_buf, dma_tx_buf)),
      display_buf: Some(display_buf),
      size: embedded_graphics::prelude::Size::new(WIDTH as u32, HEIGHT as u32),
    }
  }
  pub fn after_render(&mut self) -> anyhow::Result<()> {
    let addr_pixels = 0 | (0b10 << 22);
    let addr_spi_mode = EngineRegister::SpiWidth.addr() | (0b10 << 22);
    let mode = esp_hal::spi::SpiDataMode::Quad;
    use esp_hal::spi::master::{Address, Command};
    let mut spidma = self.inner.take().unwrap();

    // Configure Quad SPI on slave
    spidma
      .half_duplex_write(
        esp_hal::spi::SpiDataMode::Single,
        Command::None,
        Address::Address24(addr_spi_mode, esp_hal::spi::SpiDataMode::Single),
        0u8,
        &[2u8],
      )
      .map_err(|e| anyhow::anyhow!("Failed to set spi width: {:?}", e))?;

    // NEW: deconstruct
    let (spidma, rx_buf, tx_buf) = spidma.split();

    // Transfer large DMA buffer (>=100kB)
    let transfer = spidma
      .half_duplex_write(
        mode,
        Command::None,
        Address::Address24(addr_pixels, mode),
        0u8,
        WIDTH * HEIGHT,
        self.display_buf.take().unwrap(),
      )
      .map_err(|e| anyhow::anyhow!("Could not fill screen: {:?}", e))?;

    let (spidma, display_buf) = transfer.wait();
    self.display_buf.replace(display_buf);

    // Re-use old dma bufs
    self.inner.replace(spidma.with_buffers(rx_buf, tx_buf));

    // Disable Quad SPI on slave
    self
      .inner
      .as_mut()
      .unwrap()
      .half_duplex_write(
        mode,
        Command::None,
        Address::Address24(addr_spi_mode, mode),
        0u8,
        &[0u8],
      )
      .map_err(|e| anyhow::anyhow!("Failed to reset spi width: {:?}", e))
}
```

#### Testing
Testing is still on-going but since SpiDmaBus is effectively a dumb-wrapper I don't expect any issues.
