### PR TITLE
Fix priority locks on RISC-V

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `PriorityLock` being ineffective with `Priority::max()` on RISC-V CPUs (#2964)
+
 ### Removed
 
 ## [0.23.0] - 2025-01-15

--- a/hil-test/tests/critical_section.rs
+++ b/hil-test/tests/critical_section.rs
@@ -147,4 +147,36 @@ mod tests {
     fn priority_lock_panics_on_higher_priority_access(peripherals: Peripherals) {
         test_access_at_priority(peripherals, Priority::Priority2);
     }
+
+    #[test]
+    fn max_priority_lock_is_masking_interrupt(peripherals: Peripherals) {
+        use portable_atomic::{AtomicU32, Ordering};
+
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+        extern "C" fn increment<const INT: u8>() {
+            unsafe { SoftwareInterrupt::<INT>::steal().reset() };
+            COUNTER.fetch_add(1, Ordering::AcqRel);
+        }
+
+        let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+
+        let mut interrupt = sw_ints.software_interrupt0;
+        interrupt.set_interrupt_handler(InterruptHandler::new(increment::<0>, Priority::Priority1));
+
+        let lock = RawPriorityLimitedMutex::new(Priority::max());
+
+        let delay = Delay::new();
+
+        // Taking the lock masks the lower priority interrupt
+        lock.lock(|| {
+            interrupt.raise();
+            delay.delay_millis(1);
+            assert_eq!(COUNTER.load(Ordering::Acquire), 0); // not incremented
+        });
+
+        // Releasing the lock unmasks the lower priority interrupt
+        delay.delay_millis(1);
+        assert_eq!(COUNTER.load(Ordering::Acquire), 1);
+    }
 }


### PR DESCRIPTION
Because we need to increment the level by one that we write into `cpu_int_thresh`, the value for `Priority::max()` overflows and becomes 0. This means that a PriorityLock at max level has no effect whatsoever.