### PR TITLE
Cache bus clock register and support clock source

### DIFF
--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `#[builder_lite_into]` attribute that generates the setter with `impl Into<T>` parameter (#2897)
+
 ### Changed
 
 ### Fixed

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -244,7 +244,7 @@ pub fn blocking_main(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// [Builder Lite]: https://matklad.github.io/2022/05/29/builder-lite.html
-#[proc_macro_derive(BuilderLite)]
+#[proc_macro_derive(BuilderLite, attributes(builder_lite_into))]
 pub fn builder_lite_derive(item: TokenStream) -> TokenStream {
     builder::builder_lite_derive(item)
 }

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SPI: Added support for 3-wire SPI (#2919)
 
+- `spi::master::BusClockConfig` (#2897)
+
 ### Changed
 - RMT: `TxChannelConfig` and `RxChannelConfig` now support the builder-lite pattern (#2978)
 - RMT: Some fields of `TxChannelConfig` and `RxChannelConfig` are now `gpio::Level`-valued instead of `bool` (#2989)
@@ -23,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Rng` and `Trng` now implement `Peripheral<P = Self>` (#2992)
 
 - `Async` drivers are no longer `Send` (#2980)
+
+- SPI `Config::frequency` has been replaced by `clock`. (#2897)
+- SPI `Config::with_frequency` has been renamed to `with_clock`. (#2897)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -127,3 +127,17 @@ Use `DataMode::SingleTwoDataLines` to get the previous behavior.
 ```
 
 `Spi` now offers both, `with_mosi` and `with_sio0`. Consider using `with_sio` for half-duplex SPI except for [DataMode::SingleTwoDataLines] or for a mixed-bus.
+
+### SPI master driver configuration
+
+SPI `Config::with_frequency` has been renamed to `with_clock`. This function now takes either
+a `fugit::HertzU32` or `BusClockConfig`.
+
+```diff
+ let config = Config::default()
+-   .with_frequency(10.MHz());
++   .with_clock(10.MHz());
+```
+
+The new structure supports configuring a clock source, although currently only `ClockSource::Apb`
+is available.

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -28,7 +28,7 @@
 //!
 //! let mut spi = Spi::new(
 //!     peripherals.SPI2,
-//!     Config::default().with_frequency(100.kHz()).with_mode(Mode::_0)
+//!     Config::default().with_clock(100.kHz()).with_mode(Mode::_0)
 //! )
 //! .unwrap()
 //! .with_sck(sclk)

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -56,7 +56,7 @@
 //! [`embedded-hal-bus`]: https://docs.rs/embedded-hal-bus/latest/embedded_hal_bus/spi/index.html
 //! [`embassy-embedded-hal`]: https://docs.embassy.dev/embassy-embedded-hal/git/default/shared_bus/index.html
 
-use core::{cell::Cell, marker::PhantomData};
+use core::marker::PhantomData;
 
 #[instability::unstable]
 pub use dma::*;
@@ -450,11 +450,11 @@ pub enum ClockSource {
 /// Bus clock configuration.
 ///
 /// This struct holds information necessary to configure the SPI bus clock.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BusClockConfig {
     /// The saved register value, calculated when first needed.
-    reg: Cell<Option<Result<u32, ConfigError>>>,
+    reg: Result<u32, ConfigError>,
 
     /// The target frequency
     frequency: HertzU32,
@@ -463,33 +463,29 @@ pub struct BusClockConfig {
     clock_source: ClockSource,
 }
 
-impl Clone for BusClockConfig {
-    fn clone(&self) -> Self {
-        _ = self.recalculate();
-
-        Self {
-            reg: self.reg.clone(),
-            frequency: self.frequency,
-            clock_source: self.clock_source,
-        }
-    }
-}
-
 impl Default for BusClockConfig {
     fn default() -> Self {
-        BusClockConfig {
-            reg: Cell::new(None),
-            frequency: 1_u32.MHz(),
-            clock_source: ClockSource::Apb,
-        }
+        Self::new(1_u32.MHz(), ClockSource::Apb)
     }
 }
 
 impl BusClockConfig {
+    fn new(frequency: HertzU32, clock_source: ClockSource) -> Self {
+        let mut this = Self {
+            reg: Ok(0),
+            frequency,
+            clock_source,
+        };
+
+        this.reg = this.recalculate();
+
+        this
+    }
+
     /// Set the frequency of the SPI bus clock.
     pub fn with_frequency(mut self, frequency: HertzU32) -> Self {
         self.frequency = frequency;
-        self.reg.set(None);
+        self.reg = self.recalculate();
 
         self
     }
@@ -497,25 +493,21 @@ impl BusClockConfig {
     /// Set the clock source of the SPI bus.
     pub fn with_clock_source(mut self, clock_source: ClockSource) -> Self {
         self.clock_source = clock_source;
-        self.reg.set(None);
+        self.reg = self.recalculate();
 
         self
     }
 
     fn recalculate(&self) -> Result<u32, ConfigError> {
-        if let Some(result) = self.reg.get() {
-            return result;
-        }
-
         // taken from https://github.com/apache/incubator-nuttx/blob/8267a7618629838231256edfa666e44b5313348e/arch/risc-v/src/esp32c3/esp32c3_spi.c#L496
 
         let clocks = Clocks::get();
         cfg_if::cfg_if! {
             if #[cfg(esp32h2)] {
                 // ESP32-H2 is using PLL_48M_CLK source instead of APB_CLK
-                let apb_clk_freq = HertzU32::Hz(clocks.pll_48m_clock.to_Hz());
+                let apb_clk_freq = clocks.pll_48m_clock;
             } else {
-                let apb_clk_freq = HertzU32::Hz(clocks.apb_clock.to_Hz());
+                let apb_clk_freq = clocks.apb_clock;
             }
         }
 
@@ -543,6 +535,7 @@ impl BusClockConfig {
             let mut errval: i32;
 
             let raw_freq = self.frequency.raw() as i32;
+            let raw_apb_freq = apb_clk_freq.raw() as i32;
 
             // Start at n = 2. We need to be able to set h/l so we have at least
             // one high and one low pulse.
@@ -551,7 +544,7 @@ impl BusClockConfig {
                 // Effectively, this does:
                 // pre = round((APB_CLK_FREQ / n) / frequency)
 
-                pre = ((apb_clk_freq.raw() as i32 / n) + (raw_freq / 2)) / raw_freq;
+                pre = ((raw_apb_freq / n) + (raw_freq / 2)) / raw_freq;
 
                 if pre <= 0 {
                     pre = 1;
@@ -561,7 +554,7 @@ impl BusClockConfig {
                     pre = 16;
                 }
 
-                errval = (apb_clk_freq.raw() as i32 / (pre * n) - raw_freq).abs();
+                errval = (raw_apb_freq / (pre * n) - raw_freq).abs();
                 if bestn == -1 || errval <= besterr {
                     besterr = errval;
                     bestn = n;
@@ -587,34 +580,30 @@ impl BusClockConfig {
                 | ((pre as u32 - 1) << 18);
         }
 
-        self.reg.set(Some(Ok(reg_val)));
         Ok(reg_val)
     }
 
     fn raw_clock_reg_value(&self) -> Result<u32, ConfigError> {
-        self.recalculate()
+        self.reg
     }
 }
 
 impl From<HertzU32> for BusClockConfig {
     fn from(frequency: HertzU32) -> Self {
-        BusClockConfig {
-            frequency,
-            ..Default::default()
-        }
+        Self::new(frequency, ClockSource::Apb)
     }
 }
 
 impl core::hash::Hash for BusClockConfig {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.reg.get().hash(state);
+        self.reg.hash(state);
         self.frequency.to_Hz().hash(state); // HertzU32 doesn't implement Hash
         self.clock_source.hash(state);
     }
 }
 
 /// SPI peripheral configuration
-#[derive(Clone, Debug, PartialEq, Eq, procmacros::BuilderLite)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, procmacros::BuilderLite)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct Config {

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -59,9 +59,7 @@ async fn main(_spawner: Spawner) {
 
     let mut spi = Spi::new(
         peripherals.SPI2,
-        Config::default()
-            .with_frequency(100.kHz())
-            .with_mode(Mode::_0),
+        Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
     )
     .unwrap()
     .with_sck(sclk)

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -41,9 +41,7 @@ fn main() -> ! {
 
     let mut spi = Spi::new(
         peripherals.SPI2,
-        Config::default()
-            .with_frequency(100.kHz())
-            .with_mode(Mode::_0),
+        Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
     )
     .unwrap()
     .with_sck(sclk)

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -91,9 +91,7 @@ fn main() -> ! {
     // output connection (because we are using the same pin to loop back)
     let mut spi = Spi::new(
         peripherals.SPI2,
-        Config::default()
-            .with_frequency(100.kHz())
-            .with_mode(Mode::_0),
+        Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
     )
     .unwrap()
     .with_sck(sclk)

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -121,7 +121,7 @@ mod test {
         let mut spi = Spi::new(
             peripherals.SPI2,
             Config::default()
-                .with_frequency(10000.kHz())
+                .with_clock(10000.kHz())
                 .with_mode(Mode::_0),
         )
         .unwrap()
@@ -135,7 +135,7 @@ mod test {
         let other_peripheral = Spi::new(
             peripherals.SPI3,
             Config::default()
-                .with_frequency(10000.kHz())
+                .with_clock(10000.kHz())
                 .with_mode(Mode::_0),
         )
         .unwrap()
@@ -222,9 +222,7 @@ mod test {
 
             let mut spi = Spi::new(
                 peripherals.spi,
-                Config::default()
-                    .with_frequency(100.kHz())
-                    .with_mode(Mode::_0),
+                Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
             )
             .unwrap()
             .with_dma(peripherals.dma_channel)

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -211,9 +211,7 @@ mod tests {
 
         let spi = Spi::new(
             peripherals.SPI2,
-            Config::default()
-                .with_frequency(100.kHz())
-                .with_mode(Mode::_0),
+            Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
         )
         .unwrap();
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -101,7 +101,7 @@ mod tests {
 
         // Need to set miso first so that mosi can overwrite the
         // output connection (because we are using the same pin to loop back)
-        let spi = Spi::new(peripherals.SPI2, Config::default().with_frequency(10.MHz()))
+        let spi = Spi::new(peripherals.SPI2, Config::default().with_clock(10.MHz()))
             .unwrap()
             .with_sck(peripherals.GPIO0)
             .with_miso(miso)
@@ -231,7 +231,7 @@ mod tests {
         let mut spi = ctx.spi.into_async();
 
         // Slow down SCLK so that transferring the buffer takes a while.
-        spi.apply_config(&Config::default().with_frequency(80.kHz()))
+        spi.apply_config(&Config::default().with_clock(80.kHz()))
             .expect("Apply config failed");
 
         SpiBus::write(&mut spi, &write[..]).expect("Sync write failed");
@@ -705,7 +705,7 @@ mod tests {
         // This means that without working cancellation, the test case should
         // fail.
         ctx.spi
-            .apply_config(&Config::default().with_frequency(80.kHz()))
+            .apply_config(&Config::default().with_clock(80.kHz()))
             .unwrap();
 
         // Set up a large buffer that would trigger a timeout
@@ -728,7 +728,7 @@ mod tests {
     fn can_transmit_after_cancel(mut ctx: Context) {
         // Slow down. At 80kHz, the transfer is supposed to take a bit over 3 seconds.
         ctx.spi
-            .apply_config(&Config::default().with_frequency(80.kHz()))
+            .apply_config(&Config::default().with_clock(80.kHz()))
             .unwrap();
 
         // Set up a large buffer that would trigger a timeout
@@ -745,7 +745,7 @@ mod tests {
         transfer.cancel();
         (spi, (dma_rx_buf, dma_tx_buf)) = transfer.wait();
 
-        spi.apply_config(&Config::default().with_frequency(10.MHz()))
+        spi.apply_config(&Config::default().with_clock(10.MHz()))
             .unwrap();
 
         let transfer = spi

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -49,9 +49,7 @@ mod tests {
 
         let spi = Spi::new(
             peripherals.SPI2,
-            Config::default()
-                .with_frequency(100.kHz())
-                .with_mode(Mode::_0),
+            Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
         )
         .unwrap()
         .with_sck(sclk)

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -128,9 +128,7 @@ mod tests {
 
         let spi = Spi::new(
             peripherals.SPI2,
-            Config::default()
-                .with_frequency(100.kHz())
-                .with_mode(Mode::_0),
+            Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
         )
         .unwrap()
         .with_sck(sclk)

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -65,9 +65,7 @@ mod tests {
 
         let spi = Spi::new(
             peripherals.SPI2,
-            Config::default()
-                .with_frequency(100.kHz())
-                .with_mode(Mode::_0),
+            Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
         )
         .unwrap()
         .with_sck(sclk)

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -79,9 +79,7 @@ fn main() -> ! {
 
     let mut spi = Spi::new(
         peripherals.SPI2,
-        Config::default()
-            .with_frequency(100.kHz())
-            .with_mode(Mode::_0),
+        Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
     )
     .unwrap()
     .with_sck(sclk)

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -65,9 +65,7 @@ fn main() -> ! {
 
     let mut spi = Spi::new(
         peripherals.SPI2,
-        Config::default()
-            .with_frequency(100.kHz())
-            .with_mode(Mode::_0),
+        Config::default().with_clock(100.kHz()).with_mode(Mode::_0),
     )
     .unwrap()
     .with_sck(sclk)


### PR DESCRIPTION
Rough draft of my idea to resolve (eventually) #1666 and #1668

The main idea is to handle clock source and clock frequency as a unit, instead of separate values. This allows us to calculate and store the register value to save time when reapplying the same configuration.

The idea relies on peripherals having the same possible set of clock sources. I think that's generally okay, as we don't aim to support LP peripherals with the same drivers, for example.

I've chosen to update right before applying, so that writing the fields is trivial. This means `Config` is no longer `Copy`, which is a pretty unfortunate side-effect. We can, instead, update on each field update, which makes things a bit more expensive. We can also provide a chain updater that uses Drop trickery to update when the user is done touching the struct. This is more of an implementation detail than a substantial part of the design at this point.

The BuilderLite change is supposed to provide a semblance of backwards compatibility, especially since SPI really only supports PLL clock source in half of the chips and selecting Xtal also feels pretty rare in those that support it.