### PR TITLE
Remove internal_pull_in_sleep_mode

### DIFF
--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -442,8 +442,6 @@ impl OutputSignal {
             pub fn set_output_high(&mut self, on: bool);
             pub fn set_drive_strength(&mut self, strength: gpio::DriveStrength);
             pub fn enable_open_drain(&mut self, on: bool);
-            pub fn internal_pull_up_in_sleep_mode(&mut self, on: bool);
-            pub fn internal_pull_down_in_sleep_mode(&mut self, on: bool);
             pub fn is_set_high(&self) -> bool;
         }
     }
@@ -490,8 +488,6 @@ impl DirectOutputSignal {
             fn set_output_high(&mut self, on: bool);
             fn set_drive_strength(&mut self, strength: gpio::DriveStrength);
             fn enable_open_drain(&mut self, on: bool);
-            fn internal_pull_up_in_sleep_mode(&mut self, on: bool);
-            fn internal_pull_down_in_sleep_mode(&mut self, on: bool);
             fn is_set_high(&self) -> bool;
         }
     }
@@ -708,8 +704,6 @@ impl OutputConnection {
             pub fn set_output_high(&mut self, on: bool);
             pub fn set_drive_strength(&mut self, strength: gpio::DriveStrength);
             pub fn enable_open_drain(&mut self, on: bool);
-            pub fn internal_pull_up_in_sleep_mode(&mut self, on: bool);
-            pub fn internal_pull_down_in_sleep_mode(&mut self, on: bool);
 
             // These don't need to be public, the intended way is `connect_to` and `disconnect_from`
             fn connect_peripheral_to_output(&mut self, signal: gpio::OutputSignal);

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -2045,18 +2045,6 @@ impl AnyPin {
             .modify(|_, w| w.pad_driver().bit(on));
     }
 
-    /// Configure internal pull-up resistor in sleep mode
-    #[inline]
-    pub(crate) fn internal_pull_up_in_sleep_mode(&mut self, on: bool) {
-        io_mux_reg(self.number()).modify(|_, w| w.mcu_wpu().bit(on));
-    }
-
-    /// Configure internal pull-down resistor in sleep mode
-    #[inline]
-    pub(crate) fn internal_pull_down_in_sleep_mode(&mut self, on: bool) {
-        io_mux_reg(self.number()).modify(|_, w| w.mcu_wpd().bit(on));
-    }
-
     /// Is the output set to high
     #[inline]
     pub(crate) fn is_set_high(&self) -> bool {

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -50,8 +50,6 @@ impl Level {
     pub(crate) fn set_output_high(&mut self, _on: bool) {}
     pub(crate) fn set_drive_strength(&mut self, _strength: DriveStrength) {}
     pub(crate) fn enable_open_drain(&mut self, _on: bool) {}
-    pub(crate) fn internal_pull_up_in_sleep_mode(&mut self, _on: bool) {}
-    pub(crate) fn internal_pull_down_in_sleep_mode(&mut self, _on: bool) {}
 
     pub(crate) fn is_set_high(&self) -> bool {
         false


### PR DESCRIPTION
These functions are only available on the interconnect types, and even there they are hidden. We'll have to come back to them eventually, but right now they are just noise.