### PR TITLE
make esp_wifi::init take impl Peripheral for the RNG source

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `embedded-hal-nb` traits (#2882)
 - `timer::wait` is now blocking (#2882)
 
+- `Rng` and `Trng` now implement `Peripheral<P = Self>` (#2992)
+
 ### Fixed
 
 - `DmaDescriptor` is now `#[repr(C)]` (#2988)
@@ -242,7 +244,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix conflict between `RtcClock::get_xtal_freq` and `Rtc::disable_rom_message_printing` (#2360)
 - Fixed an issue where interrupts enabled before `esp_hal::init` were disabled. This issue caused the executor created by `#[esp_hal_embassy::main]` to behave incorrectly in multi-core applications. (#2377)
 - Fixed `TWAI::transmit_async`: bus-off state is not reached when CANH and CANL are shorted. (#2421)
-- ESP32: added UART-specific workaround for https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/03-errata-description/esp32/cpu-subsequent-access-halted-when-get-interrupted.html (#2441)
+- ESP32: added UART-specific workaround for <https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/03-errata-description/esp32/cpu-subsequent-access-halted-when-get-interrupted.html> (#2441)
 - Fixed some SysTimer race conditions and panics (#2451)
 - TWAI: accept all messages by default (#2467)
 - I8080: `set_byte_order()` now works correctly in 16-bit mode (#2487)

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -144,7 +144,7 @@ impl Peripheral for Rng {
 
     #[inline]
     unsafe fn clone_unchecked(&self) -> Self::P {
-        self.clone()
+        *self
     }
 }
 

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -136,6 +136,15 @@ impl Rng {
     }
 }
 
+impl Peripheral for Rng {
+    type P = Self;
+
+    #[inline]
+    unsafe fn clone_unchecked(&self) -> Self::P {
+        self.clone()
+    }
+}
+
 impl rand_core::RngCore for Rng {
     fn next_u32(&mut self) -> u32 {
         self.random()
@@ -239,3 +248,15 @@ impl rand_core::RngCore for Trng<'_> {
 /// Implementing a CryptoRng marker trait that indicates that the generator is
 /// cryptographically secure.
 impl rand_core::CryptoRng for Trng<'_> {}
+
+impl Peripheral for Trng<'_> {
+    type P = Self;
+
+    #[inline]
+    unsafe fn clone_unchecked(&self) -> Self::P {
+        Self {
+            rng: self.rng.clone_unchecked(),
+            _adc: self._adc.clone_unchecked(),
+        }
+    }
+}

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -92,6 +92,7 @@ use core::marker::PhantomData;
 use crate::{
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{ADC1, RNG},
+    private::Sealed,
 };
 
 /// Random number generator driver
@@ -135,6 +136,8 @@ impl Rng {
         }
     }
 }
+
+impl Sealed for Rng {}
 
 impl Peripheral for Rng {
     type P = Self;
@@ -248,6 +251,8 @@ impl rand_core::RngCore for Trng<'_> {
 /// Implementing a CryptoRng marker trait that indicates that the generator is
 /// cryptographically secure.
 impl rand_core::CryptoRng for Trng<'_> {}
+
+impl Sealed for Trng<'_> {}
 
 impl Peripheral for Trng<'_> {
     type P = Self;

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `esp_wifi::init` now takes an `impl Peripheral` for RNG source (#2992)
+
 ### Fixed
 
 - Fixed a problem using BLE on ESP32-C6 when connected via Serial-JTAG (#2981)

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -364,9 +364,9 @@ impl private::Sealed for Trng<'_> {}
 /// .unwrap();
 /// # }
 /// ```
-pub fn init<'d, T: EspWifiTimerSource>(
+pub fn init<'d, T: EspWifiTimerSource, R: EspWifiRngSource>(
     timer: impl Peripheral<P = T> + 'd,
-    _rng: impl EspWifiRngSource,
+    _rng: impl Peripheral<P = R> + 'd,
     _radio_clocks: impl Peripheral<P = hal::peripherals::RADIO_CLK> + 'd,
 ) -> Result<EspWifiController<'d>, InitializationError> {
     // A minimum clock of 80MHz is required to operate WiFi module.


### PR DESCRIPTION
Previously `esp_wifi::init` took ownership of a `EspWifiRngSource`, now it takes an `impl Peripheral<P = impl EspWifiRngSource>` instead.

(#2972 2: electric boogaloo)