### PR TITLE
Switch wifi tasks at priority level 3

### DIFF
--- a/esp-wifi/src/preempt_builtin/timer/xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/timer/xtensa.rs
@@ -49,17 +49,13 @@ pub(crate) fn disable_multitasking() {
     );
 }
 
-fn do_task_switch(context: &mut TrapFrame) {
+extern "C" fn handler(context: &mut TrapFrame) {
     TIMER.with(|timer| {
         let timer = unwrap!(timer.as_mut());
         timer.clear_interrupt();
     });
 
     task_switch(context);
-}
-
-extern "C" fn handler(context: &mut TrapFrame) {
-    do_task_switch(context);
 }
 
 #[allow(non_snake_case)]
@@ -70,7 +66,7 @@ fn Software1(_level: u32, context: &mut TrapFrame) {
         core::arch::asm!("wsr.intclear  {0}", in(reg) intr, options(nostack));
     }
 
-    do_task_switch(context);
+    task_switch(context);
 }
 
 pub(crate) fn yield_task() {

--- a/esp-wifi/src/preempt_builtin/timer/xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/timer/xtensa.rs
@@ -20,7 +20,9 @@ pub(crate) fn setup_timer(mut timer1: TimeBase) {
     // The timer needs to tick at Priority 1 to prevent accidentally interrupting
     // priority 1 limited locks.
     timer1.set_interrupt_handler(InterruptHandler::new(
-        unsafe { core::mem::transmute::<*const (), extern "C" fn()>(handler as *const ()) },
+        unsafe {
+            core::mem::transmute::<*const (), extern "C" fn()>(timer_tick_handler as *const ())
+        },
         interrupt::Priority::Priority1,
     ));
     unwrap!(timer1.start(TIMESLICE_FREQUENCY.as_duration()));
@@ -54,7 +56,7 @@ pub(crate) fn disable_multitasking() {
     xtensa_lx::interrupt::disable_mask(SW_INTERRUPT);
 }
 
-extern "C" fn handler() {
+extern "C" fn timer_tick_handler() {
     TIMER.with(|timer| {
         let timer = unwrap!(timer.as_mut());
         timer.clear_interrupt();

--- a/esp-wifi/src/preempt_builtin/timer/xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/timer/xtensa.rs
@@ -62,6 +62,8 @@ extern "C" fn timer_tick_handler() {
         timer.clear_interrupt();
     });
 
+    // For unknown reasons, task_switch would end up generating an exception when
+    // called at priority 1, so trigger the level 3 interrupt instead.
     yield_task();
 }
 

--- a/xtensa-lx-rt/src/exception/asm.rs
+++ b/xtensa-lx-rt/src/exception/asm.rs
@@ -513,16 +513,16 @@ __default_naked_exception:
 .Ldefault_naked_exception_start:
     SAVE_CONTEXT 1
 
+    l32i    a6, sp, +XT_STK_EXCCAUSE  // put cause in a6 = a2 in callee
+    mov     a7, sp                    // put address of save frame in a7=a3 in callee
+
+    beqi    a6, 4, .Level1Interrupt   // Handle Level1 interrupt
+
     movi    a0, (PS_INTLEVEL_EXCM | PS_WOE)
     wsr     a0, PS
     rsync
 
-    l32i    a6, sp, +XT_STK_EXCCAUSE  // put cause in a6 = a2 in callee
-    beqi    a6, 4, .Level1Interrupt
-
-    mov     a7, sp                    // put address of save frame in a7=a3 in callee
     call4   __exception               // call handler <= actual call!
-
     j       .RestoreContext
 
 .Level1Interrupt:
@@ -531,7 +531,6 @@ __default_naked_exception:
     rsync
 
     movi    a6, 1                     // put interrupt level in a6 = a2 in callee
-    mov     a7, sp                    // put address of save frame in a7=a3 in callee
     call4   __level_1_interrupt       // call handler <= actual call!
 
 .RestoreContext:


### PR DESCRIPTION
Alternative to https://github.com/esp-rs/esp-hal/pull/3164 because ESP32 uses Software0 for some bluetooth-related things. Closes #3160 although not by switching tasks at level 1, but at level 3. The scheduler tick is ticking at level 1, though, so the scheduler is technically running at priority level 1, allowing us to use prio-limited locks at level 1 safely, unless someone calls `yield_task` in such a lock.

The downside of this PR is that the timer interrupt is now triggering a software interrupt to switch tasks, which is probably slightly less performant than before.