### PR TITLE
(Somewhat) clean up wifi timer queue

### DIFF
--- a/esp-wifi/src/tasks.rs
+++ b/esp-wifi/src/tasks.rs
@@ -19,7 +19,7 @@ pub(crate) extern "C" fn timer_task(_param: *mut esp_wifi_sys::c_types::c_void) 
     loop {
         let current_timestamp = systimer_count();
         let to_run = TIMERS.with(|timers| {
-            let to_run = unsafe { timers.find_next_due(current_timestamp) }?;
+            let to_run = timers.find_next_due(current_timestamp)?;
 
             to_run.active = to_run.periodic;
 

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -152,7 +152,6 @@ async fn main(spawner: Spawner) -> ! {
         use embedded_io_async::Write;
 
         let mut buffer = [0u8; 1024];
-        let mut pos = 0;
         loop {
             match socket.read(&mut buffer).await {
                 Ok(0) => {
@@ -160,16 +159,13 @@ async fn main(spawner: Spawner) -> ! {
                     break;
                 }
                 Ok(len) => {
-                    let to_print =
-                        unsafe { core::str::from_utf8_unchecked(&buffer[..(pos + len)]) };
+                    let to_print = unsafe { core::str::from_utf8_unchecked(&buffer[..len]) };
 
+                    print!("{}", to_print);
                     if to_print.contains("\r\n\r\n") {
-                        print!("{}", to_print);
                         println!();
                         break;
                     }
-
-                    pos += len;
                 }
                 Err(e) => {
                     println!("read error: {:?}", e);


### PR DESCRIPTION
A bit heavy-handed maybe, but malloc tends to screw up alignment by the 4-byte offsetting it does, so I needed a typed alternative that doesn't add 4 bytes of size info when we don't need it to.

The main change is that the timer queue is now linked in the other direction, so pushing is O(1) and removal has been simplified to one scan instead of two.