### PR TITLE
fix #3051: pass attributes through heap_allocator macro

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `esp_alloc::heap_allocator!` now accepts attributes, e.g., `esp_alloc::heap_allocator!(#[link_section = ".dram2_uninit"] size: 64000)`
+- `esp_alloc::heap_allocator!` now accepts attributes, e.g., `esp_alloc::heap_allocator!(#[link_section = ".dram2_uninit"] size: 64000)` (#3133)
 
 ### Changed
 

--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `esp_alloc::heap_allocator!` now accepts attributes, e.g., `esp_alloc::heap_allocator!(#[link_section = ".dram2_uninit"] size: 64000)`
+
 ### Changed
 
 ### Fixed

--- a/esp-alloc/src/macros.rs
+++ b/esp-alloc/src/macros.rs
@@ -14,7 +14,7 @@
 /// ```
 #[macro_export]
 macro_rules! heap_allocator {
-    ($size:expr) => (heap_allocator!(size: $size));
+    ($size:expr) => ($crate::heap_allocator!(size: $size));
     ($(#[$m:meta])* size: $size:expr) => {{
         $(#[$m])*
         static mut HEAP: core::mem::MaybeUninit<[u8; $size]> = core::mem::MaybeUninit::uninit();

--- a/esp-alloc/src/macros.rs
+++ b/esp-alloc/src/macros.rs
@@ -4,13 +4,11 @@
 /// bytes. This supports attributes.
 ///
 /// # Usage
-/// ```
+/// ```rust, no_run
 /// // Use 64kB in the same region stack uses (dram_seg), for the heap.
-/// heap_allocator(64000)
-/// // Use 64kB in the same region stack uses (dram_seg), for the heap.
-/// heap_allocator(size: 64000)
+/// heap_allocator!(size: 64000);
 /// // Use 64kB in dram2_seg for the heap, which is otherwise unused.
-/// heap_allocator(#[link_section = ".dram2_uninit"] size: 64000)
+/// heap_allocator!(#[link_section = ".dram2_uninit"] size: 64000);
 /// ```
 #[macro_export]
 macro_rules! heap_allocator {

--- a/esp-alloc/src/macros.rs
+++ b/esp-alloc/src/macros.rs
@@ -1,10 +1,22 @@
 //! Macros provided for convenience
 
 /// Initialize a global heap allocator providing a heap of the given size in
-/// bytes
+/// bytes. This supports attributes.
+///
+/// # Usage
+/// ```
+/// // Use 64kB in the same region stack uses (dram_seg), for the heap.
+/// heap_allocator(64000)
+/// // Use 64kB in the same region stack uses (dram_seg), for the heap.
+/// heap_allocator(size: 64000)
+/// // Use 64kB in dram2_seg for the heap, which is otherwise unused.
+/// heap_allocator(#[link_section = ".dram2_uninit"] size: 64000)
+/// ```
 #[macro_export]
 macro_rules! heap_allocator {
-    ($size:expr) => {{
+    ($size:expr) => (heap_allocator!(size: $size));
+    ($(#[$m:meta])* size: $size:expr) => {{
+        $(#[$m])*
         static mut HEAP: core::mem::MaybeUninit<[u8; $size]> = core::mem::MaybeUninit::uninit();
 
         unsafe {

--- a/examples/src/bin/wifi_coex.rs
+++ b/examples/src/bin/wifi_coex.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
 
     esp_alloc::heap_allocator!(size: 72 * 1024);
     // COEX needs more RAM - add some more
-    esp_alloc::heap_allocator!(#[link_section = ".dram2_uninit"] size: 72 * 1024);
+    esp_alloc::heap_allocator!(#[link_section = ".dram2_uninit"] size: 64 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_embassy_bench.rs
+++ b/examples/src/bin/wifi_embassy_bench.rs
@@ -73,25 +73,9 @@ async fn main(spawner: Spawner) -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    static mut HEAP: core::mem::MaybeUninit<[u8; 32 * 1024]> = core::mem::MaybeUninit::uninit();
-
-    #[link_section = ".dram2_uninit"]
-    static mut HEAP2: core::mem::MaybeUninit<[u8; 64 * 1024]> = core::mem::MaybeUninit::uninit();
-
-    unsafe {
-        esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
-            HEAP.as_mut_ptr() as *mut u8,
-            core::mem::size_of_val(&*core::ptr::addr_of!(HEAP)),
-            esp_alloc::MemoryCapability::Internal.into(),
-        ));
-
-        // add some more RAM
-        esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
-            HEAP2.as_mut_ptr() as *mut u8,
-            core::mem::size_of_val(&*core::ptr::addr_of!(HEAP2)),
-            esp_alloc::MemoryCapability::Internal.into(),
-        ));
-    }
+    esp_alloc::heap_allocator!(size: 32 * 1024);
+    // add some more RAM
+    esp_alloc::heap_allocator!(#[link_section = ".dram2_uninit"] size: 64 * 1024);
 
     let server_address: Ipv4Addr = HOST_IP.parse().expect("Invalid HOST_IP address");
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Enable passing attributes to the static used by `heap_allocator!` macro. Primarily useful for using the `#[link_section = ".dram2_uninit"]`. Fixes https://github.com/esp-rs/esp-hal/issues/3051

#### Testing
This macro is a copy-paste of a macro I'm using in another project (on esp32). It seems to work there.
