### PR TITLE
Migrate AES driver to DMA move API

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Async` drivers are no longer `Send` (#2980)
 - GPIO drivers now take configuration structs (#2990, #3029)
 - `flip-link` feature is now a config option (`ESP_HAL_CONFIG_FLIP_LINK`) (#3001)
-
+- Migrate AES driver to DMA move API (#3084)
 - Removed features `psram-quad` and `psram-octal` - replaced by `psram` and the `ESP_HAL_CONFIG_PSRAM_MODE` (`quad`/`octal`) (#3001)
 
 - I2C: Async functions are postfixed with `_async`, non-async functions are available in async-mode (#3056)

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -200,6 +200,36 @@ The OutputOpenDrain driver has been removed. You can use `Output` instead with
  );
 ```
 
+## AES DMA driver changes
+AES now uses the newer DMA move API.
+
+```diff
+  let (output, rx_descriptors, input, tx_descriptors) = dma_buffers!(32000);
++ let mut output = DmaRxBuf::new(rx_descriptors, output).unwrap();
++ let mut input = DmaTxBuf::new(tx_descriptors, input).unwrap();
+
+  let mut aes = Aes::new(peripherals.AES).with_dma(
+      dma_channel,
+-     rx_descriptors,
+-     tx_descriptors,
+  );
+
+  let transfer = aes
+      .process(
+-         &input,
+-         &mut output,
++         output.len().div_ceil(16), // Number of blocks
++         output,
++         input,
+          Mode::Encryption128,
+          CipherMode::Ecb,
+          keybuf,
+      )
++     .map_err(|e| e.0)
+      .unwrap();
+  transfer.wait();
+```
+
 ## I2C Changes
 
 All async functions now include the `_async` postfix. Additionally the non-async functions are now available in async-mode.

--- a/hil-test/tests/aes_dma.rs
+++ b/hil-test/tests/aes_dma.rs
@@ -18,6 +18,8 @@ const DMA_BUFFER_SIZE: usize = 16;
 #[cfg(test)]
 #[embedded_test::tests(default_timeout = 3)]
 mod tests {
+    use esp_hal::dma::{DmaRxBuf, DmaTxBuf};
+
     use super::*;
 
     #[init]
@@ -35,17 +37,18 @@ mod tests {
             }
         }
 
-        let (mut output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let (output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let mut output = DmaRxBuf::new(rx_descriptors, output).unwrap();
+        let mut input = DmaTxBuf::new(tx_descriptors, input).unwrap();
 
-        let mut aes =
-            Aes::new(peripherals.AES).with_dma(dma_channel, rx_descriptors, tx_descriptors);
+        let aes = Aes::new(peripherals.AES).with_dma(dma_channel);
 
         let keytext = b"SUp4SeCp@sSw0rd";
         let mut keybuf = [0_u8; 16];
         keybuf[..keytext.len()].copy_from_slice(keytext);
 
         let plaintext = b"message";
-        input[..plaintext.len()].copy_from_slice(plaintext);
+        input.as_mut_slice()[..plaintext.len()].copy_from_slice(plaintext);
 
         let encrypted_message = [
             0xb3, 0xc8, 0xd2, 0x3b, 0xa7, 0x36, 0x5f, 0x18, 0x61, 0x70, 0x0, 0x3e, 0xd9, 0x3a,
@@ -54,17 +57,19 @@ mod tests {
 
         let transfer = aes
             .process(
-                &input,
-                &mut output,
+                1,
+                output,
+                input,
                 Mode::Encryption128,
                 CipherMode::Ecb,
                 keybuf,
             )
+            .map_err(|e| e.0)
             .unwrap();
-        transfer.wait().unwrap();
+        (_, output, _) = transfer.wait();
 
         let mut encrypted_output = [0u8; 16];
-        (&mut encrypted_output[..]).copy_from_slice(output);
+        (&mut encrypted_output[..]).copy_from_slice(output.as_slice());
 
         assert_eq!(encrypted_output, encrypted_message);
     }
@@ -79,10 +84,11 @@ mod tests {
             }
         }
 
-        let (mut output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let (output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let mut output = DmaRxBuf::new(rx_descriptors, output).unwrap();
+        let mut input = DmaTxBuf::new(tx_descriptors, input).unwrap();
 
-        let mut aes =
-            Aes::new(peripherals.AES).with_dma(dma_channel, rx_descriptors, tx_descriptors);
+        let aes = Aes::new(peripherals.AES).with_dma(dma_channel);
 
         let keytext = b"SUp4SeCp@sSw0rd";
         let mut keybuf = [0_u8; 16];
@@ -93,21 +99,23 @@ mod tests {
             0xb3, 0xc8, 0xd2, 0x3b, 0xa7, 0x36, 0x5f, 0x18, 0x61, 0x70, 0x0, 0x3e, 0xd9, 0x3a,
             0x31, 0x96,
         ];
-        input.copy_from_slice(&encrypted_message);
+        input.as_mut_slice().copy_from_slice(&encrypted_message);
 
         let transfer = aes
             .process(
-                &input,
-                &mut output,
+                1,
+                output,
+                input,
                 Mode::Decryption128,
                 CipherMode::Ecb,
                 keybuf,
             )
+            .map_err(|e| e.0)
             .unwrap();
-        transfer.wait().unwrap();
+        (_, output, _) = transfer.wait();
 
         let mut decrypted_output = [0u8; 16];
-        (&mut decrypted_output[..]).copy_from_slice(output);
+        (&mut decrypted_output[..]).copy_from_slice(output.as_slice());
 
         assert_eq!(&decrypted_output[..plaintext.len()], plaintext);
     }
@@ -122,17 +130,18 @@ mod tests {
             }
         }
 
-        let (mut output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let (output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let mut output = DmaRxBuf::new(rx_descriptors, output).unwrap();
+        let mut input = DmaTxBuf::new(tx_descriptors, input).unwrap();
 
-        let mut aes =
-            Aes::new(peripherals.AES).with_dma(dma_channel, rx_descriptors, tx_descriptors);
+        let aes = Aes::new(peripherals.AES).with_dma(dma_channel);
 
         let keytext = b"SUp4SeCp@sSw0rd";
         let mut keybuf = [0_u8; 16];
         keybuf[..keytext.len()].copy_from_slice(keytext);
 
         let plaintext = b"message";
-        input[..plaintext.len()].copy_from_slice(plaintext);
+        input.as_mut_slice()[..plaintext.len()].copy_from_slice(plaintext);
 
         let encrypted_message = [
             0x0, 0x63, 0x3f, 0x2, 0xa4, 0x53, 0x9, 0x72, 0x20, 0x6d, 0xc9, 0x8, 0x7c, 0xe5, 0xfd,
@@ -141,17 +150,19 @@ mod tests {
 
         let transfer = aes
             .process(
-                &input,
-                &mut output,
+                1,
+                output,
+                input,
                 Mode::Encryption256,
                 CipherMode::Ecb,
                 keybuf,
             )
+            .map_err(|e| e.0)
             .unwrap();
-        transfer.wait().unwrap();
+        (_, output, _) = transfer.wait();
 
         let mut encrypted_output = [0u8; 16];
-        (&mut encrypted_output[..]).copy_from_slice(output);
+        (&mut encrypted_output[..]).copy_from_slice(output.as_slice());
 
         assert_eq!(encrypted_output, encrypted_message);
     }
@@ -166,10 +177,11 @@ mod tests {
             }
         }
 
-        let (mut output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let (output, rx_descriptors, input, tx_descriptors) = dma_buffers!(DMA_BUFFER_SIZE);
+        let mut output = DmaRxBuf::new(rx_descriptors, output).unwrap();
+        let mut input = DmaTxBuf::new(tx_descriptors, input).unwrap();
 
-        let mut aes =
-            Aes::new(peripherals.AES).with_dma(dma_channel, rx_descriptors, tx_descriptors);
+        let aes = Aes::new(peripherals.AES).with_dma(dma_channel);
 
         let keytext = b"SUp4SeCp@sSw0rd";
         let mut keybuf = [0_u8; 16];
@@ -180,21 +192,23 @@ mod tests {
             0x0, 0x63, 0x3f, 0x2, 0xa4, 0x53, 0x9, 0x72, 0x20, 0x6d, 0xc9, 0x8, 0x7c, 0xe5, 0xfd,
             0xc,
         ];
-        input.copy_from_slice(&encrypted_message);
+        input.as_mut_slice().copy_from_slice(&encrypted_message);
 
         let transfer = aes
             .process(
-                &input,
-                &mut output,
+                1,
+                output,
+                input,
                 Mode::Decryption256,
                 CipherMode::Ecb,
                 keybuf,
             )
+            .map_err(|e| e.0)
             .unwrap();
-        transfer.wait().unwrap();
+        (_, output, _) = transfer.wait();
 
         let mut decrypted_output = [0u8; 16];
-        (&mut decrypted_output[..]).copy_from_slice(output);
+        (&mut decrypted_output[..]).copy_from_slice(output.as_slice());
 
         assert_eq!(&decrypted_output[..plaintext.len()], plaintext);
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
It's as the title says, AES now used the DMA buffers.

#### Testing
HIL
