### PR TITLE
i2c_master: Add interrupt APIs

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `with_rx()` and `with_tx()` methods to Uart, UartRx, and UartTx (#2904)
 - ESP32-S2: Made Wi-Fi peripheral non virtual. (#2942)
 - `UartRx::check_for_errors`, `Uart::check_for_rx_errors`, `{Uart, UartRx}::read_buffered_bytes` (#2935)
+- Added `i2c` interrupt API (#2944)
 
 ### Changed
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1384,24 +1384,28 @@ impl<'d> Input<'d> {
     /// }
     /// ```
     #[inline]
+    #[instability::unstable]
     pub fn listen(&mut self, event: Event) {
         self.pin.listen(event);
     }
 
     /// Stop listening for interrupts
     #[inline]
+    #[instability::unstable]
     pub fn unlisten(&mut self) {
         self.pin.unlisten();
     }
 
     /// Clear the interrupt status bit for this Pin
     #[inline]
+    #[instability::unstable]
     pub fn clear_interrupt(&mut self) {
         self.pin.clear_interrupt();
     }
 
     /// Checks if the interrupt status bit for this Pin is set
     #[inline]
+    #[instability::unstable]
     pub fn is_interrupt_set(&self) -> bool {
         self.pin.is_interrupt_set()
     }
@@ -1560,18 +1564,21 @@ impl<'d> OutputOpenDrain<'d> {
     ///
     /// See [`Input::listen`] for more information and an example.
     #[inline]
+    #[instability::unstable]
     pub fn listen(&mut self, event: Event) {
         self.pin.listen(event);
     }
 
     /// Stop listening for interrupts.
     #[inline]
+    #[instability::unstable]
     pub fn unlisten(&mut self) {
         self.pin.unlisten();
     }
 
     /// Clear the interrupt status bit for this Pin
     #[inline]
+    #[instability::unstable]
     pub fn clear_interrupt(&mut self) {
         self.pin.clear_interrupt();
     }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -980,25 +980,27 @@ mod dma {
         }
     }
 
-    #[cfg(any(doc, feature = "unstable"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     impl SpiDma<'_, Blocking> {
         /// Listen for the given interrupts
+        #[instability::unstable]
         pub fn listen(&mut self, interrupts: impl Into<EnumSet<SpiInterrupt>>) {
             self.driver().enable_listen(interrupts.into(), true);
         }
 
         /// Unlisten the given interrupts
+        #[instability::unstable]
         pub fn unlisten(&mut self, interrupts: impl Into<EnumSet<SpiInterrupt>>) {
             self.driver().enable_listen(interrupts.into(), false);
         }
 
         /// Gets asserted interrupts
+        #[instability::unstable]
         pub fn interrupts(&mut self) -> EnumSet<SpiInterrupt> {
             self.driver().interrupts()
         }
 
         /// Resets asserted interrupts
+        #[instability::unstable]
         pub fn clear_interrupts(&mut self, interrupts: impl Into<EnumSet<SpiInterrupt>>) {
             self.driver().clear_interrupts(interrupts.into());
         }
@@ -1645,25 +1647,27 @@ mod dma {
         }
     }
 
-    #[cfg(any(doc, feature = "unstable"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     impl SpiDmaBus<'_, Blocking> {
         /// Listen for the given interrupts
+        #[instability::unstable]
         pub fn listen(&mut self, interrupts: impl Into<EnumSet<SpiInterrupt>>) {
             self.spi_dma.listen(interrupts.into());
         }
 
         /// Unlisten the given interrupts
+        #[instability::unstable]
         pub fn unlisten(&mut self, interrupts: impl Into<EnumSet<SpiInterrupt>>) {
             self.spi_dma.unlisten(interrupts.into());
         }
 
         /// Gets asserted interrupts
+        #[instability::unstable]
         pub fn interrupts(&mut self) -> EnumSet<SpiInterrupt> {
             self.spi_dma.interrupts()
         }
 
         /// Resets asserted interrupts
+        #[instability::unstable]
         pub fn clear_interrupts(&mut self, interrupts: impl Into<EnumSet<SpiInterrupt>>) {
             self.spi_dma.clear_interrupts(interrupts.into());
         }


### PR DESCRIPTION
closes #2905

Adds `i2c` interrupts API, mark interrupt API as `unstable` in drivers we are stabilizing. 