### PR TITLE
RMT: Use gpio::Level for carrier and pulse levels

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - RMT: `TxChannelConfig` and `RxChannelConfig` now support the builder-lite pattern (#2978)
+- RMT: Some fields of `TxChannelConfig` and `RxChannelConfig` are now `gpio::Level`-valued instead of `bool` (#2989)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - RMT: `TxChannelConfig` and `RxChannelConfig` now support the builder-lite pattern (#2978)
 - RMT: Some fields of `TxChannelConfig` and `RxChannelConfig` are now `gpio::Level`-valued instead of `bool` (#2989)
+- RMT: The `PulseCode` trait now uses `gpio::Level` to specify output levels instead of `bool` (#2989)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -60,3 +60,13 @@ take the more descriptive `gpio::Level` type instead of a plain `bool`.
      .unwrap();
 ```
 
+### `PulseCode` now uses `gpio::Level` instead of `bool` to specify output levels
+
+The more descriptive `gpio::Level` enum is now used to specify output levels of `PulseCode`:
+
+```diff
++ use esp_hal::gpio::Level;
++ 
+- let code = PulseCode::new(true, 200, false, 50);
++ let code = PulseCode::new(Level::High, 200, Level::Low, 50);
+```

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -2,6 +2,8 @@
 
 ## RMT changes
 
+### Configurations structs now support the builder-lite pattern
+
 The `TxChannelConfig` and `RxChannelConfig` structs now support the builder-lite pattern.
 Thus, explicit initialization of all fields can be replaced by only the necessary setter methods:
 
@@ -23,3 +25,38 @@ Thus, explicit initialization of all fields can be replaced by only the necessar
       )
      .unwrap();
 ```
+
+### Some configuration fields now take `gpio::Level` instead of `bool`
+
+Fields related to the carrier level in the channel configuration structs now
+take the more descriptive `gpio::Level` type instead of a plain `bool`.
+
+```diff
+  let mut tx_channel = rmt
+      .channel0
+      .configure(
+          peripherals.GPIO1,
+          TxChannelConfig::default()
+              .with_clk_divider(1)
+-             .with_idle_output_level(false)
++             .with_idle_output_level(Level::Low)
+-             .with_carrier_level(true)
++             .with_carrier_level(Level::High)
+      )
+     .unwrap();
+
+  let mut rx_channel = rmt
+      .channel1
+      .configure(
+          peripherals.GPIO2,
+          RxChannelConfig::default()
+              .with_clk_divider(1)
+              .with_carrier_modulation(true)
+              .with_carrier_high(1)
+              .with_carrier_low(1)
+-             .with_carrier_level(false),
++             .with_carrier_level(Level::Low),
+      )
+     .unwrap();
+```
+

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -95,7 +95,10 @@ async fn main(spawner: Spawner) {
             }
 
             let count = WIDTH / (total / entry.length1() as usize);
-            let c = if entry.level1() { '-' } else { '_' };
+            let c = match entry.level1() {
+                Level::High => '-',
+                Level::Low => '_',
+            };
             for _ in 0..count + 1 {
                 print!("{}", c);
             }
@@ -105,7 +108,10 @@ async fn main(spawner: Spawner) {
             }
 
             let count = WIDTH / (total / entry.length2() as usize);
-            let c = if entry.level2() { '-' } else { '_' };
+            let c = match entry.level2() {
+                Level::High => '-',
+                Level::Low => '_',
+            };
             for _ in 0..count + 1 {
                 print!("{}", c);
             }

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -15,6 +15,7 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
+    gpio::Level,
     rmt::{PulseCode, Rmt, TxChannelAsync, TxChannelConfig, TxChannelCreatorAsync},
     time::RateExtU32,
     timer::timg::TimerGroup,
@@ -47,9 +48,9 @@ async fn main(_spawner: Spawner) {
         )
         .unwrap();
 
-    let mut data = [PulseCode::new(true, 200, false, 50); 20];
+    let mut data = [PulseCode::new(Level::High, 200, Level::Low, 50); 20];
 
-    data[data.len() - 2] = PulseCode::new(true, 3000, false, 500);
+    data[data.len() - 2] = PulseCode::new(Level::High, 3000, Level::Low, 500);
     data[data.len() - 1] = PulseCode::empty();
 
     loop {

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -7,6 +7,7 @@
 #![no_main]
 
 use esp_hal::{
+    gpio::Level,
     rmt::{PulseCode, Rmt, RxChannel, RxChannelConfig, TxChannel, TxChannelConfig},
     time::RateExtU32,
 };
@@ -38,21 +39,16 @@ mod tests {
 
         let (rx, tx) = hil_test::common_test_pins!(peripherals);
 
-        let tx_config = TxChannelConfig {
-            clk_divider: 255,
-            ..TxChannelConfig::default()
-        };
+        let tx_config = TxChannelConfig::default().with_clk_divider(255);
 
         let tx_channel = {
             use esp_hal::rmt::TxChannelCreator;
             rmt.channel0.configure(tx, tx_config).unwrap()
         };
 
-        let rx_config = RxChannelConfig {
-            clk_divider: 255,
-            idle_threshold: 1000,
-            ..RxChannelConfig::default()
-        };
+        let rx_config = RxChannelConfig::default()
+            .with_clk_divider(255)
+            .with_idle_threshold(1000);
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "esp32")] {
@@ -78,9 +74,9 @@ mod tests {
             }
         }
 
-        let mut tx_data = [PulseCode::new(true, 200, false, 50); 20];
+        let mut tx_data = [PulseCode::new(Level::High, 200, Level::Low, 50); 20];
 
-        tx_data[tx_data.len() - 2] = PulseCode::new(true, 3000, false, 500);
+        tx_data[tx_data.len() - 2] = PulseCode::new(Level::High, 3000, Level::Low, 500);
         tx_data[tx_data.len() - 1] = PulseCode::empty();
 
         let mut rcv_data: [u32; 20] = [PulseCode::empty(); 20];
@@ -122,7 +118,7 @@ mod tests {
             rmt.channel0.configure(tx, tx_config).unwrap()
         };
 
-        let tx_data = [PulseCode::new(true, 200, false, 50); 20];
+        let tx_data = [PulseCode::new(Level::High, 200, Level::Low, 50); 20];
 
         let tx_transaction = tx_channel.transmit(&tx_data);
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This changes the RMT configuration structs and `PulseCode`s to use `gpio::Level` instead of `bool` to specify output levels.

I found this much more descriptive and readable than `bool`s. What do you think?

#### Testing
- Tested that the `embassy_hal_{r|t}x` examples compile for riscv.
- Tested a heavily modified RMT driver including this change in tx mode on an ESP Rust Board.
