### PR TITLE
Rename Spi enums

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `PeripheralInput` and `PeripheralOutput` traits are now sealed (#2690)
 - `esp_hal::sync::Lock` has been renamed to RawMutex (#2684)
 - Updated `esp-pacs` with support for Wi-Fi on the ESP32 and made the peripheral non virtual
+- `SpiBitOrder`, `SpiDataMode`, `SpiMode` were renamed to `BitOder`, `DataMode` and `Mode` (#2828)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `esp_hal::sync::Lock` has been renamed to RawMutex (#2684)
 - Updated `esp-pacs` with support for Wi-Fi on the ESP32 and made the peripheral non virtual
 - `SpiBitOrder`, `SpiDataMode`, `SpiMode` were renamed to `BitOder`, `DataMode` and `Mode` (#2828)
-
+- `crate::Mode` was renamed to `crate::DriverMode` (#2828)
 ### Fixed
 
 - Xtensa devices now correctly enable the `esp-hal-procmacros/rtc-slow` feature (#2594)

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -581,7 +581,7 @@ impl InterruptAccess<DmaRxInterrupt> for AnyGdmaRxChannel {
     }
 }
 
-impl<CH: DmaChannel, Dm: Mode> Channel<'_, Dm, CH> {
+impl<CH: DmaChannel, Dm: DriverMode> Channel<'_, Dm, CH> {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible<P: DmaEligible>(&self, _peripheral: &PeripheralRef<'_, P>) {
         // No runtime checks; GDMA channels are compatible with any peripheral

--- a/esp-hal/src/dma/m2m.rs
+++ b/esp-hal/src/dma/m2m.rs
@@ -20,7 +20,7 @@ use crate::{
     peripheral::Peripheral,
     Async,
     Blocking,
-    Mode,
+    DriverMode,
 };
 
 /// DMA Memory to Memory pseudo-Peripheral
@@ -30,7 +30,7 @@ use crate::{
 /// to memory transfers.
 pub struct Mem2Mem<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     channel: Channel<'d, Dm, AnyGdmaChannel>,
     rx_chain: DescriptorChain,
@@ -125,7 +125,7 @@ impl<'d> Mem2Mem<'d, Blocking> {
 
 impl<Dm> Mem2Mem<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Start a memory to memory transfer.
     pub fn start_transfer<'t, TXBUF, RXBUF>(
@@ -158,7 +158,7 @@ where
 
 impl<Dm> DmaSupport for Mem2Mem<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
         while !self.channel.rx.is_done() {}
@@ -171,7 +171,7 @@ where
 
 impl<'d, Dm> DmaSupportRx for Mem2Mem<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type RX = ChannelRx<'d, Dm, AnyGdmaRxChannel>;
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -69,7 +69,7 @@ use crate::{
     Async,
     Blocking,
     Cpu,
-    Mode,
+    DriverMode,
 };
 
 trait Word: crate::private::Sealed {}
@@ -1810,7 +1810,7 @@ fn create_guard(_ch: &impl RegisterAccess) -> PeripheralGuard {
 #[doc(hidden)]
 pub struct ChannelRx<'a, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaRxChannel,
 {
     pub(crate) rx_impl: PeripheralRef<'a, CH>,
@@ -1894,7 +1894,7 @@ where
 
 impl<Dm, CH> ChannelRx<'_, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaRxChannel,
 {
     /// Configure the channel.
@@ -1938,14 +1938,14 @@ where
 
 impl<Dm, CH> crate::private::Sealed for ChannelRx<'_, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaRxChannel,
 {
 }
 
 impl<Dm, CH> Rx for ChannelRx<'_, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaRxChannel,
 {
     // TODO: used by I2S, which should be rewritten to use the Preparation-based
@@ -2110,7 +2110,7 @@ pub trait Tx: crate::private::Sealed {
 #[doc(hidden)]
 pub struct ChannelTx<'a, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaTxChannel,
 {
     pub(crate) tx_impl: PeripheralRef<'a, CH>,
@@ -2188,7 +2188,7 @@ where
 
 impl<Dm, CH> ChannelTx<'_, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaTxChannel,
 {
     /// Configure the channel priority.
@@ -2232,14 +2232,14 @@ where
 
 impl<Dm, CH> crate::private::Sealed for ChannelTx<'_, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaTxChannel,
 {
 }
 
 impl<Dm, CH> Tx for ChannelTx<'_, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaTxChannel,
 {
     // TODO: used by I2S, which should be rewritten to use the Preparation-based
@@ -2450,7 +2450,7 @@ pub trait InterruptAccess<T: EnumSetType>: crate::private::Sealed {
 #[non_exhaustive]
 pub struct Channel<'d, Dm, CH>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     CH: DmaChannel,
 {
     /// RX half of the channel

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -18,7 +18,7 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::dma_buffers;
-//! # use esp_hal::spi::{master::{Config, Spi}, SpiMode};
+//! # use esp_hal::spi::{master::{Config, Spi}, Mode};
 #![cfg_attr(pdma, doc = "let dma_channel = peripherals.DMA_SPI2;")]
 #![cfg_attr(gdma, doc = "let dma_channel = peripherals.DMA_CH0;")]
 //! let sclk = peripherals.GPIO0;
@@ -28,7 +28,7 @@
 //!
 //! let mut spi = Spi::new(
 //!     peripherals.SPI2,
-//!     Config::default().with_frequency(100.kHz()).with_mode(SpiMode::Mode0)
+//!     Config::default().with_frequency(100.kHz()).with_mode(Mode::Mode0)
 //! )
 //! .unwrap()
 //! .with_sck(sclk)

--- a/esp-hal/src/dma/pdma/mod.rs
+++ b/esp-hal/src/dma/pdma/mod.rs
@@ -197,7 +197,7 @@ pub(super) fn init_dma(_cs: CriticalSection<'_>) {
 impl<CH, Dm> Channel<'_, Dm, CH>
 where
     CH: DmaChannel,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Asserts that the channel is compatible with the given peripheral.
     pub fn runtime_ensure_compatible(&self, peripheral: &PeripheralRef<'_, impl DmaEligible>) {

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 /// The ECC Accelerator driver instance
-pub struct Ecc<'d, DM: crate::Mode> {
+pub struct Ecc<'d, DM: crate::DriverMode> {
     ecc: PeripheralRef<'d, ECC>,
     alignment_helper: AlignmentHelper<SocDependentEndianess>,
     phantom: PhantomData<DM>,
@@ -125,7 +125,7 @@ impl InterruptConfigurable for Ecc<'_, crate::Blocking> {
     }
 }
 
-impl<DM: crate::Mode> Ecc<'_, DM> {
+impl<DM: crate::DriverMode> Ecc<'_, DM> {
     /// Resets the ECC peripheral.
     pub fn reset(&mut self) {
         self.ecc.mult_conf().reset()

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -36,10 +36,10 @@ use crate::{
 };
 
 /// The ECC Accelerator driver instance
-pub struct Ecc<'d, DM: crate::DriverMode> {
+pub struct Ecc<'d, Dm: crate::DriverMode> {
     ecc: PeripheralRef<'d, ECC>,
     alignment_helper: AlignmentHelper<SocDependentEndianess>,
-    phantom: PhantomData<DM>,
+    phantom: PhantomData<Dm>,
     _guard: GenericPeripheralGuard<{ system::Peripheral::Ecc as u8 }>,
 }
 
@@ -125,7 +125,7 @@ impl InterruptConfigurable for Ecc<'_, crate::Blocking> {
     }
 }
 
-impl<DM: crate::DriverMode> Ecc<'_, DM> {
+impl<Dm: crate::DriverMode> Ecc<'_, Dm> {
     /// Resets the ECC peripheral.
     pub fn reset(&mut self) {
         self.ecc.mult_conf().reset()

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -64,7 +64,7 @@ use crate::{
     Async,
     Blocking,
     Cpu,
-    Mode,
+    DriverMode,
 };
 
 cfg_if::cfg_if! {
@@ -274,7 +274,7 @@ impl Default for Config {
 }
 
 /// I2C driver
-pub struct I2c<'d, Dm: Mode, T = AnyI2c> {
+pub struct I2c<'d, Dm: DriverMode, T = AnyI2c> {
     i2c: PeripheralRef<'d, T>,
     phantom: PhantomData<Dm>,
     config: Config,
@@ -283,7 +283,7 @@ pub struct I2c<'d, Dm: Mode, T = AnyI2c> {
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-impl<T: Instance, Dm: Mode> SetConfig for I2c<'_, Dm, T> {
+impl<T: Instance, Dm: DriverMode> SetConfig for I2c<'_, Dm, T> {
     type Config = Config;
     type ConfigError = ConfigError;
 
@@ -292,11 +292,11 @@ impl<T: Instance, Dm: Mode> SetConfig for I2c<'_, Dm, T> {
     }
 }
 
-impl<T, Dm: Mode> embedded_hal::i2c::ErrorType for I2c<'_, Dm, T> {
+impl<T, Dm: DriverMode> embedded_hal::i2c::ErrorType for I2c<'_, Dm, T> {
     type Error = Error;
 }
 
-impl<T, Dm: Mode> embedded_hal::i2c::I2c for I2c<'_, Dm, T>
+impl<T, Dm: DriverMode> embedded_hal::i2c::I2c for I2c<'_, Dm, T>
 where
     T: Instance,
 {
@@ -310,7 +310,7 @@ where
     }
 }
 
-impl<'d, T, Dm: Mode> I2c<'d, Dm, T>
+impl<'d, T, Dm: DriverMode> I2c<'d, Dm, T>
 where
     T: Instance,
 {

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -104,7 +104,7 @@ use crate::{
     system::PeripheralGuard,
     Async,
     Blocking,
-    Mode,
+    DriverMode,
 };
 
 #[derive(Debug, EnumSetType)]
@@ -757,7 +757,7 @@ mod private {
         peripheral::{Peripheral, PeripheralRef},
         peripherals::{Interrupt, I2S0},
         private,
-        Mode,
+        DriverMode,
     };
 
     pub struct TxCreator<'d, Dm, T>

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -253,7 +253,7 @@ impl DataFormat {
 pub struct I2s<'d, Dm, T = AnyI2s>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Handles the reception (RX) side of the I2S peripheral.
     pub i2s_rx: RxCreator<'d, Dm, T>,
@@ -311,7 +311,7 @@ where
 impl<Dm, T> I2s<'_, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Sets the interrupt handler
     ///
@@ -349,14 +349,14 @@ where
 impl<Dm, I> crate::private::Sealed for I2s<'_, Dm, I>
 where
     I: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
 }
 
 impl<Dm, I> InterruptConfigurable for I2s<'_, Dm, I>
 where
     I: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         I2s::set_interrupt_handler(self, handler);
@@ -444,7 +444,7 @@ where
 impl<'d, Dm, T> I2s<'d, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Configures the I2S peripheral to use a master clock (MCLK) output pin.
     pub fn with_mclk<P: PeripheralOutput>(self, pin: impl Peripheral<P = P> + 'd) -> Self {
@@ -460,7 +460,7 @@ where
 pub struct I2sTx<'d, Dm, T = AnyI2s>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     i2s: PeripheralRef<'d, T>,
     tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<T>>,
@@ -471,7 +471,7 @@ where
 impl<Dm, T> core::fmt::Debug for I2sTx<'_, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("I2sTx").finish()
@@ -481,7 +481,7 @@ where
 impl<Dm, T> DmaSupport for I2sTx<'_, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
         self.i2s.wait_for_tx_done();
@@ -495,7 +495,7 @@ where
 impl<'d, Dm, T> DmaSupportTx for I2sTx<'d, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type TX = ChannelTx<'d, Dm, PeripheralTxChannel<T>>;
 
@@ -511,7 +511,7 @@ where
 impl<Dm, T> I2sTx<'_, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
         self.start_tx_transfer(&data, false)?;
@@ -529,7 +529,7 @@ where
     ) -> Result<(), Error>
     where
         TXBUF: ReadBuffer,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         let (ptr, len) = unsafe { words.read_buffer() };
 
@@ -593,7 +593,7 @@ where
 pub struct I2sRx<'d, Dm, T = AnyI2s>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     i2s: PeripheralRef<'d, T>,
     rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<T>>,
@@ -604,7 +604,7 @@ where
 impl<Dm, T> core::fmt::Debug for I2sRx<'_, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("I2sRx").finish()
@@ -614,7 +614,7 @@ where
 impl<Dm, T> DmaSupport for I2sRx<'_, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
         self.i2s.wait_for_rx_done();
@@ -628,7 +628,7 @@ where
 impl<'d, Dm, T> DmaSupportRx for I2sRx<'d, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type RX = ChannelRx<'d, Dm, PeripheralRxChannel<T>>;
 
@@ -644,7 +644,7 @@ where
 impl<Dm, T> I2sRx<'_, Dm, T>
 where
     T: RegisterAccess,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read_bytes(&mut self, mut data: &mut [u8]) -> Result<(), Error> {
         self.start_rx_transfer(&mut data, false)?;
@@ -763,7 +763,7 @@ mod private {
     pub struct TxCreator<'d, Dm, T>
     where
         T: RegisterAccess,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         pub i2s: PeripheralRef<'d, T>,
         pub tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<T>>,
@@ -773,7 +773,7 @@ mod private {
 
     impl<'d, Dm, T> TxCreator<'d, Dm, T>
     where
-        Dm: Mode,
+        Dm: DriverMode,
         T: RegisterAccess,
     {
         pub fn build(self) -> I2sTx<'d, Dm, T> {
@@ -823,7 +823,7 @@ mod private {
     pub struct RxCreator<'d, Dm, T>
     where
         T: RegisterAccess,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         pub i2s: PeripheralRef<'d, T>,
         pub rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<T>>,
@@ -833,7 +833,7 @@ mod private {
 
     impl<'d, Dm, T> RxCreator<'d, Dm, T>
     where
-        Dm: Mode,
+        Dm: DriverMode,
         T: RegisterAccess,
     {
         pub fn build(self) -> I2sRx<'d, Dm, T> {

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -128,7 +128,7 @@ use crate::{
     system::PeripheralGuard,
     Async,
     Blocking,
-    Mode,
+    DriverMode,
 };
 
 #[doc(hidden)]

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -238,7 +238,7 @@ impl<'d> TxPins<'d> for TxEightBits<'d> {
 /// I2S Parallel Interface
 pub struct I2sParallel<'d, Dm, I = AnyI2s>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     I: Instance,
 {
     instance: PeripheralRef<'d, I>,
@@ -326,7 +326,7 @@ where
 impl<'d, I, Dm> I2sParallel<'d, Dm, I>
 where
     I: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Write data to the I2S peripheral
     pub fn send<BUF: DmaTxBuffer>(
@@ -358,7 +358,7 @@ pub struct I2sParallelTransfer<'d, BUF, Dm, I = AnyI2s>
 where
     I: Instance,
     BUF: DmaTxBuffer,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     i2s: ManuallyDrop<I2sParallel<'d, Dm, I>>,
     buf_view: ManuallyDrop<BUF::View>,
@@ -368,7 +368,7 @@ impl<'d, I, BUF, Dm> I2sParallelTransfer<'d, BUF, Dm, I>
 where
     I: Instance,
     BUF: DmaTxBuffer,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Returns true when [Self::wait] will not block.
     pub fn is_done(&self) -> bool {
@@ -405,7 +405,7 @@ impl<I, BUF, Dm> Deref for I2sParallelTransfer<'_, BUF, Dm, I>
 where
     I: Instance,
     BUF: DmaTxBuffer,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Target = BUF::View;
 
@@ -418,7 +418,7 @@ impl<I, BUF, Dm> DerefMut for I2sParallelTransfer<'_, BUF, Dm, I>
 where
     I: Instance,
     BUF: DmaTxBuffer,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.buf_view
@@ -429,7 +429,7 @@ impl<I, BUF, Dm> Drop for I2sParallelTransfer<'_, BUF, Dm, I>
 where
     I: Instance,
     BUF: DmaTxBuffer,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn drop(&mut self) {
         self.stop_peripherals();

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -116,7 +116,7 @@ use crate::{
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
     Blocking,
-    Mode,
+    DriverMode,
 };
 
 /// Errors that can occur when configuring the DPI peripheral.

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -128,7 +128,7 @@ pub enum ConfigError {
 }
 
 /// Represents the RGB LCD interface.
-pub struct Dpi<'d, Dm: Mode> {
+pub struct Dpi<'d, Dm: DriverMode> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
     tx_channel: ChannelTx<'d, Blocking, PeripheralTxChannel<LCD_CAM>>,
     _mode: PhantomData<Dm>,
@@ -136,7 +136,7 @@ pub struct Dpi<'d, Dm: Mode> {
 
 impl<'d, Dm> Dpi<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Create a new instance of the RGB/DPI driver.
     pub fn new<CH>(
@@ -587,12 +587,12 @@ where
 
 /// Represents an ongoing (or potentially finished) transfer using the RGB LCD
 /// interface
-pub struct DpiTransfer<'d, BUF: DmaTxBuffer, Dm: Mode> {
+pub struct DpiTransfer<'d, BUF: DmaTxBuffer, Dm: DriverMode> {
     dpi: ManuallyDrop<Dpi<'d, Dm>>,
     buffer_view: ManuallyDrop<BUF::View>,
 }
 
-impl<'d, BUF: DmaTxBuffer, Dm: Mode> DpiTransfer<'d, BUF, Dm> {
+impl<'d, BUF: DmaTxBuffer, Dm: DriverMode> DpiTransfer<'d, BUF, Dm> {
     /// Returns true when [Self::wait] will not block.
     pub fn is_done(&self) -> bool {
         self.dpi
@@ -661,7 +661,7 @@ impl<'d, BUF: DmaTxBuffer, Dm: Mode> DpiTransfer<'d, BUF, Dm> {
     }
 }
 
-impl<BUF: DmaTxBuffer, Dm: Mode> Deref for DpiTransfer<'_, BUF, Dm> {
+impl<BUF: DmaTxBuffer, Dm: DriverMode> Deref for DpiTransfer<'_, BUF, Dm> {
     type Target = BUF::View;
 
     fn deref(&self) -> &Self::Target {
@@ -669,13 +669,13 @@ impl<BUF: DmaTxBuffer, Dm: Mode> Deref for DpiTransfer<'_, BUF, Dm> {
     }
 }
 
-impl<BUF: DmaTxBuffer, Dm: Mode> DerefMut for DpiTransfer<'_, BUF, Dm> {
+impl<BUF: DmaTxBuffer, Dm: DriverMode> DerefMut for DpiTransfer<'_, BUF, Dm> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.buffer_view
     }
 }
 
-impl<BUF: DmaTxBuffer, Dm: Mode> Drop for DpiTransfer<'_, BUF, Dm> {
+impl<BUF: DmaTxBuffer, Dm: DriverMode> Drop for DpiTransfer<'_, BUF, Dm> {
     fn drop(&mut self) {
         self.stop_peripherals();
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -80,7 +80,7 @@ use crate::{
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
     Blocking,
-    Mode,
+    DriverMode,
 };
 
 /// A configuration error.

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -92,7 +92,7 @@ pub enum ConfigError {
 }
 
 /// Represents the I8080 LCD interface.
-pub struct I8080<'d, Dm: Mode> {
+pub struct I8080<'d, Dm: DriverMode> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
     tx_channel: ChannelTx<'d, Blocking, PeripheralTxChannel<LCD_CAM>>,
     _mode: PhantomData<Dm>,
@@ -100,7 +100,7 @@ pub struct I8080<'d, Dm: Mode> {
 
 impl<'d, Dm> I8080<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Creates a new instance of the I8080 LCD interface.
     pub fn new<P, CH>(
@@ -396,7 +396,7 @@ where
     }
 }
 
-impl<Dm: Mode> core::fmt::Debug for I8080<'_, Dm> {
+impl<Dm: DriverMode> core::fmt::Debug for I8080<'_, Dm> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("I8080").finish()
     }
@@ -404,12 +404,12 @@ impl<Dm: Mode> core::fmt::Debug for I8080<'_, Dm> {
 
 /// Represents an ongoing (or potentially finished) transfer using the I8080 LCD
 /// interface
-pub struct I8080Transfer<'d, BUF: DmaTxBuffer, Dm: Mode> {
+pub struct I8080Transfer<'d, BUF: DmaTxBuffer, Dm: DriverMode> {
     i8080: ManuallyDrop<I8080<'d, Dm>>,
     buf_view: ManuallyDrop<BUF::View>,
 }
 
-impl<'d, BUF: DmaTxBuffer, Dm: Mode> I8080Transfer<'d, BUF, Dm> {
+impl<'d, BUF: DmaTxBuffer, Dm: DriverMode> I8080Transfer<'d, BUF, Dm> {
     /// Returns true when [Self::wait] will not block.
     pub fn is_done(&self) -> bool {
         self.i8080
@@ -470,7 +470,7 @@ impl<'d, BUF: DmaTxBuffer, Dm: Mode> I8080Transfer<'d, BUF, Dm> {
     }
 }
 
-impl<BUF: DmaTxBuffer, Dm: Mode> Deref for I8080Transfer<'_, BUF, Dm> {
+impl<BUF: DmaTxBuffer, Dm: DriverMode> Deref for I8080Transfer<'_, BUF, Dm> {
     type Target = BUF::View;
 
     fn deref(&self) -> &Self::Target {
@@ -478,7 +478,7 @@ impl<BUF: DmaTxBuffer, Dm: Mode> Deref for I8080Transfer<'_, BUF, Dm> {
     }
 }
 
-impl<BUF: DmaTxBuffer, Dm: Mode> DerefMut for I8080Transfer<'_, BUF, Dm> {
+impl<BUF: DmaTxBuffer, Dm: DriverMode> DerefMut for I8080Transfer<'_, BUF, Dm> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.buf_view
     }
@@ -523,7 +523,7 @@ impl<'d, BUF: DmaTxBuffer> I8080Transfer<'d, BUF, crate::Async> {
     }
 }
 
-impl<BUF: DmaTxBuffer, Dm: Mode> Drop for I8080Transfer<'_, BUF, Dm> {
+impl<BUF: DmaTxBuffer, Dm: DriverMode> Drop for I8080Transfer<'_, BUF, Dm> {
     fn drop(&mut self) {
         self.stop_peripherals();
 

--- a/esp-hal/src/lcd_cam/lcd/mod.rs
+++ b/esp-hal/src/lcd_cam/lcd/mod.rs
@@ -17,7 +17,7 @@ pub mod dpi;
 pub mod i8080;
 
 /// Represents an LCD interface.
-pub struct Lcd<'d, Dm: crate::Mode> {
+pub struct Lcd<'d, Dm: crate::DriverMode> {
     /// The `LCD_CAM` peripheral reference for managing the LCD functionality.
     pub(crate) lcd_cam: PeripheralRef<'d, LCD_CAM>,
 

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Represents a combined LCD and Camera interface.
-pub struct LcdCam<'d, Dm: crate::Mode> {
+pub struct LcdCam<'d, Dm: crate::DriverMode> {
     /// The LCD interface.
     pub lcd: Lcd<'d, Dm>,
     /// The Camera interface.

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -293,7 +293,7 @@ WARNING: use --release
 "}
 
 /// A marker trait for initializing drivers in a specific mode.
-pub trait Mode: crate::private::Sealed {}
+pub trait DriverMode: crate::private::Sealed {}
 
 /// Driver initialized in blocking mode.
 #[derive(Debug)]
@@ -303,8 +303,8 @@ pub struct Blocking;
 #[derive(Debug)]
 pub struct Async;
 
-impl crate::Mode for Blocking {}
-impl crate::Mode for Async {}
+impl crate::DriverMode for Blocking {}
+impl crate::DriverMode for Async {}
 impl crate::private::Sealed for Blocking {}
 impl crate::private::Sealed for Async {}
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -846,7 +846,7 @@ impl ContainsValidSignalPin for RxSixteenBits<'_> {}
 
 impl<'d, Dm> TxCreatorFullDuplex<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Configure TX to use the given pins and settings
     pub fn with_config<P, CP>(
@@ -878,7 +878,7 @@ where
 
 impl<'d, Dm> TxCreator<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Configure TX to use the given pins and settings
     pub fn with_config<P, CP>(
@@ -911,7 +911,7 @@ where
 /// Parallel IO TX channel
 pub struct ParlIoTx<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<PARL_IO>>,
     tx_chain: DescriptorChain,
@@ -920,7 +920,7 @@ where
 
 impl<Dm> core::fmt::Debug for ParlIoTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ParlIoTx").finish()
@@ -929,7 +929,7 @@ where
 
 impl<'d, Dm> RxCreatorFullDuplex<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Configure RX to use the given pins and settings
     pub fn with_config<P, CP>(
@@ -961,7 +961,7 @@ where
 
 impl<'d, Dm> RxCreator<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Configure RX to use the given pins and settings
     pub fn with_config<P, CP>(
@@ -992,7 +992,7 @@ where
 /// Parallel IO RX channel
 pub struct ParlIoRx<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<PARL_IO>>,
     rx_chain: DescriptorChain,
@@ -1001,7 +1001,7 @@ where
 
 impl<Dm> core::fmt::Debug for ParlIoRx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ParlIoTx").finish()
@@ -1095,7 +1095,7 @@ fn internal_clear_interrupts(interrupts: EnumSet<ParlIoInterrupt>) {
 /// Full duplex mode might limit the maximum possible bit width.
 pub struct ParlIoFullDuplex<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// The transmitter (TX) channel responsible for handling DMA transfers in
     /// the parallel I/O full-duplex operation.
@@ -1221,7 +1221,7 @@ impl<'d> ParlIoFullDuplex<'d, Async> {
 /// Parallel IO in half duplex / TX only mode
 pub struct ParlIoTxOnly<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// The transmitter (TX) channel responsible for handling DMA transfers in
     /// the parallel I/O operation.
@@ -1327,7 +1327,7 @@ impl InterruptConfigurable for ParlIoTxOnly<'_, Blocking> {
 /// Parallel IO in half duplex / RX only mode
 pub struct ParlIoRxOnly<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// The receiver (RX) channel responsible for handling DMA transfers in the
     /// parallel I/O operation.
@@ -1463,7 +1463,7 @@ fn internal_init(frequency: HertzU32) -> Result<(), Error> {
 
 impl<Dm> ParlIoTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Perform a DMA write.
     ///
@@ -1518,7 +1518,7 @@ where
 
 impl<Dm> DmaSupport for ParlIoTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
         while !Instance::is_tx_eof() {}
@@ -1533,7 +1533,7 @@ where
 
 impl<'d, Dm> DmaSupportTx for ParlIoTx<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type TX = ChannelTx<'d, Dm, PeripheralTxChannel<PARL_IO>>;
 
@@ -1548,7 +1548,7 @@ where
 
 impl<'d, Dm> ParlIoRx<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Perform a DMA read.
     ///
@@ -1607,7 +1607,7 @@ where
 
 impl<Dm> DmaSupport for ParlIoRx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
         loop {
@@ -1629,7 +1629,7 @@ where
 
 impl<'d, Dm> DmaSupportRx for ParlIoRx<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type RX = ChannelRx<'d, Dm, PeripheralRxChannel<PARL_IO>>;
 
@@ -1645,7 +1645,7 @@ where
 /// Creates a TX channel
 pub struct TxCreator<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<PARL_IO>>,
     descriptors: &'static mut [DmaDescriptor],
@@ -1655,7 +1655,7 @@ where
 /// Creates a RX channel
 pub struct RxCreator<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<PARL_IO>>,
     descriptors: &'static mut [DmaDescriptor],
@@ -1665,7 +1665,7 @@ where
 /// Creates a TX channel
 pub struct TxCreatorFullDuplex<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<PARL_IO>>,
     descriptors: &'static mut [DmaDescriptor],
@@ -1675,7 +1675,7 @@ where
 /// Creates a RX channel
 pub struct RxCreatorFullDuplex<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<PARL_IO>>,
     descriptors: &'static mut [DmaDescriptor],

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -162,7 +162,7 @@ use crate::{
     system::{self, GenericPeripheralGuard},
     Async,
     Blocking,
-    Mode,
+    DriverMode,
 };
 
 #[allow(unused)]

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -353,7 +353,7 @@ pub use impl_for_chip::{ChannelCreator, Rmt};
 
 impl<'d, Dm> Rmt<'d, Dm>
 where
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     pub(crate) fn new_internal(
         peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
@@ -425,7 +425,7 @@ impl InterruptConfigurable for Rmt<'_, Blocking> {
     }
 }
 
-fn configure_rx_channel<'d, P: PeripheralInput, T: RxChannelInternal<Dm>, Dm: crate::Mode>(
+fn configure_rx_channel<'d, P: PeripheralInput, T: RxChannelInternal<Dm>, Dm: crate::DriverMode>(
     pin: impl Peripheral<P = P> + 'd,
     config: RxChannelConfig,
 ) -> Result<T, Error> {
@@ -462,7 +462,12 @@ fn configure_rx_channel<'d, P: PeripheralInput, T: RxChannelInternal<Dm>, Dm: cr
     Ok(T::new())
 }
 
-fn configure_tx_channel<'d, P: PeripheralOutput, T: TxChannelInternal<Dm>, Dm: crate::Mode>(
+fn configure_tx_channel<
+    'd,
+    P: PeripheralOutput,
+    T: TxChannelInternal<Dm>,
+    Dm: crate::DriverMode,
+>(
     pin: impl Peripheral<P = P> + 'd,
     config: TxChannelConfig,
 ) -> Result<T, Error> {
@@ -746,7 +751,7 @@ mod impl_for_chip {
     /// RMT Instance
     pub struct Rmt<'d, Dm>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         pub(super) peripheral: PeripheralRef<'d, crate::peripherals::RMT>,
         /// RMT Channel 0.
@@ -762,7 +767,7 @@ mod impl_for_chip {
 
     impl<'d, Dm> Rmt<'d, Dm>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         pub(super) fn create(
             peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
@@ -795,7 +800,7 @@ mod impl_for_chip {
     /// RMT Channel Creator
     pub struct ChannelCreator<Dm, const CHANNEL: u8>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         phantom: PhantomData<Dm>,
         _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
@@ -826,7 +831,7 @@ mod impl_for_chip {
     /// RMT Instance
     pub struct Rmt<'d, Dm>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         pub(super) peripheral: PeripheralRef<'d, crate::peripherals::RMT>,
         /// RMT Channel 0.
@@ -850,7 +855,7 @@ mod impl_for_chip {
 
     impl<'d, Dm> Rmt<'d, Dm>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         pub(super) fn create(
             peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
@@ -898,7 +903,7 @@ mod impl_for_chip {
     /// RMT Channel Creator
     pub struct ChannelCreator<Dm, const CHANNEL: u8>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         phantom: PhantomData<Dm>,
         _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
@@ -953,7 +958,7 @@ mod impl_for_chip {
     /// RMT Instance
     pub struct Rmt<'d, Dm>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         pub(super) peripheral: PeripheralRef<'d, crate::peripherals::RMT>,
         /// RMT Channel 0.
@@ -969,7 +974,7 @@ mod impl_for_chip {
 
     impl<'d, Dm> Rmt<'d, Dm>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         pub(super) fn create(
             peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
@@ -1002,7 +1007,7 @@ mod impl_for_chip {
     /// RMT Channel Creator
     pub struct ChannelCreator<Dm, const CHANNEL: u8>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         phantom: PhantomData<Dm>,
         _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
@@ -1041,7 +1046,7 @@ mod impl_for_chip {
     /// RMT Instance
     pub struct Rmt<'d, Dm>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         pub(super) peripheral: PeripheralRef<'d, crate::peripherals::RMT>,
         /// RMT Channel 0.
@@ -1065,7 +1070,7 @@ mod impl_for_chip {
 
     impl<'d, Dm> Rmt<'d, Dm>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         pub(super) fn create(
             peripheral: impl Peripheral<P = crate::peripherals::RMT> + 'd,
@@ -1114,7 +1119,7 @@ mod impl_for_chip {
     /// RMT Channel Creator
     pub struct ChannelCreator<Dm, const CHANNEL: u8>
     where
-        Dm: crate::Mode,
+        Dm: crate::DriverMode,
     {
         phantom: PhantomData<Dm>,
         _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
@@ -1146,7 +1151,7 @@ mod impl_for_chip {
 #[non_exhaustive]
 pub struct Channel<Dm, const CHANNEL: u8>
 where
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     phantom: PhantomData<Dm>,
     _guard: GenericPeripheralGuard<{ system::Peripheral::Rmt as u8 }>,
@@ -1532,7 +1537,7 @@ pub enum Event {
 #[doc(hidden)]
 pub trait TxChannelInternal<Dm>
 where
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     const CHANNEL: u8;
 
@@ -1628,7 +1633,7 @@ where
 #[doc(hidden)]
 pub trait RxChannelInternal<Dm>
 where
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     const CHANNEL: u8;
 
@@ -1765,7 +1770,7 @@ mod chip_specific {
     macro_rules! impl_tx_channel {
         ($signal:ident, $ch_num:literal) => {
             paste::paste! {
-                impl<Dm> $crate::rmt::TxChannelInternal<Dm> for $crate::rmt::Channel<Dm, $ch_num> where Dm: $crate::Mode {
+                impl<Dm> $crate::rmt::TxChannelInternal<Dm> for $crate::rmt::Channel<Dm, $ch_num> where Dm: $crate::DriverMode {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
@@ -1928,7 +1933,7 @@ mod chip_specific {
     macro_rules! impl_rx_channel {
         ($signal:ident, $ch_num:literal, $ch_index:literal) => {
             paste::paste! {
-                impl<Dm> $crate::rmt::RxChannelInternal<Dm> for $crate::rmt::Channel<Dm, $ch_num> where Dm: $crate::Mode {
+                impl<Dm> $crate::rmt::RxChannelInternal<Dm> for $crate::rmt::Channel<Dm, $ch_num> where Dm: $crate::DriverMode {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
@@ -2119,7 +2124,7 @@ mod chip_specific {
     macro_rules! impl_tx_channel {
         ($signal:ident, $ch_num:literal) => {
             paste::paste! {
-                impl<Dm> super::TxChannelInternal<Dm> for $crate::rmt::Channel<Dm, $ch_num> where Dm: $crate::Mode {
+                impl<Dm> super::TxChannelInternal<Dm> for $crate::rmt::Channel<Dm, $ch_num> where Dm: $crate::DriverMode {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {
@@ -2272,7 +2277,7 @@ mod chip_specific {
     macro_rules! impl_rx_channel {
         ($signal:ident, $ch_num:literal) => {
             paste::paste! {
-                impl<Dm> super::RxChannelInternal<Dm> for $crate::rmt::Channel<Dm, $ch_num> where Dm: $crate::Mode {
+                impl<Dm> super::RxChannelInternal<Dm> for $crate::rmt::Channel<Dm, $ch_num> where Dm: $crate::DriverMode {
                     const CHANNEL: u8 = $ch_num;
 
                     fn new() -> Self {

--- a/esp-hal/src/rsa/esp32.rs
+++ b/esp-hal/src/rsa/esp32.rs
@@ -10,7 +10,7 @@ use crate::rsa::{
     RsaMultiplication,
 };
 
-impl<Dm: crate::Mode> Rsa<'_, Dm> {
+impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     /// After the RSA Accelerator is released from reset, the memory blocks
     /// needs to be initialized, only after that peripheral should be used.
     /// This function would return without an error if the memory is initialized
@@ -79,7 +79,7 @@ pub mod operand_sizes {
     );
 }
 
-impl<'d, T: RsaMode, Dm: crate::Mode, const N: usize> RsaModularMultiplication<'_, 'd, T, Dm>
+impl<'d, T: RsaMode, Dm: crate::DriverMode, const N: usize> RsaModularMultiplication<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -98,7 +98,7 @@ where
     }
 }
 
-impl<'d, T: RsaMode, Dm: crate::Mode, const N: usize> RsaModularExponentiation<'_, 'd, T, Dm>
+impl<'d, T: RsaMode, Dm: crate::DriverMode, const N: usize> RsaModularExponentiation<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -108,7 +108,7 @@ where
     }
 }
 
-impl<'d, T: RsaMode + Multi, Dm: crate::Mode, const N: usize> RsaMultiplication<'_, 'd, T, Dm>
+impl<'d, T: RsaMode + Multi, Dm: crate::DriverMode, const N: usize> RsaMultiplication<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {

--- a/esp-hal/src/rsa/esp32cX.rs
+++ b/esp-hal/src/rsa/esp32cX.rs
@@ -10,7 +10,7 @@ use crate::rsa::{
     RsaMultiplication,
 };
 
-impl<Dm: crate::Mode> Rsa<'_, Dm> {
+impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     /// After the RSA Accelerator is released from reset, the memory blocks
     /// needs to be initialized, only after that peripheral should be used.
     /// This function would return without an error if the memory is initialized
@@ -229,7 +229,7 @@ pub mod operand_sizes {
     );
 }
 
-impl<'d, T: RsaMode, Dm: crate::Mode, const N: usize> RsaModularExponentiation<'_, 'd, T, Dm>
+impl<'d, T: RsaMode, Dm: crate::DriverMode, const N: usize> RsaModularExponentiation<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -249,7 +249,7 @@ where
     }
 }
 
-impl<'d, T: RsaMode, Dm: crate::Mode, const N: usize> RsaModularMultiplication<'_, 'd, T, Dm>
+impl<'d, T: RsaMode, Dm: crate::DriverMode, const N: usize> RsaModularMultiplication<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -262,7 +262,7 @@ where
     }
 }
 
-impl<'d, T: RsaMode + Multi, Dm: crate::Mode, const N: usize> RsaMultiplication<'_, 'd, T, Dm>
+impl<'d, T: RsaMode + Multi, Dm: crate::DriverMode, const N: usize> RsaMultiplication<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {

--- a/esp-hal/src/rsa/esp32sX.rs
+++ b/esp-hal/src/rsa/esp32sX.rs
@@ -10,7 +10,7 @@ use crate::rsa::{
     RsaMultiplication,
 };
 
-impl<Dm: crate::Mode> Rsa<'_, Dm> {
+impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     /// After the RSA accelerator is released from reset, the memory blocks
     /// needs to be initialized, only after that peripheral should be used.
     /// This function would return without an error if the memory is
@@ -248,7 +248,7 @@ pub mod operand_sizes {
     );
 }
 
-impl<'d, T: RsaMode, Dm: crate::Mode, const N: usize> RsaModularExponentiation<'_, 'd, T, Dm>
+impl<'d, T: RsaMode, Dm: crate::DriverMode, const N: usize> RsaModularExponentiation<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -268,7 +268,7 @@ where
     }
 }
 
-impl<'d, T: RsaMode, Dm: crate::Mode, const N: usize> RsaModularMultiplication<'_, 'd, T, Dm>
+impl<'d, T: RsaMode, Dm: crate::DriverMode, const N: usize> RsaModularMultiplication<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -281,7 +281,7 @@ where
     }
 }
 
-impl<'d, T: RsaMode + Multi, Dm: crate::Mode, const N: usize> RsaMultiplication<'_, 'd, T, Dm>
+impl<'d, T: RsaMode + Multi, Dm: crate::DriverMode, const N: usize> RsaMultiplication<'_, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -44,7 +44,7 @@ mod rsa_spec_impl;
 pub use rsa_spec_impl::operand_sizes;
 
 /// RSA peripheral container
-pub struct Rsa<'d, Dm: crate::Mode> {
+pub struct Rsa<'d, Dm: crate::DriverMode> {
     rsa: PeripheralRef<'d, RSA>,
     phantom: PhantomData<Dm>,
     _guard: GenericPeripheralGuard<{ PeripheralEnable::Rsa as u8 }>,
@@ -93,7 +93,7 @@ impl<'d> Rsa<'d, Async> {
     }
 }
 
-impl<'d, Dm: crate::Mode> Rsa<'d, Dm> {
+impl<'d, Dm: crate::DriverMode> Rsa<'d, Dm> {
     fn new_internal(rsa: impl Peripheral<P = RSA> + 'd) -> Self {
         crate::into_ref!(rsa);
 
@@ -215,12 +215,13 @@ use implement_op;
 /// used to find the `(base ^ exponent) mod modulus`.
 ///
 /// Each operand is a little endian byte array of the same size
-pub struct RsaModularExponentiation<'a, 'd, T: RsaMode, Dm: crate::Mode> {
+pub struct RsaModularExponentiation<'a, 'd, T: RsaMode, Dm: crate::DriverMode> {
     rsa: &'a mut Rsa<'d, Dm>,
     phantom: PhantomData<T>,
 }
 
-impl<'a, 'd, T: RsaMode, Dm: crate::Mode, const N: usize> RsaModularExponentiation<'a, 'd, T, Dm>
+impl<'a, 'd, T: RsaMode, Dm: crate::DriverMode, const N: usize>
+    RsaModularExponentiation<'a, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -281,12 +282,13 @@ where
 /// used to find the `(operand a * operand b) mod modulus`.
 ///
 /// Each operand is a little endian byte array of the same size
-pub struct RsaModularMultiplication<'a, 'd, T: RsaMode, Dm: crate::Mode> {
+pub struct RsaModularMultiplication<'a, 'd, T: RsaMode, Dm: crate::DriverMode> {
     rsa: &'a mut Rsa<'d, Dm>,
     phantom: PhantomData<T>,
 }
 
-impl<'a, 'd, T: RsaMode, Dm: crate::Mode, const N: usize> RsaModularMultiplication<'a, 'd, T, Dm>
+impl<'a, 'd, T: RsaMode, Dm: crate::DriverMode, const N: usize>
+    RsaModularMultiplication<'a, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {
@@ -336,12 +338,13 @@ where
 /// be used to find the `operand a * operand b`.
 ///
 /// Each operand is a little endian byte array of the same size
-pub struct RsaMultiplication<'a, 'd, T: RsaMode + Multi, Dm: crate::Mode> {
+pub struct RsaMultiplication<'a, 'd, T: RsaMode + Multi, Dm: crate::DriverMode> {
     rsa: &'a mut Rsa<'d, Dm>,
     phantom: PhantomData<T>,
 }
 
-impl<'a, 'd, T: RsaMode + Multi, Dm: crate::Mode, const N: usize> RsaMultiplication<'a, 'd, T, Dm>
+impl<'a, 'd, T: RsaMode + Multi, Dm: crate::DriverMode, const N: usize>
+    RsaMultiplication<'a, 'd, T, Dm>
 where
     T: RsaMode<InputType = [u32; N]>,
 {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -86,7 +86,7 @@ use crate::{
     Async,
     Blocking,
     Cpu,
-    Mode,
+    DriverMode,
 };
 
 /// Enumeration of possible SPI interrupt events.
@@ -467,12 +467,12 @@ pub struct Spi<'d, Dm, T = AnySpi> {
     guard: PeripheralGuard,
 }
 
-impl<Dm: Mode, T: Instance> Sealed for Spi<'_, Dm, T> {}
+impl<Dm: DriverMode, T: Instance> Sealed for Spi<'_, Dm, T> {}
 
 impl<Dm, T> Spi<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn driver(&self) -> Driver {
         Driver {
@@ -603,7 +603,7 @@ where
 impl<'d, Dm, T> Spi<'d, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Constructs an SPI instance in 8bit dataframe mode.
     pub fn new_typed(
@@ -706,7 +706,7 @@ where
 impl<Dm, T> SetConfig for Spi<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Config = Config;
     type ConfigError = ConfigError;
@@ -719,7 +719,7 @@ where
 impl<'d, Dm, T> Spi<'d, Dm, T>
 where
     T: Instance + QspiInstance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Assign the SIO2 pin for the SPI instance.
     ///
@@ -761,7 +761,7 @@ where
 impl<Dm, T> Spi<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Half-duplex read.
     #[instability::unstable]
@@ -887,7 +887,7 @@ mod dma {
     pub struct SpiDma<'d, Dm, T = AnySpi>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
         pub(crate) channel: Channel<'d, Dm, PeripheralDmaChannel<T>>,
@@ -901,7 +901,7 @@ mod dma {
     impl<Dm, T> crate::private::Sealed for SpiDma<'_, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
     }
 
@@ -944,7 +944,7 @@ mod dma {
     impl<Dm, T> core::fmt::Debug for SpiDma<'_, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         /// Formats the `SpiDma` instance for debugging purposes.
         ///
@@ -1045,7 +1045,7 @@ mod dma {
     impl<'d, Dm, T> SpiDma<'d, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         fn driver(&self) -> Driver {
             Driver {
@@ -1239,7 +1239,7 @@ mod dma {
     impl<Dm, T> SetConfig for SpiDma<'_, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         type Config = Config;
         type ConfigError = ConfigError;
@@ -1256,7 +1256,7 @@ mod dma {
     pub struct SpiDmaTransfer<'d, Dm, Buf, T = AnySpi>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         spi_dma: ManuallyDrop<SpiDma<'d, Dm, T>>,
         dma_buf: ManuallyDrop<Buf>,
@@ -1265,7 +1265,7 @@ mod dma {
     impl<'d, Dm, T, Buf> SpiDmaTransfer<'d, Dm, Buf, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         fn new(spi_dma: SpiDma<'d, Dm, T>, dma_buf: Buf) -> Self {
             Self {
@@ -1309,7 +1309,7 @@ mod dma {
     impl<Dm, T, Buf> Drop for SpiDmaTransfer<'_, Dm, Buf, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         fn drop(&mut self) {
             if !self.is_done() {
@@ -1339,7 +1339,7 @@ mod dma {
     impl<'d, Dm, T> SpiDma<'d, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         /// # Safety:
         ///
@@ -1578,7 +1578,7 @@ mod dma {
     pub struct SpiDmaBus<'d, Dm, T = AnySpi>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         spi_dma: SpiDma<'d, Dm, T>,
         rx_buf: DmaRxBuf,
@@ -1588,7 +1588,7 @@ mod dma {
     impl<Dm, T> crate::private::Sealed for SpiDmaBus<'_, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
     }
 
@@ -1623,7 +1623,7 @@ mod dma {
     impl<'d, Dm, T> SpiDmaBus<'d, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         /// Creates a new `SpiDmaBus` with the specified SPI instance and DMA
         /// buffers.
@@ -1677,7 +1677,7 @@ mod dma {
     impl<Dm, T> SpiDmaBus<'_, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         fn wait_for_idle(&mut self) {
             self.spi_dma.wait_for_idle();
@@ -1869,7 +1869,7 @@ mod dma {
     impl<Dm, T> SetConfig for SpiDmaBus<'_, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         type Config = Config;
         type ConfigError = ConfigError;
@@ -2089,7 +2089,7 @@ mod dma {
         impl<Dm, T> ErrorType for SpiDmaBus<'_, Dm, T>
         where
             T: Instance,
-            Dm: Mode,
+            Dm: DriverMode,
         {
             type Error = Error;
         }
@@ -2097,7 +2097,7 @@ mod dma {
         impl<Dm, T> SpiBus for SpiDmaBus<'_, Dm, T>
         where
             T: Instance,
-            Dm: Mode,
+            Dm: DriverMode,
         {
             fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
                 self.read(words)
@@ -2137,7 +2137,7 @@ mod ehal1 {
     impl<Dm, T> FullDuplex for Spi<'_, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         fn read(&mut self) -> nb::Result<u8, Self::Error> {
             self.driver().read_byte()
@@ -2151,7 +2151,7 @@ mod ehal1 {
     impl<Dm, T> SpiBus for Spi<'_, Dm, T>
     where
         T: Instance,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
             self.driver().read_bytes(words)

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -36,7 +36,7 @@
 //! ### SPI Initialization
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
-//! # use esp_hal::spi::SpiMode;
+//! # use esp_hal::spi::Mode;
 //! # use esp_hal::spi::master::{Config, Spi};
 //! let sclk = peripherals.GPIO0;
 //! let miso = peripherals.GPIO2;
@@ -44,7 +44,7 @@
 //!
 //! let mut spi = Spi::new(
 //!     peripherals.SPI2,
-//!     Config::default().with_frequency(100.kHz()).with_mode(SpiMode::Mode0)
+//!     Config::default().with_frequency(100.kHz()).with_mode(Mode::Mode0)
 //! )
 //! .unwrap()
 //! .with_sck(sclk)
@@ -69,7 +69,7 @@ use fugit::HertzU32;
 #[cfg(place_spi_driver_in_ram)]
 use procmacros::ram;
 
-use super::{DmaError, Error, SpiBitOrder, SpiDataMode, SpiMode};
+use super::{BitOrder, DataMode, DmaError, Error, Mode};
 use crate::{
     asynch::AtomicWaker,
     clock::Clocks,
@@ -121,37 +121,37 @@ pub enum Command {
     /// No command is sent.
     None,
     /// A 1-bit command.
-    Command1(u16, SpiDataMode),
+    Command1(u16, DataMode),
     /// A 2-bit command.
-    Command2(u16, SpiDataMode),
+    Command2(u16, DataMode),
     /// A 3-bit command.
-    Command3(u16, SpiDataMode),
+    Command3(u16, DataMode),
     /// A 4-bit command.
-    Command4(u16, SpiDataMode),
+    Command4(u16, DataMode),
     /// A 5-bit command.
-    Command5(u16, SpiDataMode),
+    Command5(u16, DataMode),
     /// A 6-bit command.
-    Command6(u16, SpiDataMode),
+    Command6(u16, DataMode),
     /// A 7-bit command.
-    Command7(u16, SpiDataMode),
+    Command7(u16, DataMode),
     /// A 8-bit command.
-    Command8(u16, SpiDataMode),
+    Command8(u16, DataMode),
     /// A 9-bit command.
-    Command9(u16, SpiDataMode),
+    Command9(u16, DataMode),
     /// A 10-bit command.
-    Command10(u16, SpiDataMode),
+    Command10(u16, DataMode),
     /// A 11-bit command.
-    Command11(u16, SpiDataMode),
+    Command11(u16, DataMode),
     /// A 12-bit command.
-    Command12(u16, SpiDataMode),
+    Command12(u16, DataMode),
     /// A 13-bit command.
-    Command13(u16, SpiDataMode),
+    Command13(u16, DataMode),
     /// A 14-bit command.
-    Command14(u16, SpiDataMode),
+    Command14(u16, DataMode),
     /// A 15-bit command.
-    Command15(u16, SpiDataMode),
+    Command15(u16, DataMode),
     /// A 16-bit command.
-    Command16(u16, SpiDataMode),
+    Command16(u16, DataMode),
 }
 
 impl Command {
@@ -199,9 +199,9 @@ impl Command {
         }
     }
 
-    fn mode(&self) -> SpiDataMode {
+    fn mode(&self) -> DataMode {
         match self {
-            Command::None => SpiDataMode::Single,
+            Command::None => DataMode::Single,
             Command::Command1(_, mode)
             | Command::Command2(_, mode)
             | Command::Command3(_, mode)
@@ -237,69 +237,69 @@ pub enum Address {
     /// No address phase.
     None,
     /// A 1-bit address.
-    Address1(u32, SpiDataMode),
+    Address1(u32, DataMode),
     /// A 2-bit address.
-    Address2(u32, SpiDataMode),
+    Address2(u32, DataMode),
     /// A 3-bit address.
-    Address3(u32, SpiDataMode),
+    Address3(u32, DataMode),
     /// A 4-bit address.
-    Address4(u32, SpiDataMode),
+    Address4(u32, DataMode),
     /// A 5-bit address.
-    Address5(u32, SpiDataMode),
+    Address5(u32, DataMode),
     /// A 6-bit address.
-    Address6(u32, SpiDataMode),
+    Address6(u32, DataMode),
     /// A 7-bit address.
-    Address7(u32, SpiDataMode),
+    Address7(u32, DataMode),
     /// A 8-bit address.
-    Address8(u32, SpiDataMode),
+    Address8(u32, DataMode),
     /// A 9-bit address.
-    Address9(u32, SpiDataMode),
+    Address9(u32, DataMode),
     /// A 10-bit address.
-    Address10(u32, SpiDataMode),
+    Address10(u32, DataMode),
     /// A 11-bit address.
-    Address11(u32, SpiDataMode),
+    Address11(u32, DataMode),
     /// A 12-bit address.
-    Address12(u32, SpiDataMode),
+    Address12(u32, DataMode),
     /// A 13-bit address.
-    Address13(u32, SpiDataMode),
+    Address13(u32, DataMode),
     /// A 14-bit address.
-    Address14(u32, SpiDataMode),
+    Address14(u32, DataMode),
     /// A 15-bit address.
-    Address15(u32, SpiDataMode),
+    Address15(u32, DataMode),
     /// A 16-bit address.
-    Address16(u32, SpiDataMode),
+    Address16(u32, DataMode),
     /// A 17-bit address.
-    Address17(u32, SpiDataMode),
+    Address17(u32, DataMode),
     /// A 18-bit address.
-    Address18(u32, SpiDataMode),
+    Address18(u32, DataMode),
     /// A 19-bit address.
-    Address19(u32, SpiDataMode),
+    Address19(u32, DataMode),
     /// A 20-bit address.
-    Address20(u32, SpiDataMode),
+    Address20(u32, DataMode),
     /// A 21-bit address.
-    Address21(u32, SpiDataMode),
+    Address21(u32, DataMode),
     /// A 22-bit address.
-    Address22(u32, SpiDataMode),
+    Address22(u32, DataMode),
     /// A 23-bit address.
-    Address23(u32, SpiDataMode),
+    Address23(u32, DataMode),
     /// A 24-bit address.
-    Address24(u32, SpiDataMode),
+    Address24(u32, DataMode),
     /// A 25-bit address.
-    Address25(u32, SpiDataMode),
+    Address25(u32, DataMode),
     /// A 26-bit address.
-    Address26(u32, SpiDataMode),
+    Address26(u32, DataMode),
     /// A 27-bit address.
-    Address27(u32, SpiDataMode),
+    Address27(u32, DataMode),
     /// A 28-bit address.
-    Address28(u32, SpiDataMode),
+    Address28(u32, DataMode),
     /// A 29-bit address.
-    Address29(u32, SpiDataMode),
+    Address29(u32, DataMode),
     /// A 30-bit address.
-    Address30(u32, SpiDataMode),
+    Address30(u32, DataMode),
     /// A 31-bit address.
-    Address31(u32, SpiDataMode),
+    Address31(u32, DataMode),
     /// A 32-bit address.
-    Address32(u32, SpiDataMode),
+    Address32(u32, DataMode),
 }
 
 impl Address {
@@ -383,9 +383,9 @@ impl Address {
         matches!(self, Address::None)
     }
 
-    fn mode(&self) -> SpiDataMode {
+    fn mode(&self) -> DataMode {
         match self {
-            Address::None => SpiDataMode::Single,
+            Address::None => DataMode::Single,
             Address::Address1(_, mode)
             | Address::Address2(_, mode)
             | Address::Address3(_, mode)
@@ -431,13 +431,13 @@ pub struct Config {
     pub frequency: HertzU32,
 
     /// SPI sample/shift mode.
-    pub mode: SpiMode,
+    pub mode: Mode,
 
     /// Bit order of the read data.
-    pub read_bit_order: SpiBitOrder,
+    pub read_bit_order: BitOrder,
 
     /// Bit order of the written data.
-    pub write_bit_order: SpiBitOrder,
+    pub write_bit_order: BitOrder,
 }
 
 impl Default for Config {
@@ -445,9 +445,9 @@ impl Default for Config {
         use fugit::RateExtU32;
         Config {
             frequency: 1_u32.MHz(),
-            mode: SpiMode::Mode0,
-            read_bit_order: SpiBitOrder::MsbFirst,
-            write_bit_order: SpiBitOrder::MsbFirst,
+            mode: Mode::Mode0,
+            read_bit_order: BitOrder::MsbFirst,
+            write_bit_order: BitOrder::MsbFirst,
         }
     }
 }
@@ -767,7 +767,7 @@ where
     #[instability::unstable]
     pub fn half_duplex_read(
         &mut self,
-        data_mode: SpiDataMode,
+        data_mode: DataMode,
         cmd: Command,
         address: Address,
         dummy: u8,
@@ -801,7 +801,7 @@ where
     #[instability::unstable]
     pub fn half_duplex_write(
         &mut self,
-        data_mode: SpiDataMode,
+        data_mode: DataMode,
         cmd: Command,
         address: Address,
         dummy: u8,
@@ -1456,7 +1456,7 @@ mod dma {
         #[cfg_attr(place_spi_driver_in_ram, ram)]
         unsafe fn start_half_duplex_read(
             &mut self,
-            data_mode: SpiDataMode,
+            data_mode: DataMode,
             cmd: Command,
             address: Address,
             dummy: u8,
@@ -1481,7 +1481,7 @@ mod dma {
         #[cfg_attr(place_spi_driver_in_ram, ram)]
         pub fn half_duplex_read<RX: DmaRxBuffer>(
             mut self,
-            data_mode: SpiDataMode,
+            data_mode: DataMode,
             cmd: Command,
             address: Address,
             dummy: u8,
@@ -1512,7 +1512,7 @@ mod dma {
         #[cfg_attr(place_spi_driver_in_ram, ram)]
         unsafe fn start_half_duplex_write(
             &mut self,
-            data_mode: SpiDataMode,
+            data_mode: DataMode,
             cmd: Command,
             address: Address,
             dummy: u8,
@@ -1523,7 +1523,7 @@ mod dma {
             {
                 // On the ESP32, if we don't have data, the address is always sent
                 // on a single line, regardless of its data mode.
-                if bytes_to_write == 0 && address.mode() != SpiDataMode::Single {
+                if bytes_to_write == 0 && address.mode() != DataMode::Single {
                     return self.set_up_address_workaround(cmd, address, dummy);
                 }
             }
@@ -1546,7 +1546,7 @@ mod dma {
         #[cfg_attr(place_spi_driver_in_ram, ram)]
         pub fn half_duplex_write<TX: DmaTxBuffer>(
             mut self,
-            data_mode: SpiDataMode,
+            data_mode: DataMode,
             cmd: Command,
             address: Address,
             dummy: u8,
@@ -1801,7 +1801,7 @@ mod dma {
         /// Half-duplex read.
         pub fn half_duplex_read(
             &mut self,
-            data_mode: SpiDataMode,
+            data_mode: DataMode,
             cmd: Command,
             address: Address,
             dummy: u8,
@@ -1835,7 +1835,7 @@ mod dma {
         /// Half-duplex write.
         pub fn half_duplex_write(
             &mut self,
-            data_mode: SpiDataMode,
+            data_mode: DataMode,
             cmd: Command,
             address: Address,
             dummy: u8,
@@ -2550,22 +2550,22 @@ impl Driver {
     #[cfg(not(esp32))]
     fn init_spi_data_mode(
         &self,
-        cmd_mode: SpiDataMode,
-        address_mode: SpiDataMode,
-        data_mode: SpiDataMode,
+        cmd_mode: DataMode,
+        address_mode: DataMode,
+        data_mode: DataMode,
     ) -> Result<(), Error> {
         let reg_block = self.register_block();
         reg_block.ctrl().modify(|_, w| {
-            w.fcmd_dual().bit(cmd_mode == SpiDataMode::Dual);
-            w.fcmd_quad().bit(cmd_mode == SpiDataMode::Quad);
-            w.faddr_dual().bit(address_mode == SpiDataMode::Dual);
-            w.faddr_quad().bit(address_mode == SpiDataMode::Quad);
-            w.fread_dual().bit(data_mode == SpiDataMode::Dual);
-            w.fread_quad().bit(data_mode == SpiDataMode::Quad)
+            w.fcmd_dual().bit(cmd_mode == DataMode::Dual);
+            w.fcmd_quad().bit(cmd_mode == DataMode::Quad);
+            w.faddr_dual().bit(address_mode == DataMode::Dual);
+            w.faddr_quad().bit(address_mode == DataMode::Quad);
+            w.fread_dual().bit(data_mode == DataMode::Dual);
+            w.fread_quad().bit(data_mode == DataMode::Quad)
         });
         reg_block.user().modify(|_, w| {
-            w.fwrite_dual().bit(data_mode == SpiDataMode::Dual);
-            w.fwrite_quad().bit(data_mode == SpiDataMode::Quad)
+            w.fwrite_dual().bit(data_mode == DataMode::Dual);
+            w.fwrite_quad().bit(data_mode == DataMode::Quad)
         });
         Ok(())
     }
@@ -2573,45 +2573,45 @@ impl Driver {
     #[cfg(esp32)]
     fn init_spi_data_mode(
         &self,
-        cmd_mode: SpiDataMode,
-        address_mode: SpiDataMode,
-        data_mode: SpiDataMode,
+        cmd_mode: DataMode,
+        address_mode: DataMode,
+        data_mode: DataMode,
     ) -> Result<(), Error> {
         let reg_block = self.register_block();
         match cmd_mode {
-            SpiDataMode::Single => (),
+            DataMode::Single => (),
             // FIXME: more detailed error - Only 1-bit commands are supported.
             _ => return Err(Error::Unsupported),
         }
 
         match address_mode {
-            SpiDataMode::Single => {
+            DataMode::Single => {
                 reg_block.ctrl().modify(|_, w| {
                     w.fread_dio().clear_bit();
                     w.fread_qio().clear_bit();
-                    w.fread_dual().bit(data_mode == SpiDataMode::Dual);
-                    w.fread_quad().bit(data_mode == SpiDataMode::Quad)
+                    w.fread_dual().bit(data_mode == DataMode::Dual);
+                    w.fread_quad().bit(data_mode == DataMode::Quad)
                 });
 
                 reg_block.user().modify(|_, w| {
                     w.fwrite_dio().clear_bit();
                     w.fwrite_qio().clear_bit();
-                    w.fwrite_dual().bit(data_mode == SpiDataMode::Dual);
-                    w.fwrite_quad().bit(data_mode == SpiDataMode::Quad)
+                    w.fwrite_dual().bit(data_mode == DataMode::Dual);
+                    w.fwrite_quad().bit(data_mode == DataMode::Quad)
                 });
             }
             address_mode if address_mode == data_mode => {
                 reg_block.ctrl().modify(|_, w| {
                     w.fastrd_mode().set_bit();
-                    w.fread_dio().bit(address_mode == SpiDataMode::Dual);
-                    w.fread_qio().bit(address_mode == SpiDataMode::Quad);
+                    w.fread_dio().bit(address_mode == DataMode::Dual);
+                    w.fread_qio().bit(address_mode == DataMode::Quad);
                     w.fread_dual().clear_bit();
                     w.fread_quad().clear_bit()
                 });
 
                 reg_block.user().modify(|_, w| {
-                    w.fwrite_dio().bit(address_mode == SpiDataMode::Dual);
-                    w.fwrite_qio().bit(address_mode == SpiDataMode::Quad);
+                    w.fwrite_dio().bit(address_mode == DataMode::Dual);
+                    w.fwrite_qio().bit(address_mode == DataMode::Quad);
                     w.fwrite_dual().clear_bit();
                     w.fwrite_quad().clear_bit()
                 });
@@ -2759,7 +2759,7 @@ impl Driver {
         Ok(())
     }
 
-    fn set_data_mode(&self, data_mode: SpiMode) {
+    fn set_data_mode(&self, data_mode: Mode) {
         let reg_block = self.register_block();
 
         cfg_if::cfg_if! {
@@ -2772,11 +2772,11 @@ impl Driver {
 
         pin_reg.modify(|_, w| {
             w.ck_idle_edge()
-                .bit(matches!(data_mode, SpiMode::Mode2 | SpiMode::Mode3))
+                .bit(matches!(data_mode, Mode::Mode2 | Mode::Mode3))
         });
         reg_block.user().modify(|_, w| {
             w.ck_out_edge()
-                .bit(matches!(data_mode, SpiMode::Mode1 | SpiMode::Mode2))
+                .bit(matches!(data_mode, Mode::Mode1 | Mode::Mode2))
         });
     }
 
@@ -2799,16 +2799,16 @@ impl Driver {
     }
 
     #[cfg(not(any(esp32, esp32c3, esp32s2)))]
-    fn set_bit_order(&self, read_order: SpiBitOrder, write_order: SpiBitOrder) {
+    fn set_bit_order(&self, read_order: BitOrder, write_order: BitOrder) {
         let reg_block = self.register_block();
 
         let read_value = match read_order {
-            SpiBitOrder::MsbFirst => 0,
-            SpiBitOrder::LsbFirst => 1,
+            BitOrder::MsbFirst => 0,
+            BitOrder::LsbFirst => 1,
         };
         let write_value = match write_order {
-            SpiBitOrder::MsbFirst => 0,
-            SpiBitOrder::LsbFirst => 1,
+            BitOrder::MsbFirst => 0,
+            BitOrder::LsbFirst => 1,
         };
         reg_block.ctrl().modify(|_, w| unsafe {
             w.rd_bit_order().bits(read_value);
@@ -2818,16 +2818,16 @@ impl Driver {
     }
 
     #[cfg(any(esp32, esp32c3, esp32s2))]
-    fn set_bit_order(&self, read_order: SpiBitOrder, write_order: SpiBitOrder) {
+    fn set_bit_order(&self, read_order: BitOrder, write_order: BitOrder) {
         let reg_block = self.register_block();
 
         let read_value = match read_order {
-            SpiBitOrder::MsbFirst => false,
-            SpiBitOrder::LsbFirst => true,
+            BitOrder::MsbFirst => false,
+            BitOrder::LsbFirst => true,
         };
         let write_value = match write_order {
-            SpiBitOrder::MsbFirst => false,
-            SpiBitOrder::LsbFirst => true,
+            BitOrder::MsbFirst => false,
+            BitOrder::LsbFirst => true,
         };
         reg_block.ctrl().modify(|_, w| {
             w.rd_bit_order().bit(read_value);
@@ -3098,7 +3098,7 @@ impl Driver {
         dummy_idle: bool,
         dummy: u8,
         no_mosi_miso: bool,
-        data_mode: SpiDataMode,
+        data_mode: DataMode,
     ) -> Result<(), Error> {
         self.init_spi_data_mode(cmd.mode(), address.mode(), data_mode)?;
 

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -64,7 +64,7 @@ impl embedded_hal::spi::Error for Error {
 /// and shifted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SpiMode {
+pub enum Mode {
     /// Mode 0 (CPOL = 0, CPHA = 0): Clock is low when idle, data is captured on
     /// the rising edge and propagated on the falling edge.
     Mode0,
@@ -82,7 +82,7 @@ pub enum SpiMode {
 /// SPI Bit Order
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SpiBitOrder {
+pub enum BitOrder {
     /// Most Significant Bit (MSB) is transmitted first.
     MsbFirst,
     /// Least Significant Bit (LSB) is transmitted first.
@@ -92,7 +92,7 @@ pub enum SpiBitOrder {
 /// SPI data mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SpiDataMode {
+pub enum DataMode {
     /// `Single` Data Mode - 1 bit, 2 wires.
     Single,
     /// `Dual` Data Mode - 2 bit, 2 wires

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -16,7 +16,7 @@
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
 //! # use esp_hal::dma_buffers;
-//! # use esp_hal::spi::SpiMode;
+//! # use esp_hal::spi::Mode;
 //! # use esp_hal::spi::slave::Spi;
 #![cfg_attr(pdma, doc = "let dma_channel = peripherals.DMA_SPI2;")]
 #![cfg_attr(gdma, doc = "let dma_channel = peripherals.DMA_CH0;")]
@@ -29,7 +29,7 @@
 //! dma_buffers!(32000);
 //! let mut spi = Spi::new(
 //!     peripherals.SPI2,
-//!     SpiMode::Mode0,
+//!     Mode::Mode0,
 //! )
 //! .with_sck(sclk)
 //! .with_mosi(mosi)
@@ -69,7 +69,7 @@
 
 use core::marker::PhantomData;
 
-use super::{Error, SpiMode};
+use super::{Error, Mode};
 use crate::{
     dma::DmaEligible,
     gpio::{
@@ -94,14 +94,14 @@ const MAX_DMA_SIZE: usize = 32768 - 32;
 pub struct Spi<'d, Dm, T = AnySpi> {
     spi: PeripheralRef<'d, T>,
     #[allow(dead_code)]
-    data_mode: SpiMode,
+    data_mode: Mode,
     _mode: PhantomData<Dm>,
     _guard: PeripheralGuard,
 }
 
 impl<'d> Spi<'d, Blocking> {
     /// Constructs an SPI instance in 8bit dataframe mode.
-    pub fn new(spi: impl Peripheral<P = impl Instance> + 'd, mode: SpiMode) -> Spi<'d, Blocking> {
+    pub fn new(spi: impl Peripheral<P = impl Instance> + 'd, mode: Mode) -> Spi<'d, Blocking> {
         Self::new_typed(spi.map_into(), mode)
     }
 }
@@ -111,7 +111,7 @@ where
     T: Instance,
 {
     /// Constructs an SPI instance in 8bit dataframe mode.
-    pub fn new_typed(spi: impl Peripheral<P = T> + 'd, mode: SpiMode) -> Spi<'d, Dm, T> {
+    pub fn new_typed(spi: impl Peripheral<P = T> + 'd, mode: Mode) -> Spi<'d, Dm, T> {
         crate::into_ref!(spi);
 
         let guard = PeripheralGuard::new(spi.info().peripheral);
@@ -674,39 +674,39 @@ impl Info {
         reg_block.misc().write(|w| unsafe { w.bits(0) });
     }
 
-    fn set_data_mode(&self, data_mode: SpiMode, dma: bool) {
+    fn set_data_mode(&self, data_mode: Mode, dma: bool) {
         let reg_block = self.register_block();
         #[cfg(esp32)]
         {
             reg_block.pin().modify(|_, w| {
                 w.ck_idle_edge()
-                    .bit(matches!(data_mode, SpiMode::Mode0 | SpiMode::Mode1))
+                    .bit(matches!(data_mode, Mode::Mode0 | Mode::Mode1))
             });
             reg_block.user().modify(|_, w| {
                 w.ck_i_edge()
-                    .bit(matches!(data_mode, SpiMode::Mode1 | SpiMode::Mode2))
+                    .bit(matches!(data_mode, Mode::Mode1 | Mode::Mode2))
             });
             reg_block.ctrl2().modify(|_, w| unsafe {
                 match data_mode {
-                    SpiMode::Mode0 => {
+                    Mode::Mode0 => {
                         w.miso_delay_mode().bits(0);
                         w.miso_delay_num().bits(0);
                         w.mosi_delay_mode().bits(2);
                         w.mosi_delay_num().bits(2)
                     }
-                    SpiMode::Mode1 => {
+                    Mode::Mode1 => {
                         w.miso_delay_mode().bits(2);
                         w.miso_delay_num().bits(0);
                         w.mosi_delay_mode().bits(0);
                         w.mosi_delay_num().bits(0)
                     }
-                    SpiMode::Mode2 => {
+                    Mode::Mode2 => {
                         w.miso_delay_mode().bits(0);
                         w.miso_delay_num().bits(0);
                         w.mosi_delay_mode().bits(1);
                         w.mosi_delay_num().bits(2)
                     }
-                    SpiMode::Mode3 => {
+                    Mode::Mode3 => {
                         w.miso_delay_mode().bits(1);
                         w.miso_delay_num().bits(0);
                         w.mosi_delay_mode().bits(0);
@@ -717,7 +717,7 @@ impl Info {
 
             if dma {
                 assert!(
-                    matches!(data_mode, SpiMode::Mode1 | SpiMode::Mode3),
+                    matches!(data_mode, Mode::Mode1 | Mode::Mode3),
                     "Mode {:?} is not supported with DMA",
                     data_mode
                 );
@@ -736,13 +736,13 @@ impl Info {
             }
             reg_block.user().modify(|_, w| {
                 w.tsck_i_edge()
-                    .bit(matches!(data_mode, SpiMode::Mode1 | SpiMode::Mode2));
+                    .bit(matches!(data_mode, Mode::Mode1 | Mode::Mode2));
                 w.rsck_i_edge()
-                    .bit(matches!(data_mode, SpiMode::Mode1 | SpiMode::Mode2))
+                    .bit(matches!(data_mode, Mode::Mode1 | Mode::Mode2))
             });
             ctrl1_reg.modify(|_, w| {
                 w.clk_mode_13()
-                    .bit(matches!(data_mode, SpiMode::Mode1 | SpiMode::Mode3))
+                    .bit(matches!(data_mode, Mode::Mode1 | Mode::Mode3))
             });
         }
     }

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -188,7 +188,7 @@ pub mod dma {
             Tx,
             WriteBuffer,
         },
-        Mode,
+        DriverMode,
     };
 
     impl<'d, T> Spi<'d, Blocking, T>
@@ -221,7 +221,7 @@ pub mod dma {
     pub struct SpiDma<'d, Dm, T = AnySpi>
     where
         T: InstanceDma,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         pub(crate) spi: PeripheralRef<'d, T>,
         pub(crate) channel: Channel<'d, Dm, PeripheralDmaChannel<T>>,
@@ -233,7 +233,7 @@ pub mod dma {
     impl<Dm, T> core::fmt::Debug for SpiDma<'_, Dm, T>
     where
         T: InstanceDma,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             f.debug_struct("SpiDma").finish()
@@ -243,7 +243,7 @@ pub mod dma {
     impl<Dm, T> DmaSupport for SpiDma<'_, Dm, T>
     where
         T: InstanceDma,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         fn peripheral_wait_dma(&mut self, is_rx: bool, is_tx: bool) {
             while !((!is_tx || self.channel.tx.is_done())
@@ -262,7 +262,7 @@ pub mod dma {
     impl<'d, Dm, T> DmaSupportTx for SpiDma<'d, Dm, T>
     where
         T: InstanceDma,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         type TX = ChannelTx<'d, Dm, PeripheralTxChannel<T>>;
 
@@ -278,7 +278,7 @@ pub mod dma {
     impl<'d, Dm, T> DmaSupportRx for SpiDma<'d, Dm, T>
     where
         T: InstanceDma,
-        Dm: Mode,
+        Dm: DriverMode,
     {
         type RX = ChannelRx<'d, Dm, PeripheralRxChannel<T>>;
 
@@ -317,7 +317,7 @@ pub mod dma {
 
     impl<Dm, T> SpiDma<'_, Dm, T>
     where
-        Dm: Mode,
+        Dm: DriverMode,
         T: InstanceDma,
     {
         fn driver(&self) -> DmaDriver {

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     Async,
     Blocking,
     Cpu,
-    Mode,
+    DriverMode,
 };
 
 #[cfg(systimer)]
@@ -199,7 +199,7 @@ where
 
 impl<Dm, T> OneShotTimer<'_, Dm, T>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     T: Timer,
 {
     /// Delay for *at least* `ms` milliseconds.
@@ -270,13 +270,13 @@ where
 impl<Dm, T> crate::private::Sealed for OneShotTimer<'_, Dm, T>
 where
     T: Timer,
-    Dm: Mode,
+    Dm: DriverMode,
 {
 }
 
 impl<Dm, T> InterruptConfigurable for OneShotTimer<'_, Dm, T>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     T: Timer,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
@@ -331,7 +331,7 @@ where
 
 impl<Dm, T> PeriodicTimer<'_, Dm, T>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     T: Timer,
 {
     /// Start a new count down.
@@ -394,7 +394,7 @@ impl<Dm, T> crate::private::Sealed for PeriodicTimer<'_, Dm, T> where T: Timer {
 
 impl<Dm, T> InterruptConfigurable for PeriodicTimer<'_, Dm, T>
 where
-    Dm: Mode,
+    Dm: DriverMode,
     T: Timer,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -36,7 +36,7 @@ use crate::{
     rtc_cntl::Rtc,
     Async,
     Blocking,
-    Mode,
+    DriverMode,
 };
 
 /// A marker trait describing the mode the touch pad is set to.

--- a/esp-hal/src/touch.rs
+++ b/esp-hal/src/touch.rs
@@ -85,12 +85,12 @@ pub struct TouchConfig {
 }
 
 /// This struct marks a successfully initialized touch peripheral
-pub struct Touch<'d, Tm: TouchMode, Dm: Mode> {
+pub struct Touch<'d, Tm: TouchMode, Dm: DriverMode> {
     _inner: PeripheralRef<'d, TOUCH>,
     _touch_mode: PhantomData<Tm>,
     _mode: PhantomData<Dm>,
 }
-impl<Tm: TouchMode, Dm: Mode> Touch<'_, Tm, Dm> {
+impl<Tm: TouchMode, Dm: DriverMode> Touch<'_, Tm, Dm> {
     /// Common initialization of the touch peripheral.
     fn initialize_common(config: Option<TouchConfig>) {
         let rtccntl = unsafe { &*RTC_CNTL::ptr() };
@@ -318,7 +318,7 @@ impl<'d> Touch<'d, Continuous, Async> {
 }
 
 /// A pin that is configured as a TouchPad.
-pub struct TouchPad<P: TouchPin, Tm: TouchMode, Dm: Mode> {
+pub struct TouchPad<P: TouchPin, Tm: TouchMode, Dm: DriverMode> {
     pin: P,
     _touch_mode: PhantomData<Tm>,
     _mode: PhantomData<Dm>,
@@ -362,7 +362,7 @@ impl<P: TouchPin> TouchPad<P, OneShot, Blocking> {
             .modify(|_, w| w.touch_start_en().set_bit());
     }
 }
-impl<P: TouchPin, Tm: TouchMode, Dm: Mode> TouchPad<P, Tm, Dm> {
+impl<P: TouchPin, Tm: TouchMode, Dm: DriverMode> TouchPad<P, Tm, Dm> {
     /// Construct a new instance of [`TouchPad`].
     ///
     /// ## Parameters:

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -662,7 +662,7 @@ impl BaudRate {
 }
 
 /// An inactive TWAI peripheral in the "Reset"/configuration state.
-pub struct TwaiConfiguration<'d, Dm: crate::Mode, T = AnyTwai> {
+pub struct TwaiConfiguration<'d, Dm: crate::DriverMode, T = AnyTwai> {
     twai: PeripheralRef<'d, T>,
     filter: Option<(FilterType, [u8; 8])>,
     phantom: PhantomData<Dm>,
@@ -673,7 +673,7 @@ pub struct TwaiConfiguration<'d, Dm: crate::Mode, T = AnyTwai> {
 impl<'d, Dm, T> TwaiConfiguration<'d, Dm, T>
 where
     T: Instance,
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     fn new_internal<TX: PeripheralOutput, RX: PeripheralInput>(
         twai: impl Peripheral<P = T> + 'd,
@@ -1075,7 +1075,7 @@ where
 ///
 /// In this mode, the TWAI controller can transmit and receive messages
 /// including error signals (such as error and overload frames).
-pub struct Twai<'d, Dm: crate::Mode, T = AnyTwai> {
+pub struct Twai<'d, Dm: crate::DriverMode, T = AnyTwai> {
     twai: PeripheralRef<'d, T>,
     tx: TwaiTx<'d, Dm, T>,
     rx: TwaiRx<'d, Dm, T>,
@@ -1085,7 +1085,7 @@ pub struct Twai<'d, Dm: crate::Mode, T = AnyTwai> {
 impl<'d, T, Dm> Twai<'d, Dm, T>
 where
     T: Instance,
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     fn mode(&self) -> TwaiMode {
         let mode = self.twai.register_block().mode().read();
@@ -1196,7 +1196,7 @@ where
 }
 
 /// Interface to the TWAI transmitter part.
-pub struct TwaiTx<'d, Dm: crate::Mode, T = AnyTwai> {
+pub struct TwaiTx<'d, Dm: crate::DriverMode, T = AnyTwai> {
     twai: PeripheralRef<'d, T>,
     phantom: PhantomData<Dm>,
     _guard: PeripheralGuard,
@@ -1205,7 +1205,7 @@ pub struct TwaiTx<'d, Dm: crate::Mode, T = AnyTwai> {
 impl<Dm, T> TwaiTx<'_, Dm, T>
 where
     T: Instance,
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     /// Transmit a frame.
     ///
@@ -1239,7 +1239,7 @@ where
 }
 
 /// Interface to the TWAI receiver part.
-pub struct TwaiRx<'d, Dm: crate::Mode, T = AnyTwai> {
+pub struct TwaiRx<'d, Dm: crate::DriverMode, T = AnyTwai> {
     twai: PeripheralRef<'d, T>,
     phantom: PhantomData<Dm>,
     _guard: PeripheralGuard,
@@ -1248,7 +1248,7 @@ pub struct TwaiRx<'d, Dm: crate::Mode, T = AnyTwai> {
 impl<Dm, T> TwaiRx<'_, Dm, T>
 where
     T: Instance,
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     /// Receive a frame
     pub fn receive(&mut self) -> nb::Result<EspTwaiFrame, EspTwaiError> {
@@ -1338,7 +1338,7 @@ unsafe fn copy_to_data_register(dest: *mut u32, src: &[u8]) {
 impl<Dm, T> embedded_can::nb::Can for Twai<'_, Dm, T>
 where
     T: Instance,
-    Dm: crate::Mode,
+    Dm: crate::DriverMode,
 {
     type Frame = EspTwaiFrame;
     type Error = EspTwaiError;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -32,7 +32,7 @@
 //! ).unwrap();
 //! # }
 //! ```
-//! 
+//!
 //! The UART controller can be configured to invert the polarity of the pins.
 //! This is achieved by inverting the desired pins, and then constructing the
 //! UART instance using the inverted pins.
@@ -64,7 +64,7 @@
 //! uart1.write_bytes(b"Hello, world!").expect("write error!");
 //! # }
 //! ```
-//! 
+//!
 //! ### Splitting the UART into RX and TX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -83,7 +83,7 @@
 //! let byte = rx.read_byte().expect("read error!");
 //! # }
 //! ```
-//! 
+//!
 //! ### Inverting RX and TX Pins
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -99,7 +99,7 @@
 //! ).unwrap();
 //! # }
 //! ```
-//! 
+//!
 //! ### Constructing RX and TX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -117,7 +117,7 @@
 //! ).unwrap();
 //! # }
 //! ```
-//! 
+//!
 //! ### Operation with interrupts that by UART/Serial
 //! Notice, that in practice a proper serial terminal should be used
 //! to connect to the board (espmonitor and espflash won't work)
@@ -178,7 +178,7 @@
 //!         writeln!(serial,
 //!             "Hello World! Send a single `#` character or send
 //!                 at least 30 characters to trigger interrupts.")
-//!         .ok();     
+//!         .ok();
 //!     });
 //!     delay.delay(1.secs());
 //! }
@@ -218,7 +218,7 @@
 //!     });
 //! }
 //! ```
-//! 
+//!
 //! [embedded-hal]: https://docs.rs/embedded-hal/latest/embedded_hal/
 //! [embedded-io]: https://docs.rs/embedded-io/latest/embedded_io/
 //! [embedded-hal-async]: https://docs.rs/embedded-hal-async/latest/embedded_hal_async/
@@ -247,7 +247,7 @@ use crate::{
     system::{PeripheralClockControl, PeripheralGuard},
     Async,
     Blocking,
-    Mode,
+    DriverMode,
 };
 
 const UART_FIFO_SIZE: u16 = 128;
@@ -545,7 +545,7 @@ struct UartBuilder<'d, Dm, T = AnyUart> {
 impl<'d, Dm, T> UartBuilder<'d, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn new(uart: impl Peripheral<P = T> + 'd) -> Self {
         crate::into_ref!(uart);
@@ -630,7 +630,7 @@ pub enum ConfigError {
 impl<Dm, T> SetConfig for Uart<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Config = Config;
     type ConfigError = ConfigError;
@@ -645,7 +645,7 @@ where
 impl<Dm, T> SetConfig for UartRx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Config = Config;
     type ConfigError = ConfigError;
@@ -660,7 +660,7 @@ where
 impl<Dm, T> SetConfig for UartTx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Config = Config;
     type ConfigError = ConfigError;
@@ -673,7 +673,7 @@ where
 impl<'d, Dm, T> UartTx<'d, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Configure RTS pin
     pub fn with_rts(self, rts: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
@@ -864,7 +864,7 @@ fn sync_regs(_register_block: &RegisterBlock) {
 impl<'d, Dm, T> UartRx<'d, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Configure CTS pin
     pub fn with_cts(self, cts: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
@@ -1145,7 +1145,7 @@ pub enum UartInterrupt {
 impl<'d, Dm, T> Uart<'d, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     /// Configure CTS pin
     pub fn with_cts(mut self, cts: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
@@ -1356,7 +1356,7 @@ where
 impl<T, Dm> ufmt_write::uWrite for Uart<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 
@@ -1374,7 +1374,7 @@ where
 impl<T, Dm> ufmt_write::uWrite for UartTx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 
@@ -1388,7 +1388,7 @@ where
 impl<T, Dm> core::fmt::Write for Uart<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     #[inline]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
@@ -1399,7 +1399,7 @@ where
 impl<T, Dm> core::fmt::Write for UartTx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     #[inline]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
@@ -1424,7 +1424,7 @@ impl<T, Dm> embedded_hal_nb::serial::ErrorType for UartRx<'_, Dm, T> {
 impl<T, Dm> embedded_hal_nb::serial::Read for Uart<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.read_byte()
@@ -1434,7 +1434,7 @@ where
 impl<T, Dm> embedded_hal_nb::serial::Read for UartRx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.read_byte()
@@ -1444,7 +1444,7 @@ where
 impl<T, Dm> embedded_hal_nb::serial::Write for Uart<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         self.write_byte(word)
@@ -1458,7 +1458,7 @@ where
 impl<T, Dm> embedded_hal_nb::serial::Write for UartTx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         self.write_byte(word)
@@ -1492,7 +1492,7 @@ impl<T, Dm> embedded_io::ErrorType for UartRx<'_, Dm, T> {
 impl<T, Dm> embedded_io::Read for Uart<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         self.rx.read(buf)
@@ -1504,7 +1504,7 @@ where
 impl<T, Dm> embedded_io::Read for UartRx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         if buf.is_empty() {
@@ -1524,7 +1524,7 @@ where
 impl<T, Dm> embedded_io::ReadReady for Uart<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read_ready(&mut self) -> Result<bool, Self::Error> {
         self.rx.read_ready()
@@ -1536,7 +1536,7 @@ where
 impl<T, Dm> embedded_io::ReadReady for UartRx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read_ready(&mut self) -> Result<bool, Self::Error> {
         Ok(self.rx_fifo_count() > 0)
@@ -1548,7 +1548,7 @@ where
 impl<T, Dm> embedded_io::Write for Uart<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.tx.write(buf)
@@ -1564,7 +1564,7 @@ where
 impl<T, Dm> embedded_io::Write for UartTx<'_, Dm, T>
 where
     T: Instance,
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.write_bytes(buf)

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -32,7 +32,7 @@
 //! ).unwrap();
 //! # }
 //! ```
-//!
+//! 
 //! The UART controller can be configured to invert the polarity of the pins.
 //! This is achieved by inverting the desired pins, and then constructing the
 //! UART instance using the inverted pins.
@@ -64,7 +64,7 @@
 //! uart1.write_bytes(b"Hello, world!").expect("write error!");
 //! # }
 //! ```
-//!
+//! 
 //! ### Splitting the UART into RX and TX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -83,7 +83,7 @@
 //! let byte = rx.read_byte().expect("read error!");
 //! # }
 //! ```
-//!
+//! 
 //! ### Inverting RX and TX Pins
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -99,7 +99,7 @@
 //! ).unwrap();
 //! # }
 //! ```
-//!
+//! 
 //! ### Constructing RX and TX Components
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -117,7 +117,7 @@
 //! ).unwrap();
 //! # }
 //! ```
-//!
+//! 
 //! ### Operation with interrupts that by UART/Serial
 //! Notice, that in practice a proper serial terminal should be used
 //! to connect to the board (espmonitor and espflash won't work)
@@ -218,7 +218,7 @@
 //!     });
 //! }
 //! ```
-//!
+//! 
 //! [embedded-hal]: https://docs.rs/embedded-hal/latest/embedded_hal/
 //! [embedded-io]: https://docs.rs/embedded-io/latest/embedded_io/
 //! [embedded-hal-async]: https://docs.rs/embedded-hal-async/latest/embedded_hal_async/

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -168,7 +168,7 @@ pub struct UsbSerialJtagRx<'d, Dm> {
 
 impl<'d, Dm> UsbSerialJtagTx<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn new_inner(peripheral: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         crate::into_ref!(peripheral);
@@ -247,7 +247,7 @@ where
 
 impl<'d, Dm> UsbSerialJtagRx<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn new_inner(peripheral: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         crate::into_ref!(peripheral);
@@ -363,7 +363,7 @@ impl InterruptConfigurable for UsbSerialJtag<'_, Blocking> {
 
 impl<'d, Dm> UsbSerialJtag<'d, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn new_inner(usb_device: impl Peripheral<P = USB_DEVICE> + 'd) -> Self {
         // Do NOT reset the peripheral. Doing so will result in a broken USB JTAG
@@ -486,7 +486,7 @@ impl Instance for USB_DEVICE {
 
 impl<Dm> core::fmt::Write for UsbSerialJtag<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         core::fmt::Write::write_str(&mut self.tx, s)
@@ -495,7 +495,7 @@ where
 
 impl<Dm> core::fmt::Write for UsbSerialJtagTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         self.write_bytes(s.as_bytes())
@@ -506,7 +506,7 @@ where
 
 impl<Dm> ufmt_write::uWrite for UsbSerialJtag<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 
@@ -523,7 +523,7 @@ where
 
 impl<Dm> ufmt_write::uWrite for UsbSerialJtagTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 
@@ -544,28 +544,28 @@ where
 
 impl<Dm> embedded_hal_nb::serial::ErrorType for UsbSerialJtag<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 }
 
 impl<Dm> embedded_hal_nb::serial::ErrorType for UsbSerialJtagTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 }
 
 impl<Dm> embedded_hal_nb::serial::ErrorType for UsbSerialJtagRx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 }
 
 impl<Dm> embedded_hal_nb::serial::Read for UsbSerialJtag<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         embedded_hal_nb::serial::Read::read(&mut self.rx)
@@ -574,7 +574,7 @@ where
 
 impl<Dm> embedded_hal_nb::serial::Read for UsbSerialJtagRx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.read_byte()
@@ -583,7 +583,7 @@ where
 
 impl<Dm> embedded_hal_nb::serial::Write for UsbSerialJtag<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         embedded_hal_nb::serial::Write::write(&mut self.tx, word)
@@ -596,7 +596,7 @@ where
 
 impl<Dm> embedded_hal_nb::serial::Write for UsbSerialJtagTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         self.write_byte_nb(word)
@@ -611,7 +611,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<Dm> embedded_io::ErrorType for UsbSerialJtag<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 }
@@ -620,7 +620,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<Dm> embedded_io::ErrorType for UsbSerialJtagTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 }
@@ -629,7 +629,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<Dm> embedded_io::ErrorType for UsbSerialJtagRx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     type Error = Error;
 }
@@ -638,7 +638,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<Dm> embedded_io::Read for UsbSerialJtag<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         embedded_io::Read::read(&mut self.rx, buf)
@@ -649,7 +649,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<Dm> embedded_io::Read for UsbSerialJtagRx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         loop {
@@ -665,7 +665,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<Dm> embedded_io::Write for UsbSerialJtag<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         embedded_io::Write::write(&mut self.tx, buf)
@@ -680,7 +680,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<Dm> embedded_io::Write for UsbSerialJtagTx<'_, Dm>
 where
-    Dm: Mode,
+    Dm: DriverMode,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.write_bytes(buf)?;

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -142,7 +142,7 @@ use crate::{
     Async,
     Blocking,
     Cpu,
-    Mode,
+    DriverMode,
 };
 
 /// Custom USB serial error type

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -27,7 +27,7 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Config, Spi},
-        SpiMode,
+        Mode,
     },
     timer::timg::TimerGroup,
 };
@@ -61,7 +61,7 @@ async fn main(_spawner: Spawner) {
         peripherals.SPI2,
         Config::default()
             .with_frequency(100.kHz())
-            .with_mode(SpiMode::Mode0),
+            .with_mode(Mode::Mode0),
     )
     .unwrap()
     .with_sck(sclk)

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -23,7 +23,7 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Config, Spi},
-        SpiMode,
+        Mode,
     },
 };
 use esp_println::println;
@@ -42,7 +42,7 @@ fn main() -> ! {
         peripherals.SPI2,
         Config::default()
             .with_frequency(100.kHz())
-            .with_mode(SpiMode::Mode0),
+            .with_mode(Mode::Mode0),
     )
     .unwrap()
     .with_sck(sclk)

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -30,7 +30,7 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Config, Spi},
-        SpiMode,
+        Mode,
     },
 };
 extern crate alloc;
@@ -92,7 +92,7 @@ fn main() -> ! {
         peripherals.SPI2,
         Config::default()
             .with_frequency(100.kHz())
-            .with_mode(SpiMode::Mode0),
+            .with_mode(Mode::Mode0),
     )
     .unwrap()
     .with_sck(sclk)

--- a/examples/src/bin/spi_slave_dma.rs
+++ b/examples/src/bin/spi_slave_dma.rs
@@ -36,7 +36,7 @@ use esp_hal::{
     dma_buffers,
     gpio::{Input, Level, Output, Pull},
     prelude::*,
-    spi::{slave::Spi, SpiMode},
+    spi::{slave::Spi, Mode},
 };
 use esp_println::println;
 
@@ -64,7 +64,7 @@ fn main() -> ! {
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
 
-    let mut spi = Spi::new(peripherals.SPI2, SpiMode::Mode0)
+    let mut spi = Spi::new(peripherals.SPI2, Mode::Mode0)
         .with_sck(slave_sclk)
         .with_mosi(slave_mosi)
         .with_miso(slave_miso)

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -16,7 +16,7 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Config, Spi},
-        SpiMode,
+        Mode,
     },
     timer::AnyTimer,
     Async,
@@ -121,7 +121,7 @@ mod test {
             peripherals.SPI2,
             Config::default()
                 .with_frequency(10000.kHz())
-                .with_mode(SpiMode::Mode0),
+                .with_mode(Mode::Mode0),
         )
         .unwrap()
         .with_miso(unsafe { mosi.clone_unchecked() })
@@ -135,7 +135,7 @@ mod test {
             peripherals.SPI3,
             Config::default()
                 .with_frequency(10000.kHz())
-                .with_mode(SpiMode::Mode0),
+                .with_mode(Mode::Mode0),
         )
         .unwrap()
         .with_dma(dma_channel2)
@@ -229,7 +229,7 @@ mod test {
                 peripherals.spi,
                 Config::default()
                     .with_frequency(100.kHz())
-                    .with_mode(SpiMode::Mode0),
+                    .with_mode(Mode::Mode0),
             )
             .unwrap()
             .with_dma(peripherals.dma_channel)

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -14,8 +14,8 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Address, Command, Config, Spi, SpiDma},
-        SpiDataMode,
-        SpiMode,
+        DataMode,
+        Mode,
     },
     Blocking,
 };
@@ -31,9 +31,9 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(esp32)] {
-        const COMMAND_DATA_MODES: [SpiDataMode; 1] = [SpiDataMode::Single];
+        const COMMAND_DATA_MODES: [DataMode; 1] = [DataMode::Single];
     } else {
-        const COMMAND_DATA_MODES: [SpiDataMode; 2] = [SpiDataMode::Single, SpiDataMode::Quad];
+        const COMMAND_DATA_MODES: [DataMode; 2] = [DataMode::Single, DataMode::Quad];
     }
 }
 
@@ -54,7 +54,7 @@ fn transfer_read(
 ) -> (SpiUnderTest, DmaRxBuf) {
     let transfer = spi
         .half_duplex_read(
-            SpiDataMode::Quad,
+            DataMode::Quad,
             command,
             Address::None,
             0,
@@ -70,15 +70,15 @@ fn transfer_write(
     spi: SpiUnderTest,
     dma_tx_buf: DmaTxBuf,
     write: u8,
-    command_data_mode: SpiDataMode,
+    command_data_mode: DataMode,
 ) -> (SpiUnderTest, DmaTxBuf) {
     let transfer = spi
         .half_duplex_write(
-            SpiDataMode::Quad,
+            DataMode::Quad,
             Command::Command8(write as u16, command_data_mode),
             Address::Address24(
                 write as u32 | (write as u32) << 8 | (write as u32) << 16,
-                SpiDataMode::Quad,
+                DataMode::Quad,
             ),
             0,
             dma_tx_buf.len(),
@@ -154,7 +154,7 @@ fn execute_write(
         assert_eq!(unit0.value() + unit1.value(), 8);
 
         if data_on_multiple_pins {
-            if command_data_mode == SpiDataMode::Single {
+            if command_data_mode == DataMode::Single {
                 assert_eq!(unit0.value(), 1);
                 assert_eq!(unit1.value(), 7);
             } else {
@@ -172,7 +172,7 @@ fn execute_write(
         assert_eq!(unit0.value() + unit1.value(), 4);
 
         if data_on_multiple_pins {
-            if command_data_mode == SpiDataMode::Single {
+            if command_data_mode == DataMode::Single {
                 assert_eq!(unit0.value(), 1);
                 assert_eq!(unit1.value(), 3);
             } else {
@@ -212,7 +212,7 @@ mod tests {
             peripherals.SPI2,
             Config::default()
                 .with_frequency(100.kHz())
-                .with_mode(SpiMode::Mode0),
+                .with_mode(Mode::Mode0),
         )
         .unwrap();
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -12,8 +12,8 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Address, Command, Config, Spi, SpiDma},
-        SpiDataMode,
-        SpiMode,
+        DataMode,
+        Mode,
     },
     Blocking,
 };
@@ -50,7 +50,7 @@ mod tests {
             peripherals.SPI2,
             Config::default()
                 .with_frequency(100.kHz())
-                .with_mode(SpiMode::Mode0),
+                .with_mode(Mode::Mode0),
         )
         .unwrap()
         .with_sck(sclk)
@@ -74,7 +74,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_read(
-                SpiDataMode::Single,
+                DataMode::Single,
                 Command::None,
                 Address::None,
                 0,
@@ -92,7 +92,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_read(
-                SpiDataMode::Single,
+                DataMode::Single,
                 Command::None,
                 Address::None,
                 0,
@@ -123,7 +123,7 @@ mod tests {
 
         let mut buffer = [0xAA; DMA_BUFFER_SIZE];
         spi.half_duplex_read(
-            SpiDataMode::Single,
+            DataMode::Single,
             Command::None,
             Address::None,
             0,
@@ -137,7 +137,7 @@ mod tests {
         ctx.miso_mirror.set_high();
 
         spi.half_duplex_read(
-            SpiDataMode::Single,
+            DataMode::Single,
             Command::None,
             Address::None,
             0,

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -13,8 +13,8 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Address, Command, Config, Spi, SpiDma},
-        SpiDataMode,
-        SpiMode,
+        DataMode,
+        Mode,
     },
     Blocking,
 };
@@ -54,7 +54,7 @@ mod tests {
             peripherals.SPI2,
             Config::default()
                 .with_frequency(100.kHz())
-                .with_mode(SpiMode::Mode0),
+                .with_mode(Mode::Mode0),
         )
         .unwrap()
         .with_sck(sclk)
@@ -87,7 +87,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_write(
-                SpiDataMode::Single,
+                DataMode::Single,
                 Command::None,
                 Address::None,
                 0,
@@ -102,7 +102,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_write(
-                SpiDataMode::Single,
+                DataMode::Single,
                 Command::None,
                 Address::None,
                 0,
@@ -134,25 +134,13 @@ mod tests {
 
         let buffer = [0b0110_1010; DMA_BUFFER_SIZE];
         // Write the buffer where each byte has 3 pos edges.
-        spi.half_duplex_write(
-            SpiDataMode::Single,
-            Command::None,
-            Address::None,
-            0,
-            &buffer,
-        )
-        .unwrap();
+        spi.half_duplex_write(DataMode::Single, Command::None, Address::None, 0, &buffer)
+            .unwrap();
 
         assert_eq!(unit.value(), (3 * DMA_BUFFER_SIZE) as _);
 
-        spi.half_duplex_write(
-            SpiDataMode::Single,
-            Command::None,
-            Address::None,
-            0,
-            &buffer,
-        )
-        .unwrap();
+        spi.half_duplex_write(DataMode::Single, Command::None, Address::None, 0, &buffer)
+            .unwrap();
 
         assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -15,8 +15,8 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Address, Command, Config, Spi, SpiDma},
-        SpiDataMode,
-        SpiMode,
+        DataMode,
+        Mode,
     },
     Blocking,
 };
@@ -66,7 +66,7 @@ mod tests {
             peripherals.SPI2,
             Config::default()
                 .with_frequency(100.kHz())
-                .with_mode(SpiMode::Mode0),
+                .with_mode(Mode::Mode0),
         )
         .unwrap()
         .with_sck(sclk)
@@ -101,7 +101,7 @@ mod tests {
         dma_tx_buf.fill(&[0b0110_1010; DMA_BUFFER_SIZE]);
         let transfer = spi
             .half_duplex_write(
-                SpiDataMode::Single,
+                DataMode::Single,
                 Command::None,
                 Address::None,
                 0,
@@ -116,7 +116,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_write(
-                SpiDataMode::Single,
+                DataMode::Single,
                 Command::None,
                 Address::None,
                 0,
@@ -152,25 +152,13 @@ mod tests {
 
         let buffer = [0b0110_1010; DMA_BUFFER_SIZE];
         // Write the buffer where each byte has 3 pos edges.
-        spi.half_duplex_write(
-            SpiDataMode::Single,
-            Command::None,
-            Address::None,
-            0,
-            &buffer,
-        )
-        .unwrap();
+        spi.half_duplex_write(DataMode::Single, Command::None, Address::None, 0, &buffer)
+            .unwrap();
 
         assert_eq!(unit.value(), (3 * DMA_BUFFER_SIZE) as _);
 
-        spi.half_duplex_write(
-            SpiDataMode::Single,
-            Command::None,
-            Address::None,
-            0,
-            &buffer,
-        )
-        .unwrap();
+        spi.half_duplex_write(DataMode::Single, Command::None, Address::None, 0, &buffer)
+            .unwrap();
 
         assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }

--- a/hil-test/tests/spi_slave.rs
+++ b/hil-test/tests/spi_slave.rs
@@ -12,7 +12,7 @@ use esp_hal::{
     dma_buffers,
     gpio::{Input, Level, Output, Pull},
     peripheral::Peripheral,
-    spi::{slave::Spi, SpiMode},
+    spi::{slave::Spi, Mode},
     Blocking,
 };
 use hil_test as _;
@@ -125,7 +125,7 @@ mod tests {
         let miso = unsafe { miso_gpio.clone_unchecked() }.into_peripheral_output();
 
         Context {
-            spi: Spi::new(peripherals.SPI2, SpiMode::Mode1)
+            spi: Spi::new(peripherals.SPI2, Mode::Mode1)
                 .with_sck(sclk)
                 .with_mosi(mosi)
                 .with_miso(miso)

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -35,8 +35,8 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Address, Command, Config, Spi},
-        SpiDataMode,
-        SpiMode,
+        DataMode,
+        Mode,
     },
 };
 use esp_println::{print, println};
@@ -79,7 +79,7 @@ fn main() -> ! {
         peripherals.SPI2,
         Config::default()
             .with_frequency(100.kHz())
-            .with_mode(SpiMode::Mode0),
+            .with_mode(Mode::Mode0),
     )
     .unwrap()
     .with_sck(sclk)
@@ -96,8 +96,8 @@ fn main() -> ! {
     dma_tx_buf.set_length(0);
     let transfer = spi
         .half_duplex_write(
-            SpiDataMode::Single,
-            Command::Command8(0x06, SpiDataMode::Single),
+            DataMode::Single,
+            Command::Command8(0x06, DataMode::Single),
             Address::None,
             0,
             0,
@@ -111,9 +111,9 @@ fn main() -> ! {
     // erase sector
     let transfer = spi
         .half_duplex_write(
-            SpiDataMode::Single,
-            Command::Command8(0x20, SpiDataMode::Single),
-            Address::Address24(0x000000, SpiDataMode::Single),
+            DataMode::Single,
+            Command::Command8(0x20, DataMode::Single),
+            Address::Address24(0x000000, DataMode::Single),
             0,
             dma_tx_buf.len(),
             dma_tx_buf,
@@ -126,8 +126,8 @@ fn main() -> ! {
     // write enable
     let transfer = spi
         .half_duplex_write(
-            SpiDataMode::Single,
-            Command::Command8(0x06, SpiDataMode::Single),
+            DataMode::Single,
+            Command::Command8(0x06, DataMode::Single),
             Address::None,
             0,
             dma_tx_buf.len(),
@@ -144,9 +144,9 @@ fn main() -> ! {
     dma_tx_buf.as_mut_slice()[0..][..5].copy_from_slice(&b"Hello"[..]);
     let transfer = spi
         .half_duplex_write(
-            SpiDataMode::Quad,
-            Command::Command8(0x32, SpiDataMode::Single),
-            Address::Address24(0x000000, SpiDataMode::Single),
+            DataMode::Quad,
+            Command::Command8(0x32, DataMode::Single),
+            Address::Address24(0x000000, DataMode::Single),
             0,
             dma_tx_buf.len(),
             dma_tx_buf,
@@ -160,9 +160,9 @@ fn main() -> ! {
         // quad fast read
         let transfer = spi
             .half_duplex_read(
-                SpiDataMode::Quad,
-                Command::Command8(0xeb, SpiDataMode::Single),
-                Address::Address32(0x000000 << 8, SpiDataMode::Quad),
+                DataMode::Quad,
+                Command::Command8(0xeb, DataMode::Single),
+                Address::Address32(0x000000 << 8, DataMode::Quad),
                 4,
                 dma_rx_buf.len(),
                 dma_rx_buf,

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -33,8 +33,8 @@ use esp_hal::{
     prelude::*,
     spi::{
         master::{Address, Command, Config, Spi},
-        SpiDataMode,
-        SpiMode,
+        DataMode,
+        Mode,
     },
 };
 use esp_println::println;
@@ -65,7 +65,7 @@ fn main() -> ! {
         peripherals.SPI2,
         Config::default()
             .with_frequency(100.kHz())
-            .with_mode(SpiMode::Mode0),
+            .with_mode(Mode::Mode0),
     )
     .unwrap()
     .with_sck(sclk)
@@ -81,9 +81,9 @@ fn main() -> ! {
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
         spi.half_duplex_read(
-            SpiDataMode::Single,
-            Command::Command8(0x90, SpiDataMode::Single),
-            Address::Address24(0x000000, SpiDataMode::Single),
+            DataMode::Single,
+            Command::Command8(0x90, DataMode::Single),
+            Address::Address24(0x000000, DataMode::Single),
             0,
             &mut data,
         )
@@ -94,9 +94,9 @@ fn main() -> ! {
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
         spi.half_duplex_read(
-            SpiDataMode::Dual,
-            Command::Command8(0x92, SpiDataMode::Single),
-            Address::Address32(0x000000_00, SpiDataMode::Dual),
+            DataMode::Dual,
+            Command::Command8(0x92, DataMode::Single),
+            Address::Address32(0x000000_00, DataMode::Dual),
             0,
             &mut data,
         )
@@ -107,9 +107,9 @@ fn main() -> ! {
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
         spi.half_duplex_read(
-            SpiDataMode::Quad,
-            Command::Command8(0x94, SpiDataMode::Single),
-            Address::Address32(0x000000_00, SpiDataMode::Quad),
+            DataMode::Quad,
+            Command::Command8(0x94, DataMode::Single),
+            Address::Address32(0x000000_00, DataMode::Quad),
             4,
             &mut data,
         )


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- Rename `SpiBitOrder`, `SpiDataMode`, `SpiMode` 
- Rename DM type parameter to Dm for ECC
- Rename crate::Mode to crate::DriverMode

#### Testing
NA
