### PR TITLE
Fix async SPI with ESP32

### DIFF
--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -704,7 +704,8 @@ impl<'d> Spi<'d, Async> {
             return Ok(());
         }
 
-        SpiFuture::new(&driver).await;
+        let future = SpiFuture::setup(&driver).await;
+        future.await;
 
         Ok(())
     }
@@ -3270,10 +3271,11 @@ impl Driver {
 
     /// Starts the operation and waits for it to complete.
     async fn execute_operation_async(&self) {
-        self.enable_listen(SpiInterrupt::TransferDone.into(), false);
-        self.clear_interrupts(SpiInterrupt::TransferDone.into());
+        // On ESP32, the interrupt seems to not fire in specific circumstances, when
+        // `listen` is called after `start_operation`. Let's call it before, to be sure.
+        let future = SpiFuture::setup(self).await;
         self.start_operation();
-        SpiFuture::new(self).await;
+        future.await;
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3576,8 +3578,13 @@ struct SpiFuture<'a> {
 }
 
 impl<'a> SpiFuture<'a> {
-    pub fn new(driver: &'a Driver) -> Self {
-        Self { driver }
+    fn setup(driver: &'a Driver) -> impl Future<Output = Self> {
+        core::future::poll_fn(move |cx| {
+            driver.state.waker.register(cx.waker());
+            driver.clear_interrupts(SpiInterrupt::TransferDone.into());
+            driver.enable_listen(SpiInterrupt::TransferDone.into(), true);
+            Poll::Ready(Self { driver })
+        })
     }
 }
 
@@ -3590,7 +3597,7 @@ use core::{
 impl Future for SpiFuture<'_> {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self
             .driver
             .interrupts()
@@ -3601,9 +3608,6 @@ impl Future for SpiFuture<'_> {
             return Poll::Ready(());
         }
 
-        self.driver.state.waker.register(cx.waker());
-        self.driver
-            .enable_listen(SpiInterrupt::TransferDone.into(), true);
         Poll::Pending
     }
 }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -3579,6 +3579,8 @@ struct SpiFuture<'a> {
 
 impl<'a> SpiFuture<'a> {
     fn setup(driver: &'a Driver) -> impl Future<Output = Self> {
+        // Make sure this is called before starting an async operation. On the ESP32,
+        // calling after may cause the interrupt to not fire.
         core::future::poll_fn(move |cx| {
             driver.state.waker.register(cx.waker());
             driver.clear_interrupts(SpiInterrupt::TransferDone.into());


### PR DESCRIPTION
The previous implementation was very brittle. Based on code alignment (which is a symptom, not a cause), the TransferDone interrupt may or may not fire. This behaviour can be triggered by strategically inserting `nop`s - a certain number triggers the bug, one more or less does not. Sometimes `nop`s inserted at seemingly unrelated places also change the behaviour.

A lot of experimentation leads me to believe that there is some very specific, but (to me) unknown set of conditions, that may prevent the interrupt bit from being set. The issue isn't timing in the sense that inserting a very large delay between start and listen does not trigger the issue - I think the delay has to be very specific.

Code alignment likely had an effect because that timing may have just been precise enough to be sensitive to code cache misses.

This is all very nebulous, but the current PR seems to be resilient against my efforts, so I'm hopeful this issue goes away.