### PR TITLE
Clarify open drain

### DIFF
--- a/esp-hal/MIGRATING-0.23.md
+++ b/esp-hal/MIGRATING-0.23.md
@@ -255,16 +255,17 @@ GPIO drivers now take configuration structs.
 
 The OutputOpenDrain driver has been removed. You can use `Output` instead with
 `DriveMode::OpenDrain`. The input-related methods of `OutputOpenDrain` (`level`,
-`is_high`, `is_low`) are available through the (unstable) `Flex` driver.
+`is_high`, `is_low`) are available through the (unstable) `Flex` driver when enabling input.
 
 ```diff
-- OutputOpenDrain::new(peripherals.GPIO0, Level::Low);
-+ Output::new(
-     peripherals.GPIO0,
-     Level::Low,
-     OutputConfig::default()
-         .with_drive_mode(DriveMode::OpenDrain),
- );
+- let mut gpio = OutputOpenDrain::new(peripherals.GPIO0, Level::Low);
++ let mut gpio = Output::new(
++     peripherals.GPIO0,
++     Level::Low,
++     OutputConfig::default()
++         .with_drive_mode(DriveMode::OpenDrain),
++ ).into_flex();
++ gpio.enable_input(true);
 ```
 
 ## AES DMA driver changes

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1101,6 +1101,10 @@ pub enum DriveMode {
     /// logical [`Level`], but leaves the high level floating, which is then
     /// determined by external hardware, or internal pull-up/pull-down
     /// resistors.
+    #[cfg_attr(
+        feature = "unstable",
+        doc = "\n\nEnable the input related functionality by using [Output::into_flex] and enabling input via [Flex::enable_input]"
+    )]
     OpenDrain,
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Closes #3179

The migration-guide can do a better job at explaining how to completely mimic the previous behavior of `OutputOpenDrain`.
So, the linked issue wasn't really an issue with our code but with documentation.

#### Testing
See linked issue
