### PR TITLE
Update `portable-atomic`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,7 @@ jobs:
         with:
           ldproxy: false
           version: 1.85.0.0
-      # TODO: Remove once https://github.com/taiki-e/portable-atomic/issues/208 is resolved
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          toolchain: nightly-2025-02-21
-          components: clippy,rust-src
+
       # Install the Rust stable toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1
         with:

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -26,7 +26,7 @@ esp-config                = { version = "0.3.0", path = "../esp-config" }
 esp-hal                   = { version = "1.0.0-beta.0", path = "../esp-hal" }
 log                       = { version = "0.4.26", optional = true }
 macros                    = { version = "0.17.0", features = ["embassy"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-portable-atomic           = "1.10.0"
+portable-atomic           = "1.11.0"
 static_cell               = "2.1.0"
 
 [build-dependencies]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -46,7 +46,7 @@ instability              = "0.3.7"
 log                      = { version = "0.4.26", optional = true }
 nb                       = "1.1.0"
 paste                    = "1.0.15"
-portable-atomic          = { version = "1.10.0", default-features = false }
+portable-atomic          = { version = "1.11.0", default-features = false }
 procmacros               = { version = "0.17.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
 void                     = { version = "1.0.2", default-features = false }

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -19,7 +19,7 @@ features       = ["esp32c3"]
 critical-section = { version = "1.2.0",  optional = true }
 defmt            = { version = "0.3.10",  optional = true }
 log              = { version = "0.4.26", optional = true }
-portable-atomic  = { version = "1.10.0",  optional = true, default-features = false }
+portable-atomic  = { version = "1.11.0",  optional = true, default-features = false }
 
 [build-dependencies]
 esp-build = { version = "0.2.0", path = "../esp-build" }

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -34,7 +34,7 @@ embassy-sync = { version = "0.6.2", optional = true }
 embassy-net-driver = { version = "0.2.0", optional = true }
 libm = "0.2.11"
 cfg-if = "1.0.0"
-portable-atomic = { version = "1.10.0", default-features = false }
+portable-atomic = { version = "1.11.0", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
 rand_core           = "0.6.4"
 

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -224,7 +224,7 @@ esp-backtrace      = { path = "../esp-backtrace", default-features = false, feat
 esp-hal            = { path = "../esp-hal", default-features = false, features = ["digest"], optional = true } # TODO: default-features = false should be removed for 1.0.0-beta0
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 esp-wifi           = { path = "../esp-wifi", optional = true }
-portable-atomic    = "1.9.0"
+portable-atomic    = "1.11.0"
 static_cell        = { version = "2.1.0", features = ["nightly"] }
 semihosting        = { version = "0.1", features= ["stdio", "panic-handler"] }
 xtensa-lx-rt       = { path = "../xtensa-lx-rt", optional = true }

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -156,8 +156,7 @@ fn cargo_doc(workspace: &Path, package: Package, chip: Option<Chip>) -> Result<P
     let toolchain = if chip.is_some_and(|chip| chip.is_xtensa()) {
         "esp"
     } else {
-        // TODO: Remove date once https://github.com/taiki-e/portable-atomic/issues/208 is resolved
-        "nightly-2025-02-21"
+        "nightly"
     };
 
     // Determine the appropriate build target for the given package and chip,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -824,8 +824,7 @@ fn lint_package(
         // are not overwritten.
         builder.toolchain("esp")
     } else {
-        // TODO: Remove toolchain once https://github.com/taiki-e/portable-atomic/issues/208 is resolved
-        builder.toolchain("nightly-2025-02-21")
+        builder
     };
 
     for arg in args {
@@ -934,12 +933,7 @@ fn run_doc_tests(workspace: &Path, args: ExampleArgs) -> Result<()> {
     let features = vec![chip.to_string(), "unstable".to_string()];
 
     // We need `nightly` for building the doc tests, unfortunately:
-    let toolchain = if chip.is_xtensa() {
-        "esp"
-    } else {
-        // TODO: Remove date once https://github.com/taiki-e/portable-atomic/issues/208 is resolved
-        "nightly-2025-02-21"
-    };
+    let toolchain = if chip.is_xtensa() { "esp" } else { "nightly" };
 
     // Build up an array of command-line arguments to pass to `cargo`:
     let builder = CargoArgsBuilder::default()


### PR DESCRIPTION
Updates the `portable-atomic` dependency and removes the CI hacks required for using the previous version with the latest `nightly`.

Draft until we're ready to start merging things again.