### PR TITLE
esp-hal: add doctest showing how to use Jiff

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -83,6 +83,9 @@ esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
 serde        = { version = "1.0.218", features = ["derive"] }
 
+[dev-dependencies]
+jiff = { version = "0.2.2", default-features = false, features = ["static"] }
+
 [features]
 default = []
 

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -399,6 +399,28 @@ impl<'d> Rtc<'d> {
     }
 
     /// Get the current time in microseconds.
+    ///
+    /// # Example
+    ///
+    /// This example shows how to get the weekday of the current time in
+    /// New York using the `jiff` crate. This example works in core-only
+    /// environments without dynamic memory allocation.
+    ///
+    /// ```rust, no_run
+    #[doc = crate::before_snippet!()]
+    /// # use esp_hal::rtc_cntl::Rtc;
+    /// use jiff::{Timestamp, tz::{self, TimeZone}};
+    ///
+    /// static TZ: TimeZone = tz::get!("America/New_York");
+    ///
+    /// let rtc = Rtc::new(peripherals.LPWR);
+    /// let now = Timestamp::from_microsecond(
+    ///     rtc.current_time_us() as i64,
+    /// ).unwrap();
+    /// let weekday_in_new_york = now.to_zoned(TZ.clone()).weekday();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn current_time_us(&self) -> u64 {
         // Current time is boot time + time since boot
 


### PR DESCRIPTION
This attempts to add a doctest showing how to plug a micro-second Unix
timestamp into Jiff, and then get, e.g., the weekday in a particular
locale. The example also makes use of Jiff's new `tz::get!` proc-macro
for embedding time zones into the binary for use in core-only
environments.

Ref #3185, Ref #3200
