### PR TITLE
Remove logic from InputPin and OutputPin

### DIFF
--- a/esp-hal/src/gpio/etm.rs
+++ b/esp-hal/src/gpio/etm.rs
@@ -181,7 +181,7 @@ impl<const C: u8> EventChannel<C> {
     ) -> Event<'d> {
         crate::into_mapped_ref!(pin);
 
-        pin.init_input(pin_config.pull, private::Internal);
+        pin.init_input(pin_config.pull);
 
         enable_event_channel(C, pin.number());
         Event {
@@ -289,12 +289,12 @@ impl<const C: u8> TaskChannel<C> {
     ) -> Task<'d> {
         crate::into_mapped_ref!(pin);
 
-        pin.set_output_high(pin_config.initial_state.into(), private::Internal);
+        pin.set_output_high(pin_config.initial_state.into());
         if pin_config.open_drain {
-            pin.pull_direction(pin_config.pull, private::Internal);
-            pin.set_to_open_drain_output(private::Internal);
+            pin.pull_direction(pin_config.pull);
+            pin.set_to_open_drain_output();
         } else {
-            pin.set_to_push_pull_output(private::Internal);
+            pin.set_to_push_pull_output();
         }
 
         enable_task_channel(C, pin.number());

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -677,6 +677,9 @@ where
     /// external hardware.
     #[instability::unstable]
     pub fn split(self) -> (interconnect::InputSignal, interconnect::OutputSignal) {
+        // FIXME: we should implement this in the gpio macro for output pins, but we
+        // should also have an input-only alternative for pins that can't be used as
+        // outputs.
         self.degrade().split()
     }
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -270,17 +270,17 @@ pub enum DriveStrength {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AlternateFunction {
     /// Alternate function 0.
-    Function0 = 0,
+    _0 = 0,
     /// Alternate function 1.
-    Function1 = 1,
+    _1 = 1,
     /// Alternate function 2.
-    Function2 = 2,
+    _2 = 2,
     /// Alternate function 3.
-    Function3 = 3,
+    _3 = 3,
     /// Alternate function 4.
-    Function4 = 4,
+    _4 = 4,
     /// Alternate function 5.
-    Function5 = 5,
+    _5 = 5,
 }
 
 impl TryFrom<usize> for AlternateFunction {
@@ -288,12 +288,12 @@ impl TryFrom<usize> for AlternateFunction {
 
     fn try_from(value: usize) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(AlternateFunction::Function0),
-            1 => Ok(AlternateFunction::Function1),
-            2 => Ok(AlternateFunction::Function2),
-            3 => Ok(AlternateFunction::Function3),
-            4 => Ok(AlternateFunction::Function4),
-            5 => Ok(AlternateFunction::Function5),
+            0 => Ok(AlternateFunction::_0),
+            1 => Ok(AlternateFunction::_1),
+            2 => Ok(AlternateFunction::_2),
+            3 => Ok(AlternateFunction::_3),
+            4 => Ok(AlternateFunction::_4),
+            5 => Ok(AlternateFunction::_5),
             _ => Err(()),
         }
     }
@@ -1083,7 +1083,7 @@ macro_rules! gpio {
                             $(
                                 $(
                                     (
-                                        $crate::gpio::AlternateFunction::[< Function $af_output_num >],
+                                        $crate::gpio::AlternateFunction::[< _ $af_output_num >],
                                         $crate::gpio::OutputSignal::$af_output_signal
                                     ),
                                 )*
@@ -1096,7 +1096,7 @@ macro_rules! gpio {
                             $(
                                 $(
                                     (
-                                        $crate::gpio::AlternateFunction::[< Function $af_input_num >],
+                                        $crate::gpio::AlternateFunction::[< _ $af_input_num >],
                                         $crate::gpio::InputSignal::$af_input_signal
                                     ),
                                 )*

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -348,11 +348,6 @@ pub trait Pin: Sealed {
     /// GPIO number
     fn number(&self) -> u8;
 
-    #[doc(hidden)]
-    fn mask(&self) -> u32 {
-        1 << (self.number() % 32)
-    }
-
     /// Type-erase (degrade) this pin into an [`AnyPin`].
     ///
     /// This converts pin singletons (`GpioPin<0>`, …), which are all different

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -17,7 +17,7 @@ impl crate::peripheral::Peripheral for Level {
 }
 
 impl Level {
-    pub(crate) fn pull_direction(&self, _pull: Pull, _internal: private::Internal) {}
+    pub(crate) fn pull_direction(&self, _pull: Pull) {}
 
     pub(crate) fn input_signals(
         &self,
@@ -26,11 +26,11 @@ impl Level {
         &[]
     }
 
-    pub(crate) fn init_input(&self, _pull: Pull, _: private::Internal) {}
+    pub(crate) fn init_input(&self, _pull: Pull) {}
 
-    pub(crate) fn enable_input(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn enable_input(&mut self, _on: bool) {}
 
-    pub(crate) fn is_input_high(&self, _: private::Internal) -> bool {
+    pub(crate) fn is_input_high(&self) -> bool {
         *self == Level::High
     }
 
@@ -44,16 +44,16 @@ impl Level {
         connect_input_signal(signal, value, false, true);
     }
 
-    pub(crate) fn set_to_open_drain_output(&mut self, _: private::Internal) {}
-    pub(crate) fn set_to_push_pull_output(&mut self, _: private::Internal) {}
-    pub(crate) fn enable_output(&mut self, _on: bool, _: private::Internal) {}
-    pub(crate) fn set_output_high(&mut self, _on: bool, _: private::Internal) {}
-    pub(crate) fn set_drive_strength(&mut self, _strength: DriveStrength, _: private::Internal) {}
-    pub(crate) fn enable_open_drain(&mut self, _on: bool, _: private::Internal) {}
-    pub(crate) fn internal_pull_up_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
-    pub(crate) fn internal_pull_down_in_sleep_mode(&mut self, _on: bool, _: private::Internal) {}
+    pub(crate) fn set_to_open_drain_output(&mut self) {}
+    pub(crate) fn set_to_push_pull_output(&mut self) {}
+    pub(crate) fn enable_output(&mut self, _on: bool) {}
+    pub(crate) fn set_output_high(&mut self, _on: bool) {}
+    pub(crate) fn set_drive_strength(&mut self, _strength: DriveStrength) {}
+    pub(crate) fn enable_open_drain(&mut self, _on: bool) {}
+    pub(crate) fn internal_pull_up_in_sleep_mode(&mut self, _on: bool) {}
+    pub(crate) fn internal_pull_down_in_sleep_mode(&mut self, _on: bool) {}
 
-    pub(crate) fn is_set_high(&self, _: private::Internal) -> bool {
+    pub(crate) fn is_set_high(&self) -> bool {
         false
     }
 

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -448,11 +448,11 @@ impl<'d, Dm: DriverMode> I2c<'d, Dm> {
     ) -> Self {
         crate::into_mapped_ref!(pin);
         // avoid the pin going low during configuration
-        pin.set_output_high(true, private::Internal);
+        pin.set_output_high(true);
 
-        pin.set_to_open_drain_output(private::Internal);
-        pin.enable_input(true, private::Internal);
-        pin.pull_direction(Pull::Up, private::Internal);
+        pin.set_to_open_drain_output();
+        pin.enable_input(true);
+        pin.pull_direction(Pull::Up);
 
         input.connect_to(&mut pin);
         output.connect_to(&mut pin);

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -387,7 +387,7 @@ where
     /// Configures the I2S peripheral to use a master clock (MCLK) output pin.
     pub fn with_mclk<P: PeripheralOutput>(self, pin: impl Peripheral<P = P> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         self.i2s_tx.i2s.mclk_signal().connect_to(pin);
 
         self
@@ -684,7 +684,6 @@ mod private {
         interrupt::InterruptHandler,
         peripheral::{Peripheral, PeripheralRef},
         peripherals::{Interrupt, I2S0},
-        private,
         DriverMode,
     };
 
@@ -717,7 +716,7 @@ mod private {
             P: PeripheralOutput,
         {
             crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output(private::Internal);
+            pin.set_to_push_pull_output();
             self.i2s.bclk_signal().connect_to(pin);
 
             self
@@ -728,7 +727,7 @@ mod private {
             P: PeripheralOutput,
         {
             crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output(private::Internal);
+            pin.set_to_push_pull_output();
             self.i2s.ws_signal().connect_to(pin);
 
             self
@@ -739,7 +738,7 @@ mod private {
             P: PeripheralOutput,
         {
             crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output(private::Internal);
+            pin.set_to_push_pull_output();
             self.i2s.dout_signal().connect_to(pin);
 
             self
@@ -775,7 +774,7 @@ mod private {
             P: PeripheralOutput,
         {
             crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output(private::Internal);
+            pin.set_to_push_pull_output();
             self.i2s.bclk_rx_signal().connect_to(pin);
 
             self
@@ -786,7 +785,7 @@ mod private {
             P: PeripheralOutput,
         {
             crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output(private::Internal);
+            pin.set_to_push_pull_output();
             self.i2s.ws_rx_signal().connect_to(pin);
 
             self
@@ -797,7 +796,7 @@ mod private {
             P: PeripheralInput,
         {
             crate::into_mapped_ref!(pin);
-            pin.init_input(crate::gpio::Pull::None, private::Internal);
+            pin.init_input(crate::gpio::Pull::None);
             self.i2s.din_signal().connect_to(pin);
 
             self

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -123,7 +123,6 @@ use crate::{
     },
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{i2s0::RegisterBlock, I2S0, I2S1},
-    private::Internal,
     system::PeripheralGuard,
     Async,
     Blocking,
@@ -186,7 +185,7 @@ impl<'d> TxPins<'d> for TxSixteenBits<'d> {
         crate::into_ref!(instance);
         let bits = self.bus_width();
         for (i, pin) in self.pins.iter_mut().enumerate() {
-            pin.set_to_push_pull_output(Internal);
+            pin.set_to_push_pull_output();
             instance.data_out_signal(i, bits).connect_to(pin);
         }
     }
@@ -228,7 +227,7 @@ impl<'d> TxPins<'d> for TxEightBits<'d> {
         crate::into_ref!(instance);
         let bits = self.bus_width();
         for (i, pin) in self.pins.iter_mut().enumerate() {
-            pin.set_to_push_pull_output(Internal);
+            pin.set_to_push_pull_output();
             instance.data_out_signal(i, bits).connect_to(pin);
         }
     }
@@ -267,7 +266,7 @@ impl<'d> I2sParallel<'d, Blocking> {
         // configure the I2S peripheral for parallel mode
         i2s.setup(frequency, pins.bus_width());
         // setup the clock pin
-        clock_pin.set_to_push_pull_output(Internal);
+        clock_pin.set_to_push_pull_output();
         i2s.ws_signal().connect_to(clock_pin);
 
         pins.configure(i2s.reborrow());

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -227,7 +227,7 @@ impl<'d> Camera<'d> {
     ) -> Self {
         crate::into_mapped_ref!(mclk);
 
-        mclk.set_to_push_pull_output(crate::private::Internal);
+        mclk.set_to_push_pull_output();
         OutputSignal::CAM_CLK.connect_to(mclk);
 
         self
@@ -240,7 +240,7 @@ impl<'d> Camera<'d> {
     ) -> Self {
         crate::into_mapped_ref!(pclk);
 
-        pclk.init_input(Pull::None, crate::private::Internal);
+        pclk.init_input(Pull::None);
         InputSignal::CAM_PCLK.connect_to(pclk);
 
         self
@@ -255,9 +255,9 @@ impl<'d> Camera<'d> {
     ) -> Self {
         crate::into_mapped_ref!(vsync, h_enable);
 
-        vsync.init_input(Pull::None, crate::private::Internal);
+        vsync.init_input(Pull::None);
         InputSignal::CAM_V_SYNC.connect_to(vsync);
-        h_enable.init_input(Pull::None, crate::private::Internal);
+        h_enable.init_input(Pull::None);
         InputSignal::CAM_H_ENABLE.connect_to(h_enable);
 
         self.lcd_cam
@@ -281,11 +281,11 @@ impl<'d> Camera<'d> {
     ) -> Self {
         crate::into_mapped_ref!(vsync, hsync, h_enable);
 
-        vsync.init_input(Pull::None, crate::private::Internal);
+        vsync.init_input(Pull::None);
         InputSignal::CAM_V_SYNC.connect_to(vsync);
-        hsync.init_input(Pull::None, crate::private::Internal);
+        hsync.init_input(Pull::None);
         InputSignal::CAM_H_SYNC.connect_to(hsync);
-        h_enable.init_input(Pull::None, crate::private::Internal);
+        h_enable.init_input(Pull::None);
         InputSignal::CAM_H_ENABLE.connect_to(h_enable);
 
         self.lcd_cam
@@ -500,7 +500,7 @@ impl RxEightBits {
         ];
 
         for (pin, signal) in pairs.into_iter() {
-            pin.init_input(Pull::None, crate::private::Internal);
+            pin.init_input(Pull::None);
             signal.connect_to(pin);
         }
 
@@ -577,7 +577,7 @@ impl RxSixteenBits {
         ];
 
         for (pin, signal) in pairs.into_iter() {
-            pin.init_input(Pull::None, crate::private::Internal);
+            pin.init_input(Pull::None);
             signal.connect_to(pin);
         }
 

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -306,7 +306,7 @@ where
     /// signal.
     pub fn with_vsync<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_V_SYNC.connect_to(pin);
 
         self
@@ -318,7 +318,7 @@ where
     /// signal.
     pub fn with_hsync<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_H_SYNC.connect_to(pin);
 
         self
@@ -330,7 +330,7 @@ where
     /// signal.
     pub fn with_de<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_H_ENABLE.connect_to(pin);
 
         self
@@ -342,7 +342,7 @@ where
     /// signal.
     pub fn with_pclk<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_PCLK.connect_to(pin);
 
         self
@@ -354,7 +354,7 @@ where
     /// signal.
     pub fn with_data0<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_0.connect_to(pin);
 
         self
@@ -366,7 +366,7 @@ where
     /// signal.
     pub fn with_data1<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_1.connect_to(pin);
 
         self
@@ -378,7 +378,7 @@ where
     /// signal.
     pub fn with_data2<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_2.connect_to(pin);
 
         self
@@ -390,7 +390,7 @@ where
     /// signal.
     pub fn with_data3<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_3.connect_to(pin);
 
         self
@@ -402,7 +402,7 @@ where
     /// signal.
     pub fn with_data4<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_4.connect_to(pin);
 
         self
@@ -414,7 +414,7 @@ where
     /// signal.
     pub fn with_data5<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_5.connect_to(pin);
 
         self
@@ -426,7 +426,7 @@ where
     /// signal.
     pub fn with_data6<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_6.connect_to(pin);
 
         self
@@ -438,7 +438,7 @@ where
     /// signal.
     pub fn with_data7<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_7.connect_to(pin);
 
         self
@@ -450,7 +450,7 @@ where
     /// signal.
     pub fn with_data8<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_8.connect_to(pin);
 
         self
@@ -462,7 +462,7 @@ where
     /// signal.
     pub fn with_data9<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_9.connect_to(pin);
 
         self
@@ -474,7 +474,7 @@ where
     /// DATA_10 signal.
     pub fn with_data10<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_10.connect_to(pin);
 
         self
@@ -486,7 +486,7 @@ where
     /// DATA_11 signal.
     pub fn with_data11<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_11.connect_to(pin);
 
         self
@@ -498,7 +498,7 @@ where
     /// DATA_12 signal.
     pub fn with_data12<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_12.connect_to(pin);
 
         self
@@ -510,7 +510,7 @@ where
     /// DATA_13 signal.
     pub fn with_data13<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_13.connect_to(pin);
 
         self
@@ -522,7 +522,7 @@ where
     /// DATA_14 signal.
     pub fn with_data14<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_14.connect_to(pin);
 
         self
@@ -534,7 +534,7 @@ where
     /// DATA_15 signal.
     pub fn with_data15<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
         crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output(crate::private::Internal);
+        pin.set_to_push_pull_output();
         OutputSignal::LCD_DATA_15.connect_to(pin);
 
         self

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -264,7 +264,7 @@ where
     /// Associates a CS pin with the I8080 interface.
     pub fn with_cs<CS: PeripheralOutput>(self, cs: impl Peripheral<P = CS> + 'd) -> Self {
         crate::into_mapped_ref!(cs);
-        cs.set_to_push_pull_output(crate::private::Internal);
+        cs.set_to_push_pull_output();
         OutputSignal::LCD_CS.connect_to(cs);
 
         self
@@ -278,10 +278,10 @@ where
     ) -> Self {
         crate::into_mapped_ref!(dc, wrx);
 
-        dc.set_to_push_pull_output(crate::private::Internal);
+        dc.set_to_push_pull_output();
         OutputSignal::LCD_DC.connect_to(dc);
 
-        wrx.set_to_push_pull_output(crate::private::Internal);
+        wrx.set_to_push_pull_output();
         OutputSignal::LCD_PCLK.connect_to(wrx);
 
         self
@@ -659,7 +659,7 @@ impl TxPins for TxEightBits<'_> {
         ];
 
         for (pin, signal) in self.pins.iter_mut().zip(SIGNALS.into_iter()) {
-            pin.set_to_push_pull_output(crate::private::Internal);
+            pin.set_to_push_pull_output();
             signal.connect_to(pin);
         }
     }
@@ -728,7 +728,7 @@ impl TxPins for TxSixteenBits<'_> {
         ];
 
         for (pin, signal) in self.pins.iter_mut().zip(SIGNALS.into_iter()) {
-            pin.set_to_push_pull_output(crate::private::Internal);
+            pin.set_to_push_pull_output();
             signal.connect_to(pin);
         }
     }

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -563,12 +563,8 @@ where
             }
 
             match cfg {
-                config::PinConfig::PushPull => self
-                    .output_pin
-                    .set_to_push_pull_output(crate::private::Internal),
-                config::PinConfig::OpenDrain => self
-                    .output_pin
-                    .set_to_open_drain_output(crate::private::Internal),
+                config::PinConfig::PushPull => self.output_pin.set_to_push_pull_output(),
+                config::PinConfig::OpenDrain => self.output_pin.set_to_open_drain_output(),
             };
 
             let timer_number = timer.number() as u8;

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -16,7 +16,6 @@ use crate::{
     gpio::interconnect::{OutputConnection, PeripheralOutput},
     mcpwm::{timer::Timer, PwmPeripheral},
     peripheral::{Peripheral, PeripheralRef},
-    private,
 };
 
 /// Input/Output Stream descriptor for each channel
@@ -310,7 +309,7 @@ impl<'d, PWM: PwmPeripheral, const OP: u8, const IS_A: bool> PwmPin<'d, PWM, OP,
         pin.set_update_method(config.update_method);
 
         PWM::output_signal::<OP, IS_A>().connect_to(&mut pin.pin);
-        pin.pin.enable_output(true, private::Internal);
+        pin.pin.enable_output(true);
 
         pin
     }

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -390,7 +390,7 @@ impl<'d> ClkOutPin<'d> {
 }
 impl TxClkPin for ClkOutPin<'_> {
     fn configure(&mut self) {
-        self.pin.set_to_push_pull_output(crate::private::Internal);
+        self.pin.set_to_push_pull_output();
         crate::gpio::OutputSignal::PARL_TX_CLK.connect_to(&mut self.pin);
     }
 }
@@ -412,8 +412,7 @@ impl TxClkPin for ClkInPin<'_> {
         pcr.parl_clk_tx_conf()
             .modify(|_, w| unsafe { w.parl_clk_tx_sel().bits(3).parl_clk_tx_div_num().bits(0) }); // PAD_CLK_TX, no divider
 
-        self.pin
-            .init_input(crate::gpio::Pull::None, crate::private::Internal);
+        self.pin.init_input(crate::gpio::Pull::None);
         crate::gpio::InputSignal::PARL_TX_CLK.connect_to(&mut self.pin);
     }
 }
@@ -439,8 +438,7 @@ impl RxClkPin for RxClkInPin<'_> {
         pcr.parl_clk_rx_conf()
             .modify(|_, w| unsafe { w.parl_clk_rx_sel().bits(3).parl_clk_rx_div_num().bits(0) }); // PAD_CLK_TX, no divider
 
-        self.pin
-            .init_input(crate::gpio::Pull::None, crate::private::Internal);
+        self.pin.init_input(crate::gpio::Pull::None);
         crate::gpio::InputSignal::PARL_RX_CLK.connect_to(&mut self.pin);
 
         Instance::set_rx_clk_edge_sel(self.sample_edge);
@@ -478,8 +476,7 @@ where
 {
     fn configure(&mut self) -> Result<(), Error> {
         self.tx_pins.configure()?;
-        self.valid_pin
-            .set_to_push_pull_output(crate::private::Internal);
+        self.valid_pin.set_to_push_pull_output();
         Instance::tx_valid_pin_signal().connect_to(&mut self.valid_pin);
         Instance::set_tx_hw_valid_en(true);
         Ok(())
@@ -550,7 +547,7 @@ macro_rules! tx_pins {
             {
                 fn configure(&mut self) -> Result<(), Error>{
                     $(
-                        self.[< pin_ $pin:lower >].set_to_push_pull_output(crate::private::Internal);
+                        self.[< pin_ $pin:lower >].set_to_push_pull_output();
                         crate::gpio::OutputSignal::$signal.connect_to(&mut self.[< pin_ $pin:lower >]);
                     )+
 
@@ -669,8 +666,7 @@ where
 {
     fn configure(&mut self) -> Result<(), Error> {
         self.rx_pins.configure()?;
-        self.valid_pin
-            .init_input(crate::gpio::Pull::None, crate::private::Internal);
+        self.valid_pin.init_input(crate::gpio::Pull::None);
         Instance::rx_valid_pin_signal().connect_to(&mut self.valid_pin);
         Instance::set_rx_sw_en(false);
         if let Some(sel) = self.enable_mode.pulse_submode_sel() {
@@ -769,7 +765,7 @@ macro_rules! rx_pins {
             {
                 fn configure(&mut self)  -> Result<(), Error> {
                     $(
-                        self.[< pin_ $pin:lower >].init_input(crate::gpio::Pull::None, crate::private::Internal);
+                        self.[< pin_ $pin:lower >].init_input(crate::gpio::Pull::None);
                         crate::gpio::InputSignal::$signal.connect_to(&mut self.[< pin_ $pin:lower >]);
                     )+
 

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -122,7 +122,7 @@ impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
 
         if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
             crate::into_mapped_ref!(source);
-            source.enable_input(true, crate::private::Internal);
+            source.enable_input(true);
             signal.connect_to(source);
         }
         self
@@ -180,7 +180,7 @@ impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
 
         if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
             crate::into_mapped_ref!(source);
-            source.enable_input(true, crate::private::Internal);
+            source.enable_input(true);
             signal.connect_to(source);
         }
         self

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -419,15 +419,18 @@ mod peripheral_macros {
 
             impl $name {
                 #[doc = r"Pointer to the register block"]
+                #[instability::unstable]
                 pub const PTR: *const <super::pac::$base as core::ops::Deref>::Target = super::pac::$base::PTR;
 
                 #[doc = r"Return the pointer to the register block"]
                 #[inline(always)]
+                #[instability::unstable]
                 pub const fn ptr() -> *const <super::pac::$base as core::ops::Deref>::Target {
                     super::pac::$base::PTR
                 }
             }
 
+            #[doc(hidden)]
             impl core::ops::Deref for $name {
                 type Target = <super::pac::$base as core::ops::Deref>::Target;
 

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -445,7 +445,7 @@ fn configure_rx_channel<'d, P: PeripheralInput, T: RxChannelInternal<Dm>, Dm: cr
     }
 
     crate::into_mapped_ref!(pin);
-    pin.init_input(crate::gpio::Pull::None, crate::private::Internal);
+    pin.init_input(crate::gpio::Pull::None);
     T::input_signal().connect_to(pin);
 
     T::set_divider(config.clk_divider);
@@ -471,7 +471,7 @@ fn configure_tx_channel<
     config: TxChannelConfig,
 ) -> Result<T, Error> {
     crate::into_mapped_ref!(pin);
-    pin.set_to_push_pull_output(crate::private::Internal);
+    pin.set_to_push_pull_output();
     T::output_signal().connect_to(pin);
 
     T::set_divider(config.clk_divider);

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -61,7 +61,7 @@ pub(crate) const INPUT_SIGNAL_MAX: u16 = 539;
 pub(crate) const ONE_INPUT: u8 = 0x38;
 pub(crate) const ZERO_INPUT: u8 = 0x30;
 
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function2;
+pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_2;
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
     unsafe {

--- a/esp-hal/src/soc/esp32c2/gpio.rs
+++ b/esp-hal/src/soc/esp32c2/gpio.rs
@@ -52,7 +52,7 @@ pub(crate) const INPUT_SIGNAL_MAX: u8 = 100;
 pub(crate) const ONE_INPUT: u8 = 0x1e;
 pub(crate) const ZERO_INPUT: u8 = 0x1f;
 
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
+pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }

--- a/esp-hal/src/soc/esp32c3/gpio.rs
+++ b/esp-hal/src/soc/esp32c3/gpio.rs
@@ -54,7 +54,7 @@ pub(crate) const INPUT_SIGNAL_MAX: u8 = 100;
 pub(crate) const ONE_INPUT: u8 = 0x1e;
 pub(crate) const ZERO_INPUT: u8 = 0x1f;
 
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
+pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }

--- a/esp-hal/src/soc/esp32c6/gpio.rs
+++ b/esp-hal/src/soc/esp32c6/gpio.rs
@@ -54,7 +54,7 @@ pub(crate) const INPUT_SIGNAL_MAX: u8 = 124;
 pub(crate) const ONE_INPUT: u8 = 0x38;
 pub(crate) const ZERO_INPUT: u8 = 0x3c;
 
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
+pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }

--- a/esp-hal/src/soc/esp32h2/gpio.rs
+++ b/esp-hal/src/soc/esp32h2/gpio.rs
@@ -52,7 +52,7 @@ pub(crate) const INPUT_SIGNAL_MAX: u8 = 124;
 pub(crate) const ONE_INPUT: u8 = 0x38;
 pub(crate) const ZERO_INPUT: u8 = 0x3c;
 
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
+pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -67,7 +67,7 @@ pub(crate) const INPUT_SIGNAL_MAX: u16 = 204;
 pub(crate) const ONE_INPUT: u8 = 0x38;
 pub(crate) const ZERO_INPUT: u8 = 0x3c;
 
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
+pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
     unsafe {

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -54,7 +54,7 @@ pub(crate) const INPUT_SIGNAL_MAX: u16 = 189;
 pub(crate) const ONE_INPUT: u8 = 0x38;
 pub(crate) const ZERO_INPUT: u8 = 0x3c;
 
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::Function1;
+pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) const fn io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO {
     unsafe { (*crate::peripherals::IO_MUX::PTR).gpio(gpio_num as usize) }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -649,8 +649,8 @@ where
     /// to the MOSI signal and SIO0 input signal.
     pub fn with_mosi<MOSI: PeripheralOutput>(self, mosi: impl Peripheral<P = MOSI> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
-        mosi.enable_output(true, private::Internal);
-        mosi.enable_input(true, private::Internal);
+        mosi.enable_output(true);
+        mosi.enable_input(true);
 
         self.driver().info.mosi.connect_to(&mut mosi);
         self.driver().info.sio0_input.connect_to(&mut mosi);
@@ -664,7 +664,7 @@ where
     /// signal.
     pub fn with_miso<MISO: PeripheralInput>(self, miso: impl Peripheral<P = MISO> + 'd) -> Self {
         crate::into_mapped_ref!(miso);
-        miso.enable_input(true, private::Internal);
+        miso.enable_input(true);
 
         self.driver().info.miso.connect_to(&mut miso);
 
@@ -679,8 +679,8 @@ where
     /// Note: You do not need to call [Self::with_miso] when this is used.
     pub fn with_sio1<SIO1: PeripheralOutput>(self, miso: impl Peripheral<P = SIO1> + 'd) -> Self {
         crate::into_mapped_ref!(miso);
-        miso.enable_input(true, private::Internal);
-        miso.enable_output(true, private::Internal);
+        miso.enable_input(true);
+        miso.enable_output(true);
 
         self.driver().info.miso.connect_to(&mut miso);
         self.driver().info.sio1_output.connect_to(&mut miso);
@@ -694,7 +694,7 @@ where
     /// clock signal.
     pub fn with_sck<SCK: PeripheralOutput>(self, sclk: impl Peripheral<P = SCK> + 'd) -> Self {
         crate::into_mapped_ref!(sclk);
-        sclk.set_to_push_pull_output(private::Internal);
+        sclk.set_to_push_pull_output();
         self.driver().info.sclk.connect_to(sclk);
 
         self
@@ -707,7 +707,7 @@ where
     #[instability::unstable]
     pub fn with_cs<CS: PeripheralOutput>(self, cs: impl Peripheral<P = CS> + 'd) -> Self {
         crate::into_mapped_ref!(cs);
-        cs.set_to_push_pull_output(private::Internal);
+        cs.set_to_push_pull_output();
         self.driver().info.cs.connect_to(cs);
 
         self
@@ -745,8 +745,8 @@ where
     pub fn with_sio2<SIO2: PeripheralOutput>(self, sio2: impl Peripheral<P = SIO2> + 'd) -> Self {
         // TODO: panic if not QSPI?
         crate::into_mapped_ref!(sio2);
-        sio2.enable_input(true, private::Internal);
-        sio2.enable_output(true, private::Internal);
+        sio2.enable_input(true);
+        sio2.enable_output(true);
 
         unwrap!(self.driver().info.sio2_input).connect_to(&mut sio2);
         unwrap!(self.driver().info.sio2_output).connect_to(&mut sio2);
@@ -762,8 +762,8 @@ where
     pub fn with_sio3<SIO3: PeripheralOutput>(self, sio3: impl Peripheral<P = SIO3> + 'd) -> Self {
         // TODO: panic if not QSPI?
         crate::into_mapped_ref!(sio3);
-        sio3.enable_input(true, private::Internal);
-        sio3.enable_output(true, private::Internal);
+        sio3.enable_input(true);
+        sio3.enable_output(true);
 
         unwrap!(self.driver().info.sio3_input).connect_to(&mut sio3);
         unwrap!(self.driver().info.sio3_output).connect_to(&mut sio3);

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -82,7 +82,6 @@ use crate::{
     },
     peripheral::{Peripheral, PeripheralRef},
     peripherals::spi2::RegisterBlock,
-    private,
     spi::AnySpi,
     system::PeripheralGuard,
     Blocking,
@@ -129,7 +128,7 @@ impl<'d> Spi<'d, Blocking> {
     #[instability::unstable]
     pub fn with_sck(self, sclk: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(sclk);
-        sclk.enable_input(true, private::Internal);
+        sclk.enable_input(true);
         self.spi.info().sclk.connect_to(sclk);
         self
     }
@@ -138,7 +137,7 @@ impl<'d> Spi<'d, Blocking> {
     #[instability::unstable]
     pub fn with_mosi(self, mosi: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(mosi);
-        mosi.enable_input(true, private::Internal);
+        mosi.enable_input(true);
         self.spi.info().mosi.connect_to(mosi);
         self
     }
@@ -147,7 +146,7 @@ impl<'d> Spi<'d, Blocking> {
     #[instability::unstable]
     pub fn with_miso(self, miso: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(miso);
-        miso.set_to_push_pull_output(private::Internal);
+        miso.set_to_push_pull_output();
         self.spi.info().miso.connect_to(miso);
         self
     }
@@ -156,7 +155,7 @@ impl<'d> Spi<'d, Blocking> {
     #[instability::unstable]
     pub fn with_cs(self, cs: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(cs);
-        cs.enable_input(true, private::Internal);
+        cs.enable_input(true);
         self.spi.info().cs.connect_to(cs);
         self
     }

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -717,11 +717,11 @@ where
 
         // Set up the GPIO pins.
         let rx_pull = if no_transceiver {
-            tx_pin.set_to_open_drain_output(crate::private::Internal);
-            tx_pin.pull_direction(Pull::Up, crate::private::Internal);
+            tx_pin.set_to_open_drain_output();
+            tx_pin.pull_direction(Pull::Up);
             Pull::Up
         } else {
-            tx_pin.set_to_push_pull_output(crate::private::Internal);
+            tx_pin.set_to_push_pull_output();
             Pull::None
         };
         this.twai.output_signal().connect_to(tx_pin);
@@ -729,7 +729,7 @@ where
         // Setting up RX pin later allows us to use a single pin in tests.
         // `set_to_push_pull_output` disables input, here we re-enable it if rx_pin
         // uses the same GPIO.
-        rx_pin.init_input(rx_pull, crate::private::Internal);
+        rx_pin.init_input(rx_pull);
         this.twai.input_signal().connect_to(rx_pin);
 
         // Freeze REC by changing to LOM mode

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -242,7 +242,6 @@ use crate::{
     interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{uart0::RegisterBlock, Interrupt},
-    private::Internal,
     system::{PeripheralClockControl, PeripheralGuard},
     Async,
     Blocking,
@@ -614,7 +613,7 @@ where
     /// Configure RTS pin
     pub fn with_rts(self, rts: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(rts);
-        rts.set_to_push_pull_output(Internal);
+        rts.set_to_push_pull_output();
         self.uart.info().rts_signal.connect_to(rts);
 
         self
@@ -627,8 +626,8 @@ where
     pub fn with_tx(self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(tx);
         // Make sure we don't cause an unexpected low pulse on the pin.
-        tx.set_output_high(true, Internal);
-        tx.set_to_push_pull_output(Internal);
+        tx.set_output_high(true);
+        tx.set_to_push_pull_output();
         self.uart.info().tx_signal.connect_to(tx);
 
         self
@@ -797,7 +796,7 @@ where
     /// Configure CTS pin
     pub fn with_cts(self, cts: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(cts);
-        cts.init_input(Pull::None, Internal);
+        cts.init_input(Pull::None);
         self.uart.info().cts_signal.connect_to(cts);
 
         self
@@ -813,7 +812,7 @@ where
     /// initial low signal level.
     pub fn with_rx(self, rx: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(rx);
-        rx.init_input(Pull::Up, Internal);
+        rx.init_input(Pull::Up);
         self.uart.info().rx_signal.connect_to(rx);
 
         self
@@ -1005,7 +1004,7 @@ impl<'d> Uart<'d, Blocking> {
     /// initial low signal level.
     pub fn with_rx(self, rx: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(rx);
-        rx.init_input(Pull::Up, Internal);
+        rx.init_input(Pull::Up);
         self.rx.uart.info().rx_signal.connect_to(rx);
 
         self
@@ -1018,8 +1017,8 @@ impl<'d> Uart<'d, Blocking> {
     pub fn with_tx(self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(tx);
         // Make sure we don't cause an unexpected low pulse on the pin.
-        tx.set_output_high(true, Internal);
-        tx.set_to_push_pull_output(Internal);
+        tx.set_output_high(true);
+        tx.set_to_push_pull_output();
         self.tx.uart.info().tx_signal.connect_to(tx);
 
         self

--- a/hil-test/tests/uart_regression.rs
+++ b/hil-test/tests/uart_regression.rs
@@ -10,7 +10,7 @@
 #[embedded_test::tests(default_timeout = 3)]
 mod tests {
     use esp_hal::{
-        gpio::OutputPin,
+        gpio::Flex,
         uart::{self, UartRx, UartTx},
     };
     use hil_test as _;
@@ -20,7 +20,7 @@ mod tests {
     fn test_that_creating_tx_does_not_cause_a_pulse() {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let (rx, mut tx) = hil_test::common_test_pins!(peripherals);
+        let (rx, tx) = hil_test::common_test_pins!(peripherals);
 
         let mut rx = UartRx::new(peripherals.UART1, uart::Config::default())
             .unwrap()
@@ -29,7 +29,11 @@ mod tests {
         // start reception
         _ = rx.read_byte(); // this will just return WouldBlock
 
-        unsafe { tx.set_output_high(false, esp_hal::Internal::conjure()) };
+        // Start from a low level to verify that UartTx sets the level high initially,
+        // but don't enable output otherwise we actually pull down against RX's
+        // pullup resistor.
+        let mut tx = Flex::new(tx);
+        tx.set_low();
 
         // set up TX and send a byte
         let mut tx = UartTx::new(peripherals.UART0, uart::Config::default())


### PR DESCRIPTION
I'd say this closes #2713

Pin's `number` and `degrade` remain public. `input_signals` and `output_signals` remain "private". Rest of the traits are unstable so I didn't touch them.

This is close enough to how the embassy_stm32 Pin trait [looks](https://docs.embassy.dev/embassy-stm32/git/stm32f030rc/gpio/trait.Pin.html) so I don't think we should grind up more time on the place of degrade/number.