### PR TITLE
Enable async ADC for C2 and H2

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: Added support for 3-wire SPI (#2919)
 - UART: Add separate config for Rx and Tx (#2965)
 - Added accessor methods to config structs (#3011)
-- Async support for ADC oneshot reads for ESP32C3, ESP32C6 and ESP32H2 (#2925, #3082)
+- Async support for ADC oneshot reads for ESP32C2, ESP32C3, ESP32C6 and ESP32H2 (#2925, #3082)
 
 ### Changed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI: Added support for 3-wire SPI (#2919)
 - UART: Add separate config for Rx and Tx (#2965)
 - Added accessor methods to config structs (#3011)
+- Async support for ADC oneshot reads for ESP32C3, ESP32C6 and ESP32H2 (#2925, #3082)
 
 ### Changed
 
@@ -106,7 +107,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S2: Made Wi-Fi peripheral non virtual. (#2942)
 - `UartRx::check_for_errors`, `Uart::check_for_rx_errors`, `{Uart, UartRx}::read_buffered_bytes` (#2935)
 - Added `i2c` interrupt API (#2944)
-- Async support for ADC oneshot reads for ESP32C3 and ESP32C6 (#2925)
 
 ### Changed
 

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 cfg_if::cfg_if! {
-    if #[cfg(any(esp32c3, esp32h2))] {
+    if #[cfg(any(esp32c2, esp32c3, esp32h2))] {
         use Interrupt::APB_ADC as InterruptSource;
     } else if #[cfg(esp32c6)] {
         use Interrupt::APB_SARADC as InterruptSource;
@@ -15,7 +15,7 @@ use super::{AdcCalSource, AdcConfig, Attenuation};
 use crate::clock::clocks_ll::regi2c_write_mask;
 #[cfg(any(esp32c2, esp32c3, esp32c6))]
 use crate::efuse::Efuse;
-#[cfg(any(esp32c3, esp32c6, esp32h2))]
+#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2))]
 use crate::{
     analog::adc::asynch::AdcFuture,
     interrupt::{InterruptConfigurable, InterruptHandler},
@@ -438,7 +438,7 @@ where
         }
     }
 
-    #[cfg(any(esp32c3, esp32c6, esp32h2))]
+    #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2))]
     /// Reconfigures the ADC driver to operate in asynchronous mode.
     pub fn into_async(mut self) -> Adc<'d, ADCI, Async> {
         self.set_interrupt_handler(asynch::adc_interrupt_handler);
@@ -534,7 +534,7 @@ where
 
 impl<ADCI> crate::private::Sealed for Adc<'_, ADCI, Blocking> {}
 
-#[cfg(any(esp32c3, esp32c6, esp32h2))]
+#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2))]
 impl<ADCI> InterruptConfigurable for Adc<'_, ADCI, Blocking> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         for core in crate::Cpu::other() {
@@ -638,7 +638,7 @@ mod adc_implementation {
     }
 }
 
-#[cfg(any(esp32c3, esp32c6, esp32h2))]
+#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2))]
 impl<'d, ADCI> Adc<'d, ADCI, Async>
 where
     ADCI: RegisterAccess + 'd,
@@ -700,7 +700,7 @@ where
     }
 }
 
-#[cfg(any(esp32c3, esp32c6, esp32h2))]
+#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2))]
 /// Async functionality
 pub(crate) mod asynch {
     use core::{

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -1,9 +1,12 @@
 use core::marker::PhantomData;
 
-#[cfg(esp32c3)]
-use Interrupt::APB_ADC as InterruptSource;
-#[cfg(esp32c6)]
-use Interrupt::APB_SARADC as InterruptSource;
+cfg_if::cfg_if! {
+    if #[cfg(any(esp32c3, esp32h2))] {
+        use Interrupt::APB_ADC as InterruptSource;
+    } else if #[cfg(esp32c6)] {
+        use Interrupt::APB_SARADC as InterruptSource;
+    }
+}
 
 #[cfg(not(esp32h2))]
 pub use self::calibration::*;
@@ -12,7 +15,7 @@ use super::{AdcCalSource, AdcConfig, Attenuation};
 use crate::clock::clocks_ll::regi2c_write_mask;
 #[cfg(any(esp32c2, esp32c3, esp32c6))]
 use crate::efuse::Efuse;
-#[cfg(any(esp32c3, esp32c6))]
+#[cfg(any(esp32c3, esp32c6, esp32h2))]
 use crate::{
     analog::adc::asynch::AdcFuture,
     interrupt::{InterruptConfigurable, InterruptHandler},
@@ -435,7 +438,7 @@ where
         }
     }
 
-    #[cfg(any(esp32c3, esp32c6))]
+    #[cfg(any(esp32c3, esp32c6, esp32h2))]
     /// Reconfigures the ADC driver to operate in asynchronous mode.
     pub fn into_async(mut self) -> Adc<'d, ADCI, Async> {
         self.set_interrupt_handler(asynch::adc_interrupt_handler);
@@ -531,7 +534,7 @@ where
 
 impl<ADCI> crate::private::Sealed for Adc<'_, ADCI, Blocking> {}
 
-#[cfg(any(esp32c3, esp32c6))]
+#[cfg(any(esp32c3, esp32c6, esp32h2))]
 impl<ADCI> InterruptConfigurable for Adc<'_, ADCI, Blocking> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         for core in crate::Cpu::other() {
@@ -635,7 +638,7 @@ mod adc_implementation {
     }
 }
 
-#[cfg(any(esp32c3, esp32c6))]
+#[cfg(any(esp32c3, esp32c6, esp32h2))]
 impl<'d, ADCI> Adc<'d, ADCI, Async>
 where
     ADCI: RegisterAccess + 'd,
@@ -697,7 +700,7 @@ where
     }
 }
 
-#[cfg(any(esp32c3, esp32c6))]
+#[cfg(any(esp32c3, esp32c6, esp32h2))]
 /// Async functionality
 pub(crate) mod asynch {
     use core::{

--- a/esp-hal/src/analog/mod.rs
+++ b/esp-hal/src/analog/mod.rs
@@ -5,7 +5,7 @@
 //! available on the device. For more information about a peripheral driver,
 //! please refer to the relevant module documentation.
 
-#[cfg(adc)]
+#[cfg(any(adc1, adc2))]
 pub mod adc;
 #[cfg(dac)]
 pub mod dac;

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -228,7 +228,7 @@ pub(crate) use unstable_module;
 unstable_module! {
     #[cfg(aes)]
     pub mod aes;
-    #[cfg(any(adc, dac))]
+    #[cfg(any(adc1, adc2, dac))]
     pub mod analog;
     pub mod asynch;
     #[cfg(assist_debug)]

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -52,7 +52,8 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc",
+    "adc1",
+    "adc2",
     "dac",
     "pdma",
     "phy",

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -34,7 +34,7 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc",
+    "adc1",
     "assist_debug_sp_monitor",
     "gdma",
     "phy",

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -45,7 +45,8 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc",
+    "adc1",
+    "adc2",
     "assist_debug_sp_monitor",
     "assist_debug_region_monitor",
     "gdma",

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -71,7 +71,7 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc",
+    "adc1",
     "assist_debug_sp_monitor",
     "assist_debug_region_monitor",
     "gdma",

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -63,7 +63,7 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc",
+    "adc1",
     "assist_debug_sp_monitor",
     "assist_debug_region_monitor",
     "gdma",

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -93,6 +93,8 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
+    # "adc1",
+    # "adc2",
     "clic",
     "very_large_intr_status",
     "gpio_bank_1",

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -49,7 +49,8 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc",
+    "adc1",
+    "adc2",
     "dac",
     "pdma",
     "phy",

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -61,7 +61,8 @@ peripherals = [
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc",
+    "adc1",
+    "adc2",
     "assist_debug_region_monitor",
     "gdma",
     "phy",

--- a/qa-test/src/bin/embassy_adc.rs
+++ b/qa-test/src/bin/embassy_adc.rs
@@ -1,6 +1,6 @@
 //! This shows how to asynchronously read ADC data
 
-//% CHIPS: esp32c3 esp32c6 esp32h2
+//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2
 
 #![no_std]
 #![no_main]

--- a/qa-test/src/bin/embassy_adc.rs
+++ b/qa-test/src/bin/embassy_adc.rs
@@ -1,6 +1,6 @@
 //! This shows how to asynchronously read ADC data
 
-//% CHIPS: esp32c6 esp32c3
+//% CHIPS: esp32c3 esp32c6 esp32h2
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
They just work. Verified by running the example, and tying GPIO4 to GND (~2000 count) and 3V3 (4095 count). Also ran the example on the C6 to see that it gave similar counts.

cc #1643