### PR TITLE
Remove unnecessary prefixes/suffixes from Error and TxEvent enums

### DIFF
--- a/esp-hal/MIGRATING-0.22.md
+++ b/esp-hal/MIGRATING-0.22.md
@@ -372,7 +372,7 @@ The `Config` struct's setters are now prefixed with `with_`. `parity_none`, `par
 
 The `DataBits`, `Parity`, and `StopBits` enum variants are no longer prefixed with the name of the enum.
 
-e.g.)
+e.g.
 
 ```diff
 - DataBits::DataBits8
@@ -386,6 +386,15 @@ e.g.)
 The previous blocking implementation of `read_bytes` has been removed, and the non-blocking `drain_fifo` has instead been renamed to `read_bytes` in its place.
 
 Any code which was previously using `read_bytes` to fill a buffer in a blocking manner will now need to implement the necessary logic to block until the buffer is filled in their application instead.
+
+The `Error` enum variant uses object+verb naming.
+
+e.g.
+
+```diff
+- RxGlichDetected
++ GlitchOccurred
+```
 
 ## Spi `with_miso` has been split
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -257,11 +257,6 @@ const CMD_CHAR_DEFAULT: u8 = 0x2b;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
-    /// A zero lenght buffer was passed.
-    ///
-    /// This error occurs when an empty buffer is passed.
-    ZeroLengthBufferPassed,
-
     /// The RX FIFO overflow happened.
     ///
     /// This error occurs when RX FIFO is full and a new byte is received.
@@ -292,7 +287,6 @@ impl core::error::Error for Error {}
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Error::ZeroLengthBufferPassed => write!(f, "A zero lenght buffer was passed"),
             Error::FifoOverflowed => write!(f, "The RX FIFO overflowed"),
             Error::GlitchOccurred => write!(f, "A glitch was detected on the RX line"),
             Error::FrameFormatViolated => write!(f, "A framing error was detected on the RX line"),
@@ -1801,10 +1795,10 @@ where
     ///
     /// # Ok
     /// When successful, returns the number of bytes written to buf.
-    /// This method will never return Ok(0)
+    /// If buffer is empty, Ok(0) is returned.
     pub async fn read_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         if buf.is_empty() {
-            return Err(Error::ZeroLengthBufferPassed);
+            return Ok(0);
         }
 
         loop {

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1795,7 +1795,7 @@ where
     ///
     /// # Ok
     /// When successful, returns the number of bytes written to buf.
-    /// If buffer is empty, Ok(0) is returned.
+    /// If the passed in buffer is of length 0, Ok(0) is returned.
     pub async fn read_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         if buf.is_empty() {
             return Ok(0);

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -277,7 +277,6 @@ pub enum Error {
     ///
     /// This error occurs when the received data does not conform to the
     /// expected UART frame format.
-    #[allow(clippy::enum_variant_names, reason = "Frame error is a common term")]
     RxFrame,
 
     /// A parity error was detected on the RX line.
@@ -285,7 +284,6 @@ pub enum Error {
     /// This error occurs when the parity bit in the received data does not
     /// match the expected parity configuration.
     /// with the `async` feature.
-    #[allow(clippy::enum_variant_names, reason = "Parity error is a common term")]
     RxParity,
 }
 


### PR DESCRIPTION
As discovered in https://github.com/esp-rs/esp-hal/pull/2893#pullrequestreview-2531989493