### PR TITLE
Expose CopyDmaChannel

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -57,13 +57,13 @@ ufmt-write               = "0.1.0"
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.35.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32c2 = { version = "0.24.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32c3 = { version = "0.27.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32c6 = { version = "0.18.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32h2 = { version = "0.14.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32s2 = { version = "0.26.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32s3 = { version = "0.30.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
+esp32   = { version = "0.35.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "9e8a6f4f", optional = true }
+esp32c2 = { version = "0.24.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "9e8a6f4f", optional = true }
+esp32c3 = { version = "0.27.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "9e8a6f4f", optional = true }
+esp32c6 = { version = "0.18.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "9e8a6f4f", optional = true }
+esp32h2 = { version = "0.14.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "9e8a6f4f", optional = true }
+esp32s2 = { version = "0.26.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "9e8a6f4f", optional = true }
+esp32s3 = { version = "0.30.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "9e8a6f4f", optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.12.1" }

--- a/esp-hal/src/dma/pdma/copy.rs
+++ b/esp-hal/src/dma/pdma/copy.rs
@@ -1,0 +1,464 @@
+use portable_atomic::{AtomicBool, Ordering};
+
+use crate::{
+    asynch::AtomicWaker,
+    dma::*,
+    interrupt::{InterruptHandler, Priority},
+    peripheral::Peripheral,
+    peripherals::{Interrupt, COPY_DMA},
+};
+
+pub(super) type CopyRegisterBlock = crate::pac::copy_dma::RegisterBlock;
+
+/// The RX half of a Copy DMA channel.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct CopyDmaRxChannel(pub(crate) CopyDmaChannel);
+
+impl CopyDmaRxChannel {
+    fn regs(&self) -> &CopyRegisterBlock {
+        self.0.register_block()
+    }
+}
+
+impl crate::private::Sealed for CopyDmaRxChannel {}
+impl DmaRxChannel for CopyDmaRxChannel {}
+impl Peripheral for CopyDmaRxChannel {
+    type P = Self;
+
+    unsafe fn clone_unchecked(&self) -> Self::P {
+        Self(self.0.clone_unchecked())
+    }
+}
+
+/// The TX half of a Copy DMA channel.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct CopyDmaTxChannel(pub(crate) CopyDmaChannel);
+
+impl CopyDmaTxChannel {
+    fn regs(&self) -> &CopyRegisterBlock {
+        self.0.register_block()
+    }
+}
+
+impl crate::private::Sealed for CopyDmaTxChannel {}
+impl DmaTxChannel for CopyDmaTxChannel {}
+impl Peripheral for CopyDmaTxChannel {
+    type P = Self;
+
+    unsafe fn clone_unchecked(&self) -> Self::P {
+        Self(self.0.clone_unchecked())
+    }
+}
+
+impl RegisterAccess for CopyDmaTxChannel {
+    fn reset(&self) {
+        self.regs().conf().modify(|_, w| w.out_rst().set_bit());
+        self.regs().conf().modify(|_, w| w.out_rst().clear_bit());
+    }
+
+    fn set_burst_mode(&self, _burst_mode: BurstConfig) {}
+
+    fn set_descr_burst_mode(&self, _burst_mode: bool) {}
+
+    fn set_peripheral(&self, _peripheral: u8) {
+        // no-op
+    }
+
+    fn set_link_addr(&self, address: u32) {
+        self.regs()
+            .out_link()
+            .modify(|_, w| unsafe { w.outlink_addr().bits(address) });
+    }
+
+    fn start(&self) {
+        self.regs()
+            .out_link()
+            .modify(|_, w| w.outlink_start().set_bit());
+    }
+
+    fn stop(&self) {
+        self.regs()
+            .out_link()
+            .modify(|_, w| w.outlink_stop().set_bit());
+    }
+
+    fn restart(&self) {
+        self.regs()
+            .out_link()
+            .modify(|_, w| w.outlink_restart().set_bit());
+    }
+
+    fn set_check_owner(&self, check_owner: Option<bool>) {
+        if check_owner == Some(true) {
+            panic!("Copy DMA does not support checking descriptor ownership");
+        }
+    }
+
+    fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
+        self.0.is_compatible_with(peripheral)
+    }
+
+    #[cfg(psram_dma)]
+    fn set_ext_mem_block_size(&self, _size: DmaExtMemBKSize) {
+        // not supported
+    }
+
+    #[cfg(psram_dma)]
+    fn can_access_psram(&self) -> bool {
+        false
+    }
+}
+
+impl TxRegisterAccess for CopyDmaTxChannel {
+    fn is_fifo_empty(&self) -> bool {
+        self.regs().in_st().read().fifo_empty().bit()
+    }
+
+    fn set_auto_write_back(&self, enable: bool) {
+        self.regs()
+            .conf()
+            .modify(|_, w| w.out_auto_wrback().bit(enable));
+    }
+
+    fn last_dscr_address(&self) -> usize {
+        self.regs()
+            .out_eof_des_addr()
+            .read()
+            .out_eof_des_addr()
+            .bits() as usize
+    }
+
+    fn peripheral_interrupt(&self) -> Option<Interrupt> {
+        None
+    }
+
+    fn async_handler(&self) -> Option<InterruptHandler> {
+        None
+    }
+}
+
+impl InterruptAccess<DmaTxInterrupt> for CopyDmaTxChannel {
+    fn enable_listen(&self, interrupts: EnumSet<DmaTxInterrupt>, enable: bool) {
+        self.regs().int_ena().modify(|_, w| {
+            for interrupt in interrupts {
+                match interrupt {
+                    DmaTxInterrupt::TotalEof => w.out_total_eof().bit(enable),
+                    DmaTxInterrupt::DescriptorError => w.out_dscr_err().bit(enable),
+                    DmaTxInterrupt::Eof => w.out_eof().bit(enable),
+                    DmaTxInterrupt::Done => w.out_done().bit(enable),
+                };
+            }
+            w
+        });
+    }
+
+    fn is_listening(&self) -> EnumSet<DmaTxInterrupt> {
+        let mut result = EnumSet::new();
+
+        let int_ena = self.regs().int_ena().read();
+        if int_ena.out_total_eof().bit_is_set() {
+            result |= DmaTxInterrupt::TotalEof;
+        }
+        if int_ena.out_dscr_err().bit_is_set() {
+            result |= DmaTxInterrupt::DescriptorError;
+        }
+        if int_ena.out_eof().bit_is_set() {
+            result |= DmaTxInterrupt::Eof;
+        }
+        if int_ena.out_done().bit_is_set() {
+            result |= DmaTxInterrupt::Done;
+        }
+
+        result
+    }
+
+    fn clear(&self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
+        self.regs().int_clr().write(|w| {
+            for interrupt in interrupts.into() {
+                match interrupt {
+                    DmaTxInterrupt::TotalEof => w.out_total_eof().clear_bit_by_one(),
+                    DmaTxInterrupt::DescriptorError => w.out_dscr_err().clear_bit_by_one(),
+                    DmaTxInterrupt::Eof => w.out_eof().clear_bit_by_one(),
+                    DmaTxInterrupt::Done => w.out_done().clear_bit_by_one(),
+                };
+            }
+            w
+        });
+    }
+
+    fn pending_interrupts(&self) -> EnumSet<DmaTxInterrupt> {
+        let mut result = EnumSet::new();
+
+        let int_raw = self.regs().int_raw().read();
+        if int_raw.out_total_eof().bit_is_set() {
+            result |= DmaTxInterrupt::TotalEof;
+        }
+        if int_raw.out_dscr_err().bit_is_set() {
+            result |= DmaTxInterrupt::DescriptorError;
+        }
+        if int_raw.out_eof().bit_is_set() {
+            result |= DmaTxInterrupt::Eof;
+        }
+        if int_raw.out_done().bit_is_set() {
+            result |= DmaTxInterrupt::Done;
+        }
+
+        result
+    }
+
+    fn waker(&self) -> &'static AtomicWaker {
+        self.0.tx_waker()
+    }
+
+    fn is_async(&self) -> bool {
+        self.0.tx_async_flag().load(Ordering::Acquire)
+    }
+
+    fn set_async(&self, is_async: bool) {
+        self.0.tx_async_flag().store(is_async, Ordering::Release);
+    }
+}
+
+impl RegisterAccess for CopyDmaRxChannel {
+    fn reset(&self) {
+        self.regs().conf().modify(|_, w| w.in_rst().set_bit());
+        self.regs().conf().modify(|_, w| w.in_rst().clear_bit());
+    }
+
+    fn set_burst_mode(&self, _burst_mode: BurstConfig) {}
+
+    fn set_descr_burst_mode(&self, _burst_mode: bool) {}
+
+    fn set_peripheral(&self, _peripheral: u8) {
+        // no-op
+    }
+
+    fn set_link_addr(&self, address: u32) {
+        self.regs()
+            .in_link()
+            .modify(|_, w| unsafe { w.inlink_addr().bits(address) });
+    }
+
+    fn start(&self) {
+        self.regs()
+            .in_link()
+            .modify(|_, w| w.inlink_start().set_bit());
+    }
+
+    fn stop(&self) {
+        self.regs()
+            .in_link()
+            .modify(|_, w| w.inlink_stop().set_bit());
+    }
+
+    fn restart(&self) {
+        self.regs()
+            .in_link()
+            .modify(|_, w| w.inlink_restart().set_bit());
+    }
+
+    fn set_check_owner(&self, check_owner: Option<bool>) {
+        if check_owner == Some(true) {
+            panic!("Copy DMA does not support checking descriptor ownership");
+        }
+    }
+
+    fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
+        self.0.is_compatible_with(peripheral)
+    }
+
+    #[cfg(psram_dma)]
+    fn set_ext_mem_block_size(&self, _size: DmaExtMemBKSize) {
+        // not supported
+    }
+
+    #[cfg(psram_dma)]
+    fn can_access_psram(&self) -> bool {
+        false
+    }
+}
+
+impl RxRegisterAccess for CopyDmaRxChannel {
+    fn peripheral_interrupt(&self) -> Option<Interrupt> {
+        None
+    }
+
+    fn async_handler(&self) -> Option<InterruptHandler> {
+        None
+    }
+}
+
+impl InterruptAccess<DmaRxInterrupt> for CopyDmaRxChannel {
+    fn enable_listen(&self, interrupts: EnumSet<DmaRxInterrupt>, enable: bool) {
+        self.regs().int_ena().modify(|_, w| {
+            for interrupt in interrupts {
+                match interrupt {
+                    DmaRxInterrupt::SuccessfulEof => w.in_suc_eof().bit(enable),
+                    DmaRxInterrupt::ErrorEof => unimplemented!(),
+                    DmaRxInterrupt::DescriptorError => w.in_dscr_err().bit(enable),
+                    DmaRxInterrupt::DescriptorEmpty => w.in_dscr_empty().bit(enable),
+                    DmaRxInterrupt::Done => w.in_done().bit(enable),
+                };
+            }
+            w
+        });
+    }
+
+    fn is_listening(&self) -> EnumSet<DmaRxInterrupt> {
+        let mut result = EnumSet::new();
+
+        let int_ena = self.regs().int_ena().read();
+        if int_ena.in_dscr_err().bit_is_set() {
+            result |= DmaRxInterrupt::DescriptorError;
+        }
+        if int_ena.in_dscr_err().bit_is_set() {
+            result |= DmaRxInterrupt::DescriptorEmpty;
+        }
+        if int_ena.in_suc_eof().bit_is_set() {
+            result |= DmaRxInterrupt::SuccessfulEof;
+        }
+        if int_ena.in_done().bit_is_set() {
+            result |= DmaRxInterrupt::Done;
+        }
+
+        result
+    }
+
+    fn clear(&self, interrupts: impl Into<EnumSet<DmaRxInterrupt>>) {
+        self.regs().int_clr().write(|w| {
+            for interrupt in interrupts.into() {
+                match interrupt {
+                    DmaRxInterrupt::SuccessfulEof => w.in_suc_eof().clear_bit_by_one(),
+                    DmaRxInterrupt::ErrorEof => unimplemented!(),
+                    DmaRxInterrupt::DescriptorError => w.in_dscr_err().clear_bit_by_one(),
+                    DmaRxInterrupt::DescriptorEmpty => w.in_dscr_empty().clear_bit_by_one(),
+                    DmaRxInterrupt::Done => w.in_done().clear_bit_by_one(),
+                };
+            }
+            w
+        });
+    }
+
+    fn pending_interrupts(&self) -> EnumSet<DmaRxInterrupt> {
+        let mut result = EnumSet::new();
+
+        let int_raw = self.regs().int_raw().read();
+        if int_raw.in_dscr_err().bit_is_set() {
+            result |= DmaRxInterrupt::DescriptorError;
+        }
+        if int_raw.in_dscr_empty().bit_is_set() {
+            result |= DmaRxInterrupt::DescriptorEmpty;
+        }
+        if int_raw.in_suc_eof().bit_is_set() {
+            result |= DmaRxInterrupt::SuccessfulEof;
+        }
+        if int_raw.in_done().bit_is_set() {
+            result |= DmaRxInterrupt::Done;
+        }
+
+        result
+    }
+
+    fn waker(&self) -> &'static AtomicWaker {
+        self.0.rx_waker()
+    }
+
+    fn is_async(&self) -> bool {
+        self.0.rx_async_flag().load(Ordering::Relaxed)
+    }
+
+    fn set_async(&self, _is_async: bool) {
+        self.0.rx_async_flag().store(_is_async, Ordering::Relaxed);
+    }
+}
+
+#[doc = "DMA channel suitable for COPY"]
+#[non_exhaustive]
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct CopyDmaChannel {}
+
+impl crate::private::Sealed for CopyDmaChannel {}
+
+impl Peripheral for CopyDmaChannel {
+    type P = Self;
+    unsafe fn clone_unchecked(&self) -> Self::P {
+        Self::steal()
+    }
+}
+impl CopyDmaChannel {
+    #[doc = r" Unsafely constructs a new DMA channel."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" The caller must ensure that only a single instance is used."]
+    pub unsafe fn steal() -> Self {
+        Self {}
+    }
+}
+impl DmaChannel for CopyDmaChannel {
+    type Rx = CopyDmaRxChannel;
+    type Tx = CopyDmaTxChannel;
+    unsafe fn split_internal(self, _: crate::private::Internal) -> (Self::Rx, Self::Tx) {
+        (CopyDmaRxChannel(Self {}), CopyDmaTxChannel(Self {}))
+    }
+}
+impl DmaChannelExt for CopyDmaChannel {
+    fn rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
+        CopyDmaRxChannel(Self {})
+    }
+    fn tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
+        CopyDmaTxChannel(Self {})
+    }
+}
+impl PdmaChannel for CopyDmaChannel {
+    type RegisterBlock = CopyRegisterBlock;
+    fn register_block(&self) -> &Self::RegisterBlock {
+        COPY_DMA::regs()
+    }
+    fn tx_waker(&self) -> &'static AtomicWaker {
+        static WAKER: AtomicWaker = AtomicWaker::new();
+        &WAKER
+    }
+    fn rx_waker(&self) -> &'static AtomicWaker {
+        static WAKER: AtomicWaker = AtomicWaker::new();
+        &WAKER
+    }
+    fn is_compatible_with(&self, peripheral: DmaPeripheral) -> bool {
+        let compatible_peripherals = [DmaPeripheral::Aes, DmaPeripheral::Sha];
+        compatible_peripherals.contains(&peripheral)
+    }
+    fn peripheral_interrupt(&self) -> Interrupt {
+        Interrupt::DMA_COPY
+    }
+    fn async_handler(&self) -> InterruptHandler {
+        pub(crate) extern "C" fn __esp_hal_internal_interrupt_handler() {
+            super::asynch::handle_in_interrupt::<CopyDmaChannel>();
+            super::asynch::handle_out_interrupt::<CopyDmaChannel>();
+        }
+        #[allow(non_upper_case_globals)]
+        pub(crate) static interrupt_handler: InterruptHandler =
+            InterruptHandler::new(__esp_hal_internal_interrupt_handler, Priority::max());
+        interrupt_handler
+    }
+    fn rx_async_flag(&self) -> &'static AtomicBool {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        &FLAG
+    }
+    fn tx_async_flag(&self) -> &'static AtomicBool {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        &FLAG
+    }
+}
+impl DmaChannelConvert<CopyDmaRxChannel> for CopyDmaChannel {
+    fn degrade(self) -> CopyDmaRxChannel {
+        CopyDmaRxChannel(self)
+    }
+}
+impl DmaChannelConvert<CopyDmaTxChannel> for CopyDmaChannel {
+    fn degrade(self) -> CopyDmaTxChannel {
+        CopyDmaTxChannel(self)
+    }
+}

--- a/esp-hal/src/dma/pdma/mod.rs
+++ b/esp-hal/src/dma/pdma/mod.rs
@@ -24,10 +24,14 @@ use crate::{
 };
 
 #[cfg(esp32s2)]
+mod copy;
+#[cfg(esp32s2)]
 mod crypto;
 mod i2s;
 mod spi;
 
+#[cfg(esp32s2)]
+pub use copy::*;
 #[cfg(esp32s2)]
 pub use crypto::*;
 pub use i2s::*;

--- a/esp-hal/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal/src/soc/esp32s2/peripherals.rs
@@ -32,6 +32,7 @@ crate::peripherals! {
         APB_SARADC <= APB_SARADC,
         DAC1 <= virtual,
         DAC2 <= virtual,
+        COPY_DMA <= COPY_DMA,
         CRYPTO_DMA <= CRYPTO_DMA,
         DEDICATED_GPIO <= DEDICATED_GPIO,
         DS <= DS,
@@ -123,5 +124,6 @@ crate::peripherals! {
         DMA_SPI3: Spi3DmaChannel,
         DMA_I2S0: I2s0DmaChannel,
         DMA_CRYPTO: CryptoDmaChannel,
+        DMA_COPY: CopyDmaChannel,
     ]
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Add the `CopyDmaChannel` type, though it can't be used with the `Mem2Mem` driver just yet.
No changelog because users can't actually use the channel yet.

I was looking into adding `Mem2Mem` support for the S2 but as you can imagine there's some differences between the S2's PDMA and GDMA on other chips.
The existing constructors won't work as is since there's no extra "peripheral" besides the DMA channel itself, so some refactoring needs doing there, I'm not too excited about doing that right this second so I've decided to push what I've done so far and someone else (or me) can continue in the future.

Part of #2313 .

#### Testing
It builds
