### PR TITLE
Restore explicit stdin inherit

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -64,6 +64,7 @@ where
         } else {
             Stdio::inherit()
         })
+        .stdin(Stdio::inherit())
         .output()?;
 
     // Make sure that we return an appropriate exit code here, as Github Actions


### PR DESCRIPTION
`Command::output` opens a pipe for stdin, which macOS can't seem to handle and running examples fail.