### PR TITLE
I2c and uart docs improvement

### DIFF
--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -701,7 +701,7 @@ impl<'d> I2c<'d, Async> {
         }
     }
 
-    /// Writes bytes to slave with address `address`
+    /// Writes bytes to slave with given `address`
     pub async fn write_async<A: Into<I2cAddress>>(
         &mut self,
         address: A,
@@ -730,7 +730,7 @@ impl<'d> I2c<'d, Async> {
             .inspect_err(|_| self.internal_recover())
     }
 
-    /// Writes bytes to slave with address `address` and then reads enough
+    /// Writes bytes to slave with given `address` and then reads enough
     /// bytes to fill `buffer` *in a single transaction*
     ///
     /// # Errors
@@ -957,7 +957,7 @@ where
         *guard = OutputConnection::connect_with_guard(pin, output);
     }
 
-    /// Writes bytes to slave with address `address`
+    /// Writes bytes to slave with given `address`
     /// ```rust, no_run
     #[doc = crate::before_snippet!()]
     /// # use esp_hal::i2c::master::{Config, I2c};
@@ -1004,7 +1004,7 @@ where
             .inspect_err(|_| self.internal_recover())
     }
 
-    /// Writes bytes to slave with address `address` and then reads enough bytes
+    /// Writes bytes to slave with given `address` and then reads enough bytes
     /// to fill `buffer` *in a single transaction*
     /// ```rust, no_run
     #[doc = crate::before_snippet!()]

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -473,267 +473,6 @@ impl<Dm: DriverMode> embedded_hal::i2c::I2c for I2c<'_, Dm> {
     }
 }
 
-impl<'d, Dm> I2c<'d, Dm>
-where
-    Dm: DriverMode,
-{
-    fn driver(&self) -> Driver<'_> {
-        Driver {
-            info: self.i2c.info(),
-            state: self.i2c.state(),
-        }
-    }
-
-    fn internal_recover(&self) {
-        PeripheralClockControl::disable(self.driver().info.peripheral);
-        PeripheralClockControl::enable(self.driver().info.peripheral);
-        PeripheralClockControl::reset(self.driver().info.peripheral);
-
-        // We know the configuration is valid, we can ignore the result.
-        _ = self.driver().setup(&self.config);
-    }
-
-    /// Applies a new configuration.
-    ///
-    /// # Errors
-    ///
-    /// A [`ConfigError`] variant will be returned if bus frequency or timeout
-    /// passed in config is invalid.
-    pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
-        self.driver().setup(config)?;
-        self.config = *config;
-        Ok(())
-    }
-
-    fn transaction_impl<'a>(
-        &mut self,
-        address: I2cAddress,
-        operations: impl Iterator<Item = Operation<'a>>,
-    ) -> Result<(), Error> {
-        let mut last_op: Option<OpKind> = None;
-        // filter out 0 length read operations
-        let mut op_iter = operations
-            .filter(|op| op.is_write() || !op.is_empty())
-            .peekable();
-
-        while let Some(op) = op_iter.next() {
-            let next_op = op_iter.peek().map(|v| v.kind());
-            let kind = op.kind();
-            match op {
-                Operation::Write(buffer) => {
-                    // execute a write operation:
-                    // - issue START/RSTART if op is different from previous
-                    // - issue STOP if op is the last one
-                    self.driver().write_blocking(
-                        address,
-                        buffer,
-                        !matches!(last_op, Some(OpKind::Write)),
-                        next_op.is_none(),
-                    )?;
-                }
-                Operation::Read(buffer) => {
-                    // execute a read operation:
-                    // - issue START/RSTART if op is different from previous
-                    // - issue STOP if op is the last one
-                    // - will_continue is true if there is another read operation next
-                    self.driver().read_blocking(
-                        address,
-                        buffer,
-                        !matches!(last_op, Some(OpKind::Read)),
-                        next_op.is_none(),
-                        matches!(next_op, Some(OpKind::Read)),
-                    )?;
-                }
-            }
-
-            last_op = Some(kind);
-        }
-
-        Ok(())
-    }
-
-    /// Connect a pin to the I2C SDA signal.
-    ///
-    /// This will replace previous pin assignments for this signal.
-    pub fn with_sda(mut self, sda: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
-        let info = self.driver().info;
-        let input = info.sda_input;
-        let output = info.sda_output;
-        Self::connect_pin(sda, input, output, &mut self.sda_pin);
-
-        self
-    }
-
-    /// Connect a pin to the I2C SCL signal.
-    ///
-    /// This will replace previous pin assignments for this signal.
-    pub fn with_scl(mut self, scl: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
-        let info = self.driver().info;
-        let input = info.scl_input;
-        let output = info.scl_output;
-        Self::connect_pin(scl, input, output, &mut self.scl_pin);
-
-        self
-    }
-
-    fn connect_pin(
-        pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        input: InputSignal,
-        output: OutputSignal,
-        guard: &mut PinGuard,
-    ) {
-        crate::into_mapped_ref!(pin);
-        // avoid the pin going low during configuration
-        pin.set_output_high(true);
-
-        pin.set_to_open_drain_output();
-        pin.enable_input(true);
-        pin.pull_direction(Pull::Up);
-
-        input.connect_to(pin.reborrow());
-
-        *guard = OutputConnection::connect_with_guard(pin, output);
-    }
-
-    /// Writes bytes to slave with address `address`
-    /// ```rust, no_run
-    #[doc = crate::before_snippet!()]
-    /// # use esp_hal::i2c::master::{Config, I2c};
-    /// # let mut i2c = I2c::new(
-    /// #   peripherals.I2C0,
-    /// #   Config::default(),
-    /// # )?;
-    /// # const DEVICE_ADDR: u8 = 0x77;
-    /// i2c.write(DEVICE_ADDR, &[0xaa])?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn write<A: Into<I2cAddress>>(&mut self, address: A, buffer: &[u8]) -> Result<(), Error> {
-        self.driver()
-            .write_blocking(address.into(), buffer, true, true)
-            .inspect_err(|_| self.internal_recover())
-    }
-
-    /// Reads enough bytes from slave with `address` to fill `buffer`
-    /// ```rust, no_run
-    #[doc = crate::before_snippet!()]
-    /// # use esp_hal::i2c::master::{Config, I2c};
-    /// # let mut i2c = I2c::new(
-    /// #   peripherals.I2C0,
-    /// #   Config::default(),
-    /// # )?;
-    /// # const DEVICE_ADDR: u8 = 0x77;
-    /// let mut data = [0u8; 22];
-    /// i2c.read(DEVICE_ADDR, &mut data)?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    /// 
-    /// # Errors
-    ///
-    /// The corresponding error variant from [`Error`] will be returned if the passed buffer has zero length.
-    pub fn read<A: Into<I2cAddress>>(
-        &mut self,
-        address: A,
-        buffer: &mut [u8],
-    ) -> Result<(), Error> {
-        self.driver()
-            .read_blocking(address.into(), buffer, true, true, false)
-            .inspect_err(|_| self.internal_recover())
-    }
-
-    /// Writes bytes to slave with address `address` and then reads enough bytes
-    /// to fill `buffer` *in a single transaction*
-    /// ```rust, no_run
-    #[doc = crate::before_snippet!()]
-    /// # use esp_hal::i2c::master::{Config, I2c};
-    /// # let mut i2c = I2c::new(
-    /// #   peripherals.I2C0,
-    /// #   Config::default(),
-    /// # )?;
-    /// # const DEVICE_ADDR: u8 = 0x77;
-    /// let mut data = [0u8; 22];
-    /// i2c.write_read(DEVICE_ADDR, &[0xaa], &mut data)?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    /// 
-    /// # Errors
-    ///
-    /// The corresponding error variant from [`Error`] will be returned if the passed buffer has zero length.
-    pub fn write_read<A: Into<I2cAddress>>(
-        &mut self,
-        address: A,
-        write_buffer: &[u8],
-        read_buffer: &mut [u8],
-    ) -> Result<(), Error> {
-        let address = address.into();
-
-        self.driver()
-            .write_blocking(address, write_buffer, true, read_buffer.is_empty())
-            .inspect_err(|_| self.internal_recover())?;
-
-        self.driver()
-            .read_blocking(address, read_buffer, true, true, false)
-            .inspect_err(|_| self.internal_recover())?;
-
-        Ok(())
-    }
-
-    /// Execute the provided operations on the I2C bus.
-    ///
-    /// Transaction contract:
-    /// - Before executing the first operation an ST is sent automatically. This
-    ///   is followed by SAD+R/W as appropriate.
-    /// - Data from adjacent operations of the same type are sent after each
-    ///   other without an SP or SR.
-    /// - Between adjacent operations of a different type an SR and SAD+R/W is
-    ///   sent.
-    /// - After executing the last operation an SP is sent automatically.
-    /// - If the last operation is a `Read` the master does not send an
-    ///   acknowledge for the last byte.
-    ///
-    /// - `ST` = start condition
-    /// - `SAD+R/W` = slave address followed by bit 1 to indicate reading or 0
-    ///   to indicate writing
-    /// - `SR` = repeated start condition
-    /// - `SP` = stop condition
-    ///
-    /// ```rust, no_run
-    #[doc = crate::before_snippet!()]
-    /// # use esp_hal::i2c::master::{Config, I2c, Operation};
-    /// # let mut i2c = I2c::new(
-    /// #   peripherals.I2C0,
-    /// #   Config::default(),
-    /// # )?;
-    /// # const DEVICE_ADDR: u8 = 0x77;
-    /// let mut data = [0u8; 22];
-    /// i2c.transaction(
-    ///     DEVICE_ADDR,
-    ///     &mut [Operation::Write(&[0xaa]), Operation::Read(&mut data)]
-    /// )?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    #[cfg_attr(
-        any(esp32, esp32s2),
-        doc = "\n\nOn ESP32 and ESP32-S2 it is advisable to not combine large read/write operations with small (<3 bytes) read/write operations.\n\n"
-    )]
-    /// # Errors
-    ///
-    /// The corresponding error variant from [`Error`] will be returned if the
-    /// buffer passed to an [`Operation`] has zero length.
-    pub fn transaction<'a, A: Into<I2cAddress>>(
-        &mut self,
-        address: A,
-        operations: impl IntoIterator<Item = &'a mut Operation<'a>>,
-    ) -> Result<(), Error> {
-        self.transaction_impl(address.into(), operations.into_iter().map(Operation::from))
-            .inspect_err(|_| self.internal_recover())
-    }
-}
-
 impl<'d> I2c<'d, Blocking> {
     /// Create a new I2C instance.
     ///
@@ -764,6 +503,20 @@ impl<'d> I2c<'d, Blocking> {
         i2c.driver().setup(&i2c.config)?;
 
         Ok(i2c)
+    }
+
+    /// Configures the I2C peripheral to operate in asynchronous mode.
+    pub fn into_async(mut self) -> I2c<'d, Async> {
+        self.set_interrupt_handler(self.driver().info.async_handler);
+
+        I2c {
+            i2c: self.i2c,
+            phantom: PhantomData,
+            config: self.config,
+            guard: self.guard,
+            sda_pin: self.sda_pin,
+            scl_pin: self.scl_pin,
+        }
     }
 
     #[cfg_attr(
@@ -812,20 +565,6 @@ impl<'d> I2c<'d, Blocking> {
     #[instability::unstable]
     pub fn clear_interrupts(&mut self, interrupts: EnumSet<Event>) {
         self.i2c.info().clear_interrupts(interrupts)
-    }
-
-    /// Configures the I2C peripheral to operate in asynchronous mode.
-    pub fn into_async(mut self) -> I2c<'d, Async> {
-        self.set_interrupt_handler(self.driver().info.async_handler);
-
-        I2c {
-            i2c: self.i2c,
-            phantom: PhantomData,
-            config: self.config,
-            guard: self.guard,
-            sda_pin: self.sda_pin,
-            scl_pin: self.scl_pin,
-        }
     }
 }
 
@@ -1104,6 +843,267 @@ impl<'d> I2c<'d, Async> {
             last_op = Some(kind);
         }
 
+        Ok(())
+    }
+}
+
+impl<'d, Dm> I2c<'d, Dm>
+where
+    Dm: DriverMode,
+{
+    fn driver(&self) -> Driver<'_> {
+        Driver {
+            info: self.i2c.info(),
+            state: self.i2c.state(),
+        }
+    }
+
+    fn internal_recover(&self) {
+        PeripheralClockControl::disable(self.driver().info.peripheral);
+        PeripheralClockControl::enable(self.driver().info.peripheral);
+        PeripheralClockControl::reset(self.driver().info.peripheral);
+
+        // We know the configuration is valid, we can ignore the result.
+        _ = self.driver().setup(&self.config);
+    }
+
+    fn transaction_impl<'a>(
+        &mut self,
+        address: I2cAddress,
+        operations: impl Iterator<Item = Operation<'a>>,
+    ) -> Result<(), Error> {
+        let mut last_op: Option<OpKind> = None;
+        // filter out 0 length read operations
+        let mut op_iter = operations
+            .filter(|op| op.is_write() || !op.is_empty())
+            .peekable();
+
+        while let Some(op) = op_iter.next() {
+            let next_op = op_iter.peek().map(|v| v.kind());
+            let kind = op.kind();
+            match op {
+                Operation::Write(buffer) => {
+                    // execute a write operation:
+                    // - issue START/RSTART if op is different from previous
+                    // - issue STOP if op is the last one
+                    self.driver().write_blocking(
+                        address,
+                        buffer,
+                        !matches!(last_op, Some(OpKind::Write)),
+                        next_op.is_none(),
+                    )?;
+                }
+                Operation::Read(buffer) => {
+                    // execute a read operation:
+                    // - issue START/RSTART if op is different from previous
+                    // - issue STOP if op is the last one
+                    // - will_continue is true if there is another read operation next
+                    self.driver().read_blocking(
+                        address,
+                        buffer,
+                        !matches!(last_op, Some(OpKind::Read)),
+                        next_op.is_none(),
+                        matches!(next_op, Some(OpKind::Read)),
+                    )?;
+                }
+            }
+
+            last_op = Some(kind);
+        }
+
+        Ok(())
+    }
+
+    /// Connect a pin to the I2C SDA signal.
+    ///
+    /// This will replace previous pin assignments for this signal.
+    pub fn with_sda(mut self, sda: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+        let info = self.driver().info;
+        let input = info.sda_input;
+        let output = info.sda_output;
+        Self::connect_pin(sda, input, output, &mut self.sda_pin);
+
+        self
+    }
+
+    /// Connect a pin to the I2C SCL signal.
+    ///
+    /// This will replace previous pin assignments for this signal.
+    pub fn with_scl(mut self, scl: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+        let info = self.driver().info;
+        let input = info.scl_input;
+        let output = info.scl_output;
+        Self::connect_pin(scl, input, output, &mut self.scl_pin);
+
+        self
+    }
+
+    fn connect_pin(
+        pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        input: InputSignal,
+        output: OutputSignal,
+        guard: &mut PinGuard,
+    ) {
+        crate::into_mapped_ref!(pin);
+        // avoid the pin going low during configuration
+        pin.set_output_high(true);
+
+        pin.set_to_open_drain_output();
+        pin.enable_input(true);
+        pin.pull_direction(Pull::Up);
+
+        input.connect_to(pin.reborrow());
+
+        *guard = OutputConnection::connect_with_guard(pin, output);
+    }
+
+    /// Writes bytes to slave with address `address`
+    /// ```rust, no_run
+    #[doc = crate::before_snippet!()]
+    /// # use esp_hal::i2c::master::{Config, I2c};
+    /// # let mut i2c = I2c::new(
+    /// #   peripherals.I2C0,
+    /// #   Config::default(),
+    /// # )?;
+    /// # const DEVICE_ADDR: u8 = 0x77;
+    /// i2c.write(DEVICE_ADDR, &[0xaa])?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn write<A: Into<I2cAddress>>(&mut self, address: A, buffer: &[u8]) -> Result<(), Error> {
+        self.driver()
+            .write_blocking(address.into(), buffer, true, true)
+            .inspect_err(|_| self.internal_recover())
+    }
+
+    /// Reads enough bytes from slave with `address` to fill `buffer`
+    /// ```rust, no_run
+    #[doc = crate::before_snippet!()]
+    /// # use esp_hal::i2c::master::{Config, I2c};
+    /// # let mut i2c = I2c::new(
+    /// #   peripherals.I2C0,
+    /// #   Config::default(),
+    /// # )?;
+    /// # const DEVICE_ADDR: u8 = 0x77;
+    /// let mut data = [0u8; 22];
+    /// i2c.read(DEVICE_ADDR, &mut data)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// 
+    /// # Errors
+    ///
+    /// The corresponding error variant from [`Error`] will be returned if the passed buffer has zero length.
+    pub fn read<A: Into<I2cAddress>>(
+        &mut self,
+        address: A,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        self.driver()
+            .read_blocking(address.into(), buffer, true, true, false)
+            .inspect_err(|_| self.internal_recover())
+    }
+
+    /// Writes bytes to slave with address `address` and then reads enough bytes
+    /// to fill `buffer` *in a single transaction*
+    /// ```rust, no_run
+    #[doc = crate::before_snippet!()]
+    /// # use esp_hal::i2c::master::{Config, I2c};
+    /// # let mut i2c = I2c::new(
+    /// #   peripherals.I2C0,
+    /// #   Config::default(),
+    /// # )?;
+    /// # const DEVICE_ADDR: u8 = 0x77;
+    /// let mut data = [0u8; 22];
+    /// i2c.write_read(DEVICE_ADDR, &[0xaa], &mut data)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// 
+    /// # Errors
+    ///
+    /// The corresponding error variant from [`Error`] will be returned if the passed buffer has zero length.
+    pub fn write_read<A: Into<I2cAddress>>(
+        &mut self,
+        address: A,
+        write_buffer: &[u8],
+        read_buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        let address = address.into();
+
+        self.driver()
+            .write_blocking(address, write_buffer, true, read_buffer.is_empty())
+            .inspect_err(|_| self.internal_recover())?;
+
+        self.driver()
+            .read_blocking(address, read_buffer, true, true, false)
+            .inspect_err(|_| self.internal_recover())?;
+
+        Ok(())
+    }
+
+    /// Execute the provided operations on the I2C bus.
+    ///
+    /// Transaction contract:
+    /// - Before executing the first operation an ST is sent automatically. This
+    ///   is followed by SAD+R/W as appropriate.
+    /// - Data from adjacent operations of the same type are sent after each
+    ///   other without an SP or SR.
+    /// - Between adjacent operations of a different type an SR and SAD+R/W is
+    ///   sent.
+    /// - After executing the last operation an SP is sent automatically.
+    /// - If the last operation is a `Read` the master does not send an
+    ///   acknowledge for the last byte.
+    ///
+    /// - `ST` = start condition
+    /// - `SAD+R/W` = slave address followed by bit 1 to indicate reading or 0
+    ///   to indicate writing
+    /// - `SR` = repeated start condition
+    /// - `SP` = stop condition
+    ///
+    /// ```rust, no_run
+    #[doc = crate::before_snippet!()]
+    /// # use esp_hal::i2c::master::{Config, I2c, Operation};
+    /// # let mut i2c = I2c::new(
+    /// #   peripherals.I2C0,
+    /// #   Config::default(),
+    /// # )?;
+    /// # const DEVICE_ADDR: u8 = 0x77;
+    /// let mut data = [0u8; 22];
+    /// i2c.transaction(
+    ///     DEVICE_ADDR,
+    ///     &mut [Operation::Write(&[0xaa]), Operation::Read(&mut data)]
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    #[cfg_attr(
+        any(esp32, esp32s2),
+        doc = "\n\nOn ESP32 and ESP32-S2 it is advisable to not combine large read/write operations with small (<3 bytes) read/write operations.\n\n"
+    )]
+    /// # Errors
+    ///
+    /// The corresponding error variant from [`Error`] will be returned if the
+    /// buffer passed to an [`Operation`] has zero length.
+    pub fn transaction<'a, A: Into<I2cAddress>>(
+        &mut self,
+        address: A,
+        operations: impl IntoIterator<Item = &'a mut Operation<'a>>,
+    ) -> Result<(), Error> {
+        self.transaction_impl(address.into(), operations.into_iter().map(Operation::from))
+            .inspect_err(|_| self.internal_recover())
+    }
+
+    /// Applies a new configuration.
+    ///
+    /// # Errors
+    ///
+    /// A [`ConfigError`] variant will be returned if bus frequency or timeout
+    /// passed in config is invalid.
+    pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
+        self.driver().setup(config)?;
+        self.config = *config;
         Ok(())
     }
 }

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1532,6 +1532,11 @@ where
         self.tx.write(data)
     }
 
+    /// Flush the transmit buffer of the UART
+    pub fn flush(&mut self) -> Result<(), TxError> {
+        self.tx.flush()
+    }
+
     /// Read received bytes.
     ///
     /// The UART hardware continuously receives bytes and stores them in the RX
@@ -1551,11 +1556,6 @@ where
     /// the FIFO are not modified.
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, RxError> {
         self.rx.read(buf)
-    }
-
-    /// Flush the transmit buffer of the UART
-    pub fn flush(&mut self) -> Result<(), TxError> {
-        self.tx.flush()
     }
 
     /// Change the configuration.

--- a/esp-lp-hal/src/i2c.rs
+++ b/esp-lp-hal/src/i2c.rs
@@ -187,8 +187,8 @@ pub struct LpI2c {
 }
 
 impl LpI2c {
-    /// Writes bytes to slave with address `addr`
-    pub fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+    /// Writes bytes to slave with given `address`
+    pub fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Error> {
         let mut cmd_iterator = CommandRegister::COMD0;
 
         // If SCL is busy, reset the Master FSM
@@ -206,7 +206,7 @@ impl LpI2c {
         self.add_cmd_lp(&mut cmd_iterator, Command::Start)?;
 
         // Load device address and R/W bit into FIFO
-        self.write_fifo((addr << 1) | OperationType::Write as u8);
+        self.write_fifo((address << 1) | OperationType::Write as u8);
 
         self.add_cmd_lp(
             &mut cmd_iterator,
@@ -273,8 +273,8 @@ impl LpI2c {
         Ok(())
     }
 
-    /// Reads enough bytes from slave with `addr` to fill `buffer`
-    pub fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
+    /// Reads enough bytes from slave with given `address` to fill `buffer`
+    pub fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
         // Check size constraints
         if buffer.len() > 254 {
             return Err(Error::ExceedingFifo);
@@ -285,7 +285,7 @@ impl LpI2c {
         self.add_cmd_lp(&mut cmd_iterator, Command::Start)?;
 
         // Load device address
-        self.write_fifo((addr << 1) | OperationType::Read as u8);
+        self.write_fifo((address << 1) | OperationType::Read as u8);
 
         self.add_cmd_lp(
             &mut cmd_iterator,
@@ -372,14 +372,19 @@ impl LpI2c {
         Ok(())
     }
 
-    /// Writes bytes to slave with address `addr` and then reads enough bytes
+    /// Writes bytes to slave with given `address` and then reads enough bytes
     /// to fill `buffer` *in a single transaction*
-    pub fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
+    pub fn write_read(
+        &mut self,
+        address: u8,
+        bytes: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
         // It would be possible to combine the write and read in one transaction, but
         // filling the tx fifo with the current code is somewhat slow even in release
         // mode which can cause issues.
-        self.write(addr, bytes)?;
-        self.read(addr, buffer)?;
+        self.write(address, bytes)?;
+        self.read(address, buffer)?;
 
         Ok(())
     }


### PR DESCRIPTION
`I2c`: Make `Blocking` impl visible first in docs
`uart`: Reorder `write` and `flush` methods so they are grouped together

cc https://github.com/esp-rs/esp-hal/issues/3180