### PR TITLE
RMT: Implement builder-lite for {Rx|Tx}ChannelConfig

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- RMT: `TxChannelConfig` and `RxChannelConfig` now support the builder-lite pattern (#2978)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -1,0 +1,25 @@
+# Migration Guide from v0.23.x to v?.??.?
+
+## RMT changes
+
+The `TxChannelConfig` and `RxChannelConfig` structs now support the builder-lite pattern.
+Thus, explicit initialization of all fields can be replaced by only the necessary setter methods:
+
+```diff
+  let mut channel = rmt
+      .channel0
+      .configure(
+          peripherals.GPIO1,
+-         TxChannelConfig {
+-             clk_divider: 1,
+-             idle_output_level: false,
+-             idle_output: false,
+-             carrier_modulation: false,
+-             carrier_high: 1,
+-             carrier_low: 1,
+-             carrier_level: false,
+-         },
++          TxChannelConfig::default().with_clk_divider(1)
+      )
+     .unwrap();
+```

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -62,15 +62,14 @@
 //!     .channel0
 //!     .configure(
 //!         peripherals.GPIO1,
-//!         TxChannelConfig {
-//!             clk_divider: 1,
-//!             idle_output_level: false,
-//!             idle_output: false,
-//!             carrier_modulation: false,
-//!             carrier_high: 1,
-//!             carrier_low: 1,
-//!             carrier_level: false,
-//!         },
+//!         TxChannelConfig::default()
+//!             .with_clk_divider(1)
+//!             .with_idle_output_level(false)
+//!             .with_idle_output(false)
+//!             .with_carrier_modulation(false)
+//!             .with_carrier_high(1)
+//!             .with_carrier_low(1)
+//!             .with_carrier_level(false),
 //!     )
 //!     .unwrap();
 //! # }
@@ -87,10 +86,7 @@
 #![cfg_attr(not(esp32h2), doc = "let freq = 80.MHz();")]
 //! let rmt = Rmt::new(peripherals.RMT, freq).unwrap();
 //!
-//! let tx_config = TxChannelConfig {
-//!     clk_divider: 255,
-//!     ..TxChannelConfig::default()
-//! };
+//! let tx_config = TxChannelConfig::default().with_clk_divider(255);
 //!
 //! let mut channel = rmt
 //!     .channel0
@@ -127,11 +123,9 @@
 #![cfg_attr(not(esp32h2), doc = "let freq = 80.MHz();")]
 //! let rmt = Rmt::new(peripherals.RMT, freq).unwrap();
 //!
-//! let rx_config = RxChannelConfig {
-//!     clk_divider: 1,
-//!     idle_threshold: 10000,
-//!     ..RxChannelConfig::default()
-//! };
+//! let rx_config = RxChannelConfig::default()
+//!     .with_clk_divider(1)
+//!     .with_idle_threshold(10000);
 #![cfg_attr(
     any(esp32, esp32s2),
     doc = "let mut channel = rmt.channel0.configure(peripherals.GPIO4, rx_config).unwrap();"
@@ -310,7 +304,7 @@ impl PulseCode for u32 {
 }
 
 /// Channel configuration for TX channels
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default, procmacros::BuilderLite)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TxChannelConfig {
     /// Channel's clock divider
@@ -330,7 +324,7 @@ pub struct TxChannelConfig {
 }
 
 /// Channel configuration for RX channels
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default, procmacros::BuilderLite)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RxChannelConfig {
     /// Channel's clock divider

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -53,11 +53,9 @@ async fn main(spawner: Spawner) {
     };
 
     let rmt = Rmt::new(peripherals.RMT, freq).unwrap().into_async();
-    let rx_config = RxChannelConfig {
-        clk_divider: 255,
-        idle_threshold: 10000,
-        ..RxChannelConfig::default()
-    };
+    let rx_config = RxChannelConfig::default()
+        .with_clk_divider(255)
+        .with_idle_threshold(10000);
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -43,10 +43,7 @@ async fn main(_spawner: Spawner) {
         .channel0
         .configure(
             peripherals.GPIO4,
-            TxChannelConfig {
-                clk_divider: 255,
-                ..TxChannelConfig::default()
-            },
+            TxChannelConfig::default().with_clk_divider(255),
         )
         .unwrap();
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Adds `BuilderLite` derives for the rmt channel configuration structs.

#### Testing
- Checked that the `embassy_rmt_tx/embassy_rmt_rx` examples compile for riscv.
