### PR TITLE
Allow `set_power_saving` even for coex

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `esp_wifi::init` now takes an `impl Peripheral` for RNG source (#2992)
 
+- `set_power_saving` is now also available when the `coex` feature is activated (#3081)
+
 ### Fixed
 
 - Fixed a problem using BLE on ESP32-C6 when connected via Serial-JTAG (#2981)

--- a/esp-wifi/MIGRATING-0.11.md
+++ b/esp-wifi/MIGRATING-0.11.md
@@ -27,7 +27,3 @@ As part of limiting public API changes due to config options, the `csi_enabled` 
 -esp-wifi = { version = "0.12.0", features = ["wifi"] }
 +esp-wifi = { version = "0.12.0", features = ["wifi", "csi"] }
 ```
-
-## Setting the power-save-mode is allowed now even when `coex` feature is enabled
-
-Previously we didn't allow to change the power-save-mode with the `coex` feature. This limitation is now lifted.

--- a/esp-wifi/MIGRATING-0.11.md
+++ b/esp-wifi/MIGRATING-0.11.md
@@ -27,3 +27,7 @@ As part of limiting public API changes due to config options, the `csi_enabled` 
 -esp-wifi = { version = "0.12.0", features = ["wifi"] }
 +esp-wifi = { version = "0.12.0", features = ["wifi", "csi"] }
 ```
+
+## Setting the power-save-mode is allowed now even when `coex` feature is enabled
+
+Previously we didn't allow to change the power-save-mode with the `coex` feature. This limitation is now lifted.

--- a/esp-wifi/src/config.rs
+++ b/esp-wifi/src/config.rs
@@ -25,7 +25,6 @@ pub(crate) struct EspWifiConfig {
     pub(crate) scan_method: u32,
 }
 
-#[cfg(not(coex))]
 #[non_exhaustive]
 #[derive(Default)]
 pub enum PowerSaveMode {
@@ -35,7 +34,6 @@ pub enum PowerSaveMode {
     Maximum,
 }
 
-#[cfg(not(coex))]
 impl From<PowerSaveMode> for esp_wifi_sys::include::wifi_ps_type_t {
     fn from(s: PowerSaveMode) -> Self {
         match s {

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -16,12 +16,11 @@ use critical_section::Mutex;
 use enumset::EnumSet;
 use portable_atomic::{AtomicBool, AtomicU8, Ordering};
 
-#[cfg(not(coex))]
-use crate::config::PowerSaveMode;
 #[cfg(feature = "csi")]
 use crate::wifi::CsiConfig;
 use crate::{
     binary::include::*,
+    config::PowerSaveMode,
     hal::peripheral::{Peripheral, PeripheralRef},
     wifi::{Protocol, RxControlInfo, WifiError},
     EspWifiController,
@@ -340,7 +339,6 @@ impl EspNowManager<'_> {
         Ok(())
     }
 
-    #[cfg(not(coex))]
     /// Configures modem power saving
     pub fn set_power_saving(&self, ps: PowerSaveMode) -> Result<(), WifiError> {
         crate::wifi::apply_power_saving(ps)

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -61,10 +61,9 @@ use serde::{Deserialize, Serialize};
 use smoltcp::phy::{Device, DeviceCapabilities, RxToken, TxToken};
 pub use state::*;
 
-#[cfg(not(coex))]
-use crate::config::PowerSaveMode;
 use crate::{
     common_adapter::*,
+    config::PowerSaveMode,
     esp_wifi_result,
     hal::{
         peripheral::{Peripheral, PeripheralRef},
@@ -2516,7 +2515,6 @@ impl<'d> WifiController<'d> {
         Ok(())
     }
 
-    #[cfg(not(coex))]
     /// Configures modem power saving
     pub fn set_power_saving(&mut self, ps: PowerSaveMode) -> Result<(), WifiError> {
         apply_power_saving(ps)
@@ -3190,7 +3188,6 @@ pub(crate) mod embassy {
     }
 }
 
-#[cfg(not(coex))]
 pub(crate) fn apply_power_saving(ps: PowerSaveMode) -> Result<(), WifiError> {
     esp_wifi_result!(unsafe { esp_wifi_sys::include::esp_wifi_set_ps(ps.into()) })?;
     Ok(())

--- a/examples/src/bin/wifi_coex.rs
+++ b/examples/src/bin/wifi_coex.rs
@@ -90,6 +90,9 @@ fn main() -> ! {
 
     let (iface, device, mut controller) =
         create_network_interface(&init, &mut wifi, WifiStaDevice).unwrap();
+    controller
+        .set_power_saving(esp_wifi::config::PowerSaveMode::None)
+        .unwrap();
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let mut socket_set = SocketSet::new(&mut socket_set_entries[..]);

--- a/examples/src/bin/wifi_dhcp.rs
+++ b/examples/src/bin/wifi_dhcp.rs
@@ -63,6 +63,9 @@ fn main() -> ! {
     let mut wifi = peripherals.WIFI;
     let (iface, device, mut controller) =
         create_network_interface(&init, &mut wifi, WifiStaDevice).unwrap();
+    controller
+        .set_power_saving(esp_wifi::config::PowerSaveMode::None)
+        .unwrap();
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let mut socket_set = SocketSet::new(&mut socket_set_entries[..]);


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
I think there was a good reason not to allow any other PS than `Min` for COEX before but it turns out it's fine to set it at least to `None` and in the case of ESP32-C6 it's almost unusable with any other PS

I changed some (two) examples to set `PowerSavingMode::None` - could be applied to more / all examples.

We could also now turn `coex` into a config-option (since it doesn't change the API surface anymore)

This should be the solution for #3049 on ESP32-C6 but unfortunately doesn't help with ESP32 (so not closing it via this)

#### Testing
Run the `wifi_coex` example
