### PR TITLE
esp-wifi: fix possible deadlock

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a problem using BLE on ESP32-C6 when connected via Serial-JTAG (#2981)
 
+- Fix a possible dead-lock when the rx-queue is overrun (#3015)
+
 ### Removed
 
 ## 0.12.0 - 2025-01-15

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1541,6 +1541,7 @@ unsafe extern "C" fn recv_cb_sta(
             queue.push_back(packet);
             true
         } else {
+            mem::forget(packet);
             false
         }
     }) {
@@ -1548,6 +1549,7 @@ unsafe extern "C" fn recv_cb_sta(
         include::ESP_OK as esp_err_t
     } else {
         debug!("RX QUEUE FULL");
+        unsafe { esp_wifi_internal_free_rx_buffer(eb) };
         include::ESP_ERR_NO_MEM as esp_err_t
     }
 }
@@ -1569,6 +1571,7 @@ unsafe extern "C" fn recv_cb_ap(
             queue.push_back(packet);
             true
         } else {
+            mem::forget(packet);
             false
         }
     }) {
@@ -1576,6 +1579,7 @@ unsafe extern "C" fn recv_cb_ap(
         include::ESP_OK as esp_err_t
     } else {
         debug!("RX QUEUE FULL");
+        unsafe { esp_wifi_internal_free_rx_buffer(eb) };
         include::ESP_ERR_NO_MEM as esp_err_t
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #3008 

In case the rx-queue is overrun it was possible the drop-implementation of `EspWifiPacketBuffer` was called with interrupts disabled (which can cause a dead-lock).

#### Testing
See linked issue
