### PR TITLE
GPIO: prevent woken task interrupting GPIO handler

### DIFF
--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -930,8 +930,11 @@ fn handle_pin_interrupts(user_handler: fn()) {
             intr_bits -= 1 << pin_pos;
 
             let pin_nr = pin_pos as u8 + bank.offset();
-            asynch::PIN_WAKERS[pin_nr as usize].wake();
-            set_int_enable(pin_nr, Some(0), 0, false);
+
+            crate::interrupt::free(|| {
+                asynch::PIN_WAKERS[pin_nr as usize].wake();
+                set_int_enable(pin_nr, Some(0), 0, false);
+            });
         }
 
         bank.write_interrupt_status_clear(intrs);

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -12,6 +12,7 @@
 //! interrupt15() => Priority::Priority15
 //! ```
 
+pub(crate) use esp_riscv_rt::riscv::interrupt::free;
 pub use esp_riscv_rt::TrapFrame;
 use riscv::register::{mcause, mtvec};
 

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -1,6 +1,7 @@
 //! Interrupt handling
 
 use xtensa_lx::interrupt;
+pub(crate) use xtensa_lx::interrupt::free;
 use xtensa_lx_rt::exception::Context;
 
 pub use self::vectored::*;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -904,7 +904,7 @@ where
             cfg_if::cfg_if! {
                 if #[cfg(esp32)] {
                     // https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/03-errata-description/esp32/cpu-subsequent-access-halted-when-get-interrupted.html
-                    xtensa_lx::interrupt::free(|| {
+                    crate::interrupt::free(|| {
                         *byte = fifo.read().rxfifo_rd_byte().bits();
                     });
                 } else {


### PR DESCRIPTION
This PR fixes an issue when InterruptExecutor uses async GPIO operations, but the GPIO handler runs on a lower priority. The issue caused the interrupt executor to enter an infinite loop.