### PR TITLE
Wait for the FIFO to be empty in flush

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue setting higher UART baud rates (#3104)
 - ESP32-S2: Fixed linker script (#3096)
 - Fix auto writeback on Crypto DMA (#3108)
+- `Uart::flush()` now correctly blocks until the TX FIFO is empty (#3151)
 
 ### Removed
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -631,6 +631,11 @@ where
     /// transmitted.
     #[instability::unstable]
     pub fn flush(&mut self) -> Result<(), TxError> {
+        while self.tx_fifo_count() > 0 {}
+        // The FSM is in the Idle state for a short while after the last byte is moved
+        // out of the FIFO. It is unclear how long this takes, but 10us seems to be a
+        // good enough duration to wait, for both fast and slow baud rates.
+        crate::rom::ets_delay_us(10);
         while !self.is_tx_idle() {}
         Ok(())
     }

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -45,31 +45,23 @@ mod tests {
 
     #[test]
     fn test_different_tolerance(mut ctx: Context) {
-        ctx.uart
-            .apply_config(
-                &uart::Config::default()
-                    .with_baudrate(19_200)
-                    .with_baudrate_tolerance(uart::BaudrateTolerance::Exact),
-            )
-            .unwrap();
+        let configs = [
+            uart::Config::default()
+                .with_baudrate(19_200)
+                .with_baudrate_tolerance(uart::BaudrateTolerance::Exact),
+            uart::Config::default()
+                .with_baudrate(9600)
+                .with_baudrate_tolerance(uart::BaudrateTolerance::ErrorPercent(10)),
+        ];
 
-        ctx.uart.write(&[0x42]).unwrap();
-        let mut byte = [0u8; 1];
-        ctx.uart.read(&mut byte).unwrap();
-        assert_eq!(byte[0], 0x42);
+        for config in configs {
+            ctx.uart.apply_config(&config).unwrap();
 
-        ctx.uart
-            .apply_config(
-                &uart::Config::default()
-                    .with_baudrate(9600)
-                    .with_baudrate_tolerance(uart::BaudrateTolerance::ErrorPercent(10)),
-            )
-            .unwrap();
-
-        ctx.uart.write(&[0x42]).unwrap();
-        let mut byte = [0u8; 1];
-        ctx.uart.read(&mut byte).unwrap();
-        assert_eq!(byte[0], 0x42);
+            ctx.uart.write(&[0x42]).unwrap();
+            let mut byte = [0u8; 1];
+            ctx.uart.read(&mut byte).unwrap();
+            assert_eq!(byte[0], 0x42);
+        }
     }
 
     #[test]


### PR DESCRIPTION
This is pretty hard to test, but I think possible, therefore the PR is draft right now.

Verified using the following test that the old behaviour wasn't as desired:

<details><summary>test</summary>
<p>

```rust
#![no_std]
#![no_main]

use esp_hal::{
    gpio::Output,
    uart::{self, ClockSource, Uart},
    Blocking,
};
use hil_test as _;

struct Context {
    uart: Uart<'static, Blocking>,
    gpio: Output<'static>,
}

#[cfg(test)]
#[embedded_test::tests(default_timeout = 30)]
mod tests {
    use esp_hal::{delay::Delay, gpio::Level};

    use super::*;

    #[init]
    fn init() -> Context {
        let peripherals = esp_hal::init(esp_hal::Config::default());

        let (rx, tx) = hil_test::common_test_pins!(peripherals);

        let uart = Uart::new(peripherals.UART1, uart::Config::default())
            .unwrap()
            .with_tx(tx)
            .with_rx(rx);

        Context {
            uart,
            gpio: Output::new(peripherals.GPIO11, Level::Low, Default::default()),
        }
    }

    #[test]
    fn test_send_receive(mut ctx: Context) {
        let mut lin_uart = ctx.uart;

        let mut d = Delay::new();

        loop {
            ctx.gpio.set_low();
            lin_uart
                .apply_config(&esp_hal::uart::Config::default().with_baudrate(9600))
                .unwrap();

            lin_uart.write(&[0xaa]).unwrap();
            lin_uart.flush().unwrap();

            ctx.gpio.set_high();
            // d.delay_micros(1000); // !!!!!!

            lin_uart
                .apply_config(&esp_hal::uart::Config::default().with_baudrate(19200))
                .unwrap();

            lin_uart.write(&[0x55, 0x01, 0x02, 0x03]).unwrap();
            lin_uart.flush().unwrap();

            d.delay_millis(5);
        }
    }
}
```

</p>
</details> 

Before: 
![image](https://github.com/user-attachments/assets/c3d3d71a-2eb1-4a7c-9ee8-d30db7423085)

After:
![image](https://github.com/user-attachments/assets/8a162668-3e28-4e8d-9e45-af7300ffa493)

PR is related to https://github.com/esp-rs/esp-hal/issues/2743