### PR TITLE
UART: Remove blocking version of `read_bytes` and rename `drain_fifo` to `read_bytes` instead

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART: Make `AtCmdConfig` and `ConfigError` non-exhaustive (#2851)
 - UART: Make `AtCmdConfig` use builder-lite pattern (#2851)
 - UART: Fix naming violations for `DataBits`, `Parity`, and `StopBits` enum variants (#2893)
+- UART: Remove blocking version of `read_bytes` and rename `drain_fifo` to `read_bytes` instead (#2895)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.22.md
+++ b/esp-hal/MIGRATING-0.22.md
@@ -382,3 +382,7 @@ e.g.)
 - StopBits::Stop1
 + StopBits::_1
 ```
+
+The previous blocking implementation of `read_bytes` has been removed, and the non-blocking `drain_fifo` has instead been renamed to `read_bytes` in its place.
+
+Any code which was previously using `read_bytes` to fill a buffer in a blocking manner will now need to implement the necessary logic to block until the buffer is filled in their application instead.

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -863,7 +863,8 @@ where
         }
 
         if self.rx_fifo_count() > 0 {
-            Ok(fifo.read().rxfifo_rd_byte().bits())
+            let byte = crate::interrupt::free(|| fifo.read().rxfifo_rd_byte().bits());
+            Ok(byte)
         } else {
             Err(nb::Error::WouldBlock)
         }

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -53,7 +53,13 @@ mod tests {
         ctx.tx.flush().unwrap();
         ctx.tx.write_bytes(&bytes).unwrap();
 
-        let bytes_read = ctx.rx.read_bytes(&mut buf);
+        let mut bytes_read = 0;
+        loop {
+            bytes_read += ctx.rx.read_bytes(&mut buf[bytes_read..]);
+            if bytes_read == 3 {
+                break;
+            }
+        }
 
         assert_eq!(bytes_read, 3);
         assert_eq!(buf, bytes);

--- a/hil-test/tests/uart_tx_rx.rs
+++ b/hil-test/tests/uart_tx_rx.rs
@@ -53,8 +53,9 @@ mod tests {
         ctx.tx.flush().unwrap();
         ctx.tx.write_bytes(&bytes).unwrap();
 
-        ctx.rx.read_bytes(&mut buf).unwrap();
+        let bytes_read = ctx.rx.read_bytes(&mut buf);
 
+        assert_eq!(bytes_read, 3);
         assert_eq!(buf, bytes);
     }
 }


### PR DESCRIPTION
Hopefully I have understood the issue correctly 😅 But should close #2725. If there are any changes that need to be made let me know.