### PR TITLE
Support 3-wire-SPI

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- SPI: Added support for 3-wire SPI (#2919)
 
 ### Changed
 - RMT: `TxChannelConfig` and `RxChannelConfig` now support the builder-lite pattern (#2978)
@@ -85,7 +86,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S2: Made Wi-Fi peripheral non virtual. (#2942)
 - `UartRx::check_for_errors`, `Uart::check_for_rx_errors`, `{Uart, UartRx}::read_buffered_bytes` (#2935)
 - Added `i2c` interrupt API (#2944)
-- SPI: Added support for 3-wire SPI (#2919)
 
 ### Changed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S2: Made Wi-Fi peripheral non virtual. (#2942)
 - `UartRx::check_for_errors`, `Uart::check_for_rx_errors`, `{Uart, UartRx}::read_buffered_bytes` (#2935)
 - Added `i2c` interrupt API (#2944)
+- SPI: Added support for 3-wire SPI (#2919)
 
 ### Changed
 

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -93,3 +93,14 @@ periodic.start(100.millis()).unwrap();
 - nb::block!(periodic.wait()).unwrap();
 + periodic.wait();
 ```
+
+## SPI Changes
+
+`spi::DataMode` changed the meaning of `DataMode::Single` - it now means 3-wire SPI. Use `DataMode::FourWire` to get the previous behavior.
+
+```diff
+- DataMode::Single,
++ DataMode::FourWire,
+```
+
+`Spi` now offers both, `with_mosi` and `with_sio0`. Consider using `with_sio` for half-duplex SPI except for [DataMode::FourWire] or for a mixed-bus.

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -96,11 +96,13 @@ periodic.start(100.millis()).unwrap();
 
 ## SPI Changes
 
-`spi::DataMode` changed the meaning of `DataMode::Single` - it now means 3-wire SPI. Use `DataMode::FourWire` to get the previous behavior.
+`spi::DataMode` changed the meaning of `DataMode::Single` - it now means 3-wire SPI (using one data line).
+
+Use `DataMode::SingleTwoDataLines` to get the previous behavior.
 
 ```diff
 - DataMode::Single,
-+ DataMode::FourWire,
++ DataMode::SingleTwoDataLines,
 ```
 
-`Spi` now offers both, `with_mosi` and `with_sio0`. Consider using `with_sio` for half-duplex SPI except for [DataMode::FourWire] or for a mixed-bus.
+`Spi` now offers both, `with_mosi` and `with_sio0`. Consider using `with_sio` for half-duplex SPI except for [DataMode::SingleTwoDataLines] or for a mixed-bus.

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -643,7 +643,7 @@ where
     /// You want to use this for full-duplex SPI or [DataMode::Single]
     pub fn with_mosi<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
-        mosi.enable_output(false, private::Internal);
+        mosi.enable_output(false);
 
         self.driver().info.mosi.connect_to(&mut mosi);
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2602,13 +2602,14 @@ impl Driver {
     ) -> Result<(), Error> {
         let reg_block = self.register_block();
         match cmd_mode {
+            DataMode::Single => (),
             DataMode::SingleTwoDataLines => (),
             // FIXME: more detailed error - Only 1-bit commands are supported.
             _ => return Err(Error::Unsupported),
         }
 
         match address_mode {
-            DataMode::SingleTwoDataLines => {
+            DataMode::Single | DataMode::SingleTwoDataLines => {
                 reg_block.ctrl().modify(|_, w| {
                     w.fread_dio().clear_bit();
                     w.fread_qio().clear_bit();

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -662,6 +662,7 @@ where
     /// The pin is configured to open-drain mode.
     ///
     /// Note: You do not need to call [Self::with_mosi] when this is used.
+    #[instability::unstable]
     pub fn with_sio0<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
         mosi.enable_output(true);
@@ -699,6 +700,7 @@ where
     /// The pin is configured to open-drain mode.
     ///
     /// Note: You do not need to call [Self::with_miso] when this is used.
+    #[instability::unstable]
     pub fn with_sio1<SIO1: PeripheralOutput>(self, miso: impl Peripheral<P = SIO1> + 'd) -> Self {
         crate::into_mapped_ref!(miso);
         miso.enable_input(true);

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -216,7 +216,7 @@ impl Command {
 
     fn mode(&self) -> DataMode {
         match self {
-            Command::None => DataMode::FourWire,
+            Command::None => DataMode::SingleTwoDataLines,
             Command::_1Bit(_, mode)
             | Command::_2Bit(_, mode)
             | Command::_3Bit(_, mode)
@@ -401,7 +401,7 @@ impl Address {
 
     fn mode(&self) -> DataMode {
         match self {
-            Address::None => DataMode::FourWire,
+            Address::None => DataMode::SingleTwoDataLines,
             Address::_1Bit(_, mode)
             | Address::_2Bit(_, mode)
             | Address::_3Bit(_, mode)
@@ -640,7 +640,8 @@ where
     /// Assign the MOSI (Master Out Slave In) pin for the SPI instance.
     ///
     /// Enables output functionality for the pin, and connects it to the MOSI.
-    /// You want to use this for full-duplex SPI or [DataMode::FourWire]
+    /// You want to use this for full-duplex SPI or
+    /// [DataMode::SingleTwoDataLines]
     pub fn with_mosi<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
         mosi.enable_output(false);
@@ -654,8 +655,8 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MOSI signal and SIO0 input signal.
-    /// Use this for half-duplex SPI except for [DataMode::FourWire]. The pin is
-    /// configured to open-drain mode.
+    /// Use this for half-duplex SPI except for [DataMode::SingleTwoDataLines].
+    /// The pin is configured to open-drain mode.
     pub fn with_sio0<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
         mosi.enable_output(true);
@@ -671,7 +672,8 @@ where
     ///
     /// Enables input functionality for the pin, and connects it to the MISO
     /// signal.
-    /// You want to use this for full-duplex SPI or [DataMode::FourWire]
+    /// You want to use this for full-duplex SPI or
+    /// [DataMode::SingleTwoDataLines]
     pub fn with_miso<MISO: PeripheralInput>(self, miso: impl Peripheral<P = MISO> + 'd) -> Self {
         crate::into_mapped_ref!(miso);
         miso.enable_input(true);
@@ -685,8 +687,8 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MISO signal and SIO1 input signal.
-    /// Use this for half-duplex SPI except for [DataMode::FourWire]. The pin is
-    /// configured to open-drain mode.
+    /// Use this for half-duplex SPI except for [DataMode::SingleTwoDataLines].
+    /// The pin is configured to open-drain mode.
     ///
     /// Note: You do not need to call [Self::with_miso] when this is used.
     pub fn with_sio1<SIO1: PeripheralOutput>(self, miso: impl Peripheral<P = SIO1> + 'd) -> Self {
@@ -1543,7 +1545,7 @@ mod dma {
             {
                 // On the ESP32, if we don't have data, the address is always sent
                 // on a single line, regardless of its data mode.
-                if bytes_to_write == 0 && address.mode() != DataMode::FourWire {
+                if bytes_to_write == 0 && address.mode() != DataMode::SingleTwoDataLines {
                     return self.set_up_address_workaround(cmd, address, dummy);
                 }
             }
@@ -2592,13 +2594,13 @@ impl Driver {
     ) -> Result<(), Error> {
         let reg_block = self.register_block();
         match cmd_mode {
-            DataMode::FourWire => (),
+            DataMode::SingleTwoDataLines => (),
             // FIXME: more detailed error - Only 1-bit commands are supported.
             _ => return Err(Error::Unsupported),
         }
 
         match address_mode {
-            DataMode::FourWire => {
+            DataMode::SingleTwoDataLines => {
                 reg_block.ctrl().modify(|_, w| {
                     w.fread_dio().clear_bit();
                     w.fread_qio().clear_bit();

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -216,7 +216,7 @@ impl Command {
 
     fn mode(&self) -> DataMode {
         match self {
-            Command::None => DataMode::Single,
+            Command::None => DataMode::FourWire,
             Command::_1Bit(_, mode)
             | Command::_2Bit(_, mode)
             | Command::_3Bit(_, mode)
@@ -401,7 +401,7 @@ impl Address {
 
     fn mode(&self) -> DataMode {
         match self {
-            Address::None => DataMode::Single,
+            Address::None => DataMode::FourWire,
             Address::_1Bit(_, mode)
             | Address::_2Bit(_, mode)
             | Address::_3Bit(_, mode)
@@ -640,7 +640,7 @@ where
     /// Assign the MOSI (Master Out Slave In) pin for the SPI instance.
     ///
     /// Enables output functionality for the pin, and connects it to the MOSI.
-    /// You want to use this for full-duplex SPI or [DataMode::Single]
+    /// You want to use this for full-duplex SPI or [DataMode::FourWire]
     pub fn with_mosi<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
         mosi.enable_output(false);
@@ -654,7 +654,8 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MOSI signal and SIO0 input signal.
-    /// Use this for half-duplex SPI except for [DataMode::Single]
+    /// Use this for half-duplex SPI except for [DataMode::FourWire]. The pin is
+    /// configured to open-drain mode.
     pub fn with_sio0<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
         mosi.enable_output(true);
@@ -670,7 +671,7 @@ where
     ///
     /// Enables input functionality for the pin, and connects it to the MISO
     /// signal.
-    /// You want to use this for full-duplex SPI or [DataMode::Single]
+    /// You want to use this for full-duplex SPI or [DataMode::FourWire]
     pub fn with_miso<MISO: PeripheralInput>(self, miso: impl Peripheral<P = MISO> + 'd) -> Self {
         crate::into_mapped_ref!(miso);
         miso.enable_input(true);
@@ -684,7 +685,8 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MISO signal and SIO1 input signal.
-    /// Use this for half-duplex SPI except for [DataMode::Single
+    /// Use this for half-duplex SPI except for [DataMode::FourWire]. The pin is
+    /// configured to open-drain mode.
     ///
     /// Note: You do not need to call [Self::with_miso] when this is used.
     pub fn with_sio1<SIO1: PeripheralOutput>(self, miso: impl Peripheral<P = SIO1> + 'd) -> Self {
@@ -1541,7 +1543,7 @@ mod dma {
             {
                 // On the ESP32, if we don't have data, the address is always sent
                 // on a single line, regardless of its data mode.
-                if bytes_to_write == 0 && address.mode() != DataMode::Single {
+                if bytes_to_write == 0 && address.mode() != DataMode::FourWire {
                     return self.set_up_address_workaround(cmd, address, dummy);
                 }
             }
@@ -2590,13 +2592,13 @@ impl Driver {
     ) -> Result<(), Error> {
         let reg_block = self.register_block();
         match cmd_mode {
-            DataMode::Single => (),
+            DataMode::FourWire => (),
             // FIXME: more detailed error - Only 1-bit commands are supported.
             _ => return Err(Error::Unsupported),
         }
 
         match address_mode {
-            DataMode::Single => {
+            DataMode::FourWire => {
                 reg_block.ctrl().modify(|_, w| {
                     w.fread_dio().clear_bit();
                     w.fread_qio().clear_bit();
@@ -3114,14 +3116,14 @@ impl Driver {
         no_mosi_miso: bool,
         data_mode: DataMode,
     ) -> Result<(), Error> {
-        let three_wire = cmd.mode() == DataMode::SingleThreeWire
-            || address.mode() == DataMode::SingleThreeWire
-            || data_mode == DataMode::SingleThreeWire;
+        let three_wire = cmd.mode() == DataMode::Single
+            || address.mode() == DataMode::Single
+            || data_mode == DataMode::Single;
 
         if three_wire
-            && ((cmd != Command::None && cmd.mode() != DataMode::SingleThreeWire)
-                || (address != Address::None && address.mode() != DataMode::SingleThreeWire)
-                || data_mode != DataMode::SingleThreeWire)
+            && ((cmd != Command::None && cmd.mode() != DataMode::Single)
+                || (address != Address::None && address.mode() != DataMode::Single)
+                || data_mode != DataMode::Single)
         {
             return Err(Error::Unsupported);
         }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -640,6 +640,7 @@ where
     /// Assign the MOSI (Master Out Slave In) pin for the SPI instance.
     ///
     /// Enables output functionality for the pin, and connects it to the MOSI.
+    ///
     /// You want to use this for full-duplex SPI or
     /// [DataMode::SingleTwoDataLines]
     pub fn with_mosi<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
@@ -655,8 +656,12 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MOSI signal and SIO0 input signal.
-    /// Use this for half-duplex SPI except for [DataMode::SingleTwoDataLines].
+    ///
+    /// Use this if any of the devices on the bus use half-duplex SPI.
+    ///
     /// The pin is configured to open-drain mode.
+    ///
+    /// Note: You do not need to call [Self::with_mosi] when this is used.
     pub fn with_sio0<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
         mosi.enable_output(true);
@@ -672,6 +677,7 @@ where
     ///
     /// Enables input functionality for the pin, and connects it to the MISO
     /// signal.
+    ///
     /// You want to use this for full-duplex SPI or
     /// [DataMode::SingleTwoDataLines]
     pub fn with_miso<MISO: PeripheralInput>(self, miso: impl Peripheral<P = MISO> + 'd) -> Self {
@@ -687,7 +693,9 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MISO signal and SIO1 input signal.
-    /// Use this for half-duplex SPI except for [DataMode::SingleTwoDataLines].
+    ///
+    /// Use this if any of the devices on the bus use half-duplex SPI.
+    ///
     /// The pin is configured to open-drain mode.
     ///
     /// Note: You do not need to call [Self::with_miso] when this is used.

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -640,6 +640,7 @@ where
     /// Assign the MOSI (Master Out Slave In) pin for the SPI instance.
     ///
     /// Enables output functionality for the pin, and connects it to the MOSI.
+    /// You want to use this for full-duplex SPI or [DataMode::Single]
     pub fn with_mosi<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
         mosi.enable_output(false, private::Internal);
@@ -653,6 +654,7 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MOSI signal and SIO0 input signal.
+    /// Use this for half-duplex SPI except for [DataMode::Single]
     pub fn with_sio0<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
         mosi.enable_output(true);
@@ -668,6 +670,7 @@ where
     ///
     /// Enables input functionality for the pin, and connects it to the MISO
     /// signal.
+    /// You want to use this for full-duplex SPI or [DataMode::Single]
     pub fn with_miso<MISO: PeripheralInput>(self, miso: impl Peripheral<P = MISO> + 'd) -> Self {
         crate::into_mapped_ref!(miso);
         miso.enable_input(true);
@@ -681,6 +684,7 @@ where
     ///
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MISO signal and SIO1 input signal.
+    /// Use this for half-duplex SPI except for [DataMode::Single
     ///
     /// Note: You do not need to call [Self::with_miso] when this is used.
     pub fn with_sio1<SIO1: PeripheralOutput>(self, miso: impl Peripheral<P = SIO1> + 'd) -> Self {
@@ -3119,7 +3123,7 @@ impl Driver {
                 || (address != Address::None && address.mode() != DataMode::SingleThreeWire)
                 || data_mode != DataMode::SingleThreeWire)
         {
-            return Err(Error::ArgumentsInvalid);
+            return Err(Error::Unsupported);
         }
 
         self.init_spi_data_mode(cmd.mode(), address.mode(), data_mode)?;

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -33,10 +33,8 @@ pub enum Error {
     /// communication.
     FifoSizeExeeded,
     /// Error indicating that the operation is unsupported by the current
-    /// implementation.
+    /// implementation or for the given arguments.
     Unsupported,
-    /// The given arguments are invalid.
-    ArgumentsInvalid,
     /// An unknown error occurred during SPI communication.
     Unknown,
 }

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -98,9 +98,9 @@ pub enum BitOrder {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub enum DataMode {
-    /// Clock, CS and one data line (SIO0)
-    SingleThreeWire,
-    /// `Single` Data Mode - 1 bit, two data lines. (SIO0, SIO1)
+    /// 4-Wire Data Mode - 1 bit, two data lines. (MOSI, MISO)
+    FourWire,
+    /// 3-Wire Data Mode, Clock, CS and one data line (SIO0)
     Single,
     /// `Dual` Data Mode - 2 bits, two data lines. (SIO0, SIO1)
     Dual,

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -98,16 +98,16 @@ pub enum BitOrder {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub enum DataMode {
-    /// 4-Wire Data Mode - 1 bit, two data lines. (MOSI, MISO)
-    FourWire,
-    /// 3-Wire Data Mode, Clock, CS and one data line (SIO0)
+    /// 1 bit, two data lines. (MOSI, MISO)
+    SingleTwoDataLines,
+    /// 1 bit, 1 data line (SIO0)
     Single,
-    /// `Dual` Data Mode - 2 bits, two data lines. (SIO0, SIO1)
+    /// 2 bits, two data lines. (SIO0, SIO1)
     Dual,
-    /// `Quad` Data Mode - 4 bit, 4 data lines. (SIO0 .. SIO3)
+    /// 4 bit, 4 data lines. (SIO0 .. SIO3)
     Quad,
     #[cfg(spi_octal)]
-    /// `Octal` Data Mode - 8 bit, 8 data lines. (SIO0 .. SIO7)
+    /// 8 bit, 8 data lines. (SIO0 .. SIO7)
     Octal,
 }
 

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -35,6 +35,8 @@ pub enum Error {
     /// Error indicating that the operation is unsupported by the current
     /// implementation.
     Unsupported,
+    /// The given arguments are invalid.
+    ArgumentsInvalid,
     /// An unknown error occurred during SPI communication.
     Unknown,
 }
@@ -98,14 +100,16 @@ pub enum BitOrder {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub enum DataMode {
-    /// `Single` Data Mode - 1 bit, 2 wires.
+    /// Clock, CS and one data line (SIO0)
+    SingleThreeWire,
+    /// `Single` Data Mode - 1 bit, two data lines. (SIO0, SIO1)
     Single,
-    /// `Dual` Data Mode - 2 bit, 2 wires
+    /// `Dual` Data Mode - 2 bits, two data lines. (SIO0, SIO1)
     Dual,
-    /// `Quad` Data Mode - 4 bit, 4 wires
+    /// `Quad` Data Mode - 4 bit, 4 data lines. (SIO0 .. SIO3)
     Quad,
     #[cfg(spi_octal)]
-    /// `Octal` Data Mode - 8 bit, 8 wires
+    /// `Octal` Data Mode - 8 bit, 8 data lines. (SIO0 .. SIO7)
     Octal,
 }
 

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -32,9 +32,9 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(esp32)] {
-        const COMMAND_DATA_MODES: [DataMode; 1] = [DataMode::Single];
+        const COMMAND_DATA_MODES: [DataMode; 1] = [DataMode::FourWire];
     } else {
-        const COMMAND_DATA_MODES: [DataMode; 2] = [DataMode::Single, DataMode::Quad];
+        const COMMAND_DATA_MODES: [DataMode; 2] = [DataMode::FourWire, DataMode::Quad];
     }
 }
 
@@ -155,7 +155,7 @@ fn execute_write(
         assert_eq!(unit0.value() + unit1.value(), 8);
 
         if data_on_multiple_pins {
-            if command_data_mode == DataMode::Single {
+            if command_data_mode == DataMode::FourWire {
                 assert_eq!(unit0.value(), 1);
                 assert_eq!(unit1.value(), 7);
             } else {
@@ -173,7 +173,7 @@ fn execute_write(
         assert_eq!(unit0.value() + unit1.value(), 4);
 
         if data_on_multiple_pins {
-            if command_data_mode == DataMode::Single {
+            if command_data_mode == DataMode::FourWire {
                 assert_eq!(unit0.value(), 1);
                 assert_eq!(unit1.value(), 3);
             } else {

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -32,9 +32,9 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(esp32)] {
-        const COMMAND_DATA_MODES: [DataMode; 1] = [DataMode::FourWire];
+        const COMMAND_DATA_MODES: [DataMode; 1] = [DataMode::SingleTwoDataLines];
     } else {
-        const COMMAND_DATA_MODES: [DataMode; 2] = [DataMode::FourWire, DataMode::Quad];
+        const COMMAND_DATA_MODES: [DataMode; 2] = [DataMode::SingleTwoDataLines, DataMode::Quad];
     }
 }
 
@@ -155,7 +155,7 @@ fn execute_write(
         assert_eq!(unit0.value() + unit1.value(), 8);
 
         if data_on_multiple_pins {
-            if command_data_mode == DataMode::FourWire {
+            if command_data_mode == DataMode::SingleTwoDataLines {
                 assert_eq!(unit0.value(), 1);
                 assert_eq!(unit1.value(), 7);
             } else {
@@ -173,7 +173,7 @@ fn execute_write(
         assert_eq!(unit0.value() + unit1.value(), 4);
 
         if data_on_multiple_pins {
-            if command_data_mode == DataMode::FourWire {
+            if command_data_mode == DataMode::SingleTwoDataLines {
                 assert_eq!(unit0.value(), 1);
                 assert_eq!(unit1.value(), 3);
             } else {

--- a/hil-test/tests/qspi.rs
+++ b/hil-test/tests/qspi.rs
@@ -231,7 +231,7 @@ mod tests {
         let [pin, pin_mirror, _] = ctx.gpios;
         let pin_mirror = Output::new(pin_mirror, Level::High);
 
-        let spi = ctx.spi.with_mosi(pin).with_dma(ctx.dma_channel);
+        let spi = ctx.spi.with_sio0(pin).with_dma(ctx.dma_channel);
 
         super::execute_read(spi, pin_mirror, 0b0001_0001);
     }
@@ -241,7 +241,7 @@ mod tests {
         let [pin, pin_mirror, _] = ctx.gpios;
         let pin_mirror = Output::new(pin_mirror, Level::High);
 
-        let spi = ctx.spi.with_miso(pin).with_dma(ctx.dma_channel);
+        let spi = ctx.spi.with_sio1(pin).with_dma(ctx.dma_channel);
 
         super::execute_read(spi, pin_mirror, 0b0010_0010);
     }
@@ -271,7 +271,7 @@ mod tests {
         let [pin, pin_mirror, _] = ctx.gpios;
         let pin_mirror = Output::new(pin_mirror, Level::High);
 
-        let spi = ctx.spi.with_mosi(pin).with_dma(ctx.dma_channel);
+        let spi = ctx.spi.with_sio0(pin).with_dma(ctx.dma_channel);
 
         super::execute_write_read(spi, pin_mirror, 0b0001_0001);
     }
@@ -324,7 +324,7 @@ mod tests {
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        let spi = ctx.spi.with_mosi(mosi).with_dma(ctx.dma_channel);
+        let spi = ctx.spi.with_sio0(mosi).with_dma(ctx.dma_channel);
 
         super::execute_write(unit0, unit1, spi, 0b0000_0001, false);
     }
@@ -355,7 +355,7 @@ mod tests {
 
         let spi = ctx
             .spi
-            .with_mosi(mosi)
+            .with_sio0(mosi)
             .with_sio1(gpio)
             .with_dma(ctx.dma_channel);
 
@@ -388,7 +388,7 @@ mod tests {
 
         let spi = ctx
             .spi
-            .with_mosi(mosi)
+            .with_sio0(mosi)
             .with_sio2(gpio)
             .with_dma(ctx.dma_channel);
 
@@ -421,7 +421,7 @@ mod tests {
 
         let spi = ctx
             .spi
-            .with_mosi(mosi)
+            .with_sio0(mosi)
             .with_sio3(gpio)
             .with_dma(ctx.dma_channel);
 

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -75,7 +75,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_read(
-                DataMode::FourWire,
+                DataMode::SingleTwoDataLines,
                 Command::None,
                 Address::None,
                 0,
@@ -93,7 +93,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_read(
-                DataMode::FourWire,
+                DataMode::SingleTwoDataLines,
                 Command::None,
                 Address::None,
                 0,
@@ -124,7 +124,7 @@ mod tests {
 
         let mut buffer = [0xAA; DMA_BUFFER_SIZE];
         spi.half_duplex_read(
-            DataMode::FourWire,
+            DataMode::SingleTwoDataLines,
             Command::None,
             Address::None,
             0,
@@ -138,7 +138,7 @@ mod tests {
         ctx.miso_mirror.set_high();
 
         spi.half_duplex_read(
-            DataMode::FourWire,
+            DataMode::SingleTwoDataLines,
             Command::None,
             Address::None,
             0,

--- a/hil-test/tests/spi_half_duplex_read.rs
+++ b/hil-test/tests/spi_half_duplex_read.rs
@@ -75,7 +75,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_read(
-                DataMode::Single,
+                DataMode::FourWire,
                 Command::None,
                 Address::None,
                 0,
@@ -93,7 +93,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_read(
-                DataMode::Single,
+                DataMode::FourWire,
                 Command::None,
                 Address::None,
                 0,
@@ -124,7 +124,7 @@ mod tests {
 
         let mut buffer = [0xAA; DMA_BUFFER_SIZE];
         spi.half_duplex_read(
-            DataMode::Single,
+            DataMode::FourWire,
             Command::None,
             Address::None,
             0,
@@ -138,7 +138,7 @@ mod tests {
         ctx.miso_mirror.set_high();
 
         spi.half_duplex_read(
-            DataMode::Single,
+            DataMode::FourWire,
             Command::None,
             Address::None,
             0,

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -163,4 +163,14 @@ mod tests {
     fn test_spidmabus_writes_are_correctly_by_pcnt_tree_wire(ctx: Context) {
         super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::SingleTwoDataLines);
     }
+
+    #[test]
+    fn test_spi_writes_are_correctly_by_pcnt_four_wire(ctx: Context) {
+        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::Single);
+    }
+
+    #[test]
+    fn test_spidmabus_writes_are_correctly_by_pcnt_four_wire(ctx: Context) {
+        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::Single);
+    }
 }

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -146,21 +146,21 @@ mod tests {
 
     #[test]
     fn test_spi_writes_are_correctly_by_pcnt(ctx: Context) {
-        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::Single);
+        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::FourWire);
     }
 
     #[test]
     fn test_spidmabus_writes_are_correctly_by_pcnt(ctx: Context) {
-        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::Single);
+        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::FourWire);
     }
 
     #[test]
     fn test_spi_writes_are_correctly_by_pcnt_tree_wire(ctx: Context) {
-        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::SingleThreeWire);
+        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::FourWire);
     }
 
     #[test]
     fn test_spidmabus_writes_are_correctly_by_pcnt_tree_wire(ctx: Context) {
-        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::SingleThreeWire);
+        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::FourWire);
     }
 }

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -146,21 +146,21 @@ mod tests {
 
     #[test]
     fn test_spi_writes_are_correctly_by_pcnt(ctx: Context) {
-        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::FourWire);
+        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::SingleTwoDataLines);
     }
 
     #[test]
     fn test_spidmabus_writes_are_correctly_by_pcnt(ctx: Context) {
-        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::FourWire);
+        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::SingleTwoDataLines);
     }
 
     #[test]
     fn test_spi_writes_are_correctly_by_pcnt_tree_wire(ctx: Context) {
-        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::FourWire);
+        super::perform_spi_writes_are_correctly_by_pcnt(ctx, DataMode::SingleTwoDataLines);
     }
 
     #[test]
     fn test_spidmabus_writes_are_correctly_by_pcnt_tree_wire(ctx: Context) {
-        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::FourWire);
+        super::perform_spidmabus_writes_are_correctly_by_pcnt(ctx, DataMode::SingleTwoDataLines);
     }
 }

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -102,7 +102,7 @@ mod tests {
         dma_tx_buf.fill(&[0b0110_1010; DMA_BUFFER_SIZE]);
         let transfer = spi
             .half_duplex_write(
-                DataMode::FourWire,
+                DataMode::SingleTwoDataLines,
                 Command::None,
                 Address::None,
                 0,
@@ -117,7 +117,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_write(
-                DataMode::FourWire,
+                DataMode::SingleTwoDataLines,
                 Command::None,
                 Address::None,
                 0,
@@ -153,13 +153,25 @@ mod tests {
 
         let buffer = [0b0110_1010; DMA_BUFFER_SIZE];
         // Write the buffer where each byte has 3 pos edges.
-        spi.half_duplex_write(DataMode::FourWire, Command::None, Address::None, 0, &buffer)
-            .unwrap();
+        spi.half_duplex_write(
+            DataMode::SingleTwoDataLines,
+            Command::None,
+            Address::None,
+            0,
+            &buffer,
+        )
+        .unwrap();
 
         assert_eq!(unit.value(), (3 * DMA_BUFFER_SIZE) as _);
 
-        spi.half_duplex_write(DataMode::FourWire, Command::None, Address::None, 0, &buffer)
-            .unwrap();
+        spi.half_duplex_write(
+            DataMode::SingleTwoDataLines,
+            Command::None,
+            Address::None,
+            0,
+            &buffer,
+        )
+        .unwrap();
 
         assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);
     }

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -102,7 +102,7 @@ mod tests {
         dma_tx_buf.fill(&[0b0110_1010; DMA_BUFFER_SIZE]);
         let transfer = spi
             .half_duplex_write(
-                DataMode::Single,
+                DataMode::FourWire,
                 Command::None,
                 Address::None,
                 0,
@@ -117,7 +117,7 @@ mod tests {
 
         let transfer = spi
             .half_duplex_write(
-                DataMode::Single,
+                DataMode::FourWire,
                 Command::None,
                 Address::None,
                 0,
@@ -153,12 +153,12 @@ mod tests {
 
         let buffer = [0b0110_1010; DMA_BUFFER_SIZE];
         // Write the buffer where each byte has 3 pos edges.
-        spi.half_duplex_write(DataMode::Single, Command::None, Address::None, 0, &buffer)
+        spi.half_duplex_write(DataMode::FourWire, Command::None, Address::None, 0, &buffer)
             .unwrap();
 
         assert_eq!(unit.value(), (3 * DMA_BUFFER_SIZE) as _);
 
-        spi.half_duplex_write(DataMode::Single, Command::None, Address::None, 0, &buffer)
+        spi.half_duplex_write(DataMode::FourWire, Command::None, Address::None, 0, &buffer)
             .unwrap();
 
         assert_eq!(unit.value(), (6 * DMA_BUFFER_SIZE) as _);

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -71,7 +71,7 @@ mod tests {
         )
         .unwrap()
         .with_sck(sclk)
-        .with_mosi(mosi)
+        .with_sio0(mosi)
         .with_dma(dma_channel);
 
         Context {

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -98,8 +98,8 @@ fn main() -> ! {
     dma_tx_buf.set_length(0);
     let transfer = spi
         .half_duplex_write(
-            DataMode::FourWire,
-            Command::_8Bit(0x06, DataMode::FourWire),
+            DataMode::SingleTwoDataLines,
+            Command::_8Bit(0x06, DataMode::SingleTwoDataLines),
             Address::None,
             0,
             0,
@@ -113,9 +113,9 @@ fn main() -> ! {
     // erase sector
     let transfer = spi
         .half_duplex_write(
-            DataMode::FourWire,
-            Command::_8Bit(0x20, DataMode::FourWire),
-            Address::_24Bit(0x000000, DataMode::FourWire),
+            DataMode::SingleTwoDataLines,
+            Command::_8Bit(0x20, DataMode::SingleTwoDataLines),
+            Address::_24Bit(0x000000, DataMode::SingleTwoDataLines),
             0,
             dma_tx_buf.len(),
             dma_tx_buf,
@@ -128,8 +128,8 @@ fn main() -> ! {
     // write enable
     let transfer = spi
         .half_duplex_write(
-            DataMode::FourWire,
-            Command::_8Bit(0x06, DataMode::FourWire),
+            DataMode::SingleTwoDataLines,
+            Command::_8Bit(0x06, DataMode::SingleTwoDataLines),
             Address::None,
             0,
             dma_tx_buf.len(),
@@ -147,8 +147,8 @@ fn main() -> ! {
     let transfer = spi
         .half_duplex_write(
             DataMode::Quad,
-            Command::_8Bit(0x32, DataMode::FourWire),
-            Address::_24Bit(0x000000, DataMode::FourWire),
+            Command::_8Bit(0x32, DataMode::SingleTwoDataLines),
+            Address::_24Bit(0x000000, DataMode::SingleTwoDataLines),
             0,
             dma_tx_buf.len(),
             dma_tx_buf,
@@ -163,7 +163,7 @@ fn main() -> ! {
         let transfer = spi
             .half_duplex_read(
                 DataMode::Quad,
-                Command::_8Bit(0xeb, DataMode::FourWire),
+                Command::_8Bit(0xeb, DataMode::SingleTwoDataLines),
                 Address::_32Bit(0x000000 << 8, DataMode::Quad),
                 4,
                 dma_rx_buf.len(),

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -98,8 +98,8 @@ fn main() -> ! {
     dma_tx_buf.set_length(0);
     let transfer = spi
         .half_duplex_write(
-            DataMode::Single,
-            Command::_8Bit(0x06, DataMode::Single),
+            DataMode::FourWire,
+            Command::_8Bit(0x06, DataMode::FourWire),
             Address::None,
             0,
             0,
@@ -113,9 +113,9 @@ fn main() -> ! {
     // erase sector
     let transfer = spi
         .half_duplex_write(
-            DataMode::Single,
-            Command::_8Bit(0x20, DataMode::Single),
-            Address::_24Bit(0x000000, DataMode::Single),
+            DataMode::FourWire,
+            Command::_8Bit(0x20, DataMode::FourWire),
+            Address::_24Bit(0x000000, DataMode::FourWire),
             0,
             dma_tx_buf.len(),
             dma_tx_buf,
@@ -128,8 +128,8 @@ fn main() -> ! {
     // write enable
     let transfer = spi
         .half_duplex_write(
-            DataMode::Single,
-            Command::_8Bit(0x06, DataMode::Single),
+            DataMode::FourWire,
+            Command::_8Bit(0x06, DataMode::FourWire),
             Address::None,
             0,
             dma_tx_buf.len(),
@@ -147,8 +147,8 @@ fn main() -> ! {
     let transfer = spi
         .half_duplex_write(
             DataMode::Quad,
-            Command::_8Bit(0x32, DataMode::Single),
-            Address::_24Bit(0x000000, DataMode::Single),
+            Command::_8Bit(0x32, DataMode::FourWire),
+            Address::_24Bit(0x000000, DataMode::FourWire),
             0,
             dma_tx_buf.len(),
             dma_tx_buf,
@@ -163,7 +163,7 @@ fn main() -> ! {
         let transfer = spi
             .half_duplex_read(
                 DataMode::Quad,
-                Command::_8Bit(0xeb, DataMode::Single),
+                Command::_8Bit(0xeb, DataMode::FourWire),
                 Address::_32Bit(0x000000 << 8, DataMode::Quad),
                 4,
                 dma_rx_buf.len(),

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -83,9 +83,9 @@ fn main() -> ! {
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
         spi.half_duplex_read(
-            DataMode::FourWire,
-            Command::_8Bit(0x90, DataMode::FourWire),
-            Address::_24Bit(0x000000, DataMode::FourWire),
+            DataMode::SingleTwoDataLines,
+            Command::_8Bit(0x90, DataMode::SingleTwoDataLines),
+            Address::_24Bit(0x000000, DataMode::SingleTwoDataLines),
             0,
             &mut data,
         )
@@ -97,7 +97,7 @@ fn main() -> ! {
         let mut data = [0u8; 2];
         spi.half_duplex_read(
             DataMode::Dual,
-            Command::_8Bit(0x92, DataMode::FourWire),
+            Command::_8Bit(0x92, DataMode::SingleTwoDataLines),
             Address::_32Bit(0x000000_00, DataMode::Dual),
             0,
             &mut data,
@@ -110,7 +110,7 @@ fn main() -> ! {
         let mut data = [0u8; 2];
         spi.half_duplex_read(
             DataMode::Quad,
-            Command::_8Bit(0x94, DataMode::FourWire),
+            Command::_8Bit(0x94, DataMode::SingleTwoDataLines),
             Address::_32Bit(0x000000_00, DataMode::Quad),
             4,
             &mut data,

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -71,8 +71,8 @@ fn main() -> ! {
     )
     .unwrap()
     .with_sck(sclk)
-    .with_mosi(mosi)
-    .with_miso(miso)
+    .with_sio0(mosi)
+    .with_sio1(miso)
     .with_sio2(sio2)
     .with_sio3(sio3)
     .with_cs(cs);

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -83,9 +83,9 @@ fn main() -> ! {
         // READ MANUFACTURER ID FROM FLASH CHIP
         let mut data = [0u8; 2];
         spi.half_duplex_read(
-            DataMode::Single,
-            Command::_8Bit(0x90, DataMode::Single),
-            Address::_24Bit(0x000000, DataMode::Single),
+            DataMode::FourWire,
+            Command::_8Bit(0x90, DataMode::FourWire),
+            Address::_24Bit(0x000000, DataMode::FourWire),
             0,
             &mut data,
         )
@@ -97,7 +97,7 @@ fn main() -> ! {
         let mut data = [0u8; 2];
         spi.half_duplex_read(
             DataMode::Dual,
-            Command::_8Bit(0x92, DataMode::Single),
+            Command::_8Bit(0x92, DataMode::FourWire),
             Address::_32Bit(0x000000_00, DataMode::Dual),
             0,
             &mut data,
@@ -110,7 +110,7 @@ fn main() -> ! {
         let mut data = [0u8; 2];
         spi.half_duplex_read(
             DataMode::Quad,
-            Command::_8Bit(0x94, DataMode::Single),
+            Command::_8Bit(0x94, DataMode::FourWire),
             Address::_32Bit(0x000000_00, DataMode::Quad),
             4,
             &mut data,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Implement 3-wire half-duplex SPI.

Closes #2687 
Closes #1826

#### Testing
While there is an adapted hil-test I used a C3 to simulate a slave-device and checked the implementation works for me

