### PR TITLE
feat(esp-println): Add timestamp to logging

### DIFF
--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added new `_esp_println_timestamp()` hook, gated by the `timestamp` feature to provide timestamp for logging (#3194)
+
 ### Changed
 
 ### Fixed

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -55,6 +55,7 @@ defmt-espflash = ["dep:defmt", "defmt?/encoding-rzcobs"]
 
 # logging sub-features
 colors = []
+timestamp = []
 
 [lints.rust]
 static_mut_refs = "allow"

--- a/esp-println/src/logger.rs
+++ b/esp-println/src/logger.rs
@@ -62,8 +62,47 @@ impl log::Log for EspLogger {
         #[cfg(not(feature = "colors"))]
         let reset = "";
 
+        #[cfg(feature = "timestamp")]
+        println!(
+            "{}{} ({}) - {}{}",
+            color,
+            record.level(),
+            unsafe { _esp_println_timestamp() },
+            record.args(),
+            reset
+        );
+        #[cfg(not(feature = "timestamp"))]
         println!("{}{} - {}{}", color, record.level(), record.args(), reset);
     }
 
     fn flush(&self) {}
+}
+
+/// A user-provided hook to supply a timestamp in milliseconds for logging.
+///
+/// When enabled via the `"timestamp"` feature, this function should be
+/// implemented to return a timestamp in milliseconds since a reference point
+/// (e.g., system boot or Unix epoch).
+///
+/// # Example
+///
+/// When using [`esp-hal`], you can define this function as follows:
+///
+/// ```rust
+/// #[no_mangle]
+/// pub extern "Rust" fn _esp_println_timestamp() -> u64 {
+///     esp_hal::time::Instant::now()
+///         .duration_since_epoch()
+///         .as_millis()
+/// }
+/// ```
+///
+/// # Notes
+///
+/// - If no implementations is provided, attempting to use this function will
+///   result in a linker
+/// error.
+#[cfg(feature = "timestamp")]
+extern "Rust" {
+    fn _esp_println_timestamp() -> u64;
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- Introduce new `timestamp` (non-default) feature to enable logging with a timestamp in millis, in the same format as the bootloader. ~~Considering Rust offers no standard way to fetch time through APIs or traits, this new feature requires pulling `esp-hal` as a dependency.~~


#### Testing
I've tested the changes in a local project, and it both build with and without the feature enabled.
