### PR TITLE
Add repr(C) to DmaDescriptor, allow unstably constructing `dma::Channel`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DmaDescriptor` is now `#[repr(C)]` (#2988)
+
 ### Removed
 
 ## [0.23.1] - 2025-01-15

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -274,6 +274,7 @@ impl defmt::Format for DmaDescriptorFlags {
 /// A DMA transfer descriptor.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(C)]
 pub struct DmaDescriptor {
     /// Descriptor flags.
     pub flags: DmaDescriptorFlags,

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2464,7 +2464,9 @@ impl<'d, CH> Channel<'d, Blocking, CH>
 where
     CH: DmaChannel,
 {
-    pub(crate) fn new(channel: impl Peripheral<P = CH>) -> Self {
+    /// Creates a new DMA channel driver.
+    #[instability::unstable]
+    pub fn new(channel: impl Peripheral<P = CH>) -> Self {
         let (rx, tx) = unsafe {
             channel
                 .clone_unchecked()


### PR DESCRIPTION
Oops