### PR TITLE
migration: Fix example to use correct method `.with_pull(...)`

### DIFF
--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -244,7 +244,7 @@ GPIO drivers now take configuration structs.
 
 ```diff
 - Input::new(peripherals.GPIO0, Pull::Up);
-+ Input::new(peripherals.GPIO0, InputConfig::default().with_pull_direction(Pull::Up));
++ Input::new(peripherals.GPIO0, InputConfig::default().with_pull(Pull::Up));
  
 - Output::new(peripherals.GPIO0, Level::Low);
 + Output::new(peripherals.GPIO0, Level::Low, OutputConfig::default());


### PR DESCRIPTION
Migration example uses `with_pull_direction(...)` method, which doesn't exist (anymore?). Switch it to `with_pull()`. 