### PR TITLE
Fix esp-lp-hal gpio reading for the esp32s3 and esp32s2

### DIFF
--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump MSRV to 1.84 (#2951)
+- Fix gpio `input_state` and `output_state` for the ESP32-S3
 
 ### Fixed
 

--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump MSRV to 1.84 (#2951)
-- Fix gpio `input_state` and `output_state` for the ESP32-S3
+- Fix gpio `input_state` and `output_state` for the ESP32-S3 and ESP32-S2
 
 ### Fixed
 

--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump MSRV to 1.84 (#2951)
-- Fix gpio `input_state` and `output_state` for the ESP32-S3 and ESP32-S2
+- Fix gpio `input_state` and `output_state` for the ESP32-S3 and ESP32-S2 (#3191)
 
 ### Fixed
 

--- a/esp-lp-hal/src/gpio.rs
+++ b/esp-lp-hal/src/gpio.rs
@@ -39,7 +39,15 @@ pub struct Input<const PIN: u8>;
 impl<const PIN: u8> Input<PIN> {
     /// Read the input state/level of the pin.
     pub fn input_state(&self) -> bool {
-        (unsafe { &*LpIo::PTR }.in_().read().next().bits() >> PIN) & 0x1 != 0
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "esp32c6")] {
+                (unsafe { &*LpIo::PTR }.in_().read().bits() >> PIN) & 0x1 != 0
+            } else if #[cfg(feature = "esp32s2")] {
+                (unsafe { &*LpIo::PTR }.in_().read().gpio_in_next().bits() >> PIN) & 0x1 != 0
+            } else if #[cfg(feature = "esp32s3")] {
+                (unsafe { &*LpIo::PTR }.in_().read().next().bits() >> PIN) & 0x1 != 0
+            }
+        }
     }
 }
 
@@ -49,7 +57,15 @@ pub struct Output<const PIN: u8>;
 impl<const PIN: u8> Output<PIN> {
     /// Read the output state/level of the pin.
     pub fn output_state(&self) -> bool {
-        (unsafe { &*LpIo::PTR }.out().read().data().bits() >> PIN) & 0x1 != 0
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "esp32c6")] {
+                (unsafe { &*LpIo::PTR }.out().read().bits() >> PIN) & 0x1 != 0
+            } else if #[cfg(feature = "esp32s2")] {
+                (unsafe { &*LpIo::PTR }.out().read().gpio_out_data().bits() >> PIN) & 0x1 != 0
+            } else if #[cfg(feature = "esp32s3")] {
+                (unsafe { &*LpIo::PTR }.out().read().data().bits() >> PIN) & 0x1 != 0
+            }
+        }
     }
 
     /// Set the output state/level of the pin.

--- a/esp-lp-hal/src/gpio.rs
+++ b/esp-lp-hal/src/gpio.rs
@@ -39,7 +39,7 @@ pub struct Input<const PIN: u8>;
 impl<const PIN: u8> Input<PIN> {
     /// Read the input state/level of the pin.
     pub fn input_state(&self) -> bool {
-        (unsafe { &*LpIo::PTR }.in_().read().bits() >> PIN) & 0x1 != 0
+        (unsafe { &*LpIo::PTR }.in_().read().next().bits() >> PIN) & 0x1 != 0
     }
 }
 
@@ -49,7 +49,7 @@ pub struct Output<const PIN: u8>;
 impl<const PIN: u8> Output<PIN> {
     /// Read the output state/level of the pin.
     pub fn output_state(&self) -> bool {
-        (unsafe { &*LpIo::PTR }.out().read().bits() >> PIN) & 0x1 != 0
+        (unsafe { &*LpIo::PTR }.out().read().data().bits() >> PIN) & 0x1 != 0
     }
 
     /// Set the output state/level of the pin.


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR fixes GPIO reading for the esp32-s3.
In the current release, the input register (and similarly when reading the output register) is accessed using the raw value. However, on the esp32-s3, there is a 10bit offset.
The lead to a bug where, in order to access a GPIO n from the ULP, you had to use the GPIO n+10.

This PR fixes this by using the higher-level field from the PAC.

For reference:
- [esp32s3-pac input register](https://github.com/esp-rs/esp-pacs/blob/75300707b3ef4ba6101b2ddc2c0984b0fbd60e12/esp32s3-ulp/src/rtc_io/in_.rs#L5)
- [esp32s3-pac output register](https://github.com/esp-rs/esp-pacs/blob/75300707b3ef4ba6101b2ddc2c0984b0fbd60e12/esp32s3-ulp/src/rtc_io/out.rs#L9)

#### Testing
**Testing was only performed on an esp32-s3, as I don't own other chips.**

To test `input_state()`, I built a ULP firmware that wakes-up the esp when the pin (gpio6 in my case) goes high, then waited a few seconds before triggering the GPIO.
Using the previous release, it only worked if I used GPIO16 in the code.
Using this PR, it works correctly, using GPIO6.

To test `output_state()`, I built a ULP firmware that sets the GPIO value, then read it, and sends the value to the esp, which prints it.
I got similar results than for `input_state()`.
