### PR TITLE
bump rand_core version to 0.9.0

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - SPI: Added support for 3-wire SPI (#2919)
 - UART: Add separate config for Rx and Tx (#2965)
 
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `Pin`, `RtcPin` and `RtcPinWithResistors` implementations from `Flex` (#2938)
 - OutputOpenDrain has been removed (#3029)
+- `try_fill_bytes` implementation removed from esp-hal::rng::Rng (#3046)
 
 ## [0.23.1] - 2025-01-15
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -50,7 +50,7 @@ procmacros               = { version = "0.16.0", package = "esp-hal-procmacros",
 strum                    = { version = "0.26.3", default-features = false, features = ["derive"] }
 void                     = { version = "1.0.2", default-features = false }
 usb-device               = { version = "0.3.2", optional = true }
-rand_core                = "0.6.4"
+rand_core                = "0.9.0"
 ufmt-write               = "0.1.0"
 
 # IMPORTANT:

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -133,12 +133,14 @@ Use `DataMode::SingleTwoDataLines` to get the previous behavior.
 The `flip-link` feature is removed and replaced by the `ESP_HAL_CONFIG_FLIP_LINK` option.
 
 Cargo.toml
+
 ```diff
 - esp-hal = { version = "0.23.0", features = ["flip-link"]}
 + esp-hal = "0.23.0"
 ```
 
 config/config.toml
+
 ```diff
 [env]
 + ESP_HAL_CONFIG_FLIP_LINK = "true"
@@ -151,17 +153,18 @@ The features `psram-quad`/`prsram-octal` are replaced by a single `psram` featur
 `ESP_HAL_CONFIG_PSRAM_MODE` defaults to `quad` and (for ESP32-S3) also allows `octal`.
 
 Cargo.toml
+
 ```diff
 - esp-hal = { version = "0.23.0", features = ["psram-octal"]}
 + esp-hal = { version = "0.23.0", features = ["psram"]}
 ```
 
 config/config.toml
+
 ```diff
 [env]
 + ESP_HAL_CONFIG_PSRAM_MODE = "octal"
 ```
-
 
 ## UART halves have their configuration split too
 
@@ -199,4 +202,17 @@ The OutputOpenDrain driver has been removed. You can use `Output` instead with
      OutputConfig::default()
          .with_drive_mode(DriveMode::OpenDrain),
  );
+```
+
+## Rng changes
+
+`rng::Rng::try_fill_bytes` is now behind the `rand_core::TryRngCore` trait.
+
+```diff
+- use rand_core::RngCore;
++ use rand_core::TryRngCore;
+
+let mut rng = Rng::new(peripherals.RNG);
+let mut buf = [0u8, 4];
+rng.try_fill_bytes(&mut buf).unwrap();
 ```

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -160,11 +160,6 @@ impl rand_core::RngCore for Rng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.read(dest);
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.read(dest);
-        Ok(())
-    }
 }
 
 /// True Random Number Generator (TRNG) driver
@@ -238,10 +233,6 @@ impl rand_core::RngCore for Trng<'_> {
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.rng.fill_bytes(dest)
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.rng.try_fill_bytes(dest)
     }
 }
 

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -37,7 +37,7 @@ libm = "0.2.11"
 cfg-if = "1.0.0"
 portable-atomic = { version = "1.10.0", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
-rand_core           = "0.6.4"
+rand_core           = "0.9.0"
 
 bt-hci = { version = "0.2.0", optional = true }
 esp-config = { version = "0.3.0", path = "../esp-config" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -49,6 +49,7 @@ edge-dhcp = { version = "0.5.0" }
 edge-raw = { version = "0.5.0" }
 edge-nal = { version = "0.5.0" }
 edge-nal-embassy = { version = "0.5.0" }
+rand_core = "0.9.0"
 
 [features]
 esp32   = ["esp-hal/esp32",   "esp-backtrace/esp32",   "esp-hal-embassy?/esp32",   "esp-println/esp32",   "esp-storage?/esp32",   "esp-wifi?/esp32"]

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -45,6 +45,7 @@ use esp_wifi::{
     },
     EspWifiController,
 };
+use rand_core::RngCore;
 
 // When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
 macro_rules! mk_static {
@@ -98,7 +99,7 @@ async fn main(spawner: Spawner) -> ! {
         dns_servers: Default::default(),
     });
 
-    let seed = (rng.random() as u64) << 32 | rng.random() as u64;
+    let seed = rng.next_u64();
 
     // Init network stack
     let (stack, runner) = embassy_net::new(

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -49,6 +49,7 @@ use esp_wifi::{
     },
     EspWifiController,
 };
+use rand_core::RngCore;
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -101,7 +102,7 @@ async fn main(spawner: Spawner) -> ! {
     });
     let sta_config = embassy_net::Config::dhcpv4(Default::default());
 
-    let seed = (rng.random() as u64) << 32 | rng.random() as u64;
+    let seed = rng.next_u64();
 
     // Init network stacks
     let (ap_stack, ap_runner) = embassy_net::new(

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -40,6 +40,7 @@ use esp_wifi::{
     },
     EspWifiController,
 };
+use rand_core::RngCore;
 
 // When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
 macro_rules! mk_static {
@@ -120,7 +121,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let config = embassy_net::Config::dhcpv4(Default::default());
 
-    let seed = (rng.random() as u64) << 32 | rng.random() as u64;
+    let seed = rng.next_u64();
 
     // Init network stack
     let (stack, runner) = embassy_net::new(

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -35,6 +35,7 @@ use esp_wifi::{
     },
     EspWifiController,
 };
+use rand_core::RngCore;
 
 // When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
 macro_rules! mk_static {
@@ -82,7 +83,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let config = embassy_net::Config::dhcpv4(Default::default());
 
-    let seed = (rng.random() as u64) << 32 | rng.random() as u64;
+    let seed = rng.next_u64();
 
     // Init network stack
     let (stack, runner) = embassy_net::new(


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

These changes are to support the latest version of rand_core's `RngCore` trait, where `try_fill_bytes` has been moved to the `TryRngCore` trait.

#### Testing
Describe how you tested your changes.

Tested by running wifi examples where a u64 seed is generated via RngCore::next_u64 on a esp32-c6 devkit.
