### PR TITLE
Don't enable unstable for stable SPI tests

### DIFF
--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -1,7 +1,7 @@
 //! SPI Full Duplex test suite.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: unstable
+//% FEATURES(unstable): unstable
 //% FEATURES(stable):
 
 // FIXME: add async test cases that don't rely on PCNT


### PR DESCRIPTION
Running tests locally I noticed this:

```
[2025-01-28T07:59:37Z INFO  xtask] Building example 'tests\spi_full_duplex.rs' for 'esp32'
[2025-01-28T07:59:37Z INFO  xtask]   Configuration: stable
[2025-01-28T07:59:37Z INFO  xtask]   Features:      unstable
```

Which is a bit smelly, we shouldn't enable the `unstable` feature for stable esp-hal tests.