### PR TITLE
TWAI: make async transmission abortable and wait for actuall transmission

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Rng` and `Trng` now implement `Peripheral<P = Self>` (#2992)
 - SPI, UART, I2C: `with_<pin>` functions of peripheral drivers now disconnect the previously assigned pins from the peripheral. (#3012)
 - SPI, UART, I2C: Dropping a driver now disconnects pins from their peripherals. (#3012)
+- TWAI: Async transmission future resolves after successful transmission and can be aborted by dropping the future.
 - Migrate PARL_IO driver to DMA move API (#3033)
 - `Async` drivers are no longer `Send` (#2980)
 - GPIO drivers now take configuration structs (#2990, #3029)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The current implementation for async transmission of TWAI frames does not wait for the frame to been transmitted on the wire. Instead it only waits async for the TWAI peripheral to transmit the frame in its TX buffer. It then fills the TX buffer again, sets the TX request bit and resolves the future.

This implementation has the limitation a) we do not know when the frame has been transmitted which for an overloaded CAN bus could be in the distant future (seconds later) and b) we can not abort the transmission in case the frame could not be transmitted in time.

Therefor I propose to change the behavior to only resolve the future as soon as the TWAI raises the TX interrupt after having requested the transmission of this frame. This also allows to set the abort flag in the TWAI command register in case the future is dropped and therefor abort the transmission automatically in case of for example a timeout.

Possible problems where this change can be useful include the implementation of ISO 15765-2 standard (ISO-TP) where you have to time the transmission of future frames relative to the point in time where the last frame was actually transmitted.

#### Testing
I have tested the implementation on a custom ESP32-C6-WROOM-1 based board with real CAN hardware. The following code was used to verify the correct behavior which sets a GPIO to high until the transmission future is resolved. This pin was captured using a oscilloscope. The green and yellow traces are the CAN high/low signals, the blue trace is the GPIO pin.

Current behavior: https://i.imgur.com/y8M7IUN.png
Proposed behavior: https://i.imgur.com/Aqp6ZXQ.png

##### Code used for testing
```rust
#![no_std]
#![no_main]

use esp_backtrace as _;

use esp_hal::{
    gpio::{Level, Output, OutputConfig},
    timer::systimer::SystemTimer,
    twai::{BaudRate, EspTwaiFrame, StandardId, TwaiConfiguration, TwaiMode},
};

use embassy_executor::Spawner;
use embassy_time::{Duration, Ticker};

#[esp_hal_embassy::main]
async fn main(_spawner: Spawner) {
    let config = esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max());
    let peripherals = esp_hal::init(config);
    let timer0 = SystemTimer::new(peripherals.SYSTIMER);
    esp_hal_embassy::init(timer0.alarm0);

    let mut tx_indicator_output =
        Output::new(peripherals.GPIO1, Level::Low, OutputConfig::default());

    let twai_config = TwaiConfiguration::new(
        peripherals.TWAI0,
        peripherals.GPIO19,
        peripherals.GPIO18,
        BaudRate::B1000K,
        TwaiMode::Normal,
    )
    .into_async();

    let mut twai = twai_config.start();
    let tx_id = StandardId::new(0x100).unwrap();
    let frame = EspTwaiFrame::new(tx_id, &[0xCC; 4]).unwrap();

    let mut ticker = Ticker::every(Duration::from_millis(1));
    loop {
        tx_indicator_output.set_high();
        twai.transmit_async(&frame).await.unwrap();
        tx_indicator_output.set_low();

        ticker.next().await;
    }
}
```
