### PR TITLE
docs: RMT_CHANNEL_RAM_SIZE counts pulse codes, not bytes

### DIFF
--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -44,7 +44,7 @@ pub(crate) mod constants {
     pub const I2S_DEFAULT_CLK_SRC: u32 = 2;
     /// The starting address of the Remote Control (RMT) module's RAM.
     pub const RMT_RAM_START: usize = 0x3ff56800;
-    /// The size, in bytes, of each RMT channel's dedicated RAM.
+    /// The size (number of pulse codes) of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 64;
     /// The lower bound of the system's DRAM (Data RAM) address space.
     pub const SOC_DRAM_LOW: usize = 0x3FFA_E000;

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -47,7 +47,7 @@ pub(crate) mod constants {
 
     /// The starting address of the Remote Control (RMT) module's RAM.
     pub const RMT_RAM_START: usize = 0x60016400;
-    /// The size, in bytes, of each RMT channel's dedicated RAM.
+    /// The size (number of pulse codes) of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 48;
     /// RMT Clock source value.
     pub const RMT_CLOCK_SRC: u8 = 1;

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -52,7 +52,7 @@ pub(crate) mod constants {
 
     /// The starting address of the RMT (Remote Control) peripheral's RAM.
     pub const RMT_RAM_START: usize = 0x60006400;
-    /// The size of each RMT channel's RAM in bytes.
+    /// The size (number of pulse codes) of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 48;
     /// The default clock source for the RMT peripheral.
     pub const RMT_CLOCK_SRC: u8 = 1;

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -51,7 +51,7 @@ pub(crate) mod constants {
 
     /// Start address of the RMT (Remote Control) peripheral's RAM.
     pub const RMT_RAM_START: usize = 0x60007400;
-    /// Size of the RAM allocated per RMT channel, in bytes.
+    /// The size (number of pulse codes) of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 48;
     /// Clock source for the RMT peripheral (false = default source).
     pub const RMT_CLOCK_SRC: bool = false;

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -48,7 +48,7 @@ pub(crate) mod constants {
     pub const I2S_DEFAULT_CLK_SRC: u32 = 2;
     /// Start address of the RMT (Remote Control) peripheral's RAM.
     pub const RMT_RAM_START: usize = 0x3f416400;
-    /// Size of the RAM allocated per RMT channel, in bytes.
+    /// The size (number of pulse codes) of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 64;
     /// Start address of the system's DRAM (low range).
     pub const SOC_DRAM_LOW: usize = 0x3FFB_0000;

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -50,7 +50,7 @@ pub(crate) mod constants {
 
     /// The starting address of the Remote Control (RMT) module's RAM.
     pub const RMT_RAM_START: usize = 0x60016800;
-    /// The size, in bytes, of each RMT channel's dedicated RAM.
+    /// The size (number of pulse codes) of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 48;
     /// RMT Clock source value.
     pub const RMT_CLOCK_SRC: u8 = 1;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This corrects a code comment explaining the meaning of `RMT_CHANNEL_RAM_SIZE`. These values are given in the manuals as "XXX x 32bit RAM", i.e. it's not bytes but pulse codes counted by `RMT_CHANNEL_RAM_SIZE`. This matches how the codes uses the constant.

#### Testing
Not relevant, only code comments changed. I did have a quick look at all reference manuals: The values do appear to be correct.
