### PR TITLE
ADC: Add async support for oneshot reads for esp32c3 and esp32c6

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S2: Made Wi-Fi peripheral non virtual. (#2942)
 - `UartRx::check_for_errors`, `Uart::check_for_rx_errors`, `{Uart, UartRx}::read_buffered_bytes` (#2935)
 - Added `i2c` interrupt API (#2944)
+- Async support for ADC oneshot reads for ESP32C3 and ESP32C6 (#2925)
 
 ### Changed
 

--- a/esp-hal/MIGRATING-0.22.md
+++ b/esp-hal/MIGRATING-0.22.md
@@ -522,6 +522,15 @@ The GPIO drive strength variants are renamed from e.g. `I5mA` to `_5mA`.
 
 ## ADC Changes
 
+The ADC driver has gained a new `Async`/`Blocking` mode parameter.
+NOTE: Async support is only supported in ESP32C3 and ESP32C6 for now
+
+
+```diff
+- Adc<'d, ADC>;
++ Adc<'d, ADC, Blocking;
+```
+
 The ADC attenuation variants are renamed from e.g. `Attenuation0dB` to `_0dB`.
 
 ```diff

--- a/esp-hal/MIGRATING-0.22.md
+++ b/esp-hal/MIGRATING-0.22.md
@@ -522,15 +522,6 @@ The GPIO drive strength variants are renamed from e.g. `I5mA` to `_5mA`.
 
 ## ADC Changes
 
-The ADC driver has gained a new `Async`/`Blocking` mode parameter.
-NOTE: Async support is only supported in ESP32C3 and ESP32C6 for now
-
-
-```diff
-- Adc<'d, ADC>;
-+ Adc<'d, ADC, Blocking;
-```
-
 The ADC attenuation variants are renamed from e.g. `Attenuation0dB` to `_0dB`.
 
 ```diff

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -207,4 +207,14 @@ All async functions now include the `_async` postfix. Additionally the non-async
 ```diff
 - let result = i2c.write_read(0x77, &[0xaa], &mut data).await;
 + let result = i2c.write_read_async(0x77, &[0xaa], &mut data).await;
+
+## ADC Changes
+
+The ADC driver has gained a new `Async`/`Blocking` mode parameter.
+NOTE: Async support is only supported in ESP32C3 and ESP32C6 for now
+
+
+```diff
+- Adc<'d, ADC>
++ Adc<'d, ADC, Blocking>
 ```

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -1,3 +1,4 @@
+use core::marker::PhantomData;
 use super::{AdcConfig, Attenuation};
 use crate::{
     peripheral::PeripheralRef,
@@ -198,13 +199,14 @@ impl RegisterAccess for ADC2 {
 }
 
 /// Analog-to-Digital Converter peripheral driver.
-pub struct Adc<'d, ADC> {
+pub struct Adc<'d, ADC, Dm: crate::DriverMode> {
     _adc: PeripheralRef<'d, ADC>,
     attenuations: [Option<Attenuation>; NUM_ATTENS],
     active_channel: Option<u8>,
+    _phantom: PhantomData<Dm>,
 }
 
-impl<'d, ADCI> Adc<'d, ADCI>
+impl<'d, ADCI> Adc<'d, ADCI, crate::Blocking>
 where
     ADCI: RegisterAccess,
 {
@@ -280,6 +282,7 @@ where
             _adc: adc_instance.into_ref(),
             attenuations: config.attenuations,
             active_channel: None,
+            _phantom: PhantomData,
         }
     }
 
@@ -329,7 +332,7 @@ where
     }
 }
 
-impl<ADC1> Adc<'_, ADC1> {
+impl<ADC1> Adc<'_, ADC1, crate::Blocking> {
     /// Enable the Hall sensor
     pub fn enable_hall_sensor() {
         RTC_IO::regs()

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use super::{AdcConfig, Attenuation};
 use crate::{
     peripheral::PeripheralRef,

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -657,9 +657,6 @@ where
     /// This method takes an [AdcPin](super::AdcPin) reference, as it is
     /// expected that the ADC will be able to sample whatever channel
     /// underlies the pin.
-    ///
-    /// TODO: This method does not handle concurrent reads to multiple channels
-    /// yet
     pub async fn read_oneshot<PIN, CS>(&mut self, pin: &mut super::AdcPin<PIN, ADCI, CS>) -> u16
     where
         ADCI: asynch::AsyncAccess,

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 #[cfg(esp32s3)]
 pub use self::calibration::*;
 use super::{AdcCalScheme, AdcCalSource, AdcChannel, AdcConfig, AdcPin, Attenuation};

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -1,3 +1,4 @@
+use core::marker::PhantomData;
 #[cfg(esp32s3)]
 pub use self::calibration::*;
 use super::{AdcCalScheme, AdcCalSource, AdcChannel, AdcConfig, AdcPin, Attenuation};
@@ -380,14 +381,15 @@ impl super::CalibrationAccess for crate::peripherals::ADC2 {
 }
 
 /// Analog-to-Digital Converter peripheral driver.
-pub struct Adc<'d, ADC> {
+pub struct Adc<'d, ADC, Dm: crate::DriverMode> {
     _adc: PeripheralRef<'d, ADC>,
     active_channel: Option<u8>,
     last_init_code: u16,
     _guard: GenericPeripheralGuard<{ Peripheral::ApbSarAdc as u8 }>,
+    _phantom: PhantomData<Dm>,
 }
 
-impl<'d, ADCI> Adc<'d, ADCI>
+impl<'d, ADCI> Adc<'d, ADCI, crate::Blocking>
 where
     ADCI: RegisterAccess,
 {
@@ -467,6 +469,7 @@ where
             active_channel: None,
             last_init_code: 0,
             _guard: guard,
+            _phantom: PhantomData,
         }
     }
 

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -60,6 +60,7 @@
 //! ### TRNG operation
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
+//! # use esp_hal::Blocking;
 //! # use esp_hal::rng::Trng;
 //! # use esp_hal::peripherals::Peripherals;
 //! # use esp_hal::peripherals::ADC1;
@@ -80,7 +81,7 @@
 //!     analog_pin,
 //!     Attenuation::_11dB
 //! );
-//! let mut adc1 = Adc::<ADC1>::new(peripherals.ADC1, adc1_config);
+//! let mut adc1 = Adc::<ADC1, Blocking>::new(peripherals.ADC1, adc1_config);
 //! let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin))?;
 //! rng.read(&mut buf);
 //! true_rand = rng.random();

--- a/qa-test/src/bin/embassy_adc.rs
+++ b/qa-test/src/bin/embassy_adc.rs
@@ -1,0 +1,37 @@
+//! This shows how to asynchronously read ADC data
+
+//% CHIPS: esp32c6 esp32c3
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use esp_backtrace as _;
+use esp_hal::{
+    analog::adc::{Adc, AdcConfig, Attenuation},
+    delay::Delay,
+    timer::timg::TimerGroup,
+};
+use esp_println::println;
+
+#[esp_hal_embassy::main]
+async fn main(_spawner: Spawner) {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_hal_embassy::init(timg0.timer0);
+
+    let mut adc1_config = AdcConfig::new();
+    let analog_pin = peripherals.GPIO5;
+    let mut pin = adc1_config.enable_pin(analog_pin, Attenuation::_11dB);
+    let mut adc1 = Adc::new(peripherals.ADC1, adc1_config).into_async();
+
+    let delay = Delay::new();
+
+    loop {
+        let adc_value: u16 = adc1.read_oneshot(&mut pin).await;
+        println!("ADC value: {}", adc_value);
+        delay.delay_millis(1000);
+    }
+}

--- a/qa-test/src/bin/embassy_adc.rs
+++ b/qa-test/src/bin/embassy_adc.rs
@@ -23,15 +23,30 @@ async fn main(_spawner: Spawner) {
     esp_hal_embassy::init(timg0.timer0);
 
     let mut adc1_config = AdcConfig::new();
-    let analog_pin = peripherals.GPIO5;
-    let mut pin = adc1_config.enable_pin(analog_pin, Attenuation::_11dB);
+    let analog_pin1 = peripherals.GPIO4;
+    let mut pin1 = adc1_config.enable_pin(analog_pin1, Attenuation::_11dB);
     let mut adc1 = Adc::new(peripherals.ADC1, adc1_config).into_async();
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32c3")] {
+            let mut adc2_config = AdcConfig::new();
+            let analog_pin2 = peripherals.GPIO5;
+            let mut pin2 = adc2_config.enable_pin(analog_pin2, Attenuation::_11dB);
+            let mut adc2 = Adc::new(peripherals.ADC2, adc2_config).into_async();
+        }
+    }
 
     let delay = Delay::new();
 
     loop {
-        let adc_value: u16 = adc1.read_oneshot(&mut pin).await;
-        println!("ADC value: {}", adc_value);
+        let adc1_value: u16 = adc1.read_oneshot(&mut pin1).await;
+        println!("ADC1 value: {}", adc1_value);
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "esp32c3")] {
+                let adc2_value: u16 = adc2.read_oneshot(&mut pin2).await;
+                println!("ADC2 value: {}", adc2_value);
+            }
+        }
         delay.delay_millis(1000);
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Add support for ADC async oneshot reads for esp32c3 and esp32c6. Fixes https://github.com/esp-rs/esp-hal/issues/1643

#### Testing

Added QA example that uses embassy executor and reads every second from GPIO5. I am able to measure distinct values just by handling the devkit board with my hands.

#### Extra notes

1. It seems the [double oneshot read hack for esp32c6](https://github.com/esp-rs/esp-hal/blob/19eb7728bbbb333a5c75b55036a2549ee2a901fd/esp-hal/src/analog/adc/riscv.rs#L469-L473) is not required if interrupts are used. If someone is able to help me figure out a way to replicate the issue I could try to see if we need to add that hack back.

2. Not sure if this is critical, but I am unsure if its possible to perform concurrent reads to multiple channels using the same ADC interface, in order to address the potential issue that is currently solved by using the [`active_channel` attribute](https://github.com/esp-rs/esp-hal/blob/19eb7728bbbb333a5c75b55036a2549ee2a901fd/esp-hal/src/analog/adc/riscv.rs#L448-L474) for the blocking implementation, in order to implement some kind of synchronization mechanism for the async version.

3. ~Should I add the `Dm: crate::DriverMode` generic and only provide the Blocking implementation for the [xtensa version of the Adc driver](https://github.com/davoclavo/esp-hal/blob/feat/async_adc_read_oneshot/esp-hal/src/analog/adc/xtensa.rs#L390-L398) (and the esp32 Driver too) or leave it as is without the extra parameter?~ Done
