### PR TITLE
Fix PeripheralRef

### DIFF
--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -155,7 +155,7 @@ pub(crate) fn connect_input_signal(
 }
 
 fn connect_pin_to_input_signal(
-    pin: &mut AnyPin,
+    pin: &AnyPin,
     signal: gpio::InputSignal,
     is_inverted: bool,
     force_gpio: bool,
@@ -176,7 +176,7 @@ fn connect_pin_to_input_signal(
 }
 
 fn connect_peripheral_to_output(
-    pin: &mut AnyPin,
+    pin: &AnyPin,
     signal: gpio::OutputSignal,
     is_inverted: bool,
     force_gpio: bool,
@@ -217,7 +217,7 @@ fn connect_peripheral_to_output(
         });
 }
 
-fn disconnect_peripheral_output_from_pin(pin: &mut AnyPin, signal: gpio::OutputSignal) {
+fn disconnect_peripheral_output_from_pin(pin: &AnyPin, signal: gpio::OutputSignal) {
     pin.set_alternate_function(GPIO_FUNCTION);
 
     GPIO::regs()
@@ -307,8 +307,8 @@ impl InputSignal {
     /// Since there can only be one input signal connected to a peripheral at a
     /// time, this function will disconnect any previously connected input
     /// signals.
-    fn connect_input_to_peripheral(&mut self, signal: gpio::InputSignal) {
-        connect_pin_to_input_signal(&mut self.pin, signal, self.is_inverted, true);
+    fn connect_input_to_peripheral(&self, signal: gpio::InputSignal) {
+        connect_pin_to_input_signal(&self.pin, signal, self.is_inverted, true);
     }
 
     delegate::delegate! {
@@ -318,7 +318,7 @@ impl InputSignal {
             pub fn input_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::InputSignal)];
             pub fn init_input(&self, pull: Pull);
             pub fn is_input_high(&self) -> bool;
-            pub fn enable_input(&mut self, on: bool);
+            pub fn enable_input(&self, on: bool);
         }
     }
 }
@@ -346,8 +346,8 @@ impl DirectInputSignal {
     /// Since there can only be one input signal connected to a peripheral at a
     /// time, this function will disconnect any previously connected input
     /// signals.
-    fn connect_input_to_peripheral(&mut self, signal: gpio::InputSignal) {
-        connect_pin_to_input_signal(&mut self.pin, signal, false, false);
+    fn connect_input_to_peripheral(&self, signal: gpio::InputSignal) {
+        connect_pin_to_input_signal(&self.pin, signal, false, false);
     }
 
     delegate::delegate! {
@@ -356,7 +356,7 @@ impl DirectInputSignal {
             fn input_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::InputSignal)];
             fn init_input(&self, pull: Pull);
             fn is_input_high(&self) -> bool;
-            fn enable_input(&mut self, on: bool);
+            fn enable_input(&self, on: bool);
         }
     }
 }
@@ -428,8 +428,8 @@ impl OutputSignal {
     }
 
     /// Connect the pin to a peripheral output signal.
-    fn connect_peripheral_to_output(&mut self, signal: gpio::OutputSignal) {
-        connect_peripheral_to_output(&mut self.pin, signal, self.is_inverted, true, true, false);
+    fn connect_peripheral_to_output(&self, signal: gpio::OutputSignal) {
+        connect_peripheral_to_output(&self.pin, signal, self.is_inverted, true, true, false);
     }
 
     /// Remove this output pin from a connected [signal](`gpio::OutputSignal`).
@@ -437,8 +437,8 @@ impl OutputSignal {
     /// Clears the entry in the GPIO matrix / Io mux that associates this output
     /// pin with a previously connected [signal](`gpio::OutputSignal`). Any
     /// other outputs connected to the peripheral remain intact.
-    fn disconnect_from_peripheral_output(&mut self, signal: gpio::OutputSignal) {
-        disconnect_peripheral_output_from_pin(&mut self.pin, signal);
+    fn disconnect_from_peripheral_output(&self, signal: gpio::OutputSignal) {
+        disconnect_peripheral_output_from_pin(&self.pin, signal);
     }
 
     delegate::delegate! {
@@ -448,15 +448,15 @@ impl OutputSignal {
             pub fn input_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::InputSignal)];
             pub fn init_input(&self, pull: Pull);
             pub fn is_input_high(&self) -> bool;
-            pub fn enable_input(&mut self, on: bool);
+            pub fn enable_input(&self, on: bool);
 
             pub fn output_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::OutputSignal)];
-            pub fn set_to_open_drain_output(&mut self);
-            pub fn set_to_push_pull_output(&mut self);
-            pub fn enable_output(&mut self, on: bool);
-            pub fn set_output_high(&mut self, on: bool);
-            pub fn set_drive_strength(&mut self, strength: gpio::DriveStrength);
-            pub fn enable_open_drain(&mut self, on: bool);
+            pub fn set_to_open_drain_output(&self);
+            pub fn set_to_push_pull_output(&self);
+            pub fn enable_output(&self, on: bool);
+            pub fn set_output_high(&self, on: bool);
+            pub fn set_drive_strength(&self, strength: gpio::DriveStrength);
+            pub fn enable_open_drain(&self, on: bool);
             pub fn is_set_high(&self) -> bool;
         }
     }
@@ -475,8 +475,8 @@ impl DirectOutputSignal {
     }
 
     /// Connect the pin to a peripheral output signal.
-    fn connect_peripheral_to_output(&mut self, signal: gpio::OutputSignal) {
-        connect_peripheral_to_output(&mut self.pin, signal, false, false, true, false);
+    fn connect_peripheral_to_output(&self, signal: gpio::OutputSignal) {
+        connect_peripheral_to_output(&self.pin, signal, false, false, true, false);
     }
 
     /// Remove this output pin from a connected [signal](`gpio::OutputSignal`).
@@ -484,8 +484,8 @@ impl DirectOutputSignal {
     /// Clears the entry in the GPIO matrix / Io mux that associates this output
     /// pin with a previously connected [signal](`gpio::OutputSignal`). Any
     /// other outputs connected to the peripheral remain intact.
-    fn disconnect_from_peripheral_output(&mut self, signal: gpio::OutputSignal) {
-        disconnect_peripheral_output_from_pin(&mut self.pin, signal);
+    fn disconnect_from_peripheral_output(&self, signal: gpio::OutputSignal) {
+        disconnect_peripheral_output_from_pin(&self.pin, signal);
     }
 
     delegate::delegate! {
@@ -494,15 +494,15 @@ impl DirectOutputSignal {
             fn input_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::InputSignal)];
             fn init_input(&self, pull: Pull);
             fn is_input_high(&self) -> bool;
-            fn enable_input(&mut self, on: bool);
+            fn enable_input(&self, on: bool);
 
             fn output_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::OutputSignal)];
-            fn set_to_open_drain_output(&mut self);
-            fn set_to_push_pull_output(&mut self);
-            fn enable_output(&mut self, on: bool);
-            fn set_output_high(&mut self, on: bool);
-            fn set_drive_strength(&mut self, strength: gpio::DriveStrength);
-            fn enable_open_drain(&mut self, on: bool);
+            fn set_to_open_drain_output(&self);
+            fn set_to_push_pull_output(&self);
+            fn enable_output(&self, on: bool);
+            fn set_output_high(&self, on: bool);
+            fn set_drive_strength(&self, strength: gpio::DriveStrength);
+            fn enable_open_drain(&self, on: bool);
             fn is_set_high(&self) -> bool;
         }
     }
@@ -605,18 +605,10 @@ impl InputConnection {
             pub fn init_input(&self, pull: Pull);
             pub fn is_input_high(&self) -> bool;
             pub fn input_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::InputSignal)];
-        }
-
-        #[instability::unstable]
-        to match &mut self.0 {
-            InputConnectionInner::Input(pin) => pin,
-            InputConnectionInner::DirectInput(pin) => pin,
-            InputConnectionInner::Constant(level) => level,
-        } {
-            pub fn enable_input(&mut self, on: bool);
+            pub fn enable_input(&self, on: bool);
 
             // This doesn't need to be public, the intended way is `connect_to` and `disconnect_from`
-            fn connect_input_to_peripheral(&mut self, signal: gpio::InputSignal);
+            fn connect_input_to_peripheral(&self, signal: gpio::InputSignal);
         }
     }
 }
@@ -702,27 +694,20 @@ impl OutputConnection {
 
             pub fn is_set_high(&self) -> bool;
             pub fn output_signals(&self, _internal: private::Internal) -> &'static [(AlternateFunction, gpio::OutputSignal)];
-        }
-        #[instability::unstable]
-        to match &mut self.0 {
-            OutputConnectionInner::Output(pin) => pin,
-            OutputConnectionInner::DirectOutput(pin) => pin,
-            OutputConnectionInner::Constant(level) => level,
-        } {
-            pub fn pull_direction(&mut self, pull: Pull);
-            pub fn init_input(&mut self, pull: Pull);
-            pub fn enable_input(&mut self, on: bool);
+            pub fn pull_direction(&self, pull: Pull);
+            pub fn init_input(&self, pull: Pull);
+            pub fn enable_input(&self, on: bool);
 
-            pub fn set_to_open_drain_output(&mut self);
-            pub fn set_to_push_pull_output(&mut self);
-            pub fn enable_output(&mut self, on: bool);
-            pub fn set_output_high(&mut self, on: bool);
-            pub fn set_drive_strength(&mut self, strength: gpio::DriveStrength);
-            pub fn enable_open_drain(&mut self, on: bool);
+            pub fn set_to_open_drain_output(&self);
+            pub fn set_to_push_pull_output(&self);
+            pub fn enable_output(&self, on: bool);
+            pub fn set_output_high(&self, on: bool);
+            pub fn set_drive_strength(&self, strength: gpio::DriveStrength);
+            pub fn enable_open_drain(&self, on: bool);
 
             // These don't need to be public, the intended way is `connect_to` and `disconnect_from`
-            fn connect_peripheral_to_output(&mut self, signal: gpio::OutputSignal);
-            fn disconnect_from_peripheral_output(&mut self, signal: gpio::OutputSignal);
+            fn connect_peripheral_to_output(&self, signal: gpio::OutputSignal);
+            fn disconnect_from_peripheral_output(&self, signal: gpio::OutputSignal);
         }
     }
 

--- a/esp-hal/src/gpio/lp_io.rs
+++ b/esp-hal/src/gpio/lp_io.rs
@@ -200,14 +200,14 @@ macro_rules! lp_gpio {
     ) => {
         $(
             impl $crate::gpio::RtcPin for GpioPin<$gpionum> {
-                unsafe fn apply_wakeup(&mut self, wakeup: bool, level: u8) {
+                unsafe fn apply_wakeup(&self, wakeup: bool, level: u8) {
                     let lp_io = $crate::peripherals::LP_IO::regs();
                     lp_io.pin($gpionum).modify(|_, w| {
                         w.wakeup_enable().bit(wakeup).int_type().bits(level)
                     });
                 }
 
-                fn rtcio_pad_hold(&mut self, enable: bool) {
+                fn rtcio_pad_hold(&self, enable: bool) {
                     let mask = 1 << $gpionum;
                     unsafe {
                         let lp_aon = $crate::peripherals::LP_AON::regs();
@@ -224,7 +224,7 @@ macro_rules! lp_gpio {
 
                 /// Set the LP properties of the pin. If `mux` is true then then pin is
                 /// routed to LP_IO, when false it is routed to IO_MUX.
-                fn rtc_set_config(&mut self, input_enable: bool, mux: bool, func: $crate::gpio::RtcFunction) {
+                fn rtc_set_config(&self, input_enable: bool, mux: bool, func: $crate::gpio::RtcFunction) {
                     let mask = 1 << $gpionum;
                     unsafe {
                         let lp_aon = $crate::peripherals::LP_AON::regs();
@@ -251,12 +251,12 @@ macro_rules! lp_gpio {
             }
 
             impl $crate::gpio::RtcPinWithResistors for GpioPin<$gpionum> {
-                fn rtcio_pullup(&mut self, enable: bool) {
+                fn rtcio_pullup(&self, enable: bool) {
                     let lp_io = $crate::peripherals::LP_IO::regs();
                     lp_io.gpio($gpionum).modify(|_, w| w.fun_wpu().bit(enable));
                 }
 
-                fn rtcio_pulldown(&mut self, enable: bool) {
+                fn rtcio_pulldown(&self, enable: bool) {
                     let lp_io = $crate::peripherals::LP_IO::regs();
                     lp_io.gpio($gpionum).modify(|_, w| w.fun_wpd().bit(enable));
                 }

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -28,13 +28,13 @@ impl Level {
 
     pub(crate) fn init_input(&self, _pull: Pull) {}
 
-    pub(crate) fn enable_input(&mut self, _on: bool) {}
+    pub(crate) fn enable_input(&self, _on: bool) {}
 
     pub(crate) fn is_input_high(&self) -> bool {
         *self == Level::High
     }
 
-    pub(crate) fn connect_input_to_peripheral(&mut self, signal: InputSignal) {
+    pub(crate) fn connect_input_to_peripheral(&self, signal: InputSignal) {
         let value = match self {
             Level::High => ONE_INPUT,
             Level::Low => ZERO_INPUT,
@@ -43,12 +43,12 @@ impl Level {
         connect_input_signal(signal, value, false, true);
     }
 
-    pub(crate) fn set_to_open_drain_output(&mut self) {}
-    pub(crate) fn set_to_push_pull_output(&mut self) {}
-    pub(crate) fn enable_output(&mut self, _on: bool) {}
-    pub(crate) fn set_output_high(&mut self, _on: bool) {}
-    pub(crate) fn set_drive_strength(&mut self, _strength: DriveStrength) {}
-    pub(crate) fn enable_open_drain(&mut self, _on: bool) {}
+    pub(crate) fn set_to_open_drain_output(&self) {}
+    pub(crate) fn set_to_push_pull_output(&self) {}
+    pub(crate) fn enable_output(&self, _on: bool) {}
+    pub(crate) fn set_output_high(&self, _on: bool) {}
+    pub(crate) fn set_drive_strength(&self, _strength: DriveStrength) {}
+    pub(crate) fn enable_open_drain(&self, _on: bool) {}
 
     pub(crate) fn is_set_high(&self) -> bool {
         false
@@ -61,9 +61,9 @@ impl Level {
         &[]
     }
 
-    pub(crate) fn connect_peripheral_to_output(&mut self, _signal: OutputSignal) {}
+    pub(crate) fn connect_peripheral_to_output(&self, _signal: OutputSignal) {}
 
-    pub(crate) fn disconnect_from_peripheral_output(&mut self, _signal: OutputSignal) {}
+    pub(crate) fn disconnect_from_peripheral_output(&self, _signal: OutputSignal) {}
 }
 
 /// Placeholder pin, used when no pin is required when using a peripheral.

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -587,7 +587,7 @@ impl<'d, Dm: DriverMode> I2c<'d, Dm> {
         pin.enable_input(true);
         pin.pull_direction(Pull::Up);
 
-        input.connect_to(&mut pin);
+        input.connect_to(pin.reborrow());
 
         *guard = OutputConnection::connect_with_guard(pin, output);
     }

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -74,7 +74,7 @@ impl Ext1WakeupSource<'_, '_> {
     fn wake_io_reset() {
         use crate::gpio::{GpioPin, RtcPin};
 
-        fn uninit_pin(mut pin: impl RtcPin, wakeup_pins: u8) {
+        fn uninit_pin(pin: impl RtcPin, wakeup_pins: u8) {
             if wakeup_pins & (1 << pin.number()) != 0 {
                 pin.rtcio_pad_hold(false);
                 pin.rtc_set_config(false, false, RtcFunction::Rtc);

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -542,7 +542,7 @@ macro_rules! rtcio_analog {
 
             /// Set the RTC properties of the pin. If `mux` is true then then pin is
             /// routed to RTC, when false it is routed to IO_MUX.
-            fn rtc_set_config(&mut self, input_enable: bool, mux: bool, func: $crate::gpio::RtcFunction) {
+            fn rtc_set_config(&self, input_enable: bool, mux: bool, func: $crate::gpio::RtcFunction) {
                 // disable input
                 paste::paste!{
                     $crate::peripherals::RTC_IO::regs()
@@ -554,7 +554,7 @@ macro_rules! rtcio_analog {
                 }
             }
 
-            fn rtcio_pad_hold(&mut self, enable: bool) {
+            fn rtcio_pad_hold(&self, enable: bool) {
                 $crate::peripherals::LPWR::regs()
                     .hold_force()
                     .modify(|_, w| w.$hold().bit(enable));
@@ -565,14 +565,14 @@ macro_rules! rtcio_analog {
             // FIXME: replace with $(ignore($rue)) once stable
             $crate::ignore!($rue);
             impl $crate::gpio::RtcPinWithResistors for $crate::gpio::GpioPin<$pin_num> {
-                fn rtcio_pullup(&mut self, enable: bool) {
+                fn rtcio_pullup(&self, enable: bool) {
                     paste::paste! {
                         $crate::peripherals::RTC_IO::regs()
                             .$pin_reg.modify(|_, w| w.[< $prefix rue >]().bit(enable));
                     }
                 }
 
-                fn rtcio_pulldown(&mut self, enable: bool) {
+                fn rtcio_pulldown(&self, enable: bool) {
                     paste::paste! {
                         $crate::peripherals::RTC_IO::regs()
                             .$pin_reg.modify(|_, w| w.[< $prefix rde >]().bit(enable));
@@ -628,7 +628,7 @@ macro_rules! rtcio_analog {
             rtcio_analog!($pin_num, $rtc_pin, $pin_reg, $prefix, $hold $(, $rue )?);
         )+
 
-        pub(crate) fn errata36(mut pin: $crate::gpio::AnyPin, pull_up: bool, pull_down: bool) {
+        pub(crate) fn errata36(pin: $crate::gpio::AnyPin, pull_up: bool, pull_down: bool) {
             use $crate::gpio::{Pin, RtcPinWithResistors};
 
             let has_pullups = match pin.number() {

--- a/esp-hal/src/soc/esp32c2/gpio.rs
+++ b/esp-hal/src/soc/esp32c2/gpio.rs
@@ -178,7 +178,7 @@ macro_rules! rtc_pins {
     ( $( $pin_num:expr )+ ) => {
         $(
             impl $crate::gpio::RtcPin for GpioPin<$pin_num> {
-                unsafe fn apply_wakeup(&mut self, wakeup: bool, level: u8) {
+                unsafe fn apply_wakeup(&self, wakeup: bool, level: u8) {
                     let gpio_wakeup = $crate::peripherals::LPWR::regs().cntl_gpio_wakeup();
                     paste::paste! {
                         gpio_wakeup.modify(|_, w| w.[< gpio_pin $pin_num _wakeup_enable >]().bit(wakeup));
@@ -186,7 +186,7 @@ macro_rules! rtc_pins {
                     }
                 }
 
-                fn rtcio_pad_hold(&mut self, enable: bool) {
+                fn rtcio_pad_hold(&self, enable: bool) {
                     paste::paste! {
                         $crate::peripherals::LPWR::regs()
                             .pad_hold().modify(|_, w| w.[< gpio_pin $pin_num _hold >]().bit(enable));
@@ -201,13 +201,13 @@ impl<const N: u8> crate::gpio::RtcPinWithResistors for GpioPin<N>
 where
     Self: crate::gpio::RtcPin,
 {
-    fn rtcio_pullup(&mut self, enable: bool) {
+    fn rtcio_pullup(&self, enable: bool) {
         IO_MUX::regs()
             .gpio(N as usize)
             .modify(|_, w| w.fun_wpu().bit(enable));
     }
 
-    fn rtcio_pulldown(&mut self, enable: bool) {
+    fn rtcio_pulldown(&self, enable: bool) {
         IO_MUX::regs()
             .gpio(N as usize)
             .modify(|_, w| w.fun_wpd().bit(enable));

--- a/esp-hal/src/soc/esp32c3/gpio.rs
+++ b/esp-hal/src/soc/esp32c3/gpio.rs
@@ -206,7 +206,7 @@ macro_rules! rtc_pins {
     ( $( $pin_num:expr )+ ) => {
         $(
             impl $crate::gpio::RtcPin for GpioPin<$pin_num> {
-                unsafe fn apply_wakeup(&mut self, wakeup: bool, level: u8) {
+                unsafe fn apply_wakeup(&self, wakeup: bool, level: u8) {
                     let rtc_cntl = $crate::peripherals::LPWR::regs();
                     let gpio_wakeup = rtc_cntl.gpio_wakeup();
 
@@ -216,7 +216,7 @@ macro_rules! rtc_pins {
                     }
                 }
 
-                fn rtcio_pad_hold(&mut self, enable: bool) {
+                fn rtcio_pad_hold(&self, enable: bool) {
                     paste::paste! {
                         $crate::peripherals::LPWR::regs()
                             .pad_hold().modify(|_, w| w.[< gpio_pin $pin_num _hold >]().bit(enable));
@@ -231,13 +231,13 @@ impl<const N: u8> crate::gpio::RtcPinWithResistors for GpioPin<N>
 where
     Self: crate::gpio::RtcPin,
 {
-    fn rtcio_pullup(&mut self, enable: bool) {
+    fn rtcio_pullup(&self, enable: bool) {
         IO_MUX::regs()
             .gpio(N as usize)
             .modify(|_, w| w.fun_wpu().bit(enable));
     }
 
-    fn rtcio_pulldown(&mut self, enable: bool) {
+    fn rtcio_pulldown(&self, enable: bool) {
         IO_MUX::regs()
             .gpio(N as usize)
             .modify(|_, w| w.fun_wpd().bit(enable));

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -328,7 +328,7 @@ macro_rules! rtcio_analog {
 
             /// Set the RTC properties of the pin. If `mux` is true then then pin is
             /// routed to RTC, when false it is routed to IO_MUX.
-            fn rtc_set_config(&mut self, input_enable: bool, mux: bool, func: $crate::gpio::RtcFunction) {
+            fn rtc_set_config(&self, input_enable: bool, mux: bool, func: $crate::gpio::RtcFunction) {
                 enable_iomux_clk_gate();
 
                 // disable input
@@ -342,7 +342,7 @@ macro_rules! rtcio_analog {
                 }
             }
 
-            fn rtcio_pad_hold(&mut self, enable: bool) {
+            fn rtcio_pad_hold(&self, enable: bool) {
                 $crate::peripherals::LPWR::regs()
                     .pad_hold()
                     .modify(|_, w| w.$hold().bit(enable));
@@ -351,14 +351,14 @@ macro_rules! rtcio_analog {
 
         impl $crate::gpio::RtcPinWithResistors for GpioPin<$pin_num>
         {
-            fn rtcio_pullup(&mut self, enable: bool) {
+            fn rtcio_pullup(&self, enable: bool) {
                 paste::paste! {
                     $crate::peripherals::RTC_IO::regs()
                         .$pin_reg.modify(|_, w| w.[< $prefix rue >]().bit(enable));
                 }
             }
 
-            fn rtcio_pulldown(&mut self, enable: bool) {
+            fn rtcio_pulldown(&self, enable: bool) {
                 paste::paste! {
                     $crate::peripherals::RTC_IO::regs()
                         .$pin_reg.modify(|_, w| w.[< $prefix rde >]().bit(enable));

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -406,7 +406,7 @@ macro_rules! rtcio_analog {
 
             /// Set the RTC properties of the pin. If `mux` is true then then pin is
             /// routed to RTC, when false it is routed to IO_MUX.
-            fn rtc_set_config(&mut self, input_enable: bool, mux: bool, func: $crate::gpio::RtcFunction) {
+            fn rtc_set_config(&self, input_enable: bool, mux: bool, func: $crate::gpio::RtcFunction) {
                 enable_iomux_clk_gate();
 
                 // disable input
@@ -420,7 +420,7 @@ macro_rules! rtcio_analog {
                 }
             }
 
-            fn rtcio_pad_hold(&mut self, enable: bool) {
+            fn rtcio_pad_hold(&self, enable: bool) {
                 $crate::peripherals::LPWR::regs()
                     .pad_hold()
                     .modify(|_, w| w.$hold().bit(enable));
@@ -429,14 +429,14 @@ macro_rules! rtcio_analog {
 
         impl $crate::gpio::RtcPinWithResistors for GpioPin<$pin_num>
         {
-            fn rtcio_pullup(&mut self, enable: bool) {
+            fn rtcio_pullup(&self, enable: bool) {
                 paste::paste! {
                     $crate::peripherals::RTC_IO::regs()
                         .$pin_reg.modify(|_, w| w.[< $prefix rue >]().bit(enable));
                 }
             }
 
-            fn rtcio_pulldown(&mut self, enable: bool) {
+            fn rtcio_pulldown(&self, enable: bool) {
                 paste::paste! {
                     $crate::peripherals::RTC_IO::regs()
                         .$pin_reg.modify(|_, w| w.[< $prefix rde >]().bit(enable));

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -775,7 +775,7 @@ where
         crate::into_mapped_ref!(miso);
         miso.enable_input(true);
 
-        self.driver().info.miso.connect_to(&mut miso);
+        self.driver().info.miso.connect_to(miso);
 
         self
     }

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -23,7 +23,7 @@ use fugit::{Instant, MicrosDurationU64};
 
 use super::{Error, Timer as _};
 use crate::{
-    interrupt::{self, InterruptConfigurable, InterruptHandler},
+    interrupt::{self, InterruptHandler},
     peripheral::Peripheral,
     peripherals::{Interrupt, SYSTIMER},
     sync::{lock, RawMutex},
@@ -386,7 +386,7 @@ impl Alarm {
     }
 
     /// Set the interrupt handler for this comparator.
-    fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
+    fn set_interrupt_handler(&self, handler: InterruptHandler) {
         let interrupt = match self.channel() {
             0 => Interrupt::SYSTIMER_TARGET0,
             1 => Interrupt::SYSTIMER_TARGET1,
@@ -435,12 +435,6 @@ impl Alarm {
             }
         }
         unwrap!(interrupt::enable(interrupt, handler.priority()));
-    }
-}
-
-impl InterruptConfigurable for Alarm {
-    fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
-        self.set_interrupt_handler(handler)
     }
 }
 
@@ -586,6 +580,10 @@ impl super::Timer for Alarm {
             2 => Interrupt::SYSTIMER_TARGET2,
             _ => unreachable!(),
         }
+    }
+
+    fn set_interrupt_handler(&self, handler: InterruptHandler) {
+        self.set_interrupt_handler(handler)
     }
 }
 

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -351,10 +351,8 @@ impl super::Timer for Timer {
             _ => unreachable!(),
         }
     }
-}
 
-impl InterruptConfigurable for Timer {
-    fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
+    fn set_interrupt_handler(&self, handler: InterruptHandler) {
         self.set_interrupt_handler(handler)
     }
 }
@@ -382,7 +380,7 @@ unsafe impl Send for Timer {}
 
 /// Timer peripheral instance
 impl Timer {
-    fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
+    pub(crate) fn set_interrupt_handler(&self, handler: InterruptHandler) {
         let interrupt = match (self.timer_group(), self.timer_number()) {
             (0, 0) => Interrupt::TG0_T0_LEVEL,
             #[cfg(timg_timer1)]


### PR DESCRIPTION
This PR applies the soundness fixes from embassy-hal-internal to our copy-pasted implementation, and modifies code where necessary to allow that change.

There are three noteworthy items:
- I've removed Peripheral: Sealed, as it is just in the way. Preventing the users from implementing the trait (e.g. like we do for Flex) doesn't give us much, I believe.
- I've removed a few InterruptConfigurable implementations from timers. I don't think we should implement that trait for peripheral singletons, we should keep it for peripheral drivers only.
- I've changed all methods on peripheral singletons to use `&self`. These are supposed to be singletons, and they shouldn't really have user-facing APIs anyway. `&mut self` wasn't really preventing anything anyway (e.g. we can race on GPIO configuration), but it was in the way of this PR.

Closes #2661 as we now have an identical implementation to embassy, except for a few custom additions where we abuse the pattern a bit.