### PR TITLE
UART: Make the tx_fifo_count and is_tx_idle UART functions public

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I2C: Replaced potential panics with errors. (#2831)
 - UART: Make `AtCmdConfig` and `ConfigError` non-exhaustive (#2851)
 - UART: Make `AtCmdConfig` use builder-lite pattern (#2851)
+- UART: Make `is_tx_idle` and `tx_fifo_count` public (#2887)
 
 ### Fixed
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -686,7 +686,7 @@ where
     #[allow(clippy::useless_conversion)]
     /// Returns the number of bytes currently in the TX FIFO for this UART
     /// instance.
-    fn tx_fifo_count(&self) -> u16 {
+    pub fn tx_fifo_count(&self) -> u16 {
         self.register_block()
             .status()
             .read()
@@ -708,7 +708,7 @@ where
     ///
     /// Returns `true` if the transmit line is idle, meaning no data is
     /// currently being transmitted.
-    fn is_tx_idle(&self) -> bool {
+    pub fn is_tx_idle(&self) -> bool {
         #[cfg(esp32)]
         let status = self.register_block().status();
         #[cfg(not(esp32))]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Marked the ``` fn is_tx_idle(&self) ``` and ``` fn tx_fifo_count(&self) ``` as public as my project requires access to these functions.

#### Testing
Compilation was successful and all examples execute