### PR TITLE
qa-test

### DIFF
--- a/qa-test/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/qa-test/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -12,6 +12,7 @@
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: embassy-generic-timers
+//% TAG: bmp180
 
 #![no_std]
 #![no_main]

--- a/qa-test/src/bin/i2c_bmp180_calibration_data.rs
+++ b/qa-test/src/bin/i2c_bmp180_calibration_data.rs
@@ -7,6 +7,7 @@
 //! - SCL => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% TAG: bmp180
 
 #![no_std]
 #![no_main]

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -23,6 +23,7 @@
 //! register is set.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% TAG: flashchip
 
 #![no_std]
 #![no_main]

--- a/qa-test/src/bin/ram.rs
+++ b/qa-test/src/bin/ram.rs
@@ -46,16 +46,14 @@ fn main() -> ! {
         function_in_ram as *const ()
     );
     unsafe {
-        println!("SOME_INITED_DATA {:x?}", SOME_INITED_DATA);
-        println!("SOME_PERSISTENT_DATA {:x?}", SOME_PERSISTENT_DATA);
-        println!("SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA);
+        assert_eq!(&[0xaa, 0xbb], &SOME_INITED_DATA);
+        assert_eq!(&[0; 8], &SOME_ZEROED_DATA);
 
         SOME_INITED_DATA[0] = 0xff;
         SOME_ZEROED_DATA[0] = 0xff;
 
-        println!("SOME_INITED_DATA {:x?}", SOME_INITED_DATA);
-        println!("SOME_PERSISTENT_DATA {:x?}", SOME_PERSISTENT_DATA);
-        println!("SOME_ZEROED_DATA {:x?}", SOME_ZEROED_DATA);
+        assert_eq!(&[0xff, 0xbb], &SOME_INITED_DATA);
+        assert_eq!(&[0xff, 0, 0, 0, 0, 0, 0, 0], &SOME_ZEROED_DATA);
 
         if SOME_PERSISTENT_DATA[1] == 0xff {
             SOME_PERSISTENT_DATA[1] = 0;
@@ -69,17 +67,22 @@ fn main() -> ! {
         "RTC_FAST function located at {:p}",
         function_in_rtc_ram as *const ()
     );
-    println!("Result {}", function_in_rtc_ram());
 
+    assert_eq!(42, function_in_rtc_ram());
+
+    println!("Restarting in ~ 10 seconds.");
+    let mut i = 10;
     loop {
-        function_in_ram();
+        assert_eq!(42, function_in_rtc_ram());
+        function_in_ram(i);
+        i = i.saturating_sub(1);
         delay.delay(1.secs());
     }
 }
 
 #[ram]
-fn function_in_ram() {
-    println!("Hello world!");
+fn function_in_ram(count: u32) {
+    println!("{}", count);
 }
 
 #[ram(rtc_fast)]

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -23,6 +23,7 @@
 //! register is set.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% TAG: flashchip
 
 #![no_std]
 #![no_main]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,6 +9,7 @@ anyhow       = "1.0.93"
 basic-toml   = "0.1.9"
 chrono       = "0.4.38"
 clap         = { version = "4.5.20",  features = ["derive", "wrap_help"] }
+console      = "0.15.10"
 csv          = "1.3.1"
 env_logger   = "0.11.5"
 esp-metadata = { path = "../esp-metadata", features = ["clap"] }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Closes #2566

We have the `qa-test` folder but running those tests was annoying and error-prone.

While it was always possible to run `cargo xtask run-example FOLDER TARGET` (i.e. w/o the example name) it always gave an error.

Now it will
- run all examples / tests for the given chip
- show the top-level comment - give the user time to attach / prepare whatever is needed
- let the user decide to run or skip the example (e.g. if the user doesn't have the needed external components at hand)
- run next example when the example was quit via CTRL-C

Additionally, this introduces a new key `TAG` which is used to group the examples (i.e. multiple examples needing the same wiring should run after each other)

In future we will move everything from examples over to qa-test (and adapt those examples to better serve as tests) but that is out of scope for this PR.

`skip-changelog` since this isn't really worth mentioning there

#### Testing
See above
