### PR TITLE
Patch generated documentation to include a version selector

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+xdoc = "run --package xtask --features=deploy-docs --"
 xfmt = "xtask fmt-packages"
 qa = "xtask run-example qa-test"

--- a/resources/select.html.jinja
+++ b/resources/select.html.jinja
@@ -1,0 +1,48 @@
+<div style="margin-top: 0.5rem; width: 100%">
+  <label for="version-select">Version:</label>
+  <select id="version-select" name="version-select" style="text-align: center; width: 100%">
+    <option value="{{ version }}" selected="selected">{{ version }}</option>
+  </select>
+</div>
+
+<script type="text/javascript">
+  const select = document.querySelector("#version-select");
+
+  select.addEventListener("change", (e) => {
+    const selected = select.value;
+
+    // Replace the existing version number in the URL with the newly
+    // selected version:
+    let href = window.location.href;
+    href = href.replace(/[\d]+\.[\d]+\.[\d]+[^\/]*/g, selected);
+
+    // Redirect to the new URL:
+    window.location.href = href;
+  });
+
+  document.addEventListener("DOMContentLoaded", (e) => {
+    const selected = select.value;
+
+    // Remove any options currently present in the select box:
+    for (let child of select.children) {
+      child.remove();
+    }
+
+    // Load the manifest JSON file and re-populate the select box with new
+    // options for all available versions:
+    const manifestUrl = "{{ base_url }}/{{ package }}/manifest.json";
+    fetch(manifestUrl)
+      .then((res) => res.json())
+      .then(({ versions }) => {
+        for (let version of versions) {
+          let option = document.createElement("option");
+          option.text = version;
+          option.value = version;
+          select.appendChild(option);
+        }
+
+        select.value = selected;
+      })
+      .catch((err) => console.error(err));
+  });
+</script>

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,10 +16,19 @@ esp-metadata = { path = "../esp-metadata", features = ["clap"] }
 kuchikiki    = "0.8.2"
 log          = "0.4.22"
 minijinja    = "2.5.0"
-reqwest      = { version = "0.12.12", features = ["blocking", "json", "native-tls-vendored"] }
 semver       = { version = "1.0.23", features = ["serde"] }
 serde        = { version = "1.0.215", features = ["derive"] }
 serde_json   = "1.0.70"
 strum        = { version = "0.26.3", features = ["derive"] }
 toml_edit    = "0.22.22"
 walkdir      = "2.5.0"
+
+# Only required when building documentation for deployment:
+reqwest = { version = "0.12.12", features = [
+    "blocking",
+    "json",
+    "native-tls-vendored",
+], optional = true }
+
+[features]
+deploy-docs = ["dep:reqwest"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,16 +8,18 @@ publish = false
 anyhow       = "1.0.93"
 basic-toml   = "0.1.9"
 chrono       = "0.4.38"
-clap         = { version = "4.5.20",  features = ["derive", "wrap_help"] }
+clap         = { version = "4.5.20", features = ["derive", "wrap_help"] }
 console      = "0.15.10"
 csv          = "1.3.1"
 env_logger   = "0.11.5"
 esp-metadata = { path = "../esp-metadata", features = ["clap"] }
+kuchikiki    = "0.8.2"
 log          = "0.4.22"
 minijinja    = "2.5.0"
-semver       = { version = "1.0.23",  features = ["serde"] }
+reqwest      = { version = "0.12.12", features = ["blocking", "json", "native-tls-vendored"] }
+semver       = { version = "1.0.23", features = ["serde"] }
 serde        = { version = "1.0.215", features = ["derive"] }
 serde_json   = "1.0.70"
-strum        = { version = "0.26.3",  features = ["derive"] }
+strum        = { version = "0.26.3", features = ["derive"] }
 toml_edit    = "0.22.22"
 walkdir      = "2.5.0"

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -28,7 +28,7 @@ pub fn build_documentation(
 
     for package in packages {
         // Not all packages need documentation built:
-        if !package.should_document() {
+        if !package.is_published() {
             continue;
         }
 
@@ -241,7 +241,7 @@ pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> 
 
     for package in packages {
         // Not all packages have documentation built:
-        if !package.should_document() {
+        if !package.is_published() {
             continue;
         }
 
@@ -355,7 +355,7 @@ fn generate_documentation_meta_for_index(workspace: &Path) -> Result<Vec<Value>>
 
     for package in Package::iter() {
         // Not all packages have documentation built:
-        if !package.should_document() {
+        if !package.is_published() {
             continue;
         }
 

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -1,0 +1,409 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{ensure, Context as _, Result};
+use clap::ValueEnum;
+use esp_metadata::Config;
+use minijinja::Value;
+use strum::IntoEnumIterator;
+
+use crate::{cargo::CargoArgsBuilder, Chip, Package};
+
+// ----------------------------------------------------------------------------
+// Build Documentation
+
+pub fn build_documentation(
+    workspace: &Path,
+    packages: &mut [Package],
+    chips: &mut [Chip],
+) -> Result<()> {
+    let output_path = workspace.join("docs");
+
+    fs::create_dir_all(&output_path)
+        .with_context(|| format!("Failed to create {}", output_path.display()))?;
+
+    packages.sort();
+
+    for package in packages {
+        // Not all packages need documentation built:
+        if !package.should_document() {
+            continue;
+        }
+
+        // If the package does not have chip features, then just ignore
+        // whichever chip(s) were specified as arguments:
+        let chips = if package.has_chip_features() {
+            // Some packages have chip features, but they have no effect on the public API;
+            // in this case, there's no point building it multiple times, so just build one
+            // copy of the docs. Otherwise, use the provided chip arguments:
+            match package {
+                _ if package.chip_features_matter() => chips.to_vec(),
+                Package::XtensaLxRt => vec![Chip::Esp32s3],
+                _ => vec![Chip::Esp32c6],
+            }
+        } else {
+            log::warn!("Package '{package}' does not have chip features, ignoring argument");
+            vec![]
+        };
+
+        if chips.is_empty() {
+            build_documentation_for_package(workspace, package, None)?;
+        } else {
+            for chip in chips {
+                build_documentation_for_package(workspace, package, Some(chip))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn build_documentation_for_package(
+    workspace: &Path,
+    package: &Package,
+    chip: Option<Chip>,
+) -> Result<()> {
+    let version = crate::package_version(workspace, *package)?;
+
+    // Ensure that the package/chip combination provided are valid:
+    if let Some(chip) = chip {
+        if let Err(err) = crate::validate_package_chip(package, &chip) {
+            log::warn!("{err}");
+            return Ok(());
+        }
+    }
+
+    // Build the documentation for the specified package, targeting the
+    // specified chip:
+    let docs_path = cargo_doc(workspace, *package, chip)?;
+
+    ensure!(
+        docs_path.exists(),
+        "Documentation not found at {}",
+        docs_path.display()
+    );
+
+    let mut output_path = workspace
+        .join("docs")
+        .join(package.to_string())
+        .join(version.to_string());
+
+    if let Some(chip) = chip {
+        // Sometimes we need to specify a chip feature, but it does not affect the
+        // public API; so, only append the chip name to the path if it is significant:
+        if package.chip_features_matter() {
+            output_path = output_path.join(chip.to_string());
+        }
+    }
+
+    let output_path = crate::windows_safe_path(&output_path);
+
+    // Create the output directory, and copy the built documentation into it:
+    fs::create_dir_all(&output_path)
+        .with_context(|| format!("Failed to create {}", output_path.display()))?;
+
+    crate::copy_dir_all(&docs_path, &output_path).with_context(|| {
+        format!(
+            "Failed to copy {} to {}",
+            docs_path.display(),
+            output_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+fn cargo_doc(workspace: &Path, package: Package, chip: Option<Chip>) -> Result<PathBuf> {
+    let package_name = package.to_string();
+    let package_path = crate::windows_safe_path(&workspace.join(&package_name));
+
+    if let Some(chip) = chip {
+        log::info!("Building '{package_name}' documentation targeting '{chip}'");
+    } else {
+        log::info!("Building '{package_name}' documentation");
+    }
+
+    // We require some nightly features to build the documentation:
+    let toolchain = if chip.is_some_and(|chip| chip.is_xtensa()) {
+        "esp"
+    } else {
+        "nightly"
+    };
+
+    // Determine the appropriate build target for the given package and chip,
+    // if we're able to:
+    let target = if let Some(ref chip) = chip {
+        Some(crate::target_triple(package, chip)?)
+    } else {
+        None
+    };
+
+    let mut features = vec![];
+    if let Some(chip) = chip {
+        features.push(chip.to_string());
+        features.extend(apply_feature_rules(&package, Config::for_chip(&chip)));
+    }
+
+    // Build up an array of command-line arguments to pass to `cargo`:
+    let mut builder = CargoArgsBuilder::default()
+        .toolchain(toolchain)
+        .subcommand("doc")
+        .features(&features)
+        .arg("-Zrustdoc-map")
+        .arg("--lib")
+        .arg("--no-deps");
+
+    if let Some(target) = target {
+        builder = builder.target(target);
+    }
+
+    // Special case: `esp-metadata` requires `std`, and we get some really confusing
+    // errors if we try to pass `-Zbuild-std=core`:
+    if package != Package::EspMetadata {
+        builder = builder.arg("-Zbuild-std=alloc,core");
+    }
+
+    let args = builder.build();
+    log::debug!("{args:#?}");
+
+    let mut envs = vec![("RUSTDOCFLAGS", "--cfg docsrs --cfg not_really_docsrs")];
+    // Special case: `esp-storage` requires the optimization level to be 2 or 3:
+    if package == Package::EspStorage {
+        envs.push(("CARGO_PROFILE_DEBUG_OPT_LEVEL", "3"));
+    }
+
+    // Execute `cargo doc` from the package root:
+    crate::cargo::run_with_env(&args, &package_path, envs, false)?;
+
+    // Build up the path at which the built documentation can be found:
+    let mut docs_path = workspace.join(package.to_string()).join("target");
+    if let Some(target) = target {
+        docs_path = docs_path.join(target);
+    }
+    docs_path = docs_path.join("doc");
+
+    Ok(crate::windows_safe_path(&docs_path))
+}
+
+fn apply_feature_rules(package: &Package, config: &Config) -> Vec<String> {
+    let chip_name = &config.name();
+
+    let mut features = vec![];
+    match package {
+        Package::EspBacktrace => features.push("defmt".to_owned()),
+        Package::EspConfig => features.push("build".to_owned()),
+        Package::EspHal => {
+            features.push("unstable".to_owned());
+            features.push("ci".to_owned());
+            match chip_name.as_str() {
+                "esp32" => features.push("psram".to_owned()),
+                "esp32s2" => features.push("psram".to_owned()),
+                "esp32s3" => features.push("psram".to_owned()),
+                _ => {}
+            };
+        }
+        Package::EspWifi => {
+            features.push("esp-hal/unstable".to_owned());
+            if config.contains("wifi") {
+                features.push("wifi".to_owned());
+                features.push("esp-now".to_owned());
+                features.push("sniffer".to_owned());
+                features.push("utils".to_owned());
+                features.push("smoltcp/proto-ipv4".to_owned());
+                features.push("smoltcp/proto-ipv6".to_owned());
+            }
+            if config.contains("ble") {
+                features.push("ble".to_owned());
+            }
+            if config.contains("wifi") && config.contains("ble") {
+                features.push("coex".to_owned());
+            }
+        }
+        Package::EspHalEmbassy => {
+            features.push("esp-hal/unstable".to_owned());
+        }
+        _ => {}
+    }
+
+    features
+}
+
+// ----------------------------------------------------------------------------
+// Build Documentation Index
+
+pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> Result<()> {
+    let docs_path = workspace.join("docs");
+    let resources_path = workspace.join("resources");
+
+    packages.sort();
+
+    for package in packages {
+        // Not all packages have documentation built:
+        if !package.should_document() {
+            continue;
+        }
+
+        // If the chip features are not relevant, then there is no need to generate an
+        // index for the given package's documentation:
+        if !package.chip_features_matter() {
+            log::warn!("Package '{package}' does not have device-specific documentation, no need to generate an index");
+            continue;
+        }
+
+        let package_docs_path = docs_path.join(package.to_string());
+        let mut device_doc_paths = Vec::new();
+
+        // Each path we iterate over should be the directory for a given version of
+        // the package's documentation:
+        for version_path in fs::read_dir(package_docs_path)? {
+            let version_path = version_path?.path();
+            if version_path.is_file() {
+                log::debug!(
+                    "Path is not a directory, skipping: '{}'",
+                    version_path.display()
+                );
+                continue;
+            }
+
+            for path in fs::read_dir(&version_path)? {
+                let path = path?.path();
+                if path.is_dir() {
+                    device_doc_paths.push(path);
+                }
+            }
+
+            let mut chips = device_doc_paths
+                .iter()
+                .map(|path| {
+                    let chip = path
+                        .components()
+                        .last()
+                        .unwrap()
+                        .as_os_str()
+                        .to_string_lossy();
+
+                    let chip = Chip::from_str(&chip, true).unwrap();
+
+                    chip
+                })
+                .collect::<Vec<_>>();
+
+            chips.sort();
+
+            let meta = generate_documentation_meta_for_package(workspace, *package, &chips)?;
+            render_template(
+                "package_index.html.jinja",
+                "index.html",
+                &version_path,
+                &resources_path,
+                minijinja::context! { metadata => meta },
+            )?;
+        }
+    }
+
+    // Copy any additional assets to the documentation's output path:
+    fs::copy(
+        resources_path.join("esp-rs.svg"),
+        docs_path.join("esp-rs.svg"),
+    )
+    .context("Failed to copy esp-rs.svg")?;
+
+    let meta = generate_documentation_meta_for_index(&workspace)?;
+
+    render_template(
+        "index.html.jinja",
+        "index.html",
+        &docs_path,
+        &resources_path,
+        minijinja::context! { metadata => meta },
+    )?;
+
+    Ok(())
+}
+
+fn generate_documentation_meta_for_package(
+    workspace: &Path,
+    package: Package,
+    chips: &[Chip],
+) -> Result<Vec<Value>> {
+    let version = crate::package_version(workspace, package)?;
+
+    let mut metadata = Vec::new();
+
+    for chip in chips {
+        // Ensure that the package/chip combination provided are valid:
+        crate::validate_package_chip(&package, chip)?;
+
+        // Build the context object required for rendering this particular build's
+        // information on the documentation index:
+        metadata.push(minijinja::context! {
+            name => package,
+            version => version,
+            chip => chip.to_string(),
+            chip_pretty => chip.pretty_name(),
+            package => package.to_string().replace('-', "_"),
+        });
+    }
+
+    Ok(metadata)
+}
+
+fn generate_documentation_meta_for_index(workspace: &Path) -> Result<Vec<Value>> {
+    let mut metadata = Vec::new();
+
+    for package in Package::iter() {
+        // Not all packages have documentation built:
+        if !package.should_document() {
+            continue;
+        }
+
+        let version = crate::package_version(workspace, package)?;
+
+        let url = if package.chip_features_matter() {
+            format!("{package}/{version}/index.html")
+        } else {
+            let crate_name = package.to_string().replace('-', "_");
+            format!("{package}/{version}/{crate_name}/index.html")
+        };
+
+        metadata.push(minijinja::context! {
+            name => package,
+            version => version,
+            url => url,
+        });
+    }
+
+    Ok(metadata)
+}
+
+// ----------------------------------------------------------------------------
+// Helper Functions
+
+fn render_template<C>(
+    template: &str,
+    name: &str,
+    path: &Path,
+    resources: &Path,
+    ctx: C,
+) -> Result<()>
+where
+    C: serde::Serialize,
+{
+    let source = fs::read_to_string(resources.join(template))
+        .context(format!("Failed to read {template}"))?;
+
+    let mut env = minijinja::Environment::new();
+    env.add_template(template, &source)?;
+
+    let tmpl = env.get_template(template)?;
+    let html = tmpl.render(ctx)?;
+
+    // Write out the rendered HTML to the desired path:
+    let path = path.join(name);
+    fs::write(&path, html).context(format!("Failed to write {name}"))?;
+    log::info!("Created {}", path.display());
+
+    Ok(())
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -83,7 +83,7 @@ impl Package {
     }
 
     /// Should documentation be built for the package?
-    pub fn should_document(&self) -> bool {
+    pub fn is_published(&self) -> bool {
         !matches!(self, Package::Examples | Package::HilTest | Package::QaTest)
     }
 }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -6,15 +6,16 @@ use std::{
     process::Command,
 };
 
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use cargo::CargoAction;
 use clap::ValueEnum;
-use esp_metadata::{Chip, Config};
+use esp_metadata::Chip;
 use strum::{Display, EnumIter, IntoEnumIterator as _};
 
 use crate::{cargo::CargoArgsBuilder, firmware::Metadata};
 
 pub mod cargo;
+pub mod documentation;
 pub mod firmware;
 
 #[derive(
@@ -93,127 +94,6 @@ pub enum Version {
     Major,
     Minor,
     Patch,
-}
-
-/// Build the documentation for the specified package and, optionally, a
-/// specific chip.
-pub fn build_documentation(
-    workspace: &Path,
-    package: Package,
-    chip: Option<Chip>,
-) -> Result<PathBuf> {
-    let package_name = package.to_string();
-    let package_path = windows_safe_path(&workspace.join(&package_name));
-
-    if let Some(chip) = chip {
-        log::info!("Building '{package_name}' documentation targeting '{chip}'");
-    } else {
-        log::info!("Building '{package_name}' documentation");
-    }
-
-    // We require some nightly features to build the documentation:
-    let toolchain = if chip.is_some_and(|chip| chip.is_xtensa()) {
-        "esp"
-    } else {
-        "nightly"
-    };
-
-    // Determine the appropriate build target for the given package and chip,
-    // if we're able to:
-    let target = if let Some(ref chip) = chip {
-        Some(target_triple(package, chip)?)
-    } else {
-        None
-    };
-
-    let mut features = vec![];
-    if let Some(chip) = chip {
-        features.push(chip.to_string());
-        features.extend(apply_feature_rules(&package, Config::for_chip(&chip)));
-    }
-
-    // Build up an array of command-line arguments to pass to `cargo`:
-    let mut builder = CargoArgsBuilder::default()
-        .toolchain(toolchain)
-        .subcommand("doc")
-        .features(&features)
-        .arg("-Zrustdoc-map")
-        .arg("--lib")
-        .arg("--no-deps");
-
-    if let Some(target) = target {
-        builder = builder.target(target);
-    }
-
-    // Special case: `esp-metadata` requires `std`, and we get some really confusing
-    // errors if we try to pass `-Zbuild-std=core`:
-    if package != Package::EspMetadata {
-        builder = builder.arg("-Zbuild-std=alloc,core");
-    }
-
-    let args = builder.build();
-    log::debug!("{args:#?}");
-
-    let mut envs = vec![("RUSTDOCFLAGS", "--cfg docsrs --cfg not_really_docsrs")];
-    // Special case: `esp-storage` requires the optimization level to be 2 or 3:
-    if package == Package::EspStorage {
-        envs.push(("CARGO_PROFILE_DEBUG_OPT_LEVEL", "3"));
-    }
-
-    // Execute `cargo doc` from the package root:
-    cargo::run_with_env(&args, &package_path, envs, false)?;
-
-    // Build up the path at which the built documentation can be found:
-    let mut docs_path = workspace.join(package.to_string()).join("target");
-    if let Some(target) = target {
-        docs_path = docs_path.join(target);
-    }
-    docs_path = docs_path.join("doc");
-
-    Ok(windows_safe_path(&docs_path))
-}
-
-fn apply_feature_rules(package: &Package, config: &Config) -> Vec<String> {
-    let chip_name = &config.name();
-
-    let mut features = vec![];
-    match package {
-        Package::EspBacktrace => features.push("defmt".to_owned()),
-        Package::EspConfig => features.push("build".to_owned()),
-        Package::EspHal => {
-            features.push("unstable".to_owned());
-            features.push("ci".to_owned());
-            match chip_name.as_str() {
-                "esp32" => features.push("psram".to_owned()),
-                "esp32s2" => features.push("psram".to_owned()),
-                "esp32s3" => features.push("psram".to_owned()),
-                _ => {}
-            };
-        }
-        Package::EspWifi => {
-            features.push("esp-hal/unstable".to_owned());
-            if config.contains("wifi") {
-                features.push("wifi".to_owned());
-                features.push("esp-now".to_owned());
-                features.push("sniffer".to_owned());
-                features.push("utils".to_owned());
-                features.push("smoltcp/proto-ipv4".to_owned());
-                features.push("smoltcp/proto-ipv6".to_owned());
-            }
-            if config.contains("ble") {
-                features.push("ble".to_owned());
-            }
-            if config.contains("wifi") && config.contains("ble") {
-                features.push("coex".to_owned());
-            }
-        }
-        Package::EspHalEmbassy => {
-            features.push("esp-hal/unstable".to_owned());
-        }
-        _ => {}
-    }
-
-    features
 }
 
 /// Run or build the specified test or example for the specified chip.
@@ -584,6 +464,25 @@ pub fn generate_efuse_table(
 // ----------------------------------------------------------------------------
 // Helper Functions
 
+// Copy an entire directory recursively.
+// https://stackoverflow.com/a/65192210
+pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
+    fs::create_dir_all(&dst)?;
+
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Return a (sorted) list of paths to each valid Cargo package in the
 /// workspace.
 pub fn package_paths(workspace: &Path) -> Result<Vec<PathBuf>> {
@@ -635,4 +534,16 @@ pub fn target_triple(package: Package, chip: &Chip) -> Result<&str> {
     } else {
         Ok(chip.target())
     }
+}
+
+/// Validate that the specified chip is valid for the specified package.
+pub fn validate_package_chip(package: &Package, chip: &Chip) -> Result<()> {
+    ensure!(
+        *package != Package::EspLpHal || chip.has_lp_core(),
+        "Invalid chip provided for package '{}': '{}'",
+        package,
+        chip
+    );
+
+    Ok(())
 }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -30,6 +30,7 @@ pub mod firmware;
     Display,
     EnumIter,
     ValueEnum,
+    serde::Deserialize,
     serde::Serialize,
 )]
 #[serde(rename_all = "kebab-case")]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -89,6 +89,9 @@ struct BuildDocumentationArgs {
     /// Chip(s) to build documentation for.
     #[arg(long, value_enum, value_delimiter = ',', default_values_t = Chip::iter())]
     chips: Vec<Chip>,
+    /// Base URL of the deployed documentation.
+    #[arg(long)]
+    base_url: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -474,7 +477,12 @@ fn tests(workspace: &Path, args: TestArgs, action: CargoAction) -> Result<()> {
 }
 
 fn build_documentation(workspace: &Path, mut args: BuildDocumentationArgs) -> Result<()> {
-    xtask::documentation::build_documentation(workspace, &mut args.packages, &mut args.chips)
+    xtask::documentation::build_documentation(
+        workspace,
+        &mut args.packages,
+        &mut args.chips,
+        args.base_url,
+    )
 }
 
 fn build_documentation_index(


### PR DESCRIPTION
First off, sorry for the noise here. There's a lot of documentation-related code in the `xtask` package now, so I pulled it into its own module. The only real interesting commit here is https://github.com/esp-rs/esp-hal/commit/816e7a55770a10bfd6f2660f1d5ea50d8c858a51, so you can just review that for the most part.

Hopefully it's reasonably self-explanatory, but the gist is:

- We now generate a JSON manifest for each package listing all deployed versions
    - When generating new docs, this is pulled down from the server and updated to include the new version
    - The newly updated manifest can then be re-deployed to the server
    - This allows older, already-deployed versions of the docs to have their version selectors updated without being rebuilt
- The generated documentation is patched to include a version selector in the sidebar
    - On page load, this is automatically updated to include all versions from the JSON manifest
    - When the selector is change, the page is redirected to the selected version

I did some basic testing locally and it at least appears to be working as intended, but will try to test it a bit more. Should be reasonably complete at this point I think, though.

Some caveats:

- I have not tested any browsers other than Firefox. The JS should work on anything modern; maybe IE11 it will not work (but anybody still using that in 2025 kind of deserves whatever they get anyway 🤣 )
- I have not tested this on a mobile device; should be fine I think, but not certain
- There may still be some lingering bugs; as mentioned previously I will do some more testing

Closes #2968