### PR TITLE
Remove `DmaChannel::set_priority`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `Pin`, `RtcPin` and `RtcPinWithResistors` implementations from `Flex` (#2938)
 - OutputOpenDrain has been removed (#3029)
 - The fields of config structs are no longer public (#3011)
+- Removed the dysfunctional `DmaChannel::set_priority` function (#3088)
 
 ## [0.23.1] - 2025-01-15
 

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -42,11 +42,6 @@ impl DmaChannel for AnyGdmaChannel {
     type Rx = AnyGdmaRxChannel;
     type Tx = AnyGdmaTxChannel;
 
-    fn set_priority(&self, priority: DmaPriority) {
-        AnyGdmaRxChannel(self.0).set_priority(priority);
-        AnyGdmaTxChannel(self.0).set_priority(priority);
-    }
-
     unsafe fn split_internal(self, _: crate::private::Internal) -> (Self::Rx, Self::Tx) {
         (AnyGdmaRxChannel(self.0), AnyGdmaTxChannel(self.0))
     }
@@ -675,10 +670,6 @@ macro_rules! impl_channel {
             impl DmaChannel for [<DmaChannel $num>] {
                 type Rx = AnyGdmaRxChannel;
                 type Tx = AnyGdmaTxChannel;
-
-                fn set_priority(&self, priority: DmaPriority) {
-                    AnyGdmaChannel($num).set_priority(priority);
-                }
 
                 unsafe fn split_internal(self, _: $crate::private::Internal) -> (Self::Rx, Self::Tx) {
                     (AnyGdmaRxChannel($num), AnyGdmaTxChannel($num))

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1618,10 +1618,6 @@ pub trait DmaChannel: Peripheral<P = Self> {
     /// A description of the TX half of a DMA Channel.
     type Tx: DmaTxChannel;
 
-    /// Sets the priority of the DMA channel.
-    #[cfg(gdma)]
-    fn set_priority(&self, priority: DmaPriority);
-
     /// Splits the DMA channel into its RX and TX halves.
     #[cfg(any(esp32c6, esp32h2, esp32s3))] // TODO relax this to allow splitting on all chips
     fn split(self) -> (Self::Rx, Self::Tx) {


### PR DESCRIPTION
Closes #3085

The intended way is to configure either the dma-enabled peripheral, or the transfer itself to run at a certain priority. Also, we treat the DMA channels as peripheral singletons, and those aren't supposed to have any methods, logic, or even state attached to them.