### PR TITLE
feat: uart tx software break

### DIFF
--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -754,6 +754,26 @@ where
         }
     }
 
+    /// Sends a break signal for a specified duration in bit time, i.e. the time
+    /// it takes to transfer one bit at the current baud rate. The delay during
+    /// the break is just is busy-waiting.
+    pub fn send_break(&mut self, bits: u32) {
+        // Invert the TX line
+        self.register_block()
+            .conf0()
+            .modify(|_, w| w.txd_inv().bit(true));
+
+        // 1 bit time in microseconds = 1_000_000 / baudrate
+        // TODO: Proper baudrate retrieval!
+        let bit_period_us: u32 = 1_000_000 / 19200;
+        crate::rom::ets_delay_us(bit_period_us * bits);
+
+        // Revert the TX line
+        self.register_block()
+            .conf0()
+            .modify(|_, w| w.txd_inv().bit(false));
+    }
+
     /// Checks if the TX line is idle for this UART instance.
     ///
     /// Returns `true` if the transmit line is idle, meaning no data is
@@ -1250,6 +1270,11 @@ where
     /// Flush the transmit buffer of the UART
     pub fn flush(&mut self) -> nb::Result<(), Error> {
         self.tx.flush()
+    }
+
+    /// Sends a break signal for a specified duration
+    pub fn send_break(&mut self, bits: u32) {
+        self.tx.send_break(bits)
     }
 
     /// Read a byte from the UART
@@ -1802,6 +1827,11 @@ where
         self.tx.write_async(words).await
     }
 
+    /// Asynchronously sends a break signal.
+    pub async fn send_break_async(&mut self, bits: u32) {
+        self.tx.send_break_async(bits).await;
+    }
+
     /// Asynchronously flushes the UART transmit buffer.
     pub async fn flush_async(&mut self) -> Result<(), Error> {
         self.tx.flush_async().await
@@ -1855,6 +1885,29 @@ where
         }
 
         Ok(())
+    }
+
+    /// Asynchronously sends a break signal.
+    ///
+    /// This function sends a break signal on the UART TX line. The break
+    /// duration is specified in bit time, i.e. the time it takes to send
+    /// one bit at the current baudrate.
+    pub async fn send_break_async(&mut self, bits: u32) {
+        // Invert the TX line
+        self.register_block()
+            .conf0()
+            .modify(|_, w| w.txd_inv().bit(true));
+
+        // 1 bit time in microseconds = 1_000_000 / baudrate
+        // TODO: Proper baudrate retrieval!
+        let bit_period_us: u32 = 1_000_000 / 19200;
+        // TODO: Proper async delay!
+        crate::rom::ets_delay_us(bit_period_us * bits);
+
+        // Revert the TX line
+        self.register_block()
+            .conf0()
+            .modify(|_, w| w.txd_inv().bit(false));
     }
 }
 

--- a/examples/src/bin/uart_send_break.rs
+++ b/examples/src/bin/uart_send_break.rs
@@ -1,0 +1,50 @@
+//! Example of sending a software break signal from a UART in
+//! Blocking mode.
+//!
+//! The following wiring is assumed:
+//! - TEST IO PIN => GPIO2
+//! - TX => GPIO17
+//! - RX => GPIO16
+//% CHIPS: esp32
+
+#![no_std]
+#![no_main]
+
+use esp_backtrace as _;
+use esp_hal::{
+    delay::Delay,
+    entry,
+    gpio::{Level, Output},
+    uart::{Config as UartConfig, DataBits, StopBits, Uart},
+};
+
+#[entry]
+fn main() -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+    let uart_config = UartConfig::default()
+        .baudrate(19200)
+        .data_bits(DataBits::DataBits8)
+        .parity_none()
+        .stop_bits(StopBits::Stop1);
+
+    let mut uart = Uart::new(
+        peripherals.UART1,
+        uart_config,
+        peripherals.GPIO16, // RX
+        peripherals.GPIO17, // TX
+    )
+    .expect("Failed to initialize UART");
+
+    let delay = Delay::new();
+
+    // Used to toggle an output pin for comparing its timing with
+    // the TX line on an oscilloscope. It's also the LED pin.
+    let mut test_io_pin = Output::new(peripherals.GPIO2, Level::Low);
+
+    loop {
+        test_io_pin.toggle();
+        uart.send_break(19200); // 19200 bits at 19200bps = 1 second
+        test_io_pin.toggle();
+        delay.delay_millis(1000);
+    }
+}

--- a/examples/src/bin/uart_send_break_async.rs
+++ b/examples/src/bin/uart_send_break_async.rs
@@ -1,0 +1,57 @@
+//! Example of sending a software break signal from a UART in
+//! Async mode.
+//!
+//! The following wiring is assumed:
+//! - TEST IO PIN => GPIO2
+//! - TX => GPIO17
+//! - RX => GPIO16
+//% CHIPS: esp32
+//% FEATURES: embassy embassy-generic-timers esp-hal/unstable
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use esp_backtrace as _;
+use esp_hal::{
+    delay::Delay,
+    gpio::{Level, Output},
+    timer::timg::TimerGroup,
+    uart::{Config as UartConfig, DataBits, StopBits, Uart},
+};
+
+#[esp_hal_embassy::main]
+async fn main(_spawner: Spawner) {
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_hal_embassy::init(timg0.timer0);
+
+    let uart_config = UartConfig::default()
+        .baudrate(19200)
+        .data_bits(DataBits::DataBits8)
+        .parity_none()
+        .stop_bits(StopBits::Stop1);
+
+    let mut uart = Uart::new(
+        peripherals.UART1,
+        uart_config,
+        peripherals.GPIO16, // RX
+        peripherals.GPIO17, // TX
+    )
+    .expect("Failed to initialize UART")
+    .into_async();
+
+    let delay = Delay::new();
+
+    // Used to toggle an output pin for comparing its timing with
+    // the TX line on an oscilloscope. It's also the LED pin.
+    let mut test_io_pin = Output::new(peripherals.GPIO2, Level::Low);
+
+    loop {
+        test_io_pin.toggle();
+        uart.send_break_async(19200).await; // 19200 bits at 19200bps = 1 second
+        test_io_pin.toggle();
+        Timer::after_millis(1000).await;
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Adding ability to send a software break on the UART TX line. This is achieved by inverting the TX line, waiting some time, and then reverting the line back. The duration to leave it inverted (the break duration) is kept in `bit time` - the time it takes to send one bit at the current baud rate.

New Functions:
- `send_break_async(bits: u32)` - async delay during the break
- `send_break(bits: u32)` - busy waits during the break

#### Open Items

- [ ] How to retrieve the current baud rate for break duration calculation
- [ ] How to perform async delay within the Uart (can I use embassy-time `after(..).await`?)

#### Testing
Tested with the added `examples/uart_send_break` and `examples/uart_send_break_async` on my pocket oscilloscope and visually with the helper LED toggle also in each example.

Since I also have open PR #2858 for detecting breaks - these can eventually be tested together in HIL.