### PR TITLE
More validation and `# Errors` entries

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `esp_hal::time::{Rate, Duration, Instant}` (#3083)
 - Async support for ADC oneshot reads for ESP32C2, ESP32C3, ESP32C6 and ESP32H2 (#2925, #3082)
 - `ESP_HAL_CONFIG_XTAL_FREQUENCY` configuration. For now, chips other than ESP32 and ESP32-C2 have a single option only. (#3054)
+- Added more validation to UART and SPI. User can now specify the baudrate tolerance of UART config (#3074)
 
 ### Changed
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1262,7 +1262,6 @@ impl<'d> Output<'d> {
     }
 
     /// Change the configuration.
-    // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
     #[inline]
     pub fn apply_config(&mut self, config: &OutputConfig) {
         self.pin.apply_output_config(config)
@@ -1451,7 +1450,6 @@ impl<'d> Input<'d> {
     }
 
     /// Change the configuration.
-    // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
     pub fn apply_config(&mut self, config: &InputConfig) {
         self.pin.apply_input_config(config)
     }

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -166,10 +166,11 @@ impl<'d> Camera<'d> {
     }
 
     /// Applies the configuration to the camera interface.
-    /// 
+    ///
     /// # Errors
     ///
-    /// A [`ConfigError`] variant will be returned if the frequency passed in `Config` is too low.
+    /// A [`ConfigError`] variant will be returned if the frequency passed in
+    /// `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
         let (i, divider) = calculate_clkm(

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -169,7 +169,7 @@ impl<'d> Camera<'d> {
     ///
     /// # Errors
     ///
-    /// A [`ConfigError`] variant will be returned if the frequency passed in
+    /// [`ConfigError::Clock`] will be returned if the frequency passed in
     /// `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -166,6 +166,10 @@ impl<'d> Camera<'d> {
     }
 
     /// Applies the configuration to the camera interface.
+    /// 
+    /// # Errors
+    ///
+    /// A [`ConfigError`] variant will be returned if the frequency passed in `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
         let (i, divider) = calculate_clkm(

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -169,10 +169,11 @@ where
     }
 
     /// Applies the configuration to the peripheral.
-    /// 
+    ///
     /// # Errors
     ///
-    /// A [`ConfigError`] variant will be returned if the frequency passed in `Config` is too low.
+    /// A [`ConfigError`] variant will be returned if the frequency passed in
+    /// `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
         // Due to https://www.espressif.com/sites/default/files/documentation/esp32-s3_errata_en.pdf

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -169,6 +169,10 @@ where
     }
 
     /// Applies the configuration to the peripheral.
+    /// 
+    /// # Errors
+    ///
+    /// A [`ConfigError`] variant will be returned if the frequency passed in `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
         // Due to https://www.espressif.com/sites/default/files/documentation/esp32-s3_errata_en.pdf

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -172,8 +172,8 @@ where
     ///
     /// # Errors
     ///
-    /// A [`ConfigError`] variant will be returned if the frequency passed in
-    /// `Config` is too low.
+    /// [`ConfigError::Clock`] variant will be returned if the frequency passed
+    /// in `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
         // Due to https://www.espressif.com/sites/default/files/documentation/esp32-s3_errata_en.pdf

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -137,8 +137,8 @@ where
     ///
     /// # Errors
     ///
-    /// A [`ConfigError`] variant will be returned if the frequency passed in
-    /// `Config` is too low.
+    /// [`ConfigError::Clock`] variant will be returned if the frequency passed
+    /// in `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
         // Due to https://www.espressif.com/sites/default/files/documentation/esp32-s3_errata_en.pdf

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -134,6 +134,10 @@ where
     }
 
     /// Applies configuration.
+    /// 
+    /// # Errors
+    ///
+    /// A [`ConfigError`] variant will be returned if the frequency passed in `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
         // Due to https://www.espressif.com/sites/default/files/documentation/esp32-s3_errata_en.pdf

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -134,10 +134,11 @@ where
     }
 
     /// Applies configuration.
-    /// 
+    ///
     /// # Errors
     ///
-    /// A [`ConfigError`] variant will be returned if the frequency passed in `Config` is too low.
+    /// A [`ConfigError`] variant will be returned if the frequency passed in
+    /// `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         let clocks = Clocks::get();
         // Due to https://www.espressif.com/sites/default/files/documentation/esp32-s3_errata_en.pdf

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -590,11 +590,11 @@ impl Config {
         // Maximum supported frequency is 80Mhz, minimum is about 70khz.
         cfg_if::cfg_if! {
             if #[cfg(esp32h2)] {
-                if self.frequency < HertzU32::kHz(70) || self.frequency > HertzU32::MHz(48) {
+                if self.frequency < Rate::from_khz(70) || self.frequency > Rate::from_mhz(48) {
                     return Err(ConfigError::UnsupportedFrequency);
                 }
             } else {
-                if self.frequency < HertzU32::kHz(70) || self.frequency > HertzU32::MHz(80) {
+                if self.frequency < Rate::from_khz(70) || self.frequency > Rate::from_mhz(80) {
                     return Err(ConfigError::UnsupportedFrequency);
                 }
             }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -577,7 +577,6 @@ impl Config {
                 | ((h as u32 - 1) << 6)
                 | ((n as u32 - 1) << 12)
                 | ((pre as u32 - 1) << 18);
-
         }
 
         Ok(reg_val)
@@ -698,7 +697,9 @@ where
 
 impl<'d> Spi<'d, Blocking> {
     /// Constructs an SPI instance in 8bit dataframe mode.
-    // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
+    ///
+    /// # Errors
+    /// See [`Spi::apply_config`].
     pub fn new(
         spi: impl Peripheral<P = impl PeripheralInstance> + 'd,
         config: Config,
@@ -1017,12 +1018,11 @@ where
     /// Change the bus configuration.
     ///
     /// # Errors.
-    /// If frequency passed in config exceeds 80Mhz or is below 70kHz, a
-    /// corresponding [`ConfigError`] variant will be returned. If the user
-    /// has specified in the configuration that they want frequency to
-    /// correspond exactly or with some percentage of deviation to the
-    /// desired value, and the driver cannot reach this speed - an error
-    /// will also be returned.
+    /// If frequency passed in config exceeds
+    #[cfg_attr(not(esp32h2), doc = " 80MHz")]
+    #[cfg_attr(esp32h2, doc = " 48MHz")]
+    /// or is below 70kHz,
+    /// [`ConfigError::UnsupportedFrequency`] error will be returned.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.driver().apply_config(config)
     }
@@ -1110,10 +1110,10 @@ where
     ///
     /// # Errors
     ///
-    /// The corresponding error variant from [`Error`] will be returned if
+    /// [`Error::FifoSizeExeeded`] or [`Error::Unsupported`] will be returned if
     /// passed buffer is bigger than FIFO size or if buffer is empty (currently
     /// unsupported). `DataMode::Single` cannot be combined with any other
-    /// [`DataMode`].
+    /// [`DataMode`], otherwise [`Error::Unsupported`] will be returned.
     #[instability::unstable]
     pub fn half_duplex_read(
         &mut self,
@@ -1151,7 +1151,7 @@ where
     ///
     /// # Errors
     ///
-    /// The corresponding error variant from [`Error`] will be returned if
+    /// [`Error::FifoSizeExeeded`] will be returned if
     /// passed buffer is bigger than FIFO size.
     #[cfg_attr(
         esp32,
@@ -1597,7 +1597,7 @@ mod dma {
         ///
         /// # Errors.
         /// If frequency passed in config exceeds 80Mhz, a corresponding
-        /// [`ConfigError`] variant will be returned.
+        /// [`ConfigError::UnsupportedFrequency`] error will be returned.
         #[instability::unstable]
         pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
             self.driver().apply_config(config)
@@ -2063,7 +2063,7 @@ mod dma {
         ///
         /// # Errors.
         /// If frequency passed in config exceeds 80Mhz, a corresponding
-        /// [`ConfigError`] variant will be returned.
+        /// [`ConfigError::UnsupportedFrequency`] error will be returned.
         #[instability::unstable]
         pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
             self.spi_dma.apply_config(config)

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -698,6 +698,7 @@ impl<'d> Spi<'d, Blocking> {
     /// Constructs an SPI instance in 8bit dataframe mode.
     ///
     /// # Errors
+    ///
     /// See [`Spi::apply_config`].
     pub fn new(
         spi: impl Peripheral<P = impl PeripheralInstance> + 'd,
@@ -1016,7 +1017,8 @@ where
 
     /// Change the bus configuration.
     ///
-    /// # Errors.
+    /// # Errors
+    ///
     /// If frequency passed in config exceeds
     #[cfg_attr(not(esp32h2), doc = " 80MHz")]
     #[cfg_attr(esp32h2, doc = " 48MHz")]
@@ -1594,7 +1596,8 @@ mod dma {
 
         /// Change the bus configuration.
         ///
-        /// # Errors.
+        /// # Errors
+        ///
         /// If frequency passed in config exceeds
         #[cfg_attr(not(esp32h2), doc = " 80MHz")]
         #[cfg_attr(esp32h2, doc = " 48MHz")]
@@ -2063,7 +2066,8 @@ mod dma {
 
         /// Change the bus configuration.
         ///
-        /// # Errors.
+        /// # Errors
+        ///
         /// If frequency passed in config exceeds
         #[cfg_attr(not(esp32h2), doc = " 80MHz")]
         #[cfg_attr(esp32h2, doc = " 48MHz")]

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -587,7 +587,6 @@ impl Config {
     }
 
     fn validate(&self) -> Result<(), ConfigError> {
-        // Maximum supported frequency is 80Mhz, minimum is about 70khz.
         cfg_if::cfg_if! {
             if #[cfg(esp32h2)] {
                 if self.frequency < Rate::from_khz(70) || self.frequency > Rate::from_mhz(48) {
@@ -629,7 +628,7 @@ impl core::fmt::Display for ConfigError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ConfigError::UnsupportedFrequency => {
-                write!(f, " The requested frequency is not supported")
+                write!(f, "The requested frequency is not supported")
             }
         }
     }
@@ -1596,7 +1595,10 @@ mod dma {
         /// Change the bus configuration.
         ///
         /// # Errors.
-        /// If frequency passed in config exceeds 80Mhz, a corresponding
+        /// If frequency passed in config exceeds
+        #[cfg_attr(not(esp32h2), doc = " 80MHz")]
+        #[cfg_attr(esp32h2, doc = " 48MHz")]
+        /// or is below 70kHz,
         /// [`ConfigError::UnsupportedFrequency`] error will be returned.
         #[instability::unstable]
         pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
@@ -2062,7 +2064,10 @@ mod dma {
         /// Change the bus configuration.
         ///
         /// # Errors.
-        /// If frequency passed in config exceeds 80Mhz, a corresponding
+        /// If frequency passed in config exceeds
+        #[cfg_attr(not(esp32h2), doc = " 80MHz")]
+        #[cfg_attr(esp32h2, doc = " 48MHz")]
+        /// or is below 70kHz,
         /// [`ConfigError::UnsupportedFrequency`] error will be returned.
         #[instability::unstable]
         pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -604,7 +604,8 @@ impl Config {
                     return Err(ConfigError::UnsupportedFrequency)
                 }
                 FrequencyTolerance::ErrorPercent(percent) => {
-                    let deviation = ((raw_desired_freq as i64 - actual_freq as i64).unsigned_abs() * 100)
+                    let deviation = ((raw_desired_freq as i64 - actual_freq as i64).unsigned_abs()
+                        * 100)
                         / actual_freq as u64;
                     if deviation > percent as u64 {
                         return Err(ConfigError::UnsupportedFrequency);
@@ -612,7 +613,7 @@ impl Config {
                 }
                 _ => {}
             }
-        }        
+        }
 
         Ok(reg_val)
     }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -623,8 +623,8 @@ impl Config {
     }
 
     fn validate(&self) -> Result<(), ConfigError> {
-        // Max supported frequency is 80Mhz
-        if self.frequency > HertzU32::MHz(80) {
+        // Maximum supported frequency is 80Mhz, minimum is about 70khz.
+        if self.frequency < HertzU32::kHz(70) || self.frequency > HertzU32::MHz(80) {
             return Err(ConfigError::UnsupportedFrequency);
         }
         Ok(())
@@ -1044,8 +1044,12 @@ where
     /// Change the bus configuration.
     ///
     /// # Errors.
-    /// If frequency passed in config exceeds 80Mhz, a corresponding
-    /// [`ConfigError`] variant will be returned.
+    /// If frequency passed in config exceeds 80Mhz or is below 70kHz, a
+    /// corresponding [`ConfigError`] variant will be returned. If the user
+    /// has specified in the configuration that they want frequency to
+    /// correspond exactly or with some percentage of deviation to the
+    /// desired value, and the driver cannot reach this speed - an error
+    /// will also be returned.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.driver().apply_config(config)
     }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -983,7 +983,6 @@ where
     }
 
     /// Change the bus configuration.
-    // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.driver().apply_config(config)
     }
@@ -1073,7 +1072,8 @@ where
     ///
     /// The corresponding error variant from [`Error`] will be returned if
     /// passed buffer is bigger than FIFO size or if buffer is empty (currently
-    /// unsupported).
+    /// unsupported). `DataMode::Single` cannot be combined with any other
+    /// [`DataMode`].
     #[instability::unstable]
     pub fn half_duplex_read(
         &mut self,
@@ -1554,7 +1554,6 @@ mod dma {
         }
 
         /// Change the bus configuration.
-        // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
         #[instability::unstable]
         pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
             self.driver().apply_config(config)
@@ -2017,7 +2016,6 @@ mod dma {
         }
 
         /// Change the bus configuration.
-        // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
         #[instability::unstable]
         pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
             self.spi_dma.apply_config(config)

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -545,7 +545,6 @@ where
     /// Change the configuration.
     ///
     /// Note that this also changes the configuration of the RX half.
-    // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
     #[instability::unstable]
     pub fn apply_config(&mut self, _config: &Config) -> Result<(), ConfigError> {
         // Nothing to do so far.
@@ -739,7 +738,18 @@ where
     /// Change the configuration.
     ///
     /// Note that this also changes the configuration of the TX half.
-    // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
+    ///
+    /// # Errors
+    /// The corresponding error variant from [`ConfigError`] will be returned if
+    /// the RX FIFO threshold passed in `Config` exceeds the maximum value (
+    #[cfg_attr(esp32, doc = "0x7F")]
+    #[cfg_attr(any(esp32c6, esp32h2), doc = "0xFF")]
+    #[cfg_attr(any(esp32c3, esp32c2, esp32s2), doc = "0x1FF")]
+    #[cfg_attr(esp32h2, doc = "0x3FF")]
+    /// ) or if the passed timeout exceeds the maximum value (
+    #[cfg_attr(esp32, doc = "0x7F")]
+    #[cfg_attr(not(esp32), doc = "0x3FF")]
+    /// ).
     #[instability::unstable]
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.uart
@@ -1165,7 +1175,10 @@ where
     }
 
     /// Change the configuration.
-    // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
+    ///
+    /// # Errors.
+    /// Errors will be returned in the cases described in
+    /// [`UartRx::apply_config`].
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.rx.apply_config(config)?;
         self.tx.apply_config(config)?;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2505,7 +2505,8 @@ impl Info {
                 return Err(ConfigError::UnachievableBaudrate)
             }
             BaudrateTolerance::ErrorPercent(percent) => {
-                let deviation = ((config.baudrate as i64 - actual_baud as i64).unsigned_abs() * 100)
+                let deviation = ((config.baudrate as i64 - actual_baud as i64).unsigned_abs()
+                    * 100)
                     / actual_baud as u64;
                 if deviation > percent as u64 {
                     return Err(ConfigError::UnachievableBaudrate);
@@ -2578,7 +2579,7 @@ impl Info {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32, esp32s2))] {
                 let clkdiv_reg = self.regs().clkdiv().read();
-                let clkdiv = clkdiv_reg.clkdiv().bits() as u32;
+                let clkdiv = clkdiv_reg.clkdiv().bits();
                 let clkdiv_frag = clkdiv_reg.frag().bits() as u32;
                 (clk << 4) / ((clkdiv << 4) | clkdiv_frag)
             } else if #[cfg(any(esp32c2, esp32c3, esp32s3))] {

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -268,6 +268,7 @@ pub enum StopBits {
 /// Defines how strictly the requested baud rate must be met.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub enum BaudrateTolerance {
     /// Accept the closest achievable baud rate without restriction.
     #[default]
@@ -349,6 +350,7 @@ impl Default for RxConfig {
 
 impl Config {
     /// Set the baudrate tolerance of the UART configuration.
+    #[instability::unstable]
     pub fn with_baudrate_tolerance(mut self, tolerance: BaudrateTolerance) -> Self {
         self.baudrate_tolerance = match tolerance {
             BaudrateTolerance::Exact => BaudrateTolerance::Exact,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -792,8 +792,8 @@ where
     /// Note that this also changes the configuration of the TX half.
     ///
     /// # Errors
-    /// The corresponding error variant from [`ConfigError`] will be returned if
-    /// the RX FIFO threshold passed in `Config` exceeds the maximum value (
+    /// [`ConfigError::UnsupportedFifoThreshold`] will be returned if the RX
+    /// FIFO threshold passed in `Config` exceeds the maximum value (
     #[cfg_attr(esp32, doc = "0x7F")]
     #[cfg_attr(any(esp32c6, esp32h2), doc = "0xFF")]
     #[cfg_attr(any(esp32c3, esp32c2, esp32s2), doc = "0x1FF")]
@@ -1036,7 +1036,9 @@ impl<'d> Uart<'d, Blocking> {
     /// # Ok(())
     /// # }
     /// ```
-    // FIXME: when https://github.com/esp-rs/esp-hal/issues/2839 is resolved, add an appropriate `# Error` entry.
+    /// 
+    /// # Errors
+    /// See [`Uart::apply_config`].
     pub fn new(
         uart: impl Peripheral<P = impl Instance> + 'd,
         config: Config,
@@ -1229,12 +1231,13 @@ where
     /// Change the configuration.
     ///
     /// # Errors.
-    /// Errors will be returned in the cases described in
-    /// [`UartRx::apply_config`] and if baud rate passed in config exceeds
-    /// 5MBaud or is equal to zero. If the user has specified in the
+    /// [`ConfigError::UnsupportedFifoThreshold`] will be returned in the cases
+    /// described in [`UartRx::apply_config`] and
+    /// [`ConfigError::UnsupportedBaudrate`] if baud rate passed in config
+    /// exceeds 5MBaud or is equal to zero. If the user has specified in the
     /// configuration that they want baudrate to correspond exactly or with some
     /// percentage of deviation to the desired value, and the driver cannot
-    /// reach this speed - an error will also be returned.
+    /// reach this speed - an above mentioned error will also be returned.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.rx.apply_config(config)?;
         self.tx.apply_config(config)?;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -267,6 +267,7 @@ pub enum StopBits {
 
 /// Defines how strictly the requested baud rate must be met.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BaudrateTolerance {
     /// Accept the closest achievable baud rate without restriction.
     #[default]
@@ -2504,7 +2505,7 @@ impl Info {
                 return Err(ConfigError::UnachievableBaudrate)
             }
             BaudrateTolerance::ErrorPercent(percent) => {
-                let deviation = ((config.baudrate as i64 - actual_baud as i64).abs() as u64 * 100)
+                let deviation = ((config.baudrate as i64 - actual_baud as i64).unsigned_abs() * 100)
                     / actual_baud as u64;
                 if deviation > percent as u64 {
                     return Err(ConfigError::UnachievableBaudrate);

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2530,7 +2530,7 @@ impl Info {
                     / actual_baud as u64;
                 // We tolerate deviation of 1% from the desired baud value, as it never will be
                 // exactly the same
-                if deviation > 1 as u64 {
+                if deviation > 1_u64 {
                     return Err(ConfigError::UnachievableBaudrate);
                 }
             }

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -44,6 +44,35 @@ mod tests {
     }
 
     #[test]
+    fn test_different_tolerance(mut ctx: Context) {
+        ctx.uart
+            .apply_config(
+                &uart::Config::default()
+                    .with_baudrate(19_200)
+                    .with_baudrate_tolerance(uart::BaudrateTolerance::Exact),
+            )
+            .unwrap();
+
+        ctx.uart.write_bytes(&[0x42]).unwrap();
+        let mut byte = [0u8; 1];
+        ctx.uart.read_bytes(&mut byte).unwrap();
+        assert_eq!(byte[0], 0x42);
+
+        ctx.uart
+            .apply_config(
+                &uart::Config::default()
+                    .with_baudrate(9600)
+                    .with_baudrate_tolerance(uart::BaudrateTolerance::ErrorPercent(10)),
+            )
+            .unwrap();
+
+        ctx.uart.write_bytes(&[0x42]).unwrap();
+        let mut byte = [0u8; 1];
+        ctx.uart.read_bytes(&mut byte).unwrap();
+        assert_eq!(byte[0], 0x42);
+    }
+
+    #[test]
     fn test_send_receive_buffer(mut ctx: Context) {
         const BUF_SIZE: usize = 128; // UART_FIFO_SIZE
 

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -102,6 +102,8 @@ mod tests {
             (9600, ClockSource::RefTick),
             (921_600, ClockSource::Apb),
             (2_000_000, ClockSource::Apb),
+            (3_500_000, ClockSource::Apb),
+            (5_000_000, ClockSource::Apb),
         ];
 
         let mut byte_to_write = 0xA5;


### PR DESCRIPTION
Introduces more validation for SPI and UART, allows setting baudrate tolerance for UART config, adds more `# Errors` entries
closes #2839 