### PR TITLE
`dma_tx_buffer` no longer returns an error

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `flip-link` feature is now a config option (`ESP_HAL_CONFIG_FLIP_LINK`) (#3001)
 
 - Removed features `psram-quad` and `psram-octal` - replaced by `psram` and the `ESP_HAL_CONFIG_PSRAM_MODE` (`quad`/`octal`) (#3001)
-
+- `dma_tx_buffer` no longer returns an error (#3085)
 - I2C: Async functions are postfixed with `_async`, non-async functions are available in async-mode (#3056)
 
 ### Fixed

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -218,3 +218,12 @@ NOTE: Async support is only supported in ESP32C3 and ESP32C6 for now
 - Adc<'d, ADC>
 + Adc<'d, ADC, Blocking>
 ```
+
+## DMA macro changes
+
+`dma_tx_buffer` no longer returns an error
+
+```diff
+- let mut dma_buf = dma_tx_buffer!(32678).unwrap();
++ let mut dma_buf = dma_tx_buffer!(32678);
+```

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -750,7 +750,7 @@ macro_rules! dma_tx_buffer {
     ($tx_size:expr) => {{
         let (tx_buffer, tx_descriptors) = $crate::dma_buffers_impl!($tx_size, is_circular = false);
 
-        $crate::dma::DmaTxBuf::new(tx_descriptors, tx_buffer)
+        $crate::dma::DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap()
     }};
 }
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -19,7 +19,7 @@
 //! # use esp_hal::dma_tx_buffer;
 //! # use esp_hal::dma::DmaTxBuf;
 //!
-//! # let mut dma_buf = dma_tx_buffer!(32678)?;
+//! # let mut dma_buf = dma_tx_buffer!(32678);
 //!
 //! let tx_pins = TxEightBits::new(
 //!     peripherals.GPIO9,

--- a/hil-test/tests/dma_macros.rs
+++ b/hil-test/tests/dma_macros.rs
@@ -205,18 +205,11 @@ mod tests {
 
     #[test]
     fn test_dma_tx_buffer() {
-        use esp_hal::dma::{DmaBufError, DmaTxBuf};
+        use esp_hal::dma::DmaTxBuf;
         const TX_SIZE: usize = DATA_SIZE;
 
-        fn check(result: Result<DmaTxBuf, DmaBufError>, size: usize) {
-            match result {
-                Ok(tx_buf) => {
-                    core::assert_eq!(tx_buf.len(), size);
-                }
-                Err(_) => {
-                    core::panic!("Failed to create DmaTxBuf");
-                }
-            }
+        fn check(tx_buf: DmaTxBuf, size: usize) {
+            core::assert_eq!(tx_buf.len(), size);
         }
         check(esp_hal::dma_tx_buffer!(TX_SIZE), TX_SIZE);
         check(esp_hal::dma_tx_buffer!(TX_SIZE + 1), TX_SIZE + 1);

--- a/hil-test/tests/i2s_parallel.rs
+++ b/hil-test/tests/i2s_parallel.rs
@@ -49,7 +49,7 @@ mod tests {
         let i2s = I2sParallel::new(ctx.i2s, ctx.dma_channel, 20.MHz(), pins, NoPin).into_async();
 
         // Try sending an empty buffer, as an edge case
-        let tx_buf = esp_hal::dma_tx_buffer!(4096).unwrap();
+        let tx_buf = esp_hal::dma_tx_buffer!(4096);
         let mut xfer = i2s
             .send(tx_buf)
             .map_err(|_| "failed to send empty buffer")

--- a/qa-test/src/bin/lcd_i8080.rs
+++ b/qa-test/src/bin/lcd_i8080.rs
@@ -49,7 +49,7 @@ fn main() -> ! {
     let lcd_wr = peripherals.GPIO47; // Write clock
     let lcd_te = peripherals.GPIO48; // Frame sync
 
-    let dma_tx_buf = dma_tx_buffer!(4000).unwrap();
+    let dma_tx_buf = dma_tx_buffer!(4000);
 
     let delay = Delay::new();
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The error from this macro isn't really actionable by the user as it means there's a bug in the macro.
The only thing to do is panic really.

#### Testing
CI
