### PR TITLE
Remove note about fixed cargo bug

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -100,10 +100,6 @@
 #![doc = ""]
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_hal_config_table.md"))]
 #![doc = ""]
-//! It's important to note that due to a [bug in cargo](https://github.com/rust-lang/cargo/issues/10358),
-//! any modifications to the environment, local or otherwise will only get
-//! picked up on a full clean build of the project.
-//!
 //! ## `Peripheral` Pattern
 //!
 //! Drivers take pins and peripherals as [peripheral::Peripheral] in most

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -79,11 +79,6 @@
 //! for this crate:
 #![doc = ""]
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_wifi_config_table.md"))]
-#![doc = ""]
-//! It's important to note that due to a [bug in cargo](https://github.com/rust-lang/cargo/issues/10358),
-//! any modifications to the environment, local or otherwise will only get
-//! picked up on a full clean build of the project.
-
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![no_std]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]


### PR DESCRIPTION
https://github.com/rust-lang/cargo/issues/10358 has been fixed, we probably no longer want to call it out.

The fix will be part of 1.86, so we can delay merging the PR until that, if important.