### PR TITLE
esp-wifi: Late enable BT interrupts

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a problem using BLE on ESP32-C6 when connected via Serial-JTAG (#2981)
+
 ### Removed
 
 ## 0.12.0 - 2025-01-15

--- a/esp-wifi/src/ble/npl.rs
+++ b/esp-wifi/src/ble/npl.rs
@@ -856,7 +856,7 @@ unsafe extern "C" fn ble_npl_eventq_remove(
     queue: *const ble_npl_eventq,
     event: *const ble_npl_event,
 ) {
-    info!("ble_npl_eventq_remove {:?} {:?}", queue, event);
+    trace!("ble_npl_eventq_remove {:?} {:?}", queue, event);
 
     assert!((*queue).dummy != 0);
     let evt = (*event).dummy as *mut Event;

--- a/esp-wifi/src/ble/os_adapter_esp32.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32.rs
@@ -1,16 +1,19 @@
 use core::ptr::addr_of_mut;
 
 use super::*;
-use crate::binary::{
-    c_types,
-    include::{
-        esp_bt_controller_config_t,
-        esp_bt_mode_t,
-        esp_bt_mode_t_ESP_BT_MODE_BLE,
-        esp_bt_mode_t_ESP_BT_MODE_BTDM,
-        esp_bt_mode_t_ESP_BT_MODE_CLASSIC_BT,
-        esp_bt_mode_t_ESP_BT_MODE_IDLE,
+use crate::{
+    binary::{
+        c_types,
+        include::{
+            esp_bt_controller_config_t,
+            esp_bt_mode_t,
+            esp_bt_mode_t_ESP_BT_MODE_BLE,
+            esp_bt_mode_t_ESP_BT_MODE_BTDM,
+            esp_bt_mode_t_ESP_BT_MODE_CLASSIC_BT,
+            esp_bt_mode_t_ESP_BT_MODE_IDLE,
+        },
     },
+    hal::{interrupt, peripherals::Interrupt},
 };
 
 pub static mut ISR_INTERRUPT_5: (
@@ -547,12 +550,20 @@ pub(crate) unsafe extern "C" fn set_isr(n: i32, f: unsafe extern "C" fn(), arg: 
     match n {
         5 => {
             ISR_INTERRUPT_5 = (f as *mut c_types::c_void, arg as *mut c_types::c_void);
+            unwrap!(interrupt::enable(
+                Interrupt::RWBT,
+                interrupt::Priority::Priority1
+            ));
         }
         7 => {
             ISR_INTERRUPT_7 = (f as *mut c_types::c_void, arg as *mut c_types::c_void);
         }
         8 => {
             ISR_INTERRUPT_8 = (f as *mut c_types::c_void, arg as *mut c_types::c_void);
+            unwrap!(interrupt::enable(
+                Interrupt::BT_BB,
+                interrupt::Priority::Priority1,
+            ));
         }
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }

--- a/esp-wifi/src/ble/os_adapter_esp32c2.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32c2.rs
@@ -1,4 +1,7 @@
-use crate::{binary::include::esp_bt_controller_config_t, hal::system::RadioClockController};
+use crate::{
+    binary::include::esp_bt_controller_config_t,
+    hal::{interrupt, peripherals::Interrupt, system::RadioClockController},
+};
 
 pub(crate) static mut ISR_INTERRUPT_4: (
     *mut crate::binary::c_types::c_void,
@@ -90,8 +93,20 @@ pub(super) unsafe extern "C" fn esp_intr_alloc(
     );
 
     match source {
-        4 => ISR_INTERRUPT_4 = (handler, arg),
-        7 => ISR_INTERRUPT_7 = (handler, arg),
+        4 => {
+            ISR_INTERRUPT_4 = (handler, arg);
+            unwrap!(interrupt::enable(
+                Interrupt::BT_MAC,
+                interrupt::Priority::Priority1
+            ));
+        }
+        7 => {
+            ISR_INTERRUPT_7 = (handler, arg);
+            unwrap!(interrupt::enable(
+                Interrupt::LP_TIMER,
+                interrupt::Priority::Priority1
+            ));
+        }
         _ => panic!("Unexpected interrupt source {}", source),
     }
 

--- a/esp-wifi/src/ble/os_adapter_esp32c3.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32c3.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::hal::{interrupt, peripherals::Interrupt};
 
 pub(crate) static mut BT_INTERRUPT_FUNCTION5: (
     *mut crate::binary::c_types::c_void,
@@ -357,13 +358,25 @@ pub(crate) unsafe extern "C" fn interrupt_handler_set(
             BT_INTERRUPT_FUNCTION5 = (
                 func as *mut crate::binary::c_types::c_void,
                 arg as *mut crate::binary::c_types::c_void,
-            )
+            );
+            unwrap!(interrupt::enable(
+                Interrupt::RWBT,
+                interrupt::Priority::Priority1
+            ));
+            unwrap!(interrupt::enable(
+                Interrupt::BT_BB,
+                interrupt::Priority::Priority1
+            ));
         }
         8 => {
             BT_INTERRUPT_FUNCTION8 = (
                 func as *mut crate::binary::c_types::c_void,
                 arg as *mut crate::binary::c_types::c_void,
-            )
+            );
+            unwrap!(interrupt::enable(
+                Interrupt::RWBLE,
+                interrupt::Priority::Priority1
+            ));
         }
         _ => panic!("Unsupported interrupt number {}", interrupt_no),
     }

--- a/esp-wifi/src/ble/os_adapter_esp32c6.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32c6.rs
@@ -1,6 +1,10 @@
 use crate::{
     binary::include::esp_bt_controller_config_t,
-    hal::system::{RadioClockController, RadioPeripherals},
+    hal::{
+        interrupt,
+        peripherals::Interrupt,
+        system::{RadioClockController, RadioPeripherals},
+    },
 };
 
 pub(crate) static mut ISR_INTERRUPT_4: (
@@ -92,8 +96,20 @@ pub(super) unsafe extern "C" fn esp_intr_alloc(
     );
 
     match source {
-        4 => ISR_INTERRUPT_4 = (handler, arg),
-        7 => ISR_INTERRUPT_7 = (handler, arg),
+        4 => {
+            ISR_INTERRUPT_4 = (handler, arg);
+            unwrap!(interrupt::enable(
+                Interrupt::BT_MAC,
+                interrupt::Priority::Priority1
+            ));
+        }
+        7 => {
+            ISR_INTERRUPT_7 = (handler, arg);
+            unwrap!(interrupt::enable(
+                Interrupt::LP_TIMER,
+                interrupt::Priority::Priority1
+            ));
+        }
         _ => panic!("Unexpected interrupt source {}", source),
     }
 

--- a/esp-wifi/src/ble/os_adapter_esp32h2.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32h2.rs
@@ -1,6 +1,10 @@
 use crate::{
     binary::include::esp_bt_controller_config_t,
-    hal::system::{RadioClockController, RadioPeripherals},
+    hal::{
+        interrupt,
+        peripherals::Interrupt,
+        system::{RadioClockController, RadioPeripherals},
+    },
 };
 
 pub(crate) static mut ISR_INTERRUPT_15: (
@@ -92,8 +96,20 @@ pub(super) unsafe extern "C" fn esp_intr_alloc(
     );
 
     match source {
-        3 => ISR_INTERRUPT_3 = (handler, arg),
-        15 => ISR_INTERRUPT_15 = (handler, arg),
+        3 => {
+            ISR_INTERRUPT_3 = (handler, arg);
+            unwrap!(interrupt::enable(
+                Interrupt::LP_BLE_TIMER,
+                interrupt::Priority::Priority1
+            ));
+        }
+        15 => {
+            ISR_INTERRUPT_15 = (handler, arg);
+            unwrap!(interrupt::enable(
+                Interrupt::BT_MAC,
+                interrupt::Priority::Priority1
+            ));
+        }
         _ => panic!("Unexpected interrupt source {}", source),
     }
 

--- a/esp-wifi/src/ble/os_adapter_esp32s3.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32s3.rs
@@ -370,13 +370,21 @@ pub(crate) unsafe extern "C" fn interrupt_handler_set(
             ISR_INTERRUPT_5 = (
                 func as *mut crate::binary::c_types::c_void,
                 arg as *mut crate::binary::c_types::c_void,
-            )
+            );
+            unwrap!(interrupt::enable(
+                Interrupt::BT_BB,
+                interrupt::Priority::Priority1,
+            ));
         }
         8 => {
             ISR_INTERRUPT_8 = (
                 func as *mut crate::binary::c_types::c_void,
                 arg as *mut crate::binary::c_types::c_void,
-            )
+            );
+            unwrap!(interrupt::enable(
+                Interrupt::RWBLE,
+                interrupt::Priority::Priority1,
+            ));
         }
         _ => panic!("Unsupported interrupt number {}", interrupt_no),
     }

--- a/esp-wifi/src/timer/timer_esp32.rs
+++ b/esp-wifi/src/timer/timer_esp32.rs
@@ -3,18 +3,8 @@
 use crate::hal::{interrupt, peripherals};
 
 pub(crate) fn setup_radio_isr() {
-    // wifi enabled in set_isr
     #[cfg(feature = "ble")]
     {
-        unwrap!(interrupt::enable(
-            peripherals::Interrupt::RWBT,
-            interrupt::Priority::Priority1
-        ));
-        unwrap!(interrupt::enable(
-            peripherals::Interrupt::BT_BB,
-            interrupt::Priority::Priority1,
-        ));
-
         // It's a mystery why these interrupts are enabled now since it worked without
         // this before Now at least without disabling these nothing will work
         interrupt::disable(crate::hal::Cpu::ProCpu, peripherals::Interrupt::ETH_MAC);

--- a/esp-wifi/src/timer/timer_esp32c2.rs
+++ b/esp-wifi/src/timer/timer_esp32c2.rs
@@ -6,18 +6,7 @@ use crate::{
 };
 
 pub(crate) fn setup_radio_isr() {
-    // wifi enabled in set_isr
-    #[cfg(feature = "ble")]
-    {
-        unwrap!(interrupt::enable(
-            Interrupt::LP_TIMER,
-            interrupt::Priority::Priority1
-        ));
-        unwrap!(interrupt::enable(
-            Interrupt::BT_MAC,
-            interrupt::Priority::Priority1
-        ));
-    }
+    // no-op
 }
 
 pub(crate) fn shutdown_radio_isr() {

--- a/esp-wifi/src/timer/timer_esp32c3.rs
+++ b/esp-wifi/src/timer/timer_esp32c3.rs
@@ -6,22 +6,7 @@ use crate::{
 };
 
 pub(crate) fn setup_radio_isr() {
-    // wifi enabled in set_isr
-    #[cfg(feature = "ble")]
-    {
-        unwrap!(interrupt::enable(
-            Interrupt::RWBT,
-            interrupt::Priority::Priority1
-        ));
-        unwrap!(interrupt::enable(
-            Interrupt::RWBLE,
-            interrupt::Priority::Priority1
-        ));
-        unwrap!(interrupt::enable(
-            Interrupt::BT_BB,
-            interrupt::Priority::Priority1
-        ));
-    }
+    // no-op
 }
 
 pub(crate) fn shutdown_radio_isr() {

--- a/esp-wifi/src/timer/timer_esp32c6.rs
+++ b/esp-wifi/src/timer/timer_esp32c6.rs
@@ -7,8 +7,6 @@ use crate::{
 };
 
 pub(crate) fn setup_radio_isr() {
-    // wifi enabled in set_isr
-
     // make sure to disable WIFI_BB/MODEM_PERI_TIMEOUT by mapping it to CPU
     // interrupt 31 which is masked by default for some reason for this
     // interrupt, mapping it to 0 doesn't deactivate it
@@ -19,18 +17,6 @@ pub(crate) fn setup_radio_isr() {
     interrupt_core0
         .modem_peri_timeout_intr_map()
         .write(|w| unsafe { w.modem_peri_timeout_intr_map().bits(31) });
-
-    #[cfg(feature = "ble")]
-    {
-        unwrap!(interrupt::enable(
-            Interrupt::LP_TIMER,
-            interrupt::Priority::Priority1
-        ));
-        unwrap!(interrupt::enable(
-            Interrupt::BT_MAC,
-            interrupt::Priority::Priority1
-        ));
-    }
 }
 
 pub(crate) fn shutdown_radio_isr() {

--- a/esp-wifi/src/timer/timer_esp32h2.rs
+++ b/esp-wifi/src/timer/timer_esp32h2.rs
@@ -5,17 +5,7 @@ use crate::{
 };
 
 pub(crate) fn setup_radio_isr() {
-    #[cfg(feature = "ble")]
-    {
-        unwrap!(interrupt::enable(
-            Interrupt::LP_BLE_TIMER,
-            interrupt::Priority::Priority1
-        ));
-        unwrap!(interrupt::enable(
-            Interrupt::BT_MAC,
-            interrupt::Priority::Priority1
-        ));
-    }
+    // no-op
 }
 
 pub(crate) fn shutdown_radio_isr() {

--- a/esp-wifi/src/timer/timer_esp32s3.rs
+++ b/esp-wifi/src/timer/timer_esp32s3.rs
@@ -3,18 +3,7 @@
 use crate::hal::{interrupt, peripherals::Interrupt};
 
 pub(crate) fn setup_radio_isr() {
-    // wifi enabled in set_isr
-    #[cfg(feature = "ble")]
-    {
-        unwrap!(interrupt::enable(
-            Interrupt::BT_BB,
-            interrupt::Priority::Priority1,
-        ));
-        unwrap!(interrupt::enable(
-            Interrupt::RWBLE,
-            interrupt::Priority::Priority1,
-        ));
-    }
+    // no-op
 }
 
 pub(crate) fn shutdown_radio_isr() {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -45,10 +45,10 @@ embedded-time       = "=0.12.1"
 static_cell         = { version = "2.1.0", features = ["nightly"] }
 usb-device          = "0.3.2"
 usbd-serial         = "0.2.2"
-edge-dhcp = { version = "0.5.0", git = "https://github.com/bugadani/edge-net", rev = "b72678e15bb7c6e72809df235778bb7b48ac146d" }
-edge-raw = { version = "0.5.0", git = "https://github.com/bugadani/edge-net", rev = "b72678e15bb7c6e72809df235778bb7b48ac146d" }
-edge-nal = { version = "0.5.0", git = "https://github.com/bugadani/edge-net", rev = "b72678e15bb7c6e72809df235778bb7b48ac146d" }
-edge-nal-embassy = { version = "0.5.0", git = "https://github.com/bugadani/edge-net", rev = "b72678e15bb7c6e72809df235778bb7b48ac146d" }
+edge-dhcp = { version = "0.5.0" }
+edge-raw = { version = "0.5.0" }
+edge-nal = { version = "0.5.0" }
+edge-nal-embassy = { version = "0.5.0" }
 
 [features]
 esp32   = ["esp-hal/esp32",   "esp-backtrace/esp32",   "esp-hal-embassy?/esp32",   "esp-println/esp32",   "esp-storage?/esp32",   "esp-wifi?/esp32"]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #2883 

For whatever reason when using Serial-JTAG it triggered a BT interrupt which made the interrupt fire before we had a callback which handled it correctly.

Additionally using the published `edge-*` crates now - DHCP is working again in the example.

`skip-changelog` because of the change `Cargo.toml` in `examples`
#### Testing
Manual testing of the examples
