### PR TITLE
Remove peripheral instance types

### DIFF
--- a/documentation/API-GUIDELINES.md
+++ b/documentation/API-GUIDELINES.md
@@ -26,17 +26,15 @@ In general, the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines
 - Drivers must take peripherals via the `PeripheralRef` pattern - they don't consume peripherals directly.
 - If a driver requires pins, those pins should be configured using `fn with_signal_name(self, pin: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self` or `fn with_signal_name(self, pin: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self`
 - If a driver supports multiple peripheral instances (for example, I2C0 is one such instance):
-  - The peripheral instance type must be positioned as the last type parameter of the driver type.
-  - The peripheral instance type must default to a type that supports any of the peripheral instances.
+  - The driver should not be generic over the peripheral instance.
   - The author must to use `crate::any_peripheral` to define the "any" peripheral instance type.
-  - The driver must implement a `new` constructor that automatically converts the peripheral instance into the any type, and a `new_typed` that preserves the peripheral type.
+  - The driver must implement a `new` constructor that automatically converts the peripheral instance into the any type.
 - If a driver is configurable, configuration options should be implemented as a `Config` struct in the same module where the driver is located.
   - The driver's constructor should take the config struct by value, and it should return `Result<Self, ConfigError>`.
   - The `ConfigError` enum should be separate from other `Error` enums used by the driver.
   - The driver should implement `fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError>`.
   - In case the driver's configuration is infallible (all possible combinations of options are supported by the hardware), the `ConfigError` should be implemented as an empty `enum`.
   - Configuration structs should derive `procmacros::BuilderLite` in order to automatically implement the Builder Lite pattern for them.
-- If a driver only supports a single peripheral instance, no instance type parameter is necessary.
 - If a driver implements both blocking and async operations, or only implements blocking operations, but may support asynchronous ones in the future, the driver's type signature must include a `crate::Mode` type parameter.
 - By default, constructors must configure the driver for blocking mode. The driver must implement `into_async` (and a matching `into_blocking`) function that reconfigures the driver.
   - `into_async` must configure the driver and/or the associated DMA channels. This most often means enabling an interrupt handler.

--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -5,11 +5,11 @@ use esp_hal::{
     interrupt::{InterruptHandler, Priority},
     sync::Locked,
     time::{now, ExtU64},
-    timer::{AnyTimer, OneShotTimer},
+    timer::OneShotTimer,
     Blocking,
 };
 
-pub type Timer = OneShotTimer<'static, Blocking, AnyTimer>;
+pub type Timer = OneShotTimer<'static, Blocking>;
 
 enum AlarmState {
     Created(extern "C" fn()),

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -127,6 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `prelude` module has been removed (#2845)
 
+- Removed all peripheral instance type parameters and `new_typed` constructors (#2907)
+
 ## [0.22.0] - 2024-11-20
 
 ### Added

--- a/esp-hal/MIGRATING-0.22.md
+++ b/esp-hal/MIGRATING-0.22.md
@@ -262,6 +262,15 @@ is not compatible with the hardware.
 +.unwrap();
 ```
 
+## Peripheral instance type parameters and `new_typed` constructors have been removed
+
+Call `new` instead and remove the type parameters if you've used them.
+
+```diff
+-let mut spi: Spi<'lt, SPI2> = Spi::new_typed(..).unwrap();
++let mut spi: Spi<'lt> = Spi::new(..).unwrap();
+```
+
 ## LCD_CAM configuration changes
 
 - `cam` now has a `Config` strurct that contains frequency, bit/byte order, VSync filter options.

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1668,18 +1668,18 @@ impl<DEG: DmaChannel> DmaChannelConvert<DEG> for DEG {
 ///
 /// ```rust,no_run
 #[doc = crate::before_snippet!()]
+/// use esp_hal::spi::AnySpi;
 /// use esp_hal::spi::master::{Spi, SpiDma, Config, Instance as SpiInstance};
 /// use esp_hal::dma::DmaChannelFor;
 /// use esp_hal::peripheral::Peripheral;
 /// use esp_hal::Blocking;
 ///
-/// fn configures_spi_dma<'d, S, CH>(
-///     spi: Spi<'d, Blocking, S>,
+/// fn configures_spi_dma<'d, CH>(
+///     spi: Spi<'d, Blocking>,
 ///     channel: impl Peripheral<P = CH> + 'd,
-/// ) -> SpiDma<'d, Blocking, S>
+/// ) -> SpiDma<'d, Blocking>
 /// where
-///     S: SpiInstance,
-///     CH: DmaChannelFor<S> + 'd,
+///     CH: DmaChannelFor<AnySpi> + 'd,
 ///  {
 ///     spi.with_dma(channel)
 /// }

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -41,8 +41,8 @@ impl<P: InputPin> PeripheralInput for P {}
 impl<P: OutputPin> PeripheralOutput for P {}
 
 // Pin drivers
-impl<P: InputPin> PeripheralInput for Flex<'static, P> {}
-impl<P: OutputPin> PeripheralOutput for Flex<'static, P> {}
+impl PeripheralInput for Flex<'static> {}
+impl PeripheralOutput for Flex<'static> {}
 
 // Placeholders
 impl PeripheralInput for NoPin {}
@@ -226,11 +226,8 @@ where
     }
 }
 
-impl<P> From<Flex<'static, P>> for InputSignal
-where
-    P: InputPin,
-{
-    fn from(input: Flex<'static, P>) -> Self {
+impl From<Flex<'static>> for InputSignal {
+    fn from(input: Flex<'static>) -> Self {
         Self::new(input.degrade())
     }
 }
@@ -364,11 +361,8 @@ where
     }
 }
 
-impl<P> From<Flex<'static, P>> for OutputSignal
-where
-    P: OutputPin,
-{
-    fn from(input: Flex<'static, P>) -> Self {
+impl From<Flex<'static>> for OutputSignal {
+    fn from(input: Flex<'static>) -> Self {
         Self::new(input.degrade())
     }
 }
@@ -576,11 +570,8 @@ impl From<OutputConnection> for InputConnection {
     }
 }
 
-impl<P> From<Flex<'static, P>> for InputConnection
-where
-    P: InputPin,
-{
-    fn from(pin: Flex<'static, P>) -> Self {
+impl From<Flex<'static>> for InputConnection {
+    fn from(pin: Flex<'static>) -> Self {
         pin.peripheral_input().into()
     }
 }
@@ -668,11 +659,8 @@ impl From<OutputSignal> for OutputConnection {
     }
 }
 
-impl<P> From<Flex<'static, P>> for OutputConnection
-where
-    P: OutputPin,
-{
-    fn from(pin: Flex<'static, P>) -> Self {
+impl From<Flex<'static>> for OutputConnection {
+    fn from(pin: Flex<'static>) -> Self {
         pin.into_peripheral_output().into()
     }
 }

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -320,8 +320,8 @@ impl Default for Config {
 /// I2C driver
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct I2c<'d, Dm: DriverMode, T = AnyI2c> {
-    i2c: PeripheralRef<'d, T>,
+pub struct I2c<'d, Dm: DriverMode> {
+    i2c: PeripheralRef<'d, AnyI2c>,
     phantom: PhantomData<Dm>,
     config: Config,
     guard: PeripheralGuard,
@@ -329,7 +329,7 @@ pub struct I2c<'d, Dm: DriverMode, T = AnyI2c> {
 
 #[cfg(any(doc, feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-impl<T: Instance, Dm: DriverMode> SetConfig for I2c<'_, Dm, T> {
+impl<Dm: DriverMode> SetConfig for I2c<'_, Dm> {
     type Config = Config;
     type ConfigError = ConfigError;
 
@@ -338,14 +338,11 @@ impl<T: Instance, Dm: DriverMode> SetConfig for I2c<'_, Dm, T> {
     }
 }
 
-impl<T, Dm: DriverMode> embedded_hal::i2c::ErrorType for I2c<'_, Dm, T> {
+impl<Dm: DriverMode> embedded_hal::i2c::ErrorType for I2c<'_, Dm> {
     type Error = Error;
 }
 
-impl<T, Dm: DriverMode> embedded_hal::i2c::I2c for I2c<'_, Dm, T>
-where
-    T: Instance,
-{
+impl<Dm: DriverMode> embedded_hal::i2c::I2c for I2c<'_, Dm> {
     fn transaction(
         &mut self,
         address: u8,
@@ -356,10 +353,7 @@ where
     }
 }
 
-impl<'d, T, Dm: DriverMode> I2c<'d, Dm, T>
-where
-    T: Instance,
-{
+impl<'d, Dm: DriverMode> I2c<'d, Dm> {
     fn driver(&self) -> Driver<'_> {
         Driver {
             info: self.i2c.info(),
@@ -475,22 +469,7 @@ impl<'d> I2c<'d, Blocking> {
         i2c: impl Peripheral<P = impl Instance> + 'd,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        Self::new_typed(i2c.map_into(), config)
-    }
-}
-
-impl<'d, T> I2c<'d, Blocking, T>
-where
-    T: Instance,
-{
-    /// Create a new I2C instance
-    /// This will enable the peripheral but the peripheral won't get
-    /// automatically disabled when this gets dropped.
-    pub fn new_typed(
-        i2c: impl Peripheral<P = T> + 'd,
-        config: Config,
-    ) -> Result<Self, ConfigError> {
-        crate::into_ref!(i2c);
+        crate::into_mapped_ref!(i2c);
 
         let guard = PeripheralGuard::new(i2c.info().peripheral);
 
@@ -509,7 +488,7 @@ where
     // TODO: missing interrupt APIs
 
     /// Configures the I2C peripheral to operate in asynchronous mode.
-    pub fn into_async(mut self) -> I2c<'d, Async, T> {
+    pub fn into_async(mut self) -> I2c<'d, Async> {
         self.set_interrupt_handler(self.driver().info.async_handler);
 
         I2c {
@@ -581,12 +560,9 @@ where
     }
 }
 
-impl<T> private::Sealed for I2c<'_, Blocking, T> where T: Instance {}
+impl private::Sealed for I2c<'_, Blocking> {}
 
-impl<T> InterruptConfigurable for I2c<'_, Blocking, T>
-where
-    T: Instance,
-{
+impl InterruptConfigurable for I2c<'_, Blocking> {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         let interrupt = self.driver().info.interrupt;
         for core in Cpu::other() {
@@ -698,12 +674,9 @@ impl core::future::Future for I2cFuture<'_> {
     }
 }
 
-impl<'d, T> I2c<'d, Async, T>
-where
-    T: Instance,
-{
+impl<'d> I2c<'d, Async> {
     /// Configure the I2C peripheral to operate in blocking mode.
-    pub fn into_blocking(self) -> I2c<'d, Blocking, T> {
+    pub fn into_blocking(self) -> I2c<'d, Blocking> {
         crate::interrupt::disable(Cpu::current(), self.driver().info.interrupt);
 
         I2c {
@@ -832,10 +805,7 @@ where
     }
 }
 
-impl<T> embedded_hal_async::i2c::I2c for I2c<'_, Async, T>
-where
-    T: Instance,
-{
+impl embedded_hal_async::i2c::I2c for I2c<'_, Async> {
     async fn transaction(
         &mut self,
         address: u8,

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -90,7 +90,6 @@ use crate::{
         DmaTransferRxCircular,
         DmaTransferTx,
         DmaTransferTxCircular,
-        PeripheralDmaChannel,
         PeripheralRxChannel,
         PeripheralTxChannel,
         ReadBuffer,
@@ -251,67 +250,18 @@ impl DataFormat {
 
 /// Instance of the I2S peripheral driver
 #[non_exhaustive]
-pub struct I2s<'d, Dm, T = AnyI2s>
+pub struct I2s<'d, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     /// Handles the reception (RX) side of the I2S peripheral.
-    pub i2s_rx: RxCreator<'d, Dm, T>,
+    pub i2s_rx: RxCreator<'d, Dm>,
     /// Handles the transmission (TX) side of the I2S peripheral.
-    pub i2s_tx: TxCreator<'d, Dm, T>,
+    pub i2s_tx: TxCreator<'d, Dm>,
 }
 
-impl<'d, T> I2s<'d, Blocking, T>
+impl<Dm> I2s<'_, Dm>
 where
-    T: RegisterAccess,
-{
-    #[allow(clippy::too_many_arguments)]
-    fn new_internal(
-        i2s: PeripheralRef<'d, T>,
-        standard: Standard,
-        data_format: DataFormat,
-        sample_rate: impl Into<fugit::HertzU32>,
-        channel: PeripheralRef<'d, PeripheralDmaChannel<T>>,
-        rx_descriptors: &'static mut [DmaDescriptor],
-        tx_descriptors: &'static mut [DmaDescriptor],
-    ) -> Self {
-        let channel = Channel::new(channel);
-        channel.runtime_ensure_compatible(&i2s);
-        // on ESP32-C3 / ESP32-S3 and later RX and TX are independent and
-        // could be configured totally independently but for now handle all
-        // the targets the same and force same configuration for both, TX and RX
-
-        // make sure the peripheral is enabled before configuring it
-        let peripheral = i2s.peripheral();
-        let rx_guard = PeripheralGuard::new(peripheral);
-        let tx_guard = PeripheralGuard::new(peripheral);
-
-        i2s.set_clock(calculate_clock(sample_rate, 2, data_format.channel_bits()));
-        i2s.configure(&standard, &data_format);
-        i2s.set_master();
-        i2s.update();
-
-        Self {
-            i2s_rx: RxCreator {
-                i2s: unsafe { i2s.clone_unchecked() },
-                rx_channel: channel.rx,
-                descriptors: rx_descriptors,
-                guard: rx_guard,
-            },
-            i2s_tx: TxCreator {
-                i2s,
-                tx_channel: channel.tx,
-                descriptors: tx_descriptors,
-                guard: tx_guard,
-            },
-        }
-    }
-}
-
-impl<Dm, T> I2s<'_, Dm, T>
-where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     /// Sets the interrupt handler
@@ -347,16 +297,10 @@ where
     }
 }
 
-impl<Dm, I> crate::private::Sealed for I2s<'_, Dm, I>
-where
-    I: RegisterAccess,
-    Dm: DriverMode,
-{
-}
+impl<Dm> crate::private::Sealed for I2s<'_, Dm> where Dm: DriverMode {}
 
-impl<Dm, I> InterruptConfigurable for I2s<'_, Dm, I>
+impl<Dm> InterruptConfigurable for I2s<'_, Dm>
 where
-    I: RegisterAccess,
     Dm: DriverMode,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
@@ -380,51 +324,45 @@ impl<'d> I2s<'d, Blocking> {
     where
         CH: DmaChannelFor<AnyI2s>,
     {
-        Self::new_typed(
-            i2s.map_into(),
-            standard,
-            data_format,
-            sample_rate,
-            channel,
-            rx_descriptors,
-            tx_descriptors,
-        )
-    }
-}
-
-impl<'d, T> I2s<'d, Blocking, T>
-where
-    T: RegisterAccess,
-{
-    /// Construct a new I2S peripheral driver instance for the first I2S
-    /// peripheral
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_typed<CH>(
-        i2s: impl Peripheral<P = T> + 'd,
-        standard: Standard,
-        data_format: DataFormat,
-        sample_rate: impl Into<fugit::HertzU32>,
-        channel: impl Peripheral<P = CH> + 'd,
-        rx_descriptors: &'static mut [DmaDescriptor],
-        tx_descriptors: &'static mut [DmaDescriptor],
-    ) -> Self
-    where
-        CH: DmaChannelFor<T>,
-    {
         crate::into_ref!(i2s);
-        Self::new_internal(
-            i2s,
-            standard,
-            data_format,
-            sample_rate,
-            channel.map(|ch| ch.degrade()).into_ref(),
-            rx_descriptors,
-            tx_descriptors,
-        )
+
+        let channel = Channel::new(channel.map(|ch| ch.degrade()));
+        channel.runtime_ensure_compatible(&i2s);
+
+        // on ESP32-C3 / ESP32-S3 and later RX and TX are independent and
+        // could be configured totally independently but for now handle all
+        // the targets the same and force same configuration for both, TX and RX
+
+        // make sure the peripheral is enabled before configuring it
+        let peripheral = i2s.peripheral();
+        let rx_guard = PeripheralGuard::new(peripheral);
+        let tx_guard = PeripheralGuard::new(peripheral);
+
+        i2s.set_clock(calculate_clock(sample_rate, 2, data_format.channel_bits()));
+        i2s.configure(&standard, &data_format);
+        i2s.set_master();
+        i2s.update();
+
+        let i2s = i2s.map_into();
+
+        Self {
+            i2s_rx: RxCreator {
+                i2s: unsafe { i2s.clone_unchecked() },
+                rx_channel: channel.rx,
+                descriptors: rx_descriptors,
+                guard: rx_guard,
+            },
+            i2s_tx: TxCreator {
+                i2s,
+                tx_channel: channel.tx,
+                descriptors: tx_descriptors,
+                guard: tx_guard,
+            },
+        }
     }
 
     /// Converts the I2S instance into async mode.
-    pub fn into_async(self) -> I2s<'d, Async, T> {
+    pub fn into_async(self) -> I2s<'d, Async> {
         I2s {
             i2s_rx: RxCreator {
                 i2s: self.i2s_rx.i2s,
@@ -442,9 +380,8 @@ where
     }
 }
 
-impl<'d, Dm, T> I2s<'d, Dm, T>
+impl<'d, Dm> I2s<'d, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     /// Configures the I2S peripheral to use a master clock (MCLK) output pin.
@@ -458,20 +395,18 @@ where
 }
 
 /// I2S TX channel
-pub struct I2sTx<'d, Dm, T = AnyI2s>
+pub struct I2sTx<'d, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
-    i2s: PeripheralRef<'d, T>,
-    tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<T>>,
+    i2s: PeripheralRef<'d, AnyI2s>,
+    tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<AnyI2s>>,
     tx_chain: DescriptorChain,
     _guard: PeripheralGuard,
 }
 
-impl<Dm, T> core::fmt::Debug for I2sTx<'_, Dm, T>
+impl<Dm> core::fmt::Debug for I2sTx<'_, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -479,9 +414,8 @@ where
     }
 }
 
-impl<Dm, T> DmaSupport for I2sTx<'_, Dm, T>
+impl<Dm> DmaSupport for I2sTx<'_, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
@@ -493,12 +427,11 @@ where
     }
 }
 
-impl<'d, Dm, T> DmaSupportTx for I2sTx<'d, Dm, T>
+impl<'d, Dm> DmaSupportTx for I2sTx<'d, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
-    type TX = ChannelTx<'d, Dm, PeripheralTxChannel<T>>;
+    type TX = ChannelTx<'d, Dm, PeripheralTxChannel<AnyI2s>>;
 
     fn tx(&mut self) -> &mut Self::TX {
         &mut self.tx_channel
@@ -509,9 +442,8 @@ where
     }
 }
 
-impl<Dm, T> I2sTx<'_, Dm, T>
+impl<Dm> I2sTx<'_, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
@@ -591,20 +523,18 @@ where
 }
 
 /// I2S RX channel
-pub struct I2sRx<'d, Dm, T = AnyI2s>
+pub struct I2sRx<'d, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
-    i2s: PeripheralRef<'d, T>,
-    rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<T>>,
+    i2s: PeripheralRef<'d, AnyI2s>,
+    rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<AnyI2s>>,
     rx_chain: DescriptorChain,
     _guard: PeripheralGuard,
 }
 
-impl<Dm, T> core::fmt::Debug for I2sRx<'_, Dm, T>
+impl<Dm> core::fmt::Debug for I2sRx<'_, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -612,9 +542,8 @@ where
     }
 }
 
-impl<Dm, T> DmaSupport for I2sRx<'_, Dm, T>
+impl<Dm> DmaSupport for I2sRx<'_, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     fn peripheral_wait_dma(&mut self, _is_rx: bool, _is_tx: bool) {
@@ -626,12 +555,11 @@ where
     }
 }
 
-impl<'d, Dm, T> DmaSupportRx for I2sRx<'d, Dm, T>
+impl<'d, Dm> DmaSupportRx for I2sRx<'d, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
-    type RX = ChannelRx<'d, Dm, PeripheralRxChannel<T>>;
+    type RX = ChannelRx<'d, Dm, PeripheralRxChannel<AnyI2s>>;
 
     fn rx(&mut self) -> &mut Self::RX {
         &mut self.rx_channel
@@ -642,9 +570,8 @@ where
     }
 }
 
-impl<Dm, T> I2sRx<'_, Dm, T>
+impl<Dm> I2sRx<'_, Dm>
 where
-    T: RegisterAccess,
     Dm: DriverMode,
 {
     fn read_bytes(&mut self, mut data: &mut [u8]) -> Result<(), Error> {
@@ -761,23 +688,21 @@ mod private {
         DriverMode,
     };
 
-    pub struct TxCreator<'d, Dm, T>
+    pub struct TxCreator<'d, Dm>
     where
-        T: RegisterAccess,
         Dm: DriverMode,
     {
-        pub i2s: PeripheralRef<'d, T>,
-        pub tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<T>>,
+        pub i2s: PeripheralRef<'d, AnyI2s>,
+        pub tx_channel: ChannelTx<'d, Dm, PeripheralTxChannel<AnyI2s>>,
         pub descriptors: &'static mut [DmaDescriptor],
         pub(crate) guard: PeripheralGuard,
     }
 
-    impl<'d, Dm, T> TxCreator<'d, Dm, T>
+    impl<'d, Dm> TxCreator<'d, Dm>
     where
         Dm: DriverMode,
-        T: RegisterAccess,
     {
-        pub fn build(self) -> I2sTx<'d, Dm, T> {
+        pub fn build(self) -> I2sTx<'d, Dm> {
             let peripheral = self.i2s.peripheral();
             I2sTx {
                 i2s: self.i2s,
@@ -821,23 +746,21 @@ mod private {
         }
     }
 
-    pub struct RxCreator<'d, Dm, T>
+    pub struct RxCreator<'d, Dm>
     where
-        T: RegisterAccess,
         Dm: DriverMode,
     {
-        pub i2s: PeripheralRef<'d, T>,
-        pub rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<T>>,
+        pub i2s: PeripheralRef<'d, AnyI2s>,
+        pub rx_channel: ChannelRx<'d, Dm, PeripheralRxChannel<AnyI2s>>,
         pub descriptors: &'static mut [DmaDescriptor],
         pub(crate) guard: PeripheralGuard,
     }
 
-    impl<'d, Dm, T> RxCreator<'d, Dm, T>
+    impl<'d, Dm> RxCreator<'d, Dm>
     where
         Dm: DriverMode,
-        T: RegisterAccess,
     {
-        pub fn build(self) -> I2sRx<'d, Dm, T> {
+        pub fn build(self) -> I2sRx<'d, Dm> {
             let peripheral = self.i2s.peripheral();
             I2sRx {
                 i2s: self.i2s,
@@ -1876,10 +1799,11 @@ mod private {
 
 /// Async functionality
 pub mod asynch {
-    use super::{Error, I2sRx, I2sTx, RegisterAccess};
+    use super::{Error, I2sRx, I2sTx, RegisterAccessPrivate};
     use crate::{
         dma::{
             asynch::{DmaRxDoneChFuture, DmaRxFuture, DmaTxDoneChFuture, DmaTxFuture},
+            DmaEligible,
             ReadBuffer,
             Rx,
             RxCircularState,
@@ -1890,10 +1814,7 @@ pub mod asynch {
         Async,
     };
 
-    impl<'d, T> I2sTx<'d, Async, T>
-    where
-        T: RegisterAccess,
-    {
+    impl<'d> I2sTx<'d, Async> {
         /// One-shot write I2S.
         pub async fn write_dma_async(&mut self, words: &mut [u8]) -> Result<(), Error> {
             let (ptr, len) = (words.as_ptr(), words.len());
@@ -1920,7 +1841,7 @@ pub mod asynch {
         pub fn write_dma_circular_async<TXBUF: ReadBuffer>(
             mut self,
             words: TXBUF,
-        ) -> Result<I2sWriteDmaTransferAsync<'d, TXBUF, T>, Error> {
+        ) -> Result<I2sWriteDmaTransferAsync<'d, TXBUF>, Error> {
             let (ptr, len) = unsafe { words.read_buffer() };
 
             // Reset TX unit and TX FIFO
@@ -1951,19 +1872,13 @@ pub mod asynch {
     }
 
     /// An in-progress async circular DMA write transfer.
-    pub struct I2sWriteDmaTransferAsync<'d, BUFFER, T = super::AnyI2s>
-    where
-        T: RegisterAccess,
-    {
-        i2s_tx: I2sTx<'d, Async, T>,
+    pub struct I2sWriteDmaTransferAsync<'d, BUFFER> {
+        i2s_tx: I2sTx<'d, Async>,
         state: TxCircularState,
         _buffer: BUFFER,
     }
 
-    impl<T, BUFFER> I2sWriteDmaTransferAsync<'_, BUFFER, T>
-    where
-        T: RegisterAccess,
-    {
+    impl<BUFFER> I2sWriteDmaTransferAsync<'_, BUFFER> {
         /// How many bytes can be pushed into the DMA transaction.
         /// Will wait for more than 0 bytes available.
         pub async fn available(&mut self) -> Result<usize, Error> {
@@ -2000,10 +1915,7 @@ pub mod asynch {
         }
     }
 
-    impl<'d, T> I2sRx<'d, Async, T>
-    where
-        T: RegisterAccess,
-    {
+    impl<'d> I2sRx<'d, Async> {
         /// One-shot read I2S.
         pub async fn read_dma_async(&mut self, words: &mut [u8]) -> Result<(), Error> {
             let (ptr, len) = (words.as_mut_ptr(), words.len());
@@ -2038,7 +1950,7 @@ pub mod asynch {
         pub fn read_dma_circular_async<RXBUF>(
             mut self,
             mut words: RXBUF,
-        ) -> Result<I2sReadDmaTransferAsync<'d, RXBUF, T>, Error>
+        ) -> Result<I2sReadDmaTransferAsync<'d, RXBUF>, Error>
         where
             RXBUF: WriteBuffer,
         {
@@ -2074,19 +1986,13 @@ pub mod asynch {
     }
 
     /// An in-progress async circular DMA read transfer.
-    pub struct I2sReadDmaTransferAsync<'d, BUFFER, T = super::AnyI2s>
-    where
-        T: RegisterAccess,
-    {
-        i2s_rx: I2sRx<'d, Async, T>,
+    pub struct I2sReadDmaTransferAsync<'d, BUFFER> {
+        i2s_rx: I2sRx<'d, Async>,
         state: RxCircularState,
         _buffer: BUFFER,
     }
 
-    impl<T, BUFFER> I2sReadDmaTransferAsync<'_, BUFFER, T>
-    where
-        T: RegisterAccess,
-    {
+    impl<BUFFER> I2sReadDmaTransferAsync<'_, BUFFER> {
         /// How many bytes can be popped from the DMA transaction.
         /// Will wait for more than 0 bytes available.
         pub async fn available(&mut self) -> Result<usize, Error> {

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -119,33 +119,25 @@ pub trait Timer: Into<AnyTimer> + InterruptConfigurable + 'static + crate::priva
 }
 
 /// A one-shot timer.
-pub struct OneShotTimer<'d, Dm, T = AnyTimer> {
-    inner: PeripheralRef<'d, T>,
+pub struct OneShotTimer<'d, Dm> {
+    inner: PeripheralRef<'d, AnyTimer>,
     _ph: PhantomData<Dm>,
 }
 
 impl<'d> OneShotTimer<'d, Blocking> {
     /// Construct a new instance of [`OneShotTimer`].
     pub fn new(inner: impl Peripheral<P = impl Timer> + 'd) -> OneShotTimer<'d, Blocking> {
-        Self::new_typed(inner.map_into())
-    }
-}
-
-impl<'d, T> OneShotTimer<'d, Blocking, T>
-where
-    T: Timer,
-{
-    /// Construct a typed instance of [`OneShotTimer`].
-    pub fn new_typed(inner: impl Peripheral<P = T> + 'd) -> Self {
-        crate::into_ref!(inner);
+        crate::into_mapped_ref!(inner);
         Self {
             inner,
             _ph: PhantomData,
         }
     }
+}
 
+impl<'d> OneShotTimer<'d, Blocking> {
     /// Converts the driver to [`Async`] mode.
-    pub fn into_async(mut self) -> OneShotTimer<'d, Async, T> {
+    pub fn into_async(mut self) -> OneShotTimer<'d, Async> {
         let handler = self.inner.async_interrupt_handler();
         self.inner.set_interrupt_handler(handler);
         OneShotTimer {
@@ -155,10 +147,7 @@ where
     }
 }
 
-impl<T> OneShotTimer<'_, Async, T>
-where
-    T: Timer,
-{
+impl OneShotTimer<'_, Async> {
     /// Converts the driver to [`Blocking`] mode.
     pub fn into_blocking(self) -> Self {
         crate::interrupt::disable(Cpu::current(), self.inner.peripheral_interrupt());
@@ -167,12 +156,7 @@ where
             _ph: PhantomData,
         }
     }
-}
 
-impl<T> OneShotTimer<'_, Async, T>
-where
-    T: Timer,
-{
     /// Delay for *at least* `ns` nanoseconds.
     pub async fn delay_nanos_async(&mut self, ns: u32) {
         self.delay_async(MicrosDurationU64::from_ticks(ns.div_ceil(1000) as u64))
@@ -197,10 +181,9 @@ where
     }
 }
 
-impl<Dm, T> OneShotTimer<'_, Dm, T>
+impl<Dm> OneShotTimer<'_, Dm>
 where
     Dm: DriverMode,
-    T: Timer,
 {
     /// Delay for *at least* `ms` milliseconds.
     pub fn delay_millis(&mut self, ms: u32) {
@@ -267,61 +250,39 @@ where
     }
 }
 
-impl<Dm, T> crate::private::Sealed for OneShotTimer<'_, Dm, T>
-where
-    T: Timer,
-    Dm: DriverMode,
-{
-}
+impl<Dm> crate::private::Sealed for OneShotTimer<'_, Dm> where Dm: DriverMode {}
 
-impl<Dm, T> InterruptConfigurable for OneShotTimer<'_, Dm, T>
+impl<Dm> InterruptConfigurable for OneShotTimer<'_, Dm>
 where
     Dm: DriverMode,
-    T: Timer,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         OneShotTimer::set_interrupt_handler(self, handler);
     }
 }
 
-impl<T> embedded_hal::delay::DelayNs for OneShotTimer<'_, Blocking, T>
-where
-    T: Timer,
-{
+impl embedded_hal::delay::DelayNs for OneShotTimer<'_, Blocking> {
     fn delay_ns(&mut self, ns: u32) {
         self.delay_nanos(ns);
     }
 }
 
-impl<T> embedded_hal_async::delay::DelayNs for OneShotTimer<'_, Async, T>
-where
-    T: Timer,
-{
+impl embedded_hal_async::delay::DelayNs for OneShotTimer<'_, Async> {
     async fn delay_ns(&mut self, ns: u32) {
         self.delay_nanos_async(ns).await
     }
 }
 
 /// A periodic timer.
-pub struct PeriodicTimer<'d, Dm, T = AnyTimer> {
-    inner: PeripheralRef<'d, T>,
+pub struct PeriodicTimer<'d, Dm> {
+    inner: PeripheralRef<'d, AnyTimer>,
     _ph: PhantomData<Dm>,
 }
 
 impl<'d> PeriodicTimer<'d, Blocking> {
     /// Construct a new instance of [`PeriodicTimer`].
     pub fn new(inner: impl Peripheral<P = impl Timer> + 'd) -> PeriodicTimer<'d, Blocking> {
-        Self::new_typed(inner.map_into())
-    }
-}
-
-impl<'d, T> PeriodicTimer<'d, Blocking, T>
-where
-    T: Timer,
-{
-    /// Construct a typed instance of [`PeriodicTimer`].
-    pub fn new_typed(inner: impl Peripheral<P = T> + 'd) -> Self {
-        crate::into_ref!(inner);
+        crate::into_mapped_ref!(inner);
         Self {
             inner,
             _ph: PhantomData,
@@ -329,10 +290,9 @@ where
     }
 }
 
-impl<Dm, T> PeriodicTimer<'_, Dm, T>
+impl<Dm> PeriodicTimer<'_, Dm>
 where
     Dm: DriverMode,
-    T: Timer,
 {
     /// Start a new count down.
     pub fn start(&mut self, timeout: MicrosDurationU64) -> Result<(), Error> {
@@ -390,12 +350,11 @@ where
     }
 }
 
-impl<Dm, T> crate::private::Sealed for PeriodicTimer<'_, Dm, T> where T: Timer {}
+impl<Dm> crate::private::Sealed for PeriodicTimer<'_, Dm> {}
 
-impl<Dm, T> InterruptConfigurable for PeriodicTimer<'_, Dm, T>
+impl<Dm> InterruptConfigurable for PeriodicTimer<'_, Dm>
 where
     Dm: DriverMode,
-    T: Timer,
 {
     fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
         PeriodicTimer::set_interrupt_handler(self, handler);

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -234,7 +234,7 @@ const _: () = {
     core::assert!(CONFIG.rx_ba_win < (CONFIG.static_rx_buf_num * 2), "WiFi configuration check: rx_ba_win should not be larger than double of the static_rx_buf_num!");
 };
 
-type TimeBase = PeriodicTimer<'static, Blocking, AnyTimer>;
+type TimeBase = PeriodicTimer<'static, Blocking>;
 
 pub(crate) mod flags {
     use portable_atomic::{AtomicBool, AtomicUsize};

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -64,7 +64,7 @@ mod test_cases {
     }
 
     pub fn run_test_periodic_timer<T: esp_hal::timer::Timer>(timer: impl Peripheral<P = T>) {
-        let mut periodic = PeriodicTimer::new_typed(timer);
+        let mut periodic = PeriodicTimer::new(timer);
 
         let t1 = esp_hal::time::now();
         periodic.start(100.millis()).unwrap();
@@ -81,7 +81,7 @@ mod test_cases {
     }
 
     pub fn run_test_oneshot_timer<T: esp_hal::timer::Timer>(timer: impl Peripheral<P = T>) {
-        let mut timer = OneShotTimer::new_typed(timer);
+        let mut timer = OneShotTimer::new(timer);
 
         let t1 = esp_hal::time::now();
         timer.delay_millis(50);

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -14,7 +14,6 @@ use esp_hal::{
     dma::{DmaDescriptor, DmaRxBuf, DmaTxBuf},
     dma_buffers,
     gpio::{Level, NoPin},
-    peripheral::Peripheral,
     spi::master::{Config, Spi},
     time::RateExtU32,
     Blocking,

--- a/qa-test/src/bin/lcd_cam_ov2640.rs
+++ b/qa-test/src/bin/lcd_cam_ov2640.rs
@@ -167,15 +167,12 @@ fn main() -> ! {
 
 pub const OV2640_ADDRESS: u8 = 0x30;
 
-pub struct Sccb<'d, T> {
-    i2c: I2c<'d, Blocking, T>,
+pub struct Sccb<'d> {
+    i2c: I2c<'d, Blocking>,
 }
 
-impl<'d, T> Sccb<'d, T>
-where
-    T: i2c::master::Instance,
-{
-    pub fn new(i2c: I2c<'d, Blocking, T>) -> Self {
+impl<'d> Sccb<'d> {
+    pub fn new(i2c: I2c<'d, Blocking>) -> Self {
         Self { i2c }
     }
 


### PR DESCRIPTION
Closes #2572

Skip-changelog applied because wifi/embassy previously spelled out AnyTimer.