### PR TITLE
ESP32-S3: Fix PSRAM start address calculation

### DIFF
--- a/esp-hal/src/soc/esp32s3/psram.rs
+++ b/esp-hal/src/soc/esp32s3/psram.rs
@@ -172,6 +172,9 @@ pub(crate) fn init_psram(config: PsramConfig) {
         // the linker scripts can produce a gap between mapped IROM and DROM segments
         // bigger than a flash page - i.e. we will see an unmapped memory slot
         // start from the end and find the last mapped flash page
+        //
+        // More general information about the MMU can be found here:
+        // https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/system/mm.html#introduction
         let mmu_table_ptr = DR_REG_MMU_TABLE as *const u32;
         let mut mapped_pages = 0;
         for i in (0..FLASH_MMU_TABLE_SIZE).rev() {

--- a/esp-hal/src/soc/esp32s3/psram.rs
+++ b/esp-hal/src/soc/esp32s3/psram.rs
@@ -168,8 +168,10 @@ pub(crate) fn init_psram(config: PsramConfig) {
         const MMU_INVALID: u32 = 1 << 14;
         const DR_REG_MMU_TABLE: u32 = 0x600C5000;
 
-        // calculate the PSRAM start address to map - honor the fact there might be
-        // unmapped pages in between
+        // calculate the PSRAM start address to map
+        // the linker scripts can produce a gap between mapped IROM and DROM segments
+        // bigger than a flash page - i.e. we will see an unmapped memory slot
+        // start from the end and find the last mapped flash page
         let mmu_table_ptr = DR_REG_MMU_TABLE as *const u32;
         let mut mapped_pages = 0;
         for i in (0..FLASH_MMU_TABLE_SIZE).rev() {

--- a/esp-hal/src/soc/esp32s3/psram.rs
+++ b/esp-hal/src/soc/esp32s3/psram.rs
@@ -174,11 +174,11 @@ pub(crate) fn init_psram(config: PsramConfig) {
         let mut mapped_pages = 0;
         for i in (0..FLASH_MMU_TABLE_SIZE).rev() {
             if mmu_table_ptr.add(i).read_volatile() != MMU_INVALID {
-                mapped_pages = i;
+                mapped_pages = (i + 1) as u32;
                 break;
             }
         }
-        let start = EXTMEM_ORIGIN + MMU_PAGE_SIZE * (mapped_pages + 1) as u32;
+        let start = EXTMEM_ORIGIN + (MMU_PAGE_SIZE * mapped_pages);
         debug!("PSRAM start address = {:x}", start);
 
         // Configure the mode of instruction cache : cache size, cache line size.
@@ -188,7 +188,7 @@ pub(crate) fn init_psram(config: PsramConfig) {
             CONFIG_ESP32S3_INSTRUCTION_CACHE_LINE_SIZE,
         );
 
-        // If we need use SPIRAM, we should use data cache.Connfigure the mode of data :
+        // If we need use SPIRAM, we should use data cache.Configure the mode of data :
         // cache size, cache line size.
         Cache_Suspend_DCache();
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Fixes a problem in calculating the PSRAM start address on ESP32-S3 when there is a gap in the mapped flash pages. See https://github.com/esp-rs/esp-hal/discussions/2739#discussioncomment-11723660

While it's probably a rare situation it apparently happens in the wild. At least the reproducer linked in the issue shows that

`skip-changelog`? I can add it if we think we should include it

At some point we probably should double check the linker scripts since creating that gap isn't necessary.
We might also want to reconsider using a fixed address instead, but this fix shouldn't harm in any way.

#### Testing
Getting into that situation is not easy however the code should be easy enough and all examples are still working
