### PR TITLE
ESP32/ESP32-S2: I2C Workaround

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detecting a UART overflow now clears the RX FIFO. (#3190)
 - ESP32-S2: Fixed PSRAM initialization (#3196)
 
+- ESP32/ESP32-S2: Avoid running into timeouts with reads/writes larger than the FIFO (#3199)
+
 ### Removed
 
 ## v1.0.0-beta.0

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -713,10 +713,15 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    /// 
+    ///
+    #[cfg_attr(
+        any(esp32, esp32s2),
+        doc = "\n\nOn ESP32 and ESP32-S2 there might be issues combining large read/write operations with small (<3 bytes) read/write operations.\n\n"
+    )]
     /// # Errors
     ///
-    /// The corresponding error variant from [`Error`] will be returned if the buffer passed to an [`Operation`] has zero length.
+    /// The corresponding error variant from [`Error`] will be returned if the
+    /// buffer passed to an [`Operation`] has zero length.
     pub fn transaction<'a, A: Into<I2cAddress>>(
         &mut self,
         address: A,
@@ -1031,7 +1036,10 @@ impl<'d> I2c<'d, Async> {
     ///   to indicate writing
     /// - `SR` = repeated start condition
     /// - `SP` = stop condition
-    ///
+    #[cfg_attr(
+        any(esp32, esp32s2),
+        doc = "\n\nOn ESP32 and ESP32-S2 there might be issues combining large read/write operations with small (<3 bytes) read/write operations.\n\n"
+    )]
     /// # Errors
     ///
     /// The corresponding error variant from [`Error`] will be returned if the

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -349,7 +349,9 @@ enum Command {
         /// Enables checking the ACK value received against the ack_exp value.
         ack_check_en: bool,
         /// Length of data (in bytes) to be written. The maximum length is
-        /// 32 (16 for ESP32-C2), while the minimum is 1.
+        #[cfg_attr(esp32c2, doc = "16")]
+        #[cfg_attr(not(esp32c2), doc = "32")]
+        /// , while the minimum is 1.
         length: u8,
     },
     Read {
@@ -357,7 +359,9 @@ enum Command {
         /// been received.
         ack_value: Ack,
         /// Length of data (in bytes) to be written. The maximum length is
-        /// 32 (16 for ESP32-C2), while the minimum is 1.
+        #[cfg_attr(esp32c2, doc = "16")]
+        #[cfg_attr(not(esp32c2), doc = "32")]
+        /// , while the minimum is 1.
         length: u8,
     },
 }
@@ -713,7 +717,7 @@ where
     ///
     #[cfg_attr(
         any(esp32, esp32s2),
-        doc = "\n\nOn ESP32 and ESP32-S2 there might be issues combining large read/write operations with small (<3 bytes) read/write operations.\n\n"
+        doc = "\n\nOn ESP32 and ESP32-S2 it is advisable to not combine large read/write operations with small (<3 bytes) read/write operations.\n\n"
     )]
     /// # Errors
     ///

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -60,18 +60,11 @@ cfg_if::cfg_if! {
     }
 }
 
-// this is the real size of the FIFO
-#[cfg(any(esp32, esp32s2))]
+#[cfg(not(esp32c2))]
 const I2C_FIFO_SIZE: usize = 32;
 
-// this is somewhat made up - it's not the FIFO size but we are able write/read
-// while the transmission is in progress
-//
-// TODO: check if using the real FIFO size will make the driver less prone to
-// problems resulting from interruptions (e.g. cause by esp-wifi's scheduler or
-// general interrupts)
-#[cfg(not(any(esp32, esp32s2)))]
-const I2C_FIFO_SIZE: usize = 255;
+#[cfg(esp32c2)]
+const I2C_FIFO_SIZE: usize = 16;
 
 // Chunk writes/reads by this size
 const I2C_CHUNK_SIZE: usize = I2C_FIFO_SIZE - 1;
@@ -356,15 +349,15 @@ enum Command {
         /// Enables checking the ACK value received against the ack_exp value.
         ack_check_en: bool,
         /// Length of data (in bytes) to be written. The maximum length is
-        /// 32 for ESP32/ESP32-S2 and 255 for others, while the minimum is 1.
+        /// 32 (16 for ESP32-C2), while the minimum is 1.
         length: u8,
     },
     Read {
         /// Indicates whether the receiver will send an ACK after this byte has
         /// been received.
         ack_value: Ack,
-        /// Length of data (in bytes) to be read. The maximum length is 32/255,
-        /// while the minimum is 1.
+        /// Length of data (in bytes) to be written. The maximum length is
+        /// 32 (16 for ESP32-C2), while the minimum is 1.
         length: u8,
     },
 }

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -66,6 +66,10 @@ const I2C_FIFO_SIZE: usize = 32;
 
 // this is somewhat made up - it's not the FIFO size but we are able write/read
 // while the transmission is in progress
+//
+// TODO: check if using the real FIFO size will make the driver less prone to
+// problems resulting from interruptions (e.g. cause by esp-wifi's scheduler or
+// general interrupts)
 #[cfg(not(any(esp32, esp32s2)))]
 const I2C_FIFO_SIZE: usize = 255;
 

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -71,7 +71,7 @@ mod tests {
             }
         }
 
-        assert_eq!(ctx.i2c.write(DUT_ADDRESS, &[0xaa]), Ok(()));
+        assert_eq!(ctx.i2c.write(DUT_ADDRESS, &[]), Ok(()));
     }
 
     #[test]

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -71,7 +71,7 @@ mod tests {
             }
         }
 
-        assert_eq!(ctx.i2c.write(DUT_ADDRESS, &[]), Ok(()));
+        assert_eq!(ctx.i2c.write(DUT_ADDRESS, &[0xaa]), Ok(()));
     }
 
     #[test]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs API guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/API-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #3178 
Fixes #3167

Basically, this does three things
- don't combine STOP with other commands
- try to place END at the same index during a `write`, `read` and `write_read`
- don't use FIFO wrapping (to prevent timing issues)

I don't see how to guarantee things will always work for a custom `transaction` on ESP32/ESP32-S2 - so I added some docs

#### Testing
I used an VL53L5 sensor (which requires large (32k) writes and reads (a few hundred bytes). Additionally, I tested with a bit-banged I2C slave ( https://github.com/bjoernQ/i2c-dummy-device )
