### PR TITLE
Rework documentation generation functionality of `xtask`

### DIFF
--- a/esp-config/README.md
+++ b/esp-config/README.md
@@ -52,8 +52,8 @@ This crate is guaranteed to compile when using the latest stable Rust version at
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/resources/index.html.jinja
+++ b/resources/index.html.jinja
@@ -93,23 +93,21 @@
   <div class="content">
     <div class="logo">
       <img src="esp-rs.svg" alt="esp-rs logo" />
-      <div>esp-rs docs</div>
+      <div>{{ metadata[0].package }} Documentation</div>
     </div>
 
-    {%- for (package, metadata) in packages|items %}
-    <h2>{{ package }}</h2>
+    <h2>{{ metadata[0].package }}</h2>
 
     {%- for meta in metadata %}
     <div class="crate">
       <span class="crate-name">
-        <a href="{{ meta.name }}/{{ meta.version }}/{{ meta.chip }}/{{ meta.package }}">
+        <a href="{{ meta.chip }}/{{ meta.package }}/index.html">
           {{ meta.chip_pretty }}
         </a>
       </span>
       <span class="crate-description">{{ meta.name }} (targeting {{ meta.chip_pretty }})</span>
       <span class="crate-version">{{ meta.version }}</span>
     </div>
-    {%- endfor %}
     {%- endfor %}
   </div>
 </body>

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -149,13 +149,14 @@ pub fn build_documentation(
     let args = builder.build();
     log::debug!("{args:#?}");
 
+    let mut envs = vec![("RUSTDOCFLAGS", "--cfg docsrs --cfg not_really_docsrs")];
+    // Special case: `esp-storage` requires the optimization level to be 2 or 3:
+    if package == Package::EspStorage {
+        envs.push(("CARGO_PROFILE_DEBUG_OPT_LEVEL", "3"));
+    }
+
     // Execute `cargo doc` from the package root:
-    cargo::run_with_env(
-        &args,
-        &package_path,
-        [("RUSTDOCFLAGS", "--cfg docsrs --cfg not_really_docsrs")],
-        false,
-    )?;
+    cargo::run_with_env(&args, &package_path, envs, false)?;
 
     // Build up the path at which the built documentation can be found:
     let mut docs_path = workspace.join(package.to_string()).join("target");


### PR DESCRIPTION
This will be the first or 2 or 3 PRs for #2967.

We can now generate documentation for self-hosting for all packages in the repository, and generate the indexes for those packages which require them (i.e. `esp-hal`, `esp-lp-hal`, `esp-wifi`):

```bash
$ cargo xtask build-documentation
$ cargo xtask build-documentation-index
```

Each package will have its documentation generated, and for those which have API differences depending on which chip features is enabled, we will generate docs for each specific chip. Otherwise, just a single version is generated.

There's probably still some room for improvement here, but given that it's just automation I didn't spend too much time refining it. Happy to make any changes if requested, though.

I will still need to rework the `documentation.yml` workflow to publish to the Espressif documentation server, but need to figure that all out still (and get deployment credentials for the production server), so that will be handled separately.