### PR TITLE
DO NOT MERGE: polishing experiments

### DIFF
--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 
 /// The ECC Accelerator driver instance
-pub struct Ecc<'d, Dm: DriverMode> {
+pub struct Ecc<'d, Dm> {
     ecc: PeripheralRef<'d, ECC>,
     alignment_helper: AlignmentHelper<SocDependentEndianess>,
     phantom: PhantomData<Dm>,

--- a/esp-hal/src/hmac.rs
+++ b/esp-hal/src/hmac.rs
@@ -298,7 +298,7 @@ impl<'d> Hmac<'d> {
         // The padding will be spanned over 2 blocks
         if mod_cursor > 56 {
             let pad_len = 64 - mod_cursor;
-            self.alignment_helper.volatile_write_bytes(
+            self.alignment_helper.volatile_write(
                 #[cfg(esp32s2)]
                 self.regs().wr_message_(0).as_ptr(),
                 #[cfg(not(esp32s2))]
@@ -320,7 +320,7 @@ impl<'d> Hmac<'d> {
         let mod_cursor = self.byte_written % 64;
         let pad_len = 64 - mod_cursor - core::mem::size_of::<u64>();
 
-        self.alignment_helper.volatile_write_bytes(
+        self.alignment_helper.volatile_write(
             #[cfg(esp32s2)]
             self.regs().wr_message_(0).as_ptr(),
             #[cfg(not(esp32s2))]

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -430,7 +430,7 @@ impl Default for Config {
 /// ```
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct I2c<'d, Dm: DriverMode> {
+pub struct I2c<'d, Dm> {
     i2c: PeripheralRef<'d, AnyI2c>,
     phantom: PhantomData<Dm>,
     config: Config,
@@ -467,7 +467,7 @@ impl<Dm: DriverMode> embedded_hal::i2c::I2c for I2c<'_, Dm> {
     }
 }
 
-impl<'d, Dm: DriverMode> I2c<'d, Dm> {
+impl<'d, Dm> I2c<'d, Dm> {
     fn driver(&self) -> Driver<'_> {
         Driver {
             info: self.i2c.info(),

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -463,7 +463,7 @@ impl<Dm> I2sTx<'_, Dm>
 where
     Dm: DriverMode,
 {
-    fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
+    fn write(&mut self, data: &[u8]) -> Result<(), Error> {
         self.start_tx_transfer(&data, false)?;
 
         // wait until I2S_TX_IDLE is 1
@@ -505,8 +505,8 @@ where
     }
 
     /// Writes a slice of data to the I2S peripheral.
-    pub fn write(&mut self, words: &[impl AcceptedWord]) -> Result<(), Error> {
-        self.write_bytes(unsafe {
+    pub fn write_words(&mut self, words: &[impl AcceptedWord]) -> Result<(), Error> {
+        self.write(unsafe {
             core::slice::from_raw_parts(words.as_ptr().cast::<u8>(), core::mem::size_of_val(words))
         })
     }
@@ -591,7 +591,7 @@ impl<Dm> I2sRx<'_, Dm>
 where
     Dm: DriverMode,
 {
-    fn read_bytes(&mut self, mut data: &mut [u8]) -> Result<(), Error> {
+    fn read(&mut self, mut data: &mut [u8]) -> Result<(), Error> {
         self.start_rx_transfer(&mut data, false)?;
 
         // wait until I2S_RX_IDLE is 1
@@ -634,12 +634,12 @@ where
 
     /// Reads a slice of data from the I2S peripheral and stores it in the
     /// provided buffer.
-    pub fn read(&mut self, words: &mut [impl AcceptedWord]) -> Result<(), Error> {
+    pub fn read_words(&mut self, words: &mut [impl AcceptedWord]) -> Result<(), Error> {
         if core::mem::size_of_val(words) > 4096 || words.is_empty() {
             return Err(Error::IllegalArgument);
         }
 
-        self.read_bytes(unsafe {
+        self.read(unsafe {
             core::slice::from_raw_parts_mut(
                 words.as_mut_ptr().cast::<u8>(),
                 core::mem::size_of_val(words),

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -130,7 +130,7 @@ pub enum ConfigError {
 }
 
 /// Represents the RGB LCD interface.
-pub struct Dpi<'d, Dm: DriverMode> {
+pub struct Dpi<'d, Dm> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
     tx_channel: ChannelTx<'d, Blocking, PeripheralTxChannel<LCD_CAM>>,
     _guard: GenericPeripheralGuard<{ system::Peripheral::LcdCam as u8 }>,

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -92,7 +92,7 @@ pub enum ConfigError {
 }
 
 /// Represents the I8080 LCD interface.
-pub struct I8080<'d, Dm: DriverMode> {
+pub struct I8080<'d, Dm> {
     lcd_cam: PeripheralRef<'d, LCD_CAM>,
     tx_channel: ChannelTx<'d, Blocking, PeripheralTxChannel<LCD_CAM>>,
     _guard: GenericPeripheralGuard<{ system::Peripheral::LcdCam as u8 }>,

--- a/esp-hal/src/reg_access.rs
+++ b/esp-hal/src/reg_access.rs
@@ -127,13 +127,7 @@ impl<E: EndianessConverter> AlignmentHelper<E> {
 
     // This function is similar to `volatile_set_memory` but will prepend data that
     // was previously ingested and ensure aligned (u32) writes.
-    pub fn volatile_write_bytes(
-        &mut self,
-        dst_ptr: *mut u32,
-        val: u8,
-        count: usize,
-        offset: usize,
-    ) {
+    pub fn volatile_write(&mut self, dst_ptr: *mut u32, val: u8, count: usize, offset: usize) {
         let dst_ptr = unsafe { dst_ptr.add(offset) };
 
         let mut cursor = if self.buf_fill != 0 {

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -120,8 +120,8 @@ impl crate::interrupt::InterruptConfigurable for Sha<'_> {
 }
 
 // A few notes on this implementation with regards to 'memcpy',
-// - It seems that ptr::write_bytes already acts as volatile, while ptr::copy_*
-//   does not (in this case)
+// - It seems that ptr::write already acts as volatile, while ptr::copy_* does
+//   not (in this case)
 // - The registers are *not* cleared after processing, so padding needs to be
 //   written out
 // - This component uses core::intrinsics::volatile_* which is unstable, but is
@@ -256,7 +256,7 @@ impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> ShaDigest<'d, A, S> {
             // Zero out remaining data if buffer is almost full (>=448/896), and process
             // buffer
             let pad_len = A::CHUNK_LENGTH - mod_cursor;
-            self.alignment_helper.volatile_write_bytes(
+            self.alignment_helper.volatile_write(
                 m_mem(&self.sha.borrow().sha, 0),
                 0_u8,
                 pad_len / self.alignment_helper.align_size(),
@@ -274,7 +274,7 @@ impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> ShaDigest<'d, A, S> {
         let mod_cursor = self.cursor % A::CHUNK_LENGTH; // Should be zero if branched above
         let pad_len = A::CHUNK_LENGTH - mod_cursor - size_of::<u64>();
 
-        self.alignment_helper.volatile_write_bytes(
+        self.alignment_helper.volatile_write(
             m_mem(&self.sha.borrow().sha, 0),
             0,
             pad_len / self.alignment_helper.align_size(),

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -675,8 +675,8 @@ where
 
     /// Write bytes to SPI. After writing, flush is called to ensure all data
     /// has been transmitted.
-    pub fn write_bytes(&mut self, words: &[u8]) -> Result<(), Error> {
-        self.driver().write_bytes(words)?;
+    pub fn write(&mut self, words: &[u8]) -> Result<(), Error> {
+        self.driver().write(words)?;
         self.driver().flush()?;
 
         Ok(())
@@ -684,8 +684,8 @@ where
 
     /// Read bytes from SPI. The provided slice is filled with data received
     /// from the slave.
-    pub fn read_bytes(&mut self, words: &mut [u8]) -> Result<(), Error> {
-        self.driver().read_bytes(words)
+    pub fn read(&mut self, words: &mut [u8]) -> Result<(), Error> {
+        self.driver().read(words)
     }
 
     /// Sends `words` to the slave. Returns the `words` received from the slave.
@@ -1145,7 +1145,7 @@ where
         self.driver().configure_datalen(buffer.len(), 0);
         self.driver().start_operation();
         self.driver().flush()?;
-        self.driver().read_bytes_from_fifo(buffer)
+        self.driver().read_from_fifo(buffer)
     }
 
     /// Half-duplex write.
@@ -1208,7 +1208,7 @@ where
 
         if !buffer.is_empty() {
             // re-using the full-duplex write here
-            self.driver().write_bytes(buffer)?;
+            self.driver().write(buffer)?;
         } else {
             self.driver().start_operation();
         }
@@ -2534,11 +2534,11 @@ mod ehal1 {
         Dm: DriverMode,
     {
         fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
-            self.driver().read_bytes(words)
+            self.driver().read(words)
         }
 
         fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-            self.driver().write_bytes(words)
+            self.driver().write(words)
         }
 
         fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
@@ -2578,7 +2578,7 @@ mod ehal1 {
                 if read_inc > 0 {
                     SpiBus::flush(self)?;
                     self.driver()
-                        .read_bytes_from_fifo(&mut read[read_from..read_to])?;
+                        .read_from_fifo(&mut read[read_from..read_to])?;
                 }
 
                 write_from = write_to;
@@ -2601,14 +2601,14 @@ mod ehal1 {
             // We need to flush because the blocking transfer functions may return while a
             // transfer is still in progress.
             self.flush_async().await?;
-            self.driver().read_bytes_async(words).await
+            self.driver().read_async(words).await
         }
 
         async fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
             // We need to flush because the blocking transfer functions may return while a
             // transfer is still in progress.
             self.flush_async().await?;
-            self.driver().write_bytes_async(words).await
+            self.driver().write_async(words).await
         }
 
         async fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
@@ -2647,7 +2647,7 @@ mod ehal1 {
 
                 if read_inc > 0 {
                     self.driver()
-                        .read_bytes_from_fifo(&mut read[read_from..read_to])?;
+                        .read_from_fifo(&mut read[read_from..read_to])?;
                 }
 
                 write_from = write_to;
@@ -3233,7 +3233,7 @@ impl Driver {
     /// have been sent to the wire. If you must ensure that the whole
     /// messages was written correctly, use [`Self::flush`].
     #[cfg_attr(place_spi_driver_in_ram, ram)]
-    fn write_bytes(&self, words: &[u8]) -> Result<(), Error> {
+    fn write(&self, words: &[u8]) -> Result<(), Error> {
         let num_chunks = words.len() / FIFO_SIZE;
 
         // Flush in case previous writes have not completed yet, required as per
@@ -3260,7 +3260,7 @@ impl Driver {
 
     /// Write bytes to SPI.
     #[cfg_attr(place_spi_driver_in_ram, ram)]
-    async fn write_bytes_async(&self, words: &[u8]) -> Result<(), Error> {
+    async fn write_async(&self, words: &[u8]) -> Result<(), Error> {
         // The fifo has a limited fixed size, so the data must be chunked and then
         // transmitted
         for chunk in words.chunks(FIFO_SIZE) {
@@ -3277,13 +3277,13 @@ impl Driver {
     /// perform flushing. If you want to read the response to something you
     /// have written before, consider using [`Self::transfer`] instead.
     #[cfg_attr(place_spi_driver_in_ram, ram)]
-    fn read_bytes(&self, words: &mut [u8]) -> Result<(), Error> {
+    fn read(&self, words: &mut [u8]) -> Result<(), Error> {
         let empty_array = [EMPTY_WRITE_PAD; FIFO_SIZE];
 
         for chunk in words.chunks_mut(FIFO_SIZE) {
-            self.write_bytes(&empty_array[0..chunk.len()])?;
+            self.write(&empty_array[0..chunk.len()])?;
             self.flush()?;
-            self.read_bytes_from_fifo(chunk)?;
+            self.read_from_fifo(chunk)?;
         }
         Ok(())
     }
@@ -3294,12 +3294,12 @@ impl Driver {
     /// perform flushing. If you want to read the response to something you
     /// have written before, consider using [`Self::transfer`] instead.
     #[cfg_attr(place_spi_driver_in_ram, ram)]
-    async fn read_bytes_async(&self, words: &mut [u8]) -> Result<(), Error> {
+    async fn read_async(&self, words: &mut [u8]) -> Result<(), Error> {
         let empty_array = [EMPTY_WRITE_PAD; FIFO_SIZE];
 
         for chunk in words.chunks_mut(FIFO_SIZE) {
-            self.write_bytes_async(&empty_array[0..chunk.len()]).await?;
-            self.read_bytes_from_fifo(chunk)?;
+            self.write_async(&empty_array[0..chunk.len()]).await?;
+            self.read_from_fifo(chunk)?;
         }
         Ok(())
     }
@@ -3311,7 +3311,7 @@ impl Driver {
     /// something you have written before, consider using [`Self::transfer`]
     /// instead.
     #[cfg_attr(place_spi_driver_in_ram, ram)]
-    fn read_bytes_from_fifo(&self, words: &mut [u8]) -> Result<(), Error> {
+    fn read_from_fifo(&self, words: &mut [u8]) -> Result<(), Error> {
         let reg_block = self.regs();
 
         for chunk in words.chunks_mut(FIFO_SIZE) {
@@ -3345,9 +3345,9 @@ impl Driver {
     #[cfg_attr(place_spi_driver_in_ram, ram)]
     fn transfer<'w>(&self, words: &'w mut [u8]) -> Result<&'w [u8], Error> {
         for chunk in words.chunks_mut(FIFO_SIZE) {
-            self.write_bytes(chunk)?;
+            self.write(chunk)?;
             self.flush()?;
-            self.read_bytes_from_fifo(chunk)?;
+            self.read_from_fifo(chunk)?;
         }
 
         Ok(words)
@@ -3356,8 +3356,8 @@ impl Driver {
     #[cfg_attr(place_spi_driver_in_ram, ram)]
     async fn transfer_in_place_async(&self, words: &mut [u8]) -> Result<(), Error> {
         for chunk in words.chunks_mut(FIFO_SIZE) {
-            self.write_bytes_async(chunk).await?;
-            self.read_bytes_from_fifo(chunk)?;
+            self.write_async(chunk).await?;
+            self.read_from_fifo(chunk)?;
         }
 
         Ok(())

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -655,7 +655,7 @@ impl BaudRate {
 }
 
 /// An inactive TWAI peripheral in the "Reset"/configuration state.
-pub struct TwaiConfiguration<'d, Dm: DriverMode> {
+pub struct TwaiConfiguration<'d, Dm> {
     twai: PeripheralRef<'d, AnyTwai>,
     filter: Option<(FilterType, [u8; 8])>,
     phantom: PhantomData<Dm>,
@@ -1014,7 +1014,7 @@ impl crate::interrupt::InterruptConfigurable for TwaiConfiguration<'_, Blocking>
 ///
 /// In this mode, the TWAI controller can transmit and receive messages
 /// including error signals (such as error and overload frames).
-pub struct Twai<'d, Dm: DriverMode> {
+pub struct Twai<'d, Dm> {
     twai: PeripheralRef<'d, AnyTwai>,
     tx: TwaiTx<'d, Dm>,
     rx: TwaiRx<'d, Dm>,
@@ -1119,7 +1119,7 @@ where
 }
 
 /// Interface to the TWAI transmitter part.
-pub struct TwaiTx<'d, Dm: DriverMode> {
+pub struct TwaiTx<'d, Dm> {
     twai: PeripheralRef<'d, AnyTwai>,
     phantom: PhantomData<Dm>,
     _guard: PeripheralGuard,
@@ -1164,7 +1164,7 @@ where
 }
 
 /// Interface to the TWAI receiver part.
-pub struct TwaiRx<'d, Dm: DriverMode> {
+pub struct TwaiRx<'d, Dm> {
     twai: PeripheralRef<'d, AnyTwai>,
     phantom: PhantomData<Dm>,
     _guard: PeripheralGuard,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -406,7 +406,7 @@ where
 /// .with_rx(peripherals.GPIO1)
 /// .with_tx(peripherals.GPIO2);
 ///
-/// uart.write_bytes(b"Hello world!")?;
+/// uart.write(b"Hello world!")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -552,7 +552,7 @@ where
 
     /// Writes bytes
     #[instability::unstable]
-    pub fn write_bytes(&mut self, data: &[u8]) -> Result<usize, Error> {
+    pub fn write(&mut self, data: &[u8]) -> Result<usize, Error> {
         let count = data.len();
 
         for &byte in data {
@@ -578,8 +578,10 @@ where
 
     /// Flush the transmit buffer of the UART
     #[instability::unstable]
-    pub fn flush(&mut self) {
+    pub fn flush(&mut self) -> Result<(), Error> {
         while !self.is_tx_idle() {}
+
+        Ok(())
     }
 
     /// Checks if the TX line is idle for this UART instance.
@@ -820,20 +822,16 @@ where
 
     /// Reads bytes from the UART
     #[instability::unstable]
-    pub fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error> {
-        let buffered = self.read_buffered_bytes(buf)?;
-        let buf = &mut buf[buffered..];
-
-        for byte in buf.iter_mut() {
-            loop {
-                if let Some(b) = self.read_byte() {
-                    *byte = b;
-                    break;
-                }
-                self.check_for_errors()?;
-            }
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        if buf.is_empty() {
+            return Ok(0);
         }
-        Ok(())
+
+        while self.rx_fifo_count() == 0 {
+            // Block until we received at least one byte
+        }
+
+        self.read_buffered_bytes(buf)
     }
 
     /// Read all available bytes from the RX FIFO into the provided buffer and
@@ -1106,9 +1104,9 @@ where
     /// let (mut rx, mut tx) = uart1.split();
     ///
     /// // Each component can be used individually to interact with the UART:
-    /// tx.write_bytes(&[42u8])?;
+    /// tx.write(&[42u8])?;
     /// let mut byte = [0u8; 1];
-    /// rx.read_bytes(&mut byte);
+    /// rx.read(&mut byte);
     /// # Ok(())
     /// # }
     /// ```
@@ -1125,12 +1123,12 @@ where
     /// #     peripherals.UART1,
     /// #     Config::default())?;
     /// // Write bytes out over the UART:
-    /// uart1.write_bytes(b"Hello, world!")?;
+    /// uart1.write(b"Hello, world!")?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn write_bytes(&mut self, data: &[u8]) -> Result<usize, Error> {
-        self.tx.write_bytes(data)
+    pub fn write(&mut self, data: &[u8]) -> Result<usize, Error> {
+        self.tx.write(data)
     }
 
     /// Reads and clears errors set by received data.
@@ -1140,8 +1138,8 @@ where
     }
 
     /// Reads bytes from the UART
-    pub fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error> {
-        self.rx.read_bytes(buf)
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        self.rx.read(buf)
     }
 
     /// Read all available bytes from the RX FIFO into the provided buffer and
@@ -1189,7 +1187,7 @@ where
     }
 
     /// Flush the transmit buffer of the UART
-    pub fn flush(&mut self) {
+    pub fn flush(&mut self) -> Result<(), Error> {
         self.tx.flush()
     }
 
@@ -1432,7 +1430,7 @@ where
 
     #[inline]
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
-        self.write_bytes(s.as_bytes())?;
+        self.write(s.as_bytes())?;
         Ok(())
     }
 }
@@ -1453,8 +1451,7 @@ where
 {
     #[inline]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        self.write_bytes(s.as_bytes())
-            .map_err(|_| core::fmt::Error)?;
+        self.write(s.as_bytes()).map_err(|_| core::fmt::Error)?;
         Ok(())
     }
 }
@@ -1490,15 +1487,7 @@ where
     Dm: DriverMode,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        if buf.is_empty() {
-            return Ok(0);
-        }
-
-        while self.rx_fifo_count() == 0 {
-            // Block until we received at least one byte
-        }
-
-        self.read_buffered_bytes(buf)
+        self.read(buf)
     }
 }
 
@@ -1532,7 +1521,7 @@ where
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        embedded_io::Write::flush(&mut self.tx)
+        self.tx.flush()
     }
 }
 
@@ -1542,12 +1531,11 @@ where
     Dm: DriverMode,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.write_bytes(buf)
+        self.write(buf)
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        self.flush();
-        Ok(())
+        self.flush()
     }
 }
 
@@ -1826,7 +1814,7 @@ impl UartRx<'_, Async> {
 
             let events_happened = UartRxFuture::new(self.uart.reborrow(), events).await;
             // always drain the fifo, if an error has occurred the data is lost
-            let read_bytes = self.flush_buffer(buf);
+            let read = self.flush_buffer(buf);
             // check error events
             rx_event_check_for_error(events_happened)?;
             // Unfortunately, the uart's rx-timeout counter counts up whenever there is
@@ -1837,8 +1825,8 @@ impl UartRx<'_, Async> {
                 .int_clr()
                 .write(|w| w.rxfifo_tout().clear_bit_by_one());
 
-            if read_bytes > 0 {
-                return Ok(read_bytes);
+            if read > 0 {
+                return Ok(read);
             }
         }
     }

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -36,70 +36,6 @@
 //! available. See the examples below for more information on how to interact
 //! with this driver.
 //!
-//! ## Example
-//!
-//! ### Handling UART Interrupts
-//! Notice, that in practice a proper serial terminal should be used
-//! to connect to the board (espmonitor and espflash won't work)
-//! ```rust, no_run
-#![doc = crate::before_snippet!()]
-//! # use esp_hal::delay::Delay;
-//! # use esp_hal::uart::{AtCmdConfig, Config, RxConfig, Uart, UartInterrupt};
-//! # let delay = Delay::new();
-//! # let config = Config::default().with_rx(
-//! #    RxConfig::default().with_fifo_full_threshold(30)
-//! # );
-//! # let mut uart0 = Uart::new(
-//! #    peripherals.UART0,
-//! #    config)?;
-//! uart0.set_interrupt_handler(interrupt_handler);
-//!
-//! critical_section::with(|cs| {
-//!     uart0.set_at_cmd(AtCmdConfig::default().with_cmd_char(b'#'));
-//!     uart0.listen(UartInterrupt::AtCmd | UartInterrupt::RxFifoFull);
-//!
-//!     SERIAL.borrow_ref_mut(cs).replace(uart0);
-//! });
-//!
-//! loop {
-//!     println!("Send `#` character or >=30 characters");
-//!     delay.delay(Duration::from_secs(1));
-//! }
-//! # }
-//!
-//! # use core::cell::RefCell;
-//! # use critical_section::Mutex;
-//! # use esp_hal::uart::Uart;
-//! static SERIAL: Mutex<RefCell<Option<Uart<esp_hal::Blocking>>>> =
-//!     Mutex::new(RefCell::new(None));
-//!
-//! # use esp_hal::uart::UartInterrupt;
-//! # use core::fmt::Write;
-//! #[handler]
-//! fn interrupt_handler() {
-//!     critical_section::with(|cs| {
-//!         let mut serial = SERIAL.borrow_ref_mut(cs);
-//!         if let Some(serial) = serial.as_mut() {
-//!             let mut buf = [0u8; 64];
-//!             if let Ok(cnt) = serial.read_buffered_bytes(&mut buf) {
-//!                 println!("Read {} bytes", cnt);
-//!             }
-//!
-//!             let pending_interrupts = serial.interrupts();
-//!             println!(
-//!                 "Interrupt AT-CMD: {} RX-FIFO-FULL: {}",
-//!                 pending_interrupts.contains(UartInterrupt::AtCmd),
-//!                 pending_interrupts.contains(UartInterrupt::RxFifoFull),
-//!             );
-//!
-//!             serial.clear_interrupts(
-//!                 UartInterrupt::AtCmd | UartInterrupt::RxFifoFull
-//!             );
-//!         }
-//!     });
-//! }
-//! ```
-//! 
 //! [embedded-hal]: embedded_hal
 //! [embedded-io]: embedded_io
 //! [embedded-hal-async]: embedded_hal_async
@@ -460,12 +396,27 @@ where
 }
 
 /// UART (Full-duplex)
+///
+/// ```rust, no_run
+#[doc = crate::before_snippet!()]
+/// # use esp_hal::uart::{Config, Uart};
+/// let mut uart = Uart::new(
+///     peripherals.UART0,
+///     Config::default())?
+/// .with_rx(peripherals.GPIO1)
+/// .with_tx(peripherals.GPIO2);
+///
+/// uart.write_bytes(b"Hello world!")?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct Uart<'d, Dm> {
     rx: UartRx<'d, Dm>,
     tx: UartTx<'d, Dm>,
 }
 
 /// UART (Transmit)
+#[instability::unstable]
 pub struct UartTx<'d, Dm> {
     uart: PeripheralRef<'d, AnyUart>,
     phantom: PhantomData<Dm>,
@@ -475,6 +426,7 @@ pub struct UartTx<'d, Dm> {
 }
 
 /// UART (Receive)
+#[instability::unstable]
 pub struct UartRx<'d, Dm> {
     uart: PeripheralRef<'d, AnyUart>,
     phantom: PhantomData<Dm>,
@@ -562,6 +514,7 @@ where
     Dm: DriverMode,
 {
     /// Configure RTS pin
+    #[instability::unstable]
     pub fn with_rts(mut self, rts: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(rts);
         rts.set_to_push_pull_output();
@@ -576,6 +529,7 @@ where
     /// TX signal.
     ///
     /// Disconnects the previous pin that was assigned with `with_tx`.
+    #[instability::unstable]
     pub fn with_tx(mut self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
         crate::into_mapped_ref!(tx);
         // Make sure we don't cause an unexpected low pulse on the pin.
@@ -597,6 +551,7 @@ where
     }
 
     /// Writes bytes
+    #[instability::unstable]
     pub fn write_bytes(&mut self, data: &[u8]) -> Result<usize, Error> {
         let count = data.len();
 
@@ -622,6 +577,7 @@ where
     }
 
     /// Flush the transmit buffer of the UART
+    #[instability::unstable]
     pub fn flush(&mut self) {
         while !self.is_tx_idle() {}
     }
@@ -677,6 +633,7 @@ impl<'d> UartTx<'d, Blocking> {
     /// # Ok(())
     /// # }
     /// ```
+    #[instability::unstable]
     pub fn new(
         uart: impl Peripheral<P = impl Instance> + 'd,
         config: Config,
@@ -687,6 +644,7 @@ impl<'d> UartTx<'d, Blocking> {
     }
 
     /// Reconfigures the driver to operate in [`Async`] mode.
+    #[instability::unstable]
     pub fn into_async(self) -> UartTx<'d, Async> {
         if !self.uart.state().is_rx_async.load(Ordering::Acquire) {
             self.uart
@@ -707,6 +665,7 @@ impl<'d> UartTx<'d, Blocking> {
 
 impl<'d> UartTx<'d, Async> {
     /// Reconfigures the driver to operate in [`Blocking`] mode.
+    #[instability::unstable]
     pub fn into_blocking(self) -> UartTx<'d, Blocking> {
         self.uart
             .state()
@@ -755,6 +714,7 @@ where
     }
 
     /// Configure CTS pin
+    #[instability::unstable]
     pub fn with_cts(self, cts: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(cts);
         cts.init_input(Pull::None);
@@ -771,6 +731,7 @@ where
     /// configure the driver side (i.e. the TX pin), or ensure that the line is
     /// initially high, to avoid receiving a non-data byte caused by an
     /// initial low signal level.
+    #[instability::unstable]
     pub fn with_rx(self, rx: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
         crate::into_mapped_ref!(rx);
         rx.init_input(Pull::Up);
@@ -858,6 +819,7 @@ where
     }
 
     /// Reads bytes from the UART
+    #[instability::unstable]
     pub fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error> {
         let buffered = self.read_buffered_bytes(buf)?;
         let buf = &mut buf[buffered..];
@@ -876,6 +838,7 @@ where
 
     /// Read all available bytes from the RX FIFO into the provided buffer and
     /// returns the number of read bytes without blocking.
+    #[instability::unstable]
     pub fn read_buffered_bytes(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         let mut count = 0;
         while count < buf.len() {
@@ -974,6 +937,7 @@ impl<'d> UartRx<'d, Blocking> {
     /// # Ok(())
     /// # }
     /// ```
+    #[instability::unstable]
     pub fn new(
         uart: impl Peripheral<P = impl Instance> + 'd,
         config: Config,
@@ -984,6 +948,7 @@ impl<'d> UartRx<'d, Blocking> {
     }
 
     /// Reconfigures the driver to operate in [`Async`] mode.
+    #[instability::unstable]
     pub fn into_async(self) -> UartRx<'d, Async> {
         if !self.uart.state().is_tx_async.load(Ordering::Acquire) {
             self.uart
@@ -1002,6 +967,7 @@ impl<'d> UartRx<'d, Blocking> {
 
 impl<'d> UartRx<'d, Async> {
     /// Reconfigures the driver to operate in [`Blocking`] mode.
+    #[instability::unstable]
     pub fn into_blocking(self) -> UartRx<'d, Blocking> {
         self.uart
             .state()
@@ -1146,6 +1112,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
+    #[instability::unstable]
     pub fn split(self) -> (UartRx<'d, Dm>, UartTx<'d, Dm>) {
         (self.rx, self.tx)
     }
@@ -1179,6 +1146,7 @@ where
 
     /// Read all available bytes from the RX FIFO into the provided buffer and
     /// returns the number of read bytes without blocking.
+    #[instability::unstable]
     pub fn read_buffered_bytes(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         self.rx.read_buffered_bytes(buf)
     }
@@ -1351,6 +1319,68 @@ impl Uart<'_, Blocking> {
     }
 
     /// Listen for the given interrupts
+    ///
+    /// ### Example
+    /// **Note**: In practice a proper serial terminal should be used
+    /// to connect to the board (espflash won't work)
+    /// ```rust, no_run
+    #[doc = crate::before_snippet!()]
+    /// # use esp_hal::delay::Delay;
+    /// # use esp_hal::uart::{AtCmdConfig, Config, RxConfig, Uart, UartInterrupt};
+    /// # let delay = Delay::new();
+    /// # let config = Config::default().with_rx(
+    /// #    RxConfig::default().with_fifo_full_threshold(30)
+    /// # );
+    /// # let mut uart0 = Uart::new(
+    /// #    peripherals.UART0,
+    /// #    config)?;
+    /// uart0.set_interrupt_handler(interrupt_handler);
+    ///
+    /// critical_section::with(|cs| {
+    ///     uart0.set_at_cmd(AtCmdConfig::default().with_cmd_char(b'#'));
+    ///     uart0.listen(UartInterrupt::AtCmd | UartInterrupt::RxFifoFull);
+    ///
+    ///     SERIAL.borrow_ref_mut(cs).replace(uart0);
+    /// });
+    ///
+    /// loop {
+    ///     println!("Send `#` character or >=30 characters");
+    ///     delay.delay(Duration::from_secs(1));
+    /// }
+    /// # }
+    ///
+    /// # use core::cell::RefCell;
+    /// # use critical_section::Mutex;
+    /// # use esp_hal::uart::Uart;
+    /// static SERIAL: Mutex<RefCell<Option<Uart<esp_hal::Blocking>>>> =
+    ///     Mutex::new(RefCell::new(None));
+    ///
+    /// # use esp_hal::uart::UartInterrupt;
+    /// # use core::fmt::Write;
+    /// #[handler]
+    /// fn interrupt_handler() {
+    ///     critical_section::with(|cs| {
+    ///         let mut serial = SERIAL.borrow_ref_mut(cs);
+    ///         if let Some(serial) = serial.as_mut() {
+    ///             let mut buf = [0u8; 64];
+    ///             if let Ok(cnt) = serial.read_buffered_bytes(&mut buf) {
+    ///                 println!("Read {} bytes", cnt);
+    ///             }
+    ///
+    ///             let pending_interrupts = serial.interrupts();
+    ///             println!(
+    ///                 "Interrupt AT-CMD: {} RX-FIFO-FULL: {}",
+    ///                 pending_interrupts.contains(UartInterrupt::AtCmd),
+    ///                 pending_interrupts.contains(UartInterrupt::RxFifoFull),
+    ///             );
+    ///
+    ///             serial.clear_interrupts(
+    ///                 UartInterrupt::AtCmd | UartInterrupt::RxFifoFull
+    ///             );
+    ///         }
+    ///     });
+    /// }
+    /// ```
     #[instability::unstable]
     pub fn listen(&mut self, interrupts: impl Into<EnumSet<UartInterrupt>>) {
         self.tx.uart.info().enable_listen(interrupts.into(), true)

--- a/esp-hal/src/usb_serial_jtag.rs
+++ b/esp-hal/src/usb_serial_jtag.rs
@@ -49,7 +49,7 @@
 //! let mut usb_serial = UsbSerialJtag::new(peripherals.USB_DEVICE);
 //!
 //! // Write bytes out over the USB Serial/JTAG:
-//! usb_serial.write_bytes(b"Hello, world!")?;
+//! usb_serial.write(b"Hello, world!")?;
 //! # Ok(())
 //! # }
 //! ```
@@ -66,7 +66,7 @@
 //!
 //! // Each component can be used individually to interact with the USB
 //! // Serial/JTAG:
-//! tx.write_bytes(&[42u8])?;
+//! tx.write(&[42u8])?;
 //! let byte = rx.read_byte()?;
 //! # Ok(())
 //! # }
@@ -177,7 +177,7 @@ where
     }
 
     /// Write data to the serial output in chunks of up to 64 bytes
-    pub fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
+    pub fn write(&mut self, data: &[u8]) -> Result<(), Error> {
         for chunk in data.chunks(64) {
             for byte in chunk {
                 self.regs()
@@ -396,8 +396,8 @@ where
     }
 
     /// Write data to the serial output in chunks of up to 64 bytes
-    pub fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
-        self.tx.write_bytes(data)
+    pub fn write(&mut self, data: &[u8]) -> Result<(), Error> {
+        self.tx.write(data)
     }
 
     /// Write data to the serial output in a non-blocking manner
@@ -508,8 +508,7 @@ where
     Dm: DriverMode,
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        self.write_bytes(s.as_bytes())
-            .map_err(|_| core::fmt::Error)?;
+        self.write(s.as_bytes()).map_err(|_| core::fmt::Error)?;
         Ok(())
     }
 }
@@ -541,14 +540,14 @@ where
 
     #[inline]
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
-        self.write_bytes(s.as_bytes())?;
+        self.write(s.as_bytes())?;
         Ok(())
     }
 
     #[inline]
     fn write_char(&mut self, ch: char) -> Result<(), Self::Error> {
         let mut buffer = [0u8; 4];
-        self.write_bytes(ch.encode_utf8(&mut buffer).as_bytes())?;
+        self.write(ch.encode_utf8(&mut buffer).as_bytes())?;
 
         Ok(())
     }
@@ -623,7 +622,7 @@ where
     Dm: DriverMode,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.write_bytes(buf)?;
+        self.write(buf)?;
 
         Ok(buf.len())
     }
@@ -744,7 +743,7 @@ impl<'d> UsbSerialJtag<'d, Async> {
 }
 
 impl UsbSerialJtagTx<'_, Async> {
-    async fn write_bytes_async(&mut self, words: &[u8]) -> Result<(), Error> {
+    async fn write_async(&mut self, words: &[u8]) -> Result<(), Error> {
         for chunk in words.chunks(64) {
             for byte in chunk {
                 self.regs()
@@ -775,15 +774,15 @@ impl UsbSerialJtagTx<'_, Async> {
 }
 
 impl UsbSerialJtagRx<'_, Async> {
-    async fn read_bytes_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+    async fn read_async(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         if buf.is_empty() {
             return Ok(0);
         }
 
         loop {
-            let read_bytes = self.drain_rx_fifo(buf);
-            if read_bytes > 0 {
-                return Ok(read_bytes);
+            let read = self.drain_rx_fifo(buf);
+            if read > 0 {
+                return Ok(read);
             }
             UsbSerialJtagReadFuture::new(self.peripheral.reborrow()).await;
         }
@@ -804,7 +803,7 @@ impl embedded_io_async::Write for UsbSerialJtag<'_, Async> {
 #[instability::unstable]
 impl embedded_io_async::Write for UsbSerialJtagTx<'_, Async> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.write_bytes_async(buf).await?;
+        self.write_async(buf).await?;
 
         Ok(buf.len())
     }
@@ -824,7 +823,7 @@ impl embedded_io_async::Read for UsbSerialJtag<'_, Async> {
 #[instability::unstable]
 impl embedded_io_async::Read for UsbSerialJtagRx<'_, Async> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        self.read_bytes_async(buf).await
+        self.read_async(buf).await
     }
 }
 


### PR DESCRIPTION
I suggest bulding and viewing the docs locally, then reviewing this commit by commit. The intention is not to merge this, but choose what we want from it and I'll PR them seperately. 

* Commit 1 should be fairly uncontroversial I think. I don't think the `split` API is fully ready yet, and we may want to experiment more here.
* Commit 2 replaces `write|read_bytes` with just `write|read` when the input parameter is a byte slice. Imo this is fine, and there is precidence in the std (e.g https://doc.rust-lang.org/std/fs/fn.write.html only accepts bytes)(and other crates in the embedded ecosystem for this)
* Commit three shuffles some things around to firstly show stable items for uart, then unstable, to complete this I would apply this to all partially stable drivers.

Comments appreciated.