### PR TITLE
Update esp-wifi to match changes made to esp-hal

### DIFF
--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -32,7 +32,7 @@ heapless = { version = "0.8.0", default-features = false, features = [
 num-derive = { version = "0.4.2" }
 num-traits = { version = "0.2.19", default-features = false }
 esp-wifi-sys = "0.7.0"
-embassy-sync = { version = "0.6.0", optional = true }
+embassy-sync = { version = "0.6.1", optional = true }
 embassy-net-driver = { version = "0.2.0", optional = true }
 libm = "0.2.11"
 cfg-if = "1.0.0"

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -16,7 +16,7 @@ defmt = { version = "0.3.8", optional = true }
 log = { version = "0.4.22", optional = true }
 document-features  = "0.2.10"
 esp-alloc = { version = "0.5.0", path = "../esp-alloc", optional = true }
-esp-hal = { version = "0.22.0", path = "../esp-hal", default-features = false }
+esp-hal = { version = "0.22.0", path = "../esp-hal", default-features = false, features = ["unstable"] }
 smoltcp = { version = "0.12.0", default-features = false, features = [
   "medium-ethernet",
   "socket-raw",


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Changes to allow the development of projects using both esp-hal and esp-wifi 

Bump version of `embassy-sync` to 0.6.1 to match the change to `esp-hal` made in (#2555) which prevented compilation of projects with both dependencies 

Enabled the `unstable` feature on the esp-hal dependency introduced in (#2628) which is required for esp-wifi to compile


#### Testing
Projects which depend on upstream esp-hal can now compile
