### PR TITLE
ethernet frame header is 14 not 18

### DIFF
--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -73,7 +73,7 @@ use crate::{
     EspWifiController,
 };
 
-const ETHERNET_FRAME_HEADER_SIZE: usize = 18;
+const ETHERNET_FRAME_HEADER_SIZE: usize = 14;
 
 const MTU: usize = crate::CONFIG.mtu;
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
`ETHERNET_HEADER_FRAME_SIZE ` = 18 in the following code https://github.com/esp-rs/esp-hal/blob/f247b4099c116979bf2bad8cb405da33858a7f52/esp-wifi/src/wifi/mod.rs#L76
is only used here https://github.com/esp-rs/esp-hal/blob/f247b4099c116979bf2bad8cb405da33858a7f52/esp-wifi/src/wifi/mod.rs#L950
which is only used here https://github.com/esp-rs/esp-hal/blob/f247b4099c116979bf2bad8cb405da33858a7f52/esp-wifi/src/wifi/mod.rs#L2715
I thought maybe the extra 4 bytes were for the fcs at the end but the buffer is passed with the length given by caller here https://github.com/esp-rs/esp-hal/blob/f247b4099c116979bf2bad8cb405da33858a7f52/esp-wifi/src/wifi/mod.rs#L2717-L2721
so that can't be it.

The only reason I noticed this is because smoltcp doesn't support ipv6 fragmentation and ignores if the given MTU is too large ([see here](https://github.com/smoltcp-rs/smoltcp/blob/74bd1e5ee9dce51f5128d207b4d924889c72cda5/src/iface/interface/mod.rs#L1300-L1312)) and I tried to send a max MTU UDP packet. It panicked indexing `[..len]` so I calculated what the max non-fragmenting size would be like so:
```rust
    pub const UDP_FORWARD_HEADER_LEN: usize = {
        let out = smoltcp::wire::IPV6_HEADER_LEN
            + smoltcp::wire::UDP_HEADER_LEN
            + size_of::<PacketHeader>(); // repr(C) custom protocol header in the udp payload
        assert!(out == 56);
        out
    };
    pub const MTU: usize = 1492 // matching ESP32 ESP_WIFI_CONFIG_MTU
    // minus the headers
    - UDP_FORWARD_HEADER_LEN;
```
but was surprised to find the calculated MTU seemed to be 4 bytes less than the panic message implied was valid. I believe I tracked down the source of this discrepancy to the changed line in the PR. As seen [here](https://docs.rs/smoltcp/0.12.0/smoltcp/wire/constant.ETHERNET_HEADER_LEN.html) and [here](https://en.wikipedia.org/wiki/Ethernet_frame) an ethernet header is 14 bytes not 18.

I don't know if this would be considered public facing enough to warrant a change log entry, but I'm pretty sure it's a bug.

If my analysis is wrong and the fcs *is* included in that sizing, then there should at least be an assert that the passed length matches the configured MTU and not config.MTU+4 as it does now. The index check of `[..len]` should optimize out if the assert occurs before it.

Sidenote: It's a good thing the buffer index was checked and panicked in the esp-wifi code or I probably would never have figured this out. Also, I'll file an issue with smoltcp to at least warn when a packet which is too large and can't be fragmented needs to be sent.

#### Testing
See above.
