### PR TITLE
Support "build-documentation-index --serve"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
-xdoc = "run --package xtask --features=deploy-docs --"
+xdoc = "run --package xtask --features=deploy-docs,preview-docs --"
 xfmt = "xtask fmt-packages"
 qa = "xtask run-example qa-test"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "xtask"
+name = "xtask"
 version = "0.0.0"
 edition = "2021"
 publish = false
@@ -16,6 +16,8 @@ esp-metadata = { path = "../esp-metadata", features = ["clap"] }
 kuchikiki    = "0.8.2"
 log          = "0.4.22"
 minijinja    = "2.5.0"
+opener       = { version = "0.7.2", optional = true }
+rocket       = { version = "0.5.1", optional = true }
 semver       = { version = "1.0.23", features = ["serde"] }
 serde        = { version = "1.0.215", features = ["derive"] }
 serde_json   = "1.0.70"
@@ -32,3 +34,4 @@ reqwest = { version = "0.12.12", features = [
 
 [features]
 deploy-docs = ["dep:reqwest"]
+preview-docs = ["dep:rocket", "dep:opener"]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This adds a `--serve` option to `build-documentation-index` - e.g. `cargo xdoc build-documentation-index --serve`

#### Testing
Run the command above
