### PR TITLE
Do not rerun HIL tests when a PR is marked ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ name: CI
 
 on:
   pull_request:
+      types: [opened, synchronize, reopened]
   push:
     branches-ignore:
       - "gh-readonly-queue/**"

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -2,7 +2,7 @@ name: HIL
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   merge_group:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Currently, when a draft PR is updated, we run CI. Then, if that PR is marked ready for review, we run HIL tests again. This is a waste of time.

Alternatively, we can skip HIL tests while a PR is draft.