### PR TITLE
`SpiDmaBus` no longer adjusts the DMA buffer length for each transfer

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `chrono::NaiveDateTime` on the RTC API by raw `u64` timestamps (#3200)
 - `esp_hal::i2s::master::AnyI2s` has been moved to `esp_hal::i2s::AnyI2s` (#3226)
 - `esp_hal::i2c::master::AnyI2c` has been moved to `esp_hal::i2c::AnyI2c` (#3226)
+- `SpiDmaBus` no longer adjusts the DMA buffer length for each transfer (#3263)
 
 ### Fixed
 

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -782,6 +782,8 @@ impl DmaRxBuf {
     ///
     /// Returns the number of bytes in written to `buf`.
     pub fn read_received_data(&self, mut buf: &mut [u8]) -> usize {
+        // Note that due to an ESP32 quirk, the last received descriptor may not get
+        // updated.
         let capacity = buf.len();
         for chunk in self.received_data() {
             if buf.is_empty() {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2932,6 +2932,7 @@ pub(crate) mod asynch {
     where
         TX: Tx,
     {
+        #[cfg_attr(esp32c2, allow(dead_code))]
         pub fn new(tx: &'a mut TX) -> Self {
             Self { tx }
         }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2040,8 +2040,7 @@ mod dma {
 
                 spi.wait_for_idle_async().await;
 
-                let bytes_read = self.rx_buf.read_received_data(chunk);
-                debug_assert_eq!(bytes_read, chunk.len());
+                chunk.copy_from_slice(&self.rx_buf.as_slice()[..chunk.len()]);
 
                 spi.defuse();
             }
@@ -2100,8 +2099,7 @@ mod dma {
                 }
                 spi.wait_for_idle_async().await;
 
-                let bytes_read = self.rx_buf.read_received_data(read_chunk);
-                debug_assert_eq!(bytes_read, read_chunk.len());
+                read_chunk.copy_from_slice(&self.rx_buf.as_slice()[..read_chunk.len()]);
             }
 
             spi.defuse();
@@ -2135,9 +2133,7 @@ mod dma {
                     )?;
                 }
                 spi.wait_for_idle_async().await;
-
-                let bytes_read = self.rx_buf.read_received_data(chunk);
-                debug_assert_eq!(bytes_read, chunk.len());
+                chunk.copy_from_slice(&self.rx_buf.as_slice()[..chunk.len()]);
             }
 
             spi.defuse();
@@ -2201,9 +2197,7 @@ mod dma {
                 }
 
                 self.wait_for_idle();
-
-                let bytes_read = self.rx_buf.read_received_data(chunk);
-                debug_assert_eq!(bytes_read, chunk.len());
+                chunk.copy_from_slice(&self.rx_buf.as_slice()[..chunk.len()]);
             }
 
             Ok(())
@@ -2259,8 +2253,7 @@ mod dma {
                 }
                 self.wait_for_idle();
 
-                let bytes_read = self.rx_buf.read_received_data(read_chunk);
-                debug_assert_eq!(bytes_read, read_chunk.len());
+                read_chunk.copy_from_slice(&self.rx_buf.as_slice()[..read_chunk.len()]);
             }
 
             if !read_remainder.is_empty() {
@@ -2291,9 +2284,7 @@ mod dma {
                     )?;
                 }
                 self.wait_for_idle();
-
-                let bytes_read = self.rx_buf.read_received_data(chunk);
-                debug_assert_eq!(bytes_read, chunk.len());
+                chunk.copy_from_slice(&self.rx_buf.as_slice()[..chunk.len()]);
             }
 
             Ok(())
@@ -2327,8 +2318,7 @@ mod dma {
 
             self.wait_for_idle();
 
-            let bytes_read = self.rx_buf.read_received_data(buffer);
-            debug_assert_eq!(bytes_read, buffer.len());
+            buffer.copy_from_slice(&self.rx_buf.as_slice()[..buffer.len()]);
 
             Ok(())
         }

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2059,7 +2059,7 @@ mod dma {
             let chunk_size = self.tx_buf.capacity();
 
             for chunk in words.chunks(chunk_size) {
-                self.tx_buf.as_mut_slice()[..chunk_size].copy_from_slice(chunk);
+                self.tx_buf.as_mut_slice()[..chunk.len()].copy_from_slice(chunk);
 
                 unsafe { spi.start_dma_transfer(0, chunk.len(), &mut EmptyBuf, &mut self.tx_buf)? };
 
@@ -2088,7 +2088,7 @@ mod dma {
                 .chunks_mut(chunk_size)
                 .zip(write_common.chunks(chunk_size))
             {
-                self.tx_buf.as_mut_slice()[..chunk_size].copy_from_slice(write_chunk);
+                self.tx_buf.as_mut_slice()[..write_chunk.len()].copy_from_slice(write_chunk);
 
                 unsafe {
                     spi.start_dma_transfer(
@@ -2247,7 +2247,7 @@ mod dma {
                 .chunks_mut(chunk_size)
                 .zip(write_common.chunks(chunk_size))
             {
-                self.tx_buf.as_mut_slice()[..chunk_size].copy_from_slice(write_chunk);
+                self.tx_buf.as_mut_slice()[..write_chunk.len()].copy_from_slice(write_chunk);
 
                 unsafe {
                     self.spi_dma.start_dma_transfer(

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1228,7 +1228,7 @@ mod dma {
     use super::*;
     use crate::{
         dma::{
-            asynch::{DmaRxFuture, DmaTxFuture},
+            asynch::DmaRxFuture,
             Channel,
             DmaRxBuf,
             DmaTxBuf,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1227,14 +1227,7 @@ mod dma {
 
     use super::*;
     use crate::{
-        dma::{
-            asynch::DmaRxFuture,
-            Channel,
-            DmaRxBuf,
-            DmaTxBuf,
-            EmptyBuf,
-            PeripheralDmaChannel,
-        },
+        dma::{asynch::DmaRxFuture, Channel, DmaRxBuf, DmaTxBuf, EmptyBuf, PeripheralDmaChannel},
         spi::master::dma::asynch::DropGuard,
     };
 

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -655,14 +655,15 @@ mod tests {
         let transmit = [0b0110_1010; TRANSFER_SIZE];
 
         for i in 1..4 {
-            receive.copy_from_slice(&[5, 5, 5, 5, 5]);
+            receive.copy_from_slice(&[5; TRANSFER_SIZE]);
             SpiBusAsync::read(&mut spi, &mut receive).await.unwrap();
-            assert_eq!(receive, [0, 0, 0, 0, 0]);
+            assert_eq!(receive, [0; TRANSFER_SIZE]);
 
             SpiBusAsync::transfer(&mut spi, &mut receive, &transmit)
                 .await
                 .unwrap();
             assert_eq!(ctx.pcnt_unit.value(), (i * 3 * TRANSFER_SIZE) as _);
+            assert_eq!(receive, [0b0110_1010; TRANSFER_SIZE]);
         }
     }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Before this PR, `SpiDmaBus` would call `DmaTxBuf::set_length`/`DmaRxBuf::set_length` on its DMA buffers for each transfer.
After this PR, `SpiDmaBus` no longer does this and always uses the full capacity of the DMA buffer whilst configuring the SPI hardware with the correct number of bytes to transfer.

Why?
- This saves on some CPU cycles used to create the DMA linked list that matches the exact length of the transfer.
- We no longer have to worry about hitting alignment issues when working with `set_length`. (Think of burst mode, PSRAM or the P4 in general) More info about this problem in #2587.
- I'm hoping this provides a fix for https://github.com/esp-rs/esp-hal/issues/3262 and allows [this](https://github.com/esp-rs/esp-hal/blob/7c159b6070b9025903de7d24ac600839625a191f/esp-hal/src/dma/buffers.rs#L204-L212) to be uncommented.

A small consequence of this change is the OUT_TOTAL_EOF interrupt of the DMA can no longer be used to await the SPI's completion. This isn't really a problem as the SPI has it's own completion interrupt. I'm just stating this here to explain why I made the code changes I made to `is_done` and `wait_for_done_async`.

#### Testing
HIL
