### PR TITLE
Uart tweaks

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uart `flush` is now blocking (#2882)
 - Uart errors have been split into `RxError` and `TxError`. A combined `IoError` has been created for embedded-io. (#3138)
 - `{Uart, UartTx}::flush()` is now fallible. (#3138)
+- The `apply_config` of `UartRx` and `UartTx` now only take their relevant configuration structs. (#3141)
 - Removed `embedded-hal-nb` traits (#2882)
 - `timer::wait` is now blocking (#2882)
 - By default, set `tx_idle_num` to 0 so that bytes written to TX FIFO are always immediately transmitted. (#2859)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uart `flush` is now blocking (#2882)
 - Uart errors have been split into `RxError` and `TxError`. A combined `IoError` has been created for embedded-io. (#3138)
 - `{Uart, UartTx}::flush()` is now fallible. (#3138)
-- The `apply_config` of `UartRx` and `UartTx` now only take their relevant configuration structs. (#3141)
 - Removed `embedded-hal-nb` traits (#2882)
 - `timer::wait` is now blocking (#2882)
 - By default, set `tx_idle_num` to 0 so that bytes written to TX FIFO are always immediately transmitted. (#2859)

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -142,7 +142,7 @@ added for `embedded-io` errors associated to the unsplit `Uart` driver. On `Uart
 or `UartTx`) TX-related trait methods return `IoError::Tx(TxError)`, while RX-related methods return
 `IoError::Rx(RxError)`.
 
-### UART halves have their configuration split too
+### UART halves have their configuration split, too
 
 `Uart::Config` structure now contains separate `RxConfig` and `TxConfig`:
 
@@ -153,6 +153,9 @@ or `UartTx`) TX-related trait methods return `IoError::Tx(TxError)`, while RX-re
 +       .with_fifo_full_threshold(30)
 + );
 ```
+
+The `apply_config` functions of `UartRx` and `UartTx` driver halves now take `RxConfig` and
+`TxConfig` respectively.
 
 ## `timer::wait` is now blocking
 

--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -154,9 +154,6 @@ or `UartTx`) TX-related trait methods return `IoError::Tx(TxError)`, while RX-re
 + );
 ```
 
-The `apply_config` functions of `UartRx` and `UartTx` driver halves now take `RxConfig` and
-`TxConfig` respectively.
-
 ## `timer::wait` is now blocking
 
 ```diff

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1202,6 +1202,8 @@ where
     /// This function returns a [`ConfigError`] if the configuration is not
     /// supported by the hardware.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
+        // Must apply the common settings first, as `rx.apply_config` reads back symbol
+        // size.
         self.rx.uart.info().apply_config(config)?;
         self.rx.apply_config(config)?;
         self.tx.apply_config(config)?;

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -175,14 +175,14 @@ const UART_TOUT_THRESH_DEFAULT: u8 = 10;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DataBits {
     /// 5 data bits per frame.
-    _5 = 0,
+    _5,
     /// 6 data bits per frame.
-    _6 = 1,
+    _6,
     /// 7 data bits per frame.
-    _7 = 2,
+    _7,
     /// 8 data bits per frame.
     #[default]
-    _8 = 3,
+    _8,
 }
 
 /// Parity check
@@ -215,11 +215,11 @@ pub enum Parity {
 pub enum StopBits {
     /// 1 stop bit.
     #[default]
-    _1   = 1,
+    _1,
     /// 1.5 stop bits.
-    _1p5 = 2,
+    _1p5,
     /// 2 stop bits.
-    _2   = 3,
+    _2,
 }
 
 /// Defines how strictly the requested baud rate must be met.
@@ -2150,7 +2150,6 @@ pub mod lp_uart {
                 .modify(|_, w| unsafe { w.bit_num().bits(data_bits as u8) });
 
             self.update();
-
             self
         }
 
@@ -2158,7 +2157,7 @@ pub mod lp_uart {
             self.uart
                 .register_block()
                 .conf0()
-                .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8) });
+                .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8 + 1) });
 
             self.update();
             self
@@ -2621,7 +2620,7 @@ impl Info {
         #[cfg(not(esp32))]
         self.regs()
             .conf0()
-            .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8) });
+            .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8 + 1) });
     }
 
     fn rxfifo_reset(&self) {
@@ -2697,7 +2696,7 @@ impl Info {
 
     fn current_symbol_length(&self) -> u8 {
         let conf0 = self.regs().conf0().read();
-        let data_bits = conf0.bit_num().bits();
+        let data_bits = conf0.bit_num().bits() + 5; // 5 data bits are encoded as variant 0
         let parity = conf0.parity_en().bit() as u8;
         let mut stop_bits = conf0.stop_bit_num().bits();
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -298,6 +298,7 @@ impl Config {
 #[non_exhaustive]
 pub struct RxConfig {
     /// Threshold level at which the RX FIFO is considered full.
+    #[cfg_attr(not(feature = "unstable"), builder_lite(skip))]
     fifo_full_threshold: u16,
     /// Optional timeout value for RX operations.
     timeout: Option<u8>,

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -263,17 +263,6 @@ pub struct Config {
     tx: TxConfig,
 }
 
-/// UART Receive part configuration.
-#[derive(Debug, Clone, Copy, procmacros::BuilderLite)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub struct RxConfig {
-    /// Threshold level at which the RX FIFO is considered full.
-    fifo_full_threshold: u16,
-    /// Optional timeout value for RX operations.
-    timeout: Option<u8>,
-}
-
 impl Default for Config {
     fn default() -> Config {
         Config {
@@ -285,21 +274,6 @@ impl Default for Config {
             parity: Default::default(),
             stop_bits: Default::default(),
             clock_source: Default::default(),
-        }
-    }
-}
-
-/// UART Transmit part configuration.
-#[derive(Debug, Clone, Copy, Default, procmacros::BuilderLite)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub struct TxConfig {}
-
-impl Default for RxConfig {
-    fn default() -> RxConfig {
-        RxConfig {
-            fifo_full_threshold: UART_FULL_THRESH_DEFAULT,
-            timeout: Some(UART_TOUT_THRESH_DEFAULT),
         }
     }
 }
@@ -338,6 +312,32 @@ impl Config {
         Ok(())
     }
 }
+
+/// UART Receive part configuration.
+#[derive(Debug, Clone, Copy, procmacros::BuilderLite)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct RxConfig {
+    /// Threshold level at which the RX FIFO is considered full.
+    fifo_full_threshold: u16,
+    /// Optional timeout value for RX operations.
+    timeout: Option<u8>,
+}
+
+impl Default for RxConfig {
+    fn default() -> RxConfig {
+        RxConfig {
+            fifo_full_threshold: UART_FULL_THRESH_DEFAULT,
+            timeout: Some(UART_TOUT_THRESH_DEFAULT),
+        }
+    }
+}
+
+/// UART Transmit part configuration.
+#[derive(Debug, Clone, Copy, Default, procmacros::BuilderLite)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct TxConfig {}
 
 /// Configuration for the AT-CMD detection functionality
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, procmacros::BuilderLite)]

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -502,7 +502,7 @@ impl<Dm> embassy_embedded_hal::SetConfig for UartRx<'_, Dm>
 where
     Dm: DriverMode,
 {
-    type Config = RxConfig;
+    type Config = Config;
     type ConfigError = ConfigError;
 
     fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
@@ -515,7 +515,7 @@ impl<Dm> embassy_embedded_hal::SetConfig for UartTx<'_, Dm>
 where
     Dm: DriverMode,
 {
-    type Config = TxConfig;
+    type Config = Config;
     type ConfigError = ConfigError;
 
     fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
@@ -559,7 +559,7 @@ where
     /// This function returns a [`ConfigError`] if the configuration is not
     /// supported by the hardware.
     #[instability::unstable]
-    pub fn apply_config(&mut self, _config: &TxConfig) -> Result<(), ConfigError> {
+    pub fn apply_config(&mut self, _config: &Config) -> Result<(), ConfigError> {
         // Nothing to do so far.
         self.uart.info().txfifo_reset();
         Ok(())
@@ -765,13 +765,13 @@ where
     /// This function returns a [`ConfigError`] if the configuration is not
     /// supported by the hardware.
     #[instability::unstable]
-    pub fn apply_config(&mut self, config: &RxConfig) -> Result<(), ConfigError> {
+    pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.uart
             .info()
-            .set_rx_fifo_full_threshold(config.fifo_full_threshold)?;
+            .set_rx_fifo_full_threshold(config.rx.fifo_full_threshold)?;
         self.uart
             .info()
-            .set_rx_timeout(config.timeout, self.uart.info().current_symbol_length())?;
+            .set_rx_timeout(config.rx.timeout, self.uart.info().current_symbol_length())?;
 
         self.uart.info().rxfifo_reset();
         Ok(())
@@ -1202,8 +1202,8 @@ where
     /// supported by the hardware.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.rx.uart.info().apply_config(config)?;
-        self.rx.apply_config(&config.rx)?;
-        self.tx.apply_config(&config.tx)?;
+        self.rx.apply_config(config)?;
+        self.tx.apply_config(config)?;
         Ok(())
     }
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -541,9 +541,7 @@ where
     }
 
     /// Change the configuration.
-    ///
-    /// Note that this also changes the configuration of the RX half.
-    #[instability::unstable]
+        #[instability::unstable]
     pub fn apply_config(&mut self, _config: &TxConfig) -> Result<(), ConfigError> {
         // Nothing to do so far.
         self.uart.info().txfifo_reset();
@@ -744,8 +742,6 @@ where
     }
 
     /// Change the configuration.
-    ///
-    /// Note that this also changes the configuration of the TX half.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
- We have had documented that TX/RX config changes the other half, which is untrue.
- ~We have taken the unsplit configuration in all `apply_config` methods, which made the config split meaningless.~ Undid this change but there's a related bugfix: RX config reads back the symbol size to correctly calculate the timeout value from the actually active config.
- Error cases were documented on functions, instead of the enum values. Since `apply` config on the split halves are unstable, this meant broken links in the stable documentation.
- Constants were displayed in hex, making them unnecessarily hard to interpret
- `impl` blocks were intermixed making navigating in the code difficult.
- `ConfigError::UnsupportedFifoThreshold` was not specific enough. We have a separate "TX FIFO empty" configuration, which configuration is currently not supported.
- Removed the explicit numeric determinant values from the public enums. Those values are implementation details and were unnecessarily public.
