### PR TITLE
i2s: fix pin offset for 8bit parallel on i2s1

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It is no longer possible to safely conjure `GpioPin` instances (#2688)
 - UART: Public API follows `C-WORD_ORDER` Rust API standard (`VerbObject` order) (#2851)
 - `DmaRxStreamBuf` now correctly resets the descriptors the next time it's used (#2890)
+- i2s: fix pin offset logic for parallel output on i2s1
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -115,7 +115,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It is no longer possible to safely conjure `GpioPin` instances (#2688)
 - UART: Public API follows `C-WORD_ORDER` Rust API standard (`VerbObject` order) (#2851)
 - `DmaRxStreamBuf` now correctly resets the descriptors the next time it's used (#2890)
-- i2s: fix pin offset logic for parallel output on i2s1
 - i2s: fix pin offset logic for parallel output on i2s1 (#2886)
 
 ### Removed

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART: Public API follows `C-WORD_ORDER` Rust API standard (`VerbObject` order) (#2851)
 - `DmaRxStreamBuf` now correctly resets the descriptors the next time it's used (#2890)
 - i2s: fix pin offset logic for parallel output on i2s1
+- i2s: fix pin offset logic for parallel output on i2s1 (#2886)
 
 ### Removed
 

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -736,10 +736,10 @@ impl Instance for I2S1 {
             bits
         );
 
-        // signals for 8bit  start at an offset of  0 and 16bit start at an offset of 8 for I2S1
-        let pin_offset = if bits == 8 { 0 } else { 8 };
+        // signals for 8bit  start at an offset of  8 for 16bit on I2S1
+        let pin_offset = if bits == 16 { 8 } else { 0 };
 
-        match i + 8 {
+        match i + pin_offset {
             0 => OutputSignal::I2S1O_DATA_0,
             1 => OutputSignal::I2S1O_DATA_1,
             2 => OutputSignal::I2S1O_DATA_2,

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -736,8 +736,9 @@ impl Instance for I2S1 {
             bits
         );
 
-        // signals for 8bit and 16bit both start at an offset of 8 for I2S1
-        // https://github.com/espressif/esp-idf/blob/9106c43accd9f5e75379f62f12597677213f5023/components/esp_lcd/i80/esp_lcd_panel_io_i2s.c#L701
+        // signals for 8bit  start at an offset of  0 and 16bit start at an offset of 8 for I2S1
+        let pin_offset = if bits == 8 { 0 } else { 8 };
+
         match i + 8 {
             0 => OutputSignal::I2S1O_DATA_0,
             1 => OutputSignal::I2S1O_DATA_1,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fix a bug introduced in [this commit](https://github.com/esp-rs/esp-hal/commit/111ae93cc55abefaf9a61049889baab91850abe9), i2s1 needs a pin offset of 8 only for 16bit.

#### Testing
Logic analyzer and a WIP Hub75 driver for [SmartMatrix V0 hardware](https://github.com/pixelmatix/SmartMatrix/blob/master/extras/hardware/ESP32/SmartLEDShield_ESP32_V0_sch.pdf) (uses a latch to use less ram & pins)
