### PR TITLE
Minor pre-release cleanup

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -84,7 +84,7 @@ esp-config   = { version = "0.2.0", path = "../esp-config", features = ["build"]
 serde        = { version = "1.0.215", features = ["derive"] }
 
 [features]
-default = []
+default = ["unstable"] # FIXME: Unstable needs to be disabled before 1.0.0-beta0
 
 bluetooth = []
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -24,7 +24,7 @@ cfg-if                   = "1.0.0"
 chrono                   = { version = "0.4.38", default-features = false }
 critical-section         = "1.2.0"
 defmt                    = { version = "0.3.8", optional = true }
-delegate                 = "0.13.1"
+delegate                 = "0.13.2"
 digest                   = { version = "0.10.7", default-features = false, optional = true }
 document-features        = "0.2.10"
 embassy-embedded-hal     = { version = "0.2.0", optional = true }

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -28,12 +28,20 @@ use crate::{
 ///
 /// Peripheral drivers are encouraged to accept types that implement this and
 /// [`PeripheralOutput`] as arguments instead of pin types.
+#[allow(
+    private_bounds,
+    reason = "InputConnection is unstable, but the trait needs to be public"
+)]
 pub trait PeripheralInput: Into<InputConnection> + 'static + crate::private::Sealed {}
 
 /// A signal that can be connected to a peripheral input and/or output.
 ///
 /// Peripheral drivers are encouraged to accept types that implement this and
 /// [`PeripheralInput`] as arguments instead of pin types.
+#[allow(
+    private_bounds,
+    reason = "OutputConnection is unstable, but the trait needs to be public"
+)]
 pub trait PeripheralOutput: Into<OutputConnection> + 'static + crate::private::Sealed {}
 
 // Pins
@@ -427,7 +435,7 @@ impl OutputSignal {
     }
 
     delegate::delegate! {
-        #[doc(hidden)]
+        #[instability::unstable]
         to self.pin {
             pub fn pull_direction(&self, pull: Pull);
             pub fn input_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::InputSignal)];
@@ -505,7 +513,7 @@ enum InputConnectionInner {
 /// This is mainly intended for internal use, but it can be used to connect
 /// peripherals within the MCU without external hardware.
 #[derive(Clone)]
-#[doc(hidden)] // FIXME: replace with `#[unstable]` when we can mark delegated methods https://github.com/Kobzol/rust-delegate/issues/77
+#[instability::unstable]
 pub struct InputConnection(InputConnectionInner);
 
 impl Peripheral for InputConnection {
@@ -580,7 +588,7 @@ impl Sealed for InputConnection {}
 
 impl InputConnection {
     delegate::delegate! {
-        #[doc(hidden)]
+        #[instability::unstable]
         to match &self.0 {
             InputConnectionInner::Input(pin) => pin,
             InputConnectionInner::DirectInput(pin) => pin,
@@ -592,7 +600,7 @@ impl InputConnection {
             pub fn input_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::InputSignal)];
         }
 
-        #[doc(hidden)]
+        #[instability::unstable]
         to match &mut self.0 {
             InputConnectionInner::Input(pin) => pin,
             InputConnectionInner::DirectInput(pin) => pin,
@@ -616,7 +624,7 @@ enum OutputConnectionInner {
 ///
 /// This is mainly intended for internal use, but it can be used to connect
 /// peripherals within the MCU without external hardware.
-#[doc(hidden)] // FIXME: replace with `#[unstable]` when we can mark delegated methods https://github.com/Kobzol/rust-delegate/issues/77
+#[instability::unstable]
 pub struct OutputConnection(OutputConnectionInner);
 
 impl Sealed for OutputConnection {}
@@ -676,7 +684,7 @@ impl From<DirectOutputSignal> for OutputConnection {
 
 impl OutputConnection {
     delegate::delegate! {
-        #[doc(hidden)]
+        #[instability::unstable]
         to match &self.0 {
             OutputConnectionInner::Output(pin) => pin,
             OutputConnectionInner::DirectOutput(pin) => pin,
@@ -688,7 +696,7 @@ impl OutputConnection {
             pub fn is_set_high(&self) -> bool;
             pub fn output_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::OutputSignal)];
         }
-        #[doc(hidden)]
+        #[instability::unstable]
         to match &mut self.0 {
             OutputConnectionInner::Output(pin) => pin,
             OutputConnectionInner::DirectOutput(pin) => pin,

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -34,7 +34,6 @@ impl Level {
         *self == Level::High
     }
 
-    #[doc(hidden)]
     pub(crate) fn connect_input_to_peripheral(&mut self, signal: InputSignal) {
         let value = match self {
             Level::High => ONE_INPUT,

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -207,7 +207,7 @@ embedded-hal-async = "1.0.0"
 embedded-hal-nb    = "1.0.0"
 esp-alloc          = { path = "../esp-alloc", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "defmt", "semihosting"] }
-esp-hal            = { path = "../esp-hal", features = ["digest"], optional = true }
+esp-hal            = { path = "../esp-hal", default-features = false, features = ["digest"], optional = true } # TODO: default-features = false should be removed for 1.0.0-beta0
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 esp-wifi           = { path = "../esp-wifi", optional = true, features = ["wifi"] }
 portable-atomic    = "1.9.0"


### PR DESCRIPTION
- I propose enabling the stable feature by default while we're still not in beta. While it's easy to opt-in, I want to avoid forcing projects into it now, when they can forget it being enabled.
- The rest just updates `delegate` and touches up parts that the new release affects.