### PR TITLE
implement EspWifiRngSource for mut refs

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- implement EspWifiRngSource for mut refs (#2972)
+
 ### Changed
 
 ### Fixed

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -336,6 +336,8 @@ impl EspWifiRngSource for Rng {}
 impl private::Sealed for Rng {}
 impl EspWifiRngSource for Trng<'_> {}
 impl private::Sealed for Trng<'_> {}
+impl<R: EspWifiRngSource + private::Sealed> EspWifiRngSource for &'_ mut R {}
+impl<R: EspWifiRngSource + private::Sealed> private::Sealed for &'_ mut R {}
 
 /// Initialize for using WiFi and or BLE.
 ///


### PR DESCRIPTION
`EspWifiRngSource` is essentially `RngCore`, and all `RngCore` methods only take a mutable reference, and there's already an `impl<R: RngCore + ?Sized> RngCore for &'_ mut R` anyway. This lets users optionally keep ownership of `Rng`/`Trng` (for example with `esp_wifi::init`).