### PR TITLE
Fix SpiDmaBus write impl

### DIFF
--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1720,8 +1720,8 @@ mod dma {
 
                 unsafe {
                     self.spi_dma.start_dma_transfer(
-                        chunk.len(),
                         0,
+                        chunk.len(),
                         &mut EmptyBuf,
                         &mut self.tx_buf,
                     )?;


### PR DESCRIPTION
The following code currently does not run:
```rust
  let spi_config_slow = esp_hal::spi::master::Config::default()
    .with_frequency((11).MHz())
    .with_mode(esp_hal::spi::SpiMode::Mode0);

  let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
    esp_hal::dma_buffers!(DMA_BUFFER_SIZE);

  defmt::info!(
    "RX: {:x} len {} ({} descripters)",
    rx_buffer.as_ptr(),
    rx_buffer.len(),
    rx_descriptors.len()
  );

  defmt::info!(
    "TX: {:x} len {} ({} descripters)",
    tx_buffer.as_ptr(),
    tx_buffer.len(),
    tx_descriptors.len()
  );

  let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
  let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();

  // let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);

  let mut spi = Spi::new(spi2, spi_config_slow)
    .unwrap()
    .with_sck(sclk)
    .with_mosi(mosi)
    .with_miso(miso)
    .with_dma(dma_channel)
    .with_buffers(dma_rx_buf, dma_tx_buf);

  spi.read(&mut [0u8]).unwrap();
  spi.write(&[0u8]).unwrap();
```
It will show:
```
INFO RX: 0x3fc8da28 len 4096 (2 descripters)
0x3fc8da28 - main::display::initialize_display::init_display::{{closure}}::BUFFER
    at ??:??
INFO TX: 0x3fc8ea40 len 4096 (2 descripters)
0x3fc8ea40 - main::display::initialize_display::init_display::{{closure}}::BUFFER
    at ??:??
DEBUG Enable Spi2 true
DEBUG Reset Spi2
DEBUG Enable Gdma true
DEBUG Reset Gdma
DEBUG Preparing RX transfer Preparation { start: 0x3fc8ea28, direction: In, accesses_psram: false, burst_transfer: BurstConfig { external_memory: Size16, internal_memory: Disabled }, check_owner: None }
0x3fc8ea28 - main::display::initialize_display::init_display::{{closure}}::BUFFER
    at ??:??
DEBUG Preparing RX transfer Preparation { start: 0x3fc90be0, direction: In, accesses_psram: false, burst_transfer: BurstConfig { external_memory: Size16, internal_memory: Disabled }, check_owner: Some(false) }
0x3fc90be0 - esp_hal::soc::MAPPED_PSRAM.1
    at ??:??


PanicInfo { message: called `Result::unwrap()` on an `Err` value: DmaError(DescriptorError), location: Location { file: "src/bin/display/initialize_display.rs", line: 74, col: 21 }, can_unwind: true, force_no_backtrace: false }
```


#### Description
Currently SpiDmaBus::write is broken due to the Rx being attempted instead of Tx.

#### Testing
Ongoing.
