### PR TITLE
Fix DMA not having data available in time

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `DmaDescriptor` is now `#[repr(C)]` (#2988)
 - Fixed an issue that caused LCD_CAM drivers to turn off their clocks unexpectedly (#3007)
+- Fixed an issue where DMA-driver peripherals started transferring before the data was ready (#3003)
 
 ### Removed
 

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -204,6 +204,16 @@ impl RegisterAccess for AnyGdmaTxChannel {
 }
 
 impl TxRegisterAccess for AnyGdmaTxChannel {
+    fn is_fifo_empty(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32s3)] {
+                 self.ch().outfifo_status().read().outfifo_empty_l3().bit_is_set()
+            } else {
+                 self.ch().outfifo_status().read().outfifo_empty().bit_is_set()
+            }
+        }
+    }
+
     fn set_auto_write_back(&self, enable: bool) {
         self.ch()
             .out_conf0()

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2308,6 +2308,7 @@ where
 
     fn start_transfer(&mut self) -> Result<(), DmaError> {
         self.tx_impl.start();
+        while self.tx_impl.is_fifo_empty() && self.pending_out_interrupts().is_empty() {}
 
         if self
             .pending_out_interrupts()
@@ -2414,6 +2415,9 @@ pub trait RxRegisterAccess: RegisterAccess {
 
 #[doc(hidden)]
 pub trait TxRegisterAccess: RegisterAccess {
+    /// Returns whether the DMA's FIFO is empty.
+    fn is_fifo_empty(&self) -> bool;
+
     /// Enable/disable outlink-writeback
     fn set_auto_write_back(&self, enable: bool);
 

--- a/esp-hal/src/dma/pdma/crypto.rs
+++ b/esp-hal/src/dma/pdma/crypto.rs
@@ -138,6 +138,10 @@ impl RegisterAccess for CryptoDmaTxChannel {
 }
 
 impl TxRegisterAccess for CryptoDmaTxChannel {
+    fn is_fifo_empty(&self) -> bool {
+        self.regs().state1().read().outfifo_cnt_debug().bits() == 0
+    }
+
     fn set_auto_write_back(&self, enable: bool) {
         // there is no `auto_wrback` for SPI
         assert!(!enable);

--- a/esp-hal/src/dma/pdma/i2s.rs
+++ b/esp-hal/src/dma/pdma/i2s.rs
@@ -116,6 +116,16 @@ impl RegisterAccess for AnyI2sDmaTxChannel {
 }
 
 impl TxRegisterAccess for AnyI2sDmaTxChannel {
+    fn is_fifo_empty(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                self.regs().lc_state0().read().bits() & 0x80000000 != 0
+            } else {
+                self.regs().lc_state0().read().out_empty().bit_is_set()
+            }
+        }
+    }
+
     fn set_auto_write_back(&self, enable: bool) {
         self.regs()
             .lc_conf()

--- a/esp-hal/src/dma/pdma/i2s.rs
+++ b/esp-hal/src/dma/pdma/i2s.rs
@@ -141,11 +141,11 @@ impl TxRegisterAccess for AnyI2sDmaTxChannel {
     }
 
     fn peripheral_interrupt(&self) -> Option<Interrupt> {
-        None
+        Some(self.0.peripheral_interrupt())
     }
 
     fn async_handler(&self) -> Option<InterruptHandler> {
-        None
+        Some(self.0.async_handler())
     }
 }
 

--- a/esp-hal/src/dma/pdma/spi.rs
+++ b/esp-hal/src/dma/pdma/spi.rs
@@ -118,6 +118,16 @@ impl RegisterAccess for AnySpiDmaTxChannel {
 }
 
 impl TxRegisterAccess for AnySpiDmaTxChannel {
+    fn is_fifo_empty(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32)] {
+                self.regs().dma_rstatus().read().dma_out_status().bits() & 0x80000000 != 0
+            } else {
+                self.regs().dma_outstatus().read().dma_outfifo_empty().bit_is_set()
+            }
+        }
+    }
+
     fn set_auto_write_back(&self, enable: bool) {
         // there is no `auto_wrback` for SPI
         assert!(!enable);

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -318,7 +318,6 @@ where
         if let Err(err) = result {
             return Err((err, self, data));
         }
-        crate::rom::ets_delay_us(1);
         self.instance.tx_start();
         Ok(I2sParallelTransfer {
             i2s: ManuallyDrop::new(self),

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -387,10 +387,6 @@ where
             .lc_dma_int_clr()
             .write(|w| w.lcd_trans_done_int_clr().set_bit());
 
-        // Before issuing lcd_start need to wait shortly for fifo to get data
-        // Otherwise, some garbage data will be sent out
-        crate::rom::ets_delay_us(1);
-
         self.regs().lcd_user().modify(|_, w| {
             w.lcd_update().set_bit();
             w.lcd_start().set_bit()

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -3224,10 +3224,8 @@ impl Driver {
                 while reg_block.cmd().read().update().bit_is_set() {
                     // wait
                 }
-            } else if #[cfg(esp32)] {
-                xtensa_lx::timer::delay(2); // ☠️
             } else {
-                // Doesn't seem to be needed for ESP32-S2
+                // Doesn't seem to be needed for ESP32 and ESP32-S2
             }
         }
     }

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -291,6 +291,7 @@ embassy = [
     "dep:esp-hal-embassy",
 ]
 octal-psram = ["esp-hal/octal-psram", "esp-alloc"]
+quad-psram = ["esp-hal/quad-psram", "esp-alloc"]
 
 # https://doc.rust-lang.org/cargo/reference/profiles.html#test
 # Test and bench profiles inherit from dev and release respectively.

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -76,6 +76,10 @@ name    = "i2s"
 harness = false
 
 [[test]]
+name    = "i2s_parallel"
+harness = false
+
+[[test]]
 name    = "lcd_cam"
 harness = false
 

--- a/hil-test/tests/i2s.rs
+++ b/hil-test/tests/i2s.rs
@@ -107,7 +107,9 @@ mod tests {
 
     #[init]
     fn init() -> Context {
-        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
 
         cfg_if::cfg_if! {
             if #[cfg(pdma)] {

--- a/hil-test/tests/i2s_parallel.rs
+++ b/hil-test/tests/i2s_parallel.rs
@@ -1,0 +1,76 @@
+//! I2S parallel interface tests
+
+//% CHIPS: esp32
+//% FEATURES: unstable
+
+#![no_std]
+#![no_main]
+
+use esp_hal::{
+    delay::Delay,
+    dma_buffers,
+    gpio::{AnyPin, NoPin, Pin},
+    i2s::{
+        master::{DataFormat, I2s, I2sTx, Standard},
+        parallel::{I2sParallel, TxSixteenBits},
+    },
+    peripherals::I2S0,
+    time::RateExtU32,
+    Async,
+};
+use hil_test as _;
+
+type DmaChannel0 = esp_hal::dma::I2s0DmaChannel;
+
+#[cfg(test)]
+#[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
+mod tests {
+    use super::*;
+
+    struct Context {
+        dma_channel: DmaChannel0,
+        i2s: I2S0,
+    }
+
+    #[init]
+    fn init() -> Context {
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
+
+        let dma_channel = peripherals.DMA_I2S0;
+
+        Context {
+            dma_channel,
+            i2s: peripherals.I2S0,
+        }
+    }
+
+    #[test]
+    async fn driver_does_not_hang_when_async(ctx: Context) {
+        let pins = TxSixteenBits::new(
+            NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin,
+            NoPin, NoPin, NoPin, NoPin,
+        );
+        let i2s = I2sParallel::new(ctx.i2s, ctx.dma_channel, 20.MHz(), pins, NoPin).into_async();
+
+        // Try sending an empty buffer, as an edge case
+        let tx_buf = esp_hal::dma_tx_buffer!(4096).unwrap();
+        let mut xfer = i2s
+            .send(tx_buf)
+            .map_err(|_| "failed to send empty buffer")
+            .unwrap();
+        xfer.wait_for_done().await.unwrap();
+
+        let (i2s, mut tx_buf) = xfer.wait();
+
+        // Now send some data
+        tx_buf.fill(&[0x12; 128]);
+
+        let mut xfer = i2s
+            .send(tx_buf)
+            .map_err(|_| "failed to send buffer")
+            .unwrap();
+        xfer.wait_for_done().await.unwrap();
+    }
+}

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -66,7 +66,9 @@ mod tests {
 
     #[init]
     fn init() -> Context {
-        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
 
         let (_, mosi) = hil_test::common_test_pins!(peripherals);
 
@@ -292,7 +294,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(esp32))] // https://github.com/esp-rs/esp-hal/issues/2909
     async fn test_async_symmetric_transfer_huge_buffer(ctx: Context) {
         let write = &mut ctx.tx_buffer[0..4096];
         for byte in 0..write.len() {
@@ -325,7 +326,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(esp32))] // https://github.com/esp-rs/esp-hal/issues/2909
     async fn test_async_symmetric_transfer_huge_buffer_in_place(ctx: Context) {
         let write = &mut ctx.tx_buffer[0..4096];
         for byte in 0..write.len() {

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -51,7 +51,9 @@ mod tests {
 
     #[init]
     fn init() -> Context {
-        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
         esp_alloc::psram_allocator!(peripherals.PSRAM, esp_hal::psram);
 
         let sclk = peripherals.GPIO0;

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -15,7 +15,7 @@ embedded-graphics  = "0.8.1"
 embedded-hal-async = "1.0.0"
 esp-alloc          = { path = "../esp-alloc" }
 esp-backtrace      = { path = "../esp-backtrace", features = ["exception-handler", "panic-handler", "println"] }
-esp-hal            = { path = "../esp-hal", features = ["unstable"] }
+esp-hal            = { path = "../esp-hal", features = ["unstable", "log"] }
 esp-hal-embassy    = { path = "../esp-hal-embassy" }
 esp-println        = { path = "../esp-println", features = ["log"] }
 lis3dh-async       = "0.9.3"

--- a/qa-test/src/bin/lcd_i8080.rs
+++ b/qa-test/src/bin/lcd_i8080.rs
@@ -40,6 +40,7 @@ use esp_println::println;
 
 #[main]
 fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     let lcd_backlight = peripherals.GPIO45;


### PR DESCRIPTION
Fixes #2909

If anyone wants to check if this helps with #2863 I'd be grateful.

I bumped clocks to their max in tests to give the DMA less chance of randomly working.

The ESP32 registers were less than well described in the TRM, but other chips had enough hints.