### PR TITLE
Derive common traits for various types in `uart` and `i2c` drivers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ### Added
 
 - ESP32-S3: Added SDMMC signals (#2556)
@@ -35,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S2: DMA support for AES (#2699)
 - Added `transfer_in_place_async` and embedded-hal-async implementation to `Spi` (#2691)
 - `InterruptHandler` now implements `Hash` and `defmt::Format` (#2830)
+- `uart::ConfigError` now implements `Eq` (#2825)
+- `i2c::master::Error` now implements `Eq` and `Hash` (#2825)
+- `i2c::master::Operation` now implements `Debug`, `PartialEq`, `Eq`, `Hash`, and `Display` (#2825)
+- `i2c::master::Config` now implements `PartialEq`, `Eq`, ans `Hash` (#2825)
+- `i2c::master::I2c` now implements `Debug`, `PartialEq`, and `Eq` (#2825)
+- `i2c::master::Info` now implements `Debug` (#2825)
 
 ### Changed
 

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -308,7 +308,7 @@ impl Default for Config {
 }
 
 /// I2C driver
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct I2c<'d, Dm: DriverMode, T = AnyI2c> {
     i2c: PeripheralRef<'d, T>,

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -106,11 +106,37 @@ pub enum Error {
     InvalidZeroLength,
 }
 
+impl core::error::Error for Error {}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::ExceedingFifo => write!(f, "The transmission exceeded the FIFO size"),
+            Error::AckCheckFailed => write!(f, "The acknowledgment check failed"),
+            Error::TimeOut => write!(f, "A timeout occurred during transmission"),
+            Error::ArbitrationLost => write!(f, "The arbitration for the bus was lost"),
+            Error::ExecIncomplete => write!(f, "The execution of the I2C command was incomplete"),
+            Error::CommandNrExceeded => {
+                write!(f, "The number of commands issued exceeded the limit")
+            }
+            Error::InvalidZeroLength => write!(f, "Zero length read or write operation"),
+        }
+    }
+}
+
 /// I2C-specific configuration errors
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum ConfigError {}
+
+impl core::error::Error for ConfigError {}
+
+impl core::fmt::Display for ConfigError {
+    fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Ok(())
+    }
+}
 
 // This enum is used to keep track of the last/next operation that was/will be
 // performed in an embedded-hal(-async) I2c::transaction. It is used to

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -287,6 +287,20 @@ pub enum Error {
     RxParityError,
 }
 
+impl core::error::Error for Error {}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::InvalidArgument => write!(f, "An invalid configuration argument was provided"),
+            Error::RxFifoOvf => write!(f, "The RX FIFO overflowed"),
+            Error::RxGlitchDetected => write!(f, "A glitch was detected on the RX line"),
+            Error::RxFrameError => write!(f, "A framing error was detected on the RX line"),
+            Error::RxParityError => write!(f, "A parity error was detected on the RX line"),
+        }
+    }
+}
+
 impl embedded_hal_nb::serial::Error for Error {
     fn kind(&self) -> embedded_hal_nb::serial::ErrorKind {
         embedded_hal_nb::serial::ErrorKind::Other
@@ -621,8 +635,21 @@ pub struct UartRx<'d, Dm, T = AnyUart> {
 pub enum ConfigError {
     /// The requested timeout is not supported.
     UnsupportedTimeout,
-    /// The requested fifo threshold is not supported.
+    /// The requested FIFO threshold is not supported.
     UnsupportedFifoThreshold,
+}
+
+impl core::error::Error for ConfigError {}
+
+impl core::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ConfigError::UnsupportedTimeout => write!(f, "The requested timeout is not supported"),
+            ConfigError::UnsupportedFifoThreshold => {
+                write!(f, "The requested FIFO threshold is not supported")
+            }
+        }
+    }
 }
 
 #[cfg(any(doc, feature = "unstable"))]

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -616,7 +616,7 @@ pub struct UartRx<'d, Dm, T = AnyUart> {
 }
 
 /// A configuration error.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConfigError {
     /// The requested timeout is not supported.


### PR DESCRIPTION
Some notes related to the traits mentioned in the corresponding issues:

- `Clone`, `Copy`, `PartialEq` and `Eq` are automatically derived by `EnumSetType` already, and therefore not required for `uart::UartInterrupt`
    - https://docs.rs/enumset/latest/enumset/derive.EnumSetType.html#additional-impls
- ~~`fugit::Rate` does not implement `Hash`, so `i2c::master::Config` cannot derive it~~
- `AtomicWaker` implements no traits, therefore `i2c::master::State` cannot either

Regarding the implementation of `Display`:

- `i2c::master::ConfigError` has no variants, so implementing `Display` is meaningless for it (i.e. what would we actually display?)
    - Regardless, can derive `strum::Display` on this type if requested
- What should `Display` look like for `i2c::master::Config`
- What should `Display` look like for `i2c::master::I2c`

Happy to make the `Display`-related changes, just would like to come to a consensus with regards to how this should look so we can be consistent across drivers.

Closes #2776
Closes #2810
Closes #2788