### PR TITLE
Add rand_core 0.9 support

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for `rand_core` 0.9 (#3211)
+
 ### Changed
 
 ### Fixed

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -51,7 +51,8 @@ procmacros               = { version = "0.17.0", package = "esp-hal-procmacros",
 strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
 void                     = { version = "1.0.2", default-features = false }
 usb-device               = { version = "0.3.2", optional = true }
-rand_core                = "0.6.4"
+rand_core06              = { package = "rand_core", version = "0.6.4", optional = true }
+rand_core09              = { package = "rand_core", version = "0.9.0", optional = true }
 ufmt-write               = "0.1.0"
 
 # IMPORTANT:
@@ -158,6 +159,8 @@ unstable = [
     "dep:embedded-can",
     "dep:embedded-io",
     "dep:embedded-io-async",
+    "dep:rand_core06",
+    "dep:rand_core09",
 ]
 
 [lints.clippy]

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -147,7 +147,8 @@ impl Peripheral for Rng {
     }
 }
 
-impl rand_core::RngCore for Rng {
+#[instability::unstable]
+impl rand_core06::RngCore for Rng {
     fn next_u32(&mut self) -> u32 {
         self.random()
     }
@@ -163,9 +164,25 @@ impl rand_core::RngCore for Rng {
         self.read(dest);
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core06::Error> {
         self.read(dest);
         Ok(())
+    }
+}
+
+#[instability::unstable]
+impl rand_core09::RngCore for Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.random()
+    }
+    fn next_u64(&mut self) -> u64 {
+        let upper = self.random() as u64;
+        let lower = self.random() as u64;
+
+        (upper << 32) | lower
+    }
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.read(dest);
     }
 }
 
@@ -229,7 +246,8 @@ impl Drop for Trng<'_> {
 }
 
 /// Implementing RngCore trait from rand_core for `Trng` structure
-impl rand_core::RngCore for Trng<'_> {
+#[instability::unstable]
+impl rand_core06::RngCore for Trng<'_> {
     fn next_u32(&mut self) -> u32 {
         self.rng.next_u32()
     }
@@ -242,14 +260,30 @@ impl rand_core::RngCore for Trng<'_> {
         self.rng.fill_bytes(dest)
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core06::Error> {
         self.rng.try_fill_bytes(dest)
+    }
+}
+
+#[instability::unstable]
+impl rand_core09::RngCore for Trng<'_> {
+    fn next_u32(&mut self) -> u32 {
+        self.rng.next_u32()
+    }
+    fn next_u64(&mut self) -> u64 {
+        self.rng.next_u64()
+    }
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.fill_bytes(dest)
     }
 }
 
 /// Implementing a CryptoRng marker trait that indicates that the generator is
 /// cryptographically secure.
-impl rand_core::CryptoRng for Trng<'_> {}
+#[instability::unstable]
+impl rand_core06::CryptoRng for Trng<'_> {}
+#[instability::unstable]
+impl rand_core09::CryptoRng for Trng<'_> {}
 
 impl Sealed for Trng<'_> {}
 


### PR DESCRIPTION
This PR adds rand_core 0.9 support without removing 0.6. The dependencies are now also optional because rng is unstable. We may choose to remove 0.6 support during rng stabilization.

Closes #3046