### PR TITLE
Don't register waker if the DMA is done

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2938,7 +2938,6 @@ pub(crate) mod asynch {
             self: core::pin::Pin<&mut Self>,
             cx: &mut core::task::Context<'_>,
         ) -> Poll<Self::Output> {
-            self.tx.waker().register(cx.waker());
             if self.tx.is_done() {
                 self.tx.clear_interrupts();
                 Poll::Ready(Ok(()))
@@ -2950,6 +2949,7 @@ pub(crate) mod asynch {
                 self.tx.clear_interrupts();
                 Poll::Ready(Err(DmaError::DescriptorError))
             } else {
+                self.tx.waker().register(cx.waker());
                 self.tx
                     .listen_out(DmaTxInterrupt::TotalEof | DmaTxInterrupt::DescriptorError);
                 Poll::Pending
@@ -2994,7 +2994,6 @@ pub(crate) mod asynch {
             self: core::pin::Pin<&mut Self>,
             cx: &mut core::task::Context<'_>,
         ) -> Poll<Self::Output> {
-            self.rx.waker().register(cx.waker());
             if self.rx.is_done() {
                 self.rx.clear_interrupts();
                 Poll::Ready(Ok(()))
@@ -3006,6 +3005,7 @@ pub(crate) mod asynch {
                 self.rx.clear_interrupts();
                 Poll::Ready(Err(DmaError::DescriptorError))
             } else {
+                self.rx.waker().register(cx.waker());
                 self.rx.listen_in(
                     DmaRxInterrupt::SuccessfulEof
                         | DmaRxInterrupt::DescriptorError
@@ -3060,7 +3060,6 @@ pub(crate) mod asynch {
             self: core::pin::Pin<&mut Self>,
             cx: &mut core::task::Context<'_>,
         ) -> Poll<Self::Output> {
-            self.tx.waker().register(cx.waker());
             if self
                 .tx
                 .pending_out_interrupts()
@@ -3076,6 +3075,7 @@ pub(crate) mod asynch {
                 self.tx.clear_interrupts();
                 Poll::Ready(Err(DmaError::DescriptorError))
             } else {
+                self.tx.waker().register(cx.waker());
                 self.tx
                     .listen_out(DmaTxInterrupt::Done | DmaTxInterrupt::DescriptorError);
                 Poll::Pending
@@ -3124,7 +3124,6 @@ pub(crate) mod asynch {
             self: core::pin::Pin<&mut Self>,
             cx: &mut core::task::Context<'_>,
         ) -> Poll<Self::Output> {
-            self.rx.waker().register(cx.waker());
             if self
                 .rx
                 .pending_in_interrupts()
@@ -3140,6 +3139,7 @@ pub(crate) mod asynch {
                 self.rx.clear_interrupts();
                 Poll::Ready(Err(DmaError::DescriptorError))
             } else {
+                self.rx.waker().register(cx.waker());
                 self.rx.listen_in(
                     DmaRxInterrupt::Done
                         | DmaRxInterrupt::DescriptorError

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -502,7 +502,6 @@ impl<BUF: DmaTxBuffer> I8080Transfer<'_, BUF, crate::Async> {
             type Output = ();
 
             fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-                LCD_DONE_WAKER.register(cx.waker());
                 if Instance::is_lcd_done_set() {
                     // Interrupt bit will be cleared in Self::wait.
                     // This allows `wait_for_done` to be called more than once.
@@ -510,6 +509,7 @@ impl<BUF: DmaTxBuffer> I8080Transfer<'_, BUF, crate::Async> {
                     // Instance::clear_lcd_done();
                     Poll::Ready(())
                 } else {
+                    LCD_DONE_WAKER.register(cx.waker());
                     Instance::listen_lcd_done();
                     Poll::Pending
                 }

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -201,7 +201,7 @@ cfg-if             = "1.0.0"
 critical-section   = "1.1.3"
 defmt              = "0.3.8"
 defmt-rtt          = { version = "0.4.1", optional = true }
-embassy-executor   = "0.6.0"
+embassy-executor   = "0.7.0"
 embassy-futures    = "0.1.1"
 embassy-sync       = "0.6.0"
 embassy-time       = "0.4.0"


### PR DESCRIPTION
[This](https://github.com/esp-rs/esp-hal/pull/3033#discussion_r1930188923) but for existing code. If the future starts listening for the interrupt, we can move the waker registration to just before the listening starts. This saves a `register()` call when the future would otherwise resolve.