### PR TITLE
Fix disabling `low_power_wait`

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where the `ESP_HAL_EMBASSY_CONFIG_LOW_POWER_WAIT` option was not possible to disable (#2975)
+
 ### Removed
 
 ## 0.6.0 - 2025-01-15

--- a/esp-hal-embassy/src/executor/thread.rs
+++ b/esp-hal-embassy/src/executor/thread.rs
@@ -15,6 +15,7 @@ pub(crate) const THREAD_MODE_CONTEXT: usize = 16;
 
 /// global atomic used to keep track of whether there is work to do since sev()
 /// is not available on either Xtensa or RISC-V
+#[cfg(low_power_wait)]
 static SIGNAL_WORK_THREAD_MODE: [AtomicBool; Cpu::COUNT] =
     [const { AtomicBool::new(false) }; Cpu::COUNT];
 


### PR DESCRIPTION
#2970 will be fixed once we can add tests for this. So far, I've manually checked a build with the default flipped to false.