### PR TITLE
Add auto-writeback support to DMA buffers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Async support for ADC oneshot reads for ESP32C2, ESP32C3, ESP32C6 and ESP32H2 (#2925, #3082)
 - `ESP_HAL_CONFIG_XTAL_FREQUENCY` configuration. For now, chips other than ESP32 and ESP32-C2 have a single option only. (#3054)
 - Added more validation to UART and SPI. User can now specify the baudrate tolerance of UART config (#3074)
+- Add auto-writeback support to DMA buffers (#3107)
 
 ### Changed
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1998,6 +1998,7 @@ where
             accesses_psram: uses_psram,
             burst_transfer: BurstConfig::default(),
             check_owner: Some(false),
+            auto_write_back: true,
         };
         self.do_prepare(preparation, peri)
     }
@@ -2226,6 +2227,8 @@ where
         self.tx_impl.set_burst_mode(preparation.burst_transfer);
         self.tx_impl.set_descr_burst_mode(true);
         self.tx_impl.set_check_owner(preparation.check_owner);
+        self.tx_impl
+            .set_auto_write_back(preparation.auto_write_back);
 
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
 
@@ -2293,12 +2296,10 @@ where
             accesses_psram: uses_psram,
             burst_transfer: BurstConfig::default(),
             check_owner: Some(false),
+            // enable descriptor write back in circular mode
+            auto_write_back: !(*chain.last()).next.is_null(),
         };
         self.do_prepare(preparation, peri)?;
-
-        // enable descriptor write back in circular mode
-        self.tx_impl
-            .set_auto_write_back(!(*chain.last()).next.is_null());
 
         Ok(())
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Allows `DmaTxBuffer`s to configure auto write back mode on the channel.
This is important for streaming/circular transfers as you need to know when the DMA is done with the descriptor.

#### Testing
CI/HIL
