### PR TITLE
Use own implementation instead of ROM functions, re-add memchr

### DIFF
--- a/esp-hal/ld/esp32/rom/additional.ld
+++ b/esp-hal/ld/esp32/rom/additional.ld
@@ -16,5 +16,5 @@ PROVIDE ( strchr = 0x4000c53c );
 PROVIDE ( strlcpy = 0x4000c584 );
 PROVIDE ( strstr = 0x4000c674 );
 PROVIDE ( strcasecmp = 0x400011cc );
-PROVIDE ( strdup = 0x4000143c );
-PROVIDE ( atoi = 0x400566c4 );
+
+PROVIDE ( memchr = 0x4000c244 );

--- a/esp-hal/ld/esp32c2/rom/additional.ld
+++ b/esp-hal/ld/esp32c2/rom/additional.ld
@@ -13,5 +13,3 @@ PROVIDE ( strchr = 0x40000514 );
 PROVIDE ( strlcpy = 0x40000524 );
 PROVIDE ( strstr = 0x400004ac );
 PROVIDE ( strcasecmp = 0x40000504 );
-PROVIDE ( strdup = 0x40000510 );
-PROVIDE ( atoi = 0x40000580 );

--- a/esp-hal/ld/esp32c3/rom/additional.ld
+++ b/esp-hal/ld/esp32c3/rom/additional.ld
@@ -17,5 +17,5 @@ PROVIDE( strchr = 0x400003e0 );
 PROVIDE( strlcpy = 0x400003f0 );
 PROVIDE( strstr = 0x40000378 );
 PROVIDE( strcasecmp = 0x400003d0 );
-PROVIDE( strdup = 0x400003dc );
-PROVIDE( atoi = 0x4000044c );
+
+PROVIDE( memchr = 0x400003c8 );

--- a/esp-hal/ld/esp32c6/rom/additional.ld
+++ b/esp-hal/ld/esp32c6/rom/additional.ld
@@ -15,5 +15,3 @@ PROVIDE(strchr = 0x40000534);
 PROVIDE(strlcpy = 0x40000544);
 PROVIDE(strstr = 0x400004cc);
 PROVIDE(strcasecmp = 0x40000524);
-PROVIDE(strdup = 0x40000530);
-PROVIDE(atoi = 0x400005a0);

--- a/esp-hal/ld/esp32h2/rom/additional.ld
+++ b/esp-hal/ld/esp32h2/rom/additional.ld
@@ -15,5 +15,5 @@ PROVIDE( strchr = 0x4000052c );
 PROVIDE( strlcpy = 0x4000053c );
 PROVIDE( strstr = 0x400004c4 );
 PROVIDE( strcasecmp = 0x4000051c );
-PROVIDE( strdup = 0x40000528 );
-PROVIDE( atoi = 0x40000598 );
+
+PROVIDE( memchr = 0x40000514 );

--- a/esp-hal/ld/esp32s2/rom/additional.ld
+++ b/esp-hal/ld/esp32s2/rom/additional.ld
@@ -17,4 +17,3 @@ PROVIDE ( strchr = 0x4001adb0 );
 PROVIDE ( strlcpy = 0x4001adf8 );
 PROVIDE ( strstr = 0x4001aee8 );
 PROVIDE ( strcasecmp = 0x40007b38 );
-PROVIDE ( strdup = 0x40007d84 );

--- a/esp-hal/ld/esp32s3/rom/additional.ld
+++ b/esp-hal/ld/esp32s3/rom/additional.ld
@@ -19,5 +19,3 @@ PROVIDE( strchr = 0x4000138c );
 PROVIDE( strlcpy = 0x400013bc );
 PROVIDE( strstr = 0x40001254 );
 PROVIDE( strcasecmp = 0x4000135c );
-PROVIDE( strdup = 0x40001380 );
-PROVIDE( atoi = 0x400014d0 );

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed triggering a debug-assertion during scan (#2612)
+- Fix WPA2-ENTERPRISE functionality (#2896)
 
 ### Removed
 

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -31,7 +31,7 @@ unsafe extern "C" fn strdup(str: *const core::ffi::c_char) -> *const core::ffi::
         let len = s.count_bytes() + 1;
         let p = malloc(len);
         if !p.is_null() {
-            core::ptr::copy_nonoverlapping(str, p as *mut i8, len);
+            core::ptr::copy_nonoverlapping(str, p.cast(), len);
         }
         p.cast()
     }

--- a/esp-wifi/src/compat/misc.rs
+++ b/esp-wifi/src/compat/misc.rs
@@ -23,16 +23,17 @@ unsafe extern "C" fn fclose(stream: *const ()) -> i32 {
 
 // We cannot just use the ROM function since it needs to allocate memory
 #[no_mangle]
-unsafe extern "C" fn strdup(str: *const i8) -> *const u8 {
+unsafe extern "C" fn strdup(str: *const core::ffi::c_char) -> *const core::ffi::c_char {
     trace!("strdup {:?}", str);
 
     unsafe {
         let s = core::ffi::CStr::from_ptr(str);
-        let s = s.to_str().unwrap();
-
-        let p = malloc(s.len() + 1);
-        core::ptr::copy_nonoverlapping(str, p as *mut i8, s.len() + 1);
-        p as *const u8
+        let len = s.count_bytes() + 1;
+        let p = malloc(len);
+        if !p.is_null() {
+            core::ptr::copy_nonoverlapping(str, p as *mut i8, len);
+        }
+        p.cast()
     }
 }
 


### PR DESCRIPTION
…nction

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- replace `atoi` and `strdup` ROM-functions with our own implementation (to fix WPA2-ENTERPRISE functionality)
- re-add `memchr` ROM-function for ESP32, ESP32-C3 and ESP32-H2 (to fix the issue in https://github.com/esp-rs/esp-mbedtls/pull/62)

`skip-changelog` b.c. of the changes in `esp-hal`

#### Testing
WPA2-ENTERPRISE example (have it locally - can provide if needed)
