### PR TITLE
Split UART errors

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uart `write_bytes` and `read_bytes` are now blocking and return the number of bytes written/read (#2882)
 - Uart `read_bytes` is now blocking  returns the number of bytes read (#2882)
 - Uart `flush` is now blocking (#2882)
+- Uart errors have been split into `RxError` and `TxError`. A combined `IoError` has been created for embedded-io. (#3138)
+- `{Uart, UartTx}::flush()` is now fallible. (#3138)
 - Removed `embedded-hal-nb` traits (#2882)
 - `timer::wait` is now blocking (#2882)
 - By default, set `tx_idle_num` to 0 so that bytes written to TX FIFO are always immediately transmitted. (#2859)

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -107,6 +107,16 @@ e.g.
 + uart.read_bytes(&mut byte);
 ```
 
+### UART errors have been split into `TxError` and `RxError`.
+
+`read_*` and `write_*` functions now return different types. In practice this means you no longer
+need to check for RX errors that can't be returned by `write_*`.
+
+The error type used by `embedded-io` has been updated to reflect this. A new `IoError` enum has been
+added for `embedded-io` errors associated to the unsplit `Uart` driver. On `Uart` (but not `UartRx`
+or `UartTx`) TX-related trait methods return `IoError::Tx(TxError)`, while RX-related methods return
+`IoError::Rx(RxError)`.
+
 ### UART halves have their configuration split too
 
 `Uart::Config` structure now contains separate `RxConfig` and `TxConfig`:


### PR DESCRIPTION
It's somewhat weird that we return an enum of RX errors for `write_bytes`. This PR introduces TxError (and for embedded-io, IoError) so that we can keep these separate. TxError is currently empty, as the hardware doesn't actually handle TX errors - except for RS485 which we don't currently support. We may or may not add RS485 support to this driver (my opinion is that we should introduce a new driver for it) but the TxError enum means we leave a common implementation possible.