### PR TITLE
esp-wifi: Use `timer_queue`

### DIFF
--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -38,7 +38,8 @@ libm = "0.2.11"
 cfg-if = "1.0.0"
 portable-atomic = { version = "1.9.0", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
-rand_core           = "0.6.4"
+rand_core = "0.6.4"
+timer-queue = "0.1.0"
 
 bt-hci = { version = "0.1.1", optional = true }
 esp-config = { version = "0.2.0", path = "../esp-config" }

--- a/esp-wifi/src/compat/timer_compat.rs
+++ b/esp-wifi/src/compat/timer_compat.rs
@@ -23,7 +23,8 @@ impl EtsTimer {
 
     fn set_timer_handle(&mut self, timer: timer_queue::Timer) {
         unsafe {
-            (*(self.0)).priv_ = core::mem::transmute(timer);
+            (*(self.0)).priv_ =
+                core::mem::transmute::<timer_queue::Timer, *mut c_types::c_void>(timer);
         }
     }
 
@@ -150,9 +151,7 @@ pub(crate) fn compat_timer_setfn(
     );
 
     let mut timer = EtsTimer(ets_timer);
-    unsafe {
-        timer.set_callback(core::mem::transmute(pfunction), core::mem::transmute(parg));
-    }
+    timer.set_callback(Some(pfunction), parg);
     timer.set_armed(false);
 }
 

--- a/esp-wifi/src/compat/timer_compat.rs
+++ b/esp-wifi/src/compat/timer_compat.rs
@@ -119,7 +119,7 @@ fn compat_timer_arm_us_with_drift(ets_timer: *mut ets_timer, us: u32, repeat: bo
 }
 
 pub fn compat_timer_disarm(ets_timer: *mut ets_timer) {
-    trace!("timer disarm {:p}", ets_timer);
+    trace!("timer disarm {:x}", ets_timer as usize);
     TIMERS.with(|timers| {
         let mut timer = EtsTimer(ets_timer);
         if timer.armed() {

--- a/esp-wifi/src/tasks.rs
+++ b/esp-wifi/src/tasks.rs
@@ -20,7 +20,11 @@ pub(crate) extern "C" fn timer_task(_param: *mut esp_wifi_sys::c_types::c_void) 
         // run the due timer callback NOT in an interrupt free context
         if let Some((func, param)) = get_next_due_timer() {
             if let Some(func) = func {
-                trace!("trigger timer callback {:p} {:p}", func, param);
+                trace!(
+                    "trigger timer callback {:x} {:x}",
+                    func as usize,
+                    param as usize
+                );
                 unsafe {
                     func(param as *mut _);
                 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

`skip-changelog` - no user facing change

Draft because it needs more testing. There are some more improvements I'd like to do which would be based on this.

There are some concerns regarding adding that `timer-queue` dependency.

- it's not widely used (no dependents on crates.io)
- two additional dependencies (one transitive but that one is quite popular)
- we already have a timer-queue in esp-hal-embassy (but that one is very different and specialized - don't see that fit here)

I would like to land this PR someday (since it changes things to the better) - I could replace that crate with our own implementation but not sure it's worth it.

- that crate doesn't look too bad
- if we ever need to replace it - wouldn't be too hard to come up with our own implementation (but `timer-queue` claims to be optimized for the task)



#### Testing
Running examples
