### PR TITLE
Remove PartialEq/Eq implementations

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HAL configuration structs now implement the Builder Lite pattern (#2645)
 - Added `OutputOpenDrain::unlisten` (#2625)
 - Added `{Input, Flex}::wait_for` (#2625)
-- Peripheral singletons now implement `Debug`, `PartialEq`, `defmt::Format` and `Eq` (except AnyPeripherals) (#2682)
+- Peripheral singletons now implement `Debug` and `defmt::Format` (except AnyPeripherals) (#2682, #2834)
 - `BurstConfig`, a device-specific configuration for configuring DMA transfers in burst mode (#2543)
 - `{DmaRxBuf, DmaTxBuf, DmaRxTxBuf}::set_burst_config` (#2543)
 - ESP32-S2: DMA support for AES (#2699)

--- a/esp-hal/src/macros.rs
+++ b/esp-hal/src/macros.rs
@@ -90,7 +90,7 @@ macro_rules! any_peripheral {
     }) => {
         paste::paste! {
             $(#[$meta])*
-            #[derive(Debug, PartialEq)]
+            #[derive(Debug)]
             #[cfg_attr(feature = "defmt", derive(defmt::Format))]
             $vis struct $name([< $name Inner >]);
             impl $crate::private::Sealed for $name {}
@@ -109,7 +109,7 @@ macro_rules! any_peripheral {
             }
 
             $(#[$meta])*
-            #[derive(Debug, PartialEq)]
+            #[derive(Debug)]
             enum [< $name Inner >] {
                 $(
                     $(#[cfg($variant_meta)])*
@@ -128,36 +128,6 @@ macro_rules! any_peripheral {
                     }
                 }
             }
-
-            $(
-                // Any == Specific
-                $(#[cfg($variant_meta)])*
-                impl PartialEq<$inner> for [< $name Inner >] {
-                    fn eq(&self, _other: &$inner) -> bool {
-                        matches!(self, [< $name Inner >]::$variant(_))
-                    }
-                }
-                $(#[cfg($variant_meta)])*
-                impl PartialEq<$inner> for $name {
-                    fn eq(&self, other: &$inner) -> bool {
-                        &self.0 == other
-                    }
-                }
-
-                // Specific == Any
-                $(#[cfg($variant_meta)])*
-                impl PartialEq<[< $name Inner >]> for $inner {
-                    fn eq(&self, other: &[< $name Inner >]) -> bool {
-                        other == self
-                    }
-                }
-                $(#[cfg($variant_meta)])*
-                impl PartialEq<$name> for $inner {
-                    fn eq(&self, other: &$name) -> bool {
-                        other == self
-                    }
-                }
-            )*
 
             $(
                 $(#[cfg($variant_meta)])*

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -18,7 +18,7 @@ use core::{
 ///
 /// but it is the size of `T` not the size
 /// of a pointer. This is useful if T is a zero sized type.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PeripheralRef<'a, T> {
     inner: T,
@@ -383,7 +383,7 @@ mod peripheral_macros {
     /// Macro to create a peripheral structure.
     macro_rules! create_peripheral {
         ($name:ident <= virtual) => {
-            #[derive(Debug, PartialEq, Eq)]
+            #[derive(Debug)]
             #[cfg_attr(feature = "defmt", derive(defmt::Format))]
             #[non_exhaustive]
             #[allow(non_camel_case_types)]

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -459,7 +459,7 @@ impl Default for Config {
 pub enum ConfigError {}
 
 /// SPI peripheral driver
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Spi<'d, Dm, T = AnySpi> {
     spi: PeripheralRef<'d, T>,

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -265,7 +265,7 @@ impl Unit {
 }
 
 /// An alarm unit
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Alarm {
     comp: u8,

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -366,7 +366,7 @@ impl Peripheral for Timer {
 }
 
 /// A timer within a Timer Group.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Timer {
     register_block: *const RegisterBlock,


### PR DESCRIPTION
This PR removes `PartialEq` and `Eq` from the peripheral singletons and drivers, based on our discussions and #2832

Essentially reverts some of #2681 and #2682