### PR TITLE
Disable multiple-integrated timer queue flavour

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- The `multiple-integrated` timer queue flavour has been temporarily removed (#3159)
+
 ## 0.6.0 - 2025-01-15
 
 ### Added

--- a/esp-hal-embassy/build.rs
+++ b/esp-hal-embassy/build.rs
@@ -49,7 +49,8 @@ fn main() -> Result<(), Box<dyn StdError>> {
         ),
         (
             "timer-queue",
-            "<p>The flavour of the timer queue provided by this crate. Accepts one of `single-integrated`, `multiple-integrated` or `generic`. Integrated queues require the `executors` feature to be enabled.</p><p>If you use embassy-executor, the `single-integrated` queue is recommended for ease of use, while the `multiple-integrated` queue is recommended for performance. The `multiple-integrated` option needs one timer per executor.</p><p>The `generic` queue allows using embassy-time without the embassy executors.</p>",
+            //"<p>The flavour of the timer queue provided by this crate. Accepts one of `single-integrated`, `multiple-integrated` or `generic`. Integrated queues require the `executors` feature to be enabled.</p><p>If you use embassy-executor, the `single-integrated` queue is recommended for ease of use, while the `multiple-integrated` queue is recommended for performance. The `multiple-integrated` option needs one timer per executor.</p><p>The `generic` queue allows using embassy-time without the embassy executors.</p>",
+            "<p>The flavour of the timer queue provided by this crate. Accepts either `single-integrated` or `generic`. Integrated queues require the `executors` feature to be enabled.</p><p>If you use embassy-executor, the `single-integrated` queue is recommended.</p><p>The `generic` queue allows using embassy-time without the embassy executors.</p>",
             Value::String(if cfg!(feature = "executors") {
                 String::from("single-integrated")
             } else {
@@ -69,9 +70,10 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
                 match string.as_str() {
                     "single-integrated" => Ok(()), // preferred for ease of use
-                    "multiple-integrated" => Ok(()), // preferred for performance
+                    //"multiple-integrated" => Ok(()), // preferred for performance
                     "generic" => Ok(()), // allows using embassy-time without the embassy executors
-                    _ => Err(Error::Validation(format!("Expected 'single-integrated', 'multiple-integrated' or 'generic', found {string}")))
+                    //_ => Err(Error::Validation(format!("Expected 'single-integrated', 'multiple-integrated' or 'generic', found {string}")))
+                    _ => Err(Error::Validation(format!("Expected 'single-integrated' or 'generic', found {string}")))
                 }
             })))
         ),
@@ -94,9 +96,9 @@ fn main() -> Result<(), Box<dyn StdError>> {
             println!("cargo:rustc-cfg=integrated_timers");
             println!("cargo:rustc-cfg=single_queue");
         }
-        Value::String(s) if s.as_str() == "multiple-integrated" => {
-            println!("cargo:rustc-cfg=integrated_timers");
-        }
+        // Value::String(s) if s.as_str() == "multiple-integrated" => {
+        //    println!("cargo:rustc-cfg=integrated_timers");
+        //}
         Value::String(s) if s.as_str() == "generic" => {
             println!("cargo:rustc-cfg=generic_timers");
             println!("cargo:rustc-cfg=single_queue");

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -31,10 +31,11 @@
 //!
 //! Initialization requires a number of timers to be passed in. The number of
 //! timers required depends on the timer queue flavour used, as well as the
-//! number of executors started. If you use the `multiple-integrated` timer
-//! queue flavour, then you need to pass as many timers as you start executors.
-//! In other cases, you can pass a single timer.
-//!
+//! number of executors started.
+// TODO restore this:
+// If you use the `multiple-integrated` timer
+// queue flavour, then you need to pass as many timers as you start executors.
+// In other cases, you can pass a single timer.
 //! ## Configuration
 //!
 //! You can configure the behaviour of the embassy runtime by using the
@@ -155,11 +156,10 @@ impl_array!(4);
 /// - A mutable static slice of `OneShotTimer` instances
 /// - A mutable static array of `OneShotTimer` instances
 /// - A 2, 3, 4 element array of `AnyTimer` instances
-///
-/// Note that if you use the `multiple-integrated` timer-queue flavour, then
-/// you need to pass as many timers as you start executors. In other cases,
-/// you can pass a single timer.
-///
+// TODO: restore this:
+// /// Note that if you use the `multiple-integrated` timer-queue flavour, then
+// /// you need to pass as many timers as you start executors. In other cases,
+// /// you can pass a single timer.
 /// # Examples
 ///
 /// ```rust, no_run

--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -92,8 +92,8 @@ impl Alarm {
 /// which we do here. This trait needs us to be able to tell the current time,
 /// as well as to schedule a wake-up at a certain time.
 ///
-/// We are free to choose how we implement these features, and we provide three
-/// options:
+/// We are free to choose how we implement these features, and we provide
+/// two options:
 ///
 /// - If the `generic` feature is enabled, we implement a single timer queue,
 ///   using the implementation provided by embassy-time-queue-driver.
@@ -101,11 +101,12 @@ impl Alarm {
 ///   queue, using our own integrated timer implementation. Our implementation
 ///   is a copy of the embassy integrated timer queue, with the addition of
 ///   clearing the "owner" information upon dequeueing.
-/// - If the `multiple-integrated` feature is enabled, we provide a separate
-///   timer queue for each executor. We store a separate timer queue for each
-///   executor, and we use the scheduled task's owner to determine which queue
-///   to use. This mode allows us to use less disruptive locks around the timer
-///   queue, but requires more timers - one per timer queue.
+// TODO: restore this and update the "two options" above:
+// - If the `multiple-integrated` feature is enabled, we provide a separate
+//   timer queue for each executor. We store a separate timer queue for each
+//   executor, and we use the scheduled task's owner to determine which queue to
+//   use. This mode allows us to use less disruptive locks around the timer
+//   queue, but requires more timers - one per timer queue.
 pub(super) struct EmbassyTimer {
     /// The timer queue, if we use a single one (single-integrated, or generic).
     #[cfg(single_queue)]

--- a/hil-test/.cargo/config.toml
+++ b/hil-test/.cargo/config.toml
@@ -18,7 +18,9 @@ rustflags = [
 
 [env]
 DEFMT_LOG = "info"
-ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE="multiple-integrated"
+# TODO restore multiple-integrated
+#ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE="multiple-integrated"
+ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE="single-integrated"
 
 [unstable]
 build-std = ["core", "alloc"]

--- a/hil-test/tests/embassy_interrupt_executor.rs
+++ b/hil-test/tests/embassy_interrupt_executor.rs
@@ -4,7 +4,8 @@
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: unstable embassy
 //% ENV(single_integrated):   ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = single-integrated
-//% ENV(multiple_integrated): ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = multiple-integrated
+// TODO restore multiple-integrated
+// ENV(multiple_integrated): ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = multiple-integrated
 //% ENV(generic_queue):       ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = generic
 //% ENV(generic_queue):       ESP_HAL_EMBASSY_CONFIG_GENERIC_QUEUE_SIZE = 16
 //% ENV(default_with_waiti):  ESP_HAL_EMBASSY_CONFIG_LOW_POWER_WAIT = true

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -3,7 +3,8 @@
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c3 esp32c6 esp32h2
 //% FEATURES: unstable embassy
 //% ENV(single_integrated):   ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = single-integrated
-//% ENV(multiple_integrated): ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = multiple-integrated
+// TODO restore multiple-integrated
+// ENV(multiple_integrated): ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = multiple-integrated
 //% ENV(generic_queue):       ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = generic
 //% ENV(generic_queue):       ESP_HAL_EMBASSY_CONFIG_GENERIC_QUEUE_SIZE = 16
 

--- a/qa-test/.cargo/config.toml
+++ b/qa-test/.cargo/config.toml
@@ -28,7 +28,9 @@ rustflags = [
 
 [env]
 ESP_LOG = "info"
-ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE="multiple-integrated"
+# TODO restore multiple-integrated
+#ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE="multiple-integrated"
+ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE="single-integrated"
 
 [unstable]
 build-std = ["alloc", "core"]


### PR DESCRIPTION
Currently, this option is incompatible with esp-wifi, because esp-wifi ticks on Priority2 on Xtensa CPUs, and it is able to break out of Priority1 locks. While users can still shoot themselves in the foot by using `PriorityLock` (which is hidden for a reason), we probably shouldn't expose a feature that does the shooting for them. The symptoms are extremely hard to debug as the panics that can be triggered seem impossible to occur.