### PR TITLE
Deploy docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -57,8 +57,11 @@ jobs:
           repository: esp-rs/esp-hal
           ref: ${{ matrix.packages.tag }}
 
+      # TODO uncomment
+      # - name: Build documentation
+      #   run: hal-xtask build-documentation --packages=${{ matrix.packages.name }}
       - name: Build documentation
-        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }}
+        run: cargo xtask build-documentation --packages=${{ matrix.packages.name }}
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -91,8 +91,15 @@ jobs:
         with:
           path: "docs/"
 
+      # Create an index for _all_ packages.
       - name: Create index.html
-        run: "cargo xtask build-documentation-index --packages=$(echo '${{ needs.setup.outputs.packages }}' | jq -r '[.[].name] | join(\",\")')"
+        run: cargo xtask build-documentation-index
+
+      - name: Debug 1
+        run: "ls -la *"
+      - name: Debug 2
+        run: "ls -la docs/*"
+
 
       - if: ${{ github.event.inputs.server == 'preview' }}
         name: Deploy to preview server

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -47,18 +47,18 @@ jobs:
           repository: esp-rs/esp-hal
       - name: Build xtask
         run: |
-          cargo build --release --package=xtask
+          cargo build --release --package=xtask --features=deploy-docs
           cp target/release/xtask ~/.cargo/bin/hal-xtask
 
       # Checkout the tag we need to start building the docs
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: mabezdev/esp-hal # TODO
+          repository: mabezdev/esp-hal # FIXME change
           ref: ${{ matrix.packages.tag }}
 
       - name: Build documentation
-        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }}
+        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }} --base-url /esp-hal/ # FIXME change, base url will be /rust/ on main server
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -98,7 +98,7 @@ jobs:
         name: Deploy to preview server
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.PREVIEW_HOST }}
+          host: preview-docs.espressif.com
           username: ${{ secrets.PREVIEW_USERNAME }}
           key: ${{ secrets.PREVIEW_KEY }}
           target: ${{ secrets.PREVIEW_TARGET }}
@@ -109,7 +109,7 @@ jobs:
         name: Deploy to production server
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.PRODUCTION_HOST }}
+          host: docs.espressif.com
           username: ${{ secrets.PRODUCTION_USERNAME }}
           key: ${{ secrets.PRODUCTION_KEY }}
           target: ${{ secrets.PRODUCTION_TARGET }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: mabezdev/esp-hal # FIXME change
+          repository: esp-hal/esp-hal
           ref: ${{ matrix.packages.tag }}
 
       - name: Build documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,12 @@ on:
           A JSON structure describing the packages to build.
           E.g: [{"name":"esp-hal","tag":"v0.23.1"},{"name":"esp-wifi","tag":"esp-wifi-v0.12"}]
         required: true
+      server:
+        type: choice
+        description: Which server to deploy to
+        options:
+          - preview
+          - production
 
 env:
   CARGO_TERM_COLOR: always
@@ -58,7 +64,7 @@ jobs:
           ref: ${{ matrix.packages.tag }}
 
       - name: Build documentation
-        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }} --base-url /esp-hal/ # FIXME change, base url will be /rust/ on main server
+        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }} --base-url /rust/
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files
@@ -88,28 +94,24 @@ jobs:
       - name: Create index.html
         run: "cargo xtask build-documentation-index --packages=$(echo '${{ needs.setup.outputs.packages }}' | jq -r '[.[].name] | join(\",\")')"
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - if: ${{ github.event.inputs.server == 'preview' }}
+        name: Deploy to preview server
+        uses: appleboy/scp-action@v0.1.7
         with:
-          path: "docs/"
+          host: ${{ secrets.PREVIEW_HOST }}
+          username: ${{ secrets.PREVIEW_USERNAME }}
+          key: ${{ secrets.PREVIEW_KEY }}
+          target: ${{ secrets.PREVIEW_TARGET }}
+          source: "docs/*"
+          overwrite: true
 
-  deploy:
-    # Add a dependency to the assemble job:
-    needs: assemble
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment:
-    permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    # Specify runner + deployment step:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - if: ${{ github.event.inputs.server == 'production' }}
+        name: Deploy to production server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.PRODUCTION_HOST }}
+          username: ${{ secrets.PRODUCTION_USERNAME }}
+          key: ${{ secrets.PRODUCTION_KEY }}
+          target: ${{ secrets.PRODUCTION_TARGET }}
+          source: "docs/*"
+          overwrite: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: esp-rs/esp-hal
+          repository: mabezdev/esp-hal # TODO
           ref: ${{ matrix.packages.tag }}
 
       - name: Build documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           toolchain: stable
       - name: Prepare
-        run: mkdir docs
+        run: mkdir docs && mkdir docs/esp-hal && mkdir docs/esp-wifi && mkdir docs/esp-lp-hal
       - name: Download all docs
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,7 +6,7 @@ on:
       packages:
         description: >
           A JSON structure describing the packages to build.
-          E.g: [{"name":"esp-hal","tag":"v0.23.1"},{"name":"esp-wifi","tag":"v0.12"}]
+          E.g: [{"name":"esp-hal","tag":"v0.23.1"},{"name":"esp-wifi","tag":"esp-wifi-v0.12"}]
         required: true
 
 env:
@@ -34,6 +34,23 @@ jobs:
           ldproxy: false
           version: 1.84.0.0
 
+      # TODO: we could build this once and download onto each runner
+      # Build the `xtask` package using the latest commit, and copy the
+      # resulting binary to the `~/.cargo/bin/` directory. We do this to
+      # avoid having to rebuild different versions of the package for
+      # different tags if they do not fall on the same commit, and to
+      # make sure that we take advantage of any subsequent updates to
+      # the xtask which may have happened after a release was tagged.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: esp-rs/esp-hal
+      - name: Build xtask
+        run: |
+          cargo build --release --package=xtask
+          cp target/release/xtask ~/.cargo/bin/hal-xtask
+
+      # Checkout the tag we need to start building the docs
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -41,7 +58,7 @@ jobs:
           ref: ${{ matrix.packages.tag }}
 
       - name: Build documentation
-        run: cargo xtask build-documentation --packages=${{ matrix.packages.name }}
+        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }}
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -105,6 +105,7 @@ jobs:
           key: ${{ secrets.PREVIEW_KEY }}
           target: ${{ secrets.PREVIEW_TARGET }}
           source: "docs/"
+          strip_components: 1 # remove the docs prefix
           overwrite: true
 
       - if: ${{ github.event.inputs.server == 'production' }}
@@ -116,4 +117,5 @@ jobs:
           key: ${{ secrets.PRODUCTION_KEY }}
           target: ${{ secrets.PRODUCTION_TARGET }}
           source: "docs/"
+          strip_components: 1 # remove the docs prefix
           overwrite: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,11 +3,10 @@ name: Documentation
 on:
   workflow_dispatch:
     inputs:
-      esp-hal:
-        description: "esp-hal tag"
-        required: true
-      esp-wifi:
-        description: "esp-wifi tag"
+      packages:
+        description: >
+          A JSON structure describing the packages to build.
+          E.g: [{"name":"esp-hal","tag":"v0.23.1"},{"name":"esp-wifi","tag":"v0.12"}]
         required: true
 
 env:
@@ -17,10 +16,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      packages: '[
-            { "name": "esp-hal",  "tag": "${{ github.event.inputs.esp-hal }}" },
-            { "name": "esp-wifi", "tag": "esp-wifi-${{ github.event.inputs.esp-wifi }}" }
-          ]'
+      packages: '${{ github.event.inputs.packages }}'
     steps:
       - run: echo "Setup complete!"
   build:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -57,11 +57,8 @@ jobs:
           repository: esp-rs/esp-hal
           ref: ${{ matrix.packages.tag }}
 
-      # TODO uncomment
-      # - name: Build documentation
-      #   run: hal-xtask build-documentation --packages=${{ matrix.packages.name }}
       - name: Build documentation
-        run: cargo xtask build-documentation --packages=${{ matrix.packages.name }}
+        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }}
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ matrix.packages.tag }}
 
       - name: Build documentation
-        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }} --base-url /rust/
+        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }} --base-url /projects/rust/
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files
@@ -95,11 +95,6 @@ jobs:
       - name: Create index.html
         run: cargo xtask build-documentation-index
 
-      - name: Debug 1
-        run: "ls -la *"
-      - name: Debug 2
-        run: "ls -la docs/*"
-
 
       - if: ${{ github.event.inputs.server == 'preview' }}
         name: Deploy to preview server
@@ -109,7 +104,7 @@ jobs:
           username: ${{ secrets.PREVIEW_USERNAME }}
           key: ${{ secrets.PREVIEW_KEY }}
           target: ${{ secrets.PREVIEW_TARGET }}
-          source: "docs/*"
+          source: "docs/"
           overwrite: true
 
       - if: ${{ github.event.inputs.server == 'production' }}
@@ -120,5 +115,5 @@ jobs:
           username: ${{ secrets.PRODUCTION_USERNAME }}
           key: ${{ secrets.PRODUCTION_KEY }}
           target: ${{ secrets.PRODUCTION_TARGET }}
-          source: "docs/*"
+          source: "docs/"
           overwrite: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,8 @@ on:
         description: >
           A JSON structure describing the packages to build.
           E.g: [{"name":"esp-hal","tag":"v0.23.1"},{"name":"esp-wifi","tag":"esp-wifi-v0.12"}]
+
+          NOTE: You can run `cargo xtask tag-releases` to get the json output generated for this workflow.
         required: true
       server:
         type: choice
@@ -17,6 +19,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   setup:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1107,6 +1107,12 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
 fn tag_releases(workspace: &Path, mut args: TagReleasesArgs) -> Result<()> {
     args.packages.sort();
 
+    #[derive(serde::Serialize)]
+    struct DocumentationItem {
+        name: String,
+        tag: String,
+    }
+
     let mut created = Vec::new();
     for package in args.packages {
         // If a package does not require documentation, this also means that it is not
@@ -1136,7 +1142,7 @@ fn tag_releases(workspace: &Path, mut args: TagReleasesArgs) -> Result<()> {
         } else {
             log::info!("Would create '{tag}' if `--no-dry-run` was passed.")
         }
-        created.push(tag);
+        created.push(DocumentationItem { name: package.to_string(), tag });
     }
 
     if args.no_dry_run {


### PR DESCRIPTION
The input for this workflow is honestly pretty gruesome, I think I can improve it later though.

Basically it's some json input like `[{"name":"esp-hal","tag":"v0.23.1"},{"name":"esp-wifi","tag":"esp-wifi-v0.12"}]` along with the server to deploy to.

I got the docs to deploy to my GHA: https://mabezdev.github.io/esp-hal/esp-hal/0.23.1/esp32c6/esp_hal/index.html with the version selector etc working nicely. So the next step is to switch out the GHA step with the SCP step instead.

---

It works, docs now deploying to preview here: https://preview-docs.espressif.com/projects/rust/

* First run that built esp-hal and esp-wifi: https://github.com/esp-rs/esp-hal/actions/runs/13399549430.
* Follow up run that added esp-backtrace but left the others in tact: https://github.com/esp-rs/esp-hal/actions/runs/13400731461