### PR TITLE
Add `AcknowledgeCheckFailedReason`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART: Make `AtCmdConfig` and `ConfigError` non-exhaustive (#2851)
 - UART: Make `AtCmdConfig` use builder-lite pattern (#2851)
 - UART: Fix naming violations for `DataBits`, `Parity`, and `StopBits` enum variants (#2893)
+- Renamed / changed some I2C error variants (#2844, #2862)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.22.md
+++ b/esp-hal/MIGRATING-0.22.md
@@ -317,6 +317,13 @@ To avoid abbreviations and contractions (as per the esp-hal guidelines), some er
 + Error::ZeroLengthInvalid
 ```
 
+The `AckCheckFailed` variant changed to `AcknowledgeCheckFailed(AcknowledgeCheckFailedReason)`
+
+```diff
+-            Err(Error::AckCheckFailed)
++            Err(Error::AcknowledgeCheckFailed(reason))
+```
+
 ## The crate prelude has been removed
 
 The reexports that were previously part of the prelude are available through other paths:

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -111,11 +111,6 @@ pub enum Error {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum AcknowledgeCheckFailedReason {
-    /// The device did not acknowledge its address. The device may be missing.
-    Address,
-    /// The device did not acknowledge the data. It may not be ready to process
-    /// requests at the moment.
-    Data,
     /// Either the device did not acknowledge its address or the data, but it is
     /// unknown which.
     Unknown,
@@ -124,8 +119,6 @@ pub enum AcknowledgeCheckFailedReason {
 impl core::fmt::Display for AcknowledgeCheckFailedReason {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            AcknowledgeCheckFailedReason::Address => write!(f, "Address"),
-            AcknowledgeCheckFailedReason::Data => write!(f, "Data"),
             AcknowledgeCheckFailedReason::Unknown => write!(f, "Unknown"),
         }
     }
@@ -134,10 +127,6 @@ impl core::fmt::Display for AcknowledgeCheckFailedReason {
 impl From<&AcknowledgeCheckFailedReason> for embedded_hal::i2c::NoAcknowledgeSource {
     fn from(value: &AcknowledgeCheckFailedReason) -> Self {
         match value {
-            AcknowledgeCheckFailedReason::Address => {
-                embedded_hal::i2c::NoAcknowledgeSource::Address
-            }
-            AcknowledgeCheckFailedReason::Data => embedded_hal::i2c::NoAcknowledgeSource::Data,
             AcknowledgeCheckFailedReason::Unknown => {
                 embedded_hal::i2c::NoAcknowledgeSource::Unknown
             }

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -1730,7 +1730,7 @@ impl Driver<'_> {
                 let retval = if interrupts.time_out().bit_is_set() {
                     Err(Error::Timeout)
                 } else if interrupts.nack().bit_is_set() {
-                    Err(Error::AcknowledgeCheckFailed)
+                    Err(Error::AcknowledgeCheckFailed(AcknowledgeCheckFailedReason::Unknown))
                 } else if interrupts.arbitration_lost().bit_is_set() {
                     Err(Error::ArbitrationLost)
                 } else {

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -2342,11 +2342,10 @@ fn estimate_ack_failed_reason(_register_block: &RegisterBlock) -> AcknowledgeChe
         } else {
             // this is based on observations rather than documented behavior
             if _register_block.fifo_st().read().txfifo_raddr().bits() <= 1 {
-                return AcknowledgeCheckFailedReason::Address;
+                AcknowledgeCheckFailedReason::Address
             } else {
-                return AcknowledgeCheckFailedReason::Data;
+                AcknowledgeCheckFailedReason::Data
             }
-
         }
     }
 }

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -107,10 +107,19 @@ pub enum Error {
 }
 
 /// I2C no acknowledge error reason.
+///
+/// Consider this as a hint and make sure to always handle all cases.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum AcknowledgeCheckFailedReason {
+    /// The device did not acknowledge its address. The device may be missing.
+    Address,
+
+    /// The device did not acknowledge the data. It may not be ready to process
+    /// requests at the moment.
+    Data,
+
     /// Either the device did not acknowledge its address or the data, but it is
     /// unknown which.
     Unknown,
@@ -119,6 +128,8 @@ pub enum AcknowledgeCheckFailedReason {
 impl core::fmt::Display for AcknowledgeCheckFailedReason {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            AcknowledgeCheckFailedReason::Address => write!(f, "Address"),
+            AcknowledgeCheckFailedReason::Data => write!(f, "Data"),
             AcknowledgeCheckFailedReason::Unknown => write!(f, "Unknown"),
         }
     }
@@ -127,6 +138,10 @@ impl core::fmt::Display for AcknowledgeCheckFailedReason {
 impl From<&AcknowledgeCheckFailedReason> for embedded_hal::i2c::NoAcknowledgeSource {
     fn from(value: &AcknowledgeCheckFailedReason) -> Self {
         match value {
+            AcknowledgeCheckFailedReason::Address => {
+                embedded_hal::i2c::NoAcknowledgeSource::Address
+            }
+            AcknowledgeCheckFailedReason::Data => embedded_hal::i2c::NoAcknowledgeSource::Data,
             AcknowledgeCheckFailedReason::Unknown => {
                 embedded_hal::i2c::NoAcknowledgeSource::Unknown
             }
@@ -687,9 +702,9 @@ impl<'a> I2cFuture<'a> {
         }
 
         if r.nack().bit_is_set() {
-            return Err(Error::AcknowledgeCheckFailed(
-                AcknowledgeCheckFailedReason::Unknown,
-            ));
+            return Err(Error::AcknowledgeCheckFailed(estimate_ack_failed_reason(
+                self.info.register_block(),
+            )));
         }
 
         #[cfg(not(esp32))]
@@ -703,7 +718,7 @@ impl<'a> I2cFuture<'a> {
                 .bit_is_clear()
         {
             return Err(Error::AcknowledgeCheckFailed(
-                AcknowledgeCheckFailedReason::Unknown,
+                AcknowledgeCheckFailedReason::Data,
             ));
         }
 
@@ -1719,7 +1734,7 @@ impl Driver<'_> {
                 let retval = if interrupts.time_out().bit_is_set() {
                     Err(Error::Timeout)
                 } else if interrupts.nack().bit_is_set() {
-                    Err(Error::AcknowledgeCheckFailed(AcknowledgeCheckFailedReason::Unknown))
+                    Err(Error::AcknowledgeCheckFailed(estimate_ack_failed_reason(self.register_block())))
                 } else if interrupts.arbitration_lost().bit_is_set() {
                     Err(Error::ArbitrationLost)
                 } else {
@@ -1730,11 +1745,11 @@ impl Driver<'_> {
                 let retval = if interrupts.time_out().bit_is_set() {
                     Err(Error::Timeout)
                 } else if interrupts.nack().bit_is_set() {
-                    Err(Error::AcknowledgeCheckFailed(AcknowledgeCheckFailedReason::Unknown))
+                    Err(Error::AcknowledgeCheckFailed(estimate_ack_failed_reason(self.register_block())))
                 } else if interrupts.arbitration_lost().bit_is_set() {
                     Err(Error::ArbitrationLost)
                 } else if interrupts.trans_complete().bit_is_set() && self.register_block().sr().read().resp_rec().bit_is_clear() {
-                    Err(Error::AcknowledgeCheckFailed(AcknowledgeCheckFailedReason::Unknown))
+                    Err(Error::AcknowledgeCheckFailed(AcknowledgeCheckFailedReason::Data))
                 } else {
                     Ok(())
                 };
@@ -2315,6 +2330,24 @@ fn write_fifo(register_block: &RegisterBlock, data: u8) {
     }) as *mut u32;
     unsafe {
         fifo_ptr.write_volatile(data as u32);
+    }
+}
+
+// Estimate the reason for an acknowledge check failure on a best effort basis.
+// When in doubt it's better to return `Unknown` than to return a wrong reason.
+fn estimate_ack_failed_reason(_register_block: &RegisterBlock) -> AcknowledgeCheckFailedReason {
+    cfg_if::cfg_if! {
+        if #[cfg(any(esp32, esp32s2, esp32c2, esp32c3))] {
+            AcknowledgeCheckFailedReason::Unknown
+        } else {
+            // this is based on observations rather than documented behavior
+            if _register_block.fifo_st().read().txfifo_raddr().bits() <= 1 {
+                return AcknowledgeCheckFailedReason::Address;
+            } else {
+                return AcknowledgeCheckFailedReason::Data;
+            }
+
+        }
     }
 }
 

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -6,7 +6,7 @@
 #![no_main]
 
 use esp_hal::{
-    i2c::master::{Config, Error, I2c, Operation},
+    i2c::master::{AcknowledgeCheckFailedReason, Config, Error, I2c, Operation},
     Async,
     Blocking,
 };
@@ -50,9 +50,12 @@ mod tests {
 
     #[test]
     fn empty_write_returns_ack_error_for_unknown_address(mut ctx: Context) {
+        // we don't specify the exact reason yet
         assert_eq!(
             ctx.i2c.write(NON_EXISTENT_ADDRESS, &[]),
-            Err(Error::AckCheckFailed)
+            Err(Error::AcknowledgeCheckFailed(
+                AcknowledgeCheckFailedReason::Unknown
+            ))
         );
         assert_eq!(ctx.i2c.write(DUT_ADDRESS, &[]), Ok(()));
     }

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -50,13 +50,26 @@ mod tests {
 
     #[test]
     fn empty_write_returns_ack_error_for_unknown_address(mut ctx: Context) {
-        // we don't specify the exact reason yet
-        assert_eq!(
-            ctx.i2c.write(NON_EXISTENT_ADDRESS, &[]),
-            Err(Error::AcknowledgeCheckFailed(
-                AcknowledgeCheckFailedReason::Unknown
-            ))
-        );
+        // on some chips we can determine the ack-check-failed reason but not on all
+        // chips
+        cfg_if::cfg_if! {
+            if #[cfg(any(esp32,esp32s2,esp32c2,esp32c3))] {
+                assert_eq!(
+                    ctx.i2c.write(NON_EXISTENT_ADDRESS, &[]),
+                    Err(Error::AcknowledgeCheckFailed(
+                        AcknowledgeCheckFailedReason::Unknown
+                    ))
+                );
+            } else {
+                assert_eq!(
+                    ctx.i2c.write(NON_EXISTENT_ADDRESS, &[]),
+                    Err(Error::AcknowledgeCheckFailed(
+                        AcknowledgeCheckFailedReason::Address
+                    ))
+                );
+            }
+        }
+
         assert_eq!(ctx.i2c.write(DUT_ADDRESS, &[]), Ok(()));
     }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This prepares for a maybe-future breaking change when we want to give the user an indication of an AckCheckFailed reason. For now it's just using `Unknown` but changing that shouldn't be a breaking change in future

#### Testing
CI
