### PR TITLE
De-allocate memory used by timers on removal

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed triggering a debug-assertion during scan (#2612)
 - Fix WPA2-ENTERPRISE functionality (#2896)
+- Make sure to de-allocate memory used by timers on removal (#2936)
 
 ### Removed
 

--- a/esp-wifi/src/compat/timer_compat.rs
+++ b/esp-wifi/src/compat/timer_compat.rs
@@ -112,6 +112,11 @@ impl TimerQueue {
             };
 
             if let Some(before) = before {
+                let to_remove = before.next.take().unwrap();
+                let to_remove = Box::into_raw(to_remove);
+                unsafe {
+                    crate::compat::malloc::free(to_remove as *mut _);
+                }
                 before.next = tail;
             }
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Hopefully fixes #2892

Turned out the memory taken by a timer wasn't de-allocated. (I plan to rewrite timer handling sooner or later, but this should fix it for now)

#### Testing
Before especially on disconnection / re-connection there was a steady decrease in free memory so you can modify one of the examples accordingly 
