### PR TITLE
esp_alloc: Remove redundant macro syntax

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `esp_alloc::heap_allocator!` syntax has been changed to `esp_alloc::heap_allocator!(size: 64000)` (#3135)
+
 ### Fixed
 
 ### Removed

--- a/esp-alloc/src/macros.rs
+++ b/esp-alloc/src/macros.rs
@@ -12,7 +12,6 @@
 /// ```
 #[macro_export]
 macro_rules! heap_allocator {
-    ($size:expr) => ($crate::heap_allocator!(size: $size));
     ($(#[$m:meta])* size: $size:expr) => {{
         $(#[$m])*
         static mut HEAP: core::mem::MaybeUninit<[u8; $size]> = core::mem::MaybeUninit::uninit();

--- a/examples/src/bin/wifi_80211_tx.rs
+++ b/examples/src/bin/wifi_80211_tx.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let delay = Delay::new();
 

--- a/examples/src/bin/wifi_access_point.rs
+++ b/examples/src/bin/wifi_access_point.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_access_point_with_sta.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_bench.rs
+++ b/examples/src/bin/wifi_bench.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let server_address: Ipv4Addr = HOST_IP.parse().expect("Invalid HOST_IP address");
 

--- a/examples/src/bin/wifi_ble.rs
+++ b/examples/src/bin/wifi_ble.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_csi.rs
+++ b/examples/src/bin/wifi_csi.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let mut rng = Rng::new(peripherals.RNG);
 

--- a/examples/src/bin/wifi_dhcp.rs
+++ b/examples/src/bin/wifi_dhcp.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -64,7 +64,7 @@ async fn main(spawner: Spawner) -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let mut rng = Rng::new(peripherals.RNG);

--- a/examples/src/bin/wifi_embassy_access_point_with_sta.rs
+++ b/examples/src/bin/wifi_embassy_access_point_with_sta.rs
@@ -69,7 +69,7 @@ async fn main(spawner: Spawner) -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let mut rng = Rng::new(peripherals.RNG);

--- a/examples/src/bin/wifi_embassy_ble.rs
+++ b/examples/src/bin/wifi_embassy_ble.rs
@@ -53,7 +53,7 @@ async fn main(_spawner: Spawner) -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_embassy_dhcp.rs
+++ b/examples/src/bin/wifi_embassy_dhcp.rs
@@ -55,7 +55,7 @@ async fn main(spawner: Spawner) -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let mut rng = Rng::new(peripherals.RNG);

--- a/examples/src/bin/wifi_embassy_esp_now.rs
+++ b/examples/src/bin/wifi_embassy_esp_now.rs
@@ -39,7 +39,7 @@ async fn main(_spawner: Spawner) -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_embassy_esp_now_duplex.rs
+++ b/examples/src/bin/wifi_embassy_esp_now_duplex.rs
@@ -39,7 +39,7 @@ async fn main(spawner: Spawner) -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_esp_now.rs
+++ b/examples/src/bin/wifi_esp_now.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/examples/src/bin/wifi_sniffer.rs
+++ b/examples/src/bin/wifi_sniffer.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let init = init(

--- a/examples/src/bin/wifi_static_ip.rs
+++ b/examples/src/bin/wifi_static_ip.rs
@@ -49,7 +49,7 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(72 * 1024);
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/hil-test/tests/esp_wifi_ble_controller.rs
+++ b/hil-test/tests/esp_wifi_ble_controller.rs
@@ -33,7 +33,7 @@ mod tests {
 
     #[init]
     fn init() -> Peripherals {
-        esp_alloc::heap_allocator!(72 * 1024);
+        esp_alloc::heap_allocator!(size: 72 * 1024);
 
         let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
         esp_hal::init(config)

--- a/hil-test/tests/esp_wifi_floats.rs
+++ b/hil-test/tests/esp_wifi_floats.rs
@@ -56,7 +56,7 @@ mod tests {
 
     #[init]
     fn test_init() -> Peripherals {
-        esp_alloc::heap_allocator!(72 * 1024);
+        esp_alloc::heap_allocator!(size: 72 * 1024);
 
         let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
         esp_hal::init(config)


### PR DESCRIPTION
We probably don't want the `heap_allocator!(1234)` syntax, as it suggests `size:` is optional, but `heap_allocator!(#meta] 1234)` is not valid syntax.