### PR TITLE
Fix thread-mode executor on core1 not waking up

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue with using thread-mode executors on both cores (#2924)
+
 ### Removed
 
 ## 0.5.0 - 2024-11-20

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -158,5 +158,24 @@ impl_array!(4);
 /// # }
 /// ```
 pub fn init(time_driver: impl TimerCollection) {
+    #[cfg(all(feature = "executors", multi_core, low_power_wait))]
+    unsafe {
+        use esp_hal::interrupt::software::SoftwareInterrupt;
+
+        #[esp_hal::macros::ram]
+        extern "C" fn software3_interrupt() {
+            // This interrupt is fired when the thread-mode executor's core needs to be
+            // woken. It doesn't matter which core handles this interrupt first, the
+            // point is just to wake up the core that is currently executing
+            // `waiti`.
+            unsafe { SoftwareInterrupt::<3>::steal().reset() };
+        }
+
+        esp_hal::interrupt::bind_interrupt(
+            esp_hal::peripherals::Interrupt::FROM_CPU_INTR3,
+            software3_interrupt,
+        );
+    }
+
     EmbassyTimer::init(time_driver.timers())
 }


### PR DESCRIPTION
Found while testing https://github.com/esp-rs/esp-hal/pull/2701 - apparently this is an unrelated issue :) Bug was caused by `SoftwareInterrupt::set_interrupt_handler` which when called, disabled the interrupt handler on the "other" core. This meant that creating a handler on both cores ended up with only one of them handling the cross-core interrupt.

Now the interrupt is registered once, then enabled on only the core(s) that need it.