### PR TITLE
Slight GPIO cleanup, un-stabilize Io

### DIFF
--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -1,5 +1,12 @@
 //! Peripheral signal interconnect using IOMUX or GPIOMUX.
 
+// FIXME: https://github.com/esp-rs/esp-hal/issues/2954 The GPIO implementation does not contain any
+// locking. This is okay there, because the implementation uses either W1TS/W1TC
+// registers to set certain bits, or separate registers for each pin - and there
+// can only be one instance of every GPIO struct in safe code. However, with the
+// interconnect module we allow multiple handles, which means possible RMW
+// operations on the pin registers cause data races.
+
 use crate::{
     gpio::{
         self,

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -59,12 +59,12 @@ use procmacros::ram;
 use strum::EnumCount;
 
 #[cfg(feature = "unstable")]
-use crate::interrupt::{InterruptConfigurable, InterruptHandler};
+use crate::interrupt::InterruptConfigurable;
 #[cfg(any(lp_io, rtc_cntl))]
 use crate::peripherals::gpio::{handle_rtcio, handle_rtcio_with_resistors};
 pub use crate::soc::gpio::*;
 use crate::{
-    interrupt::{self, Priority, DEFAULT_INTERRUPT_HANDLER},
+    interrupt::{self, InterruptHandler, Priority, DEFAULT_INTERRUPT_HANDLER},
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{
         gpio::{handle_gpio_input, handle_gpio_output},
@@ -92,7 +92,6 @@ crate::unstable_module! {
     pub mod rtc_io;
 }
 
-#[cfg(feature = "unstable")]
 mod user_irq {
     use portable_atomic::{AtomicPtr, Ordering};
     use procmacros::ram;
@@ -681,14 +680,15 @@ pub struct Io {
     _io_mux: IO_MUX,
 }
 
-#[instability::unstable]
 impl Io {
     /// Initialize the I/O driver.
+    #[instability::unstable]
     pub fn new(_io_mux: IO_MUX) -> Self {
         Io { _io_mux }
     }
 
     /// Set the interrupt priority for GPIO interrupts.
+    #[instability::unstable]
     pub fn set_interrupt_priority(&self, prio: Priority) {
         unwrap!(interrupt::enable(Interrupt::GPIO, prio));
     }
@@ -706,6 +706,7 @@ impl Io {
     /// we clear the interrupt status register for you. This is NOT the case
     /// if you register the interrupt handler directly, by defining a
     /// `#[no_mangle] unsafe extern "C" fn GPIO()` function.
+    #[instability::unstable]
     pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         for core in crate::Cpu::other() {
             crate::interrupt::disable(core, Interrupt::GPIO);

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -624,7 +624,7 @@ impl<'d> I2c<'d, Blocking> {
     /// You can restore the default/unhandled interrupt handler by using
     /// [crate::DEFAULT_INTERRUPT_HANDLER]
     #[instability::unstable]
-    fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
+    pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         self.i2c.info().set_interrupt_handler(handler);
     }
 

--- a/esp-hal/src/soc/esp32/peripherals.rs
+++ b/esp-hal/src/soc/esp32/peripherals.rs
@@ -20,7 +20,6 @@ crate::peripherals! {
     peripherals: [
         I2C0 <= I2C0,
         I2C1 <= I2C1,
-        IO_MUX <= IO_MUX,
         SPI2 <= SPI2 (SPI2_DMA, SPI2),
         SPI3 <= SPI3 (SPI3_DMA, SPI3),
         UART0 <= UART0,
@@ -46,6 +45,7 @@ crate::peripherals! {
         HINF <= HINF,
         I2S0 <= I2S0 (I2S0),
         I2S1 <= I2S1 (I2S1),
+        IO_MUX <= IO_MUX,
         LEDC <= LEDC,
         LPWR <= RTC_CNTL,
         MCPWM0 <= MCPWM0,

--- a/esp-hal/src/soc/esp32c2/peripherals.rs
+++ b/esp-hal/src/soc/esp32c2/peripherals.rs
@@ -19,7 +19,6 @@ pub use pac::Interrupt;
 crate::peripherals! {
     peripherals: [
         I2C0 <= I2C0,
-        IO_MUX <= IO_MUX,
         SPI2 <= SPI2 (SPI2),
         UART0 <= UART0,
         UART1 <= UART1,
@@ -37,6 +36,7 @@ crate::peripherals! {
         EXTMEM <= EXTMEM,
         GPIO <= GPIO,
         INTERRUPT_CORE0 <= INTERRUPT_CORE0,
+        IO_MUX <= IO_MUX,
         LEDC <= LEDC,
         LPWR <= RTC_CNTL,
         MODEM_CLKRST <= MODEM_CLKRST,

--- a/esp-hal/src/soc/esp32c3/peripherals.rs
+++ b/esp-hal/src/soc/esp32c3/peripherals.rs
@@ -19,7 +19,6 @@ pub use pac::Interrupt;
 crate::peripherals! {
     peripherals: [
         I2C0 <= I2C0,
-        IO_MUX <= IO_MUX,
         SPI2 <= SPI2 (SPI2),
         UART0 <= UART0,
         UART1 <= UART1,
@@ -44,6 +43,7 @@ crate::peripherals! {
         HMAC <= HMAC,
         I2S0 <= I2S0 (I2S0),
         INTERRUPT_CORE0 <= INTERRUPT_CORE0,
+        IO_MUX <= IO_MUX,
         LEDC <= LEDC,
         LPWR <= RTC_CNTL,
         NRX <= NRX,

--- a/esp-hal/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal/src/soc/esp32c6/peripherals.rs
@@ -19,7 +19,6 @@ pub use pac::Interrupt;
 crate::peripherals! {
     peripherals: [
         I2C0 <= I2C0,
-        IO_MUX <= IO_MUX,
         SPI2 <= SPI2 (SPI2),
         UART0 <= UART0,
         UART1 <= UART1,
@@ -46,6 +45,7 @@ crate::peripherals! {
         IEEE802154 <= IEEE802154,
         INTERRUPT_CORE0 <= INTERRUPT_CORE0,
         INTPRI <= INTPRI,
+        IO_MUX <= IO_MUX,
         LEDC <= LEDC,
         LPWR <= LP_CLKRST,
         LP_CORE <= virtual,

--- a/esp-hal/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal/src/soc/esp32h2/peripherals.rs
@@ -20,7 +20,6 @@ crate::peripherals! {
     peripherals: [
         I2C0 <= I2C0,
         I2C1 <= I2C1,
-        IO_MUX <= IO_MUX,
         SPI2 <= SPI2 (SPI2),
         UART0 <= UART0,
         UART1 <= UART1,
@@ -44,6 +43,7 @@ crate::peripherals! {
         IEEE802154 <= IEEE802154,
         INTERRUPT_CORE0 <= INTERRUPT_CORE0,
         INTPRI <= INTPRI,
+        IO_MUX <= IO_MUX,
         LEDC <= LEDC,
         LPWR <= LP_CLKRST,
         LP_ANA <= LP_ANA,

--- a/esp-hal/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal/src/soc/esp32s2/peripherals.rs
@@ -20,7 +20,6 @@ crate::peripherals! {
     peripherals: [
         I2C0 <= I2C0,
         I2C1 <= I2C1,
-        IO_MUX <= IO_MUX,
         SPI2 <= SPI2 (SPI2_DMA, SPI2),
         SPI3 <= SPI3 (SPI3_DMA, SPI3),
         UART0 <= UART0,
@@ -43,6 +42,7 @@ crate::peripherals! {
         HMAC <= HMAC,
         I2S0 <= I2S0 (I2S0),
         INTERRUPT_CORE0 <= INTERRUPT_CORE0,
+        IO_MUX <= IO_MUX,
         LEDC <= LEDC,
         LPWR <= RTC_CNTL,
         PCNT <= PCNT,

--- a/esp-hal/src/soc/esp32s3/peripherals.rs
+++ b/esp-hal/src/soc/esp32s3/peripherals.rs
@@ -20,7 +20,6 @@ crate::peripherals! {
     peripherals: [
         I2C0 <= I2C0,
         I2C1 <= I2C1,
-        IO_MUX <= IO_MUX,
         SPI2 <= SPI2 (SPI2),
         SPI3 <= SPI3 (SPI3),
         UART0 <= UART0,
@@ -47,6 +46,7 @@ crate::peripherals! {
         I2S1 <= I2S1 (I2S1),
         INTERRUPT_CORE0 <= INTERRUPT_CORE0,
         INTERRUPT_CORE1 <= INTERRUPT_CORE1,
+        IO_MUX <= IO_MUX,
         LCD_CAM <= LCD_CAM,
         LEDC <= LEDC,
         LPWR <= RTC_CNTL,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -599,7 +599,7 @@ impl<'d> Spi<'d, Blocking> {
     /// You can restore the default/unhandled interrupt handler by using
     /// [crate::interrupt::DEFAULT_INTERRUPT_HANDLER]
     #[instability::unstable]
-    fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
+    pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         let interrupt = self.driver().info.interrupt;
         for core in Cpu::other() {
             crate::interrupt::disable(core, interrupt);

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -21,7 +21,6 @@ use esp_hal::{
     delay::Delay,
     gpio::{Event, Input, InputConfig, Io, Level, Output, OutputConfig, Pull},
     handler,
-    interrupt::InterruptConfigurable,
     main,
     ram,
 };

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -21,7 +21,6 @@ use esp_hal::{
     delay::Delay,
     gpio::{Event, Flex, Io, OutputOpenDrain, OutputOpenDrainConfig},
     handler,
-    interrupt::InterruptConfigurable,
     timer::timg::TimerGroup,
 };
 use hil_test as _;


### PR DESCRIPTION
This PR finishes #2905 by adding the function to Io, and making it public in spi and i2c master. It also marks the Io struct unstable as it is pretty much useless without any sort of stable interrupt API.

This PR also contains a few cleanups I made while reviewing the GPIO register accesses to see if we need any sort of locking. It renames the nebulous `GpioRegisterAccess` into `GpioBank` and renames its variants according to the new convention. The PR also removes the separate bank access structs and inlines their implementation into `GpioBank`.