### PR TITLE
Add xtal frequency configuration

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added accessor methods to config structs (#3011)
 - `esp_hal::time::{Rate, Duration, Instant}` (#3083)
 - Async support for ADC oneshot reads for ESP32C2, ESP32C3, ESP32C6 and ESP32H2 (#2925, #3082)
+- `ESP_HAL_CONFIG_XTAL_FREQUENCY` configuration. For now, chips other than ESP32 and ESP32-C2 have a single option only. (#3054)
 
 ### Changed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -39,6 +39,7 @@ embedded-io              = { version = "0.6.1", optional = true }
 embedded-io-async        = { version = "0.6.1", optional = true }
 enumset                  = "1.1.5"
 esp-build                = { version = "0.2.0", path = "../esp-build" }
+esp-config               = { version = "0.3.0", path = "../esp-config" }
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                    = "0.3.7"
 instability              = "0.3.7"

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -77,6 +77,28 @@ fn main() -> Result<(), Box<dyn Error>> {
             Value::Bool(false),
             None
         ),
+        // Ideally, we should be able to set any clock frequency for any chip. However, currently
+        // only the 32 and C2 implements any sort of configurability, and the rest have a fixed
+        // clock frequeny.
+        // TODO: only show this configuration for chips that have multiple valid options.
+        (
+            "xtal-frequency",
+            "The frequency of the crystal oscillator, in MHz. Set to `auto` to automatically detect the frequency. `auto` may not be able to identify the clock frequency in some cases. Also, configuring a specific frequency may increase performance slightly.",
+            Value::String(match device_name {
+                "esp32" | "esp32c2" => String::from("auto"),
+                // The rest has only one option
+                "esp32c3" | "esp32c6" | "esp32s2" | "esp32s3" => String::from("40"),
+                "esp32h2" => String::from("32"),
+                _ => unreachable!(),
+            }),
+            Some(Validator::Enumeration(match device_name {
+                "esp32" | "esp32c2" => vec![String::from("auto"), String::from("26"), String::from("40")],
+                // The rest has only one option
+                "esp32c3" | "esp32c6" | "esp32s2" | "esp32s3" => vec![String::from("40")],
+                "esp32h2" => vec![String::from("32")],
+                _ => unreachable!(),
+            })),
+        ),
         // ideally we should only offer this for ESP32 but the config system doesn't
         // support per target configs, yet
         (
@@ -98,7 +120,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             "(ESP32, ESP32-S2 and ESP32-S3 only, `octal` is only supported for ESP32-S3) SPIRAM chip mode",
             Value::String(String::from("quad")),
             Some(Validator::Enumeration(
-                    vec![String::from("quad"), String::from("octal")]
+                vec![String::from("quad"), String::from("octal")]
             )),
         )
     ], true);

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -341,7 +341,7 @@ impl Clocks {
         } else {
             const {
                 match esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY").as_bytes() {
-                    b"auto" => XtalClock::Other(0),
+                    b"auto" => XtalClock::Other(0), // Can't be `unreachable!` due to const eval.
                     b"26" => XtalClock::_26M,
                     b"40" => XtalClock::_40M,
                     other => XtalClock::Other(esp_config::esp_config_int_parse!(u32, other)),
@@ -392,7 +392,7 @@ impl Clocks {
         } else {
             const {
                 match esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY").as_bytes() {
-                    b"auto" => XtalClock::Other(0),
+                    b"auto" => XtalClock::Other(0), // Can't be `unreachable!` due to const eval.
                     b"26" => XtalClock::_26M,
                     b"40" => XtalClock::_40M,
                     other => XtalClock::Other(esp_config::esp_config_int_parse!(u32, other)),


### PR DESCRIPTION
This PR adds `ESP_HAL_CONFIG_XTAL_FREQUENCY` - although only 32 and C2 have meaningful configurability. THe point of this PR is to allow const-propagating `xtal_freq` wherever possible, mostly affecting `esp_hal::time::now()` and indirectly embassy-time.

We could probably double-check in `Clocks::init` that the configured frequency matches what we measure, I don't know how badly we would want that, though.

---

Running a modified `embassy_executor_benchmark` on the S2 (no time queue tasks, Task1 reading current time in every loop):

| Test case | main | PR | 
| --------- | ---- | -- |
| no-op     | count=483798, cycles=24803/100 | count=483791, cycles=24804/100 |
| `now()`   | count=357079, cycles=33606/100 | count=373770, cycles=32105/100 |
| `black_box(now())` | count=279690, cycles=42904/100 | count=330518, cycles=36306/100 |

- count: iterations in 500ms, higher is better
- cycles: CPU clock cycles per iteration (x100), lower is better