### PR TITLE
Fix flip-link, make SSP configurable

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for `rand_core` 0.9 (#3211)
+- `ESP_HAL_CONFIG_STACK_GUARD_OFFSET` and `ESP_HAL_CONFIG_STACK_GUARD_VALUE` to configure Rust's [Stack smashing protection](https://doc.rust-lang.org/rustc/exploit-mitigations.html#stack-smashing-protection) (#3203)
 
 ### Changed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detecting a UART overflow now clears the RX FIFO. (#3190)
 - ESP32-S2: Fixed PSRAM initialization (#3196)
 - ESP32: Fixed SPI3 QSPI signals (#3201)
+- ESP32-C6/H2: The `flip_link` feature should no longer crash (#3203)
 
 ### Removed
 

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -218,6 +218,8 @@ fn preprocess_file(
     src: impl AsRef<Path>,
     dst: impl AsRef<Path>,
 ) -> std::io::Result<()> {
+    println!("cargo:rerun-if-changed={}", src.as_ref().display());
+
     let file = File::open(src)?;
     let mut out_file = File::create(dst)?;
 

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -122,6 +122,19 @@ fn main() -> Result<(), Box<dyn Error>> {
             Some(Validator::Enumeration(
                 vec![String::from("quad"), String::from("octal")]
             )),
+        ),
+        // Rust's stack smashing protection configuration
+        (
+            "stack-guard-offset",
+            "The stack guard variable will be placed this many bytes from the stack's end.",
+            Value::Integer(4096),
+            None
+        ),
+        (
+            "stack-guard-value",
+            "The value to be written to the stack guard variable.",
+            Value::Integer(0xDEED_BAAD),
+            None
         )
     ], true);
 

--- a/esp-hal/ld/esp32/esp32.x
+++ b/esp-hal/ld/esp32/esp32.x
@@ -19,9 +19,11 @@ INCLUDE "fixups/rtc_fast_rwdata_dummy.x"
 /* END ESP32 fixups */
 
 /* Shared sections - ordering matters */
-INCLUDE "rwtext.x"
+SECTIONS {
+  INCLUDE "rwtext.x"
+  INCLUDE "rwdata.x"
+}
 INCLUDE "text.x"
-INCLUDE "rwdata.x"
 INCLUDE "rodata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"

--- a/esp-hal/ld/esp32c2/esp32c2.x
+++ b/esp-hal/ld/esp32c2/esp32c2.x
@@ -80,9 +80,11 @@ PROVIDE(__global_pointer$ = _data_start + 0x800);
 /* end of esp32c2 fixups */
 
 /* Shared sections - ordering matters */
-INCLUDE "rwtext.x"
+SECTIONS {
+  INCLUDE "rwtext.x"
+  INCLUDE "rwdata.x"
+}
 INCLUDE "text.x"
-INCLUDE "rwdata.x"
 INCLUDE "rodata.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"

--- a/esp-hal/ld/esp32c3/esp32c3.x
+++ b/esp-hal/ld/esp32c3/esp32c3.x
@@ -80,9 +80,11 @@ PROVIDE(__global_pointer$ = _data_start + 0x800);
 /* end of esp32c3 fixups */
 
 /* Shared sections - ordering matters */
-INCLUDE "rwtext.x"
+SECTIONS {
+  INCLUDE "rwtext.x"
+  INCLUDE "rwdata.x"
+}
 INCLUDE "text.x"
-INCLUDE "rwdata.x"
 INCLUDE "rodata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"

--- a/esp-hal/ld/esp32c6/esp32c6.x
+++ b/esp-hal/ld/esp32c6/esp32c6.x
@@ -55,8 +55,17 @@ SECTIONS {
     KEEP(*(.trap));
     *(.trap.*);
   } > RWTEXT
+
+  /* Shared sections - ordering matters */
+  INCLUDE "rwtext.x"
+  INCLUDE "rwdata.x"
+  /* End of Shared sections */
 }
-INSERT BEFORE .rwtext;
+#IF ESP_HAL_CONFIG_FLIP_LINK
+/* INSERT BEFORE does not seem to work for the .stack section. Instead, we place every RAM
+  section after .stack if `flip_link` is enabled. */
+INSERT AFTER .stack;
+#ENDIF
 
 SECTIONS {
   /**
@@ -71,15 +80,13 @@ SECTIONS {
 INSERT BEFORE .rodata;
 /* end of esp32c6 fixups */
 
-/* Shared sections - ordering matters */
-INCLUDE "rwtext.x"
+/* Shared sections #2 - ordering matters */
 INCLUDE "text.x"
-INCLUDE "rwdata.x"
 INCLUDE "rodata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
-/* End of Shared sections */
+/* End of Shared sections #2 */
 
 INCLUDE "debug.x"
 

--- a/esp-hal/ld/esp32h2/esp32h2.x
+++ b/esp-hal/ld/esp32h2/esp32h2.x
@@ -43,14 +43,24 @@ PROVIDE(_start_trap = default_start_trap);
 /* Must be called __global_pointer$ for linker relaxations to work. */
 PROVIDE(__global_pointer$ = _data_start + 0x800);
 
+
 SECTIONS {
   .trap : ALIGN(4)
   {
     KEEP(*(.trap));
     *(.trap.*);
   } > RWTEXT
+
+  /* Shared sections - ordering matters */
+  INCLUDE "rwtext.x"
+  INCLUDE "rwdata.x"
+  /* End of Shared sections */
 }
-INSERT BEFORE .rwtext;
+#IF ESP_HAL_CONFIG_FLIP_LINK
+/* INSERT BEFORE does not seem to work for the .stack section. Instead, we place every RAM
+  section after .stack if `flip_link` is enabled. */
+INSERT AFTER .stack;
+#ENDIF
 
 SECTIONS {
   /**
@@ -64,15 +74,13 @@ SECTIONS {
 }
 INSERT BEFORE .rodata;
 
-/* Shared sections - ordering matters */
-INCLUDE "rwtext.x"
+/* Shared sections #2 - ordering matters */
 INCLUDE "text.x"
-INCLUDE "rwdata.x"
 INCLUDE "rodata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
-/* End of Shared sections */
+/* End of Shared sections #2 */
 
 INCLUDE "debug.x"
 

--- a/esp-hal/ld/esp32s2/esp32s2.x
+++ b/esp-hal/ld/esp32s2/esp32s2.x
@@ -27,9 +27,11 @@ INCLUDE "fixups/rtc_fast_rwdata_dummy.x"
 /* End of fixups for esp32s2 */
 
 /* Shared sections - ordering matters */
-INCLUDE "rwtext.x"
+SECTIONS {
+  INCLUDE "rwtext.x"
+  INCLUDE "rwdata.x"
+}
 INCLUDE "text.x"
-INCLUDE "rwdata.x"
 INCLUDE "rodata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"

--- a/esp-hal/ld/esp32s3/esp32s3.x
+++ b/esp-hal/ld/esp32s3/esp32s3.x
@@ -41,9 +41,11 @@ INCLUDE "fixups/rodata_dummy.x"
 /* End of ESP32S3 fixups */
 
 /* Shared sections - ordering matters */
-INCLUDE "rwtext.x"
+SECTIONS {
+  INCLUDE "rwtext.x"
+  INCLUDE "rwdata.x"
+}
 INCLUDE "text.x"
-INCLUDE "rwdata.x"
 INCLUDE "rodata.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"

--- a/esp-hal/ld/sections/rwdata.x
+++ b/esp-hal/ld/sections/rwdata.x
@@ -1,63 +1,59 @@
+.data : ALIGN(4)
+{
+  _data_start = ABSOLUTE(.);
+  . = ALIGN (4);
 
+  #IF ESP_HAL_CONFIG_PLACE_SWITCH_TABLES_IN_RAM
+    *(.rodata.*_esp_hal_internal_handler*)
+    *(.rodata..Lswitch.table.*)
+    *(.rodata.cst*)
+  #ENDIF
 
-SECTIONS {
-  .data : ALIGN(4)
-  {
-    _data_start = ABSOLUTE(.);
-    . = ALIGN (4);
+  #IF ESP_HAL_CONFIG_PLACE_ANON_IN_RAM
+    *(.rodata..Lanon .rodata..Lanon.*)
+  #ENDIF
 
-    #IF ESP_HAL_CONFIG_PLACE_SWITCH_TABLES_IN_RAM
-      *(.rodata.*_esp_hal_internal_handler*)
-      *(.rodata..Lswitch.table.*)
-      *(.rodata.cst*)
-    #ENDIF
+  *(.sdata .sdata.* .sdata2 .sdata2.*);
+  *(.data .data.*);
+  *(.data1)
+  _data_end = ABSOLUTE(.);
+  . = ALIGN(4);
+} > RWDATA AT > RODATA
 
-    #IF ESP_HAL_CONFIG_PLACE_ANON_IN_RAM
-      *(.rodata..Lanon .rodata..Lanon.*)
-    #ENDIF
+/* LMA of .data */
+_sidata = LOADADDR(.data);
 
-    *(.sdata .sdata.* .sdata2 .sdata2.*);
-    *(.data .data.*);
-    *(.data1)
-    _data_end = ABSOLUTE(.);
-    . = ALIGN(4);
-  } > RWDATA AT > RODATA
+.bss (NOLOAD) : ALIGN(4)
+{
+  _bss_start = ABSOLUTE(.);
+  . = ALIGN (4);
+  *(.dynsbss)
+  *(.sbss)
+  *(.sbss.*)
+  *(.gnu.linkonce.sb.*)
+  *(.scommon)
+  *(.sbss2)
+  *(.sbss2.*)
+  *(.gnu.linkonce.sb2.*)
+  *(.dynbss)
+  *(.sbss .sbss.* .bss .bss.*);
+  *(.share.mem)
+  *(.gnu.linkonce.b.*)
+  *(COMMON)
+  _bss_end = ABSOLUTE(.);
+  . = ALIGN(4);
+} > RWDATA
 
-  /* LMA of .data */
-  _sidata = LOADADDR(.data);
+.noinit (NOLOAD) : ALIGN(4)
+{
+  . = ALIGN(4);
+  *(.noinit .noinit.*)
+  . = ALIGN(4);
+} > RWDATA
 
-  .bss (NOLOAD) : ALIGN(4)
-  {
-    _bss_start = ABSOLUTE(.);
-    . = ALIGN (4);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.sbss .sbss.* .bss .bss.*);
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-    _bss_end = ABSOLUTE(.);
-    . = ALIGN(4);
-  } > RWDATA
-
-  .noinit (NOLOAD) : ALIGN(4)
-  {
-    . = ALIGN(4);
-    *(.noinit .noinit.*)
-    . = ALIGN(4);
-  } > RWDATA
-
-  .data.wifi :
-  {
-    . = ALIGN(4);
-    *( .dram1 .dram1.*)
-    . = ALIGN(4);
-  } > RWDATA AT > RODATA
-}
+.data.wifi :
+{
+  . = ALIGN(4);
+  *( .dram1 .dram1.*)
+  . = ALIGN(4);
+} > RWDATA AT > RODATA

--- a/esp-hal/ld/sections/rwtext.x
+++ b/esp-hal/ld/sections/rwtext.x
@@ -1,22 +1,20 @@
-SECTIONS {
-  .rwtext : ALIGN(4)
-  {
-    . = ALIGN (4);
-    *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
-    . = ALIGN(4);
-  } > RWTEXT
+.rwtext : ALIGN(4)
+{
+  . = ALIGN (4);
+  *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
+  . = ALIGN(4);
+} > RWTEXT
 
-  .rwtext.wifi :
-  {
-    . = ALIGN(4);
-    *( .wifi0iram  .wifi0iram.*)
-    *( .wifirxiram  .wifirxiram.*)
-    *( .wifislprxiram  .wifislprxiram.*)
-    *( .wifislpiram  .wifislpiram.*)
-    *( .phyiram  .phyiram.*)
-    *( .iram1  .iram1.*)
-    *( .wifiextrairam.* )
-    *( .coexiram.* )
-    . = ALIGN(4);
-  } > RWTEXT AT > RODATA
-}
+.rwtext.wifi :
+{
+  . = ALIGN(4);
+  *( .wifi0iram  .wifi0iram.*)
+  *( .wifirxiram  .wifirxiram.*)
+  *( .wifislprxiram  .wifislprxiram.*)
+  *( .wifislpiram  .wifislpiram.*)
+  *( .phyiram  .phyiram.*)
+  *( .iram1  .iram1.*)
+  *( .wifiextrairam.* )
+  *( .coexiram.* )
+  . = ALIGN(4);
+} > RWTEXT AT > RODATA

--- a/esp-hal/ld/sections/stack.x
+++ b/esp-hal/ld/sections/stack.x
@@ -38,6 +38,6 @@ PROVIDE(_stack_start_cpu0 = ORIGIN(RWDATA) + LENGTH(RWDATA));
 /*
 Provide the stack_guard for `stack-protector`
 
-Ideally the offset should be configurable - should be done once we have https://github.com/esp-rs/esp-hal/issues/1111
+TODO: Ideally the offset should be configurable - should be done once we have https://github.com/esp-rs/esp-hal/issues/1111
 */
 PROVIDE(__stack_chk_guard = _stack_end + 4096);

--- a/esp-hal/ld/sections/stack.x
+++ b/esp-hal/ld/sections/stack.x
@@ -6,7 +6,7 @@ SECTIONS {
     _stack_end_cpu0 = ABSOLUTE(.);
 
     /* The stack_guard for `stack-protector` mitigation - https://doc.rust-lang.org/rustc/exploit-mitigations.html#stack-smashing-protection */
-    __stack_chk_guard = _stack_end + ESP_HAL_CONFIG_STACK_GUARD_OFFSET;
+    __stack_chk_guard = _stack_end + ${ESP_HAL_CONFIG_STACK_GUARD_OFFSET};
 
 /* no Xtensa chip is supported - so we can assume RISC-V */
 #IF ESP_HAL_CONFIG_FLIP_LINK

--- a/esp-hal/ld/sections/stack.x
+++ b/esp-hal/ld/sections/stack.x
@@ -1,5 +1,3 @@
-#IF ESP_HAL_CONFIG_FLIP_LINK
-/* no Xtensa chip is supported - so we can assume RISC-V */
 SECTIONS {
   /* must be last segment using RWDATA */
   .stack (NOLOAD) : ALIGN(4)
@@ -7,40 +5,23 @@ SECTIONS {
     _stack_end = ABSOLUTE(.);
     _stack_end_cpu0 = ABSOLUTE(.);
 
+    /*
+    Provide the stack_guard for `stack-protector`
+
+    TODO: Ideally the offset should be configurable - should be done once we have https://github.com/esp-rs/esp-hal/issues/1111
+    */
+    __stack_chk_guard = _stack_end + 4096;
+
+/* no Xtensa chip is supported - so we can assume RISC-V */
+#IF ESP_HAL_CONFIG_FLIP_LINK
     /* Since we cannot know how much the alignment padding of the sections will add we shrink the stack for "the worst case"
     */
     . = . + LENGTH(RWDATA) -  (SIZEOF(.trap) + SIZEOF(.rwtext) + SIZEOF(.rwtext.wifi) + SIZEOF(.data) + SIZEOF(.bss) + SIZEOF(.noinit) + SIZEOF(.data.wifi)) - 304;
-
-    . = ALIGN (4);
-    _stack_start = ABSOLUTE(.);
-    _stack_start_cpu0 = ABSOLUTE(.);
-  } > RWDATA
-}
-INSERT BEFORE .trap;
-
 #ELSE
-
-SECTIONS {
-  /* must be last segment using RWDATA */
-  .stack (NOLOAD) : ALIGN(4)
-  {
-    . = ALIGN (4);
-    _stack_end = ABSOLUTE(.);
-    _stack_end_cpu0 = ABSOLUTE(.);
-
     . = ORIGIN(RWDATA) + LENGTH(RWDATA);
-
+#ENDIF
     . = ALIGN (4);
     _stack_start = ABSOLUTE(.);
     _stack_start_cpu0 = ABSOLUTE(.);
   } > RWDATA
 }
-
-#ENDIF
-
-/*
-Provide the stack_guard for `stack-protector`
-
-TODO: Ideally the offset should be configurable - should be done once we have https://github.com/esp-rs/esp-hal/issues/1111
-*/
-PROVIDE(__stack_chk_guard = _stack_end + 4096);

--- a/esp-hal/ld/sections/stack.x
+++ b/esp-hal/ld/sections/stack.x
@@ -27,11 +27,14 @@ SECTIONS {
     . = ALIGN (4);
     _stack_end = ABSOLUTE(.);
     _stack_end_cpu0 = ABSOLUTE(.);
+
+    . = ORIGIN(RWDATA) + LENGTH(RWDATA);
+
+    . = ALIGN (4);
+    _stack_start = ABSOLUTE(.);
+    _stack_start_cpu0 = ABSOLUTE(.);
   } > RWDATA
 }
-
-PROVIDE(_stack_start = ORIGIN(RWDATA) + LENGTH(RWDATA));
-PROVIDE(_stack_start_cpu0 = ORIGIN(RWDATA) + LENGTH(RWDATA));
 
 #ENDIF
 

--- a/esp-hal/ld/sections/stack.x
+++ b/esp-hal/ld/sections/stack.x
@@ -5,12 +5,8 @@ SECTIONS {
     _stack_end = ABSOLUTE(.);
     _stack_end_cpu0 = ABSOLUTE(.);
 
-    /*
-    Provide the stack_guard for `stack-protector`
-
-    TODO: Ideally the offset should be configurable - should be done once we have https://github.com/esp-rs/esp-hal/issues/1111
-    */
-    __stack_chk_guard = _stack_end + 4096;
+    /* The stack_guard for `stack-protector` mitigation - https://doc.rust-lang.org/rustc/exploit-mitigations.html#stack-smashing-protection */
+    __stack_chk_guard = _stack_end + ESP_HAL_CONFIG_STACK_GUARD_OFFSET;
 
 /* no Xtensa chip is supported - so we can assume RISC-V */
 #IF ESP_HAL_CONFIG_FLIP_LINK

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -418,7 +418,10 @@ fn hal_main(a0: usize, a1: usize, a2: usize) -> ! {
         let stack_chk_guard = core::ptr::addr_of_mut!(__stack_chk_guard);
         // we _should_ use a random value but we don't have a good source for random
         // numbers here
-        stack_chk_guard.write_volatile(0xdeadbabe);
+        stack_chk_guard.write_volatile(esp_config::esp_config_int!(
+            u32,
+            "ESP_HAL_CONFIG_STACK_GUARD_VALUE"
+        ));
 
         main(a0, a1, a2);
     }

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -114,7 +114,10 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         let stack_chk_guard = core::ptr::addr_of_mut!(__stack_chk_guard);
         // we _should_ use a random value but we don't have a good source for random
         // numbers here
-        stack_chk_guard.write_volatile(0xdeadbabe);
+        stack_chk_guard.write_volatile(esp_config::esp_config_int!(
+            u32,
+            "ESP_HAL_CONFIG_STACK_GUARD_VALUE"
+        ));
     }
 
     crate::interrupt::setup_interrupts();

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -118,7 +118,10 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         let stack_chk_guard = core::ptr::addr_of_mut!(__stack_chk_guard);
         // we _should_ use a random value but we don't have a good source for random
         // numbers here
-        stack_chk_guard.write_volatile(0xdeadbabe);
+        stack_chk_guard.write_volatile(esp_config::esp_config_int!(
+            u32,
+            "ESP_HAL_CONFIG_STACK_GUARD_VALUE"
+        ));
     }
 
     crate::interrupt::setup_interrupts();

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -157,7 +157,10 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         let stack_chk_guard = core::ptr::addr_of_mut!(__stack_chk_guard);
         // we _should_ use a random value but we don't have a good source for random
         // numbers here
-        stack_chk_guard.write_volatile(0xdeadbabe);
+        stack_chk_guard.write_volatile(esp_config::esp_config_int!(
+            u32,
+            "ESP_HAL_CONFIG_STACK_GUARD_VALUE"
+        ));
     }
 
     crate::interrupt::setup_interrupts();

--- a/hil-test/.cargo/config.toml
+++ b/hil-test/.cargo/config.toml
@@ -1,9 +1,9 @@
 [target.'cfg(target_arch = "riscv32")']
 runner    = "probe-rs run --preverify"
 rustflags = [
-    "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Tembedded-test.x",
     "-C", "link-arg=-Tdefmt.x",
+    "-C", "link-arg=-Tlinkall.x",
     "-C", "force-frame-pointers"
 ]
 
@@ -11,9 +11,9 @@ rustflags = [
 runner    = "probe-rs run --preverify"
 rustflags = [
     "-C", "link-arg=-nostartfiles",
-    "-C", "link-arg=-Wl,-Tlinkall.x",
-    "-C", "link-arg=-Tdefmt.x",
     "-C", "link-arg=-Tembedded-test.x",
+    "-C", "link-arg=-Tdefmt.x",
+    "-C", "link-arg=-Wl,-Tlinkall.x",
 ]
 
 [env]

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -57,6 +57,10 @@ name    = "get_time"
 harness = false
 
 [[test]]
+name    = "flip_link"
+harness = false
+
+[[test]]
 name    = "gpio"
 harness = false
 

--- a/hil-test/tests/flip_link.rs
+++ b/hil-test/tests/flip_link.rs
@@ -1,0 +1,20 @@
+//! Tests flip_link
+
+//% CHIPS: esp32c6 esp32h2
+//% ENV: ESP_HAL_CONFIG_FLIP_LINK = true
+
+#![no_std]
+#![no_main]
+
+use hil_test as _;
+
+#[cfg(test)]
+#[embedded_test::tests(default_timeout = 3)]
+mod tests {
+    #[test]
+    fn test() {
+        let _p = esp_hal::init(Default::default());
+        defmt::info!("Hello, world!");
+        defmt::assert_eq!(1 + 1, 2);
+    }
+}


### PR DESCRIPTION
We have a [reproducer](https://github.com/flippette/esp32c6-flip-reproducer) showing that flip-link does not work. I've also tried a freshly generated project, and it also doesn't work. So it's time to add a test.

I had to modify `config.toml` a bit to get this to fail, but that should be okay because our template says the following:

> // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)

I've ran the `wifi_embassy_access_point_with_sta` example on both S3 and C6 (with and without flip_link) and all three tests were successful.

Closes #3213