### PR TITLE
Update Xtensa Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           ldproxy: false
-          version: 1.83.0.1
+          version: 1.84.0.0
       # Install the Rust stable toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           default: true
           ldproxy: false
-          version: 1.83.0.1
+          version: 1.84.0.0
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: "docs/"
-      
+
       - name: Create index.html
         run: "cargo xtask build-documentation-index --packages=$(echo '${{ needs.setup.outputs.packages }}' | jq -r '[.[].name] | join(\",\")')"
 

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -116,7 +116,7 @@ jobs:
           buildtargets: ${{ matrix.target.soc }}
           default: true
           ldproxy: false
-          version: 1.83.0.1
+          version: 1.84.0.0
 
       - name: Build tests
         run: cargo xtask build-tests ${{ matrix.target.soc }}

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -362,7 +362,7 @@ where
     }
 }
 
-impl<'d, BUF> I2sParallelTransfer<'d, BUF, Async>
+impl<BUF> I2sParallelTransfer<'_, BUF, Async>
 where
     BUF: DmaTxBuffer,
 {

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -484,7 +484,7 @@ impl<BUF: DmaTxBuffer, Dm: DriverMode> DerefMut for I8080Transfer<'_, BUF, Dm> {
     }
 }
 
-impl<'d, BUF: DmaTxBuffer> I8080Transfer<'d, BUF, crate::Async> {
+impl<BUF: DmaTxBuffer> I8080Transfer<'_, BUF, crate::Async> {
     /// Waits for [Self::is_done] to return true.
     pub async fn wait_for_done(&mut self) {
         use core::{

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -298,7 +298,7 @@ pub mod asynch {
         }
     }
 
-    impl<'d> embassy_usb_driver::Bus for Bus<'d> {
+    impl embassy_usb_driver::Bus for Bus<'_> {
         async fn poll(&mut self) -> Event {
             self.inner.poll().await
         }
@@ -336,12 +336,6 @@ pub mod asynch {
 
     #[handler(priority = crate::interrupt::Priority::max())]
     fn interrupt_handler() {
-        unsafe {
-            on_interrupt(
-                Driver::REGISTERS,
-                &STATE,
-                Usb::ENDPOINT_COUNT,
-            )
-        }
+        unsafe { on_interrupt(Driver::REGISTERS, &STATE, Usb::ENDPOINT_COUNT) }
     }
 }

--- a/esp-storage/build.rs
+++ b/esp-storage/build.rs
@@ -1,7 +1,7 @@
 fn main() -> Result<(), String> {
     // Ensure that only a single chip is specified
     esp_build::assert_unique_used_features!(
-        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32p4", "esp32s2", "esp32s3"
+        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"
     );
 
     if cfg!(feature = "esp32") {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Pin Xtensa Rust version to 1.84.0.0 this will serve as a test for the toolchain and we still need it to be pinned.

#### Testing
CI/HIL