### PR TITLE
fix: LpUart::new() set `tx_idle_num` to 0 twice

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `spi::master::Spi::{into_async, into_blocking}` are now correctly available on the typed driver, to. (#2674)
 - It is no longer possible to safely conjure `GpioPin` instances (#2688)
 - UART: Public API follows `C-WORD_ORDER` Rust API standard (`VerbObject` order) (#2851)
+- `LpUart::new()` was setting `tx_idle_num` to 0 twice (#2860)
 
 ### Removed
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2077,10 +2077,7 @@ pub mod lp_uart {
                 w.bit_num().bits(0x3);
                 w.stop_bit_num().bits(0x1)
             });
-            // Set tx idle
-            me.uart
-                .idle_conf()
-                .modify(|_, w| unsafe { w.tx_idle_num().bits(0) });
+
             // Disable hw-flow control
             me.uart
                 .hwfc_conf()


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
In the `LpUart::new()` function in `esp-hal/src/uart.rs`

```rust
// 🟨 FIRST TIME:
// Set tx idle
me.uart
    .idle_conf()
    .modify(|_, w| unsafe { w.tx_idle_num().bits(0) });

// Disable hw-flow control
me.uart
    .hwfc_conf()
    .modify(|_, w| w.rx_flow_en().clear_bit());

// Get source clock frequency
// default == SOC_MOD_CLK_RTC_FAST == 2

// LP_CLKRST.lpperi.lp_uart_clk_sel = 0;
unsafe { LP_CLKRST::steal() }
    .lpperi()
    .modify(|_, w| w.lp_uart_clk_sel().clear_bit());

// Override protocol parameters from the configuration
// uart_hal_set_baudrate(&hal, cfg->uart_proto_cfg.baud_rate, sclk_freq);
me.change_baud_internal(config.baudrate, config.clock_source);
// uart_hal_set_parity(&hal, cfg->uart_proto_cfg.parity);
me.change_parity(config.parity);
// uart_hal_set_data_bit_num(&hal, cfg->uart_proto_cfg.data_bits);
me.change_data_bits(config.data_bits);
// uart_hal_set_stop_bits(&hal, cfg->uart_proto_cfg.stop_bits);
me.change_stop_bits(config.stop_bits);

// 🟨 SECOND TIME:
// uart_hal_set_tx_idle_num(&hal, LP_UART_TX_IDLE_NUM_DEFAULT);
me.change_tx_idle(0); // LP_UART_TX_IDLE_NUM_DEFAULT == 0
```


I removed `🟨 FIRST TIME`, as I do not see any impacts of leaving `tx_idle_num` as default (256) until it is called a few lines later.


#### Testing
Ongoing

