### PR TITLE
Hide Info,State,Instance

### DIFF
--- a/esp-hal/src/gpio/lp_io.rs
+++ b/esp-hal/src/gpio/lp_io.rs
@@ -191,7 +191,6 @@ pub(crate) fn init_low_power_pin(pin: u8) {
 }
 
 #[doc(hidden)]
-#[macro_export]
 macro_rules! lp_gpio {
     (
         $($gpionum:literal)+
@@ -262,3 +261,5 @@ macro_rules! lp_gpio {
         )+
     }
 }
+
+pub(crate) use lp_gpio;

--- a/esp-hal/src/gpio/lp_io.rs
+++ b/esp-hal/src/gpio/lp_io.rs
@@ -42,6 +42,7 @@ pub struct LowPowerOutput<'d, const PIN: u8> {
 
 impl<'d, const PIN: u8> LowPowerOutput<'d, PIN> {
     /// Create a new output pin for use by the low-power core
+    #[instability::unstable] 
     pub fn new<P>(_pin: impl Peripheral<P = P> + 'd) -> Self
     where
         P: OutputPin + RtcPin,
@@ -77,6 +78,7 @@ pub struct LowPowerInput<'d, const PIN: u8> {
 
 impl<'d, const PIN: u8> LowPowerInput<'d, PIN> {
     /// Create a new input pin for use by the low-power core
+    #[instability::unstable] 
     pub fn new<P>(_pin: impl Peripheral<P = P> + 'd) -> Self
     where
         P: InputPin + RtcPin,
@@ -121,6 +123,7 @@ pub struct LowPowerOutputOpenDrain<'d, const PIN: u8> {
 
 impl<'d, const PIN: u8> LowPowerOutputOpenDrain<'d, PIN> {
     /// Create a new output pin for use by the low-power core
+    #[instability::unstable] 
     pub fn new<P>(_pin: impl Peripheral<P = P> + 'd) -> Self
     where
         P: InputPin + OutputPin + RtcPin,

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -85,12 +85,18 @@ mod placeholder;
 
 pub use placeholder::NoPin;
 
+#[cfg(soc_etm)]
 crate::unstable_module! {
-    #[cfg(soc_etm)]
     pub mod etm;
-    #[cfg(lp_io)]
+}
+
+#[cfg(lp_io)]
+crate::unstable_module! {
     pub mod lp_io;
-    #[cfg(all(rtc_io, not(esp32)))]
+}
+
+#[cfg(all(rtc_io, not(esp32)))]
+crate::unstable_module! {
     pub mod rtc_io;
 }
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -85,12 +85,14 @@ mod placeholder;
 
 pub use placeholder::NoPin;
 
-#[cfg(soc_etm)]
-pub mod etm;
-#[cfg(lp_io)]
-pub mod lp_io;
-#[cfg(all(rtc_io, not(esp32)))]
-pub mod rtc_io;
+crate::unstable_module! {
+    #[cfg(soc_etm)]
+    pub mod etm;
+    #[cfg(lp_io)]
+    pub mod lp_io;
+    #[cfg(all(rtc_io, not(esp32)))]
+    pub mod rtc_io;
+}
 
 /// Convenience constant for `Option::None` pin
 static USER_INTERRUPT_HANDLER: CFnPtr = CFnPtr::new();
@@ -139,6 +141,7 @@ impl From<WakeEvent> for Event {
 }
 
 /// Event used to wake up from light sleep.
+#[instability::unstable]
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WakeEvent {
@@ -233,6 +236,7 @@ pub enum DriveStrength {
 ///
 /// The different variants correspond to different functionality depending on
 /// the chip and the specific pin. For more information, refer to your chip's
+#[doc(hidden)]
 #[doc = crate::trm_markdown_link!("iomuxgpio")]
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -268,6 +272,7 @@ impl TryFrom<usize> for AlternateFunction {
 }
 
 /// RTC function
+#[instability::unstable]
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RtcFunction {
@@ -278,6 +283,7 @@ pub enum RtcFunction {
 }
 
 /// Trait implemented by RTC pins
+#[instability::unstable]
 pub trait RtcPin: Pin {
     /// RTC number of the pin
     #[cfg(xtensa)]
@@ -300,6 +306,7 @@ pub trait RtcPin: Pin {
 
 /// Trait implemented by RTC pins which supporting internal pull-up / pull-down
 /// resistors.
+#[instability::unstable]
 pub trait RtcPinWithResistors: RtcPin {
     /// Enable/disable the internal pull-up resistor
     fn rtcio_pullup(&mut self, enable: bool);
@@ -516,6 +523,7 @@ pub trait OutputPin: Pin + Into<AnyPin> + 'static {
 }
 
 /// Trait implemented by pins which can be used as analog pins
+#[instability::unstable]
 pub trait AnalogPin: Pin {
     /// Configure the pin for analog operation
     #[doc(hidden)]
@@ -523,6 +531,8 @@ pub trait AnalogPin: Pin {
 }
 
 /// Trait implemented by pins which can be used as Touchpad pins
+#[cfg(touch)]
+#[instability::unstable]
 pub trait TouchPin: Pin {
     /// Configure the pin for analog operation
     #[doc(hidden)]
@@ -1583,6 +1593,7 @@ where
     /// Enable as a wake-up source.
     ///
     /// This will unlisten for interrupts
+    #[instability::unstable]
     #[inline]
     pub fn wakeup_enable(&mut self, enable: bool, event: WakeEvent) {
         self.pin.wakeup_enable(enable, event);
@@ -1982,6 +1993,7 @@ where
     /// Enable as a wake-up source.
     ///
     /// This will unlisten for interrupts
+    #[instability::unstable]
     #[inline]
     pub fn wakeup_enable(&mut self, enable: bool, event: WakeEvent) {
         self.listen_with_options(event.into(), false, false, enable);

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -985,6 +985,7 @@ fn configure_clock(
 }
 
 /// Peripheral data describing a particular I2C instance.
+#[doc(hidden)]
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Info {
@@ -2188,6 +2189,7 @@ impl Driver<'_> {
 }
 
 /// Peripheral state for an I2C instance.
+#[doc(hidden)]
 #[non_exhaustive]
 pub struct State {
     /// Waker for the asynchronous operations.
@@ -2195,6 +2197,7 @@ pub struct State {
 }
 
 /// I2C Peripheral Instance
+#[doc(hidden)]
 pub trait Instance: Peripheral<P = Self> + Into<AnyI2c> + 'static {
     /// Returns the peripheral data and state describing this instance.
     fn parts(&self) -> (&Info, &State);

--- a/esp-hal/src/soc/esp32c6/gpio.rs
+++ b/esp-hal/src/soc/esp32c6/gpio.rs
@@ -287,7 +287,7 @@ pub enum OutputSignal {
     GPIO                  = 128,
 }
 
-crate::lp_gpio! {
+crate::gpio::lp_io::lp_gpio! {
     0
     1
     2

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2362,15 +2362,18 @@ mod ehal1 {
 }
 
 /// SPI peripheral instance.
+#[doc(hidden)]
 pub trait PeripheralInstance: private::Sealed + Into<AnySpi> + DmaEligible + 'static {
     /// Returns the peripheral data describing this SPI instance.
     fn info(&self) -> &'static Info;
 }
 
 /// Marker trait for QSPI-capable SPI peripherals.
+#[doc(hidden)]
 pub trait QspiInstance: PeripheralInstance {}
 
 /// Peripheral data describing a particular SPI instance.
+#[doc(hidden)]
 #[non_exhaustive]
 pub struct Info {
     /// Pointer to the register block for this SPI instance.

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -602,6 +602,7 @@ impl InstanceDma for crate::peripherals::SPI2 {}
 impl InstanceDma for crate::peripherals::SPI3 {}
 
 /// Peripheral data describing a particular SPI instance.
+#[doc(hidden)]
 #[non_exhaustive]
 #[doc(hidden)]
 pub struct Info {

--- a/esp-hal/src/trace.rs
+++ b/esp-hal/src/trace.rs
@@ -207,6 +207,7 @@ where
 }
 
 /// Trace peripheral instance
+#[doc(hidden)]
 pub trait Instance: crate::private::Sealed {
     /// Get a reference to the peripheral's underlying register block
     fn register_block(&self) -> &RegisterBlock;

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1360,6 +1360,7 @@ where
 }
 
 /// TWAI peripheral instance.
+#[doc(hidden)]
 pub trait Instance: Peripheral<P = Self> + Into<AnyTwai> + 'static {
     /// The identifier number for this TWAI instance.
     fn number(&self) -> usize;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2221,6 +2221,7 @@ pub mod lp_uart {
 }
 
 /// UART Peripheral Instance
+#[doc(hidden)]
 pub trait Instance: Peripheral<P = Self> + Into<AnyUart> + 'static {
     /// Returns the peripheral data and state describing this UART instance.
     fn parts(&self) -> (&'static Info, &'static State);
@@ -2239,6 +2240,7 @@ pub trait Instance: Peripheral<P = Self> + Into<AnyUart> + 'static {
 }
 
 /// Peripheral data describing a particular UART instance.
+#[doc(hidden)]
 #[non_exhaustive]
 pub struct Info {
     /// Pointer to the register block for this UART instance.
@@ -2269,6 +2271,7 @@ pub struct Info {
 }
 
 /// Peripheral state for a UART instance.
+#[doc(hidden)]
 #[non_exhaustive]
 pub struct State {
     /// Waker for the asynchronous RX operations.

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -450,6 +450,7 @@ where
 }
 
 /// USB Serial/JTAG peripheral instance
+#[doc(hidden)]
 pub trait Instance: crate::private::Sealed {
     /// Get a reference to the peripheral's underlying register block
     fn register_block() -> &'static RegisterBlock;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Closes #2766 but not fully #2697 (besides hiding `AlternateFunction` - posted an open question there)

Additionally it marks `gpio/etm`, `gpio/lp_io`, `gpio/rtc_io`, `gpio/etm`, `RtcPin`, `RtcFunction`, `WakeEvent`, `RtcPinWithResistors` , `AnalogPin`, `TouchPin` as unstable.

`TouchPin` is feature gated by `#[cfg(touch)]`

No CHANGELOG.md entry (can add it if we want it - seems unnecessary since one of the main things to mention for the next release is the introduction of the unstable feature)

#### Testing
n.a. / builds passing
inspect the generated docs
