### PR TITLE
Format PanicInfo with defmt

### DIFF
--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -60,7 +60,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     println!("{}", info);
 
     #[cfg(feature = "defmt")]
-    println!("{}", defmt::Display2Format(info));
+    println!("{}", info);
 
     println!("");
     println!("Backtrace:");


### PR DESCRIPTION
Remove use of Display2Format to format PanicInfo. Format has been implemented on PanicInfo.

https://docs.rs/defmt/0.3.10/defmt/trait.Format.html
