### PR TITLE
Add support for 32MB flash

### DIFF
--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump MSRV to 1.84 (#2951)
+- Add support for 32MB flash
 
 ### Fixed
 

--- a/esp-storage/src/common.rs
+++ b/esp-storage/src/common.rs
@@ -79,6 +79,7 @@ impl FlashStorage {
             0x20 => 4,
             0x30 => 8,
             0x40 => 16,
+            0x50 => 32,
             _ => 0,
         };
         storage.capacity = mb * 1024 * 1024;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [X] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
  - No breaking changes here.
- [X] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [X] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Add support for when the flash size part of the header is `0x50`, meaning 32MB.

This doesn't seem to be listed on the [Firmware Image Format](https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/firmware-image-format.html) page in the docs, but it follows the pattern of the other values.

#### Testing
Confirmed working on my [ESP32-S3-WROOM-2 devboard](https://www.adafruit.com/product/5364) with 32MB flash. Without this, esp-storage falls back to a capacity of 0.

I did not see any tests on this from a cursory glance. If I missed something, please let me know!