### PR TITLE
Remove Pin trait impls from Flex

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed `Pin`, `RtcPin` and `RtcPinWithResistors` implementations from `Flex` (#2938)
+
 ## [0.23.1] - 2025-01-15
 
 ### Fixed

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -238,7 +238,7 @@ where
 
 impl From<Flex<'static>> for InputSignal {
     fn from(input: Flex<'static>) -> Self {
-        Self::new(input.degrade())
+        Self::new(unsafe { AnyPin::steal(input.pin.number()) })
     }
 }
 
@@ -367,14 +367,14 @@ impl<P> From<P> for OutputSignal
 where
     P: OutputPin,
 {
-    fn from(input: P) -> Self {
-        Self::new(input.degrade())
+    fn from(output: P) -> Self {
+        Self::new(output.degrade())
     }
 }
 
 impl From<Flex<'static>> for OutputSignal {
-    fn from(input: Flex<'static>) -> Self {
-        Self::new(input.degrade())
+    fn from(output: Flex<'static>) -> Self {
+        Self::new(unsafe { AnyPin::steal(output.pin.number()) })
     }
 }
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1661,6 +1661,10 @@ impl<'d> Flex<'d> {
         Self { pin }
     }
 
+    fn number(&self) -> u8 {
+        self.pin.number()
+    }
+
     /// Returns a peripheral [input][interconnect::InputSignal] connected to
     /// this pin.
     ///
@@ -1869,42 +1873,6 @@ impl<'d> Flex<'d> {
     #[instability::unstable]
     pub fn into_peripheral_output(self) -> interconnect::OutputSignal {
         self.split().1
-    }
-}
-
-// Unfortunate implementation details responsible for:
-// - making pin drivers work with the peripheral signal system
-// - making the pin drivers work with the sleep API
-impl Pin for Flex<'_> {
-    delegate::delegate! {
-        to self.pin {
-            fn number(&self) -> u8;
-            fn output_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, OutputSignal)];
-            fn input_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, InputSignal)];
-        }
-    }
-}
-#[cfg(any(lp_io, rtc_cntl))]
-impl RtcPin for Flex<'_> {
-    delegate::delegate! {
-        to self.pin {
-            #[cfg(xtensa)]
-            fn rtc_number(&self) -> u8;
-            #[cfg(any(xtensa, esp32c6))]
-            fn rtc_set_config(&mut self, input_enable: bool, mux: bool, func: RtcFunction);
-            fn rtcio_pad_hold(&mut self, enable: bool);
-            #[cfg(any(esp32c3, esp32c2, esp32c6))]
-            unsafe fn apply_wakeup(&mut self, wakeup: bool, level: u8);
-        }
-    }
-}
-#[cfg(any(lp_io, rtc_cntl))]
-impl RtcPinWithResistors for Flex<'_> {
-    delegate::delegate! {
-        to self.pin {
-            fn rtcio_pullup(&mut self, enable: bool);
-            fn rtcio_pulldown(&mut self, enable: bool);
-        }
     }
 }
 

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -110,7 +110,8 @@ pub enum Error {
 /// let delay = Delay::new();
 /// let mut rtc = Rtc::new(peripherals.LPWR);
 ///
-/// let pin_0 = Input::new(peripherals.GPIO4, Pull::None);
+/// let mut pin_4 = peripherals.GPIO4;
+/// let pin_4_input = Input::new(&mut pin_4, Pull::None);
 ///
 /// let reason =
 ///     reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
@@ -119,7 +120,8 @@ pub enum Error {
 ///
 /// let timer = TimerWakeupSource::new(Duration::from_secs(30));
 ///
-/// let ext0 = Ext0WakeupSource::new(pin_0, WakeupLevel::High);
+/// core::mem::drop(pin_4_input);
+/// let ext0 = Ext0WakeupSource::new(&mut pin_4, WakeupLevel::High);
 ///
 /// delay.delay_millis(100);
 /// rtc.sleep_deep(&[&timer, &ext0]);
@@ -161,19 +163,21 @@ impl<'a, P: RtcIoWakeupPinType> Ext0WakeupSource<'a, P> {
 /// let delay = Delay::new();
 /// let mut rtc = Rtc::new(peripherals.LPWR);
 ///
-/// let pin_4 = Input::new(peripherals.GPIO4, Pull::None);
 /// let mut pin_2 = peripherals.GPIO2;
+/// let mut pin_4 = peripherals.GPIO4;
+/// let pin_4_driver = Input::new(&mut pin_4, Pull::None);
 ///
-/// let reason =
-/// reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
+/// let reason = reset_reason(Cpu::ProCpu)
+///     .unwrap_or(SocResetReason::ChipPowerOn);
 ///
 /// let wake_reason = wakeup_cause();
 ///
 /// let timer = TimerWakeupSource::new(Duration::from_secs(30));
 ///
+/// // Drop the driver to access `pin_4`
+/// core::mem::drop(pin_4_driver);
 ///
-/// let mut wakeup_pins: [&mut dyn RtcPin; 2] =
-///     [&mut *pin_4.into_ref(), &mut pin_2];
+/// let mut wakeup_pins: [&mut dyn RtcPin; 2] = [&mut pin_4, &mut pin_2];
 ///
 /// let ext1 = Ext1WakeupSource::new(&mut wakeup_pins, WakeupLevel::High);
 ///
@@ -215,8 +219,9 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
 /// let delay = Delay::new();
 /// let mut rtc = Rtc::new(peripherals.LPWR);
 ///
-/// let pin2 = Input::new(peripherals.GPIO2, Pull::None);
+/// let mut pin2 = peripherals.GPIO2;
 /// let mut pin3 = peripherals.GPIO3;
+/// let mut pin2_input = Input::new(&mut pin2, Pull::None);
 ///
 /// let reason =
 /// reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
@@ -225,8 +230,11 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
 ///
 /// let timer = TimerWakeupSource::new(Duration::from_secs(30));
 ///
+/// core::mem::drop(pin2_input);
+///
 /// let wakeup_pins: &mut [(&mut dyn RtcPinWithResistors, WakeupLevel)] =
-///     &mut [(&mut *pin2.into_ref(), WakeupLevel::Low),
+/// &mut [
+///     (&mut pin2, WakeupLevel::Low),
 ///     (&mut pin3, WakeupLevel::High),
 /// ];
 ///
@@ -277,15 +285,9 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
 ///
 /// let delay = Delay::new();
 /// let timer = TimerWakeupSource::new(Duration::from_secs(10));
-#[cfg_attr(
-    any(esp32c3, esp32c2),
-    doc = "let pin_0 = Input::new(peripherals.GPIO2, Pull::None);"
-)]
+#[cfg_attr(any(esp32c3, esp32c2), doc = "let mut pin_0 = peripherals.GPIO2;")]
 #[cfg_attr(any(esp32c3, esp32c2), doc = "let mut pin_1 = peripherals.GPIO3;")]
-#[cfg_attr(
-    esp32s3,
-    doc = "let pin_0 = Input::new(peripherals.GPIO17, Pull::None);"
-)]
+#[cfg_attr(esp32s3, doc = "let mut pin_0 = peripherals.GPIO17;")]
 #[cfg_attr(esp32s3, doc = "let mut pin_1 = peripherals.GPIO18;")]
 #[cfg_attr(
     any(esp32c3, esp32c2),
@@ -295,7 +297,7 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
     esp32s3,
     doc = "let wakeup_pins: &mut [(&mut dyn gpio::RtcPin, WakeupLevel)] = &mut ["
 )]
-///     (&mut *pin_0.into_ref(), WakeupLevel::Low),
+///     (&mut pin_0, WakeupLevel::Low),
 ///     (&mut pin_1, WakeupLevel::High),
 /// ];
 ///

--- a/qa-test/src/bin/sleep_timer_ext0.rs
+++ b/qa-test/src/bin/sleep_timer_ext0.rs
@@ -32,7 +32,8 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.LPWR);
 
-    let ext0_pin = Input::new(peripherals.GPIO4, Pull::None);
+    let mut pin4 = peripherals.GPIO4;
+    let ext0_pin = Input::new(&mut pin4, Pull::None);
 
     println!("up and runnning!");
     let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
@@ -42,8 +43,10 @@ fn main() -> ! {
 
     let delay = Delay::new();
 
+    core::mem::drop(ext0_pin);
+
     let timer = TimerWakeupSource::new(Duration::from_secs(30));
-    let ext0 = Ext0WakeupSource::new(ext0_pin, WakeupLevel::High);
+    let ext0 = Ext0WakeupSource::new(&mut pin4, WakeupLevel::High);
     println!("sleeping!");
     delay.delay_millis(100);
     rtc.sleep_deep(&[&timer, &ext0]);

--- a/qa-test/src/bin/sleep_timer_ext1.rs
+++ b/qa-test/src/bin/sleep_timer_ext1.rs
@@ -15,7 +15,6 @@ use esp_hal::{
     delay::Delay,
     gpio::{Input, Pull, RtcPin},
     main,
-    peripheral::Peripheral,
     rtc_cntl::{
         reset_reason,
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
@@ -33,8 +32,9 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.LPWR);
 
-    let pin_0 = Input::new(peripherals.GPIO4, Pull::None);
     let mut pin_2 = peripherals.GPIO2;
+    let mut pin_4 = peripherals.GPIO4;
+    let input = Input::new(&mut pin_4, Pull::None);
 
     println!("up and runnning!");
     let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
@@ -45,7 +45,8 @@ fn main() -> ! {
     let delay = Delay::new();
 
     let timer = TimerWakeupSource::new(Duration::from_secs(30));
-    let mut wakeup_pins: [&mut dyn RtcPin; 2] = [&mut *pin_0.into_ref(), &mut pin_2];
+    core::mem::drop(input);
+    let mut wakeup_pins: [&mut dyn RtcPin; 2] = [&mut pin_4, &mut pin_2];
     let ext1 = Ext1WakeupSource::new(&mut wakeup_pins, WakeupLevel::High);
     println!("sleeping!");
     delay.delay_millis(100);

--- a/qa-test/src/bin/sleep_timer_lpio.rs
+++ b/qa-test/src/bin/sleep_timer_lpio.rs
@@ -16,7 +16,6 @@ use esp_hal::{
     delay::Delay,
     gpio::{Input, Pull, RtcPinWithResistors},
     main,
-    peripheral::Peripheral,
     rtc_cntl::{
         reset_reason,
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel},
@@ -34,8 +33,9 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.LPWR);
 
-    let pin2 = Input::new(peripherals.GPIO2, Pull::None);
+    let mut pin2 = peripherals.GPIO2;
     let mut pin3 = peripherals.GPIO3;
+    let input = Input::new(&mut pin2, Pull::None);
 
     println!("up and runnning!");
     let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);
@@ -46,8 +46,10 @@ fn main() -> ! {
     let delay = Delay::new();
     let timer = TimerWakeupSource::new(Duration::from_secs(10));
 
+    core::mem::drop(input);
+
     let wakeup_pins: &mut [(&mut dyn RtcPinWithResistors, WakeupLevel)] = &mut [
-        (&mut *pin2.into_ref(), WakeupLevel::Low),
+        (&mut pin2, WakeupLevel::Low),
         (&mut pin3, WakeupLevel::High),
     ];
 

--- a/qa-test/src/bin/sleep_timer_rtcio.rs
+++ b/qa-test/src/bin/sleep_timer_rtcio.rs
@@ -20,7 +20,6 @@ use esp_hal::{
     gpio,
     gpio::{Input, Pull},
     main,
-    peripheral::Peripheral,
     rtc_cntl::{
         reset_reason,
         sleep::{RtcioWakeupSource, TimerWakeupSource, WakeupLevel},
@@ -49,19 +48,21 @@ fn main() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32c3", feature = "esp32c2"))] {
-            let pin2 = Input::new(peripherals.GPIO2, Pull::None);
+            let mut pin2 = peripherals.GPIO2;
             let mut pin3 = peripherals.GPIO3;
+            let _pin2_input = Input::new(&mut pin2, Pull::None);
 
             let wakeup_pins: &mut [(&mut dyn gpio::RtcPinWithResistors, WakeupLevel)] = &mut [
-                (&mut *pin2.into_ref(), WakeupLevel::Low),
+                (&mut pin2, WakeupLevel::Low),
                 (&mut pin3, WakeupLevel::High),
             ];
         } else if #[cfg(feature = "esp32s3")] {
-            let pin17 = Input::new(peripherals.GPIO17, Pull::None);
+            let mut pin17 = peripherals.GPIO17;
             let mut pin18 = peripherals.GPIO18;
+            let _pin17_input = Input::new(&mut pin17, Pull::None);
 
             let wakeup_pins: &mut [(&mut dyn gpio::RtcPin, WakeupLevel)] = &mut [
-                (&mut *pin17.into_ref(), WakeupLevel::Low),
+                (&mut pin17, WakeupLevel::Low),
                 (&mut pin18, WakeupLevel::High),
             ];
         }


### PR DESCRIPTION
The sleep APIs are unstable and these traits are also marked as "unfortunate implementation details" (by me...) so I think it's best if we rip them out and revisit later.

As for `Pin`, the trait isn't actually needed by the interconnect impl.