### PR TITLE
Fix esp-println build failure when critical-section feature is disabled

### DIFF
--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix build failure when `critical-section` feature is disabled
+
 ### Removed
 
 ## 0.13.0 - 2025-01-15

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -471,6 +471,9 @@ mod uart_printer {
 }
 
 #[cfg(not(feature = "critical-section"))]
+use core::marker::PhantomData;
+
+#[cfg(not(feature = "critical-section"))]
 type LockInner<'a> = PhantomData<&'a ()>;
 #[cfg(feature = "critical-section")]
 type LockInner<'a> = critical_section::CriticalSection<'a>;


### PR DESCRIPTION

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

In esp-println 0.13.0, building esp-println when critical-section feature is disabled is broken as follows:

```
$ cd esp-println

$ cargo build --no-default-features --features esp32,uart
   Compiling esp-println v0.13.0 (/Users/taiki/projects/forks/others/esp-hal/esp-println)
error[E0412]: cannot find type `PhantomData` in this scope
   --> src/lib.rs:474:22
    |
474 | type LockInner<'a> = PhantomData<&'a ()>;
    |                      ^^^^^^^^^^^ not found in this scope
    |
help: consider importing this struct
    |
6   + use core::marker::PhantomData;
    |

error[E0425]: cannot find value `PhantomData` in this scope
   --> src/lib.rs:487:21
    |
487 |         let inner = PhantomData;
    |                     ^^^^^^^^^^^ not found in this scope
    |
help: consider importing this unit struct
    |
6   + use core::marker::PhantomData;
    |
```

This PR fixes this build failure.

#### Testing

Just checked the build with the above command passed.