### PR TITLE
Fix auto writeback on CryptoDMA

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue on ESP32 and S2 where short asynchronous Timer delays would never resolve (#3093)
 - Fixed an issue setting higher UART baud rates (#3104)
 - ESP32-S2: Fixed linker script (#3096)
+- Fix auto writeback on Crypto DMA (#3108)
 
 ### Removed
 

--- a/esp-hal/src/dma/pdma/crypto.rs
+++ b/esp-hal/src/dma/pdma/crypto.rs
@@ -143,8 +143,9 @@ impl TxRegisterAccess for CryptoDmaTxChannel {
     }
 
     fn set_auto_write_back(&self, enable: bool) {
-        // there is no `auto_wrback` for SPI
-        assert!(!enable);
+        self.regs()
+            .conf()
+            .modify(|_, w| w.out_auto_wrback().bit(enable));
     }
 
     fn last_dscr_address(&self) -> usize {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This was probably some copypasta on the initial PR that implemented CryproDMA on the S2

#### Testing
CI/HIL
