### PR TITLE
Remove Deref from peripheral singletons

### DIFF
--- a/esp-hal/src/aes/esp32.rs
+++ b/esp-hal/src/aes/esp32.rs
@@ -13,22 +13,22 @@ impl Aes<'_> {
     }
 
     pub(super) fn write_key(&mut self, key: &[u8]) {
-        let key_len = self.aes.key_iter().count();
+        let key_len = self.regs().key_iter().count();
         debug_assert!(key.len() <= key_len * ALIGN_SIZE);
         debug_assert_eq!(key.len() % ALIGN_SIZE, 0);
         self.alignment_helper
-            .volatile_write_regset(self.aes.key(0).as_ptr(), key, key_len);
+            .volatile_write_regset(self.regs().key(0).as_ptr(), key, key_len);
     }
 
     pub(super) fn write_block(&mut self, block: &[u8]) {
-        let text_len = self.aes.text_iter().count();
+        let text_len = self.regs().text_iter().count();
         debug_assert_eq!(block.len(), text_len * ALIGN_SIZE);
         self.alignment_helper
-            .volatile_write_regset(self.aes.text(0).as_ptr(), block, text_len);
+            .volatile_write_regset(self.regs().text(0).as_ptr(), block, text_len);
     }
 
     pub(super) fn write_mode(&self, mode: Mode) {
-        self.aes.mode().write(|w| unsafe { w.bits(mode as _) });
+        self.regs().mode().write(|w| unsafe { w.bits(mode as _) });
     }
 
     /// Configures how the state matrix would be laid out
@@ -48,22 +48,22 @@ impl Aes<'_> {
         to_write |= (input_text_word_endianess as u32) << 3;
         to_write |= (output_text_byte_endianess as u32) << 4;
         to_write |= (output_text_word_endianess as u32) << 5;
-        self.aes.endian().write(|w| unsafe { w.bits(to_write) });
+        self.regs().endian().write(|w| unsafe { w.bits(to_write) });
     }
 
     pub(super) fn write_start(&self) {
-        self.aes.start().write(|w| w.start().set_bit());
+        self.regs().start().write(|w| w.start().set_bit());
     }
 
     pub(super) fn read_idle(&mut self) -> bool {
-        self.aes.idle().read().idle().bit_is_set()
+        self.regs().idle().read().idle().bit_is_set()
     }
 
     pub(super) fn read_block(&self, block: &mut [u8]) {
-        let text_len = self.aes.text_iter().count();
+        let text_len = self.regs().text_iter().count();
         debug_assert_eq!(block.len(), text_len * ALIGN_SIZE);
         self.alignment_helper
-            .volatile_read_regset(self.aes.text(0).as_ptr(), block, text_len);
+            .volatile_read_regset(self.regs().text(0).as_ptr(), block, text_len);
     }
 }
 

--- a/esp-hal/src/aes/esp32cX.rs
+++ b/esp-hal/src/aes/esp32cX.rs
@@ -6,41 +6,40 @@ impl Aes<'_> {
     }
 
     fn write_dma(&mut self, enable_dma: bool) {
-        match enable_dma {
-            true => self.aes.dma_enable().write(|w| w.dma_enable().set_bit()),
-            false => self.aes.dma_enable().write(|w| w.dma_enable().clear_bit()),
-        };
+        self.regs()
+            .dma_enable()
+            .write(|w| w.dma_enable().bit(enable_dma));
     }
 
     pub(super) fn write_key(&mut self, key: &[u8]) {
         debug_assert!(key.len() <= 8 * ALIGN_SIZE);
         debug_assert_eq!(key.len() % ALIGN_SIZE, 0);
         self.alignment_helper
-            .volatile_write_regset(self.aes.key(0).as_ptr(), key, 8);
+            .volatile_write_regset(self.regs().key(0).as_ptr(), key, 8);
     }
 
     pub(super) fn write_block(&mut self, block: &[u8]) {
         debug_assert_eq!(block.len(), 4 * ALIGN_SIZE);
         self.alignment_helper
-            .volatile_write_regset(self.aes.text_in(0).as_ptr(), block, 4);
+            .volatile_write_regset(self.regs().text_in(0).as_ptr(), block, 4);
     }
 
     pub(super) fn write_mode(&self, mode: Mode) {
-        self.aes.mode().write(|w| unsafe { w.bits(mode as _) });
+        self.regs().mode().write(|w| unsafe { w.bits(mode as _) });
     }
 
     pub(super) fn write_start(&self) {
-        self.aes.trigger().write(|w| w.trigger().set_bit());
+        self.regs().trigger().write(|w| w.trigger().set_bit());
     }
 
     pub(super) fn read_idle(&mut self) -> bool {
-        self.aes.state().read().state().bits() == 0
+        self.regs().state().read().state().bits() == 0
     }
 
     pub(super) fn read_block(&self, block: &mut [u8]) {
         debug_assert_eq!(block.len(), 4 * ALIGN_SIZE);
         self.alignment_helper
-            .volatile_read_regset(self.aes.text_out(0).as_ptr(), block, 4);
+            .volatile_read_regset(self.regs().text_out(0).as_ptr(), block, 4);
     }
 }
 

--- a/esp-hal/src/aes/esp32s3.rs
+++ b/esp-hal/src/aes/esp32s3.rs
@@ -6,46 +6,46 @@ impl Aes<'_> {
     }
 
     fn write_dma(&mut self, enable_dma: bool) {
-        self.aes
+        self.regs()
             .dma_enable()
             .write(|w| w.dma_enable().bit(enable_dma));
     }
 
     pub(super) fn write_key(&mut self, key: &[u8]) {
-        let key_len = self.aes.key_iter().count();
+        let key_len = self.regs().key_iter().count();
         debug_assert!(key.len() <= key_len * ALIGN_SIZE);
         debug_assert_eq!(key.len() % ALIGN_SIZE, 0);
         self.alignment_helper
-            .volatile_write_regset(self.aes.key(0).as_ptr(), key, key_len);
+            .volatile_write_regset(self.regs().key(0).as_ptr(), key, key_len);
     }
 
     pub(super) fn write_block(&mut self, block: &[u8]) {
-        let text_in_len = self.aes.text_in_iter().count();
+        let text_in_len = self.regs().text_in_iter().count();
         debug_assert_eq!(block.len(), text_in_len * ALIGN_SIZE);
         self.alignment_helper.volatile_write_regset(
-            self.aes.text_in(0).as_ptr(),
+            self.regs().text_in(0).as_ptr(),
             block,
             text_in_len,
         );
     }
 
     pub(super) fn write_mode(&self, mode: Mode) {
-        self.aes.mode().write(|w| unsafe { w.bits(mode as _) });
+        self.regs().mode().write(|w| unsafe { w.bits(mode as _) });
     }
 
     pub(super) fn write_start(&self) {
-        self.aes.trigger().write(|w| w.trigger().set_bit());
+        self.regs().trigger().write(|w| w.trigger().set_bit());
     }
 
     pub(super) fn read_idle(&mut self) -> bool {
-        self.aes.state().read().state().bits() == 0
+        self.regs().state().read().state().bits() == 0
     }
 
     pub(super) fn read_block(&self, block: &mut [u8]) {
-        let text_out_len = self.aes.text_out_iter().count();
+        let text_out_len = self.regs().text_out_iter().count();
         debug_assert_eq!(block.len(), text_out_len * ALIGN_SIZE);
         self.alignment_helper.volatile_read_regset(
-            self.aes.text_out(0).as_ptr(),
+            self.regs().text_out(0).as_ptr(),
             block,
             text_out_len,
         );

--- a/esp-hal/src/hmac.rs
+++ b/esp-hal/src/hmac.rs
@@ -37,6 +37,7 @@
 use core::convert::Infallible;
 
 use crate::{
+    pac,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::HMAC,
     reg_access::{AlignmentHelper, SocDependentEndianess},
@@ -120,13 +121,17 @@ impl<'d> Hmac<'d> {
         }
     }
 
+    fn regs(&self) -> &pac::hmac::RegisterBlock {
+        self.hmac.register_block()
+    }
+
     /// Step 1. Enable HMAC module.
     ///
     /// Before these steps, the user shall set the peripheral clocks bits for
     /// HMAC and SHA peripherals and clear the corresponding peripheral
     /// reset bits.
     pub fn init(&mut self) {
-        self.hmac.set_start().write(|w| w.set_start().set_bit());
+        self.regs().set_start().write(|w| w.set_start().set_bit());
         self.alignment_helper.reset();
         self.byte_written = 64;
         self.next_command = NextCommand::None;
@@ -134,17 +139,17 @@ impl<'d> Hmac<'d> {
 
     /// Step 2. Configure HMAC keys and key purposes.
     pub fn configure(&mut self, m: HmacPurpose, key_id: KeyId) -> nb::Result<(), Error> {
-        self.hmac
+        self.regs()
             .set_para_purpose()
             .write(|w| unsafe { w.purpose_set().bits(m as u8) });
-        self.hmac
+        self.regs()
             .set_para_key()
             .write(|w| unsafe { w.key_set().bits(key_id as u8) });
-        self.hmac
+        self.regs()
             .set_para_finish()
             .write(|w| w.set_para_end().set_bit());
 
-        if self.hmac.query_error().read().query_check().bit_is_set() {
+        if self.regs().query_error().read().query_check().bit_is_set() {
             return Err(nb::Error::Other(Error::KeyPurposeMismatch));
         }
 
@@ -185,21 +190,23 @@ impl<'d> Hmac<'d> {
 
         // Checking if the message is one block including padding
         if msg_len < 64 + 56 {
-            self.hmac.one_block().write(|w| w.set_one_block().set_bit());
+            self.regs()
+                .one_block()
+                .write(|w| w.set_one_block().set_bit());
 
             while self.is_busy() {}
         }
 
         self.alignment_helper.volatile_read_regset(
             #[cfg(esp32s2)]
-            self.hmac.rd_result_(0).as_ptr(),
+            self.regs().rd_result_(0).as_ptr(),
             #[cfg(not(esp32s2))]
-            self.hmac.rd_result_mem(0).as_ptr(),
+            self.regs().rd_result_mem(0).as_ptr(),
             output,
             core::cmp::min(output.len(), 32) / self.alignment_helper.align_size(),
         );
 
-        self.hmac
+        self.regs()
             .set_result_finish()
             .write(|w| w.set_result_end().set_bit());
         self.byte_written = 64;
@@ -208,18 +215,18 @@ impl<'d> Hmac<'d> {
     }
 
     fn is_busy(&mut self) -> bool {
-        self.hmac.query_busy().read().busy_state().bit_is_set()
+        self.regs().query_busy().read().busy_state().bit_is_set()
     }
 
     fn next_command(&mut self) {
         match self.next_command {
             NextCommand::MessageIng => {
-                self.hmac
+                self.regs()
                     .set_message_ing()
                     .write(|w| w.set_text_ing().set_bit());
             }
             NextCommand::MessagePad => {
-                self.hmac
+                self.regs()
                     .set_message_pad()
                     .write(|w| w.set_text_pad().set_bit());
             }
@@ -233,9 +240,9 @@ impl<'d> Hmac<'d> {
 
         let (remaining, bound_reached) = self.alignment_helper.aligned_volatile_copy(
             #[cfg(esp32s2)]
-            self.hmac.wr_message_(0).as_ptr(),
+            self.regs().wr_message_(0).as_ptr(),
             #[cfg(not(esp32s2))]
-            self.hmac.wr_message_mem(0).as_ptr(),
+            self.regs().wr_message_mem(0).as_ptr(),
             incoming,
             64 / self.alignment_helper.align_size(),
             mod_length / self.alignment_helper.align_size(),
@@ -246,7 +253,7 @@ impl<'d> Hmac<'d> {
             .wrapping_add(incoming.len() - remaining.len());
 
         if bound_reached {
-            self.hmac
+            self.regs()
                 .set_message_one()
                 .write(|w| w.set_text_one().set_bit());
 
@@ -267,15 +274,15 @@ impl<'d> Hmac<'d> {
 
         let flushed = self.alignment_helper.flush_to(
             #[cfg(esp32s2)]
-            self.hmac.wr_message_(0).as_ptr(),
+            self.regs().wr_message_(0).as_ptr(),
             #[cfg(not(esp32s2))]
-            self.hmac.wr_message_mem(0).as_ptr(),
+            self.regs().wr_message_mem(0).as_ptr(),
             (self.byte_written % 64) / self.alignment_helper.align_size(),
         );
 
         self.byte_written = self.byte_written.wrapping_add(flushed);
         if flushed > 0 && self.byte_written % 64 == 0 {
-            self.hmac
+            self.regs()
                 .set_message_one()
                 .write(|w| w.set_text_one().set_bit());
             while self.is_busy() {}
@@ -293,14 +300,14 @@ impl<'d> Hmac<'d> {
             let pad_len = 64 - mod_cursor;
             self.alignment_helper.volatile_write_bytes(
                 #[cfg(esp32s2)]
-                self.hmac.wr_message_(0).as_ptr(),
+                self.regs().wr_message_(0).as_ptr(),
                 #[cfg(not(esp32s2))]
-                self.hmac.wr_message_mem(0).as_ptr(),
+                self.regs().wr_message_mem(0).as_ptr(),
                 0_u8,
                 pad_len / self.alignment_helper.align_size(),
                 mod_cursor / self.alignment_helper.align_size(),
             );
-            self.hmac
+            self.regs()
                 .set_message_one()
                 .write(|w| w.set_text_one().set_bit());
             self.byte_written = self.byte_written.wrapping_add(pad_len);
@@ -315,9 +322,9 @@ impl<'d> Hmac<'d> {
 
         self.alignment_helper.volatile_write_bytes(
             #[cfg(esp32s2)]
-            self.hmac.wr_message_(0).as_ptr(),
+            self.regs().wr_message_(0).as_ptr(),
             #[cfg(not(esp32s2))]
-            self.hmac.wr_message_mem(0).as_ptr(),
+            self.regs().wr_message_mem(0).as_ptr(),
             0_u8,
             pad_len / self.alignment_helper.align_size(),
             mod_cursor / self.alignment_helper.align_size(),
@@ -332,15 +339,14 @@ impl<'d> Hmac<'d> {
 
         self.alignment_helper.aligned_volatile_copy(
             #[cfg(esp32s2)]
-            self.hmac.wr_message_(0).as_ptr(),
+            self.regs().wr_message_(0).as_ptr(),
             #[cfg(not(esp32s2))]
-            self.hmac.wr_message_mem(0).as_ptr(),
+            self.regs().wr_message_mem(0).as_ptr(),
             &len_mem,
             64 / self.alignment_helper.align_size(),
             (64 - core::mem::size_of::<u64>()) / self.alignment_helper.align_size(),
         );
-
-        self.hmac
+        self.regs()
             .set_message_one()
             .write(|w| w.set_text_one().set_bit());
 

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -769,7 +769,7 @@ struct I2cFuture<'a> {
 #[cfg(not(esp32))]
 impl<'a> I2cFuture<'a> {
     pub fn new(event: Event, info: &'a Info, state: &'a State) -> Self {
-        info.register_block().int_ena().modify(|_, w| {
+        info.regs().int_ena().modify(|_, w| {
             let w = match event {
                 Event::EndDetect => w.end_detect().set_bit(),
                 Event::TxComplete => w.trans_complete().set_bit(),
@@ -788,7 +788,7 @@ impl<'a> I2cFuture<'a> {
     }
 
     fn event_bit_is_clear(&self) -> bool {
-        let r = self.info.register_block().int_ena().read();
+        let r = self.info.regs().int_ena().read();
 
         match self.event {
             Event::EndDetect => r.end_detect().bit_is_clear(),
@@ -799,7 +799,7 @@ impl<'a> I2cFuture<'a> {
     }
 
     fn check_error(&self) -> Result<(), Error> {
-        let r = self.info.register_block().int_raw().read();
+        let r = self.info.regs().int_raw().read();
 
         if r.arbitration_lost().bit_is_set() {
             return Err(Error::ArbitrationLost);
@@ -811,19 +811,12 @@ impl<'a> I2cFuture<'a> {
 
         if r.nack().bit_is_set() {
             return Err(Error::AcknowledgeCheckFailed(estimate_ack_failed_reason(
-                self.info.register_block(),
+                self.info.regs(),
             )));
         }
 
         #[cfg(not(esp32))]
-        if r.trans_complete().bit_is_set()
-            && self
-                .info
-                .register_block()
-                .sr()
-                .read()
-                .resp_rec()
-                .bit_is_clear()
+        if r.trans_complete().bit_is_set() && self.info.regs().sr().read().resp_rec().bit_is_clear()
         {
             return Err(Error::AcknowledgeCheckFailed(
                 AcknowledgeCheckFailedReason::Data,
@@ -1009,7 +1002,7 @@ impl embedded_hal_async::i2c::I2c for I2c<'_, Async> {
 }
 
 fn async_handler(info: &Info, state: &State) {
-    let regs = info.register_block();
+    let regs = info.regs();
     regs.int_ena().modify(|_, w| {
         w.end_detect().clear_bit();
         w.trans_complete().clear_bit();
@@ -1179,13 +1172,13 @@ pub struct Info {
 
 impl Info {
     /// Returns the register block for this I2C instance.
-    pub fn register_block(&self) -> &RegisterBlock {
+    pub fn regs(&self) -> &RegisterBlock {
         unsafe { &*self.register_block }
     }
 
     /// Listen for the given interrupts
     fn enable_listen(&self, interrupts: EnumSet<Event>, enable: bool) {
-        let reg_block = self.register_block();
+        let reg_block = self.regs();
 
         reg_block.int_ena().modify(|_, w| {
             for interrupt in interrupts {
@@ -1202,7 +1195,7 @@ impl Info {
 
     fn interrupts(&self) -> EnumSet<Event> {
         let mut res = EnumSet::new();
-        let reg_block = self.register_block();
+        let reg_block = self.regs();
 
         let ints = reg_block.int_raw().read();
 
@@ -1221,7 +1214,7 @@ impl Info {
     }
 
     fn clear_interrupts(&self, interrupts: EnumSet<Event>) {
-        let reg_block = self.register_block();
+        let reg_block = self.regs();
 
         reg_block.int_clr().write(|w| {
             for interrupt in interrupts {
@@ -1266,14 +1259,14 @@ struct Driver<'a> {
 }
 
 impl Driver<'_> {
-    fn register_block(&self) -> &RegisterBlock {
-        self.info.register_block()
+    fn regs(&self) -> &RegisterBlock {
+        self.info.regs()
     }
 
     /// Configures the I2C peripheral with the specified frequency, clocks, and
     /// optional timeout.
     fn setup(&self, config: &Config) -> Result<(), ConfigError> {
-        self.register_block().ctr().write(|w| {
+        self.regs().ctr().write(|w| {
             // Set I2C controller to master mode
             w.ms_mode().set_bit();
             // Use open drain output for SDA and SCL
@@ -1287,13 +1280,11 @@ impl Driver<'_> {
         });
 
         #[cfg(esp32s2)]
-        self.register_block()
-            .ctr()
-            .modify(|_, w| w.ref_always_on().set_bit());
+        self.regs().ctr().modify(|_, w| w.ref_always_on().set_bit());
 
         // Configure filter
         // FIXME if we ever change this we need to adapt `set_frequency` for ESP32
-        set_filter(self.register_block(), Some(7), Some(7));
+        set_filter(self.regs(), Some(7), Some(7));
 
         // Configure frequency
         let clocks = Clocks::get();
@@ -1322,12 +1313,10 @@ impl Driver<'_> {
         // (the option to reset the FSM is not available
         // for the ESP32)
         #[cfg(not(esp32))]
-        self.register_block()
-            .ctr()
-            .modify(|_, w| w.fsm_rst().set_bit());
+        self.regs().ctr().modify(|_, w| w.fsm_rst().set_bit());
 
         // Clear all I2C interrupts
-        self.register_block()
+        self.regs()
             .int_clr()
             .write(|w| unsafe { w.bits(I2C_LL_INTR_MASK) });
 
@@ -1341,7 +1330,7 @@ impl Driver<'_> {
     /// Resets the I2C peripheral's command registers
     fn reset_command_list(&self) {
         // Confirm that all commands that were configured were actually executed
-        for cmd in self.register_block().comd_iter() {
+        for cmd in self.regs().comd_iter() {
             cmd.reset();
         }
     }
@@ -1411,7 +1400,7 @@ impl Driver<'_> {
         let scl_stop_hold_time = hold;
 
         configure_clock(
-            self.register_block(),
+            self.regs(),
             0,
             scl_low_period,
             scl_high_period,
@@ -1473,7 +1462,7 @@ impl Driver<'_> {
         });
 
         configure_clock(
-            self.register_block(),
+            self.regs(),
             0,
             scl_low_period,
             scl_high_period,
@@ -1556,7 +1545,7 @@ impl Driver<'_> {
         };
 
         configure_clock(
-            self.register_block(),
+            self.regs(),
             clkm_div,
             scl_low_period,
             scl_high_period,
@@ -1582,7 +1571,7 @@ impl Driver<'_> {
         self.wait_for_completion(false).await?;
 
         for byte in buffer.iter_mut() {
-            *byte = read_fifo(self.register_block());
+            *byte = read_fifo(self.regs());
         }
 
         Ok(())
@@ -1637,10 +1626,7 @@ impl Driver<'_> {
             // Load address and R/W bit into FIFO
             match addr {
                 I2cAddress::SevenBit(addr) => {
-                    write_fifo(
-                        self.register_block(),
-                        (addr << 1) | OperationType::Write as u8,
-                    );
+                    write_fifo(self.regs(), (addr << 1) | OperationType::Write as u8);
                 }
             }
         }
@@ -1720,10 +1706,7 @@ impl Driver<'_> {
             // Load address and R/W bit into FIFO
             match addr {
                 I2cAddress::SevenBit(addr) => {
-                    write_fifo(
-                        self.register_block(),
-                        (addr << 1) | OperationType::Read as u8,
-                    );
+                    write_fifo(self.regs(), (addr << 1) | OperationType::Read as u8);
                 }
             }
         }
@@ -1740,13 +1723,13 @@ impl Driver<'_> {
             loop {
                 self.check_errors()?;
 
-                let reg = self.register_block().fifo_st().read();
+                let reg = self.regs().fifo_st().read();
                 if reg.rxfifo_raddr().bits() != reg.rxfifo_waddr().bits() {
                     break;
                 }
             }
 
-            *byte = read_fifo(self.register_block());
+            *byte = read_fifo(self.regs());
         }
 
         Ok(())
@@ -1772,7 +1755,7 @@ impl Driver<'_> {
         // FIXME: Handle case where less data has been provided by the slave than
         // requested? Or is this prevented from a protocol perspective?
         for byte in buffer.iter_mut() {
-            *byte = read_fifo(self.register_block());
+            *byte = read_fifo(self.regs());
         }
 
         Ok(())
@@ -1780,7 +1763,7 @@ impl Driver<'_> {
 
     /// Clears all pending interrupts for the I2C peripheral.
     fn clear_all_interrupts(&self) {
-        self.register_block()
+        self.regs()
             .int_clr()
             .write(|w| unsafe { w.bits(I2C_LL_INTR_MASK) });
     }
@@ -1792,7 +1775,7 @@ impl Driver<'_> {
         }
 
         for b in bytes {
-            write_fifo(self.register_block(), *b);
+            write_fifo(self.regs(), *b);
             self.check_errors()?;
         }
 
@@ -1807,7 +1790,7 @@ impl Driver<'_> {
 
             I2cFuture::new(Event::TxFifoWatermark, self.info, self.state).await?;
 
-            self.register_block()
+            self.regs()
                 .int_clr()
                 .write(|w| w.txfifo_wm().clear_bit_by_one());
 
@@ -1817,7 +1800,7 @@ impl Driver<'_> {
                 break Ok(());
             }
 
-            write_fifo(self.register_block(), bytes[index]);
+            write_fifo(self.regs(), bytes[index]);
             index += 1;
         }
     }
@@ -1852,7 +1835,7 @@ impl Driver<'_> {
 
         let mut tout = MAX_ITERATIONS / 10; // adjust the timeout because we are yielding in the loop
         loop {
-            let interrupts = self.register_block().int_raw().read();
+            let interrupts = self.regs().int_raw().read();
 
             self.check_errors()?;
 
@@ -1880,7 +1863,7 @@ impl Driver<'_> {
     fn wait_for_completion_blocking(&self, end_only: bool) -> Result<(), Error> {
         let mut tout = MAX_ITERATIONS;
         loop {
-            let interrupts = self.register_block().int_raw().read();
+            let interrupts = self.regs().int_raw().read();
 
             self.check_errors()?;
 
@@ -1907,7 +1890,7 @@ impl Driver<'_> {
         // NOTE: on esp32 executing the end command generates the end_detect interrupt
         //       but does not seem to clear the done bit! So we don't check the done
         //       status of an end command
-        for cmd_reg in self.register_block().comd_iter() {
+        for cmd_reg in self.regs().comd_iter() {
             let cmd = cmd_reg.read();
 
             if cmd.bits() != 0x0 && !cmd.opcode().is_end() && !cmd.command_done().bit_is_set() {
@@ -1926,7 +1909,7 @@ impl Driver<'_> {
     /// by resetting the I2C peripheral to clear the error condition and then
     /// returns an appropriate error.
     fn check_errors(&self) -> Result<(), Error> {
-        let interrupts = self.register_block().int_raw().read();
+        let interrupts = self.regs().int_raw().read();
 
         // The ESP32 variant has a slightly different interrupt naming
         // scheme!
@@ -1936,7 +1919,7 @@ impl Driver<'_> {
                 let retval = if interrupts.time_out().bit_is_set() {
                     Err(Error::Timeout)
                 } else if interrupts.nack().bit_is_set() {
-                    Err(Error::AcknowledgeCheckFailed(estimate_ack_failed_reason(self.register_block())))
+                    Err(Error::AcknowledgeCheckFailed(estimate_ack_failed_reason(self.regs())))
                 } else if interrupts.arbitration_lost().bit_is_set() {
                     Err(Error::ArbitrationLost)
                 } else {
@@ -1947,10 +1930,10 @@ impl Driver<'_> {
                 let retval = if interrupts.time_out().bit_is_set() {
                     Err(Error::Timeout)
                 } else if interrupts.nack().bit_is_set() {
-                    Err(Error::AcknowledgeCheckFailed(estimate_ack_failed_reason(self.register_block())))
+                    Err(Error::AcknowledgeCheckFailed(estimate_ack_failed_reason(self.regs())))
                 } else if interrupts.arbitration_lost().bit_is_set() {
                     Err(Error::ArbitrationLost)
-                } else if interrupts.trans_complete().bit_is_set() && self.register_block().sr().read().resp_rec().bit_is_clear() {
+                } else if interrupts.trans_complete().bit_is_set() && self.regs().sr().read().resp_rec().bit_is_clear() {
                     Err(Error::AcknowledgeCheckFailed(AcknowledgeCheckFailedReason::Data))
                 } else {
                     Ok(())
@@ -1978,43 +1961,26 @@ impl Driver<'_> {
         // Ensure that the configuration of the peripheral is correctly propagated
         // (only necessary for C2, C3, C6, H2 and S3 variant)
         #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
-        self.register_block()
-            .ctr()
-            .modify(|_, w| w.conf_upgate().set_bit());
+        self.regs().ctr().modify(|_, w| w.conf_upgate().set_bit());
     }
 
     /// Starts an I2C transmission.
     fn start_transmission(&self) {
         // Start transmission
-        self.register_block()
-            .ctr()
-            .modify(|_, w| w.trans_start().set_bit());
+        self.regs().ctr().modify(|_, w| w.trans_start().set_bit());
     }
 
     #[cfg(not(any(esp32, esp32s2)))]
     /// Fills the TX FIFO with data from the provided slice.
     fn fill_tx_fifo(&self, bytes: &[u8]) -> Result<usize, Error> {
         let mut index = 0;
-        while index < bytes.len()
-            && !self
-                .register_block()
-                .int_raw()
-                .read()
-                .txfifo_ovf()
-                .bit_is_set()
-        {
-            write_fifo(self.register_block(), bytes[index]);
+        while index < bytes.len() && !self.regs().int_raw().read().txfifo_ovf().bit_is_set() {
+            write_fifo(self.regs(), bytes[index]);
             index += 1;
         }
-        if self
-            .register_block()
-            .int_raw()
-            .read()
-            .txfifo_ovf()
-            .bit_is_set()
-        {
+        if self.regs().int_raw().read().txfifo_ovf().bit_is_set() {
             index -= 1;
-            self.register_block()
+            self.regs()
                 .int_clr()
                 .write(|w| w.txfifo_ovf().clear_bit_by_one());
         }
@@ -2033,27 +1999,15 @@ impl Driver<'_> {
         loop {
             self.check_errors()?;
 
-            while !self
-                .register_block()
-                .int_raw()
-                .read()
-                .txfifo_wm()
-                .bit_is_set()
-            {
+            while !self.regs().int_raw().read().txfifo_wm().bit_is_set() {
                 self.check_errors()?;
             }
 
-            self.register_block()
+            self.regs()
                 .int_clr()
                 .write(|w| w.txfifo_wm().clear_bit_by_one());
 
-            while !self
-                .register_block()
-                .int_raw()
-                .read()
-                .txfifo_wm()
-                .bit_is_set()
-            {
+            while !self.regs().int_raw().read().txfifo_wm().bit_is_set() {
                 self.check_errors()?;
             }
 
@@ -2061,7 +2015,7 @@ impl Driver<'_> {
                 break Ok(());
             }
 
-            write_fifo(self.register_block(), bytes[index]);
+            write_fifo(self.regs(), bytes[index]);
             index += 1;
         }
     }
@@ -2078,7 +2032,7 @@ impl Driver<'_> {
         }
 
         for b in bytes {
-            write_fifo(self.register_block(), *b);
+            write_fifo(self.regs(), *b);
         }
 
         Ok(bytes.len())
@@ -2103,7 +2057,7 @@ impl Driver<'_> {
         // this is only possible when writing the I2C address in release mode
         // from [perform_write_read]
         for b in bytes {
-            write_fifo(self.register_block(), *b);
+            write_fifo(self.regs(), *b);
             self.check_errors()?;
         }
 
@@ -2114,7 +2068,7 @@ impl Driver<'_> {
     #[cfg(not(esp32))]
     fn reset_fifo(&self) {
         // First, reset the fifo buffers
-        self.register_block().fifo_conf().modify(|_, w| unsafe {
+        self.regs().fifo_conf().modify(|_, w| unsafe {
             w.tx_fifo_rst().set_bit();
             w.rx_fifo_rst().set_bit();
             w.nonfifo_en().clear_bit();
@@ -2123,12 +2077,12 @@ impl Driver<'_> {
             w.txfifo_wm_thrhd().bits(8)
         });
 
-        self.register_block().fifo_conf().modify(|_, w| {
+        self.regs().fifo_conf().modify(|_, w| {
             w.tx_fifo_rst().clear_bit();
             w.rx_fifo_rst().clear_bit()
         });
 
-        self.register_block().int_clr().write(|w| {
+        self.regs().int_clr().write(|w| {
             w.rxfifo_wm().clear_bit_by_one();
             w.txfifo_wm().clear_bit_by_one()
         });
@@ -2140,7 +2094,7 @@ impl Driver<'_> {
     #[cfg(esp32)]
     fn reset_fifo(&self) {
         // First, reset the fifo buffers
-        self.register_block().fifo_conf().modify(|_, w| unsafe {
+        self.regs().fifo_conf().modify(|_, w| unsafe {
             w.tx_fifo_rst().set_bit();
             w.rx_fifo_rst().set_bit();
             w.nonfifo_en().clear_bit();
@@ -2148,12 +2102,12 @@ impl Driver<'_> {
             w.nonfifo_tx_thres().bits(32)
         });
 
-        self.register_block().fifo_conf().modify(|_, w| {
+        self.regs().fifo_conf().modify(|_, w| {
             w.tx_fifo_rst().clear_bit();
             w.rx_fifo_rst().clear_bit()
         });
 
-        self.register_block()
+        self.regs()
             .int_clr()
             .write(|w| w.rxfifo_full().clear_bit_by_one());
     }
@@ -2167,7 +2121,7 @@ impl Driver<'_> {
     ) -> Result<usize, Error> {
         self.reset_fifo();
         self.reset_command_list();
-        let cmd_iterator = &mut self.register_block().comd_iter();
+        let cmd_iterator = &mut self.regs().comd_iter();
 
         if start {
             add_cmd(cmd_iterator, Command::Start)?;
@@ -2206,7 +2160,7 @@ impl Driver<'_> {
         self.reset_fifo();
         self.reset_command_list();
 
-        let cmd_iterator = &mut self.register_block().comd_iter();
+        let cmd_iterator = &mut self.regs().comd_iter();
 
         if start {
             add_cmd(cmd_iterator, Command::Start)?;

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -820,7 +820,7 @@ mod private {
     }
 
     pub trait RegBlock: Peripheral<P = Self> + DmaEligible + Into<super::AnyI2s> + 'static {
-        fn register_block(&self) -> &RegisterBlock;
+        fn regs(&self) -> &RegisterBlock;
         fn peripheral(&self) -> crate::system::Peripheral;
     }
 
@@ -839,9 +839,7 @@ mod private {
         fn set_interrupt_handler(&self, handler: InterruptHandler);
 
         fn enable_listen(&self, interrupts: EnumSet<I2sInterrupt>, enable: bool) {
-            let reg_block = self.register_block();
-
-            reg_block.int_ena().modify(|_, w| {
+            self.regs().int_ena().modify(|_, w| {
                 for interrupt in interrupts {
                     match interrupt {
                         I2sInterrupt::RxHung => w.rx_hung().bit(enable),
@@ -854,8 +852,7 @@ mod private {
 
         fn interrupts(&self) -> EnumSet<I2sInterrupt> {
             let mut res = EnumSet::new();
-            let reg_block = self.register_block();
-            let ints = reg_block.int_st().read();
+            let ints = self.regs().int_st().read();
 
             if ints.rx_hung().bit() {
                 res.insert(I2sInterrupt::RxHung);
@@ -868,9 +865,7 @@ mod private {
         }
 
         fn clear_interrupts(&self, interrupts: EnumSet<I2sInterrupt>) {
-            let reg_block = self.register_block();
-
-            reg_block.int_clr().write(|w| {
+            self.regs().int_clr().write(|w| {
                 for interrupt in interrupts {
                     match interrupt {
                         I2sInterrupt::RxHung => w.rx_hung().clear_bit_by_one(),
@@ -882,46 +877,41 @@ mod private {
         }
 
         fn set_clock(&self, clock_settings: I2sClockDividers) {
-            let i2s = self.register_block();
-
-            i2s.clkm_conf().modify(|r, w| unsafe {
-                w.bits(r.bits() | (crate::soc::constants::I2S_DEFAULT_CLK_SRC << 21))
+            self.regs().clkm_conf().modify(|r, w| unsafe {
                 // select PLL_160M
+                w.bits(r.bits() | (crate::soc::constants::I2S_DEFAULT_CLK_SRC << 21))
             });
 
             #[cfg(esp32)]
-            i2s.clkm_conf().modify(|_, w| w.clka_ena().clear_bit());
+            self.regs()
+                .clkm_conf()
+                .modify(|_, w| w.clka_ena().clear_bit());
 
-            i2s.clkm_conf().modify(|_, w| unsafe {
+            self.regs().clkm_conf().modify(|_, w| unsafe {
                 w.clk_en().set_bit();
-                w.clkm_div_num().bits(clock_settings.mclk_divider as u8)
-            });
-
-            i2s.clkm_conf().modify(|_, w| unsafe {
+                w.clkm_div_num().bits(clock_settings.mclk_divider as u8);
                 w.clkm_div_a().bits(clock_settings.denominator as u8);
                 w.clkm_div_b().bits(clock_settings.numerator as u8)
             });
 
-            i2s.sample_rate_conf().modify(|_, w| unsafe {
+            self.regs().sample_rate_conf().modify(|_, w| unsafe {
                 w.tx_bck_div_num().bits(clock_settings.bclk_divider as u8);
                 w.rx_bck_div_num().bits(clock_settings.bclk_divider as u8)
             });
         }
 
         fn configure(&self, _standard: &Standard, data_format: &DataFormat) {
-            let i2s = self.register_block();
-
             let fifo_mod = match data_format {
                 DataFormat::Data32Channel32 => 2,
                 DataFormat::Data16Channel16 => 0,
             };
 
-            i2s.sample_rate_conf()
-                .modify(|_, w| unsafe { w.tx_bits_mod().bits(data_format.channel_bits()) });
-            i2s.sample_rate_conf()
-                .modify(|_, w| unsafe { w.rx_bits_mod().bits(data_format.channel_bits()) });
+            self.regs().sample_rate_conf().modify(|_, w| unsafe {
+                w.tx_bits_mod().bits(data_format.channel_bits());
+                w.rx_bits_mod().bits(data_format.channel_bits())
+            });
 
-            i2s.conf().modify(|_, w| {
+            self.regs().conf().modify(|_, w| {
                 w.tx_slave_mod().clear_bit();
                 w.rx_slave_mod().clear_bit();
                 // If the I2S_RX_MSB_SHIFT bit and the I2S_TX_MSB_SHIFT bit of register
@@ -946,7 +936,7 @@ mod private {
                 w.sig_loopback().clear_bit()
             });
 
-            i2s.fifo_conf().modify(|_, w| unsafe {
+            self.regs().fifo_conf().modify(|_, w| unsafe {
                 w.tx_fifo_mod().bits(fifo_mod);
                 w.tx_fifo_mod_force_en().set_bit();
                 w.dscr_en().set_bit();
@@ -954,32 +944,33 @@ mod private {
                 w.rx_fifo_mod_force_en().set_bit()
             });
 
-            i2s.conf_chan().modify(|_, w| unsafe {
+            self.regs().conf_chan().modify(|_, w| unsafe {
                 // for now only stereo
                 w.tx_chan_mod().bits(0);
                 w.rx_chan_mod().bits(0)
             });
 
-            i2s.conf1().modify(|_, w| {
+            self.regs().conf1().modify(|_, w| {
                 w.tx_pcm_bypass().set_bit();
                 w.rx_pcm_bypass().set_bit()
             });
 
-            i2s.pd_conf().modify(|_, w| {
+            self.regs().pd_conf().modify(|_, w| {
                 w.fifo_force_pu().set_bit();
                 w.fifo_force_pd().clear_bit()
             });
 
-            i2s.conf2().modify(|_, w| {
+            self.regs().conf2().modify(|_, w| {
                 w.camera_en().clear_bit();
                 w.lcd_en().clear_bit()
             });
         }
 
         fn set_master(&self) {
-            let i2s = self.register_block();
-            i2s.conf()
-                .modify(|_, w| w.rx_slave_mod().clear_bit().tx_slave_mod().clear_bit());
+            self.regs().conf().modify(|_, w| {
+                w.rx_slave_mod().clear_bit();
+                w.tx_slave_mod().clear_bit()
+            });
         }
 
         fn update(&self) {
@@ -987,72 +978,67 @@ mod private {
         }
 
         fn reset_tx(&self) {
-            let i2s = self.register_block();
-            i2s.conf().modify(|_, w| {
+            self.regs().conf().modify(|_, w| {
                 w.tx_reset().set_bit();
                 w.tx_fifo_reset().set_bit()
             });
-            i2s.conf().modify(|_, w| {
+            self.regs().conf().modify(|_, w| {
                 w.tx_reset().clear_bit();
                 w.tx_fifo_reset().clear_bit()
             });
 
-            i2s.lc_conf().modify(|_, w| w.out_rst().set_bit());
-            i2s.lc_conf().modify(|_, w| w.out_rst().clear_bit());
+            self.regs().lc_conf().modify(|_, w| w.out_rst().set_bit());
+            self.regs().lc_conf().modify(|_, w| w.out_rst().clear_bit());
 
-            i2s.int_clr().write(|w| {
+            self.regs().int_clr().write(|w| {
                 w.out_done().clear_bit_by_one();
                 w.out_total_eof().clear_bit_by_one()
             });
         }
 
         fn tx_start(&self) {
-            let i2s = self.register_block();
-            i2s.conf().modify(|_, w| w.tx_start().set_bit());
+            self.regs().conf().modify(|_, w| w.tx_start().set_bit());
 
-            while i2s.state().read().tx_idle().bit_is_set() {
+            while self.regs().state().read().tx_idle().bit_is_set() {
                 // wait
             }
         }
 
         fn tx_stop(&self) {
-            let i2s = self.register_block();
-            i2s.conf().modify(|_, w| w.tx_start().clear_bit());
+            self.regs().conf().modify(|_, w| w.tx_start().clear_bit());
         }
 
         fn wait_for_tx_done(&self) {
-            let i2s = self.register_block();
-            while i2s.state().read().tx_idle().bit_is_clear() {
+            while self.regs().state().read().tx_idle().bit_is_clear() {
                 // wait
             }
 
-            i2s.conf().modify(|_, w| w.tx_start().clear_bit());
+            self.regs().conf().modify(|_, w| w.tx_start().clear_bit());
         }
 
         fn reset_rx(&self) {
-            let i2s = self.register_block();
-            i2s.conf().modify(|_, w| {
+            self.regs().conf().modify(|_, w| {
                 w.rx_reset().set_bit();
                 w.rx_fifo_reset().set_bit()
             });
-            i2s.conf().modify(|_, w| {
+            self.regs().conf().modify(|_, w| {
                 w.rx_reset().clear_bit();
                 w.rx_fifo_reset().clear_bit()
             });
 
-            i2s.lc_conf().modify(|_, w| w.in_rst().set_bit());
-            i2s.lc_conf().modify(|_, w| w.in_rst().clear_bit());
+            self.regs().lc_conf().modify(|_, w| w.in_rst().set_bit());
+            self.regs().lc_conf().modify(|_, w| w.in_rst().clear_bit());
 
-            i2s.int_clr().write(|w| {
+            self.regs().int_clr().write(|w| {
                 w.in_done().clear_bit_by_one();
                 w.in_suc_eof().clear_bit_by_one()
             });
         }
 
         fn rx_start(&self, len: usize) {
-            let i2s = self.register_block();
-
-            i2s.int_clr().write(|w| w.in_suc_eof().clear_bit_by_one());
+            self.regs()
+                .int_clr()
+                .write(|w| w.in_suc_eof().clear_bit_by_one());
 
             cfg_if::cfg_if! {
                 if #[cfg(esp32)] {
@@ -1063,19 +1049,21 @@ mod private {
                 }
             }
 
-            i2s.rxeof_num()
+            self.regs()
+                .rxeof_num()
                 .modify(|_, w| unsafe { w.rx_eof_num().bits(eof_num as u32) });
 
-            i2s.conf().modify(|_, w| w.rx_start().set_bit());
+            self.regs().conf().modify(|_, w| w.rx_start().set_bit());
         }
 
         fn wait_for_rx_done(&self) {
-            let i2s = self.register_block();
-            while i2s.int_raw().read().in_suc_eof().bit_is_clear() {
+            while self.regs().int_raw().read().in_suc_eof().bit_is_clear() {
                 // wait
             }
 
-            i2s.int_clr().write(|w| w.in_suc_eof().clear_bit_by_one());
+            self.regs()
+                .int_clr()
+                .write(|w| w.in_suc_eof().clear_bit_by_one());
         }
     }
 
@@ -1084,9 +1072,7 @@ mod private {
         fn set_interrupt_handler(&self, handler: InterruptHandler);
 
         fn enable_listen(&self, interrupts: EnumSet<I2sInterrupt>, enable: bool) {
-            let reg_block = self.register_block();
-
-            reg_block.int_ena().modify(|_, w| {
+            self.regs().int_ena().modify(|_, w| {
                 for interrupt in interrupts {
                     match interrupt {
                         I2sInterrupt::RxHung => w.rx_hung().bit(enable),
@@ -1109,8 +1095,7 @@ mod private {
 
         fn interrupts(&self) -> EnumSet<I2sInterrupt> {
             let mut res = EnumSet::new();
-            let reg_block = self.register_block();
-            let ints = reg_block.int_st().read();
+            let ints = self.regs().int_st().read();
 
             if ints.rx_hung().bit() {
                 res.insert(I2sInterrupt::RxHung);
@@ -1129,9 +1114,7 @@ mod private {
         }
 
         fn clear_interrupts(&self, interrupts: EnumSet<I2sInterrupt>) {
-            let reg_block = self.register_block();
-
-            reg_block.int_clr().write(|w| {
+            self.regs().int_clr().write(|w| {
                 for interrupt in interrupts {
                     match interrupt {
                         I2sInterrupt::RxHung => w.rx_hung().clear_bit_by_one(),
@@ -1146,8 +1129,6 @@ mod private {
 
         #[cfg(any(esp32c3, esp32s3))]
         fn set_clock(&self, clock_settings: I2sClockDividers) {
-            let i2s = self.register_block();
-
             let clkm_div_x: u32;
             let clkm_div_y: u32;
             let clkm_div_z: u32;
@@ -1187,14 +1168,14 @@ mod private {
                 clkm_div_yn1 = 0;
             }
 
-            i2s.tx_clkm_div_conf().modify(|_, w| unsafe {
+            self.regs().tx_clkm_div_conf().modify(|_, w| unsafe {
                 w.tx_clkm_div_x().bits(clkm_div_x as u16);
                 w.tx_clkm_div_y().bits(clkm_div_y as u16);
                 w.tx_clkm_div_yn1().bit(clkm_div_yn1 != 0);
                 w.tx_clkm_div_z().bits(clkm_div_z as u16)
             });
 
-            i2s.tx_clkm_conf().modify(|_, w| unsafe {
+            self.regs().tx_clkm_conf().modify(|_, w| unsafe {
                 w.clk_en().set_bit();
                 w.tx_clk_active().set_bit();
                 w.tx_clk_sel()
@@ -1203,19 +1184,19 @@ mod private {
                 w.tx_clkm_div_num().bits(clock_settings.mclk_divider as u8)
             });
 
-            i2s.tx_conf1().modify(|_, w| unsafe {
+            self.regs().tx_conf1().modify(|_, w| unsafe {
                 w.tx_bck_div_num()
                     .bits((clock_settings.bclk_divider - 1) as u8)
             });
 
-            i2s.rx_clkm_div_conf().modify(|_, w| unsafe {
+            self.regs().rx_clkm_div_conf().modify(|_, w| unsafe {
                 w.rx_clkm_div_x().bits(clkm_div_x as u16);
                 w.rx_clkm_div_y().bits(clkm_div_y as u16);
                 w.rx_clkm_div_yn1().bit(clkm_div_yn1 != 0);
                 w.rx_clkm_div_z().bits(clkm_div_z as u16)
             });
 
-            i2s.rx_clkm_conf().modify(|_, w| unsafe {
+            self.regs().rx_clkm_conf().modify(|_, w| unsafe {
                 w.rx_clk_active().set_bit();
                 // for now fixed at 160MHz
                 w.rx_clk_sel()
@@ -1224,7 +1205,7 @@ mod private {
                 w.mclk_sel().bit(true)
             });
 
-            i2s.rx_conf1().modify(|_, w| unsafe {
+            self.regs().rx_conf1().modify(|_, w| unsafe {
                 w.rx_bck_div_num()
                     .bits((clock_settings.bclk_divider - 1) as u8)
             });
@@ -1232,8 +1213,8 @@ mod private {
 
         #[cfg(any(esp32c6, esp32h2))]
         fn set_clock(&self, clock_settings: I2sClockDividers) {
-            let i2s = self.register_block();
-            let pcr = crate::peripherals::PCR::regs(); // I2S clocks are configured via PCR
+            // I2S clocks are configured via PCR
+            use crate::peripherals::PCR;
 
             let clkm_div_x: u32;
             let clkm_div_y: u32;
@@ -1274,14 +1255,14 @@ mod private {
                 clkm_div_yn1 = 0;
             }
 
-            pcr.i2s_tx_clkm_div_conf().modify(|_, w| unsafe {
+            PCR::regs().i2s_tx_clkm_div_conf().modify(|_, w| unsafe {
                 w.i2s_tx_clkm_div_x().bits(clkm_div_x as u16);
                 w.i2s_tx_clkm_div_y().bits(clkm_div_y as u16);
                 w.i2s_tx_clkm_div_yn1().bit(clkm_div_yn1 != 0);
                 w.i2s_tx_clkm_div_z().bits(clkm_div_z as u16)
             });
 
-            pcr.i2s_tx_clkm_conf().modify(|_, w| unsafe {
+            PCR::regs().i2s_tx_clkm_conf().modify(|_, w| unsafe {
                 w.i2s_tx_clkm_en().set_bit();
                 // for now fixed at 160MHz for C6 and 96MHz for H2
                 w.i2s_tx_clkm_sel()
@@ -1291,24 +1272,24 @@ mod private {
             });
 
             #[cfg(not(esp32h2))]
-            i2s.tx_conf1().modify(|_, w| unsafe {
+            self.regs().tx_conf1().modify(|_, w| unsafe {
                 w.tx_bck_div_num()
                     .bits((clock_settings.bclk_divider - 1) as u8)
             });
             #[cfg(esp32h2)]
-            i2s.tx_conf().modify(|_, w| unsafe {
+            self.regs().tx_conf().modify(|_, w| unsafe {
                 w.tx_bck_div_num()
                     .bits((clock_settings.bclk_divider - 1) as u8)
             });
 
-            pcr.i2s_rx_clkm_div_conf().modify(|_, w| unsafe {
+            PCR::regs().i2s_rx_clkm_div_conf().modify(|_, w| unsafe {
                 w.i2s_rx_clkm_div_x().bits(clkm_div_x as u16);
                 w.i2s_rx_clkm_div_y().bits(clkm_div_y as u16);
                 w.i2s_rx_clkm_div_yn1().bit(clkm_div_yn1 != 0);
                 w.i2s_rx_clkm_div_z().bits(clkm_div_z as u16)
             });
 
-            pcr.i2s_rx_clkm_conf().modify(|_, w| unsafe {
+            PCR::regs().i2s_rx_clkm_conf().modify(|_, w| unsafe {
                 w.i2s_rx_clkm_en().set_bit();
                 // for now fixed at 160MHz for C6 and 96MHz for H2
                 w.i2s_rx_clkm_sel()
@@ -1318,22 +1299,20 @@ mod private {
                 w.i2s_mclk_sel().bit(true)
             });
             #[cfg(not(esp32h2))]
-            i2s.rx_conf1().modify(|_, w| unsafe {
+            self.regs().rx_conf1().modify(|_, w| unsafe {
                 w.rx_bck_div_num()
                     .bits((clock_settings.bclk_divider - 1) as u8)
             });
             #[cfg(esp32h2)]
-            i2s.rx_conf().modify(|_, w| unsafe {
+            self.regs().rx_conf().modify(|_, w| unsafe {
                 w.rx_bck_div_num()
                     .bits((clock_settings.bclk_divider - 1) as u8)
             });
         }
 
         fn configure(&self, _standard: &Standard, data_format: &DataFormat) {
-            let i2s = self.register_block();
-
             #[allow(clippy::useless_conversion)]
-            i2s.tx_conf1().modify(|_, w| unsafe {
+            self.regs().tx_conf1().modify(|_, w| unsafe {
                 w.tx_tdm_ws_width()
                     .bits((data_format.channel_bits() - 1).into());
                 w.tx_bits_mod().bits(data_format.data_bits() - 1);
@@ -1341,10 +1320,14 @@ mod private {
                 w.tx_half_sample_bits().bits(data_format.channel_bits() - 1)
             });
             #[cfg(not(esp32h2))]
-            i2s.tx_conf1().modify(|_, w| w.tx_msb_shift().set_bit());
+            self.regs()
+                .tx_conf1()
+                .modify(|_, w| w.tx_msb_shift().set_bit());
             #[cfg(esp32h2)]
-            i2s.tx_conf().modify(|_, w| w.tx_msb_shift().set_bit());
-            i2s.tx_conf().modify(|_, w| unsafe {
+            self.regs()
+                .tx_conf()
+                .modify(|_, w| w.tx_msb_shift().set_bit());
+            self.regs().tx_conf().modify(|_, w| unsafe {
                 w.tx_mono().clear_bit();
                 w.tx_mono_fst_vld().set_bit();
                 w.tx_stop_en().set_bit();
@@ -1357,7 +1340,7 @@ mod private {
                 w.tx_chan_mod().bits(0)
             });
 
-            i2s.tx_tdm_ctrl().modify(|_, w| unsafe {
+            self.regs().tx_tdm_ctrl().modify(|_, w| unsafe {
                 w.tx_tdm_tot_chan_num().bits(1);
                 w.tx_tdm_chan0_en().set_bit();
                 w.tx_tdm_chan1_en().set_bit();
@@ -1378,7 +1361,7 @@ mod private {
             });
 
             #[allow(clippy::useless_conversion)]
-            i2s.rx_conf1().modify(|_, w| unsafe {
+            self.regs().rx_conf1().modify(|_, w| unsafe {
                 w.rx_tdm_ws_width()
                     .bits((data_format.channel_bits() - 1).into());
                 w.rx_bits_mod().bits(data_format.data_bits() - 1);
@@ -1386,11 +1369,15 @@ mod private {
                 w.rx_half_sample_bits().bits(data_format.channel_bits() - 1)
             });
             #[cfg(not(esp32h2))]
-            i2s.rx_conf1().modify(|_, w| w.rx_msb_shift().set_bit());
+            self.regs()
+                .rx_conf1()
+                .modify(|_, w| w.rx_msb_shift().set_bit());
             #[cfg(esp32h2)]
-            i2s.rx_conf().modify(|_, w| w.rx_msb_shift().set_bit());
+            self.regs()
+                .rx_conf()
+                .modify(|_, w| w.rx_msb_shift().set_bit());
 
-            i2s.rx_conf().modify(|_, w| unsafe {
+            self.regs().rx_conf().modify(|_, w| unsafe {
                 w.rx_mono().clear_bit();
                 w.rx_mono_fst_vld().set_bit();
                 w.rx_stop_mode().bits(2);
@@ -1401,7 +1388,7 @@ mod private {
                 w.rx_bit_order().clear_bit()
             });
 
-            i2s.rx_tdm_ctrl().modify(|_, w| unsafe {
+            self.regs().rx_tdm_ctrl().modify(|_, w| unsafe {
                 w.rx_tdm_tot_chan_num().bits(1);
                 w.rx_tdm_pdm_chan0_en().set_bit();
                 w.rx_tdm_pdm_chan1_en().set_bit();
@@ -1423,71 +1410,77 @@ mod private {
         }
 
         fn set_master(&self) {
-            let i2s = self.register_block();
-            i2s.tx_conf().modify(|_, w| w.tx_slave_mod().clear_bit());
-            i2s.rx_conf().modify(|_, w| w.rx_slave_mod().clear_bit());
+            self.regs()
+                .tx_conf()
+                .modify(|_, w| w.tx_slave_mod().clear_bit());
+            self.regs()
+                .rx_conf()
+                .modify(|_, w| w.rx_slave_mod().clear_bit());
         }
 
         fn update(&self) {
-            let i2s = self.register_block();
-            i2s.tx_conf().modify(|_, w| w.tx_update().clear_bit());
-            i2s.tx_conf().modify(|_, w| w.tx_update().set_bit());
+            self.regs()
+                .tx_conf()
+                .modify(|_, w| w.tx_update().clear_bit());
+            self.regs().tx_conf().modify(|_, w| w.tx_update().set_bit());
 
-            i2s.rx_conf().modify(|_, w| w.rx_update().clear_bit());
-            i2s.rx_conf().modify(|_, w| w.rx_update().set_bit());
+            self.regs()
+                .rx_conf()
+                .modify(|_, w| w.rx_update().clear_bit());
+            self.regs().rx_conf().modify(|_, w| w.rx_update().set_bit());
         }
 
         fn reset_tx(&self) {
-            let i2s = self.register_block();
-            i2s.tx_conf().modify(|_, w| {
+            self.regs().tx_conf().modify(|_, w| {
                 w.tx_reset().set_bit();
                 w.tx_fifo_reset().set_bit()
             });
-            i2s.tx_conf().modify(|_, w| {
+            self.regs().tx_conf().modify(|_, w| {
                 w.tx_reset().clear_bit();
                 w.tx_fifo_reset().clear_bit()
             });
 
-            i2s.int_clr().write(|w| {
+            self.regs().int_clr().write(|w| {
                 w.tx_done().clear_bit_by_one();
                 w.tx_hung().clear_bit_by_one()
             });
         }
 
         fn tx_start(&self) {
-            let i2s = self.register_block();
-            i2s.tx_conf().modify(|_, w| w.tx_start().set_bit());
+            self.regs().tx_conf().modify(|_, w| w.tx_start().set_bit());
         }
 
         fn tx_stop(&self) {
-            let i2s = self.register_block();
-            i2s.tx_conf().modify(|_, w| w.tx_start().clear_bit());
+            self.regs()
+                .tx_conf()
+                .modify(|_, w| w.tx_start().clear_bit());
         }
 
         fn wait_for_tx_done(&self) {
-            let i2s = self.register_block();
-            while i2s.state().read().tx_idle().bit_is_clear() {
+            while self.regs().state().read().tx_idle().bit_is_clear() {
                 // wait
             }
 
-            i2s.tx_conf().modify(|_, w| w.tx_start().clear_bit());
+            self.regs()
+                .tx_conf()
+                .modify(|_, w| w.tx_start().clear_bit());
         }
 
         fn reset_rx(&self) {
-            let i2s = self.register_block();
+            self.regs()
+                .rx_conf()
+                .modify(|_, w| w.rx_start().clear_bit());
 
-            i2s.rx_conf().modify(|_, w| w.rx_start().clear_bit());
-
-            i2s.rx_conf().modify(|_, w| {
+            self.regs().rx_conf().modify(|_, w| {
                 w.rx_reset().set_bit();
                 w.rx_fifo_reset().set_bit()
             });
-            i2s.rx_conf().modify(|_, w| {
+            self.regs().rx_conf().modify(|_, w| {
                 w.rx_reset().clear_bit();
                 w.rx_fifo_reset().clear_bit()
             });
 
-            i2s.int_clr().write(|w| {
+            self.regs().int_clr().write(|w| {
                 w.rx_done().clear_bit_by_one();
                 w.rx_hung().clear_bit_by_one()
             });
@@ -1496,24 +1489,25 @@ mod private {
         fn rx_start(&self, len: usize) {
             let len = len - 1;
 
-            let i2s = self.register_block();
-            i2s.rxeof_num()
+            self.regs()
+                .rxeof_num()
                 .write(|w| unsafe { w.rx_eof_num().bits(len as u16) });
-            i2s.rx_conf().modify(|_, w| w.rx_start().set_bit());
+            self.regs().rx_conf().modify(|_, w| w.rx_start().set_bit());
         }
 
         fn wait_for_rx_done(&self) {
-            let i2s = self.register_block();
-            while i2s.int_raw().read().rx_done().bit_is_clear() {
+            while self.regs().int_raw().read().rx_done().bit_is_clear() {
                 // wait
             }
 
-            i2s.int_clr().write(|w| w.rx_done().clear_bit_by_one());
+            self.regs()
+                .int_clr()
+                .write(|w| w.rx_done().clear_bit_by_one());
         }
     }
 
     impl RegBlock for I2S0 {
-        fn register_block(&self) -> &RegisterBlock {
+        fn regs(&self) -> &RegisterBlock {
             unsafe { &*I2S0::PTR.cast::<RegisterBlock>() }
         }
 
@@ -1621,7 +1615,7 @@ mod private {
 
     #[cfg(i2s1)]
     impl RegBlock for I2S1 {
-        fn register_block(&self) -> &RegisterBlock {
+        fn regs(&self) -> &RegisterBlock {
             unsafe { &*I2S1::PTR.cast::<RegisterBlock>() }
         }
 
@@ -1694,13 +1688,20 @@ mod private {
     }
 
     impl RegBlock for super::AnyI2s {
+        fn regs(&self) -> &RegisterBlock {
+            match &self.0 {
+                super::AnyI2sInner::I2s0(i2s) => RegBlock::regs(i2s),
+                #[cfg(i2s1)]
+                super::AnyI2sInner::I2s1(i2s) => RegBlock::regs(i2s),
+            }
+        }
+
         delegate::delegate! {
             to match &self.0 {
                 super::AnyI2sInner::I2s0(i2s) => i2s,
                 #[cfg(i2s1)]
                 super::AnyI2sInner::I2s1(i2s) => i2s,
             } {
-                fn register_block(&self) -> &RegisterBlock;
                 fn peripheral(&self) -> crate::system::Peripheral;
             }
         }

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -484,121 +484,118 @@ fn calculate_clock(sample_rate: impl Into<fugit::HertzU32>, data_bits: u8) -> I2
 
 #[doc(hidden)]
 pub trait Instance: Peripheral<P = Self> + DmaEligible + Into<AnyI2s> + 'static {
-    fn register_block(&self) -> &RegisterBlock;
+    fn regs(&self) -> &RegisterBlock;
     fn peripheral(&self) -> crate::system::Peripheral;
     fn ws_signal(&self) -> OutputSignal;
     fn data_out_signal(&self, i: usize, bits: u8) -> OutputSignal;
 
     fn rx_reset(&self) {
-        let r = self.register_block();
-        r.conf().modify(|_, w| w.rx_reset().set_bit());
-        r.conf().modify(|_, w| w.rx_reset().clear_bit());
+        self.regs().conf().modify(|_, w| w.rx_reset().set_bit());
+        self.regs().conf().modify(|_, w| w.rx_reset().clear_bit());
     }
 
     fn rx_dma_reset(&self) {
-        let r = self.register_block();
-        r.lc_conf().modify(|_, w| w.in_rst().set_bit());
-        r.lc_conf().modify(|_, w| w.in_rst().clear_bit());
+        self.regs().lc_conf().modify(|_, w| w.in_rst().set_bit());
+        self.regs().lc_conf().modify(|_, w| w.in_rst().clear_bit());
     }
 
     fn rx_fifo_reset(&self) {
-        let r = self.register_block();
-        r.conf().modify(|_, w| w.rx_fifo_reset().set_bit());
-        r.conf().modify(|_, w| w.rx_fifo_reset().clear_bit());
+        self.regs()
+            .conf()
+            .modify(|_, w| w.rx_fifo_reset().set_bit());
+        self.regs()
+            .conf()
+            .modify(|_, w| w.rx_fifo_reset().clear_bit());
     }
 
     fn tx_reset(&self) {
-        let r = self.register_block();
-        r.conf().modify(|_, w| w.tx_reset().set_bit());
+        self.regs().conf().modify(|_, w| w.tx_reset().set_bit());
         // without this delay starting a subsequent transfer will hang waiting
         // for tx_idle to clear (the transfer does not start).
         // While 20 clocks works for 80MHz cpu but 100 is needed for 240MHz!
         xtensa_lx::timer::delay(100);
-        r.conf().modify(|_, w| w.tx_reset().clear_bit());
+        self.regs().conf().modify(|_, w| w.tx_reset().clear_bit());
     }
 
     fn tx_dma_reset(&self) {
-        let r = self.register_block();
-        r.lc_conf().modify(|_, w| w.out_rst().set_bit());
-        r.lc_conf().modify(|_, w| w.out_rst().clear_bit());
+        self.regs().lc_conf().modify(|_, w| w.out_rst().set_bit());
+        self.regs().lc_conf().modify(|_, w| w.out_rst().clear_bit());
     }
 
     fn tx_fifo_reset(&self) {
-        let r = self.register_block();
-        r.conf().modify(|_, w| w.tx_fifo_reset().set_bit());
-        r.conf().modify(|_, w| w.tx_fifo_reset().clear_bit());
+        self.regs()
+            .conf()
+            .modify(|_, w| w.tx_fifo_reset().set_bit());
+        self.regs()
+            .conf()
+            .modify(|_, w| w.tx_fifo_reset().clear_bit());
     }
 
     fn tx_clear_interrupts(&self) {
-        let r = self.register_block();
-        r.int_clr().write(|w| {
+        self.regs().int_clr().write(|w| {
             w.out_done().clear_bit_by_one();
             w.out_total_eof().clear_bit_by_one()
         });
     }
 
     fn tx_start(&self) {
-        let r = self.register_block();
-
         // wait for data to show up in the fifo
-        while r.int_raw().read().tx_rempty().bit_is_clear() {
+        while self.regs().int_raw().read().tx_rempty().bit_is_clear() {
             // wait
         }
 
         // without this transfers are not reliable!
         xtensa_lx::timer::delay(1);
 
-        r.conf().modify(|_, w| w.tx_start().set_bit());
+        self.regs().conf().modify(|_, w| w.tx_start().set_bit());
 
-        while r.state().read().tx_idle().bit_is_set() {
+        while self.regs().state().read().tx_idle().bit_is_set() {
             // wait
         }
     }
 
     fn tx_stop(&self) {
-        let r = self.register_block();
-        r.conf().modify(|_, w| w.tx_start().clear_bit());
+        self.regs().conf().modify(|_, w| w.tx_start().clear_bit());
     }
 
     fn is_tx_done(&self) -> bool {
-        self.register_block().state().read().tx_idle().bit_is_set()
+        self.regs().state().read().tx_idle().bit_is_set()
     }
 
     fn tx_wait_done(&self) {
-        let r = self.register_block();
-        while r.state().read().tx_idle().bit_is_clear() {
+        while self.regs().state().read().tx_idle().bit_is_clear() {
             // wait
         }
 
-        r.conf().modify(|_, w| w.tx_start().clear_bit());
-        r.int_clr().write(|w| {
+        self.regs().conf().modify(|_, w| w.tx_start().clear_bit());
+        self.regs().int_clr().write(|w| {
             w.out_done().clear_bit_by_one();
             w.out_total_eof().clear_bit_by_one()
         });
     }
 
     fn set_clock(&self, clock_settings: I2sClockDividers) {
-        let r = self.register_block();
-
-        r.clkm_conf().modify(|r, w| unsafe {
+        self.regs().clkm_conf().modify(|r, w| unsafe {
             w.bits(r.bits() | (crate::soc::constants::I2S_DEFAULT_CLK_SRC << 21))
             // select PLL_160M
         });
 
         #[cfg(esp32)]
-        r.clkm_conf().modify(|_, w| w.clka_ena().clear_bit());
+        self.regs()
+            .clkm_conf()
+            .modify(|_, w| w.clka_ena().clear_bit());
 
-        r.clkm_conf().modify(|_, w| unsafe {
+        self.regs().clkm_conf().modify(|_, w| unsafe {
             w.clk_en().set_bit();
             w.clkm_div_num().bits(clock_settings.mclk_divider as u8)
         });
 
-        r.clkm_conf().modify(|_, w| unsafe {
+        self.regs().clkm_conf().modify(|_, w| unsafe {
             w.clkm_div_a().bits(clock_settings.denominator as u8);
             w.clkm_div_b().bits(clock_settings.numerator as u8)
         });
 
-        r.sample_rate_conf().modify(|_, w| unsafe {
+        self.regs().sample_rate_conf().modify(|_, w| unsafe {
             w.tx_bck_div_num().bits(clock_settings.bclk_divider as u8);
             w.rx_bck_div_num().bits(clock_settings.bclk_divider as u8)
         });
@@ -617,21 +614,19 @@ pub trait Instance: Peripheral<P = Self> + DmaEligible + Into<AnyI2s> + 'static 
         self.rx_dma_reset();
         self.tx_dma_reset();
 
-        let r = self.register_block();
-
         // clear all bits and enable lcd mode
-        r.conf2().write(|w| {
+        self.regs().conf2().write(|w| {
             // 8 bit mode needs this or it updates on half clocks!
             w.lcd_tx_wrx2_en().bit(bits == 8);
             w.lcd_en().set_bit()
         });
 
-        r.sample_rate_conf().modify(|_, w| unsafe {
+        self.regs().sample_rate_conf().modify(|_, w| unsafe {
             w.rx_bits_mod().bits(bits);
             w.tx_bits_mod().bits(bits)
         });
 
-        r.fifo_conf().write(|w| unsafe {
+        self.regs().fifo_conf().write(|w| unsafe {
             w.rx_fifo_mod_force_en().set_bit();
             w.tx_fifo_mod_force_en().set_bit();
             w.rx_fifo_mod().bits(1);
@@ -641,26 +636,26 @@ pub trait Instance: Peripheral<P = Self> + DmaEligible + Into<AnyI2s> + 'static 
             w.dscr_en().set_bit()
         });
 
-        r.conf1().write(|w| {
+        self.regs().conf1().write(|w| {
             w.tx_stop_en().set_bit();
             w.rx_pcm_bypass().set_bit();
             w.tx_pcm_bypass().set_bit()
         });
 
-        r.conf_chan().write(|w| unsafe {
+        self.regs().conf_chan().write(|w| unsafe {
             w.rx_chan_mod().bits(1);
             w.tx_chan_mod().bits(1)
         });
 
-        r.conf().modify(|_, w| {
+        self.regs().conf().modify(|_, w| {
             w.rx_mono().set_bit();
             w.tx_mono().set_bit();
             w.rx_right_first().set_bit();
             w.tx_right_first().set_bit()
         });
-        r.timing().reset();
+        self.regs().timing().reset();
 
-        r.pd_conf().modify(|_, w| {
+        self.regs().pd_conf().modify(|_, w| {
             w.fifo_force_pu().set_bit();
             w.fifo_force_pd().clear_bit()
         });
@@ -668,7 +663,7 @@ pub trait Instance: Peripheral<P = Self> + DmaEligible + Into<AnyI2s> + 'static 
 }
 
 impl Instance for I2S0 {
-    fn register_block(&self) -> &RegisterBlock {
+    fn regs(&self) -> &RegisterBlock {
         unsafe { &*I2S0::PTR.cast::<RegisterBlock>() }
     }
 
@@ -719,7 +714,7 @@ impl Instance for I2S0 {
 }
 
 impl Instance for I2S1 {
-    fn register_block(&self) -> &RegisterBlock {
+    fn regs(&self) -> &RegisterBlock {
         unsafe { &*I2S1::PTR.cast::<RegisterBlock>() }
     }
 
@@ -795,7 +790,7 @@ impl Instance for AnyI2s {
             AnyI2sInner::I2s0(i2s) => i2s,
             AnyI2sInner::I2s1(i2s) => i2s,
         } {
-            fn register_block(&self) -> &RegisterBlock;
+            fn regs(&self) -> &RegisterBlock;
             fn peripheral(&self) -> crate::system::Peripheral;
             fn ws_signal(&self) -> OutputSignal;
             fn data_out_signal(&self, i: usize, bits: u8) -> OutputSignal ;

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -228,7 +228,7 @@ pub fn _setup_interrupts() {
         // at least after the 2nd stage bootloader there are some interrupts enabled
         // (e.g. UART)
         for peripheral_interrupt in 0..255 {
-            Interrupt::try_from(peripheral_interrupt)
+            crate::peripherals::Interrupt::try_from(peripheral_interrupt)
                 .map(|intr| {
                     #[cfg(multi_core)]
                     disable(Cpu::AppCpu, intr);

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -74,6 +74,7 @@ use crate::{
         Pull,
     },
     lcd_cam::{calculate_clkm, BitOrder, ByteOrder, ClockError},
+    pac,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
     system::{self, GenericPeripheralGuard},
@@ -154,13 +155,17 @@ impl<'d> Camera<'d> {
             _guard: cam._guard,
         };
 
-        this.lcd_cam
+        this.regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_2byte_en().bit(P::BUS_WIDTH == 2));
 
         this.apply_config(&config)?;
 
         Ok(this)
+    }
+
+    fn regs(&self) -> &pac::lcd_cam::RegisterBlock {
+        self.lcd_cam.register_block()
     }
 
     /// Applies the configuration to the camera interface.
@@ -176,7 +181,7 @@ impl<'d> Camera<'d> {
         )
         .map_err(ConfigError::Clock)?;
 
-        self.lcd_cam.cam_ctrl().write(|w| {
+        self.regs().cam_ctrl().write(|w| {
             // Force enable the clock for all configuration registers.
             unsafe {
                 w.cam_clk_sel().bits((i + 1) as _);
@@ -195,7 +200,7 @@ impl<'d> Camera<'d> {
                 w.cam_stop_en().clear_bit()
             }
         });
-        self.lcd_cam.cam_ctrl1().modify(|_, w| unsafe {
+        self.regs().cam_ctrl1().modify(|_, w| unsafe {
             w.cam_vh_de_mode_en().set_bit();
             w.cam_rec_data_bytelen().bits(0);
             w.cam_line_int_num().bits(0);
@@ -207,11 +212,11 @@ impl<'d> Camera<'d> {
             w.cam_vsync_inv().clear_bit()
         });
 
-        self.lcd_cam
+        self.regs()
             .cam_rgb_yuv()
             .write(|w| w.cam_conv_bypass().clear_bit());
 
-        self.lcd_cam
+        self.regs()
             .cam_ctrl()
             .modify(|_, w| w.cam_update().set_bit());
 
@@ -260,7 +265,7 @@ impl<'d> Camera<'d> {
         h_enable.init_input(Pull::None);
         InputSignal::CAM_H_ENABLE.connect_to(h_enable);
 
-        self.lcd_cam
+        self.regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_vh_de_mode_en().clear_bit());
 
@@ -288,7 +293,7 @@ impl<'d> Camera<'d> {
         h_enable.init_input(Pull::None);
         InputSignal::CAM_H_ENABLE.connect_to(h_enable);
 
-        self.lcd_cam
+        self.regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_vh_de_mode_en().set_bit());
 
@@ -301,16 +306,16 @@ impl<'d> Camera<'d> {
         mut buf: BUF,
     ) -> Result<CameraTransfer<'d, BUF>, (DmaError, Self, BUF)> {
         // Reset Camera control unit and Async Rx FIFO
-        self.lcd_cam
+        self.regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_reset().set_bit());
-        self.lcd_cam
+        self.regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_reset().clear_bit());
-        self.lcd_cam
+        self.regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_afifo_reset().set_bit());
-        self.lcd_cam
+        self.regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_afifo_reset().clear_bit());
 
@@ -326,13 +331,13 @@ impl<'d> Camera<'d> {
         }
 
         // Start the Camera unit to listen for incoming DVP stream.
-        self.lcd_cam.cam_ctrl().modify(|_, w| {
+        self.regs().cam_ctrl().modify(|_, w| {
             // Automatically stops the camera unit once the GDMA Rx FIFO is full.
             w.cam_stop_en().set_bit();
 
             w.cam_update().set_bit()
         });
-        self.lcd_cam
+        self.regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_start().set_bit());
 
@@ -370,7 +375,7 @@ impl<'d, BUF: DmaRxBuffer> CameraTransfer<'d, BUF> {
         // the sake of familiarity and similarity with other drivers.
 
         self.camera
-            .lcd_cam
+            .regs()
             .cam_ctrl1()
             .read()
             .cam_start()
@@ -423,7 +428,7 @@ impl<'d, BUF: DmaRxBuffer> CameraTransfer<'d, BUF> {
     fn stop_peripherals(&mut self) {
         // Stop the LCD_CAM peripheral.
         self.camera
-            .lcd_cam
+            .regs()
             .cam_ctrl1()
             .modify(|_, w| w.cam_start().clear_bit());
 

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -113,6 +113,7 @@ use crate::{
         ByteOrder,
         ClockError,
     },
+    pac,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::LCD_CAM,
     system::{self, GenericPeripheralGuard},
@@ -163,6 +164,10 @@ where
         Ok(this)
     }
 
+    fn regs(&self) -> &pac::lcd_cam::RegisterBlock {
+        self.lcd_cam.register_block()
+    }
+
     /// Applies the configuration to the peripheral.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
@@ -179,7 +184,7 @@ where
         )
         .map_err(ConfigError::Clock)?;
 
-        self.lcd_cam.lcd_clock().write(|w| unsafe {
+        self.regs().lcd_clock().write(|w| unsafe {
             // Force enable the clock for all configuration registers.
             w.clk_en().set_bit();
             w.lcd_clk_sel().bits((i + 1) as _);
@@ -193,15 +198,15 @@ where
             w.lcd_ck_out_edge()
                 .bit(config.clock_mode.phase == Phase::ShiftHigh)
         });
-        self.lcd_cam
+        self.regs()
             .lcd_user()
             .modify(|_, w| w.lcd_reset().set_bit());
 
-        self.lcd_cam
+        self.regs()
             .lcd_rgb_yuv()
             .write(|w| w.lcd_conv_bypass().clear_bit());
 
-        self.lcd_cam.lcd_user().modify(|_, w| {
+        self.regs().lcd_user().modify(|_, w| {
             if config.format.enable_2byte_mode {
                 w.lcd_8bits_order().bit(false);
                 w.lcd_byte_order()
@@ -224,7 +229,7 @@ where
         });
 
         let timing = &config.timing;
-        self.lcd_cam.lcd_ctrl().modify(|_, w| unsafe {
+        self.regs().lcd_ctrl().modify(|_, w| unsafe {
             // Enable RGB mode, and input VSYNC, HSYNC, and DE signals.
             w.lcd_rgb_mode_en().set_bit();
 
@@ -235,7 +240,7 @@ where
             w.lcd_vt_height()
                 .bits((timing.vertical_total_height as u16).saturating_sub(1))
         });
-        self.lcd_cam.lcd_ctrl1().modify(|_, w| unsafe {
+        self.regs().lcd_ctrl1().modify(|_, w| unsafe {
             w.lcd_vb_front()
                 .bits((timing.vertical_blank_front_porch as u8).saturating_sub(1));
             w.lcd_ha_width()
@@ -243,7 +248,7 @@ where
             w.lcd_ht_width()
                 .bits((timing.horizontal_total_width as u16).saturating_sub(1))
         });
-        self.lcd_cam.lcd_ctrl2().modify(|_, w| unsafe {
+        self.regs().lcd_ctrl2().modify(|_, w| unsafe {
             w.lcd_vsync_width()
                 .bits((timing.vsync_width as u8).saturating_sub(1));
             w.lcd_vsync_idle_pol().bit(config.vsync_idle_level.into());
@@ -255,7 +260,7 @@ where
             w.lcd_hsync_position().bits(timing.hsync_position as u8)
         });
 
-        self.lcd_cam.lcd_misc().modify(|_, w| unsafe {
+        self.regs().lcd_misc().modify(|_, w| unsafe {
             // TODO: Find out what this field actually does.
             // Set the threshold for Async Tx FIFO full event. (5 bits)
             w.lcd_afifo_threshold_num().bits((1 << 5) - 1);
@@ -271,13 +276,13 @@ where
             // Enable blank region when LCD sends data out.
             w.lcd_bk_en().bit(!config.disable_black_region)
         });
-        self.lcd_cam.lcd_dly_mode().modify(|_, w| unsafe {
+        self.regs().lcd_dly_mode().modify(|_, w| unsafe {
             w.lcd_de_mode().bits(config.de_mode as u8);
             w.lcd_hsync_mode().bits(config.hsync_mode as u8);
             w.lcd_vsync_mode().bits(config.vsync_mode as u8);
             w
         });
-        self.lcd_cam.lcd_data_dout_mode().modify(|_, w| unsafe {
+        self.regs().lcd_data_dout_mode().modify(|_, w| unsafe {
             w.dout0_mode().bits(config.output_bit_mode as u8);
             w.dout1_mode().bits(config.output_bit_mode as u8);
             w.dout2_mode().bits(config.output_bit_mode as u8);
@@ -296,7 +301,7 @@ where
             w.dout15_mode().bits(config.output_bit_mode as u8)
         });
 
-        self.lcd_cam
+        self.regs()
             .lcd_user()
             .modify(|_, w| w.lcd_update().set_bit());
 
@@ -562,21 +567,21 @@ where
         }
 
         // Reset LCD control unit and Async Tx FIFO
-        self.lcd_cam
+        self.regs()
             .lcd_user()
             .modify(|_, w| w.lcd_reset().set_bit());
-        self.lcd_cam
+        self.regs()
             .lcd_misc()
             .modify(|_, w| w.lcd_afifo_reset().set_bit());
 
-        self.lcd_cam.lcd_misc().modify(|_, w| {
+        self.regs().lcd_misc().modify(|_, w| {
             // 1: Send the next frame data when the current frame is sent out.
             // 0: LCD stops when the current frame is sent out.
             w.lcd_next_frame_en().bit(next_frame_en)
         });
 
         // Start the transfer.
-        self.lcd_cam.lcd_user().modify(|_, w| {
+        self.regs().lcd_user().modify(|_, w| {
             w.lcd_update().set_bit();
             w.lcd_start().set_bit()
         });
@@ -598,12 +603,7 @@ pub struct DpiTransfer<'d, BUF: DmaTxBuffer, Dm: DriverMode> {
 impl<'d, BUF: DmaTxBuffer, Dm: DriverMode> DpiTransfer<'d, BUF, Dm> {
     /// Returns true when [Self::wait] will not block.
     pub fn is_done(&self) -> bool {
-        self.dpi
-            .lcd_cam
-            .lcd_user()
-            .read()
-            .lcd_start()
-            .bit_is_clear()
+        self.dpi.regs().lcd_user().read().lcd_start().bit_is_clear()
     }
 
     /// Stops this transfer on the spot and returns the peripheral and buffer.
@@ -655,7 +655,7 @@ impl<'d, BUF: DmaTxBuffer, Dm: DriverMode> DpiTransfer<'d, BUF, Dm> {
     fn stop_peripherals(&mut self) {
         // Stop the LCD_CAM peripheral.
         self.dpi
-            .lcd_cam
+            .regs()
             .lcd_user()
             .modify(|_, w| w.lcd_start().clear_bit());
 

--- a/esp-hal/src/mcpwm/mod.rs
+++ b/esp-hal/src/mcpwm/mod.rs
@@ -84,8 +84,6 @@
 //! # }
 //! ```
 
-use core::ops::Deref;
-
 use fugit::HertzU32;
 use operator::Operator;
 use timer::Timer;
@@ -137,13 +135,15 @@ impl<'d, PWM: PwmPeripheral> McPwm<'d, PWM> {
 
         #[cfg(not(esp32c6))]
         {
+            let register_block = unsafe { &*PWM::block() };
+
             // set prescaler
-            peripheral
+            register_block
                 .clk_cfg()
                 .write(|w| unsafe { w.clk_prescale().bits(peripheral_clock.prescaler) });
 
             // enable clock
-            peripheral.clk().write(|w| w.en().set_bit());
+            register_block.clk().write(|w| w.en().set_bit());
         }
 
         #[cfg(esp32c6)]
@@ -314,7 +314,7 @@ impl PeripheralClockConfig {
 pub struct FrequencyError;
 
 /// A MCPWM peripheral
-pub trait PwmPeripheral: Deref<Target = RegisterBlock> + crate::private::Sealed {
+pub trait PwmPeripheral: crate::private::Sealed {
     /// Get a pointer to the peripheral RegisterBlock
     fn block() -> *const RegisterBlock;
     /// Get operator GPIO mux output signal
@@ -326,7 +326,7 @@ pub trait PwmPeripheral: Deref<Target = RegisterBlock> + crate::private::Sealed 
 #[cfg(mcpwm0)]
 impl PwmPeripheral for crate::peripherals::MCPWM0 {
     fn block() -> *const RegisterBlock {
-        Self::PTR
+        Self::regs()
     }
 
     fn output_signal<const OP: u8, const IS_A: bool>() -> OutputSignal {
@@ -349,7 +349,7 @@ impl PwmPeripheral for crate::peripherals::MCPWM0 {
 #[cfg(mcpwm1)]
 impl PwmPeripheral for crate::peripherals::MCPWM1 {
     fn block() -> *const RegisterBlock {
-        Self::PTR
+        Self::regs()
     }
 
     fn output_signal<const OP: u8, const IS_A: bool>() -> OutputSignal {

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -13,8 +13,8 @@ pub use crate::pac::pcnt::unit::conf0::{CTRL_MODE as CtrlMode, EDGE_MODE as Edge
 use crate::{
     gpio::{interconnect::PeripheralInput, InputSignal},
     peripheral::Peripheral,
-    system::GenericPeripheralGuard,
     peripherals::PCNT,
+    system::GenericPeripheralGuard,
 };
 
 /// Represents a channel within a pulse counter unit.

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -471,13 +471,11 @@ mod peripheral_macros {
                 pub const fn regs<'a>() -> &'a <pac::$base as core::ops::Deref>::Target {
                     unsafe { &*Self::PTR }
                 }
-            }
 
-            #[doc(hidden)]
-            impl core::ops::Deref for $name {
-                type Target = <pac::$base as core::ops::Deref>::Target;
-
-                fn deref(&self) -> &Self::Target {
+                #[doc = r"Return a reference to the register block"]
+                #[inline(always)]
+                #[instability::unstable]
+                pub fn register_block(&self) -> &<pac::$base as core::ops::Deref>::Target {
                     unsafe { &*Self::PTR }
                 }
             }

--- a/esp-hal/src/rsa/esp32.rs
+++ b/esp-hal/src/rsa/esp32.rs
@@ -15,7 +15,7 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     /// needs to be initialized, only after that peripheral should be used.
     /// This function would return without an error if the memory is initialized
     pub fn ready(&mut self) -> nb::Result<(), Infallible> {
-        if self.rsa.clean().read().clean().bit_is_clear() {
+        if self.regs().clean().read().clean().bit_is_clear() {
             return Err(nb::Error::WouldBlock);
         }
         Ok(())
@@ -23,25 +23,25 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
 
     /// Writes the multi-mode configuration to the RSA hardware.
     pub(super) fn write_multi_mode(&mut self, mode: u32) {
-        self.rsa.mult_mode().write(|w| unsafe { w.bits(mode) });
+        self.regs().mult_mode().write(|w| unsafe { w.bits(mode) });
     }
 
     /// Writes the modular exponentiation mode configuration to the RSA
     /// hardware.
     pub(super) fn write_modexp_mode(&mut self, mode: u32) {
-        self.rsa.modexp_mode().write(|w| unsafe { w.bits(mode) });
+        self.regs().modexp_mode().write(|w| unsafe { w.bits(mode) });
     }
 
     /// Starts the modular exponentiation operation.
     pub(super) fn write_modexp_start(&self) {
-        self.rsa
+        self.regs()
             .modexp_start()
             .write(|w| w.modexp_start().set_bit());
     }
 
     /// Starts the multiplication operation.
     pub(super) fn write_multi_start(&self) {
-        self.rsa.mult_start().write(|w| w.mult_start().set_bit());
+        self.regs().mult_start().write(|w| w.mult_start().set_bit());
     }
 
     /// Starts the modular multiplication operation.
@@ -51,12 +51,12 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
 
     /// Clears the RSA interrupt flag.
     pub(super) fn clear_interrupt(&mut self) {
-        self.rsa.interrupt().write(|w| w.interrupt().set_bit());
+        self.regs().interrupt().write(|w| w.interrupt().set_bit());
     }
 
     /// Checks if the RSA peripheral is idle.
     pub(super) fn is_idle(&self) -> bool {
-        self.rsa.interrupt().read().interrupt().bit_is_set()
+        self.regs().interrupt().read().interrupt().bit_is_set()
     }
 }
 

--- a/esp-hal/src/rsa/esp32cX.rs
+++ b/esp-hal/src/rsa/esp32cX.rs
@@ -15,7 +15,13 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     /// needs to be initialized, only after that peripheral should be used.
     /// This function would return without an error if the memory is initialized
     pub fn ready(&mut self) -> nb::Result<(), Infallible> {
-        if self.rsa.query_clean().read().query_clean().bit_is_clear() {
+        if self
+            .regs()
+            .query_clean()
+            .read()
+            .query_clean()
+            .bit_is_clear()
+        {
             return Err(nb::Error::WouldBlock);
         }
         Ok(())
@@ -26,11 +32,11 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     /// When enabled rsa peripheral would generate an interrupt when a operation
     /// is finished.
     pub fn enable_disable_interrupt(&mut self, enable: bool) {
-        self.rsa.int_ena().write(|w| w.int_ena().bit(enable));
+        self.regs().int_ena().write(|w| w.int_ena().bit(enable));
     }
 
     fn write_mode(&mut self, mode: u32) {
-        self.rsa.mode().write(|w| unsafe { w.bits(mode) });
+        self.regs().mode().write(|w| unsafe { w.bits(mode) });
     }
 
     /// Enables/disables search acceleration.
@@ -43,26 +49,23 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     ///
     /// For more information refer to 18.3.4 of <https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf>
     pub fn enable_disable_search_acceleration(&mut self, enable: bool) {
-        match enable {
-            true => self
-                .rsa
-                .search_enable()
-                .write(|w| w.search_enable().set_bit()),
-            false => self
-                .rsa
-                .search_enable()
-                .write(|w| w.search_enable().clear_bit()),
-        };
+        self.regs()
+            .search_enable()
+            .write(|w| w.search_enable().bit(enable));
     }
 
     /// Checks if the search functionality is enabled in the RSA hardware.
     pub(super) fn is_search_enabled(&mut self) -> bool {
-        self.rsa.search_enable().read().search_enable().bit_is_set()
+        self.regs()
+            .search_enable()
+            .read()
+            .search_enable()
+            .bit_is_set()
     }
 
     /// Sets the search position in the RSA hardware.
     pub(super) fn write_search_position(&mut self, search_position: u32) {
-        self.rsa
+        self.regs()
             .search_pos()
             .write(|w| unsafe { w.bits(search_position) });
     }
@@ -78,47 +81,40 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     ///
     /// For more information refer to 18.3.4 of <https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf>.
     pub fn enable_disable_constant_time_acceleration(&mut self, enable: bool) {
-        match enable {
-            true => self
-                .rsa
-                .constant_time()
-                .write(|w| w.constant_time().clear_bit()),
-            false => self
-                .rsa
-                .constant_time()
-                .write(|w| w.constant_time().set_bit()),
-        };
+        self.regs()
+            .constant_time()
+            .write(|w| w.constant_time().bit(enable));
     }
 
     /// Starts the modular exponentiation operation.
     pub(super) fn write_modexp_start(&self) {
-        self.rsa
+        self.regs()
             .set_start_modexp()
             .write(|w| w.set_start_modexp().set_bit());
     }
 
     /// Starts the multiplication operation.
     pub(super) fn write_multi_start(&self) {
-        self.rsa
+        self.regs()
             .set_start_mult()
             .write(|w| w.set_start_mult().set_bit());
     }
 
     /// Starts the modular multiplication operation.
     pub(super) fn write_modmulti_start(&self) {
-        self.rsa
+        self.regs()
             .set_start_modmult()
             .write(|w| w.set_start_modmult().set_bit());
     }
 
     /// Clears the RSA interrupt flag.
     pub(super) fn clear_interrupt(&mut self) {
-        self.rsa.int_clr().write(|w| w.int_clr().set_bit());
+        self.regs().int_clr().write(|w| w.int_clr().set_bit());
     }
 
     /// Checks if the RSA peripheral is idle.
     pub(super) fn is_idle(&self) -> bool {
-        self.rsa.query_idle().read().query_idle().bit_is_set()
+        self.regs().query_idle().read().query_idle().bit_is_set()
     }
 }
 

--- a/esp-hal/src/rsa/esp32sX.rs
+++ b/esp-hal/src/rsa/esp32sX.rs
@@ -16,7 +16,7 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     /// This function would return without an error if the memory is
     /// initialized.
     pub fn ready(&mut self) -> nb::Result<(), Infallible> {
-        if self.rsa.clean().read().clean().bit_is_clear() {
+        if self.regs().clean().read().clean().bit_is_clear() {
             return Err(nb::Error::WouldBlock);
         }
         Ok(())
@@ -27,11 +27,11 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     /// When enabled rsa peripheral would generate an interrupt when a operation
     /// is finished.
     pub fn enable_disable_interrupt(&mut self, enable: bool) {
-        self.rsa.int_ena().write(|w| w.int_ena().bit(enable));
+        self.regs().int_ena().write(|w| w.int_ena().bit(enable));
     }
 
     fn write_mode(&mut self, mode: u32) {
-        self.rsa.mode().write(|w| unsafe { w.bits(mode) });
+        self.regs().mode().write(|w| unsafe { w.bits(mode) });
     }
 
     /// Enables/disables search acceleration.
@@ -44,19 +44,23 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     ///
     /// For more information refer to 20.3.4 of <https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf>.
     pub fn enable_disable_search_acceleration(&mut self, enable: bool) {
-        self.rsa
+        self.regs()
             .search_enable()
             .write(|w| w.search_enable().bit(enable));
     }
 
     /// Checks if the search functionality is enabled in the RSA hardware.
     pub(super) fn is_search_enabled(&mut self) -> bool {
-        self.rsa.search_enable().read().search_enable().bit_is_set()
+        self.regs()
+            .search_enable()
+            .read()
+            .search_enable()
+            .bit_is_set()
     }
 
     /// Sets the search position in the RSA hardware.
     pub(super) fn write_search_position(&mut self, search_position: u32) {
-        self.rsa
+        self.regs()
             .search_pos()
             .write(|w| unsafe { w.bits(search_position) });
     }
@@ -72,38 +76,38 @@ impl<Dm: crate::DriverMode> Rsa<'_, Dm> {
     ///
     /// For more information refer to 20.3.4 of <https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf>.
     pub fn enable_disable_constant_time_acceleration(&mut self, enable: bool) {
-        self.rsa
+        self.regs()
             .constant_time()
             .write(|w| w.constant_time().bit(!enable));
     }
 
     /// Starts the modular exponentiation operation.
     pub(super) fn write_modexp_start(&self) {
-        self.rsa
+        self.regs()
             .modexp_start()
             .write(|w| w.modexp_start().set_bit());
     }
 
     /// Starts the multiplication operation.
     pub(super) fn write_multi_start(&self) {
-        self.rsa.mult_start().write(|w| w.mult_start().set_bit());
+        self.regs().mult_start().write(|w| w.mult_start().set_bit());
     }
 
     /// Starts the modular multiplication operation.
     pub(super) fn write_modmulti_start(&self) {
-        self.rsa
+        self.regs()
             .modmult_start()
             .write(|w| w.modmult_start().set_bit());
     }
 
     /// Clears the RSA interrupt flag.
     pub(super) fn clear_interrupt(&mut self) {
-        self.rsa.int_clr().write(|w| w.int_clr().set_bit());
+        self.regs().int_clr().write(|w| w.int_clr().set_bit());
     }
 
     /// Checks if the RSA peripheral is idle.
     pub(super) fn is_idle(&self) -> bool {
-        self.rsa.idle().read().idle().bit_is_set()
+        self.regs().idle().read().idle().bit_is_set()
     }
 }
 

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -25,6 +25,7 @@ use core::{marker::PhantomData, ptr::copy_nonoverlapping};
 
 use crate::{
     interrupt::{InterruptConfigurable, InterruptHandler},
+    pac,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{Interrupt, RSA},
     system::{GenericPeripheralGuard, Peripheral as PeripheralEnable},
@@ -106,44 +107,38 @@ impl<'d, Dm: crate::DriverMode> Rsa<'d, Dm> {
         }
     }
 
+    fn regs(&self) -> &pac::rsa::RegisterBlock {
+        self.rsa.register_block()
+    }
+
     fn write_operand_b<const N: usize>(&mut self, operand_b: &[u32; N]) {
-        unsafe {
-            copy_nonoverlapping(operand_b.as_ptr(), self.rsa.y_mem(0).as_ptr(), N);
-        }
+        unsafe { copy_nonoverlapping(operand_b.as_ptr(), self.regs().y_mem(0).as_ptr(), N) };
     }
 
     fn write_modulus<const N: usize>(&mut self, modulus: &[u32; N]) {
-        unsafe {
-            copy_nonoverlapping(modulus.as_ptr(), self.rsa.m_mem(0).as_ptr(), N);
-        }
+        unsafe { copy_nonoverlapping(modulus.as_ptr(), self.regs().m_mem(0).as_ptr(), N) };
     }
 
     fn write_mprime(&mut self, m_prime: u32) {
-        self.rsa.m_prime().write(|w| unsafe { w.bits(m_prime) });
+        self.regs().m_prime().write(|w| unsafe { w.bits(m_prime) });
     }
 
     fn write_operand_a<const N: usize>(&mut self, operand_a: &[u32; N]) {
-        unsafe {
-            copy_nonoverlapping(operand_a.as_ptr(), self.rsa.x_mem(0).as_ptr(), N);
-        }
+        unsafe { copy_nonoverlapping(operand_a.as_ptr(), self.regs().x_mem(0).as_ptr(), N) };
     }
 
     fn write_multi_operand_b<const N: usize>(&mut self, operand_b: &[u32; N]) {
-        unsafe {
-            copy_nonoverlapping(operand_b.as_ptr(), self.rsa.z_mem(0).as_ptr().add(N), N);
-        }
+        unsafe { copy_nonoverlapping(operand_b.as_ptr(), self.regs().z_mem(0).as_ptr().add(N), N) };
     }
 
     fn write_r<const N: usize>(&mut self, r: &[u32; N]) {
-        unsafe {
-            copy_nonoverlapping(r.as_ptr(), self.rsa.z_mem(0).as_ptr(), N);
-        }
+        unsafe { copy_nonoverlapping(r.as_ptr(), self.regs().z_mem(0).as_ptr(), N) };
     }
 
     fn read_out<const N: usize>(&self, outbuf: &mut [u32; N]) {
         unsafe {
             copy_nonoverlapping(
-                self.rsa.z_mem(0).as_ptr() as *const u32,
+                self.regs().z_mem(0).as_ptr() as *const u32,
                 outbuf.as_ptr() as *mut u32,
                 N,
             );
@@ -406,17 +401,17 @@ pub(crate) mod asynch {
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     struct RsaFuture<'a, 'd> {
         #[cfg_attr(esp32, allow(dead_code))]
-        instance: &'a Rsa<'d, Async>,
+        driver: &'a Rsa<'d, Async>,
     }
 
     impl<'a, 'd> RsaFuture<'a, 'd> {
-        fn new(instance: &'a Rsa<'d, Async>) -> Self {
+        fn new(driver: &'a Rsa<'d, Async>) -> Self {
             SIGNALED.store(false, Ordering::Relaxed);
 
             #[cfg(not(esp32))]
-            instance.rsa.int_ena().write(|w| w.int_ena().set_bit());
+            driver.regs().int_ena().write(|w| w.int_ena().set_bit());
 
-            Self { instance }
+            Self { driver }
         }
 
         fn is_done(&self) -> bool {
@@ -427,8 +422,8 @@ pub(crate) mod asynch {
     impl Drop for RsaFuture<'_, '_> {
         fn drop(&mut self) {
             #[cfg(not(esp32))]
-            self.instance
-                .rsa
+            self.driver
+                .regs()
                 .int_ena()
                 .write(|w| w.int_ena().clear_bit());
         }

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -1361,7 +1361,10 @@ pub(crate) enum RtcFastClock {
 impl Clock for RtcFastClock {
     fn frequency(&self) -> HertzU32 {
         match self {
-            RtcFastClock::RtcFastClockXtalD2 => HertzU32::Hz(40_000_000 / 2), // TODO: Is the value correct?
+            RtcFastClock::RtcFastClockXtalD2 => {
+                // TODO: Is the value correct?
+                HertzU32::Hz(40_000_000 / 2)
+            }
             RtcFastClock::RtcFastClockRcFast => HertzU32::Hz(17_500_000),
         }
     }

--- a/esp-hal/src/soc/esp32s3/psram.rs
+++ b/esp-hal/src/soc/esp32s3/psram.rs
@@ -1092,7 +1092,9 @@ pub(crate) mod utils {
 
         unsafe {
             // set to variable dummy mode
-            SPI1::regs().ddr().modify(|_, w| w.spi_fmem_var_dummy().set_bit());
+            SPI1::regs()
+                .ddr()
+                .modify(|_, w| w.spi_fmem_var_dummy().set_bit());
             esp_rom_spi_set_dtr_swap_mode(1, false, false);
         }
 

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -123,7 +123,7 @@ impl TimerGroupInstance for TIMG0 {
 
     #[inline(always)]
     fn register_block() -> *const RegisterBlock {
-        Self::PTR
+        Self::regs()
     }
 
     fn configure_src_clk() {
@@ -132,7 +132,7 @@ impl TimerGroupInstance for TIMG0 {
                 // ESP32 has only APB clock source, do nothing
             } else if #[cfg(any(esp32c2, esp32c3, esp32s2, esp32s3))] {
                 unsafe {
-                    (*Self::register_block())
+                    (*<Self as TimerGroupInstance>::register_block())
                         .t(0)
                         .config()
                         .modify(|_, w| w.use_xtal().clear_bit());
@@ -160,7 +160,7 @@ impl TimerGroupInstance for TIMG0 {
                 // ESP32, ESP32-S2, and ESP32-S3 use only ABP, do nothing
             } else if #[cfg(any(esp32c2, esp32c3))] {
                 unsafe {
-                    (*Self::register_block())
+                    (*<Self as TimerGroupInstance>::register_block())
                         .wdtconfig0()
                         .modify(|_, w| w.wdt_use_xtal().clear_bit());
                 }
@@ -185,7 +185,7 @@ impl TimerGroupInstance for crate::peripherals::TIMG1 {
 
     #[inline(always)]
     fn register_block() -> *const RegisterBlock {
-        Self::PTR
+        Self::regs()
     }
 
     fn configure_src_clk() {
@@ -199,7 +199,7 @@ impl TimerGroupInstance for crate::peripherals::TIMG1 {
                     .modify(|_, w| unsafe { w.tg1_timer_clk_sel().bits(TIMG_DEFAULT_CLK_SRC) });
             } else if #[cfg(any(esp32s2, esp32s3))] {
                 unsafe {
-                    (*Self::register_block())
+                    (*<Self as TimerGroupInstance>::register_block())
                         .t(1)
                         .config()
                         .modify(|_, w| w.use_xtal().clear_bit());

--- a/esp-hal/src/trace.rs
+++ b/esp-hal/src/trace.rs
@@ -218,7 +218,7 @@ pub trait Instance: crate::private::Sealed {
 
 impl Instance for crate::peripherals::TRACE0 {
     fn register_block(&self) -> &RegisterBlock {
-        self
+        self.register_block()
     }
 
     fn peripheral(&self) -> crate::system::Peripheral {

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -649,7 +649,7 @@ where
 
     fn write_byte(&mut self, word: u8) {
         while self.tx_fifo_count() >= UART_FIFO_SIZE {}
-        self.register_block()
+        self.regs()
             .fifo()
             .write(|w| unsafe { w.rxfifo_rd_byte().bits(word) });
     }
@@ -658,12 +658,7 @@ where
     /// Returns the number of bytes currently in the TX FIFO for this UART
     /// instance.
     fn tx_fifo_count(&self) -> u16 {
-        self.register_block()
-            .status()
-            .read()
-            .txfifo_cnt()
-            .bits()
-            .into()
+        self.regs().status().read().txfifo_cnt().bits().into()
     }
 
     /// Flush the transmit buffer of the UART
@@ -677,9 +672,9 @@ where
     /// currently being transmitted.
     fn is_tx_idle(&self) -> bool {
         #[cfg(esp32)]
-        let status = self.register_block().status();
+        let status = self.regs().status();
         #[cfg(not(esp32))]
-        let status = self.register_block().fsm_status();
+        let status = self.regs().fsm_status();
 
         status.read().st_utx_out().bits() == 0x0
     }
@@ -690,14 +685,14 @@ where
     /// `transmit break done`, `transmit break idle done`, and `transmit done`
     /// interrupts.
     fn disable_tx_interrupts(&self) {
-        self.register_block().int_clr().write(|w| {
+        self.regs().int_clr().write(|w| {
             w.txfifo_empty().clear_bit_by_one();
             w.tx_brk_done().clear_bit_by_one();
             w.tx_brk_idle_done().clear_bit_by_one();
             w.tx_done().clear_bit_by_one()
         });
 
-        self.register_block().int_ena().write(|w| {
+        self.regs().int_ena().write(|w| {
             w.txfifo_empty().clear_bit();
             w.tx_brk_done().clear_bit();
             w.tx_brk_idle_done().clear_bit();
@@ -705,8 +700,8 @@ where
         });
     }
 
-    fn register_block(&self) -> &RegisterBlock {
-        self.uart.info().register_block()
+    fn regs(&self) -> &RegisterBlock {
+        self.uart.info().regs()
     }
 }
 
@@ -781,6 +776,10 @@ impl<'d, Dm> UartRx<'d, Dm>
 where
     Dm: DriverMode,
 {
+    fn regs(&self) -> &RegisterBlock {
+        self.uart.info().regs()
+    }
+
     /// Configure CTS pin
     pub fn with_cts(self, cts: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(cts);
@@ -835,11 +834,11 @@ where
             if #[cfg(esp32s2)] {
                 // On the ESP32-S2 we need to use PeriBus2 to read the FIFO:
                 let fifo = unsafe {
-                    &*((self.register_block().fifo().as_ptr() as *mut u8).add(0x20C00000)
+                    &*((self.regs().fifo().as_ptr() as *mut u8).add(0x20C00000)
                         as *mut crate::pac::uart0::FIFO)
                 };
             } else {
-                let fifo = self.register_block().fifo();
+                let fifo = self.regs().fifo();
             }
         }
 
@@ -916,20 +915,14 @@ where
 
     #[allow(clippy::useless_conversion)]
     fn rx_fifo_count(&self) -> u16 {
-        let fifo_cnt: u16 = self
-            .register_block()
-            .status()
-            .read()
-            .rxfifo_cnt()
-            .bits()
-            .into();
+        let fifo_cnt: u16 = self.regs().status().read().rxfifo_cnt().bits().into();
 
         // Calculate the real count based on the FIFO read and write offset address:
         // https://www.espressif.com/sites/default/files/documentation/esp32_errata_en.pdf
         // section 3.17
         #[cfg(esp32)]
         {
-            let status = self.register_block().mem_rx_status().read();
+            let status = self.regs().mem_rx_status().read();
             let rd_addr = status.mem_rx_rd_addr().bits();
             let wr_addr = status.mem_rx_wr_addr().bits();
 
@@ -954,23 +947,19 @@ where
     /// `receive FIFO overflow`, `receive FIFO timeout`, and `AT command
     /// character detection` interrupts.
     fn disable_rx_interrupts(&self) {
-        self.register_block().int_clr().write(|w| {
+        self.regs().int_clr().write(|w| {
             w.rxfifo_full().clear_bit_by_one();
             w.rxfifo_ovf().clear_bit_by_one();
             w.rxfifo_tout().clear_bit_by_one();
             w.at_cmd_char_det().clear_bit_by_one()
         });
 
-        self.register_block().int_ena().write(|w| {
+        self.regs().int_ena().write(|w| {
             w.rxfifo_full().clear_bit();
             w.rxfifo_ovf().clear_bit();
             w.rxfifo_tout().clear_bit();
             w.at_cmd_char_det().clear_bit()
         });
-    }
-
-    fn register_block(&self) -> &RegisterBlock {
-        self.uart.info().register_block()
     }
 }
 
@@ -1113,9 +1102,9 @@ where
         self
     }
 
-    fn register_block(&self) -> &RegisterBlock {
+    fn regs(&self) -> &RegisterBlock {
         // `self.tx.uart` and `self.rx.uart` are the same
-        self.tx.uart.info().register_block()
+        self.tx.uart.info().regs()
     }
 
     /// Split the UART into a transmitter and receiver
@@ -1151,42 +1140,38 @@ where
     /// Configures the AT-CMD detection settings
     #[instability::unstable]
     pub fn set_at_cmd(&mut self, config: AtCmdConfig) {
-        let register_block = self.register_block();
-
         #[cfg(not(any(esp32, esp32s2)))]
-        register_block
+        self.regs()
             .clk_conf()
             .modify(|_, w| w.sclk_en().clear_bit());
 
-        register_block.at_cmd_char().write(|w| unsafe {
+        self.regs().at_cmd_char().write(|w| unsafe {
             w.at_cmd_char().bits(config.cmd_char);
             w.char_num().bits(config.char_num)
         });
 
         if let Some(pre_idle_count) = config.pre_idle_count {
-            register_block
+            self.regs()
                 .at_cmd_precnt()
                 .write(|w| unsafe { w.pre_idle_num().bits(pre_idle_count as _) });
         }
 
         if let Some(post_idle_count) = config.post_idle_count {
-            register_block
+            self.regs()
                 .at_cmd_postcnt()
                 .write(|w| unsafe { w.post_idle_num().bits(post_idle_count as _) });
         }
 
         if let Some(gap_timeout) = config.gap_timeout {
-            register_block
+            self.regs()
                 .at_cmd_gaptout()
                 .write(|w| unsafe { w.rx_gap_tout().bits(gap_timeout as _) });
         }
 
         #[cfg(not(any(esp32, esp32s2)))]
-        register_block
-            .clk_conf()
-            .modify(|_, w| w.sclk_en().set_bit());
+        self.regs().clk_conf().modify(|_, w| w.sclk_en().set_bit());
 
-        sync_regs(register_block);
+        sync_regs(self.regs());
     }
 
     /// Flush the transmit buffer of the UART
@@ -1210,7 +1195,7 @@ where
                     .perip_clk_en0()
                     .modify(|_, w| w.uart_mem_clk_en().set_bit());
             } else {
-                self.register_block()
+                self.regs()
                     .conf0()
                     .modify(|_, w| w.mem_clk_en().set_bit());
             }
@@ -1225,23 +1210,19 @@ where
 
         // Don't wait after transmissions by default,
         // so that bytes written to TX FIFO are always immediately transmitted.
-        self.register_block()
+        self.regs()
             .idle_conf()
             .modify(|_, w| unsafe { w.tx_idle_num().bits(0) });
 
         // Setting err_wr_mask stops uart from storing data when data is wrong according
         // to reference manual
-        self.register_block()
-            .conf0()
-            .modify(|_, w| w.err_wr_mask().set_bit());
+        self.regs().conf0().modify(|_, w| w.err_wr_mask().set_bit());
 
         crate::rom::ets_delay_us(15);
 
         // Make sure we are starting in a "clean state" - previous operations might have
         // run into error conditions
-        self.register_block()
-            .int_clr()
-            .write(|w| unsafe { w.bits(u32::MAX) });
+        self.regs().int_clr().write(|w| unsafe { w.bits(u32::MAX) });
 
         Ok(())
     }
@@ -1273,9 +1254,9 @@ where
                 .modify(|_, w| w.rst_core().bit(_enable));
         }
 
-        rst_core(self.register_block(), true);
+        rst_core(self.regs(), true);
         PeripheralClockControl::reset(self.tx.uart.info().peripheral);
-        rst_core(self.register_block(), false);
+        rst_core(self.regs(), false);
     }
 }
 
@@ -1593,7 +1574,7 @@ impl UartTxFuture {
     }
 
     fn triggered_events(&self) -> bool {
-        let interrupts_enabled = self.uart.register_block().int_ena().read();
+        let interrupts_enabled = self.uart.regs().int_ena().read();
         let mut event_triggered = false;
         for event in self.events {
             event_triggered |= match event {
@@ -1605,7 +1586,7 @@ impl UartTxFuture {
     }
 
     fn enable_listen(&self, enable: bool) {
-        self.uart.register_block().int_ena().modify(|_, w| {
+        self.uart.regs().int_ena().modify(|_, w| {
             for event in self.events {
                 match event {
                     TxEvent::Done => w.tx_done().bit(enable),
@@ -1745,16 +1726,15 @@ impl UartRx<'_, Async> {
                 | RxEvent::GlitchDetected
                 | RxEvent::ParityError;
 
-            let register_block = self.uart.info().register_block();
-            if register_block.at_cmd_char().read().char_num().bits() > 0 {
+            if self.regs().at_cmd_char().read().char_num().bits() > 0 {
                 events |= RxEvent::CmdCharDetected;
             }
 
             cfg_if::cfg_if! {
                 if #[cfg(any(esp32c6, esp32h2))] {
-                    let reg_en = register_block.tout_conf();
+                    let reg_en = self.regs().tout_conf();
                 } else {
-                    let reg_en = register_block.conf1();
+                    let reg_en = self.regs().conf1();
                 }
             };
             if reg_en.read().rx_tout_en().bit_is_set() {
@@ -1770,7 +1750,7 @@ impl UartRx<'_, Async> {
             // data in the fifo, even if the interrupt is disabled and the status bit
             // cleared. Since we do not drain the fifo in the interrupt handler, we need to
             // reset the counter here, after draining the fifo.
-            self.register_block()
+            self.regs()
                 .int_clr()
                 .write(|w| w.rxfifo_tout().clear_bit_by_one());
 
@@ -1832,7 +1812,7 @@ impl embedded_io_async::Write for UartTx<'_, Async> {
 /// bit set. The fact that an interrupt has been disabled is used by the
 /// futures to detect that they should indeed resolve after being woken up
 pub(super) fn intr_handler(uart: &Info, state: &State) {
-    let interrupts = uart.register_block().int_st().read();
+    let interrupts = uart.regs().int_st().read();
     let interrupt_bits = interrupts.bits(); // = int_raw & int_ena
     let rx_wake = interrupts.rxfifo_full().bit_is_set()
         || interrupts.rxfifo_ovf().bit_is_set()
@@ -1842,10 +1822,10 @@ pub(super) fn intr_handler(uart: &Info, state: &State) {
         || interrupts.frm_err().bit_is_set()
         || interrupts.parity_err().bit_is_set();
     let tx_wake = interrupts.tx_done().bit_is_set() || interrupts.txfifo_empty().bit_is_set();
-    uart.register_block()
+    uart.regs()
         .int_clr()
         .write(|w| unsafe { w.bits(interrupt_bits) });
-    uart.register_block()
+    uart.regs()
         .int_ena()
         .modify(|r, w| unsafe { w.bits(r.bits() & !interrupt_bits) });
 
@@ -1895,26 +1875,24 @@ pub mod lp_uart {
                 .modify(|_, w| unsafe { w.mcu_sel().bits(1) });
 
             let mut me = Self { uart };
+            let uart = me.uart.register_block();
 
             // Set UART mode - do nothing for LP
 
             // Disable UART parity
             // 8-bit world
             // 1-bit stop bit
-            me.uart.conf0().modify(|_, w| unsafe {
+            uart.conf0().modify(|_, w| unsafe {
                 w.parity().clear_bit();
                 w.parity_en().clear_bit();
                 w.bit_num().bits(0x3);
                 w.stop_bit_num().bits(0x1)
             });
             // Set tx idle
-            me.uart
-                .idle_conf()
+            uart.idle_conf()
                 .modify(|_, w| unsafe { w.tx_idle_num().bits(0) });
             // Disable hw-flow control
-            me.uart
-                .hwfc_conf()
-                .modify(|_, w| w.rx_flow_en().clear_bit());
+            uart.hwfc_conf().modify(|_, w| w.rx_flow_en().clear_bit());
 
             // Get source clock frequency
             // default == SOC_MOD_CLK_RTC_FAST == 2
@@ -1944,26 +1922,39 @@ pub mod lp_uart {
         }
 
         fn rxfifo_reset(&mut self) {
-            self.uart.conf0().modify(|_, w| w.rxfifo_rst().set_bit());
+            self.uart
+                .register_block()
+                .conf0()
+                .modify(|_, w| w.rxfifo_rst().set_bit());
             self.update();
 
-            self.uart.conf0().modify(|_, w| w.rxfifo_rst().clear_bit());
+            self.uart
+                .register_block()
+                .conf0()
+                .modify(|_, w| w.rxfifo_rst().clear_bit());
             self.update();
         }
 
         fn txfifo_reset(&mut self) {
-            self.uart.conf0().modify(|_, w| w.txfifo_rst().set_bit());
+            self.uart
+                .register_block()
+                .conf0()
+                .modify(|_, w| w.txfifo_rst().set_bit());
             self.update();
 
-            self.uart.conf0().modify(|_, w| w.txfifo_rst().clear_bit());
+            self.uart
+                .register_block()
+                .conf0()
+                .modify(|_, w| w.txfifo_rst().clear_bit());
             self.update();
         }
 
         fn update(&mut self) {
-            self.uart
+            let register_block = self.uart.register_block();
+            register_block
                 .reg_update()
                 .modify(|_, w| w.reg_update().set_bit());
-            while self.uart.reg_update().read().reg_update().bit_is_set() {
+            while register_block.reg_update().read().reg_update().bit_is_set() {
                 // wait
             }
         }
@@ -1974,7 +1965,7 @@ pub mod lp_uart {
             let max_div = 0b1111_1111_1111 - 1;
             let clk_div = clk.div_ceil(max_div * baudrate);
 
-            self.uart.clk_conf().modify(|_, w| unsafe {
+            self.uart.register_block().clk_conf().modify(|_, w| unsafe {
                 w.sclk_div_a().bits(0);
                 w.sclk_div_b().bits(0);
                 w.sclk_div_num().bits(clk_div as u8 - 1);
@@ -1991,6 +1982,7 @@ pub mod lp_uart {
             let divider = divider as u16;
 
             self.uart
+                .register_block()
                 .clkdiv()
                 .write(|w| unsafe { w.clkdiv().bits(divider).frag().bits(0) });
 
@@ -2007,21 +1999,26 @@ pub mod lp_uart {
         fn change_parity(&mut self, parity: Parity) -> &mut Self {
             if parity != Parity::None {
                 self.uart
+                    .register_block()
                     .conf0()
                     .modify(|_, w| w.parity().bit((parity as u8 & 0x1) != 0));
             }
 
-            self.uart.conf0().modify(|_, w| match parity {
-                Parity::None => w.parity_en().clear_bit(),
-                Parity::Even => w.parity_en().set_bit().parity().clear_bit(),
-                Parity::Odd => w.parity_en().set_bit().parity().set_bit(),
-            });
+            self.uart
+                .register_block()
+                .conf0()
+                .modify(|_, w| match parity {
+                    Parity::None => w.parity_en().clear_bit(),
+                    Parity::Even => w.parity_en().set_bit().parity().clear_bit(),
+                    Parity::Odd => w.parity_en().set_bit().parity().set_bit(),
+                });
 
             self
         }
 
         fn change_data_bits(&mut self, data_bits: DataBits) -> &mut Self {
             self.uart
+                .register_block()
                 .conf0()
                 .modify(|_, w| unsafe { w.bit_num().bits(data_bits as u8) });
 
@@ -2032,6 +2029,7 @@ pub mod lp_uart {
 
         fn change_stop_bits(&mut self, stop_bits: StopBits) -> &mut Self {
             self.uart
+                .register_block()
                 .conf0()
                 .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8) });
 
@@ -2041,6 +2039,7 @@ pub mod lp_uart {
 
         fn change_tx_idle(&mut self, idle_num: u16) -> &mut Self {
             self.uart
+                .register_block()
                 .idle_conf()
                 .modify(|_, w| unsafe { w.tx_idle_num().bits(idle_num) });
 
@@ -2119,13 +2118,13 @@ pub struct State {
 
 impl Info {
     /// Returns the register block for this UART instance.
-    pub fn register_block(&self) -> &RegisterBlock {
+    pub fn regs(&self) -> &RegisterBlock {
         unsafe { &*self.register_block }
     }
 
     /// Listen for the given interrupts
     fn enable_listen(&self, interrupts: EnumSet<UartInterrupt>, enable: bool) {
-        let reg_block = self.register_block();
+        let reg_block = self.regs();
 
         reg_block.int_ena().modify(|_, w| {
             for interrupt in interrupts {
@@ -2141,7 +2140,7 @@ impl Info {
 
     fn interrupts(&self) -> EnumSet<UartInterrupt> {
         let mut res = EnumSet::new();
-        let reg_block = self.register_block();
+        let reg_block = self.regs();
 
         let ints = reg_block.int_raw().read();
 
@@ -2159,7 +2158,7 @@ impl Info {
     }
 
     fn clear_interrupts(&self, interrupts: EnumSet<UartInterrupt>) {
-        let reg_block = self.register_block();
+        let reg_block = self.regs();
 
         reg_block.int_clr().write(|w| {
             for interrupt in interrupts {
@@ -2203,7 +2202,7 @@ impl Info {
     }
 
     fn enable_listen_rx(&self, events: EnumSet<RxEvent>, enable: bool) {
-        self.register_block().int_ena().modify(|_, w| {
+        self.regs().int_ena().modify(|_, w| {
             for event in events {
                 match event {
                     RxEvent::FifoFull => w.rxfifo_full().bit(enable),
@@ -2222,7 +2221,7 @@ impl Info {
 
     fn enabled_rx_events(&self, events: impl Into<EnumSet<RxEvent>>) -> EnumSet<RxEvent> {
         let events = events.into();
-        let interrupts_enabled = self.register_block().int_ena().read();
+        let interrupts_enabled = self.regs().int_ena().read();
         let mut events_triggered = EnumSet::new();
         for event in events {
             let event_triggered = match event {
@@ -2244,7 +2243,7 @@ impl Info {
 
     fn rx_events(&self, events: impl Into<EnumSet<RxEvent>>) -> EnumSet<RxEvent> {
         let events = events.into();
-        let interrupts_enabled = self.register_block().int_st().read();
+        let interrupts_enabled = self.regs().int_st().read();
         let mut events_triggered = EnumSet::new();
         for event in events {
             let event_triggered = match event {
@@ -2266,7 +2265,7 @@ impl Info {
 
     fn clear_rx_events(&self, events: impl Into<EnumSet<RxEvent>>) {
         let events = events.into();
-        self.register_block().int_clr().write(|w| {
+        self.regs().int_clr().write(|w| {
             for event in events {
                 match event {
                     RxEvent::FifoFull => w.rxfifo_full().clear_bit_by_one(),
@@ -2309,7 +2308,7 @@ impl Info {
             return Err(ConfigError::UnsupportedFifoThreshold);
         }
 
-        self.register_block()
+        self.regs()
             .conf1()
             .modify(|_, w| unsafe { w.rxfifo_full_thrhd().bits(threshold as _) });
 
@@ -2338,7 +2337,7 @@ impl Info {
             }
         }
 
-        let register_block = self.register_block();
+        let register_block = self.regs();
 
         if let Some(timeout) = timeout {
             // the esp32 counts directly in number of symbols (symbol len fixed to 8)
@@ -2399,7 +2398,7 @@ impl Info {
 
         let max_div = 0b1111_1111_1111 - 1;
         let clk_div = clk.div_ceil(max_div * baudrate);
-        self.register_block().clk_conf().write(|w| unsafe {
+        self.regs().clk_conf().write(|w| unsafe {
             w.sclk_sel().bits(match clock_source {
                 ClockSource::Apb => 1,
                 ClockSource::RcFast => 2,
@@ -2415,7 +2414,7 @@ impl Info {
         let divider = (clk << 4) / (baudrate * clk_div);
         let divider_integer = (divider >> 4) as u16;
         let divider_frag = (divider & 0xf) as u8;
-        self.register_block()
+        self.regs()
             .clkdiv()
             .write(|w| unsafe { w.clkdiv().bits(divider_integer).frag().bits(divider_frag) });
     }
@@ -2425,7 +2424,7 @@ impl Info {
     }
 
     fn sync_regs(&self) {
-        sync_regs(self.register_block());
+        sync_regs(self.regs());
     }
 
     #[cfg(any(esp32c6, esp32h2))]
@@ -2479,7 +2478,7 @@ impl Info {
         let divider = clk / baudrate;
         let divider = divider as u16;
 
-        self.register_block()
+        self.regs()
             .clkdiv()
             .write(|w| unsafe { w.clkdiv().bits(divider).frag().bits(0) });
 
@@ -2494,25 +2493,25 @@ impl Info {
             ClockSource::RefTick => crate::soc::constants::REF_TICK.to_Hz(),
         };
 
-        self.register_block()
+        self.regs()
             .conf0()
             .modify(|_, w| w.tick_ref_always_on().bit(clock_source == ClockSource::Apb));
 
         let divider = clk / baudrate;
 
-        self.register_block()
+        self.regs()
             .clkdiv()
             .write(|w| unsafe { w.clkdiv().bits(divider).frag().bits(0) });
     }
 
     fn change_data_bits(&self, data_bits: DataBits) {
-        self.register_block()
+        self.regs()
             .conf0()
             .modify(|_, w| unsafe { w.bit_num().bits(data_bits as u8) });
     }
 
     fn change_parity(&self, parity: Parity) {
-        self.register_block().conf0().modify(|_, w| match parity {
+        self.regs().conf0().modify(|_, w| match parity {
             Parity::None => w.parity_en().clear_bit(),
             Parity::Even => w.parity_en().set_bit().parity().clear_bit(),
             Parity::Odd => w.parity_en().set_bit().parity().set_bit(),
@@ -2524,18 +2523,18 @@ impl Info {
         {
             // workaround for hardware issue, when UART stop bit set as 2-bit mode.
             if stop_bits == StopBits::_2 {
-                self.register_block()
+                self.regs()
                     .rs485_conf()
                     .modify(|_, w| w.dl1_en().bit(stop_bits == StopBits::_2));
 
-                self.register_block()
+                self.regs()
                     .conf0()
                     .modify(|_, w| unsafe { w.stop_bit_num().bits(1) });
             }
         }
 
         #[cfg(not(esp32))]
-        self.register_block()
+        self.regs()
             .conf0()
             .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8) });
     }
@@ -2546,8 +2545,8 @@ impl Info {
             sync_regs(reg_block);
         }
 
-        rxfifo_rst(self.register_block(), true);
-        rxfifo_rst(self.register_block(), false);
+        rxfifo_rst(self.regs(), true);
+        rxfifo_rst(self.regs(), false);
     }
 
     fn txfifo_reset(&self) {
@@ -2556,8 +2555,8 @@ impl Info {
             sync_regs(reg_block);
         }
 
-        txfifo_rst(self.register_block(), true);
-        txfifo_rst(self.register_block(), false);
+        txfifo_rst(self.regs(), true);
+        txfifo_rst(self.regs(), false);
     }
 }
 

--- a/hil-test/tests/interrupt.rs
+++ b/hil-test/tests/interrupt.rs
@@ -77,7 +77,7 @@ mod tests {
             }
         }
 
-        let sw0_trigger_addr = cpu_intr.cpu_intr_from_cpu_0() as *const _ as u32;
+        let sw0_trigger_addr = cpu_intr.register_block().cpu_intr_from_cpu_0() as *const _ as u32;
 
         critical_section::with(|cs| {
             SWINT0


### PR DESCRIPTION
This PR removes the Deref implementation from peripheral singletons. Instead, a `register_block(&self)` and a `regs()` method (both of them public-unstable) are provided by the peripheral singletons. Drivers usually wrap these in a `.regs(&self)`. This change removes stable exposure of PAC types through the Deref trait.

cc #2525