### PR TITLE
Add degrade fns, move AnyI2s and AnyI2c

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced `chrono::NaiveDateTime` on the RTC API by raw `u64` timestamps (#3200)
-- `AnyI2s` has been moved to `esp_hal::i2s::AnyI2s` (#3226)
-- `AnyI2c` has been moved to `esp_hal::i2c::AnyI2c` (#3226)
+- `esp_hal::i2s::master::AnyI2s` has been moved to `esp_hal::i2s::AnyI2s` (#3226)
+- `esp_hal::i2c::master::AnyI2c` has been moved to `esp_hal::i2c::AnyI2c` (#3226)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced `chrono::NaiveDateTime` on the RTC API by raw `u64` timestamps (#3200)
+- `AnyI2s` has been moved to `esp_hal::i2s::AnyI2s` (#3226)
+- `AnyI2c` has been moved to `esp_hal::i2c::AnyI2c` (#3226)
 
 ### Fixed
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -405,11 +405,11 @@ pub trait Pin: Sealed {
     /// GPIO number
     fn number(&self) -> u8;
 
-    /// Type-erase (degrade) this pin into an [`AnyPin`].
+    /// Type-erase this pin into an [`AnyPin`].
     ///
-    /// This converts pin singletons (`GpioPin<0>`, …), which are all different
-    /// types, into the same type. It is useful for creating arrays of pins,
-    /// or avoiding generics.
+    /// This function converts pin singletons (`GpioPin<0>`, …), which are all
+    /// different types, into the same type. It is useful for creating
+    /// arrays of pins, or avoiding generics.
     ///
     /// ## Example
     ///
@@ -620,7 +620,7 @@ impl GpioBank {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GpioPin<const GPIONUM: u8>;
 
-/// Type-erased GPIO pin
+/// Any GPIO pin.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyPin(pub(crate) u8);

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -40,6 +40,7 @@ use crate::{
         PinGuard,
         Pull,
     },
+    i2c::{AnyI2c, AnyI2cInner},
     interrupt::InterruptHandler,
     pac::i2c0::{RegisterBlock, COMD},
     peripheral::{Peripheral, PeripheralRef},
@@ -2890,16 +2891,6 @@ macro_rules! instance {
 instance!(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA, I2C_EXT0);
 #[cfg(i2c1)]
 instance!(I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA, I2C_EXT1);
-
-crate::any_peripheral! {
-    /// Represents any I2C peripheral.
-    pub peripheral AnyI2c {
-        #[cfg(i2c0)]
-        I2c0(crate::peripherals::I2C0),
-        #[cfg(i2c1)]
-        I2c1(crate::peripherals::I2C1),
-    }
-}
 
 impl Instance for AnyI2c {
     delegate::delegate! {

--- a/esp-hal/src/i2c/mod.rs
+++ b/esp-hal/src/i2c/mod.rs
@@ -14,3 +14,13 @@ pub mod master;
 crate::unstable_module! {
     pub mod lp_i2c;
 }
+
+crate::any_peripheral! {
+    /// Any I2C peripheral.
+    pub peripheral AnyI2c {
+        #[cfg(i2c0)]
+        I2c0(crate::peripherals::I2C0),
+        #[cfg(i2c1)]
+        I2c1(crate::peripherals::I2C1),
+    }
+}

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -98,6 +98,7 @@ use crate::{
         WriteBuffer,
     },
     gpio::interconnect::PeripheralOutput,
+    i2s::AnyI2s,
     interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::{Peripheral, PeripheralRef},
     system::PeripheralGuard,
@@ -693,6 +694,7 @@ mod private {
             InputSignal,
             OutputSignal,
         },
+        i2s::AnyI2sInner,
         interrupt::InterruptHandler,
         peripheral::{Peripheral, PeripheralRef},
         peripherals::{Interrupt, I2S0},
@@ -1690,17 +1692,17 @@ mod private {
     impl RegBlock for super::AnyI2s {
         fn regs(&self) -> &RegisterBlock {
             match &self.0 {
-                super::AnyI2sInner::I2s0(i2s) => RegBlock::regs(i2s),
+                AnyI2sInner::I2s0(i2s) => RegBlock::regs(i2s),
                 #[cfg(i2s1)]
-                super::AnyI2sInner::I2s1(i2s) => RegBlock::regs(i2s),
+                AnyI2sInner::I2s1(i2s) => RegBlock::regs(i2s),
             }
         }
 
         delegate::delegate! {
             to match &self.0 {
-                super::AnyI2sInner::I2s0(i2s) => i2s,
+                AnyI2sInner::I2s0(i2s) => i2s,
                 #[cfg(i2s1)]
-                super::AnyI2sInner::I2s1(i2s) => i2s,
+                AnyI2sInner::I2s1(i2s) => i2s,
             } {
                 fn peripheral(&self) -> crate::system::Peripheral;
             }
@@ -1710,9 +1712,9 @@ mod private {
     impl RegisterAccessPrivate for super::AnyI2s {
         delegate::delegate! {
             to match &self.0 {
-                super::AnyI2sInner::I2s0(i2s) => i2s,
+                AnyI2sInner::I2s0(i2s) => i2s,
                 #[cfg(i2s1)]
-                super::AnyI2sInner::I2s1(i2s) => i2s,
+                AnyI2sInner::I2s1(i2s) => i2s,
             } {
                 fn set_interrupt_handler(&self, handler: InterruptHandler);
             }
@@ -1722,9 +1724,9 @@ mod private {
     impl Signals for super::AnyI2s {
         delegate::delegate! {
             to match &self.0 {
-                super::AnyI2sInner::I2s0(i2s) => i2s,
+                AnyI2sInner::I2s0(i2s) => i2s,
                 #[cfg(i2s1)]
-                super::AnyI2sInner::I2s1(i2s) => i2s,
+                AnyI2sInner::I2s1(i2s) => i2s,
             } {
                 fn mclk_signal(&self) -> OutputSignal;
                 fn bclk_signal(&self) -> OutputSignal;
@@ -2025,31 +2027,6 @@ pub mod asynch {
             let avail = self.available().await?;
             let to_rcv = usize::min(avail, data.len());
             Ok(self.state.pop(&mut data[..to_rcv])?)
-        }
-    }
-}
-
-crate::any_peripheral! {
-    /// Any SPI peripheral.
-    pub peripheral AnyI2s {
-        #[cfg(i2s0)]
-        I2s0(crate::peripherals::I2S0),
-        #[cfg(i2s1)]
-        I2s1(crate::peripherals::I2S1),
-    }
-}
-
-impl DmaEligible for AnyI2s {
-    #[cfg(gdma)]
-    type Dma = crate::dma::AnyGdmaChannel;
-    #[cfg(pdma)]
-    type Dma = crate::dma::AnyI2sDmaChannel;
-
-    fn dma_peripheral(&self) -> crate::dma::DmaPeripheral {
-        match &self.0 {
-            AnyI2sInner::I2s0(_) => crate::dma::DmaPeripheral::I2s0,
-            #[cfg(i2s1)]
-            AnyI2sInner::I2s1(_) => crate::dma::DmaPeripheral::I2s1,
         }
     }
 }

--- a/esp-hal/src/i2s/mod.rs
+++ b/esp-hal/src/i2s/mod.rs
@@ -1,6 +1,33 @@
 //! # Inter-IC Sound (I2S)
 
+use crate::dma::DmaEligible;
+
 pub mod master;
 
 #[cfg(esp32)]
 pub mod parallel;
+
+crate::any_peripheral! {
+    /// Any I2S peripheral.
+    pub peripheral AnyI2s {
+        #[cfg(i2s0)]
+        I2s0(crate::peripherals::I2S0),
+        #[cfg(i2s1)]
+        I2s1(crate::peripherals::I2S1),
+    }
+}
+
+impl DmaEligible for AnyI2s {
+    #[cfg(gdma)]
+    type Dma = crate::dma::AnyGdmaChannel;
+    #[cfg(pdma)]
+    type Dma = crate::dma::AnyI2sDmaChannel;
+
+    fn dma_peripheral(&self) -> crate::dma::DmaPeripheral {
+        match &self.0 {
+            AnyI2sInner::I2s0(_) => crate::dma::DmaPeripheral::I2s0,
+            #[cfg(i2s1)]
+            AnyI2sInner::I2s1(_) => crate::dma::DmaPeripheral::I2s1,
+        }
+    }
+}

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -110,7 +110,6 @@ use crate::{
         DmaChannelFor,
         DmaEligible,
         DmaError,
-        DmaPeripheral,
         DmaTxBuffer,
         PeripheralTxChannel,
         Tx,
@@ -119,6 +118,7 @@ use crate::{
         interconnect::{OutputConnection, PeripheralOutput},
         OutputSignal,
     },
+    i2s::{AnyI2s, AnyI2sInner},
     pac::i2s0::RegisterBlock,
     peripheral::{Peripheral, PeripheralRef},
     peripherals::{I2S0, I2S1},
@@ -756,25 +756,6 @@ impl Instance for I2S1 {
             22 => OutputSignal::I2S1O_DATA_22,
             23 => OutputSignal::I2S1O_DATA_23,
             other => panic!("Invalid I2S1 Dout pin {}", other),
-        }
-    }
-}
-
-crate::any_peripheral! {
-    /// Any SPI peripheral.
-    pub peripheral AnyI2s {
-        I2s0(crate::peripherals::I2S0),
-        I2s1(crate::peripherals::I2S1),
-    }
-}
-
-impl DmaEligible for AnyI2s {
-    type Dma = crate::dma::AnyI2sDmaChannel;
-
-    fn dma_peripheral(&self) -> DmaPeripheral {
-        match &self.0 {
-            AnyI2sInner::I2s0(_) => DmaPeripheral::I2s0,
-            AnyI2sInner::I2s1(_) => DmaPeripheral::I2s1,
         }
     }
 }


### PR DESCRIPTION
Closes #3205

I'm also moving the AnyI2c and AnyI2s types, but really only because of the macro change. We now generate `degrade` for singletons automatically, and if we were to introduce a separate AnyI2c for slave mode for example, we would have multiple implementations of the same function. I also don't think the peripheral instances themselves will be different, the drivers may decorate them with marker/instance traits as needed.