### PR TITLE
esp32s2: psram_cache_init typo fix

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Full-duplex SPI works when mixed with half-duplex SPI (#3176)
 - `Uart::flush_async` should no longer return prematurely (#3186)
+- ESP32-S2: Fixed PSRAM initialization (#3196)
 
 ### Removed
 

--- a/esp-hal/src/soc/esp32s2/psram.rs
+++ b/esp-hal/src/soc/esp32s2/psram.rs
@@ -594,11 +594,6 @@ pub(crate) mod utils {
                 .modify(|_, w| w.cache_sram_usr_wr_cmd_bitlen().bits(7));
 
             spi.sram_dwr_cmd().modify(|_, w| {
-                w.cache_sram_usr_wr_cmd_bitlen()
-                    .bits(PSRAM_QUAD_WRITE as u8)
-            });
-
-            spi.sram_dwr_cmd().modify(|_, w| {
                 w.cache_sram_usr_wr_cmd_value()
                     .bits(PSRAM_QUAD_WRITE as u16)
             });

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -16,6 +16,11 @@ name    = "aes_dma"
 harness = false
 
 [[test]]
+name    = "alloc_psram"
+harness = false
+required-features = ["psram"]
+
+[[test]]
 name    = "clock_monitor"
 harness = false
 
@@ -221,7 +226,7 @@ embedded-hal-async = "1.0.0"
 embedded-hal-nb    = "1.0.0"
 esp-alloc          = { path = "../esp-alloc", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "defmt", "semihosting"] }
-esp-hal            = { path = "../esp-hal", default-features = false, features = ["digest"], optional = true } # TODO: default-features = false should be removed for 1.0.0-beta0
+esp-hal            = { path = "../esp-hal", features = ["digest"], optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 esp-wifi           = { path = "../esp-wifi", optional = true }
 portable-atomic    = "1.11.0"

--- a/hil-test/tests/alloc_psram.rs
+++ b/hil-test/tests/alloc_psram.rs
@@ -1,0 +1,37 @@
+//! PSRAM-related tests
+
+//% CHIPS(quad): esp32 esp32s2
+// The S3 dev kit in the HIL-tester has octal PSRAM.
+//% CHIPS(octal): esp32s3
+//% ENV(octal): ESP_HAL_CONFIG_PSRAM_MODE=octal
+//% FEATURES: unstable psram
+
+#![no_std]
+#![no_main]
+
+use hil_test as _;
+
+extern crate alloc;
+
+#[cfg(test)]
+#[embedded_test::tests(default_timeout = 2)]
+mod tests {
+    #[init]
+    fn init() {
+        let p = esp_hal::init(esp_hal::Config::default());
+        esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
+    }
+
+    #[test]
+    fn test_simple() {
+        let mut vec = alloc::vec::Vec::new();
+
+        for i in 0..10000 {
+            vec.push(i);
+        }
+
+        for i in 0..10000 {
+            assert_eq!(vec[i], i);
+        }
+    }
+}


### PR DESCRIPTION
broken esp32s2 psram since
https://github.com/esp-rs/esp-hal/commit/cb0016aa43427d61890ec28cf382ef570a4b0604

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description


#### Testing
Describe how you tested your changes.
