### PR TITLE
Document that UART TX should be set up first

### DIFF
--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -830,6 +830,11 @@ where
     /// Assign the RX pin for UART instance.
     ///
     /// Sets the specified pin to input and connects it to the UART RX signal.
+    ///
+    /// Note: when you listen for the output of the UART peripheral, you should
+    /// configure the driver side (i.e. the TX pin), or ensure that the line is
+    /// initially high, to avoid receiving a non-data byte caused by an
+    /// initial low signal level.
     pub fn with_rx(self, rx: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(rx);
         rx.init_input(Pull::Up, Internal);
@@ -1046,6 +1051,11 @@ where
     /// Assign the RX pin for UART instance.
     ///
     /// Sets the specified pin to input and connects it to the UART RX signal.
+    ///
+    /// Note: when you listen for the output of the UART peripheral, you should
+    /// configure the driver side (i.e. the TX pin), or ensure that the line is
+    /// initially high, to avoid receiving a non-data byte caused by an
+    /// initial low signal level.
     pub fn with_rx(self, rx: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(rx);
         rx.init_input(Pull::Up, Internal);

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -26,9 +26,7 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let (_, pin) = hil_test::common_test_pins!(peripherals);
-
-        let (rx, tx) = pin.split();
+        let (rx, tx) = hil_test::common_test_pins!(peripherals);
 
         let uart = Uart::new(peripherals.UART1, uart::Config::default())
             .unwrap()


### PR DESCRIPTION
Resolves #2911 by changing the documentation.

The issue is caused by the loopback setup in our tests. When you connect RX, but the pin is not configured, there is a possibility that the pin has a low level for some time (which we try to counteract with a pullup resistor). This may cause the UART peripheral to register a start condition, and receive a byte - which, because we connect TX immediately, and set it to high, will be a `0xFF`. The hardware doesn't seem to notice that the start bit is too short.

When we set TX first, we set a high level on the pin, and then the peripheral does not misdetect a start bit on the subsequent RX configuration.

[ESP-IDF](https://github.com/espressif/esp-idf/blob/b5ac4fbdf9e9fb320bb0a98ee4fbaa18f8566f37/components/esp_driver_uart/src/uart.c#L757-L760) sets the pins together, TX-first, likely because of this same phenomenon.

This issue really only affects cases where the ESP32 listens to its own output, and the line is only driven by the ESP32. In other cases, the RX line's level should be determined by an external device and so we can't say what causes a low signal level - communication, break, or some other cause.

As the order of the pin setup is set by the user, the pins may be configured mid-operation and I can't really find a way to stop receiving a byte anyway, I'm not sure what else we can do other than document that the user should be careful when listening to their own output.