### PR TITLE
Wifi: switch tasks at interrupt level 1

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The scheduler now runs at interrupt priority 1 on Xtensa chips, too. (#3164)
+
 ### Fixed
 
 ### Removed

--- a/esp-wifi/src/preempt_builtin/timer/xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/timer/xtensa.rs
@@ -49,17 +49,13 @@ pub(crate) fn disable_multitasking() {
     );
 }
 
-fn do_task_switch(context: &mut TrapFrame) {
+extern "C" fn handler(context: &mut TrapFrame) {
     TIMER.with(|timer| {
         let timer = unwrap!(timer.as_mut());
         timer.clear_interrupt();
     });
 
     task_switch(context);
-}
-
-extern "C" fn handler(context: &mut TrapFrame) {
-    do_task_switch(context);
 }
 
 #[allow(non_snake_case)]
@@ -70,7 +66,7 @@ fn Software1(_level: u32, context: &mut TrapFrame) {
         core::arch::asm!("wsr.intclear  {0}", in(reg) intr, options(nostack));
     }
 
-    do_task_switch(context);
+    task_switch(context);
 }
 
 pub(crate) fn yield_task() {

--- a/esp-wifi/src/preempt_builtin/timer/xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/timer/xtensa.rs
@@ -11,7 +11,9 @@ const TIMESLICE_FREQUENCY: Rate = Rate::from_hz(crate::CONFIG.tick_rate_hz);
 
 use super::TIMER;
 
-const SW_INTERRUPT: u32 = 1 << 7;
+// ESP32 uses Software1 (priority 3) for task switching, because it reserves
+// Software0 for the Bluetooth stack.
+const SW_INTERRUPT: u32 = if cfg!(esp32) { 1 << 29 } else { 1 << 7 };
 
 pub(crate) fn setup_timer(mut timer1: TimeBase) {
     // The timer needs to tick at Priority 1 to prevent accidentally interrupting
@@ -53,18 +55,29 @@ pub(crate) fn disable_multitasking() {
     xtensa_lx::interrupt::disable_mask(SW_INTERRUPT);
 }
 
-extern "C" fn timer_tick_handler(context: &mut TrapFrame) {
+extern "C" fn timer_tick_handler(_context: &mut TrapFrame) {
     TIMER.with(|timer| {
         let timer = unwrap!(timer.as_mut());
         timer.clear_interrupt();
     });
 
-    task_switch(context);
+    // `task_switch` must be called on a single interrupt priority level only.
+    // Because on ESP32 the software interrupt is triggered at priority 3 but
+    // the timer interrupt is triggered at priority 1, we need to trigger the
+    // software interrupt manually.
+    cfg_if::cfg_if! {
+        if #[cfg(esp32)] {
+            yield_task();
+        } else {
+            task_switch(_context);
+        }
+    }
 }
 
 #[allow(non_snake_case)]
-#[no_mangle]
-fn Software0(_level: u32, context: &mut TrapFrame) {
+#[cfg_attr(not(esp32), export_name = "Software0")]
+#[cfg_attr(esp32, export_name = "Software1")]
+fn task_switch_interrupt(_level: u32, context: &mut TrapFrame) {
     let intr = SW_INTERRUPT;
     unsafe { core::arch::asm!("wsr.intclear  {0}", in(reg) intr, options(nostack)) };
 

--- a/esp-wifi/src/preempt_builtin/timer/xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/timer/xtensa.rs
@@ -20,7 +20,9 @@ pub(crate) fn setup_timer(mut timer1: TimeBase) {
     // The timer needs to tick at Priority 1 to prevent accidentally interrupting
     // priority 1 limited locks.
     timer1.set_interrupt_handler(InterruptHandler::new(
-        unsafe { core::mem::transmute::<*const (), extern "C" fn()>(handler as *const ()) },
+        unsafe {
+            core::mem::transmute::<*const (), extern "C" fn()>(timer_tick_handler as *const ())
+        },
         interrupt::Priority::Priority1,
     ));
     unwrap!(timer1.start(TIMESLICE_FREQUENCY.as_duration()));
@@ -54,7 +56,7 @@ pub(crate) fn disable_multitasking() {
     xtensa_lx::interrupt::disable_mask(SW_INTERRUPT);
 }
 
-extern "C" fn handler() {
+extern "C" fn timer_tick_handler() {
     TIMER.with(|timer| {
         let timer = unwrap!(timer.as_mut());
         timer.clear_interrupt();

--- a/esp-wifi/src/preempt_builtin/timer/xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/timer/xtensa.rs
@@ -62,6 +62,8 @@ extern "C" fn timer_tick_handler() {
         timer.clear_interrupt();
     });
 
+    // For unknown reasons, task_switch would end up generating an exception when
+    // called at priority 1, so trigger the level 3 interrupt instead.
     yield_task();
 }
 

--- a/xtensa-lx-rt/src/exception/asm.rs
+++ b/xtensa-lx-rt/src/exception/asm.rs
@@ -513,16 +513,16 @@ __default_naked_exception:
 .Ldefault_naked_exception_start:
     SAVE_CONTEXT 1
 
+    l32i    a6, sp, +XT_STK_EXCCAUSE  // put cause in a6 = a2 in callee
+    mov     a7, sp                    // put address of save frame in a7=a3 in callee
+
+    beqi    a6, 4, .Level1Interrupt   // Handle Level1 interrupt
+
     movi    a0, (PS_INTLEVEL_EXCM | PS_WOE)
     wsr     a0, PS
     rsync
 
-    l32i    a6, sp, +XT_STK_EXCCAUSE  // put cause in a6 = a2 in callee
-    beqi    a6, 4, .Level1Interrupt
-
-    mov     a7, sp                    // put address of save frame in a7=a3 in callee
     call4   __exception               // call handler <= actual call!
-
     j       .RestoreContext
 
 .Level1Interrupt:
@@ -531,7 +531,6 @@ __default_naked_exception:
     rsync
 
     movi    a6, 1                     // put interrupt level in a6 = a2 in callee
-    mov     a7, sp                    // put address of save frame in a7=a3 in callee
     call4   __level_1_interrupt       // call handler <= actual call!
 
 .RestoreContext:


### PR DESCRIPTION
Closes #3160

Previously, we used both Software1 and the timer interrupt to switch tasks. Software1 runs at priority level 3, while the timer ran at level 2. Trying to run the timer at level 1 meant esp-wifi crashed because the Interrupt Option and the High Priority interrupt option work a bit differently.

The root cause of the issue is that level 1 interrupt handling restores PS directly from the stack, while higher interrupt levels restore it into EPSn, and then that gets moved into PS by the `rfi` instruction.

This PR fixes this problem by using Software0, which is a level 1 priority interrupt.