### PR TITLE
`log` fixes

### DIFF
--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Manually setting a log level now correctly ignores `ESP_LOG`. (#3240)
+- Fixed logging rules being order-dependent. (#3240)
+
 ### Removed
 
 ## [0.13.1] - 2025-02-24

--- a/esp-println/build.rs
+++ b/esp-println/build.rs
@@ -100,7 +100,7 @@ fn generate_filter_snippet() {
                     ));
                 } else {
                     if global_level.is_some() {
-                        panic!("Multiple globel log levels specified in `ESP_LOG`");
+                        panic!("Multiple global log levels specified in `ESP_LOG`");
                     }
                     global_level = Some(level);
                 }

--- a/esp-println/src/logger.rs
+++ b/esp-println/src/logger.rs
@@ -7,8 +7,6 @@ include!(concat!(env!("OUT_DIR"), "/log_filter.rs"));
 include!(concat!(env!("OUT_DIR"), "\\log_filter.rs"));
 
 /// Initialize the logger with the given maximum log level.
-///
-/// `ESP_LOG` environment variable will still be honored if set.
 pub fn init_logger(level: log::LevelFilter) {
     unsafe {
         log::set_logger_racy(&EspLogger).unwrap();


### PR DESCRIPTION
This PR fixes the following issues:
- The presence of `ESP_LOG` influenced the log filter even if the user used `init_logger(log_level)` to initialize. This is surprising and undesirable behaviour.
- The filter rules were applied in order, i.e. `trace,esp_hal=info` essentially just ignored `esp_hal=info`.
- If a module spec matched, but the level did not, the filter moved on to the next rule. This meant that rules like `esp_hal=error,info` were effectively equivalent to `info`.