### PR TITLE
Rework regi2c code

### DIFF
--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -94,6 +94,7 @@ pub enum AdcCalSource {
     /// Use Ground as the calibration source
     Gnd,
     /// Use Vref as the calibration source
+    #[cfg(not(esp32h2))]
     Ref,
 }
 

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -215,6 +215,7 @@ impl super::CalibrationAccess for crate::peripherals::ADC1 {
     fn connect_cal(source: AdcCalSource, enable: bool) {
         match source {
             AdcCalSource::Gnd => regi2c::ADC_SAR1_ENCAL_GND.write_field(enable as _),
+            #[cfg(not(esp32h2))]
             AdcCalSource::Ref => regi2c::ADC_SAR1_ENCAL_REF.write_field(enable as _),
         }
     }

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -40,30 +40,6 @@ cfg_if::cfg_if! {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(adc2)] {
-        const ADC_SAR2_ENCAL_GND_ADDR: u8 = 0x7;
-        const ADC_SAR2_ENCAL_GND_ADDR_MSB: u8 = 7;
-        const ADC_SAR2_ENCAL_GND_ADDR_LSB: u8 = 7;
-
-        const ADC_SAR2_INITIAL_CODE_HIGH_ADDR: u8 = 0x4;
-        const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-        const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
-
-        const ADC_SAR2_INITIAL_CODE_LOW_ADDR: u8 = 0x3;
-        const ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
-        const ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
-
-        const ADC_SAR2_DREF_ADDR: u8 = 0x5;
-        const ADC_SAR2_DREF_ADDR_MSB: u8 = 0x6;
-        const ADC_SAR2_DREF_ADDR_LSB: u8 = 0x4;
-
-        const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
-        const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 6;
-        const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 6;
-    }
-}
-
 // The number of analog IO pins, and in turn the number of attentuations,
 // depends on which chip is being used
 cfg_if::cfg_if! {
@@ -263,22 +239,8 @@ impl RegisterAccess for crate::peripherals::ADC2 {
     fn set_init_code(data: u16) {
         let [msb, lsb] = data.to_be_bytes();
 
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
-            msb as _,
-        );
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
-            lsb as _,
-        );
+        regi2c::ADC_SAR2_INITIAL_CODE_HIGH.write_field(msb as _);
+        regi2c::ADC_SAR2_INITIAL_CODE_LOW.write_field(lsb as _);
     }
 }
 
@@ -289,36 +251,13 @@ impl super::CalibrationAccess for crate::peripherals::ADC2 {
     const ADC_VAL_MASK: u16 = ADC_VAL_MASK;
 
     fn enable_vdef(enable: bool) {
-        let value = enable as _;
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_DREF_ADDR,
-            ADC_SAR2_DREF_ADDR_MSB,
-            ADC_SAR2_DREF_ADDR_LSB,
-            value,
-        );
+        regi2c::ADC_SAR2_DREF.write_field(enable as _);
     }
 
     fn connect_cal(source: AdcCalSource, enable: bool) {
-        let value = enable as _;
         match source {
-            AdcCalSource::Gnd => regi2c_write_mask(
-                I2C_SAR_ADC,
-                I2C_SAR_ADC_HOSTID,
-                ADC_SAR2_ENCAL_GND_ADDR,
-                ADC_SAR2_ENCAL_GND_ADDR_MSB,
-                ADC_SAR2_ENCAL_GND_ADDR_LSB,
-                value,
-            ),
-            AdcCalSource::Ref => regi2c_write_mask(
-                I2C_SAR_ADC,
-                I2C_SAR_ADC_HOSTID,
-                ADC_SARADC2_ENCAL_REF_ADDR,
-                ADC_SARADC2_ENCAL_REF_ADDR_MSB,
-                ADC_SARADC2_ENCAL_REF_ADDR_LSB,
-                value,
-            ),
+            AdcCalSource::Gnd => regi2c::ADC_SAR2_ENCAL_GND.write_field(enable as _),
+            AdcCalSource::Ref => regi2c::ADC_SAR2_ENCAL_REF.write_field(enable as _),
         }
     }
 }

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -11,8 +11,6 @@ cfg_if::cfg_if! {
 #[cfg(not(esp32h2))]
 pub use self::calibration::*;
 use super::{AdcCalSource, AdcConfig, Attenuation};
-#[cfg(any(esp32c6, esp32h2))]
-use crate::clock::clocks_ll::regi2c_write_mask;
 #[cfg(any(esp32c2, esp32c3, esp32c6))]
 use crate::efuse::Efuse;
 use crate::{
@@ -20,28 +18,13 @@ use crate::{
     interrupt::{InterruptConfigurable, InterruptHandler},
     peripheral::PeripheralRef,
     peripherals::{Interrupt, APB_SARADC},
+    soc::regi2c,
     system::{GenericPeripheralGuard, Peripheral},
     Async,
     Blocking,
 };
 
 mod calibration;
-
-// polyfill for c2 and c3
-#[cfg(any(esp32c2, esp32c3))]
-#[inline(always)]
-fn regi2c_write_mask(block: u8, host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
-    unsafe {
-        crate::rom::rom_i2c_writeReg_Mask(
-            block as _,
-            host_id as _,
-            reg_add as _,
-            msb as _,
-            lsb as _,
-            data as _,
-        );
-    }
-}
 
 // Constants taken from:
 // https://github.com/espressif/esp-idf/blob/903af13e8/components/soc/esp32c2/include/soc/regi2c_saradc.h
@@ -51,32 +34,9 @@ fn regi2c_write_mask(block: u8, host_id: u8, reg_add: u8, msb: u8, lsb: u8, data
 // https://github.com/espressif/esp-idf/blob/903af13e8/components/soc/esp32h4/include/soc/regi2c_saradc.h
 cfg_if::cfg_if! {
     if #[cfg(adc1)] {
-        const I2C_SAR_ADC: u8 = 0x69;
-        const I2C_SAR_ADC_HOSTID: u8 = 0;
-
         const ADC_VAL_MASK: u16 = 0xfff;
         const ADC_CAL_CNT_MAX: u16 = 32;
         const ADC_CAL_CHANNEL: u16 = 15;
-
-        const ADC_SAR1_ENCAL_GND_ADDR: u8 = 0x7;
-        const ADC_SAR1_ENCAL_GND_ADDR_MSB: u8 = 5;
-        const ADC_SAR1_ENCAL_GND_ADDR_LSB: u8 = 5;
-
-        const ADC_SAR1_INITIAL_CODE_HIGH_ADDR: u8 = 0x1;
-        const ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-        const ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
-
-        const ADC_SAR1_INITIAL_CODE_LOW_ADDR: u8 = 0x0;
-        const ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
-        const ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
-
-        const ADC_SAR1_DREF_ADDR: u8 = 0x2;
-        const ADC_SAR1_DREF_ADDR_MSB: u8 = 0x6;
-        const ADC_SAR1_DREF_ADDR_LSB: u8 = 0x4;
-
-        const ADC_SARADC1_ENCAL_REF_ADDR: u8 = 0x7;
-        const ADC_SARADC1_ENCAL_REF_ADDR_MSB: u8 = 4;
-        const ADC_SARADC1_ENCAL_REF_ADDR_LSB: u8 = 4;
     }
 }
 
@@ -237,22 +197,8 @@ impl RegisterAccess for crate::peripherals::ADC1 {
     fn set_init_code(data: u16) {
         let [msb, lsb] = data.to_be_bytes();
 
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
-            msb as _,
-        );
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
-            lsb as _,
-        );
+        regi2c::ADC_SAR1_INITIAL_CODE_HIGH.write_field(msb);
+        regi2c::ADC_SAR1_INITIAL_CODE_LOW.write_field(lsb);
     }
 }
 
@@ -263,36 +209,13 @@ impl super::CalibrationAccess for crate::peripherals::ADC1 {
     const ADC_VAL_MASK: u16 = ADC_VAL_MASK;
 
     fn enable_vdef(enable: bool) {
-        let value = enable as _;
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_DREF_ADDR,
-            ADC_SAR1_DREF_ADDR_MSB,
-            ADC_SAR1_DREF_ADDR_LSB,
-            value,
-        );
+        regi2c::ADC_SAR1_DREF.write_field(enable as _);
     }
 
     fn connect_cal(source: AdcCalSource, enable: bool) {
-        let value = enable as _;
         match source {
-            AdcCalSource::Gnd => regi2c_write_mask(
-                I2C_SAR_ADC,
-                I2C_SAR_ADC_HOSTID,
-                ADC_SAR1_ENCAL_GND_ADDR,
-                ADC_SAR1_ENCAL_GND_ADDR_MSB,
-                ADC_SAR1_ENCAL_GND_ADDR_LSB,
-                value,
-            ),
-            AdcCalSource::Ref => regi2c_write_mask(
-                I2C_SAR_ADC,
-                I2C_SAR_ADC_HOSTID,
-                ADC_SARADC1_ENCAL_REF_ADDR,
-                ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-                ADC_SARADC1_ENCAL_REF_ADDR_LSB,
-                value,
-            ),
+            AdcCalSource::Gnd => regi2c::ADC_SAR1_ENCAL_GND.write_field(enable as _),
+            AdcCalSource::Ref => regi2c::ADC_SAR1_ENCAL_REF.write_field(enable as _),
         }
     }
 }

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -8,6 +8,7 @@ use crate::efuse::Efuse;
 use crate::{
     peripheral::PeripheralRef,
     peripherals::{APB_SARADC, SENS},
+    soc::regi2c,
     system::{GenericPeripheralGuard, Peripheral},
 };
 
@@ -15,62 +16,11 @@ mod calibration;
 
 pub(super) const NUM_ATTENS: usize = 10;
 
-// Constants taken from:
-// https://github.com/espressif/esp-idf/blob/903af13e8/components/soc/esp32s2/include/soc/regi2c_saradc.h
-// https://github.com/espressif/esp-idf/blob/903af13e8/components/soc/esp32s3/include/soc/regi2c_saradc.h
-
-cfg_if::cfg_if! {
-    if #[cfg(any(esp32s2, esp32s3))] {
-        const I2C_SAR_ADC: u8 = 0x69;
-        const I2C_SAR_ADC_HOSTID: u8 = 1;
-
-        const ADC_SAR1_INITIAL_CODE_HIGH_ADDR: u8 = 0x1;
-        const ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-        const ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
-
-        const ADC_SAR1_INITIAL_CODE_LOW_ADDR: u8 = 0x0;
-        const ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
-        const ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
-
-        const ADC_SAR2_INITIAL_CODE_HIGH_ADDR: u8 = 0x4;
-        const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-        const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
-
-        const ADC_SAR2_INITIAL_CODE_LOW_ADDR: u8 = 0x3;
-        const ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
-        const ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
-    }
-}
-
 cfg_if::cfg_if! {
     if #[cfg(esp32s3)] {
         const ADC_VAL_MASK: u16 = 0xfff;
         const ADC_CAL_CNT_MAX: u16 = 32;
         const ADC_CAL_CHANNEL: u16 = 15;
-
-        const ADC_SAR1_ENCAL_GND_ADDR: u8 = 0x7;
-        const ADC_SAR1_ENCAL_GND_ADDR_MSB: u8 = 5;
-        const ADC_SAR1_ENCAL_GND_ADDR_LSB: u8 = 5;
-
-        const ADC_SAR1_DREF_ADDR: u8 = 0x2;
-        const ADC_SAR1_DREF_ADDR_MSB: u8 = 0x6;
-        const ADC_SAR1_DREF_ADDR_LSB: u8 = 0x4;
-
-        const ADC_SARADC1_ENCAL_REF_ADDR: u8 = 0x7;
-        const ADC_SARADC1_ENCAL_REF_ADDR_MSB: u8 = 4;
-        const ADC_SARADC1_ENCAL_REF_ADDR_LSB: u8 = 4;
-
-        const ADC_SAR2_ENCAL_GND_ADDR: u8 = 0x7;
-        const ADC_SAR2_ENCAL_GND_ADDR_MSB: u8 = 5;
-        const ADC_SAR2_ENCAL_GND_ADDR_LSB: u8 = 5;
-
-        const ADC_SAR2_DREF_ADDR: u8 = 0x5;
-        const ADC_SAR2_DREF_ADDR_MSB: u8 = 0x6;
-        const ADC_SAR2_DREF_ADDR_LSB: u8 = 0x4;
-
-        const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
-        const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 4;
-        const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 4;
     }
 }
 
@@ -228,8 +178,8 @@ impl RegisterAccess for crate::peripherals::ADC1 {
     fn set_init_code(data: u16) {
         let [msb, lsb] = data.to_be_bytes();
 
-        crate::rom::regi2c_write_mask!(I2C_SAR_ADC, ADC_SAR1_INITIAL_CODE_HIGH_ADDR, msb as u32);
-        crate::rom::regi2c_write_mask!(I2C_SAR_ADC, ADC_SAR1_INITIAL_CODE_LOW_ADDR, lsb as u32);
+        regi2c::ADC_SAR1_INITIAL_CODE_HIGH.write_field(msb);
+        regi2c::ADC_SAR1_INITIAL_CODE_LOW.write_field(lsb);
     }
 
     fn reset() {
@@ -251,20 +201,16 @@ impl super::CalibrationAccess for crate::peripherals::ADC1 {
     const ADC_VAL_MASK: u16 = ADC_VAL_MASK;
 
     fn enable_vdef(enable: bool) {
-        crate::rom::regi2c_write_mask!(I2C_SAR_ADC, ADC_SAR1_DREF_ADDR, enable as u8);
+        regi2c::ADC_SAR1_DREF.write_field(enable as u8);
     }
 
     fn connect_cal(source: AdcCalSource, enable: bool) {
         match source {
             AdcCalSource::Gnd => {
-                crate::rom::regi2c_write_mask!(I2C_SAR_ADC, ADC_SAR1_ENCAL_GND_ADDR, enable as u8);
+                regi2c::ADC_SAR1_ENCAL_GND.write_field(enable as u8);
             }
             AdcCalSource::Ref => {
-                crate::rom::regi2c_write_mask!(
-                    I2C_SAR_ADC,
-                    ADC_SARADC1_ENCAL_REF_ADDR,
-                    enable as u8
-                );
+                regi2c::ADC_SARADC1_ENCAL_REF.write_field(enable as u8);
             }
         }
     }
@@ -339,8 +285,8 @@ impl RegisterAccess for crate::peripherals::ADC2 {
     fn set_init_code(data: u16) {
         let [msb, lsb] = data.to_be_bytes();
 
-        crate::rom::regi2c_write_mask!(I2C_SAR_ADC, ADC_SAR2_INITIAL_CODE_HIGH_ADDR, msb as u32);
-        crate::rom::regi2c_write_mask!(I2C_SAR_ADC, ADC_SAR2_INITIAL_CODE_LOW_ADDR, lsb as u32);
+        regi2c::ADC_SAR2_INITIAL_CODE_HIGH.write_field(msb);
+        regi2c::ADC_SAR2_INITIAL_CODE_LOW.write_field(lsb);
     }
 
     fn reset() {

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -206,12 +206,8 @@ impl super::CalibrationAccess for crate::peripherals::ADC1 {
 
     fn connect_cal(source: AdcCalSource, enable: bool) {
         match source {
-            AdcCalSource::Gnd => {
-                regi2c::ADC_SAR1_ENCAL_GND.write_field(enable as u8);
-            }
-            AdcCalSource::Ref => {
-                regi2c::ADC_SARADC1_ENCAL_REF.write_field(enable as u8);
-            }
+            AdcCalSource::Gnd => regi2c::ADC_SAR1_ENCAL_GND.write_field(enable as u8),
+            AdcCalSource::Ref => regi2c::ADC_SAR1_ENCAL_REF.write_field(enable as u8),
         }
     }
 }
@@ -308,21 +304,13 @@ impl super::CalibrationAccess for crate::peripherals::ADC2 {
     const ADC_VAL_MASK: u16 = ADC_VAL_MASK;
 
     fn enable_vdef(enable: bool) {
-        crate::rom::regi2c_write_mask!(I2C_SAR_ADC, ADC_SAR2_DREF_ADDR, enable as u8);
+        regi2c::ADC_SAR2_DREF.write_field(enable as u8);
     }
 
     fn connect_cal(source: AdcCalSource, enable: bool) {
         match source {
-            AdcCalSource::Gnd => {
-                crate::rom::regi2c_write_mask!(I2C_SAR_ADC, ADC_SAR2_ENCAL_GND_ADDR, enable as u8);
-            }
-            AdcCalSource::Ref => {
-                crate::rom::regi2c_write_mask!(
-                    I2C_SAR_ADC,
-                    ADC_SARADC2_ENCAL_REF_ADDR,
-                    enable as u8
-                );
-            }
+            AdcCalSource::Gnd => regi2c::ADC_SAR2_ENCAL_GND.write_field(enable as u8),
+            AdcCalSource::Ref => regi2c::ADC_SAR2_ENCAL_REF.write_field(enable as u8),
         }
     }
 }

--- a/esp-hal/src/clock/clocks_ll/esp32.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32.rs
@@ -42,7 +42,7 @@ pub(crate) fn esp32_rtc_bbpll_configure(xtal_freq: XtalClock, pll_freq: PllClock
         // Raise the voltage, if needed
         LPWR::regs()
             .reg()
-            .modify(|_, w| unsafe { w.dig_dbias_wak().bits(DIG_DBIAS_80M_160M as u8) });
+            .modify(|_, w| unsafe { w.dig_dbias_wak().bits(DIG_DBIAS_80M_160M) });
 
         // Configure 320M PLL
         match xtal_freq {
@@ -80,7 +80,7 @@ pub(crate) fn esp32_rtc_bbpll_configure(xtal_freq: XtalClock, pll_freq: PllClock
         // Raise the voltage
         LPWR::regs()
             .reg()
-            .modify(|_, w| unsafe { w.dig_dbias_wak().bits(dig_dbias_240_m as u8) });
+            .modify(|_, w| unsafe { w.dig_dbias_wak().bits(dig_dbias_240_m) });
 
         // Configure 480M PLL
         match xtal_freq {
@@ -167,7 +167,7 @@ pub(crate) fn esp32_rtc_update_to_xtal(freq: XtalClock, _div: u32) {
     // lower the voltage
     LPWR::regs()
         .reg()
-        .modify(|_, w| unsafe { w.dig_dbias_wak().bits(DIG_DBIAS_XTAL as u8) });
+        .modify(|_, w| unsafe { w.dig_dbias_wak().bits(DIG_DBIAS_XTAL) });
 }
 
 pub(crate) fn set_cpu_freq(cpu_freq_mhz: crate::clock::CpuClock) {
@@ -175,9 +175,9 @@ pub(crate) fn set_cpu_freq(cpu_freq_mhz: crate::clock::CpuClock) {
 
     let dig_dbias_240_m = rtc_cntl_dbias_hp_volt;
 
-    const CPU_80M: u32 = 0;
-    const CPU_160M: u32 = 1;
-    const CPU_240M: u32 = 2;
+    const CPU_80M: u8 = 0;
+    const CPU_160M: u8 = 1;
+    const CPU_240M: u8 = 2;
 
     let mut dbias = DIG_DBIAS_80M_160M;
     let per_conf = match cpu_freq_mhz {
@@ -192,10 +192,10 @@ pub(crate) fn set_cpu_freq(cpu_freq_mhz: crate::clock::CpuClock) {
     let value = (((80 * MHZ) >> 12) & UINT16_MAX) | ((((80 * MHZ) >> 12) & UINT16_MAX) << 16);
     DPORT::regs()
         .cpu_per_conf()
-        .write(|w| unsafe { w.cpuperiod_sel().bits(per_conf as u8) });
+        .write(|w| unsafe { w.cpuperiod_sel().bits(per_conf) });
     LPWR::regs()
         .reg()
-        .modify(|_, w| unsafe { w.dig_dbias_wak().bits(dbias as u8) });
+        .modify(|_, w| unsafe { w.dig_dbias_wak().bits(dbias) });
     LPWR::regs().clk_conf().modify(|_, w| w.soc_clk_sel().pll());
     LPWR::regs()
         .store5()

--- a/esp-hal/src/clock/clocks_ll/esp32c3.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32c3.rs
@@ -1,48 +1,17 @@
 use crate::{
     clock::{ApbClock, Clock, CpuClock, PllClock, XtalClock},
     peripherals::{APB_CTRL, I2C_ANA_MST, LPWR, SYSTEM},
-    rom::{regi2c_write, regi2c_write_mask},
+    soc::regi2c,
 };
 
-const I2C_BBPLL: u32 = 0x66;
-const I2C_BBPLL_HOSTID: u32 = 0;
-
-const I2C_BBPLL_MODE_HF: u32 = 4;
-
-const I2C_BBPLL_OC_REF_DIV: u32 = 2;
-const I2C_BBPLL_OC_DCHGP_LSB: u32 = 4;
-const I2C_BBPLL_OC_DIV_7_0: u32 = 3;
-
-const I2C_BBPLL_OC_DR1: u32 = 5;
-const I2C_BBPLL_OC_DR1_MSB: u32 = 2;
-const I2C_BBPLL_OC_DR1_LSB: u32 = 0;
-
-const I2C_BBPLL_OC_DR3: u32 = 5;
-const I2C_BBPLL_OC_DR3_MSB: u32 = 6;
-const I2C_BBPLL_OC_DR3_LSB: u32 = 4;
-
-const I2C_BBPLL_OC_DCUR: u32 = 6;
-
-const I2C_BBPLL_OC_VCO_DBIAS: u32 = 9;
-const I2C_BBPLL_OC_VCO_DBIAS_MSB: u32 = 1;
-const I2C_BBPLL_OC_VCO_DBIAS_LSB: u32 = 0;
-
-const I2C_BBPLL_OC_DHREF_SEL: u32 = 6;
-const I2C_BBPLL_OC_DHREF_SEL_MSB: u32 = 5;
-const I2C_BBPLL_OC_DHREF_SEL_LSB: u32 = 4;
-
-const I2C_BBPLL_OC_DLREF_SEL: u32 = 6;
-const I2C_BBPLL_OC_DLREF_SEL_MSB: u32 = 7;
-const I2C_BBPLL_OC_DLREF_SEL_LSB: u32 = 6;
-
 pub(crate) fn esp32c3_rtc_bbpll_configure(xtal_freq: XtalClock, pll_freq: PllClock) {
-    let div_ref: u32;
-    let div7_0: u32;
-    let dr1: u32;
-    let dr3: u32;
-    let dchgp: u32;
-    let dcur: u32;
-    let dbias: u32;
+    let div_ref: u8;
+    let div7_0: u8;
+    let dr1: u8;
+    let dr3: u8;
+    let dchgp: u8;
+    let dcur: u8;
+    let dbias: u8;
 
     // Set this register to let the digital part know 480M PLL is used
     SYSTEM::regs().cpu_per_conf().modify(|_, w| {
@@ -89,7 +58,7 @@ pub(crate) fn esp32c3_rtc_bbpll_configure(xtal_freq: XtalClock, pll_freq: PllClo
             }
         }
 
-        regi2c_write!(I2C_BBPLL, I2C_BBPLL_MODE_HF, 0x6b);
+        regi2c::I2C_BBPLL_REG4.write_reg(0x6b);
     } else {
         // Configure 320M PLL
         match xtal_freq {
@@ -124,29 +93,25 @@ pub(crate) fn esp32c3_rtc_bbpll_configure(xtal_freq: XtalClock, pll_freq: PllClo
             }
         }
 
-        regi2c_write!(I2C_BBPLL, I2C_BBPLL_MODE_HF, 0x69);
+        regi2c::I2C_BBPLL_REG4.write_reg(0x69);
     }
 
+    const I2C_BBPLL_OC_DCHGP_LSB: u32 = 4;
+    const I2C_BBPLL_OC_DLREF_SEL_LSB: u32 = 6;
+    const I2C_BBPLL_OC_DHREF_SEL_LSB: u32 = 4;
+
     let i2c_bbpll_lref = (dchgp << I2C_BBPLL_OC_DCHGP_LSB) | div_ref;
-    let i2c_bbpll_div_7_0 = div7_0;
     let i2c_bbpll_dcur =
         (2 << I2C_BBPLL_OC_DLREF_SEL_LSB) | (1 << I2C_BBPLL_OC_DHREF_SEL_LSB) | dcur;
 
-    regi2c_write!(I2C_BBPLL, I2C_BBPLL_OC_REF_DIV, i2c_bbpll_lref);
-
-    regi2c_write!(I2C_BBPLL, I2C_BBPLL_OC_DIV_7_0, i2c_bbpll_div_7_0);
-
-    regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_DR1, dr1);
-
-    regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_DR3, dr3);
-
-    regi2c_write!(I2C_BBPLL, I2C_BBPLL_OC_DCUR, i2c_bbpll_dcur);
-
-    regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_VCO_DBIAS, dbias);
-
-    regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_DHREF_SEL, 2);
-
-    regi2c_write_mask!(I2C_BBPLL, I2C_BBPLL_OC_DLREF_SEL, 1);
+    regi2c::I2C_BBPLL_OC_REF.write_reg(i2c_bbpll_lref);
+    regi2c::I2C_BBPLL_OC_DIV_REG.write_reg(div7_0);
+    regi2c::I2C_BBPLL_OC_DR1.write_field(dr1);
+    regi2c::I2C_BBPLL_OC_DR3.write_field(dr3);
+    regi2c::I2C_BBPLL_REG6.write_reg(i2c_bbpll_dcur);
+    regi2c::I2C_BBPLL_OC_VCO_DBIAS.write_field(dbias);
+    regi2c::I2C_BBPLL_OC_DHREF_SEL.write_field(2);
+    regi2c::I2C_BBPLL_OC_DLREF_SEL.write_field(1);
 }
 
 pub(crate) fn esp32c3_rtc_bbpll_enable() {

--- a/esp-hal/src/clock/clocks_ll/esp32c6.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32c6.rs
@@ -2,33 +2,8 @@ use crate::{
     clock::{ApbClock, Clock, CpuClock, PllClock, XtalClock},
     peripherals::{I2C_ANA_MST, LP_AON, MODEM_LPCON, MODEM_SYSCON, PCR, PMU},
     rtc_cntl::rtc::CpuClockSource,
+    soc::regi2c,
 };
-
-const I2C_BBPLL: u8 = 0x66;
-const I2C_BBPLL_HOSTID: u8 = 0;
-
-const I2C_BBPLL_OC_REF_DIV: u8 = 2;
-const I2C_BBPLL_OC_DCHGP_LSB: u32 = 4;
-
-const I2C_BBPLL_OC_DIV_7_0: u8 = 3;
-
-const I2C_BBPLL_OC_DR1: u8 = 5;
-const I2C_BBPLL_OC_DR1_MSB: u8 = 2;
-const I2C_BBPLL_OC_DR1_LSB: u8 = 0;
-
-const I2C_BBPLL_OC_DR3: u8 = 5;
-const I2C_BBPLL_OC_DR3_MSB: u8 = 6;
-const I2C_BBPLL_OC_DR3_LSB: u8 = 4;
-
-const I2C_BBPLL_OC_DCUR: u8 = 6;
-
-const I2C_BBPLL_OC_DHREF_SEL_LSB: u32 = 4;
-
-const I2C_BBPLL_OC_DLREF_SEL_LSB: u32 = 6;
-
-const I2C_BBPLL_OC_VCO_DBIAS: u8 = 9;
-const I2C_BBPLL_OC_VCO_DBIAS_MSB: u8 = 1;
-const I2C_BBPLL_OC_VCO_DBIAS_LSB: u8 = 0;
 
 // rtc_clk_bbpll_configure
 pub(crate) fn esp32c6_rtc_bbpll_configure(xtal_freq: XtalClock, pll_freq: PllClock) {
@@ -58,61 +33,24 @@ pub(crate) fn esp32c6_rtc_bbpll_configure_raw(_xtal_freq: u32, pll_freq: u32) {
             w.bbpll_stop_force_low().set_bit()
         });
 
-        let div_ref = 0;
-        let div7_0 = 8;
-        let dr1 = 0;
-        let dr3 = 0;
-        let dchgp = 5;
-        let dcur = 3;
-        let dbias = 2;
+        const DIV_REF: u8 = 0;
+        const DCHGP: u8 = 5;
+        const DCUR: u8 = 3;
 
-        let i2c_bbpll_lref = (dchgp << I2C_BBPLL_OC_DCHGP_LSB) | div_ref;
-        let i2c_bbpll_div_7_0 = div7_0;
-        let i2c_bbpll_dcur =
-            (1 << I2C_BBPLL_OC_DLREF_SEL_LSB) | (3 << I2C_BBPLL_OC_DHREF_SEL_LSB) | dcur;
+        const I2C_BBPLL_OC_DCHGP_LSB: u32 = 4;
+        const I2C_BBPLL_OC_DHREF_SEL_LSB: u32 = 4;
+        const I2C_BBPLL_OC_DLREF_SEL_LSB: u32 = 6;
 
-        regi2c_write(
-            I2C_BBPLL,
-            I2C_BBPLL_HOSTID,
-            I2C_BBPLL_OC_REF_DIV,
-            i2c_bbpll_lref,
-        );
-        regi2c_write(
-            I2C_BBPLL,
-            I2C_BBPLL_HOSTID,
-            I2C_BBPLL_OC_DIV_7_0,
-            i2c_bbpll_div_7_0,
-        );
-        regi2c_write_mask(
-            I2C_BBPLL,
-            I2C_BBPLL_HOSTID,
-            I2C_BBPLL_OC_DR1,
-            I2C_BBPLL_OC_DR1_MSB,
-            I2C_BBPLL_OC_DR1_LSB,
-            dr1,
-        );
-        regi2c_write_mask(
-            I2C_BBPLL,
-            I2C_BBPLL_HOSTID,
-            I2C_BBPLL_OC_DR3,
-            I2C_BBPLL_OC_DR3_MSB,
-            I2C_BBPLL_OC_DR3_LSB,
-            dr3,
-        );
-        regi2c_write(
-            I2C_BBPLL,
-            I2C_BBPLL_HOSTID,
-            I2C_BBPLL_OC_DCUR,
-            i2c_bbpll_dcur,
-        );
-        regi2c_write_mask(
-            I2C_BBPLL,
-            I2C_BBPLL_HOSTID,
-            I2C_BBPLL_OC_VCO_DBIAS,
-            I2C_BBPLL_OC_VCO_DBIAS_MSB,
-            I2C_BBPLL_OC_VCO_DBIAS_LSB,
-            dbias,
-        );
+        const I2C_BBPLL_LREF: u8 = (DCHGP << I2C_BBPLL_OC_DCHGP_LSB) | DIV_REF;
+        const I2C_BBPLL_DCUR: u8 =
+            (1 << I2C_BBPLL_OC_DLREF_SEL_LSB) | (3 << I2C_BBPLL_OC_DHREF_SEL_LSB) | DCUR;
+
+        regi2c::I2C_BBPLL_OC_REF.write_reg(I2C_BBPLL_LREF);
+        regi2c::I2C_BBPLL_OC_DIV_REG.write_reg(8);
+        regi2c::I2C_BBPLL_OC_DR1.write_field(0);
+        regi2c::I2C_BBPLL_OC_DR3.write_field(0);
+        regi2c::I2C_BBPLL_REG6.write_reg(I2C_BBPLL_DCUR);
+        regi2c::I2C_BBPLL_OC_VCO_DBIAS.write_field(2);
 
         // WAIT CALIBRATION DONE
         while I2C_ANA_MST::regs()
@@ -218,92 +156,6 @@ fn clk_ll_mspi_fast_set_hs_divider(divider: u32) {
     PCR::regs()
         .mspi_clk_conf()
         .modify(|_, w| unsafe { w.mspi_fast_hs_div_num().bits(div_num) });
-}
-
-const REGI2C_BBPLL: u8 = 0x66;
-const REGI2C_BIAS: u8 = 0x6a;
-const REGI2C_DIG_REG: u8 = 0x6d;
-const REGI2C_ULP_CAL: u8 = 0x61;
-const REGI2C_SAR_I2C: u8 = 0x69;
-
-const I2C_MST_ANA_CONF1_M: u32 = 0x00FFFFFF;
-
-fn regi2c_enable_block(block: u8) -> usize {
-    MODEM_LPCON::regs()
-        .clk_conf()
-        .modify(|_, w| w.clk_i2c_mst_en().set_bit());
-
-    // Before config I2C register, enable corresponding slave.
-    let i2c_sel_bits = I2C_ANA_MST::regs().ana_conf2().read();
-    let i2c_sel = match block {
-        v if v == REGI2C_BBPLL => i2c_sel_bits.bbpll_mst_sel().bit_is_set(),
-        v if v == REGI2C_BIAS => i2c_sel_bits.bias_mst_sel().bit_is_set(),
-        v if v == REGI2C_DIG_REG => i2c_sel_bits.dig_reg_mst_sel().bit_is_set(),
-        v if v == REGI2C_ULP_CAL => i2c_sel_bits.ulp_cal_mst_sel().bit_is_set(),
-        v if v == REGI2C_SAR_I2C => i2c_sel_bits.sar_i2c_mst_sel().bit_is_set(),
-        _ => unreachable!(),
-    };
-    I2C_ANA_MST::regs().ana_conf1().write(|w| unsafe {
-        w.bits(I2C_MST_ANA_CONF1_M);
-        match block {
-            v if v == REGI2C_BBPLL => w.bbpll_rd().clear_bit(),
-            v if v == REGI2C_BIAS => w.bias_rd().clear_bit(),
-            v if v == REGI2C_DIG_REG => w.dig_reg_rd().clear_bit(),
-            v if v == REGI2C_ULP_CAL => w.ulp_cal_rd().clear_bit(),
-            v if v == REGI2C_SAR_I2C => w.sar_i2c_rd().clear_bit(),
-            _ => unreachable!(),
-        }
-    });
-
-    if i2c_sel {
-        0
-    } else {
-        1
-    }
-}
-
-pub(crate) fn regi2c_write(block: u8, _host_id: u8, reg_add: u8, data: u8) {
-    let master = regi2c_enable_block(block);
-
-    I2C_ANA_MST::regs().i2c_ctrl(master).write(|w| unsafe {
-        w.slave_addr().bits(block);
-        w.slave_reg_addr().bits(reg_add);
-        w.read_write().set_bit();
-        w.data().bits(data)
-    });
-
-    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
-}
-
-pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
-    assert!(msb < 8 + lsb);
-    let master = regi2c_enable_block(block);
-
-    // Read the i2c bus register
-    I2C_ANA_MST::regs().i2c_ctrl(master).write(|w| unsafe {
-        w.slave_addr().bits(block);
-        w.slave_reg_addr().bits(reg_add)
-    });
-
-    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
-
-    // Example: LSB=2, MSB = 5
-    // unwritten_bits = 1100 0011
-    // data_mask      = 0000 1111
-    // data_bits      = 00xx xx00
-    let unwritten_bits = (!(u32::MAX << lsb) | (u32::MAX << (msb + 1))) as u8;
-    let data_mask = !(u32::MAX << (msb - lsb + 1)) as u8;
-    let data_bits = (data & data_mask) << lsb;
-
-    I2C_ANA_MST::regs().i2c_ctrl(master).modify(|r, w| unsafe {
-        w.slave_addr().bits(block);
-        w.slave_reg_addr().bits(reg_add);
-        w.read_write().set_bit();
-        w.data()
-            .bits((r.data().bits() & unwritten_bits) | data_bits)
-    });
-
-    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
 }
 
 // clk_ll_ahb_set_ls_divider

--- a/esp-hal/src/rom/mod.rs
+++ b/esp-hal/src/rom/mod.rs
@@ -29,6 +29,7 @@
 pub mod crc;
 #[cfg(any(rom_md5_bsd, rom_md5_mbedtls))]
 pub mod md5;
+pub(crate) mod regi2c;
 
 #[allow(unused)]
 extern "C" {

--- a/esp-hal/src/rom/mod.rs
+++ b/esp-hal/src/rom/mod.rs
@@ -31,60 +31,6 @@ pub mod crc;
 pub mod md5;
 pub(crate) mod regi2c;
 
-#[allow(unused)]
-extern "C" {
-    pub(crate) fn rom_i2c_writeReg(block: u32, block_hostid: u32, reg_add: u32, indata: u32);
-
-    pub(crate) fn rom_i2c_writeReg_Mask(
-        block: u32,
-        block_hostid: u32,
-        reg_add: u32,
-        reg_add_msb: u32,
-        reg_add_lsb: u32,
-        indata: u32,
-    );
-}
-
-macro_rules! regi2c_write {
-    ( $block: ident, $reg_add: ident, $indata: expr ) => {
-        paste::paste! {
-            #[allow(unused_unsafe)]
-            unsafe {
-                $crate::rom::rom_i2c_writeReg(
-                    $block as u32,
-                    [<$block _HOSTID>] as u32,
-                    $reg_add as u32,
-                    $indata as u32
-                )
-            }
-        }
-    };
-}
-
-#[allow(unused_imports)]
-pub(crate) use regi2c_write;
-
-macro_rules! regi2c_write_mask {
-    ( $block: ident, $reg_add: ident, $indata: expr ) => {
-        paste::paste! {
-            #[allow(unused_unsafe)]
-            unsafe {
-                $crate::rom::rom_i2c_writeReg_Mask(
-                    $block as u32,
-                    [<$block _HOSTID>] as u32,
-                    $reg_add as u32,
-                    [<$reg_add _MSB>] as u32,
-                    [<$reg_add _LSB>] as u32,
-                    $indata as u32
-                )
-            }
-        }
-    };
-}
-
-#[allow(unused_imports)]
-pub(crate) use regi2c_write_mask;
-
 #[inline(always)]
 pub(crate) fn ets_delay_us(us: u32) {
     extern "C" {

--- a/esp-hal/src/rom/regi2c.rs
+++ b/esp-hal/src/rom/regi2c.rs
@@ -1,0 +1,97 @@
+use crate::soc::regi2c::{regi2c_read, regi2c_write};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub(crate) struct RegI2cMaster {
+    pub master: u8,
+    pub host_id: u8,
+}
+
+impl RegI2cMaster {
+    pub const fn new(master: u8, host_id: u8) -> Self {
+        Self { master, host_id }
+    }
+
+    pub fn write(&self, reg: u8, data: u8) {
+        regi2c_write(self.master, self.host_id, reg, data);
+    }
+
+    pub fn read(&self, reg: u8) -> u8 {
+        regi2c_read(self.master, self.host_id, reg)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub(crate) struct RegI2cRegister {
+    master: RegI2cMaster,
+    reg_add: u8,
+}
+
+impl RegI2cRegister {
+    pub const fn new(master: RegI2cMaster, reg_add: u8) -> Self {
+        Self { master, reg_add }
+    }
+
+    pub fn write_reg(&self, data: u8) {
+        self.master.write(self.reg_add, data);
+    }
+
+    pub fn read(&self) -> u8 {
+        self.master.read(self.reg_add)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub(crate) struct RawRegI2cField {
+    register: RegI2cRegister,
+    msb: u8,
+    lsb: u8,
+}
+
+impl RawRegI2cField {
+    pub const fn new(register: RegI2cRegister, msb: u8, lsb: u8) -> Self {
+        ::core::assert!(msb < 8 + lsb);
+        Self { register, msb, lsb }
+    }
+
+    pub fn read(&self) -> u8 {
+        let reg_raw = self.register.read();
+        (reg_raw >> self.lsb) & !(u8::MAX << (self.msb - self.lsb + 1))
+    }
+
+    pub fn write_field(&self, data: u8) {
+        let bits = self.register.read();
+
+        let unwritten_bits = (!(u32::MAX << self.lsb) | (u32::MAX << (self.msb + 1))) as u8;
+        let data_mask = !(u32::MAX << (self.msb - self.lsb + 1)) as u8;
+        let data_bits = (data & data_mask) << self.lsb;
+
+        self.register.write_reg((bits & unwritten_bits) | data_bits);
+    }
+}
+
+macro_rules! define_regi2c {
+    ($(master: $master_name:ident($master:literal, $hostid:literal) {
+        $(reg: $register_name:ident($register:literal) {
+            $(field: $field_name:ident ( $msb:literal .. $lsb:literal )),*
+        })*
+    })+) => {
+        $(
+            #[allow(unused, reason = "We're defining everything.")]
+            pub(crate) const $master_name: RegI2cMaster = RegI2cMaster::new($master, $hostid);
+
+            $(
+                #[allow(unused, reason = "We're defining everything.")]
+                pub(crate) const $register_name: RegI2cRegister = RegI2cRegister::new($master_name, $register);
+
+                $(
+                    #[allow(unused, reason = "We're defining everything.")]
+                    pub(crate) const $field_name: RawRegI2cField = RawRegI2cField::new($register_name, $msb, $lsb);
+                )*
+            )*
+        )+
+    };
+}
+pub(crate) use define_regi2c;

--- a/esp-hal/src/rom/regi2c.rs
+++ b/esp-hal/src/rom/regi2c.rs
@@ -79,15 +79,15 @@ macro_rules! define_regi2c {
         })*
     })+) => {
         $(
-            #[allow(unused, reason = "We're defining everything.")]
+            #[allow(unused)]
             pub(crate) const $master_name: RegI2cMaster = RegI2cMaster::new($master, $hostid);
 
             $(
-                #[allow(unused, reason = "We're defining everything.")]
+                #[allow(unused)]
                 pub(crate) const $register_name: RegI2cRegister = RegI2cRegister::new($master_name, $register);
 
                 $(
-                    #[allow(unused, reason = "We're defining everything.")]
+                    #[allow(unused)]
                     pub(crate) const $field_name: RawRegI2cField = RawRegI2cField::new($register_name, $msb, $lsb);
                 )*
             )*

--- a/esp-hal/src/rom/regi2c.rs
+++ b/esp-hal/src/rom/regi2c.rs
@@ -12,10 +12,12 @@ impl RegI2cMaster {
         Self { master, host_id }
     }
 
+    #[allow(unused)]
     pub fn write(&self, reg: u8, data: u8) {
         regi2c_write(self.master, self.host_id, reg, data);
     }
 
+    #[allow(unused)]
     pub fn read(&self, reg: u8) -> u8 {
         regi2c_read(self.master, self.host_id, reg)
     }
@@ -33,10 +35,12 @@ impl RegI2cRegister {
         Self { master, reg_add }
     }
 
+    #[allow(unused)]
     pub fn write_reg(&self, data: u8) {
         self.master.write(self.reg_add, data);
     }
 
+    #[allow(unused)]
     pub fn read(&self) -> u8 {
         self.master.read(self.reg_add)
     }
@@ -51,16 +55,19 @@ pub(crate) struct RawRegI2cField {
 }
 
 impl RawRegI2cField {
+    #[allow(unused)]
     pub const fn new(register: RegI2cRegister, msb: u8, lsb: u8) -> Self {
         ::core::assert!(msb < 8 + lsb);
         Self { register, msb, lsb }
     }
 
+    #[allow(unused)]
     pub fn read(&self) -> u8 {
         let reg_raw = self.register.read();
         (reg_raw >> self.lsb) & !(u8::MAX << (self.msb - self.lsb + 1))
     }
 
+    #[allow(unused)]
     pub fn write_field(&self, data: u8) {
         let bits = self.register.read();
 

--- a/esp-hal/src/rtc_cntl/rtc/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c3.rs
@@ -3,34 +3,15 @@ use strum::FromRepr;
 use crate::{
     clock::XtalClock,
     peripherals::{APB_CTRL, EXTMEM, LPWR, SPI0, SPI1, SYSTEM},
-    rom::regi2c_write_mask,
     rtc_cntl::{RtcCalSel, RtcClock, RtcFastClock, RtcSlowClock},
+    soc::regi2c,
 };
-
-const I2C_DIG_REG: u32 = 0x6d;
-const I2C_DIG_REG_HOSTID: u32 = 0;
-
-const I2C_ULP: u32 = 0x61;
-const I2C_ULP_HOSTID: u32 = 0;
-
-const I2C_DIG_REG_XPD_RTC_REG: u32 = 13;
-const I2C_DIG_REG_XPD_RTC_REG_MSB: u32 = 2;
-const I2C_DIG_REG_XPD_RTC_REG_LSB: u32 = 2;
-
-const I2C_DIG_REG_XPD_DIG_REG: u32 = 13;
-const I2C_DIG_REG_XPD_DIG_REG_MSB: u32 = 3;
-const I2C_DIG_REG_XPD_DIG_REG_LSB: u32 = 3;
-
-const I2C_ULP_IR_FORCE_XPD_CK: u32 = 0;
-const I2C_ULP_IR_FORCE_XPD_CK_MSB: u32 = 2;
-const I2C_ULP_IR_FORCE_XPD_CK_LSB: u32 = 2;
 
 pub(crate) fn init() {
     let rtc_cntl = LPWR::regs();
 
-    regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_XPD_DIG_REG, 0);
-
-    regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_XPD_RTC_REG, 0);
+    regi2c::I2C_DIG_REG_XPD_DIG_REG.write_field(0);
+    regi2c::I2C_DIG_REG_XPD_RTC_REG.write_field(0);
 
     rtc_cntl.ana_conf().modify(|_, w| w.pvtmon_pu().clear_bit());
 
@@ -42,30 +23,20 @@ pub(crate) fn init() {
 
         // Set default powerup & wait time
         rtc_cntl.timer3().modify(|_, w| {
-            w.wifi_powerup_timer()
-                .bits(1u8)
-                .wifi_wait_timer()
-                .bits(1u16)
-                .bt_powerup_timer()
-                .bits(1u8)
-                .bt_wait_timer()
-                .bits(1u16)
+            w.wifi_powerup_timer().bits(1u8);
+            w.wifi_wait_timer().bits(1u16);
+            w.bt_powerup_timer().bits(1u8);
+            w.bt_wait_timer().bits(1u16)
         });
         rtc_cntl.timer4().modify(|_, w| {
-            w.cpu_top_powerup_timer()
-                .bits(1u8)
-                .cpu_top_wait_timer()
-                .bits(1u16)
-                .dg_wrap_powerup_timer()
-                .bits(1u8)
-                .dg_wrap_wait_timer()
-                .bits(1u16)
+            w.cpu_top_powerup_timer().bits(1u8);
+            w.cpu_top_wait_timer().bits(1u16);
+            w.dg_wrap_powerup_timer().bits(1u8);
+            w.dg_wrap_wait_timer().bits(1u16)
         });
         rtc_cntl.timer6().modify(|_, w| {
-            w.dg_peri_powerup_timer()
-                .bits(1u8)
-                .dg_peri_wait_timer()
-                .bits(1u16)
+            w.dg_peri_powerup_timer().bits(1u8);
+            w.dg_peri_wait_timer().bits(1u16)
         });
     }
 
@@ -82,7 +53,7 @@ pub(crate) fn init() {
         rtc_cntl.int_clr().write(|w| w.bits(u32::MAX));
     }
 
-    regi2c_write_mask!(I2C_ULP, I2C_ULP_IR_FORCE_XPD_CK, 0);
+    regi2c::I2C_ULP_IR_FORCE_XPD_CK.write_field(0);
 }
 
 pub(crate) fn configure_clock() {
@@ -152,32 +123,23 @@ fn power_control_init() {
 
     // Force PD APLL
     rtc_cntl.ana_conf().modify(|_, w| {
-        w.plla_force_pu()
-            .clear_bit()
-            .plla_force_pd()
-            .set_bit()
-            // Open SAR_I2C protect function to avoid SAR_I2C
-            // Reset when rtc_ldo is low.
-            .reset_por_force_pd()
-            .clear_bit()
+        w.plla_force_pu().clear_bit();
+        w.plla_force_pd().set_bit();
+        // Open SAR_I2C protect function to avoid SAR_I2C
+        // Reset when rtc_ldo is low.
+        w.reset_por_force_pd().clear_bit()
     });
 
     // Cancel BBPLL force PU if setting no force power up
     rtc_cntl.options0().modify(|_, w| {
-        w.bbpll_force_pu()
-            .clear_bit()
-            .bbpll_i2c_force_pu()
-            .clear_bit()
-            .bb_i2c_force_pu()
-            .clear_bit()
+        w.bbpll_force_pu().clear_bit();
+        w.bbpll_i2c_force_pu().clear_bit();
+        w.bb_i2c_force_pu().clear_bit()
     });
     rtc_cntl.rtc_cntl().modify(|_, w| {
-        w.regulator_force_pu()
-            .clear_bit()
-            .dboost_force_pu()
-            .clear_bit()
-            .dboost_force_pd()
-            .set_bit()
+        w.regulator_force_pu().clear_bit();
+        w.dboost_force_pu().clear_bit();
+        w.dboost_force_pd().set_bit()
     });
 
     // If this mask is enabled, all soc memories cannot enter power down mode.
@@ -190,28 +152,18 @@ fn power_control_init() {
     rtc_sleep_pu();
 
     rtc_cntl.dig_pwc().modify(|_, w| {
-        w.dg_wrap_force_pu()
-            .clear_bit()
-            .wifi_force_pu()
-            .clear_bit()
-            .bt_force_pu()
-            .clear_bit()
-            .cpu_top_force_pu()
-            .clear_bit()
-            .dg_peri_force_pu()
-            .clear_bit()
+        w.dg_wrap_force_pu().clear_bit();
+        w.wifi_force_pu().clear_bit();
+        w.bt_force_pu().clear_bit();
+        w.cpu_top_force_pu().clear_bit();
+        w.dg_peri_force_pu().clear_bit()
     });
     rtc_cntl.dig_iso().modify(|_, w| {
-        w.dg_wrap_force_noiso()
-            .clear_bit()
-            .wifi_force_noiso()
-            .clear_bit()
-            .bt_force_noiso()
-            .clear_bit()
-            .cpu_top_force_noiso()
-            .clear_bit()
-            .dg_peri_force_noiso()
-            .clear_bit()
+        w.dg_wrap_force_noiso().clear_bit();
+        w.wifi_force_noiso().clear_bit();
+        w.bt_force_noiso().clear_bit();
+        w.cpu_top_force_noiso().clear_bit();
+        w.dg_peri_force_noiso().clear_bit()
     });
 
     // Cancel digital PADS force no iso
@@ -222,10 +174,8 @@ fn power_control_init() {
     // If SYSTEM_CPU_WAIT_MODE_FORCE_ON == 0,
     // the CPU clock will be closed when CPU enter WAITI mode.
     rtc_cntl.dig_iso().modify(|_, w| {
-        w.dg_pad_force_unhold()
-            .clear_bit()
-            .dg_pad_force_noiso()
-            .clear_bit()
+        w.dg_pad_force_unhold().clear_bit();
+        w.dg_pad_force_noiso().clear_bit()
     });
 }
 
@@ -235,23 +185,19 @@ fn rtc_sleep_pu() {
     let apb_ctrl = APB_CTRL::regs();
 
     rtc_cntl.dig_pwc().modify(|_, w| {
-        w.lslp_mem_force_pu()
-            .clear_bit()
-            .fastmem_force_lpu()
-            .clear_bit()
+        w.lslp_mem_force_pu().clear_bit();
+        w.fastmem_force_lpu().clear_bit()
     });
 
     apb_ctrl.front_end_mem_pd().modify(|_, w| {
-        w.dc_mem_force_pu()
-            .clear_bit()
-            .pbus_mem_force_pu()
-            .clear_bit()
-            .agc_mem_force_pu()
-            .clear_bit()
+        w.dc_mem_force_pu().clear_bit();
+        w.pbus_mem_force_pu().clear_bit();
+        w.agc_mem_force_pu().clear_bit()
     });
-    apb_ctrl
-        .mem_power_up()
-        .modify(|_, w| unsafe { w.sram_power_up().bits(0u8).rom_power_up().bits(0u8) });
+    apb_ctrl.mem_power_up().modify(|_, w| unsafe {
+        w.sram_power_up().bits(0u8);
+        w.rom_power_up().bits(0u8)
+    });
 }
 
 // Terminology:

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -1552,16 +1552,15 @@ impl RtcClock {
                 .modify(|_, w| w.icg_hp_xtal32k().set_bit());
         }
 
-        // TODO: very hacky
+        // TODO: very hacky - icg_hp_xtal32k is already set in the above condition?
         // in ESP-IDF these are not called in this function but the fields are set
         lp_clkrst
             .clk_to_hp()
             .modify(|_, w| w.icg_hp_xtal32k().set_bit());
-        pmu.hp_sleep_lp_ck_power()
-            .modify(|_, w| w.hp_sleep_xpd_xtal32k().set_bit());
-
-        pmu.hp_sleep_lp_ck_power()
-            .modify(|_, w| w.hp_sleep_xpd_rc32k().set_bit());
+        pmu.hp_sleep_lp_ck_power().modify(|_, w| {
+            w.hp_sleep_xpd_xtal32k().set_bit();
+            w.hp_sleep_xpd_rc32k().set_bit()
+        });
 
         let rc_fast_enabled = pmu
             .hp_sleep_lp_ck_power()

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -408,16 +408,15 @@ impl RtcClock {
                 .modify(|_, w| w.icg_hp_xtal32k().set_bit());
         }
 
-        // TODO: very hacky
+        // TODO: very hacky - icg_hp_xtal32k is already set in the above condition?
         // in ESP-IDF these are not called in this function but the fields are set
         lp_clkrst
             .clk_to_hp()
             .modify(|_, w| w.icg_hp_xtal32k().set_bit());
-        pmu.hp_sleep_lp_ck_power()
-            .modify(|_, w| w.hp_sleep_xpd_xtal32k().set_bit());
-
-        pmu.hp_sleep_lp_ck_power()
-            .modify(|_, w| w.hp_sleep_xpd_rc32k().set_bit());
+        pmu.hp_sleep_lp_ck_power().modify(|_, w| {
+            w.hp_sleep_xpd_xtal32k().set_bit();
+            w.hp_sleep_xpd_rc32k().set_bit()
+        });
 
         let rc_fast_enabled = pmu
             .hp_sleep_lp_ck_power()

--- a/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
@@ -9,58 +9,31 @@ use super::{
 use crate::{
     gpio::{RtcFunction, RtcPin},
     peripherals::{APB_CTRL, EXTMEM, LPWR, RTC_IO, SPI0, SPI1, SYSTEM},
-    rom::regi2c_write_mask,
     rtc_cntl::{sleep::RtcioWakeupSource, Clock, Rtc, RtcClock},
+    soc::regi2c,
 };
-
-const I2C_DIG_REG: u32 = 0x6d;
-const I2C_DIG_REG_HOSTID: u32 = 1;
-
-const I2C_DIG_REG_EXT_RTC_DREG: u32 = 4;
-const I2C_DIG_REG_EXT_RTC_DREG_MSB: u32 = 4;
-const I2C_DIG_REG_EXT_RTC_DREG_LSB: u32 = 0;
-
-const I2C_DIG_REG_EXT_RTC_DREG_SLEEP: u32 = 5;
-const I2C_DIG_REG_EXT_RTC_DREG_SLEEP_MSB: u32 = 4;
-const I2C_DIG_REG_EXT_RTC_DREG_SLEEP_LSB: u32 = 0;
-
-const I2C_DIG_REG_EXT_DIG_DREG: u32 = 6;
-const I2C_DIG_REG_EXT_DIG_DREG_MSB: u32 = 4;
-const I2C_DIG_REG_EXT_DIG_DREG_LSB: u32 = 0;
-
-const I2C_DIG_REG_EXT_DIG_DREG_SLEEP: u32 = 7;
-const I2C_DIG_REG_EXT_DIG_DREG_SLEEP_MSB: u32 = 4;
-const I2C_DIG_REG_EXT_DIG_DREG_SLEEP_LSB: u32 = 0;
-
-const I2C_DIG_REG_XPD_RTC_REG: u32 = 13;
-const I2C_DIG_REG_XPD_RTC_REG_MSB: u32 = 2;
-const I2C_DIG_REG_XPD_RTC_REG_LSB: u32 = 2;
-
-const I2C_DIG_REG_XPD_DIG_REG: u32 = 13;
-const I2C_DIG_REG_XPD_DIG_REG_MSB: u32 = 3;
-const I2C_DIG_REG_XPD_DIG_REG_LSB: u32 = 3;
 
 // Approximate mapping of voltages to RTC_CNTL_DBIAS_WAK, RTC_CNTL_DBIAS_SLP,
 // RTC_CNTL_DIG_DBIAS_WAK, RTC_CNTL_DIG_DBIAS_SLP values.
 // Valid if RTC_CNTL_DBG_ATTEN is 0.
 /// Digital bias setting for 0.90V.
-pub const RTC_CNTL_DBIAS_0V90: u32 = 13;
+pub const RTC_CNTL_DBIAS_0V90: u8 = 13;
 /// Digital bias setting for 0.95V.
-pub const RTC_CNTL_DBIAS_0V95: u32 = 16;
+pub const RTC_CNTL_DBIAS_0V95: u8 = 16;
 /// Digital bias setting for 1.00V.
-pub const RTC_CNTL_DBIAS_1V00: u32 = 18;
+pub const RTC_CNTL_DBIAS_1V00: u8 = 18;
 /// Digital bias setting for 1.05V.
-pub const RTC_CNTL_DBIAS_1V05: u32 = 20;
+pub const RTC_CNTL_DBIAS_1V05: u8 = 20;
 /// Digital bias setting for 1.10V.
-pub const RTC_CNTL_DBIAS_1V10: u32 = 23;
+pub const RTC_CNTL_DBIAS_1V10: u8 = 23;
 /// Digital bias setting for 1.15V.
-pub const RTC_CNTL_DBIAS_1V15: u32 = 25;
+pub const RTC_CNTL_DBIAS_1V15: u8 = 25;
 /// Digital bias setting for 1.20V.
-pub const RTC_CNTL_DBIAS_1V20: u32 = 28;
+pub const RTC_CNTL_DBIAS_1V20: u8 = 28;
 /// Digital bias setting for 1.25V.
-pub const RTC_CNTL_DBIAS_1V25: u32 = 30;
+pub const RTC_CNTL_DBIAS_1V25: u8 = 30;
 /// Digital bias setting for 1.30V. Voltage is approximately 1.34V in practice.
-pub const RTC_CNTL_DBIAS_1V30: u32 = 31;
+pub const RTC_CNTL_DBIAS_1V30: u8 = 31;
 /// Default monitor debug attenuation value.
 pub const RTC_CNTL_DBG_ATTEN_MONITOR_DEFAULT: u8 = 0;
 /// ULP co-processor touch start wait time during sleep, set to maximum.
@@ -135,10 +108,8 @@ impl WakeSource for TimerWakeupSource {
                 .write(|w| w.main_timer().clear_bit_by_one());
 
             rtc_cntl.slp_timer1().write(|w| {
-                w.slp_val_hi()
-                    .bits(((time_in_ticks >> 32) & 0xffff) as u16)
-                    .main_timer_alarm_en()
-                    .set_bit()
+                w.slp_val_hi().bits(((time_in_ticks >> 32) & 0xffff) as u16);
+                w.main_timer_alarm_en().set_bit()
             });
         }
     }
@@ -320,9 +291,9 @@ bitfield::bitfield! {
     /// enable WDT flashboot mode
     pub wdt_flashboot_mod_en, set_wdt_flashboot_mod_en: 10;
     /// set bias for digital domain, in sleep mode
-    pub u32, dig_dbias_slp, set_dig_dbias_slp: 15, 11;
+    pub u8, dig_dbias_slp, set_dig_dbias_slp: 15, 11;
     /// set bias for RTC domain, in sleep mode
-    pub u32, rtc_dbias_slp, set_rtc_dbias_slp: 20, 16;
+    pub u8, rtc_dbias_slp, set_rtc_dbias_slp: 20, 16;
     /// circuit control parameter, in monitor mode
     pub bias_sleep_monitor, set_bias_sleep_monitor: 21;
     /// voltage parameter, in sleep mode
@@ -460,8 +431,8 @@ impl RtcSleepConfig {
                 .dig_pwc()
                 .modify(|_, w| w.wifi_force_pd().clear_bit());
 
-            regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_XPD_RTC_REG, 0);
-            regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_XPD_DIG_REG, 0);
+            regi2c::I2C_DIG_REG_XPD_RTC_REG.write_field(0);
+            regi2c::I2C_DIG_REG_XPD_DIG_REG.write_field(0);
 
             rtc_cntl.ana_conf().modify(|_, w| w.pvtmon_pu().clear_bit());
 
@@ -480,54 +451,36 @@ impl RtcSleepConfig {
                 .modify(|_, w| w.min_slp_val().bits(RTC_CNTL_MIN_SLP_VAL_MIN));
 
             rtc_cntl.timer3().modify(|_, w| {
-                w
-                    // set wifi timer
-                    .wifi_powerup_timer()
-                    .bits(WIFI_POWERUP_CYCLES)
-                    .wifi_wait_timer()
-                    .bits(WIFI_WAIT_CYCLES)
-                    // set bt timer
-                    .bt_powerup_timer()
-                    .bits(BT_POWERUP_CYCLES)
-                    .bt_wait_timer()
-                    .bits(BT_WAIT_CYCLES)
+                // set wifi timer
+                w.wifi_powerup_timer().bits(WIFI_POWERUP_CYCLES);
+                // set bt timer
+                w.wifi_wait_timer().bits(WIFI_WAIT_CYCLES);
+                w.bt_powerup_timer().bits(BT_POWERUP_CYCLES);
+                w.bt_wait_timer().bits(BT_WAIT_CYCLES)
             });
 
             rtc_cntl.timer6().modify(|_, w| {
-                w.cpu_top_powerup_timer()
-                    .bits(CPU_TOP_POWERUP_CYCLES)
-                    .cpu_top_wait_timer()
-                    .bits(CPU_TOP_WAIT_CYCLES)
+                w.cpu_top_powerup_timer().bits(CPU_TOP_POWERUP_CYCLES);
+                w.cpu_top_wait_timer().bits(CPU_TOP_WAIT_CYCLES)
             });
 
             rtc_cntl.timer4().modify(|_, w| {
-                w
-                    // set rtc peri timer
-                    .powerup_timer()
-                    .bits(RTC_POWERUP_CYCLES)
-                    .wait_timer()
-                    .bits(RTC_WAIT_CYCLES)
-                    // set digital wrap timer
-                    .dg_wrap_powerup_timer()
-                    .bits(DG_WRAP_POWERUP_CYCLES)
-                    .dg_wrap_wait_timer()
-                    .bits(DG_WRAP_WAIT_CYCLES)
+                // set rtc peri timer
+                w.powerup_timer().bits(RTC_POWERUP_CYCLES);
+                // set digital wrap timer
+                w.wait_timer().bits(RTC_WAIT_CYCLES);
+                w.dg_wrap_powerup_timer().bits(DG_WRAP_POWERUP_CYCLES);
+                w.dg_wrap_wait_timer().bits(DG_WRAP_WAIT_CYCLES)
             });
 
             rtc_cntl.timer6().modify(|_, w| {
-                w.dg_peri_powerup_timer()
-                    .bits(DG_PERI_POWERUP_CYCLES)
-                    .dg_peri_wait_timer()
-                    .bits(DG_PERI_WAIT_CYCLES)
+                w.dg_peri_powerup_timer().bits(DG_PERI_POWERUP_CYCLES);
+                w.dg_peri_wait_timer().bits(DG_PERI_WAIT_CYCLES)
             });
 
             // Reset RTC bias to default value (needed if waking up from deep sleep)
-            regi2c_write_mask!(
-                I2C_DIG_REG,
-                I2C_DIG_REG_EXT_RTC_DREG_SLEEP,
-                RTC_CNTL_DBIAS_1V10
-            );
-            regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_EXT_RTC_DREG, RTC_CNTL_DBIAS_1V10);
+            regi2c::I2C_DIG_REG_EXT_RTC_DREG_SLEEP.write_field(RTC_CNTL_DBIAS_1V10);
+            regi2c::I2C_DIG_REG_EXT_RTC_DREG.write_field(RTC_CNTL_DBIAS_1V10);
 
             // Set the wait time to the default value.
 
@@ -541,8 +494,8 @@ impl RtcSleepConfig {
             //       We're using a high enough default but we should read from the efuse.
             // rtc_set_stored_dbias();
 
-            regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_EXT_RTC_DREG, RTC_CNTL_DBIAS_1V25);
-            regi2c_write_mask!(I2C_DIG_REG, I2C_DIG_REG_EXT_DIG_DREG, RTC_CNTL_DBIAS_1V25);
+            regi2c::I2C_DIG_REG_EXT_RTC_DREG.write_field(RTC_CNTL_DBIAS_1V25);
+            regi2c::I2C_DIG_REG_EXT_DIG_DREG.write_field(RTC_CNTL_DBIAS_1V25);
 
             // clear CMMU clock force on
 
@@ -591,12 +544,9 @@ impl RtcSleepConfig {
             // cancel bbpll force pu if setting no force power up
 
             rtc_cntl.options0().modify(|_, w| {
-                w.bbpll_force_pu()
-                    .clear_bit()
-                    .bbpll_i2c_force_pu()
-                    .clear_bit()
-                    .bb_i2c_force_pu()
-                    .clear_bit()
+                w.bbpll_force_pu().clear_bit();
+                w.bbpll_i2c_force_pu().clear_bit();
+                w.bb_i2c_force_pu().clear_bit()
             });
 
             // cancel RTC REG force PU
@@ -604,17 +554,13 @@ impl RtcSleepConfig {
             rtc_cntl.pwc().modify(|_, w| w.force_pu().clear_bit());
 
             rtc_cntl.rtc().modify(|_, w| {
-                w.regulator_force_pu()
-                    .clear_bit()
-                    .dboost_force_pu()
-                    .clear_bit()
+                w.regulator_force_pu().clear_bit();
+                w.dboost_force_pu().clear_bit()
             });
 
             rtc_cntl.pwc().modify(|_, w| {
-                w.slowmem_force_noiso()
-                    .clear_bit()
-                    .fastmem_force_noiso()
-                    .clear_bit()
+                w.slowmem_force_noiso().clear_bit();
+                w.fastmem_force_noiso().clear_bit()
             });
 
             rtc_cntl.rtc().modify(|_, w| w.dboost_force_pd().set_bit());
@@ -637,17 +583,13 @@ impl RtcSleepConfig {
                 .modify(|_, w| w.dg_wrap_force_pu().clear_bit());
 
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.dg_wrap_force_noiso()
-                    .clear_bit()
-                    .dg_wrap_force_iso()
-                    .clear_bit()
+                w.dg_wrap_force_noiso().clear_bit();
+                w.dg_wrap_force_iso().clear_bit()
             });
 
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.wifi_force_noiso()
-                    .clear_bit()
-                    .wifi_force_iso()
-                    .clear_bit()
+                w.wifi_force_noiso().clear_bit();
+                w.wifi_force_iso().clear_bit()
             });
 
             rtc_cntl
@@ -663,10 +605,8 @@ impl RtcSleepConfig {
                 .modify(|_, w| w.bt_force_pu().clear_bit());
 
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.cpu_top_force_noiso()
-                    .clear_bit()
-                    .cpu_top_force_iso()
-                    .clear_bit()
+                w.cpu_top_force_noiso().clear_bit();
+                w.cpu_top_force_iso().clear_bit()
             });
 
             rtc_cntl
@@ -674,10 +614,8 @@ impl RtcSleepConfig {
                 .modify(|_, w| w.cpu_top_force_pu().clear_bit());
 
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.dg_peri_force_noiso()
-                    .clear_bit()
-                    .dg_peri_force_iso()
-                    .clear_bit()
+                w.dg_peri_force_noiso().clear_bit();
+                w.dg_peri_force_iso().clear_bit()
             });
 
             rtc_cntl
@@ -685,12 +623,9 @@ impl RtcSleepConfig {
                 .modify(|_, w| w.dg_peri_force_pu().clear_bit());
 
             rtc_cntl.pwc().modify(|_, w| {
-                w.force_noiso()
-                    .clear_bit()
-                    .force_iso()
-                    .clear_bit()
-                    .force_pu()
-                    .clear_bit()
+                w.force_noiso().clear_bit();
+                w.force_iso().clear_bit();
+                w.force_pu().clear_bit()
             });
 
             // if SYSTEM_CPU_WAIT_MODE_FORCE_ON == 0,
@@ -703,10 +638,8 @@ impl RtcSleepConfig {
             // cancel digital PADS force no iso
 
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.dg_pad_force_unhold()
-                    .clear_bit()
-                    .dg_pad_force_noiso()
-                    .clear_bit()
+                w.dg_pad_force_unhold().clear_bit();
+                w.dg_pad_force_noiso().clear_bit()
             });
 
             // force power down modem(wifi and ble) power domain
@@ -734,10 +667,8 @@ impl RtcSleepConfig {
 
         if self.modem_pd_en() {
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.wifi_force_noiso()
-                    .clear_bit()
-                    .wifi_force_iso()
-                    .clear_bit()
+                w.wifi_force_noiso().clear_bit();
+                w.wifi_force_iso().clear_bit()
             });
 
             rtc_cntl
@@ -749,10 +680,8 @@ impl RtcSleepConfig {
 
         if self.cpu_pd_en() {
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.cpu_top_force_noiso()
-                    .clear_bit()
-                    .cpu_top_force_iso()
-                    .clear_bit()
+                w.cpu_top_force_noiso().clear_bit();
+                w.cpu_top_force_iso().clear_bit()
             });
 
             rtc_cntl
@@ -766,10 +695,8 @@ impl RtcSleepConfig {
 
         if self.dig_peri_pd_en() {
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.dg_peri_force_noiso()
-                    .clear_bit()
-                    .dg_peri_force_iso()
-                    .clear_bit()
+                w.dg_peri_force_noiso().clear_bit();
+                w.dg_peri_force_iso().clear_bit()
             });
 
             rtc_cntl
@@ -793,17 +720,8 @@ impl RtcSleepConfig {
         }
 
         unsafe {
-            regi2c_write_mask!(
-                I2C_DIG_REG,
-                I2C_DIG_REG_EXT_RTC_DREG_SLEEP,
-                self.rtc_dbias_slp()
-            );
-
-            regi2c_write_mask!(
-                I2C_DIG_REG,
-                I2C_DIG_REG_EXT_DIG_DREG_SLEEP,
-                self.dig_dbias_slp()
-            );
+            regi2c::I2C_DIG_REG_EXT_RTC_DREG_SLEEP.write_field(self.rtc_dbias_slp());
+            regi2c::I2C_DIG_REG_EXT_DIG_DREG_SLEEP.write_field(self.dig_dbias_slp());
 
             rtc_cntl.bias_conf().modify(|_, w| {
                 w.dbg_atten_deep_slp().bits(self.dbg_atten_slp());

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -18,6 +18,7 @@ crate::unstable_module! {
 pub mod cpu_control;
 pub mod gpio;
 pub mod peripherals;
+pub(crate) mod regi2c;
 
 /// The name of the chip ("esp32") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32/regi2c.rs
+++ b/esp-hal/src/soc/esp32/regi2c.rs
@@ -1,0 +1,30 @@
+use crate::rom::regi2c::{define_regi2c, RegI2cMaster, RegI2cRegister};
+
+define_regi2c! {
+    master: REGI2C_BBPLL(0x66, 4) {
+        reg: I2C_BBPLL_IR_CAL_DELAY(0) {}
+        reg: I2C_BBPLL_IR_CAL_EXT_CAP(1) {}
+        reg: I2C_BBPLL_OC_LREF(2) {}
+        reg: I2C_BBPLL_OC_DIV_REG(3) {}
+        reg: I2C_BBPLL_OC_ENB_FCAL(4) {}
+        reg: I2C_BBPLL_OC_DCUR(5) {}
+        reg: I2C_BBPLL_BBADC_DSMP(9) {}
+        reg: I2C_BBPLL_OC_ENB_VCON(10) {}
+        reg: I2C_BBPLL_ENDIV5(11) {}
+        reg: I2C_BBPLL_BBADC_CAL_REG(12) {}
+    }
+}
+
+pub(crate) fn regi2c_read(block: u8, host_id: u8, reg_add: u8) -> u8 {
+    extern "C" {
+        pub(crate) fn esp_rom_regi2c_read(block: u8, block_hostid: u8, reg_add: u8) -> u8;
+    }
+    unsafe { esp_rom_regi2c_read(block, host_id, reg_add) }
+}
+
+pub(crate) fn regi2c_write(block: u8, host_id: u8, reg_add: u8, data: u8) {
+    extern "C" {
+        pub(crate) fn rom_i2c_writeReg(block: u8, block_hostid: u8, reg_add: u8, indata: u8);
+    }
+    unsafe { rom_i2c_writeReg(block, host_id, reg_add, data) };
+}

--- a/esp-hal/src/soc/esp32c2/mod.rs
+++ b/esp-hal/src/soc/esp32c2/mod.rs
@@ -11,6 +11,7 @@ crate::unstable_module! {
 }
 pub mod gpio;
 pub mod peripherals;
+pub(crate) mod regi2c;
 
 /// The name of the chip ("esp32c2") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32c2/regi2c.rs
+++ b/esp-hal/src/soc/esp32c2/regi2c.rs
@@ -1,0 +1,158 @@
+use crate::rom::regi2c::{define_regi2c, RawRegI2cField, RegI2cMaster, RegI2cRegister};
+
+define_regi2c! {
+    master: REGI2C_BBPLL(0x66, 0) {
+        reg: I2C_BBPLL_IR_CAL(0) {
+            field: I2C_BBPLL_IR_CAL_CK_DIV(7..4),
+            field: I2C_BBPLL_IR_CAL_DELAY(3..0)
+        }
+        reg: I2C_BBPLL_IR_CAL_EXT_REG(1) {
+            field: I2C_BBPLL_IR_CAL_UNSTOP(7..7),
+            field: I2C_BBPLL_IR_CAL_START(6..6),
+            field: I2C_BBPLL_IR_CAL_RSTB(5..5),
+            field: I2C_BBPLL_IR_CAL_ENX_CAP(4..4),
+            field: I2C_BBPLL_IR_CAL_EXT_CAP(3..0)
+        }
+        reg: I2C_BBPLL_OC_REF(2) {
+            field: I2C_BBPLL_OC_ENB_FCAL(7..7),
+            field: I2C_BBPLL_OC_DCHGP(6..4),
+            field: I2C_BBPLL_OC_REF_DIV(3..0)
+        }
+        reg: I2C_BBPLL_OC_DIV_REG(3) {
+            field: I2C_BBPLL_OC_DIV(7..0)
+        }
+        reg: I2C_BBPLL_REG4(4) {
+            field: I2C_BBPLL_OC_TSCHGP(7..7),
+            field: I2C_BBPLL_OC_ENB_VCON(6..6),
+            field: I2C_BBPLL_DIV_CPU(5..5),
+            field: I2C_BBPLL_DIV_DAC(4..4),
+            field: I2C_BBPLL_DIV_ADC(3..2),
+            field: I2C_BBPLL_MODE_HF(1..1),
+            field: I2C_BBPLL_RSTB_DIV_ADC(0..0)
+        }
+        reg: I2C_BBPLL_OC_DR(5) {
+            field: I2C_BBPLL_EN_USB(7..7),
+            field: I2C_BBPLL_OC_DR3(6..4),
+            field: I2C_BBPLL_OC_DR1(2..0)
+        }
+        reg: I2C_BBPLL_REG6(6) {
+            field: I2C_BBPLL_OC_DLREF_SEL(7..6),
+            field: I2C_BBPLL_OC_DHREF_SEL(5..4),
+            field: I2C_BBPLL_INC_CUR(3..3),
+            field: I2C_BBPLL_OC_DCUR(2..0)
+        }
+        reg: I2C_BBPLL_REG8(8) {
+            field: I2C_BBPLL_OR_LOCK(7..7),
+            field: I2C_BBPLL_OR_CAL_END(6..6),
+            field: I2C_BBPLL_OR_CAL_OVF(5..5),
+            field: I2C_BBPLL_OR_CAL_UDF(4..4),
+            field: I2C_BBPLL_OR_CAL_CAP(3..0)
+        }
+        reg: I2C_BBPLL_REG9(9) {
+            field: I2C_BBPLL_BBADC_DREF(7..6),
+            field: I2C_BBPLL_BBADC_DVDD(5..4),
+            field: I2C_BBPLL_BBADC_DELAY2(3..2),
+            field: I2C_BBPLL_OC_VCO_DBIAS(1..0)
+        }
+        reg: I2C_BBPLL_REG10(10) {
+            field: I2C_BBPLL_ENT_ADC(7..6),
+            field: I2C_BBPLL_DTEST(5..4),
+            field: I2C_BBPLL_ENT_PLL_MSB(3..3),
+            field: I2C_BBPLL_BBADC_INPUT_SHORT(2..2),
+            field: I2C_BBPLL_BBADC_DCUR(1..0)
+        }
+    }
+    master: REGI2C_BIAS(0x6a, 0) {
+        reg: I2C_BIAS_DREG(1) {
+            field: I2C_BIAS_DREG_1P1_PVT(3..0)
+        }
+    }
+    master: REGI2C_DIG_REG(0x6d, 0) {
+        reg: I2C_DIG_REG4(4) {
+            field: I2C_DIG_REG_ENX_RTC_DREG(7..7),
+            field: I2C_DIG_REG_EXT_RTC_DREG(4..0)
+        }
+        reg: I2C_DIG_REG5(5) {
+            field: I2C_DIG_REG_ENIF_RTC_DREG(7..7),
+            field: I2C_DIG_REG_EXT_RTC_DREG_SLEEP(4..0)
+        }
+        reg: I2C_DIG_REG6(6) {
+            field: I2C_DIG_REG_ENX_DIG_DREG(7..7),
+            field: I2C_DIG_REG_EXT_DIG_DREG(4..0)
+        }
+        reg: I2C_DIG_REG_ENIF_DIG(7) {
+            field: I2C_DIG_REG_ENIF_DIG_DREG(7..7),
+            field: I2C_DIG_REG_EXT_DIG_DREG_SLEEP(4..0)
+        }
+        reg: I2C_DIG_REG9(9) {
+            field: I2C_DIG_REG_OR_EN_CONT_CAL(7..7)
+        }
+        reg: I2C_DIG_REG_XPD(13) {
+            field: I2C_DIG_REG_XPD_DIG_REG(3..3),
+            field: I2C_DIG_REG_XPD_RTC_REG(2..2)
+        }
+        reg: I2C_DIG_REG_SCK_DCAP(14) {}
+    }
+    master: REGI2C_ULP_CAL(0x61, 0) {
+        reg: I2C_ULP_CAL_IR(0) {
+            field: I2C_ULP_IR_DISABLE_WATCHDOG_CK(6..6),
+            field: I2C_ULP_IR_FORCE_XPD_IPH(4..4),
+            field: I2C_ULP_IR_FORCE_XPD_CK(2..2),
+            field: I2C_ULP_IR_RESETB(0..0)
+        }
+        reg: I2C_ULP_CAL_O(3) {
+            field: I2C_ULP_BG_O_DONE_FLAG(3..3),
+            field: I2C_ULP_O_DONE_FLAG(0..0)
+        }
+        reg: I2C_ULP_CAL_OCODE(4) {}
+        reg: I2C_ULP_IR_FORCE(5) {
+            field: I2C_ULP_IR_FORCE_CODE(6..6),
+            field: I2C_BOD_THRESHOLD(2..0)
+        }
+        reg: I2C_ULP_EXT_CODE(6) {}
+    }
+    master: REGI2C_SAR_I2C(0x69, 0) {
+        reg: I2C_SAR_REG0(0) {
+            field: ADC_SAR1_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG1(1) {
+            field: ADC_SAR1_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG2(2) {
+            field: ADC_SAR1_DREF(6..4)
+        }
+        reg: I2C_SAR_REG3(3) {
+            field: ADC_SAR2_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG4(4) {
+            field: ADC_SAR2_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG5(5) {
+            field: ADC_SAR2_DREF(6..4)
+        }
+        reg: I2C_SAR_REG6(6) {}
+        reg: I2C_SAR_REG7(7) {
+            field: ADC_SAR2_ENCAL_GND(7..7),
+            field: ADC_SAR2_ENCAL_REF(6..6),
+            field: ADC_SAR1_ENCAL_GND(5..5),
+            field: ADC_SAR1_ENCAL_REF(4..4),
+            field: ADC_SAR_ENT_RTC(3..3),
+            field: ADC_SAR_ENT_TSENS(2..2),
+            field: ADC_SAR_DTEST_RTC(1..0)
+        }
+    }
+}
+
+pub(crate) fn regi2c_read(block: u8, host_id: u8, reg_add: u8) -> u8 {
+    extern "C" {
+        pub(crate) fn esp_rom_regi2c_read(block: u8, block_hostid: u8, reg_add: u8) -> u8;
+    }
+    unsafe { esp_rom_regi2c_read(block, host_id, reg_add) }
+}
+
+pub(crate) fn regi2c_write(block: u8, host_id: u8, reg_add: u8, data: u8) {
+    extern "C" {
+        pub(crate) fn rom_i2c_writeReg(block: u8, block_hostid: u8, reg_add: u8, indata: u8);
+    }
+    unsafe { rom_i2c_writeReg(block, host_id, reg_add, data) };
+}

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -15,6 +15,7 @@ crate::unstable_module! {
 }
 pub mod gpio;
 pub mod peripherals;
+pub(crate) mod regi2c;
 
 /// The name of the chip ("esp32c3") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32c3/regi2c.rs
+++ b/esp-hal/src/soc/esp32c3/regi2c.rs
@@ -1,0 +1,158 @@
+use crate::rom::regi2c::{define_regi2c, RawRegI2cField, RegI2cMaster, RegI2cRegister};
+
+define_regi2c! {
+    master: REGI2C_BBPLL(0x66, 0) {
+        reg: I2C_BBPLL_IR_CAL(0) {
+            field: I2C_BBPLL_IR_CAL_CK_DIV(7..4),
+            field: I2C_BBPLL_IR_CAL_DELAY(3..0)
+        }
+        reg: I2C_BBPLL_IR_CAL_EXT_REG(1) {
+            field: I2C_BBPLL_IR_CAL_UNSTOP(7..7),
+            field: I2C_BBPLL_IR_CAL_START(6..6),
+            field: I2C_BBPLL_IR_CAL_RSTB(5..5),
+            field: I2C_BBPLL_IR_CAL_ENX_CAP(4..4),
+            field: I2C_BBPLL_IR_CAL_EXT_CAP(3..0)
+        }
+        reg: I2C_BBPLL_OC_REF(2) {
+            field: I2C_BBPLL_OC_ENB_FCAL(7..7),
+            field: I2C_BBPLL_OC_DCHGP(6..4),
+            field: I2C_BBPLL_OC_REF_DIV(3..0)
+        }
+        reg: I2C_BBPLL_OC_DIV_REG(3) {
+            field: I2C_BBPLL_OC_DIV(7..0)
+        }
+        reg: I2C_BBPLL_REG4(4) {
+            field: I2C_BBPLL_OC_TSCHGP(7..7),
+            field: I2C_BBPLL_OC_ENB_VCON(6..6),
+            field: I2C_BBPLL_DIV_CPU(5..5),
+            field: I2C_BBPLL_DIV_DAC(4..4),
+            field: I2C_BBPLL_DIV_ADC(3..2),
+            field: I2C_BBPLL_MODE_HF(1..1),
+            field: I2C_BBPLL_RSTB_DIV_ADC(0..0)
+        }
+        reg: I2C_BBPLL_OC_DR(5) {
+            field: I2C_BBPLL_EN_USB(7..7),
+            field: I2C_BBPLL_OC_DR3(6..4),
+            field: I2C_BBPLL_OC_DR1(2..0)
+        }
+        reg: I2C_BBPLL_REG6(6) {
+            field: I2C_BBPLL_OC_DLREF_SEL(7..6),
+            field: I2C_BBPLL_OC_DHREF_SEL(5..4),
+            field: I2C_BBPLL_INC_CUR(3..3),
+            field: I2C_BBPLL_OC_DCUR(2..0)
+        }
+        reg: I2C_BBPLL_REG8(8) {
+            field: I2C_BBPLL_OR_LOCK(7..7),
+            field: I2C_BBPLL_OR_CAL_END(6..6),
+            field: I2C_BBPLL_OR_CAL_OVF(5..5),
+            field: I2C_BBPLL_OR_CAL_UDF(4..4),
+            field: I2C_BBPLL_OR_CAL_CAP(3..0)
+        }
+        reg: I2C_BBPLL_REG9(9) {
+            field: I2C_BBPLL_BBADC_DREF(7..6),
+            field: I2C_BBPLL_BBADC_DVDD(5..4),
+            field: I2C_BBPLL_BBADC_DELAY2(3..2),
+            field: I2C_BBPLL_OC_VCO_DBIAS(1..0)
+        }
+        reg: I2C_BBPLL_REG10(10) {
+            field: I2C_BBPLL_ENT_ADC(7..6),
+            field: I2C_BBPLL_DTEST(5..4),
+            field: I2C_BBPLL_ENT_PLL_MSB(3..3),
+            field: I2C_BBPLL_BBADC_INPUT_SHORT(2..2),
+            field: I2C_BBPLL_BBADC_DCUR(1..0)
+        }
+    }
+    master: REGI2C_BIAS(0x6a, 0) {
+        reg: I2C_BIAS_DREG(1) {
+            field: I2C_BIAS_DREG_1P1_PVT(3..0)
+        }
+    }
+    master: REGI2C_DIG_REG(0x6d, 0) {
+        reg: I2C_DIG_REG4(4) {
+            field: I2C_DIG_REG_ENX_RTC_DREG(7..7),
+            field: I2C_DIG_REG_EXT_RTC_DREG(4..0)
+        }
+        reg: I2C_DIG_REG5(5) {
+            field: I2C_DIG_REG_ENIF_RTC_DREG(7..7),
+            field: I2C_DIG_REG_EXT_RTC_DREG_SLEEP(4..0)
+        }
+        reg: I2C_DIG_REG6(6) {
+            field: I2C_DIG_REG_ENX_DIG_DREG(7..7),
+            field: I2C_DIG_REG_EXT_DIG_DREG(4..0)
+        }
+        reg: I2C_DIG_REG_ENIF_DIG(7) {
+            field: I2C_DIG_REG_ENIF_DIG_DREG(7..7),
+            field: I2C_DIG_REG_EXT_DIG_DREG_SLEEP(4..0)
+        }
+        reg: I2C_DIG_REG9(9) {
+            field: I2C_DIG_REG_OR_EN_CONT_CAL(7..7)
+        }
+        reg: I2C_DIG_REG_XPD(13) {
+            field: I2C_DIG_REG_XPD_DIG_REG(3..3),
+            field: I2C_DIG_REG_XPD_RTC_REG(2..2)
+        }
+        reg: I2C_DIG_REG_SCK_DCAP(14) {}
+    }
+    master: REGI2C_ULP_CAL(0x61, 0) {
+        reg: I2C_ULP_CAL_IR(0) {
+            field: I2C_ULP_IR_DISABLE_WATCHDOG_CK(6..6),
+            field: I2C_ULP_IR_FORCE_XPD_IPH(4..4),
+            field: I2C_ULP_IR_FORCE_XPD_CK(2..2),
+            field: I2C_ULP_IR_RESETB(0..0)
+        }
+        reg: I2C_ULP_CAL_O(3) {
+            field: I2C_ULP_BG_O_DONE_FLAG(3..3),
+            field: I2C_ULP_O_DONE_FLAG(0..0)
+        }
+        reg: I2C_ULP_CAL_OCODE(4) {}
+        reg: I2C_ULP_IR_FORCE(5) {
+            field: I2C_ULP_IR_FORCE_CODE(6..6),
+            field: I2C_BOD_THRESHOLD(2..0)
+        }
+        reg: I2C_ULP_EXT_CODE(6) {}
+    }
+    master: REGI2C_SAR_I2C(0x69, 0) {
+        reg: I2C_SAR_REG0(0) {
+            field: ADC_SAR1_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG1(1) {
+            field: ADC_SAR1_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG2(2) {
+            field: ADC_SAR1_DREF(6..4)
+        }
+        reg: I2C_SAR_REG3(3) {
+            field: ADC_SAR2_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG4(4) {
+            field: ADC_SAR2_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG5(5) {
+            field: ADC_SAR2_DREF(6..4)
+        }
+        reg: I2C_SAR_REG6(6) {}
+        reg: I2C_SAR_REG7(7) {
+            field: ADC_SAR2_ENCAL_GND(7..7),
+            field: ADC_SAR2_ENCAL_REF(6..6),
+            field: ADC_SAR1_ENCAL_GND(5..5),
+            field: ADC_SAR1_ENCAL_REF(4..4),
+            field: ADC_SAR_ENT_RTC(3..3),
+            field: ADC_SAR_ENT_TSENS(2..2),
+            field: ADC_SAR_DTEST_RTC(1..0)
+        }
+    }
+}
+
+pub(crate) fn regi2c_read(block: u8, host_id: u8, reg_add: u8) -> u8 {
+    extern "C" {
+        pub(crate) fn esp_rom_regi2c_read(block: u8, block_hostid: u8, reg_add: u8) -> u8;
+    }
+    unsafe { esp_rom_regi2c_read(block, host_id, reg_add) }
+}
+
+pub(crate) fn regi2c_write(block: u8, host_id: u8, reg_add: u8, data: u8) {
+    extern "C" {
+        pub(crate) fn rom_i2c_writeReg(block: u8, block_hostid: u8, reg_add: u8, indata: u8);
+    }
+    unsafe { rom_i2c_writeReg(block, host_id, reg_add, data) };
+}

--- a/esp-hal/src/soc/esp32c3/trng.rs
+++ b/esp-hal/src/soc/esp32c3/trng.rs
@@ -1,21 +1,6 @@
-const I2C_SAR_ADC: u8 = 0x69;
-const I2C_SAR_ADC_HOSTID: u8 = 0;
-const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
-const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 6;
-const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 6;
-const ADC_SARADC_DTEST_RTC_ADDR: u8 = 0x7;
-const ADC_SARADC_DTEST_RTC_ADDR_MSB: u8 = 1;
-const ADC_SARADC_DTEST_RTC_ADDR_LSB: u8 = 0;
-const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7;
-const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
-const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
-const ADC_SARADC_ENT_TSENS_ADDR: u8 = 0x07;
-const ADC_SARADC_ENT_TSENS_ADDR_MSB: u8 = 2;
-const ADC_SARADC_ENT_TSENS_ADDR_LSB: u8 = 2;
-
 use crate::{
     peripherals::{APB_SARADC, LPWR, SYSTEM},
-    rom::regi2c_write_mask,
+    soc::regi2c,
 };
 
 /// Enable true randomness by enabling the entropy source.
@@ -35,13 +20,10 @@ pub(crate) fn ensure_randomness() {
 
         // Bridging sar2 internal reference voltage
         // Cannot replace with PAC-based functions
-        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 1);
-
-        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_DTEST_RTC_ADDR, 0);
-
-        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
-
-        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
+        regi2c::ADC_SAR2_ENCAL_REF.write_field(1);
+        regi2c::ADC_SAR_DTEST_RTC.write_field(0);
+        regi2c::ADC_SAR_ENT_RTC.write_field(0);
+        regi2c::ADC_SAR_ENT_TSENS.write_field(0);
 
         // Enable SAR ADC2 internal channel to read adc2 ref voltage for additional
         // entropy
@@ -54,17 +36,11 @@ pub(crate) fn ensure_randomness() {
             .modify(|_, w| w.apb_saradc_rst().clear_bit());
 
         apb_saradc.clkm_conf().modify(|_, w| w.clk_sel().bits(2));
-
         apb_saradc.clkm_conf().modify(|_, w| w.clk_en().set_bit());
-
         apb_saradc.ctrl().modify(|_, w| w.sar_clk_gated().set_bit());
-
         apb_saradc.ctrl().modify(|_, w| w.xpd_sar_force().bits(3));
-
         apb_saradc.ctrl().modify(|_, w| w.sar_clk_div().bits(1));
-
         apb_saradc.fsm_wait().modify(|_, w| w.rstb_wait().bits(8));
-
         apb_saradc.fsm_wait().modify(|_, w| w.xpd_wait().bits(5));
 
         apb_saradc
@@ -111,7 +87,7 @@ pub(crate) fn revert_trng() {
     let apb_saradc = APB_SARADC::regs();
 
     unsafe {
-        regi2c_write_mask!(I2C_SAR_ADC, ADC_SARADC2_ENCAL_REF_ADDR, 0);
+        regi2c::ADC_SAR2_ENCAL_REF.write_field(0);
 
         apb_saradc.ctrl2().modify(|_, w| w.timer_en().clear_bit());
 

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -17,6 +17,7 @@ crate::unstable_module! {
 }
 pub mod gpio;
 pub mod peripherals;
+pub(crate) mod regi2c;
 
 /// The name of the chip ("esp32c6") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32c6/regi2c.rs
+++ b/esp-hal/src/soc/esp32c6/regi2c.rs
@@ -1,0 +1,210 @@
+use crate::{
+    peripherals::{I2C_ANA_MST, MODEM_LPCON},
+    rom::regi2c::{define_regi2c, RawRegI2cField, RegI2cMaster, RegI2cRegister},
+};
+
+define_regi2c! {
+    master: REGI2C_BBPLL(0x66, 0) {
+        reg: I2C_BBPLL_IR_CAL(0) {
+            field: I2C_BBPLL_IR_CAL_CK_DIV(7..4),
+            field: I2C_BBPLL_IR_CAL_DELAY(3..0)
+        }
+        reg: I2C_BBPLL_IR_CAL_EXT_REG(1) {
+            field: I2C_BBPLL_IR_CAL_UNSTOP(7..7),
+            field: I2C_BBPLL_IR_CAL_START(6..6),
+            field: I2C_BBPLL_IR_CAL_RSTB(5..5),
+            field: I2C_BBPLL_IR_CAL_ENX_CAP(4..4),
+            field: I2C_BBPLL_IR_CAL_EXT_CAP(3..0)
+        }
+        reg: I2C_BBPLL_OC_REF(2) {
+            field: I2C_BBPLL_OC_ENB_FCAL(7..7),
+            field: I2C_BBPLL_OC_DCHGP(6..4),
+            field: I2C_BBPLL_OC_REF_DIV(3..0)
+        }
+        reg: I2C_BBPLL_OC_DIV_REG(3) {
+            field: I2C_BBPLL_OC_DIV(7..0)
+        }
+        reg: I2C_BBPLL_REG4(4) {
+            field: I2C_BBPLL_OC_TSCHGP(7..7),
+            field: I2C_BBPLL_OC_ENB_VCON(6..6),
+            field: I2C_BBPLL_DIV_CPU(5..5),
+            field: I2C_BBPLL_DIV_DAC(4..4),
+            field: I2C_BBPLL_DIV_ADC(3..2),
+            field: I2C_BBPLL_MODE_HF(1..1),
+            field: I2C_BBPLL_RSTB_DIV_ADC(0..0)
+        }
+        reg: I2C_BBPLL_OC_DR(5) {
+            field: I2C_BBPLL_EN_USB(7..7),
+            field: I2C_BBPLL_OC_DR3(6..4),
+            field: I2C_BBPLL_OC_DR1(2..0)
+        }
+        reg: I2C_BBPLL_REG6(6) {
+            field: I2C_BBPLL_OC_DLREF_SEL(7..6),
+            field: I2C_BBPLL_OC_DHREF_SEL(5..4),
+            field: I2C_BBPLL_INC_CUR(3..3),
+            field: I2C_BBPLL_OC_DCUR(2..0)
+        }
+        reg: I2C_BBPLL_REG8(8) {
+            field: I2C_BBPLL_OR_LOCK(7..7),
+            field: I2C_BBPLL_OR_CAL_END(6..6),
+            field: I2C_BBPLL_OR_CAL_OVF(5..5),
+            field: I2C_BBPLL_OR_CAL_UDF(4..4),
+            field: I2C_BBPLL_OR_CAL_CAP(3..0)
+        }
+        reg: I2C_BBPLL_REG9(9) {
+            field: I2C_BBPLL_BBADC_DREF(7..6),
+            field: I2C_BBPLL_BBADC_DVDD(5..4),
+            field: I2C_BBPLL_BBADC_DELAY2(3..2),
+            field: I2C_BBPLL_OC_VCO_DBIAS(1..0)
+        }
+        reg: I2C_BBPLL_REG10(10) {
+            field: I2C_BBPLL_ENT_ADC(7..6),
+            field: I2C_BBPLL_DTEST(5..4),
+            field: I2C_BBPLL_ENT_PLL_MSB(3..3),
+            field: I2C_BBPLL_BBADC_INPUT_SHORT(2..2),
+            field: I2C_BBPLL_BBADC_DCUR(1..0)
+        }
+    }
+    master: REGI2C_BIAS(0x6a, 0) {
+        reg: I2C_BIAS_DREG(1) {
+            field: I2C_BIAS_DREG_1P1_PVT(3..0)
+        }
+    }
+    master: REGI2C_DIG_REG(0x6d, 0) {
+        reg: I2C_DIG_REG4(4) {
+            field: I2C_DIG_REG_ENX_RTC_DREG(7..7),
+            field: I2C_DIG_REG_EXT_RTC_DREG(4..0)
+        }
+        reg: I2C_DIG_REG5(5) {
+            field: I2C_DIG_REG_ENIF_RTC_DREG(7..7),
+            field: I2C_DIG_REG_EXT_RTC_DREG_SLEEP(4..0)
+        }
+        reg: I2C_DIG_REG6(6) {
+            field: I2C_DIG_REG_ENX_DIG_DREG(7..7),
+            field: I2C_DIG_REG_EXT_DIG_DREG(4..0)
+        }
+        reg: I2C_DIG_REG_ENIF_DIG(7) {
+            field: I2C_DIG_REG_ENIF_DIG_DREG(7..7),
+            field: I2C_DIG_REG_EXT_DIG_DREG_SLEEP(4..0)
+        }
+        reg: I2C_DIG_REG9(9) {
+            field: I2C_DIG_REG_OR_EN_CONT_CAL(7..7)
+        }
+        reg: I2C_DIG_REG_XPD(13) {
+            field: I2C_DIG_REG_XPD_DIG_REG(3..3),
+            field: I2C_DIG_REG_XPD_RTC_REG(2..2)
+        }
+        reg: I2C_DIG_REG_SCK_DCAP(14) {}
+    }
+    master: REGI2C_ULP_CAL(0x61, 0) {
+        reg: I2C_ULP_CAL_IR(0) {
+            field: I2C_ULP_IR_DISABLE_WATCHDOG_CK(6..6),
+            field: I2C_ULP_IR_FORCE_XPD_IPH(4..4),
+            field: I2C_ULP_IR_FORCE_XPD_CK(2..2),
+            field: I2C_ULP_IR_RESETB(0..0)
+        }
+        reg: I2C_ULP_CAL_O(3) {
+            field: I2C_ULP_BG_O_DONE_FLAG(3..3),
+            field: I2C_ULP_O_DONE_FLAG(0..0)
+        }
+        reg: I2C_ULP_CAL_OCODE(4) {}
+        reg: I2C_ULP_IR_FORCE(5) {
+            field: I2C_ULP_IR_FORCE_CODE(6..6),
+            field: I2C_BOD_THRESHOLD(2..0)
+        }
+        reg: I2C_ULP_EXT_CODE(6) {}
+    }
+    master: REGI2C_SAR_I2C(0x69, 0) {
+        reg: I2C_SAR_REG0(0) {
+            field: ADC_SAR1_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG1(1) {
+            field: ADC_SAR1_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG2(2) {
+            field: ADC_SAR1_DREF(6..4)
+        }
+        reg: I2C_SAR_REG3(3) {
+            field: ADC_SAR2_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG4(4) {
+            field: ADC_SAR2_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG5(5) {
+            field: ADC_SAR2_DREF(6..4)
+        }
+        reg: I2C_SAR_REG6(6) {}
+        reg: I2C_SAR_REG7(7) {
+            field: ADC_SAR2_ENCAL_GND(7..7),
+            field: ADC_SAR2_ENCAL_REF(6..6),
+            field: ADC_SAR1_ENCAL_GND(5..5),
+            field: ADC_SAR1_ENCAL_REF(4..4),
+            field: ADC_SAR_ENT_RTC(3..3),
+            field: ADC_SAR_ENT_TSENS(2..2),
+            field: ADC_SAR_DTEST_RTC(1..0)
+        }
+    }
+}
+
+fn regi2c_enable_block(block: u8) -> usize {
+    MODEM_LPCON::regs()
+        .clk_conf()
+        .modify(|_, w| w.clk_i2c_mst_en().set_bit());
+
+    // Before config I2C register, enable corresponding slave.
+    let i2c_sel_bits = I2C_ANA_MST::regs().ana_conf2().read();
+    let i2c_sel = match block {
+        v if v == REGI2C_BBPLL.master => i2c_sel_bits.bbpll_mst_sel().bit_is_set(),
+        v if v == REGI2C_BIAS.master => i2c_sel_bits.bias_mst_sel().bit_is_set(),
+        v if v == REGI2C_DIG_REG.master => i2c_sel_bits.dig_reg_mst_sel().bit_is_set(),
+        v if v == REGI2C_ULP_CAL.master => i2c_sel_bits.ulp_cal_mst_sel().bit_is_set(),
+        v if v == REGI2C_SAR_I2C.master => i2c_sel_bits.sar_i2c_mst_sel().bit_is_set(),
+        _ => unreachable!(),
+    };
+    I2C_ANA_MST::regs().ana_conf1().write(|w| unsafe {
+        const I2C_MST_ANA_CONF1_M: u32 = 0x00FFFFFF;
+        w.bits(I2C_MST_ANA_CONF1_M);
+        match block {
+            v if v == REGI2C_BBPLL.master => w.bbpll_rd().clear_bit(),
+            v if v == REGI2C_BIAS.master => w.bias_rd().clear_bit(),
+            v if v == REGI2C_DIG_REG.master => w.dig_reg_rd().clear_bit(),
+            v if v == REGI2C_ULP_CAL.master => w.ulp_cal_rd().clear_bit(),
+            v if v == REGI2C_SAR_I2C.master => w.sar_i2c_rd().clear_bit(),
+            _ => unreachable!(),
+        }
+    });
+
+    if i2c_sel {
+        0
+    } else {
+        1
+    }
+}
+
+pub(crate) fn regi2c_read(block: u8, _host_id: u8, reg_add: u8) -> u8 {
+    let master = regi2c_enable_block(block);
+
+    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
+
+    I2C_ANA_MST::regs().i2c_ctrl(master).write(|w| unsafe {
+        w.slave_addr().bits(block);
+        w.slave_reg_addr().bits(reg_add)
+    });
+
+    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
+
+    I2C_ANA_MST::regs().i2c_ctrl(master).read().data().bits()
+}
+
+pub(crate) fn regi2c_write(block: u8, _host_id: u8, reg_add: u8, data: u8) {
+    let master = regi2c_enable_block(block);
+
+    I2C_ANA_MST::regs().i2c_ctrl(master).write(|w| unsafe {
+        w.slave_addr().bits(block);
+        w.slave_reg_addr().bits(reg_add);
+        w.read_write().set_bit();
+        w.data().bits(data)
+    });
+
+    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
+}

--- a/esp-hal/src/soc/esp32c6/trng.rs
+++ b/esp-hal/src/soc/esp32c6/trng.rs
@@ -1,66 +1,12 @@
-use crate::peripherals::{APB_SARADC, PCR, PMU};
-
-const I2C_SAR_ADC: u8 = 0x69;
-const I2C_SAR_ADC_HOSTID: u8 = 0;
+use crate::{
+    peripherals::{APB_SARADC, PCR, PMU},
+    soc::regi2c,
+};
 
 const SAR2_CHANNEL: u32 = 9;
 const SAR2_ATTEN: u32 = 1;
 const SAR1_ATTEN: u32 = 1;
 const PATTERN_BIT_WIDTH: u32 = 6;
-
-const REGI2C_BBPLL: u8 = 0x66;
-const REGI2C_BIAS: u8 = 0x6a;
-const REGI2C_DIG_REG: u8 = 0x6d;
-const REGI2C_ULP_CAL: u8 = 0x61;
-const REGI2C_SAR_I2C: u8 = 0x69;
-
-const I2C_MST_ANA_CONF1_M: u32 = 0x00FFFFFF;
-const REGI2C_BBPLL_RD_MASK: u32 = !(1 << 7) & I2C_MST_ANA_CONF1_M;
-const REGI2C_BIAS_RD_MASK: u32 = !(1 << 6) & I2C_MST_ANA_CONF1_M;
-const REGI2C_DIG_REG_RD_MASK: u32 = !(1 << 10) & I2C_MST_ANA_CONF1_M;
-const REGI2C_ULP_CAL_RD_MASK: u32 = !(1 << 8) & I2C_MST_ANA_CONF1_M;
-const REGI2C_SAR_I2C_RD_MASK: u32 = !(1 << 9) & I2C_MST_ANA_CONF1_M;
-
-const REGI2C_RTC_SLAVE_ID_V: u8 = 0xFF;
-const REGI2C_RTC_SLAVE_ID_S: u8 = 0;
-const REGI2C_RTC_ADDR_V: u8 = 0xFF;
-const REGI2C_RTC_ADDR_S: u8 = 8;
-const REGI2C_RTC_WR_CNTL_V: u8 = 0x1;
-const REGI2C_RTC_WR_CNTL_S: u8 = 24;
-const REGI2C_RTC_DATA_V: u8 = 0xFF;
-const REGI2C_RTC_DATA_S: u8 = 16;
-
-const ADC_SAR2_INITIAL_CODE_HIGH_ADDR: u8 = 0x4;
-const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-const ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
-
-const ADC_SAR2_INITIAL_CODE_LOW_ADDR: u8 = 0x3;
-const ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
-const ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
-
-const ADC_SAR1_INITIAL_CODE_HIGH_ADDR: u8 = 0x1;
-const ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB: u8 = 0x3;
-const ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB: u8 = 0x0;
-
-const ADC_SAR1_INITIAL_CODE_LOW_ADDR: u8 = 0x0;
-const ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB: u8 = 0x7;
-const ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB: u8 = 0x0;
-
-const ADC_SARADC_DTEST_RTC_ADDR: u8 = 0x7;
-const ADC_SARADC_DTEST_RTC_ADDR_MSB: u8 = 1;
-const ADC_SARADC_DTEST_RTC_ADDR_LSB: u8 = 0;
-
-const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7;
-const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
-const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
-
-const ADC_SARADC1_ENCAL_REF_ADDR: u8 = 0x7;
-const ADC_SARADC1_ENCAL_REF_ADDR_MSB: u8 = 4;
-const ADC_SARADC1_ENCAL_REF_ADDR_LSB: u8 = 4;
-
-const ADC_SARADC2_ENCAL_REF_ADDR: u8 = 0x7;
-const ADC_SARADC2_ENCAL_REF_ADDR_MSB: u8 = 6;
-const ADC_SARADC2_ENCAL_REF_ADDR_LSB: u8 = 6;
 
 /// Enable true randomness by enabling the entropy source.
 /// Blocks `ADC` usage.
@@ -101,74 +47,14 @@ pub(crate) fn ensure_randomness() {
 
         // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
         // voltage as sampling source
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_DTEST_RTC_ADDR,
-            ADC_SARADC_DTEST_RTC_ADDR_MSB,
-            ADC_SARADC_DTEST_RTC_ADDR_LSB,
-            2,
-        );
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_ENT_RTC_ADDR,
-            ADC_SARADC_ENT_RTC_ADDR_MSB,
-            ADC_SARADC_ENT_RTC_ADDR_LSB,
-            1,
-        );
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC1_ENCAL_REF_ADDR,
-            ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-            ADC_SARADC1_ENCAL_REF_ADDR_LSB,
-            1,
-        );
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC2_ENCAL_REF_ADDR,
-            ADC_SARADC2_ENCAL_REF_ADDR_MSB,
-            ADC_SARADC2_ENCAL_REF_ADDR_LSB,
-            1,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
-            0x08,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
-            0x66,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
-            0x08,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
-            0x66,
-        );
+        regi2c::ADC_SAR_DTEST_RTC.write_field(2);
+        regi2c::ADC_SAR_ENT_RTC.write_field(1);
+        regi2c::ADC_SAR1_ENCAL_REF.write_field(1);
+        regi2c::ADC_SAR2_ENCAL_REF.write_field(1);
+        regi2c::ADC_SAR2_INITIAL_CODE_HIGH.write_field(0x08);
+        regi2c::ADC_SAR2_INITIAL_CODE_LOW.write_field(0x66);
+        regi2c::ADC_SAR1_INITIAL_CODE_HIGH.write_field(0x08);
+        regi2c::ADC_SAR1_INITIAL_CODE_LOW.write_field(0x66);
 
         // create patterns and set them in pattern table
         let pattern_one: u32 = (SAR2_CHANNEL << 2) | SAR2_ATTEN; // we want channel 9 with max attenuation
@@ -205,227 +91,19 @@ pub(crate) fn revert_trng() {
             .sar_patt_tab1()
             .modify(|_, w| w.bits(0xFFFFFF));
 
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_MSB,
-            ADC_SAR2_INITIAL_CODE_HIGH_ADDR_LSB,
-            0x60,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR_MSB,
-            ADC_SAR2_INITIAL_CODE_LOW_ADDR_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_MSB,
-            ADC_SAR1_INITIAL_CODE_HIGH_ADDR_LSB,
-            0x60,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR_MSB,
-            ADC_SAR1_INITIAL_CODE_LOW_ADDR_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_DTEST_RTC_ADDR,
-            ADC_SARADC_DTEST_RTC_ADDR_MSB,
-            ADC_SARADC_DTEST_RTC_ADDR_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_ENT_RTC_ADDR,
-            ADC_SARADC_ENT_RTC_ADDR_MSB,
-            ADC_SARADC_ENT_RTC_ADDR_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC1_ENCAL_REF_ADDR,
-            ADC_SARADC1_ENCAL_REF_ADDR_MSB,
-            ADC_SARADC1_ENCAL_REF_ADDR_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC2_ENCAL_REF_ADDR,
-            ADC_SARADC2_ENCAL_REF_ADDR_MSB,
-            ADC_SARADC2_ENCAL_REF_ADDR_LSB,
-            0,
-        );
+        regi2c::ADC_SAR2_INITIAL_CODE_HIGH.write_field(0x60);
+        regi2c::ADC_SAR2_INITIAL_CODE_LOW.write_field(0);
+        regi2c::ADC_SAR1_INITIAL_CODE_HIGH.write_field(0x60);
+        regi2c::ADC_SAR1_INITIAL_CODE_LOW.write_field(0);
+        regi2c::ADC_SAR_DTEST_RTC.write_field(0);
+        regi2c::ADC_SAR_ENT_RTC.write_field(0);
+        regi2c::ADC_SAR1_ENCAL_REF.write_field(0);
+        regi2c::ADC_SAR2_ENCAL_REF.write_field(0);
 
         PCR::regs()
             .saradc_clkm_conf()
             .modify(|_, w| w.bits(0x00404000));
 
         PCR::regs().saradc_conf().modify(|_, w| w.bits(0x5));
-    }
-}
-
-fn regi2c_enable_block(block: u8) {
-    let modem_lpcon = crate::peripherals::MODEM_LPCON::regs();
-    let lp_i2c_ana = crate::peripherals::LP_I2C_ANA_MST::regs();
-
-    unsafe {
-        modem_lpcon
-            .clk_conf()
-            .modify(|_, w| w.clk_i2c_mst_en().set_bit());
-
-        modem_lpcon
-            .i2c_mst_clk_conf()
-            .modify(|_, w| w.clk_i2c_mst_sel_160m().set_bit());
-
-        lp_i2c_ana
-            .date()
-            .modify(|_, w| w.lp_i2c_ana_mast_i2c_mat_clk_en().set_bit());
-
-        match block {
-            REGI2C_BBPLL => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() | REGI2C_BBPLL_RD_MASK)
-                });
-            }
-            REGI2C_BIAS => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() | REGI2C_BIAS_RD_MASK)
-                });
-            }
-            REGI2C_DIG_REG => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() | REGI2C_DIG_REG_RD_MASK)
-                });
-            }
-            REGI2C_ULP_CAL => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() | REGI2C_ULP_CAL_RD_MASK)
-                });
-            }
-            REGI2C_SAR_I2C => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() | REGI2C_SAR_I2C_RD_MASK)
-                });
-            }
-            _ => (),
-        }
-    }
-}
-
-fn regi2c_disable_block(block: u8) {
-    let lp_i2c_ana = crate::peripherals::LP_I2C_ANA_MST::regs();
-
-    unsafe {
-        match block {
-            REGI2C_BBPLL => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() & !REGI2C_BBPLL_RD_MASK)
-                });
-            }
-            REGI2C_BIAS => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() & !REGI2C_BIAS_RD_MASK)
-                });
-            }
-            REGI2C_DIG_REG => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() & !REGI2C_DIG_REG_RD_MASK)
-                });
-            }
-            REGI2C_ULP_CAL => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() & !REGI2C_ULP_CAL_RD_MASK)
-                });
-            }
-            REGI2C_SAR_I2C => {
-                lp_i2c_ana.ana_conf1().modify(|r, w| {
-                    w.lp_i2c_ana_mast_ana_conf1()
-                        .bits(r.lp_i2c_ana_mast_ana_conf1().bits() & !REGI2C_SAR_I2C_RD_MASK)
-                });
-            }
-            _ => (),
-        }
-    }
-}
-
-pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
-    assert!(msb - lsb < 8);
-    let lp_i2c_ana = crate::peripherals::LP_I2C_ANA_MST::regs();
-
-    unsafe {
-        regi2c_enable_block(block);
-
-        // Read the i2c bus register
-        let mut temp: u32 = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32)
-            << REGI2C_RTC_SLAVE_ID_S as u32)
-            | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32);
-
-        lp_i2c_ana
-            .i2c0_ctrl()
-            .modify(|_, w| w.lp_i2c_ana_mast_i2c0_ctrl().bits(temp));
-
-        while lp_i2c_ana
-            .i2c0_ctrl()
-            .read()
-            .lp_i2c_ana_mast_i2c0_busy()
-            .bit()
-        {}
-
-        temp = lp_i2c_ana
-            .i2c0_data()
-            .read()
-            .lp_i2c_ana_mast_i2c0_rdata()
-            .bits() as u32;
-
-        // Write the i2c bus register
-        temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
-        temp |= (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
-        temp = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32) << REGI2C_RTC_SLAVE_ID_S as u32)
-            | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32)
-            | ((0x1 & REGI2C_RTC_WR_CNTL_V as u32) << REGI2C_RTC_WR_CNTL_S as u32)
-            | ((temp & REGI2C_RTC_DATA_V as u32) << REGI2C_RTC_DATA_S as u32);
-
-        lp_i2c_ana
-            .i2c0_ctrl()
-            .modify(|_, w| w.lp_i2c_ana_mast_i2c0_ctrl().bits(temp));
-
-        while lp_i2c_ana
-            .i2c0_ctrl()
-            .read()
-            .lp_i2c_ana_mast_i2c0_busy()
-            .bit()
-        {}
-
-        regi2c_disable_block(block);
     }
 }

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -16,6 +16,7 @@ crate::unstable_module! {
 }
 pub mod gpio;
 pub mod peripherals;
+pub(crate) mod regi2c;
 
 /// The name of the chip ("esp32h2") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32h2/regi2c.rs
+++ b/esp-hal/src/soc/esp32h2/regi2c.rs
@@ -1,0 +1,146 @@
+use crate::{
+    peripherals::{I2C_ANA_MST, MODEM_LPCON},
+    rom::regi2c::{define_regi2c, RawRegI2cField, RegI2cMaster, RegI2cRegister},
+};
+
+define_regi2c! {
+    master: REGI2C_BBPLL(0x66, 0) {
+        reg: I2C_BBPLL_OC_REF(2) {
+            field: I2C_BBPLL_OC_REF_DIV(3..0)
+        }
+        reg: I2C_BBPLL_OC_DIV_REG(3) {
+            field: I2C_BBPLL_OC_DIV(5..0)
+        }
+        reg: I2C_BBPLL_OC_DR(5) {
+            field: I2C_BBPLL_OC_DLREF_SEL(7..6),
+            field: I2C_BBPLL_OC_DHREF_SEL(5..4)
+        }
+    }
+    master: REGI2C_BIAS(0x6a, 0) {
+        reg: I2C_BIAS_DREG0(0) {
+            field: I2C_BIAS_DREG_0P8(7..4)
+        }
+        reg: I2C_BIAS_DREG1(1) {
+            field: I2C_BIAS_DREG_1P1_PVT(3..0)
+        }
+    }
+    master: REGI2C_PMU_REG(0x6d, 0) {
+        reg: I2C_PMU_REG8(8) {
+            field: I2C_PMU_EN_I2C_DIG_DREG_SLP(3..3),
+            field: I2C_PMU_EN_I2C_RTC_DREG_SLP(2..2),
+            field: I2C_PMU_EN_I2C_DIG_DREG(1..1),
+            field: I2C_PMU_EN_I2C_RTC_DREG(0..0)
+        }
+        reg: I2C_PMU_XPD(9) {
+            field: I2C_PMU_OR_XPD_DIG_REG(6..6),
+            field: I2C_PMU_OR_XPD_RTC_REG(4..4)
+        }
+        reg: I2C_PMU_OC_SCK_DCAP(14) {}
+        reg: I2C_PMU_REG15(15) {
+            field: I2C_PMU_OR_XPD_TRX(2..2)
+        }
+        reg: I2C_PMU_REG21(21) {
+            field: I2C_PMU_SEL_PLL8M_REF(6..6)
+        }
+    }
+    master: REGI2C_ULP_CAL(0x61, 0) {
+        reg: I2C_ULP_CAL_IR(0) {
+            field: I2C_ULP_IR_RESETB(0..0)
+        }
+    }
+    master: REGI2C_SAR_I2C(0x69, 0) {
+        reg: I2C_SAR_REG0(0) {
+            field: ADC_SAR1_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG1(1) {
+            field: ADC_SAR1_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG2(2) {
+            field: ADC_SAR1_DREF(6..4),
+            field: ADC_SAR1_SAMPLE_CYCLE(2..0)
+        }
+        reg: I2C_SAR_REG3(3) {
+            field: ADC_SAR2_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG4(4) {
+            field: ADC_SAR2_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG5(5) {
+            field: ADC_SAR2_DREF(6..4)
+        }
+        reg: I2C_SAR_REG6(6) {
+            field: ADC_SARADC_TSENS_DAC(3..0)
+        }
+        reg: I2C_SAR_REG7(7) {
+            field: ADC_SARADC_EN_TOUT_SAR1_BUS(5..5),
+            field: ADC_SARADC_ENT_SAR(3..1),
+            field: ADC_SARADC_DTEST(1..0)
+        }
+        reg: I2C_SAR_REG8(8) {
+            field: ADC_SAR1_ENCAL_GND(1..1)
+        }
+    }
+}
+
+fn regi2c_enable_block(block: u8) -> usize {
+    MODEM_LPCON::regs()
+        .clk_conf()
+        .modify(|_, w| w.clk_i2c_mst_en().set_bit());
+
+    // Before config I2C register, enable corresponding slave.
+    let i2c_sel_bits = I2C_ANA_MST::regs().ana_conf2().read();
+    let i2c_sel = match block {
+        v if v == REGI2C_BBPLL.master => i2c_sel_bits.bbpll_mst_sel().bit_is_set(),
+        v if v == REGI2C_BIAS.master => i2c_sel_bits.bias_mst_sel().bit_is_set(),
+        v if v == REGI2C_PMU_REG.master => i2c_sel_bits.dig_reg_mst_sel().bit_is_set(),
+        v if v == REGI2C_ULP_CAL.master => i2c_sel_bits.ulp_cal_mst_sel().bit_is_set(),
+        v if v == REGI2C_SAR_I2C.master => i2c_sel_bits.sar_i2c_mst_sel().bit_is_set(),
+        _ => unreachable!(),
+    };
+    I2C_ANA_MST::regs().ana_conf1().write(|w| unsafe {
+        const I2C_MST_ANA_CONF1_M: u32 = 0x00FFFFFF;
+        w.bits(I2C_MST_ANA_CONF1_M);
+        match block {
+            v if v == REGI2C_BBPLL.master => w.bbpll_rd().clear_bit(),
+            v if v == REGI2C_BIAS.master => w.bias_rd().clear_bit(),
+            v if v == REGI2C_PMU_REG.master => w.dig_reg_rd().clear_bit(),
+            v if v == REGI2C_ULP_CAL.master => w.ulp_cal_rd().clear_bit(),
+            v if v == REGI2C_SAR_I2C.master => w.sar_i2c_rd().clear_bit(),
+            _ => unreachable!(),
+        }
+    });
+
+    if i2c_sel {
+        0
+    } else {
+        1
+    }
+}
+
+pub(crate) fn regi2c_read(block: u8, _host_id: u8, reg_add: u8) -> u8 {
+    let master = regi2c_enable_block(block);
+
+    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
+
+    I2C_ANA_MST::regs().i2c_ctrl(master).write(|w| unsafe {
+        w.slave_addr().bits(block);
+        w.slave_reg_addr().bits(reg_add)
+    });
+
+    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
+
+    I2C_ANA_MST::regs().i2c_ctrl(master).read().data().bits()
+}
+
+pub(crate) fn regi2c_write(block: u8, _host_id: u8, reg_add: u8, data: u8) {
+    let master = regi2c_enable_block(block);
+
+    I2C_ANA_MST::regs().i2c_ctrl(master).write(|w| unsafe {
+        w.slave_addr().bits(block);
+        w.slave_reg_addr().bits(reg_add);
+        w.read_write().set_bit();
+        w.data().bits(data)
+    });
+
+    while I2C_ANA_MST::regs().i2c_ctrl(master).read().busy().bit() {}
+}

--- a/esp-hal/src/soc/esp32h2/trng.rs
+++ b/esp-hal/src/soc/esp32h2/trng.rs
@@ -1,62 +1,12 @@
-use crate::peripherals::{APB_SARADC, PCR, PMU};
-
-const I2C_SAR_ADC: u8 = 0x69;
-const I2C_SAR_ADC_HOSTID: u8 = 0;
-
-const I2C_SARADC_DTEST: u8 = 7;
-const I2C_SARADC_DTEST_MSB: u8 = 1;
-const I2C_SARADC_DTEST_LSB: u8 = 0;
-const I2C_SARADC_ENT_SAR: u8 = 7;
-const I2C_SARADC_ENT_SAR_MSB: u8 = 3;
-const I2C_SARADC_ENT_SAR_LSB: u8 = 1;
-const I2C_SARADC_EN_TOUT_SAR1_BUS: u8 = 7;
-const I2C_SARADC_EN_TOUT_SAR1_BUS_MSB: u8 = 5;
-const I2C_SARADC_EN_TOUT_SAR1_BUS_LSB: u8 = 5;
-
-const I2C_SARADC_SAR2_INIT_CODE_MSB: u8 = 4;
-const I2C_SARADC_SAR2_INIT_CODE_MSB_MSB: u8 = 3;
-const I2C_SARADC_SAR2_INIT_CODE_MSB_LSB: u8 = 0;
-const I2C_SARADC_SAR2_INIT_CODE_LSB: u8 = 3;
-const I2C_SARADC_SAR2_INIT_CODE_LSB_MSB: u8 = 7;
-const I2C_SARADC_SAR2_INIT_CODE_LSB_LSB: u8 = 0;
-
-const I2C_SARADC_SAR1_INIT_CODE_MSB: u8 = 1;
-const I2C_SARADC_SAR1_INIT_CODE_MSB_MSB: u8 = 3;
-const I2C_SARADC_SAR1_INIT_CODE_MSB_LSB: u8 = 0;
-const I2C_SARADC_SAR1_INIT_CODE_LSB: u8 = 3;
-const I2C_SARADC_SAR1_INIT_CODE_LSB_MSB: u8 = 7;
-const I2C_SARADC_SAR1_INIT_CODE_LSB_LSB: u8 = 0;
+use crate::{
+    peripherals::{APB_SARADC, PCR, PMU},
+    soc::regi2c,
+};
 
 const SAR2_CHANNEL: u32 = 9;
 const SAR2_ATTEN: u32 = 1;
 const SAR1_ATTEN: u32 = 1;
 const PATTERN_BIT_WIDTH: u32 = 6;
-
-const REGI2C_BBPLL: u8 = 0x66;
-const REGI2C_BIAS: u8 = 0x6a;
-const REGI2C_PMU: u8 = 0x6d;
-const REGI2C_ULP_CAL: u8 = 0x61;
-const REGI2C_SAR_I2C: u8 = 0x69;
-
-const I2C_MST_ANA_CONF1_M: u32 = 0x00FFFFFF;
-const I2C_MST_I2C0_CTRL_REG: u32 = 0x600AD800;
-const I2C_MST_ANA_CONF1_REG: u32 = I2C_MST_I2C0_CTRL_REG + 0x1c;
-
-const REGI2C_BBPLL_RD_MASK: u32 = !(1 << 7) & I2C_MST_ANA_CONF1_M;
-const REGI2C_BIAS_RD_MASK: u32 = !(1 << 6) & I2C_MST_ANA_CONF1_M;
-const REGI2C_DIG_REG_RD_MASK: u32 = !(1 << 10) & I2C_MST_ANA_CONF1_M;
-const REGI2C_ULP_CAL_RD_MASK: u32 = !(1 << 8) & I2C_MST_ANA_CONF1_M;
-const REGI2C_SAR_I2C_RD_MASK: u32 = !(1 << 9) & I2C_MST_ANA_CONF1_M;
-const REGI2C_RTC_BUSY: u32 = 1 << 25;
-
-const REGI2C_RTC_SLAVE_ID_V: u8 = 0xFF;
-const REGI2C_RTC_SLAVE_ID_S: u8 = 0;
-const REGI2C_RTC_ADDR_V: u8 = 0xFF;
-const REGI2C_RTC_ADDR_S: u8 = 8;
-const REGI2C_RTC_WR_CNTL_V: u8 = 0x1;
-const REGI2C_RTC_WR_CNTL_S: u8 = 24;
-const REGI2C_RTC_DATA_V: u8 = 0xFF;
-const REGI2C_RTC_DATA_S: u8 = 16;
 
 /// Enable true randomness by enabling the entropy source.
 /// Blocks `ADC` usage.
@@ -95,67 +45,14 @@ pub(crate) fn ensure_randomness() {
 
         // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
         // voltage as sampling source
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_DTEST,
-            I2C_SARADC_DTEST_MSB,
-            I2C_SARADC_DTEST_LSB,
-            2,
-        );
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_ENT_SAR,
-            I2C_SARADC_ENT_SAR_MSB,
-            I2C_SARADC_ENT_SAR_LSB,
-            1,
-        );
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_EN_TOUT_SAR1_BUS,
-            I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
-            I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
-            1,
-        );
+        regi2c::ADC_SARADC_DTEST.write_field(2);
+        regi2c::ADC_SARADC_ENT_SAR.write_field(1);
+        regi2c::ADC_SARADC_EN_TOUT_SAR1_BUS.write_field(1);
 
-        // SAR2 High ADDR
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_SAR2_INIT_CODE_MSB,
-            I2C_SARADC_SAR2_INIT_CODE_MSB_MSB,
-            I2C_SARADC_SAR2_INIT_CODE_MSB_LSB,
-            0x08,
-        );
-        // SAR2 Low ADDR
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_SAR2_INIT_CODE_LSB,
-            I2C_SARADC_SAR2_INIT_CODE_LSB_MSB,
-            I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
-            0x66,
-        );
-        // SAR1 High ADDR
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_SAR1_INIT_CODE_MSB,
-            I2C_SARADC_SAR1_INIT_CODE_MSB_MSB,
-            I2C_SARADC_SAR1_INIT_CODE_MSB_LSB,
-            0x08,
-        );
-        // SAR1 Low ADDR
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_SAR1_INIT_CODE_LSB,
-            I2C_SARADC_SAR1_INIT_CODE_LSB_MSB,
-            I2C_SARADC_SAR1_INIT_CODE_LSB_LSB,
-            0x66,
-        );
+        regi2c::ADC_SAR2_INITIAL_CODE_HIGH.write_field(0x08);
+        regi2c::ADC_SAR2_INITIAL_CODE_LOW.write_field(0x66);
+        regi2c::ADC_SAR1_INITIAL_CODE_HIGH.write_field(0x08);
+        regi2c::ADC_SAR1_INITIAL_CODE_LOW.write_field(0x66);
 
         // create patterns and set them in pattern table
         let pattern_one: u32 = (SAR2_CHANNEL << 2) | SAR2_ATTEN; // we want channel 9 with max attenuation
@@ -193,69 +90,13 @@ pub(crate) fn revert_trng() {
             .modify(|_, w| w.bits(0xFFFFFF));
 
         // Revert ADC I2C configuration and initial voltage source setting
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_SAR2_INIT_CODE_MSB,
-            I2C_SARADC_SAR2_INIT_CODE_MSB_MSB,
-            I2C_SARADC_SAR2_INIT_CODE_MSB_LSB,
-            0x60,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_SAR2_INIT_CODE_LSB,
-            I2C_SARADC_SAR2_INIT_CODE_LSB_MSB,
-            I2C_SARADC_SAR2_INIT_CODE_LSB_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_SAR1_INIT_CODE_MSB,
-            I2C_SARADC_SAR1_INIT_CODE_MSB_MSB,
-            I2C_SARADC_SAR1_INIT_CODE_MSB_LSB,
-            0x60,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_SAR1_INIT_CODE_LSB,
-            I2C_SARADC_SAR1_INIT_CODE_LSB_MSB,
-            I2C_SARADC_SAR1_INIT_CODE_LSB_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_DTEST,
-            I2C_SARADC_DTEST_MSB,
-            I2C_SARADC_DTEST_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_ENT_SAR,
-            I2C_SARADC_ENT_SAR_MSB,
-            I2C_SARADC_ENT_SAR_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            I2C_SARADC_EN_TOUT_SAR1_BUS,
-            I2C_SARADC_EN_TOUT_SAR1_BUS_MSB,
-            I2C_SARADC_EN_TOUT_SAR1_BUS_LSB,
-            0,
-        );
-
+        regi2c::ADC_SAR2_INITIAL_CODE_HIGH.write_field(0x60);
+        regi2c::ADC_SAR2_INITIAL_CODE_LOW.write_field(0);
+        regi2c::ADC_SAR1_INITIAL_CODE_HIGH.write_field(0x60);
+        regi2c::ADC_SAR1_INITIAL_CODE_LOW.write_field(0);
+        regi2c::ADC_SARADC_DTEST.write_field(0);
+        regi2c::ADC_SARADC_ENT_SAR.write_field(0);
+        regi2c::ADC_SARADC_EN_TOUT_SAR1_BUS.write_field(0);
         // disable ADC_CTRL_CLK (SAR ADC function clock)
         PCR::regs()
             .saradc_clkm_conf()
@@ -264,109 +105,4 @@ pub(crate) fn revert_trng() {
         // Set PCR_SARADC_CONF_REG to initial state
         PCR::regs().saradc_conf().modify(|_, w| w.bits(0x5));
     }
-}
-
-fn regi2c_enable_block(block: u8) {
-    let modem_lpcon = crate::peripherals::MODEM_LPCON::regs();
-
-    modem_lpcon
-        .clk_conf()
-        .modify(|_, w| w.clk_i2c_mst_en().set_bit());
-
-    // Before config I2C register, enable corresponding slave.
-    match block {
-        v if v == REGI2C_BBPLL => {
-            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_BBPLL_RD_MASK);
-        }
-        v if v == REGI2C_BIAS => {
-            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_BIAS_RD_MASK);
-        }
-        v if v == REGI2C_PMU => {
-            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_DIG_REG_RD_MASK);
-        }
-        v if v == REGI2C_ULP_CAL => {
-            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_ULP_CAL_RD_MASK);
-        }
-        v if v == REGI2C_SAR_I2C => {
-            reg_set_bit(I2C_MST_ANA_CONF1_REG, REGI2C_SAR_I2C_RD_MASK);
-        }
-        _ => (),
-    }
-}
-
-fn regi2c_disable_block(block: u8) {
-    match block {
-        v if v == REGI2C_BBPLL => {
-            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_BBPLL_RD_MASK);
-        }
-        v if v == REGI2C_BIAS => {
-            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_BIAS_RD_MASK);
-        }
-        v if v == REGI2C_PMU => {
-            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_DIG_REG_RD_MASK);
-        }
-        v if v == REGI2C_ULP_CAL => {
-            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_ULP_CAL_RD_MASK);
-        }
-        v if v == REGI2C_SAR_I2C => {
-            reg_clr_bit(I2C_MST_ANA_CONF1_REG, REGI2C_SAR_I2C_RD_MASK);
-        }
-        _ => (),
-    }
-}
-
-fn reg_write(reg: u32, v: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(v);
-    }
-}
-
-fn reg_get_bit(reg: u32, b: u32) -> u32 {
-    unsafe { (reg as *mut u32).read_volatile() & b }
-}
-
-fn reg_set_bit(reg: u32, bit: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
-    }
-}
-
-fn reg_clr_bit(reg: u32, bit: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
-    }
-}
-
-fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
-    unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
-}
-
-pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
-    assert!(msb - lsb < 8);
-    regi2c_enable_block(block);
-
-    // Read the i2c bus register
-    while reg_get_bit(I2C_MST_I2C0_CTRL_REG, REGI2C_RTC_BUSY) != 0 {}
-
-    let mut temp: u32 = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32)
-        << REGI2C_RTC_SLAVE_ID_S as u32)
-        | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << (REGI2C_RTC_ADDR_S as u32));
-    reg_write(I2C_MST_I2C0_CTRL_REG, temp);
-    while reg_get_bit(I2C_MST_I2C0_CTRL_REG, REGI2C_RTC_BUSY) != 0 {}
-    temp = reg_get_field(
-        I2C_MST_I2C0_CTRL_REG,
-        REGI2C_RTC_DATA_S as u32,
-        REGI2C_RTC_DATA_V as u32,
-    );
-    // Write the i2c bus register
-    temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
-    temp |= (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
-    temp = ((block as u32 & REGI2C_RTC_SLAVE_ID_V as u32) << REGI2C_RTC_SLAVE_ID_S as u32)
-        | ((reg_add as u32 & REGI2C_RTC_ADDR_V as u32) << REGI2C_RTC_ADDR_S as u32)
-        | ((0x1 & REGI2C_RTC_WR_CNTL_V as u32) << REGI2C_RTC_WR_CNTL_S as u32)
-        | ((temp & REGI2C_RTC_DATA_V as u32) << REGI2C_RTC_DATA_S as u32);
-    reg_write(I2C_MST_I2C0_CTRL_REG, temp);
-    while reg_get_bit(I2C_MST_I2C0_CTRL_REG, REGI2C_RTC_BUSY) != 0 {}
-
-    regi2c_disable_block(block);
 }

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -22,6 +22,7 @@ crate::unstable_module! {
 }
 pub mod gpio;
 pub mod peripherals;
+pub(crate) mod regi2c;
 
 /// The name of the chip ("esp32s2") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32s2/regi2c.rs
+++ b/esp-hal/src/soc/esp32s2/regi2c.rs
@@ -1,0 +1,50 @@
+use crate::rom::regi2c::{define_regi2c, RawRegI2cField, RegI2cMaster, RegI2cRegister};
+
+define_regi2c! {
+    master: REGI2C_SAR_I2C(0x69, 1) {
+        reg: I2C_SAR_REG0(0) {
+            field: ADC_SAR1_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG1(1) {
+            field: ADC_SAR1_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG2(2) {
+            field: ADC_SAR1_DREF(6..4),
+            field: ADC_SAR1_SAMPLE_CYCLE(2..0)
+        }
+        reg: I2C_SAR_REG3(3) {
+            field: ADC_SAR2_INITIAL_CODE_LOW(7..0)
+        }
+        reg: I2C_SAR_REG4(4) {
+            field: ADC_SAR2_INITIAL_CODE_HIGH(3..0)
+        }
+        reg: I2C_SAR_REG5(5) {
+            field: ADC_SAR2_DREF(6..4)
+        }
+        reg: I2C_SAR_REG6(6) {
+            field: I2C_SARADC_TSENS_DAC(3..0)
+        }
+        reg: I2C_SAR_REG7(7) {
+            field: ADC_SAR2_ENCAL_GND(7..7),
+            field: ADC_SAR1_ENCAL_GND(5..5),
+            field: ADC_SAR_ENCAL_REF(4..4),
+            field: ADC_SAR_ENT_RTC(3..3),
+            field: ADC_SAR_ENT_TSENS(2..2),
+            field: ADC_SAR_DTEST_RTC(1..0)
+        }
+    }
+}
+
+pub(crate) fn regi2c_read(block: u8, host_id: u8, reg_add: u8) -> u8 {
+    extern "C" {
+        pub(crate) fn esp_rom_regi2c_read(block: u8, block_hostid: u8, reg_add: u8) -> u8;
+    }
+    unsafe { esp_rom_regi2c_read(block, host_id, reg_add) }
+}
+
+pub(crate) fn regi2c_write(block: u8, host_id: u8, reg_add: u8, data: u8) {
+    extern "C" {
+        pub(crate) fn rom_i2c_writeReg(block: u8, block_hostid: u8, reg_add: u8, indata: u8);
+    }
+    unsafe { rom_i2c_writeReg(block, host_id, reg_add, data) };
+}

--- a/esp-hal/src/soc/esp32s2/trng.rs
+++ b/esp-hal/src/soc/esp32s2/trng.rs
@@ -1,51 +1,7 @@
-use crate::peripherals::{APB_SARADC, LPWR, SENS, SYSTEM};
-
-const ANA_CONFIG_REG: u32 = 0x6000E044;
-const ANA_CONFIG2_REG: u32 = 0x6000E048;
-const I2C_SAR_ADC: u8 = 0x69;
-const I2C_SAR_ADC_HOSTID: u8 = 1;
-const ADC_SAR1_DREF_ADDR: u8 = 0x2;
-const ADC_SAR1_DREF_ADDR_MSB: u8 = 0x6;
-const ADC_SAR1_DREF_ADDR_LSB: u8 = 0x4;
-const ADC_SAR2_DREF_ADDR: u8 = 0x5;
-const ADC_SAR2_DREF_ADDR_MSB: u8 = 0x6;
-const ADC_SAR2_DREF_ADDR_LSB: u8 = 0x4;
-const ADC_SARADC_ENCAL_REF_ADDR: u8 = 0x7;
-const ADC_SARADC_ENCAL_REF_ADDR_MSB: u8 = 4;
-const ADC_SARADC_ENCAL_REF_ADDR_LSB: u8 = 4;
-const ADC_SARADC_ENT_TSENS_ADDR: u8 = 0x7;
-const ADC_SARADC_ENT_TSENS_ADDR_MSB: u8 = 2;
-const ADC_SARADC_ENT_TSENS_ADDR_LSB: u8 = 2;
-const ADC_SARADC_ENT_RTC_ADDR: u8 = 0x7;
-const ADC_SARADC_ENT_RTC_ADDR_MSB: u8 = 3;
-const ADC_SARADC_ENT_RTC_ADDR_LSB: u8 = 3;
-
-const I2C_RTC_SLAVE_ID_V: u8 = 0xFF;
-const I2C_RTC_SLAVE_ID_S: u8 = 0;
-const I2C_RTC_ADDR_V: u8 = 0xFF;
-const I2C_RTC_ADDR_S: u8 = 0x8;
-const I2C_RTC_CONFIG2: u32 = 0x6000e000;
-const I2C_RTC_BUSY: u32 = 1 << 25;
-const I2C_RTC_DATA_V: u32 = 0xFF;
-const I2C_RTC_DATA_S: u32 = 16;
-const I2C_RTC_WR_CNTL_V: u8 = 0x1;
-const I2C_RTC_WR_CNTL_S: u8 = 24;
-const I2C_RTC_CONFIG0: u32 = 0x6000e048;
-const I2C_RTC_CONFIG1: u32 = 0x6000e044;
-const I2C_RTC_MAGIC_CTRL_V: u32 = 0x1FFF;
-const I2C_RTC_MAGIC_CTRL_S: u32 = 4;
-const I2C_RTC_MAGIC_DEFAULT: u32 = 0x1c40;
-const I2C_RTC_ALL_MASK_V: u32 = 0x7FFF;
-const I2C_RTC_ALL_MASK_S: u32 = 8;
-const I2C_RTC_WIFI_CLK_EN: u32 = 0x3f426000 + 0x090;
-const I2C_RTC_CLK_GATE_EN: u32 = 1 << 18;
-const I2C_BOD: u8 = 0x61;
-const I2C_BBPLL: u8 = 0x66;
-const I2C_APLL: u8 = 0x6D;
-const I2C_RTC_APLL_MASK: u32 = 1 << 14;
-const I2C_RTC_BBPLL_MASK: u32 = 1 << 17;
-const I2C_RTC_SAR_MASK: u32 = 1 << 18;
-const I2C_RTC_BOD_MASK: u32 = 1 << 22;
+use crate::{
+    peripherals::{APB_SARADC, LPWR, SENS, SYSTEM},
+    soc::regi2c,
+};
 
 /// Enable true randomness by enabling the entropy source.
 /// Blocks `ADC` usage.
@@ -69,63 +25,25 @@ pub(crate) fn ensure_randomness() {
 
         apb_saradc.clkm_conf().modify(|_, w| w.clk_sel().bits(2));
 
-        rtc_cntl
-            .ana_conf()
-            .modify(|_, w| w.sar_i2c_force_pd().clear_bit());
-
-        rtc_cntl
-            .ana_conf()
-            .modify(|_, w| w.sar_i2c_force_pu().set_bit());
+        rtc_cntl.ana_conf().modify(|_, w| {
+            w.sar_i2c_force_pd().clear_bit();
+            w.sar_i2c_force_pu().set_bit()
+        });
 
         // Temporarily not in PACs
         // esp-idf/components/soc/esp32s2/include/soc/regi2c_defs.h
+
+        const ANA_CONFIG_REG: u32 = 0x6000E044;
+        const ANA_CONFIG2_REG: u32 = 0x6000E048;
+
         clear_peri_reg_mask(ANA_CONFIG_REG, 1 << 18);
         set_peri_reg_mask(ANA_CONFIG2_REG, 1 << 16);
 
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_DREF_ADDR,
-            ADC_SAR1_DREF_ADDR_MSB,
-            ADC_SAR1_DREF_ADDR_LSB,
-            0x4,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_DREF_ADDR,
-            ADC_SAR2_DREF_ADDR_MSB,
-            ADC_SAR2_DREF_ADDR_LSB,
-            0x4,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_ENCAL_REF_ADDR,
-            ADC_SARADC_ENCAL_REF_ADDR_MSB,
-            ADC_SARADC_ENCAL_REF_ADDR_LSB,
-            1,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_ENT_TSENS_ADDR,
-            ADC_SARADC_ENT_TSENS_ADDR_MSB,
-            ADC_SARADC_ENT_TSENS_ADDR_LSB,
-            1,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_ENT_RTC_ADDR,
-            ADC_SARADC_ENT_RTC_ADDR_MSB,
-            ADC_SARADC_ENT_RTC_ADDR_LSB,
-            0,
-        );
+        regi2c::ADC_SAR1_DREF.write_field(4);
+        regi2c::ADC_SAR2_DREF.write_field(4);
+        regi2c::ADC_SAR1_ENCAL_REF.write_field(1);
+        regi2c::ADC_SAR_ENT_TSENS.write_field(1);
+        regi2c::ADC_SAR_ENT_RTC.write_field(0);
 
         apb_saradc.ctrl().modify(|_, w| w.sar1_patt_len().bits(0));
 
@@ -151,12 +69,11 @@ pub(crate) fn ensure_randomness() {
         sens.sar_power_xpd_sar()
             .modify(|_, w| w.force_xpd_sar().bits(3));
 
-        apb_saradc.ctrl2().modify(|_, w| w.timer_sel().set_bit());
-
-        apb_saradc.ctrl2().modify(|_, w| w.timer_target().bits(100));
-
+        apb_saradc.ctrl2().modify(|_, w| {
+            w.timer_sel().set_bit();
+            w.timer_target().bits(100)
+        });
         apb_saradc.ctrl().modify(|_, w| w.start_force().clear_bit());
-
         apb_saradc.ctrl2().modify(|_, w| w.timer_en().set_bit());
     }
 }
@@ -165,50 +82,11 @@ pub(crate) fn ensure_randomness() {
 pub(crate) fn revert_trng() {
     unsafe {
         // Restore internal I2C bus state
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR1_DREF_ADDR,
-            ADC_SAR1_DREF_ADDR_MSB,
-            ADC_SAR1_DREF_ADDR_LSB,
-            0x1,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SAR2_DREF_ADDR,
-            ADC_SAR2_DREF_ADDR_MSB,
-            ADC_SAR2_DREF_ADDR_LSB,
-            0x1,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_ENCAL_REF_ADDR,
-            ADC_SARADC_ENCAL_REF_ADDR_MSB,
-            ADC_SARADC_ENCAL_REF_ADDR_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_ENT_TSENS_ADDR,
-            ADC_SARADC_ENT_TSENS_ADDR_MSB,
-            ADC_SARADC_ENT_TSENS_ADDR_LSB,
-            0,
-        );
-
-        regi2c_write_mask(
-            I2C_SAR_ADC,
-            I2C_SAR_ADC_HOSTID,
-            ADC_SARADC_ENT_RTC_ADDR,
-            ADC_SARADC_ENT_RTC_ADDR_MSB,
-            ADC_SARADC_ENT_RTC_ADDR_LSB,
-            0,
-        );
+        regi2c::ADC_SAR1_DREF.write_field(1);
+        regi2c::ADC_SAR2_DREF.write_field(1);
+        regi2c::ADC_SAR1_ENCAL_REF.write_field(0);
+        regi2c::ADC_SAR_ENT_TSENS.write_field(0);
+        regi2c::ADC_SAR_ENT_RTC.write_field(0);
 
         // Restore SARADC to default mode
         SENS::regs()
@@ -226,116 +104,6 @@ pub(crate) fn revert_trng() {
         APB_SARADC::regs()
             .ctrl2()
             .modify(|_, w| w.timer_en().clear_bit());
-    }
-}
-// Temporarily not in PACs
-fn regi2c_enable_block(block: u8) {
-    reg_set_field(
-        I2C_RTC_CONFIG0,
-        I2C_RTC_MAGIC_CTRL_V,
-        I2C_RTC_MAGIC_CTRL_S,
-        I2C_RTC_MAGIC_DEFAULT,
-    );
-    reg_set_field(
-        I2C_RTC_CONFIG1,
-        I2C_RTC_ALL_MASK_V,
-        I2C_RTC_ALL_MASK_S,
-        I2C_RTC_ALL_MASK_V,
-    );
-
-    reg_set_bit(I2C_RTC_WIFI_CLK_EN, I2C_RTC_CLK_GATE_EN);
-
-    // Before config I2C register, enable corresponding slave.
-    match block {
-        v if v == I2C_APLL => {
-            reg_set_bit(I2C_RTC_CONFIG1, I2C_RTC_APLL_MASK);
-        }
-        v if v == I2C_BBPLL => {
-            reg_set_bit(I2C_RTC_CONFIG1, I2C_RTC_BBPLL_MASK);
-        }
-        v if v == I2C_SAR_ADC => {
-            reg_set_bit(I2C_RTC_CONFIG1, I2C_RTC_SAR_MASK);
-        }
-        v if v == I2C_BOD => {
-            reg_set_bit(I2C_RTC_CONFIG1, I2C_RTC_BOD_MASK);
-        }
-        _ => (),
-    }
-}
-
-fn regi2c_disable_block(block: u8) {
-    match block {
-        v if v == I2C_APLL => {
-            reg_clr_bit(I2C_RTC_CONFIG1, I2C_RTC_APLL_MASK);
-        }
-        v if v == I2C_BBPLL => {
-            reg_clr_bit(I2C_RTC_CONFIG1, I2C_RTC_BBPLL_MASK);
-        }
-        v if v == I2C_SAR_ADC => {
-            reg_clr_bit(I2C_RTC_CONFIG1, I2C_RTC_SAR_MASK);
-        }
-        v if v == I2C_BOD => {
-            reg_clr_bit(I2C_RTC_CONFIG1, I2C_RTC_BOD_MASK);
-        }
-        _ => (),
-    }
-}
-
-pub(crate) fn regi2c_write_mask(block: u8, _host_id: u8, reg_add: u8, msb: u8, lsb: u8, data: u8) {
-    assert!(msb - lsb < 8);
-    regi2c_enable_block(block);
-
-    // Read the i2c bus register
-    let mut temp: u32 = ((block as u32 & I2C_RTC_SLAVE_ID_V as u32) << I2C_RTC_SLAVE_ID_S as u32)
-        | ((reg_add as u32 & I2C_RTC_ADDR_V as u32) << I2C_RTC_ADDR_S as u32);
-    reg_write(I2C_RTC_CONFIG2, temp);
-    while reg_get_bit(I2C_RTC_CONFIG2, I2C_RTC_BUSY) != 0 {}
-    temp = reg_get_field(I2C_RTC_CONFIG2, I2C_RTC_DATA_S, I2C_RTC_DATA_V);
-    // Write the i2c bus register
-    temp &= (!(0xFFFFFFFF << lsb)) | (0xFFFFFFFF << (msb + 1));
-    temp |= (data as u32 & (!(0xFFFFFFFF << (msb as u32 - lsb as u32 + 1)))) << (lsb as u32);
-    temp = ((block as u32 & I2C_RTC_SLAVE_ID_V as u32) << I2C_RTC_SLAVE_ID_S as u32)
-        | ((reg_add as u32 & I2C_RTC_ADDR_V as u32) << I2C_RTC_ADDR_S as u32)
-        | ((0x1 & I2C_RTC_WR_CNTL_V as u32) << I2C_RTC_WR_CNTL_S as u32)
-        | ((temp & I2C_RTC_DATA_V) << I2C_RTC_DATA_S);
-    reg_write(I2C_RTC_CONFIG2, temp);
-    while reg_get_bit(I2C_RTC_CONFIG2, I2C_RTC_BUSY) != 0 {}
-
-    regi2c_disable_block(block);
-}
-
-fn reg_write(reg: u32, v: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(v);
-    }
-}
-
-fn reg_get_bit(reg: u32, b: u32) -> u32 {
-    unsafe { (reg as *mut u32).read_volatile() & b }
-}
-
-fn reg_get_field(reg: u32, s: u32, v: u32) -> u32 {
-    unsafe { ((reg as *mut u32).read_volatile() >> s) & v }
-}
-
-fn reg_clr_bit(reg: u32, bit: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() & !bit);
-    }
-}
-
-fn reg_set_field(reg: u32, field_v: u32, field_s: u32, value: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile(
-            ((reg as *mut u32).read_volatile() & !(field_v << field_s))
-                | ((value & field_v) << field_s),
-        )
-    }
-}
-
-fn reg_set_bit(reg: u32, bit: u32) {
-    unsafe {
-        (reg as *mut u32).write_volatile((reg as *mut u32).read_volatile() | bit);
     }
 }
 

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -23,6 +23,7 @@ crate::unstable_module! {
 pub mod cpu_control;
 pub mod gpio;
 pub mod peripherals;
+pub(crate) mod regi2c;
 
 /// The name of the chip ("esp32s3") as `&str`
 #[macro_export]

--- a/esp-hal/src/soc/esp32s3/regi2c.rs
+++ b/esp-hal/src/soc/esp32s3/regi2c.rs
@@ -34,6 +34,24 @@ define_regi2c! {
             field: ADC_SAR_DTEST_RTC(1..0)
         }
     }
+    master: I2C_DIG_REG(0x6d, 1) {
+        reg: I2C_DIG_REG4(4) {
+            field: I2C_DIG_REG_EXT_RTC_DREG(4..0)
+        }
+        reg: I2C_DIG_REG5(5) {
+            field: I2C_DIG_REG_EXT_RTC_DREG_SLEEP(4..0)
+        }
+        reg: I2C_DIG_REG6(6) {
+            field: I2C_DIG_REG_EXT_DIG_DREG(4..0)
+        }
+        reg: I2C_DIG_REG7(7) {
+            field: I2C_DIG_REG_EXT_DIG_DREG_SLEEP(4..0)
+        }
+        reg: I2C_DIG_REG13(13) {
+            field: I2C_DIG_REG_XPD_DIG_REG(3..3),
+            field: I2C_DIG_REG_XPD_RTC_REG(2..2)
+        }
+    }
 }
 
 pub(crate) fn regi2c_read(block: u8, host_id: u8, reg_add: u8) -> u8 {


### PR DESCRIPTION
This PR simplifies C6/H2 regi2c function implementations, unifies the API with the other devices and actually tries to define masters/registers/bits per device, fixing issues like trying to calibrate esp32h2 with a method that doesn't seem to exist.

The PR also cleans up the duplicate implementation that is present for TRNG for whatever reason.