### PR TITLE
Rename api-guidelines and add config sturct guidelines

### DIFF
--- a/documentation/DEVELOPER-GUIDELINES.md
+++ b/documentation/DEVELOPER-GUIDELINES.md
@@ -1,4 +1,4 @@
-# `esp-rs` API Guidelines
+# `esp-hal` developers' guidelines
 
 ## About
 
@@ -35,7 +35,11 @@ In general, the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines
   - The `ConfigError` enum should be separate from other `Error` enums used by the driver.
   - The driver should implement `fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError>`.
   - In case the driver's configuration is infallible (all possible combinations of options are supported by the hardware), the `ConfigError` should be implemented as an empty `enum`.
-  - Configuration structs should derive `procmacros::BuilderLite` in order to automatically implement the Builder Lite pattern for them.
+  - Configuration structs should
+    - Derive `procmacros::BuilderLite` in order to automatically implement the Builder Lite pattern for them.
+    - Implement `Copy` if possible.
+    - The fields should be private. The `BuilderLite` macro generates setters and getters automatically.
+    - If calculating register values based on the configuration is costly, the configuration struct should precompute and store the result of those calculations.
 - If a driver implements both blocking and async operations, or only implements blocking operations, but may support asynchronous ones in the future, the driver's type signature must include a `crate::Mode` type parameter.
 - By default, constructors must configure the driver for blocking mode. The driver must implement `into_async` (and a matching `into_blocking`) function that reconfigures the driver.
   - `into_async` must configure the driver and/or the associated DMA channels. This most often means enabling an interrupt handler.

--- a/documentation/DEVELOPER-GUIDELINES.md
+++ b/documentation/DEVELOPER-GUIDELINES.md
@@ -36,7 +36,7 @@ In general, the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines
   - The driver should implement `fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError>`.
   - In case the driver's configuration is infallible (all possible combinations of options are supported by the hardware), the `ConfigError` should be implemented as an empty `enum`.
   - Configuration structs should
-    - Derive `procmacros::BuilderLite` in order to automatically implement the Builder Lite pattern for them.
+    - Use the [Builder Lite](https://matklad.github.io/2022/05/29/builder-lite.html) pattern. Prefer deriving `procmacros::BuilderLite` in order to automatically implement the pattern.
     - Implement `Copy` if possible.
     - The fields should be private. The `BuilderLite` macro generates setters and getters automatically.
     - If calculating register values based on the configuration is costly, the configuration struct should precompute and store the result of those calculations.

--- a/documentation/DEVELOPER-GUIDELINES.md
+++ b/documentation/DEVELOPER-GUIDELINES.md
@@ -39,7 +39,7 @@ In general, the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines
     - Use the [Builder Lite](https://matklad.github.io/2022/05/29/builder-lite.html) pattern. Prefer deriving `procmacros::BuilderLite` in order to automatically implement the pattern.
     - Implement `Copy` if possible.
     - The fields should be private. The `BuilderLite` macro generates setters and getters automatically.
-    - If calculating register values based on the configuration is costly, the configuration struct should precompute and store the result of those calculations.
+    - If the configuration is expected to be applied more than once (as, for example, different device configurations on a shared SPI bus may be) and calculating register values based on the configuration is costly, the configuration struct should precompute and store the result of those calculations.
 - If a driver implements both blocking and async operations, or only implements blocking operations, but may support asynchronous ones in the future, the driver's type signature must include a `crate::Mode` type parameter.
 - By default, constructors must configure the driver for blocking mode. The driver must implement `into_async` (and a matching `into_blocking`) function that reconfigures the driver.
   - `into_async` must configure the driver and/or the associated DMA channels. This most often means enabling an interrupt handler.


### PR DESCRIPTION
This PR was supposed to be a rename only, but I also included guidelines that #3011 will implement.