### PR TITLE
ESP32-H2/ESP32-C6: Don't rely on the bootloader to deconfigure permission control

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - I2C: Async functions are postfixed with `_async`, non-async functions are available in async-mode (#3056)
 
+- ESP32-H2/ESP32-C6: Don't rely on the bootloader to deconfigure permission control (#3150)
+
 ### Fixed
 
 - `DmaDescriptor` is now `#[repr(C)]` (#2988)

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -57,13 +57,13 @@ ufmt-write               = "0.1.0"
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.35.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32c2 = { version = "0.24.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32c3 = { version = "0.27.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32c6 = { version = "0.18.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32h2 = { version = "0.14.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32s2 = { version = "0.26.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
-esp32s3 = { version = "0.30.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "0f3ea9f", optional = true }
+esp32   = { version = "0.35.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "5d133b594", optional = true }
+esp32c2 = { version = "0.24.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "5d133b594", optional = true }
+esp32c3 = { version = "0.27.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "5d133b594", optional = true }
+esp32c6 = { version = "0.18.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "5d133b594", optional = true }
+esp32h2 = { version = "0.14.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "5d133b594", optional = true }
+esp32s2 = { version = "0.26.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "5d133b594", optional = true }
+esp32s3 = { version = "0.30.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "5d133b594", optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.12.1" }

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -467,6 +467,8 @@ pub struct Config {
 /// This function sets up the CPU clock and watchdog, then, returns the
 /// peripherals and clocks.
 pub fn init(config: Config) -> Peripherals {
+    crate::soc::pre_init();
+
     system::disable_peripherals();
 
     let mut peripherals = Peripherals::take();

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -131,3 +131,5 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 pub extern "Rust" fn __init_data() -> bool {
     false
 }
+
+pub(crate) fn pre_init() {}

--- a/esp-hal/src/soc/esp32c2/mod.rs
+++ b/esp-hal/src/soc/esp32c2/mod.rs
@@ -45,3 +45,5 @@ pub(crate) mod constants {
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17500);
 }
+
+pub(crate) fn pre_init() {}

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -63,3 +63,5 @@ pub(crate) mod constants {
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17500);
 }
+
+pub(crate) fn pre_init() {}

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -71,3 +71,23 @@ pub(crate) mod constants {
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17_500);
 }
+
+pub(crate) fn pre_init() {
+    // By default, these access path filters are enable and allow the access to
+    // masters only if they are in TEE mode.
+    //
+    // Since all masters except HP CPU boot in REE mode, default setting of these
+    // filters will deny the access by all masters except HP CPU.
+    //
+    // So, disabling these filters early.
+
+    crate::peripherals::LP_APM::regs()
+        .func_ctrl()
+        .write(|w| unsafe { w.bits(0x0) });
+    crate::peripherals::LP_APM0::regs()
+        .func_ctrl()
+        .write(|w| unsafe { w.bits(0x0) });
+    crate::peripherals::HP_APM::regs()
+        .func_ctrl()
+        .write(|w| unsafe { w.bits(0x0) });
+}

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -71,3 +71,23 @@ pub(crate) mod constants {
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17500);
 }
+
+pub(crate) fn pre_init() {
+    // By default, these access path filters are enable and allow the access to
+    // masters only if they are in TEE mode.
+    //
+    // Since all masters except HP CPU boot in REE mode, default setting of these
+    // filters will deny the access by all masters except HP CPU.
+    //
+    // So, disabling these filters early.
+
+    crate::peripherals::LP_APM::regs()
+        .func_ctrl()
+        .write(|w| unsafe { w.bits(0x0) });
+    crate::peripherals::LP_APM0::regs()
+        .func_ctrl()
+        .write(|w| unsafe { w.bits(0x0) });
+    crate::peripherals::HP_APM::regs()
+        .func_ctrl()
+        .write(|w| unsafe { w.bits(0x0) });
+}

--- a/esp-hal/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal/src/soc/esp32h2/peripherals.rs
@@ -50,6 +50,7 @@ crate::peripherals! {
         LP_ANA <= LP_ANA,
         LP_AON <= LP_AON,
         LP_APM <= LP_APM,
+        LP_APM0 <= LP_APM0,
         LP_PERI <= LP_PERI,
         LP_TIMER <= LP_TIMER,
         LP_WDT <= LP_WDT,

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -165,3 +165,5 @@ pub unsafe fn cache_get_dcache_line_size() -> u32 {
     }
     Cache_Get_DCache_Line_Size()
 }
+
+pub(crate) fn pre_init() {}

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -209,3 +209,5 @@ pub unsafe fn cache_get_dcache_line_size() -> u32 {
     }
     Cache_Get_DCache_Line_Size()
 }
+
+pub(crate) fn pre_init() {}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #3143

Previous bootloaders did that but now esp-idf configures PMS - so we need to do it, too.

#### Testing
Use a recent bootloader (e.g. from 5.3.1, but not too recent since it will need the app-descriptor which will be added by #3124)
