### PR TITLE
Make wifi_embassy_access_point_with_sta listen on both network addresses

### DIFF
--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -21,6 +21,7 @@
 use core::net::Ipv4Addr;
 
 use embassy_executor::Spawner;
+use embassy_futures::select::Either;
 use embassy_net::{
     tcp::TcpSocket,
     IpListenEndpoint,
@@ -113,7 +114,7 @@ async fn main(spawner: Spawner) -> ! {
     let (sta_stack, sta_runner) = embassy_net::new(
         wifi_sta_interface,
         sta_config,
-        mk_static!(StackResources<3>, StackResources::<3>::new()),
+        mk_static!(StackResources<4>, StackResources::<4>::new()),
         seed,
     );
 
@@ -134,13 +135,15 @@ async fn main(spawner: Spawner) -> ! {
     spawner.spawn(ap_task(ap_runner)).ok();
     spawner.spawn(sta_task(sta_runner)).ok();
 
-    loop {
-        if sta_stack.is_link_up() {
-            break;
+    let sta_address = loop {
+        if let Some(config) = sta_stack.config_v4() {
+            let address = config.address.address();
+            println!("Got IP: {}", address);
+            break address;
         }
         println!("Waiting for IP...");
         Timer::after(Duration::from_millis(500)).await;
-    }
+    };
     loop {
         if ap_stack.is_link_up() {
             break;
@@ -149,27 +152,53 @@ async fn main(spawner: Spawner) -> ! {
     }
     println!("Connect to the AP `esp-wifi` and point your browser to http://192.168.2.1:8080/");
     println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
+    println!("Or connect to the ap `{SSID}` and point your browser to http://{sta_address}:8080/");
 
-    let mut ap_rx_buffer = [0; 1536];
-    let mut ap_tx_buffer = [0; 1536];
+    let mut ap_server_rx_buffer = [0; 1536];
+    let mut ap_server_tx_buffer = [0; 1536];
+    let mut sta_server_rx_buffer = [0; 1536];
+    let mut sta_server_tx_buffer = [0; 1536];
+    let mut sta_client_rx_buffer = [0; 1536];
+    let mut sta_client_tx_buffer = [0; 1536];
 
-    let mut ap_socket = TcpSocket::new(ap_stack, &mut ap_rx_buffer, &mut ap_tx_buffer);
-    ap_socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
+    let mut ap_server_socket =
+        TcpSocket::new(ap_stack, &mut ap_server_rx_buffer, &mut ap_server_tx_buffer);
+    ap_server_socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
-    let mut sta_rx_buffer = [0; 1536];
-    let mut sta_tx_buffer = [0; 1536];
+    let mut sta_server_socket = TcpSocket::new(
+        sta_stack,
+        &mut sta_server_rx_buffer,
+        &mut sta_server_tx_buffer,
+    );
+    sta_server_socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
-    let mut sta_socket = TcpSocket::new(sta_stack, &mut sta_rx_buffer, &mut sta_tx_buffer);
-    sta_socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
+    let mut sta_client_socket = TcpSocket::new(
+        sta_stack,
+        &mut sta_client_rx_buffer,
+        &mut sta_client_tx_buffer,
+    );
+    sta_client_socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
     loop {
         println!("Wait for connection...");
-        let r = ap_socket
-            .accept(IpListenEndpoint {
+        // FIXME: If connections are attempted on both sockets at the same time, we might end up
+        // dropping one of them. Might be better to spawn both accept() calls, or use fused futures?
+        // Note that we only attempt to serve one connection at a time, so we don't run out of ram.
+        let either_socket = embassy_futures::select::select(
+            ap_server_socket.accept(IpListenEndpoint {
                 addr: None,
                 port: 8080,
-            })
-            .await;
+            }),
+            sta_server_socket.accept(IpListenEndpoint {
+                addr: None,
+                port: 8080,
+            }),
+        )
+        .await;
+        let (r, server_socket) = match either_socket {
+            Either::First(r) => (r, &mut ap_server_socket),
+            Either::Second(r) => (r, &mut sta_server_socket),
+        };
         println!("Connected...");
 
         if let Err(e) = r {
@@ -178,11 +207,10 @@ async fn main(spawner: Spawner) -> ! {
         }
 
         use embedded_io_async::Write;
-
         let mut buffer = [0u8; 1024];
         let mut pos = 0;
         loop {
-            match ap_socket.read(&mut buffer).await {
+            match server_socket.read(&mut buffer).await {
                 Ok(0) => {
                     println!("AP read EOF");
                     break;
@@ -205,25 +233,24 @@ async fn main(spawner: Spawner) -> ! {
                 }
             };
         }
-
         if sta_stack.is_link_up() {
             let remote_endpoint = (Ipv4Addr::new(142, 250, 185, 115), 80);
             println!("connecting...");
-            let r = sta_socket.connect(remote_endpoint).await;
+            let r = sta_client_socket.connect(remote_endpoint).await;
             if let Err(e) = r {
                 println!("STA connect error: {:?}", e);
                 continue;
             }
 
             use embedded_io_async::Write;
-            let r = sta_socket
+            let r = sta_client_socket
                 .write_all(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")
                 .await;
 
             if let Err(e) = r {
                 println!("STA write error: {:?}", e);
 
-                let r = ap_socket
+                let r = server_socket
                     .write_all(
                         b"HTTP/1.0 500 Internal Server Error\r\n\r\n\
                         <html>\
@@ -238,20 +265,20 @@ async fn main(spawner: Spawner) -> ! {
                     println!("AP write error: {:?}", e);
                 }
             } else {
-                let r = sta_socket.flush().await;
+                let r = sta_client_socket.flush().await;
                 if let Err(e) = r {
                     println!("STA flush error: {:?}", e);
                 } else {
                     println!("connected!");
                     let mut buf = [0; 1024];
                     loop {
-                        match sta_socket.read(&mut buf).await {
+                        match sta_client_socket.read(&mut buf).await {
                             Ok(0) => {
                                 println!("STA read EOF");
                                 break;
                             }
                             Ok(n) => {
-                                let r = ap_socket.write_all(&buf[..n]).await;
+                                let r = server_socket.write_all(&buf[..n]).await;
                                 if let Err(e) = r {
                                     println!("AP write error: {:?}", e);
                                     break;
@@ -266,9 +293,9 @@ async fn main(spawner: Spawner) -> ! {
                 }
             }
 
-            sta_socket.close();
+            sta_client_socket.close();
         } else {
-            let r = ap_socket
+            let r = server_socket
                 .write_all(
                     b"HTTP/1.0 200 OK\r\n\r\n\
                     <html>\
@@ -283,17 +310,14 @@ async fn main(spawner: Spawner) -> ! {
                 println!("AP write error: {:?}", e);
             }
         }
-
-        let r = ap_socket.flush().await;
+        let r = server_socket.flush().await;
         if let Err(e) = r {
             println!("AP flush error: {:?}", e);
         }
         Timer::after(Duration::from_millis(1000)).await;
-
-        ap_socket.close();
+        server_socket.close();
         Timer::after(Duration::from_millis(1000)).await;
-
-        ap_socket.abort();
+        server_socket.abort();
     }
 }
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] ~My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.~
- [x] ~I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).~
- [x] ~My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)~

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

I am planning to make a device based on ESP32+embassy as part of https://github.com/hoverkite/hoverkite/issues/232 . When testing at home, I would prefer not to have to keep disconnecting my laptop from the home wifi to test things, so I wanted to make a server that listens on both wifi networks.

To test whether it would work, I hacked something up based on the wifi_embassy_access_point_with_sta example, so I thought I might as well contribute it back.

From top to bottom:

* make the STA stack ("station"/wifi client) have an extra slot for another http socket
* find out the ip address on the internet connected wifi hotspot and print it (adapted from wifi_embassy_dhcp.rs).
* allocate an extra tx and rx buffer, and another tcp socket
  * I also grouped the buffer allocations together, to work around a borrow checker issue where ap_server_socket and sta_server_socket have their lifetimes conflated by the `server_socket` reference.
* call .accept() on both server sockets, and use select() to pick whichever one happens first, then pick the right server socket to use in the rest of the loop (which is otherwise unchanged) 
  - [ ] I left a FIXME in here: what's the recommended way to avoid problems if both accept() futures start doing work at the same time, or is this fine to leave how it is?
  - [ ] I am tempted to extract the body of the loop out into its own function. Should I do that now/as a follow-up/never?
* a bunch of variable renames

#### Testing

I tested this using `cargo xtask run-example esp-hal esp32 wifi_embassy_access_point_with_sta` on an m5stack core gray (ESP32-D0WDQ6-V3 according to https://docs.m5stack.com/en/core/gray).

The instructions render as:
```
Connect to the AP `esp-wifi` and point your browser to http://192.168.2.1:8080/
Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1
Or connect to the ap `dragnet` and point your browser to http://192.168.86.44:8080/
```
I tested both configurations from macos.
