### PR TITLE
Introduce PinGuard and reconnecting an output signal to a different pin now clears previous connections

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `timer::wait` is now blocking (#2882)
 - By default, set `tx_idle_num` to 0 so that bytes written to TX FIFO are always immediately transmitted. (#2859)
 - `Rng` and `Trng` now implement `Peripheral<P = Self>` (#2992)
+- SPI, UART, I2C: `with_<pin>` functions of peripheral drivers now disconnect the previously assigned pins from the peripheral. (#3012)
+- Dropping a driver now disconnects pins from their peripherals. (#3012)
+
 - `Async` drivers are no longer `Send` (#2980)
 - GPIO drivers now take configuration structs, and their constructors are fallible (#2990)
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - By default, set `tx_idle_num` to 0 so that bytes written to TX FIFO are always immediately transmitted. (#2859)
 - `Rng` and `Trng` now implement `Peripheral<P = Self>` (#2992)
 - SPI, UART, I2C: `with_<pin>` functions of peripheral drivers now disconnect the previously assigned pins from the peripheral. (#3012)
-- Dropping a driver now disconnects pins from their peripherals. (#3012)
+- SPI, UART, I2C: Dropping a driver now disconnects pins from their peripherals. (#3012)
 
 - `Async` drivers are no longer `Send` (#2980)
 - GPIO drivers now take configuration structs, and their constructors are fallible (#2990)

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -20,7 +20,7 @@ use crate::{
         INPUT_SIGNAL_MAX,
         OUTPUT_SIGNAL_MAX,
     },
-    peripheral::{Peripheral, PeripheralRef},
+    peripheral::Peripheral,
     peripherals::GPIO,
     private::{self, Sealed},
 };
@@ -720,9 +720,10 @@ impl OutputConnection {
     }
 
     pub(crate) fn connect_with_guard(
-        this: PeripheralRef<'_, Self>,
+        this: impl Peripheral<P = impl PeripheralOutput>,
         signal: crate::gpio::OutputSignal,
     ) -> PinGuard {
+        crate::into_mapped_ref!(this);
         match &this.0 {
             OutputConnectionInner::Output(pin) => {
                 PinGuard::new(unsafe { pin.pin.clone_unchecked() }, signal)

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -24,6 +24,8 @@ use crate::{
     private::{self, Sealed},
 };
 
+use super::PinGuard;
+
 /// A signal that can be connected to a peripheral input.
 ///
 /// Peripheral drivers are encouraged to accept types that implement this and
@@ -717,5 +719,9 @@ impl OutputConnection {
             fn connect_peripheral_to_output(&mut self, signal: gpio::OutputSignal);
             fn disconnect_from_peripheral_output(&mut self, signal: gpio::OutputSignal);
         }
+    }
+
+    fn connect_with_guard(self, signal: crate::gpio::OutputSignal) -> PinGuard {
+        PinGuard { pin: gpio::AnyPin(signal.number()), signal }
     }
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -123,6 +123,7 @@ impl CFnPtr {
 /// This only needs to be applied to output signals, as it's not possible to
 /// connect multiple inputs to the same peripheral signal.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct PinGuard {
     pin: u8,
     signal: OutputSignal,

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -122,6 +122,7 @@ impl CFnPtr {
 ///
 /// This only needs to be applied to output signals, as it's not possible to
 /// connect multiple inputs to the same peripheral signal.
+#[derive(Debug)]
 pub(crate) struct PinGuard {
     pin: u8,
     signal: OutputSignal,

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -117,6 +117,60 @@ impl CFnPtr {
     }
 }
 
+/*
+pub(crate) struct PinGuard {
+pin: u8,
+}
+
+impl PinGuard {
+pub(crate) fn new(pin: u8) -> Self {
+Self { pin }
+}
+
+pub(crate) fn connect(&self, mut pin: AnyPin, signal: OutputSignal) {
+//already connected pin need to be disconnected first
+//ME TODO: Not sure about this condition?
+//ME TODO: How it will work when called in driver?
+if self.pin != u8::MAX {
+signal.disconnect_from(&mut pin);
+}
+signal.connect_to(pin);
+}
+}
+
+impl Drop for PinGuard {
+fn drop(&mut self) {
+//ME TODO: How to get OutputSignal here for proper disconnection?
+todo!();
+//disconnect here
+
+}
+}
+*/
+
+pub(crate) struct PinGuard {
+    pin: AnyPin,
+    signal: OutputSignal,
+}
+
+impl PinGuard {
+    pub(crate) fn new(mut pin: AnyPin, signal: OutputSignal) -> Self {
+        signal.connect_to(&mut pin);
+        Self { pin, signal }
+    }
+
+    // fn with_pin(&mut self, pin: impl Into<OutputConnection> + GPIO::Pin) {
+    //     self.signal = PinGuard::new(pin.number(), || self.uart.info().some_signal);
+    // }
+        
+}
+
+impl Drop for PinGuard {
+    fn drop(&mut self) {
+        self.signal.disconnect_from(&mut self.pin);
+    }
+}
+
 /// Event used to trigger interrupts.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -559,30 +559,33 @@ impl<'d, Dm: DriverMode> I2c<'d, Dm> {
     /// Connect a pin to the I2C SDA signal.
     ///
     /// This will replace previous pin assignments for this signal.
-    pub fn with_sda(self, sda: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+    pub fn with_sda(mut self, sda: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         let info = self.driver().info;
         let input = info.sda_input;
         let output = info.sda_output;
-        self.with_pin(sda, input, output, true)
+        Self::connect_pin(sda, input, output, &mut self.sda_pin);
+
+        self
     }
 
     /// Connect a pin to the I2C SCL signal.
     ///
     /// This will replace previous pin assignments for this signal.
-    pub fn with_scl(self, scl: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+    pub fn with_scl(mut self, scl: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         let info = self.driver().info;
         let input = info.scl_input;
         let output = info.scl_output;
-        self.with_pin(scl, input, output, false)
+        Self::connect_pin(scl, input, output, &mut self.scl_pin);
+
+        self
     }
 
-    fn with_pin(
-        mut self,
+    fn connect_pin(
         pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
         input: InputSignal,
         output: OutputSignal,
-        is_sda: bool,
-    ) -> Self {
+        guard: &mut PinGuard,
+    ) {
         crate::into_mapped_ref!(pin);
         // avoid the pin going low during configuration
         pin.set_output_high(true);
@@ -592,15 +595,8 @@ impl<'d, Dm: DriverMode> I2c<'d, Dm> {
         pin.pull_direction(Pull::Up);
 
         input.connect_to(&mut pin);
-        output.connect_to(&mut pin);
 
-        if is_sda {
-            self.sda_pin = OutputConnection::connect_with_guard(pin, output);
-        } else {
-            self.scl_pin = OutputConnection::connect_with_guard(pin, output);
-        }
-
-        self
+        *guard = OutputConnection::connect_with_guard(pin, output);
     }
 }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -691,11 +691,12 @@ where
 {
     /// Assign the MOSI (Master Out Slave In) pin for the SPI instance.
     ///
-    /// Enables output functionality for the pin, and connects it to the MOSI.
-    /// Calling this will replace previous pin assignments for this signal.
+    /// Enables output functionality for the pin, and connects it as the MOSI
+    /// signal. You want to use this for full-duplex SPI or
+    /// if you intend to use [DataMode::SingleTwoDataLines].
     ///
-    /// You want to use this for full-duplex SPI or
-    /// [DataMode::SingleTwoDataLines]
+    /// Disconnects the previous pin that was assigned with `with_mosi` or
+    /// `with_sio0`.
     pub fn with_mosi<MOSI: PeripheralOutput>(
         mut self,
         mosi: impl Peripheral<P = MOSI> + 'd,
@@ -713,7 +714,8 @@ where
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MOSI signal and SIO0 input signal.
     ///
-    /// Calling this will replace previous pin assignments for the MOSI signal.
+    /// Disconnects the previous pin that was assigned with `with_sio0` or
+    /// `with_mosi`.
     ///
     /// Use this if any of the devices on the bus use half-duplex SPI.
     ///
@@ -756,7 +758,7 @@ where
     /// Enables both input and output functionality for the pin, and connects it
     /// to the MISO signal and SIO1 input signal.
     ///
-    /// Calling this will replace previous pin assignments for the SIO1 signal.
+    /// Disconnects the previous pin that was assigned with `with_sio1`.
     ///
     /// Use this if any of the devices on the bus use half-duplex SPI.
     ///
@@ -773,7 +775,6 @@ where
         miso.enable_output(true);
 
         self.driver().info.miso.connect_to(&mut miso);
-        // self.driver().info.sio1_output.connect_to(&mut miso);
         self.pins.sio1_pin =
             OutputConnection::connect_with_guard(miso, self.driver().info.sio1_output);
 
@@ -782,10 +783,10 @@ where
 
     /// Assign the SCK (Serial Clock) pin for the SPI instance.
     ///
-    /// Calling this will replace previous pin assignments for this signal.
+    /// Configures the specified pin to push-pull output and connects it to the
+    /// SPI clock signal.
     ///
-    /// Sets the specified pin to push-pull output and connects it to the SPI
-    /// clock signal.
+    /// Disconnects the previous pin that was assigned with `with_sck`.
     pub fn with_sck<SCK: PeripheralOutput>(mut self, sclk: impl Peripheral<P = SCK> + 'd) -> Self {
         crate::into_mapped_ref!(sclk);
         sclk.set_to_push_pull_output();
@@ -796,10 +797,10 @@ where
 
     /// Assign the CS (Chip Select) pin for the SPI instance.
     ///
-    /// Sets the specified pin to push-pull output and connects it to the SPI CS
-    /// signal.
+    /// Configures the specified pin to push-pull output and connects it to the
+    /// SPI CS signal.
     ///
-    /// Calling this will replace previous pin assignments for this signal.
+    /// Disconnects the previous pin that was assigned with `with_cs`.
     ///
     /// # Current Stability Limitations
     /// The hardware chip select functionality is limited; only one CS line can

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -128,6 +128,7 @@ use crate::{
         interconnect::{PeripheralInput, PeripheralOutput},
         InputSignal,
         OutputSignal,
+        PinGuard,
         Pull,
     },
     interrupt::{InterruptConfigurable, InterruptHandler},
@@ -425,6 +426,7 @@ where
                 uart: self.uart,
                 phantom: PhantomData,
                 guard: tx_guard,
+                tx_pin: PinGuard::new(crate::gpio::AnyPin(u8::MAX), OutputSignal::U1TXD),
             },
         };
         serial.init(config)?;
@@ -444,6 +446,7 @@ pub struct UartTx<'d, Dm> {
     uart: PeripheralRef<'d, AnyUart>,
     phantom: PhantomData<Dm>,
     guard: PeripheralGuard,
+    tx_pin: PinGuard,
 }
 
 /// UART (Receive)
@@ -536,12 +539,18 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the UART
     /// TX signal.
-    pub fn with_tx(self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+    pub fn with_tx(mut self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(tx);
         // Make sure we don't cause an unexpected low pulse on the pin.
         tx.set_output_high(true);
         tx.set_to_push_pull_output();
-        self.uart.info().tx_signal.connect_to(tx);
+        // self.uart.info().tx_signal.connect_to(tx);
+
+        // TODO
+        // pub fn map<U>(self, transform: impl FnOnce(T) -> U) -> PeripheralRef<'a, U> {
+        //
+
+        self.tx_pin = PinGuard::new(self.uart.info().tx_signal.number(), self.uart.info().tx_signal);
 
         self
     }
@@ -659,6 +668,7 @@ impl<'d> UartTx<'d, Blocking> {
             uart: self.uart,
             phantom: PhantomData,
             guard: self.guard,
+            tx_pin: PinGuard::new(crate::gpio::AnyPin(u8::MAX), OutputSignal::U1TXD),
         }
     }
 }
@@ -678,6 +688,7 @@ impl<'d> UartTx<'d, Async> {
             uart: self.uart,
             phantom: PhantomData,
             guard: self.guard,
+            tx_pin: PinGuard::new(crate::gpio::AnyPin(u8::MAX), OutputSignal::U1TXD),
         }
     }
 }
@@ -1013,6 +1024,7 @@ impl<'d> Uart<'d, Blocking> {
         tx.set_output_high(true);
         tx.set_to_push_pull_output();
         self.tx.uart.info().tx_signal.connect_to(tx);
+        tx.number().map(|n| self.tx.tx_pin = PinGuard::new(n, OutputSignal::U1TXD));
 
         self
     }

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -541,6 +541,8 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the UART
     /// TX signal.
+    ///
+    /// Calling this will replace previous pin assignments for this signal.
     pub fn with_tx(mut self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(tx);
         // Make sure we don't cause an unexpected low pulse on the pin.

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -542,7 +542,7 @@ where
     /// Sets the specified pin to push-pull output and connects it to the UART
     /// TX signal.
     ///
-    /// Calling this will replace previous pin assignments for this signal.
+    /// Disconnects the previous pin that was assigned with `with_tx`.
     pub fn with_tx(mut self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(tx);
         // Make sure we don't cause an unexpected low pulse on the pin.


### PR DESCRIPTION
closes #2928