### PR TITLE
Properly reset descriptors in `DmaRxStreamBuf::prepare`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `spi::master::Spi::{into_async, into_blocking}` are now correctly available on the typed driver, to. (#2674)
 - It is no longer possible to safely conjure `GpioPin` instances (#2688)
 - UART: Public API follows `C-WORD_ORDER` Rust API standard (`VerbObject` order) (#2851)
+- `DmaRxStreamBuf` now correctly resets the descriptors the next time it's used (#2890)
 
 ### Removed
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
`DmaRxStreamBuf` moves descriptors from the front of the linked list to the end of the linked list, as the user read the data that the DMA wrote to memory.
When the user stops the transfer, and starts another with the same buf, the linked list wasn't reset back to its original state (with the first the descriptor as the head of the list), it was left with in whatever state the linked list was in when the transfer stopped.
Two solutions for this:
- Find the actual head of the list and return that in the call to `prepare`.
- Restore the linked list to have the first descriptor as the head. (This is what this PR does)

#### Testing
In my MJPEG server project. The full buffer is now being used correctly. 
