### PR TITLE
Fix off-by-one in the allowed range of the spi clock calculations

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32/ESP32-S2: Avoid running into timeouts with reads/writes larger than the FIFO (#3199)
 
 - ESP32-C6: Keep ADC enabled to improve radio signal strength (#3249)
+- Fix off-by-one in the allowed range of the spi clock calculations (#3266)
 
 ### Removed
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -540,7 +540,7 @@ impl Config {
             // Start at n = 2. We need to be able to set h/l so we have at least
             // one high and one low pulse.
 
-            for n in 2..64 {
+            for n in 2..=64 {
                 // Effectively, this does:
                 // pre = round((APB_CLK_FREQ / n) / frequency)
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -539,8 +539,8 @@ impl Config {
             let mut besterr: i32 = 0;
             let mut errval: i32;
 
-            let raw_freq = self.frequency.as_hz() as i32;
-            let raw_apb_freq = source_freq.as_hz() as i32;
+            let target_freq_hz = self.frequency.as_hz() as i32;
+            let source_freq_hz = source_freq.as_hz() as i32;
 
             // Start at n = 2. We need to be able to set h/l so we have at least
             // one high and one low pulse.
@@ -549,7 +549,7 @@ impl Config {
                 // Effectively, this does:
                 // pre = round((APB_CLK_FREQ / n) / frequency)
 
-                pre = ((raw_apb_freq / n) + (raw_freq / 2)) / raw_freq;
+                pre = ((source_freq_hz / n) + (target_freq_hz / 2)) / target_freq_hz;
 
                 if pre <= 0 {
                     pre = 1;
@@ -559,7 +559,7 @@ impl Config {
                     pre = 16;
                 }
 
-                errval = (raw_apb_freq / (pre * n) - raw_freq).abs();
+                errval = (source_freq_hz / (pre * n) - target_freq_hz).abs();
                 if bestn == -1 || errval <= besterr {
                     besterr = errval;
                     bestn = n;

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -498,18 +498,23 @@ impl Config {
         self
     }
 
-    fn recalculate(&self) -> Result<u32, ConfigError> {
-        // taken from https://github.com/apache/incubator-nuttx/blob/8267a7618629838231256edfa666e44b5313348e/arch/risc-v/src/esp32c3/esp32c3_spi.c#L496
-
+    fn clock_source_freq_hz(&self) -> Rate {
         let clocks = Clocks::get();
+
+        // FIXME: take clock source into account
         cfg_if::cfg_if! {
             if #[cfg(esp32h2)] {
                 // ESP32-H2 is using PLL_48M_CLK source instead of APB_CLK
-                let apb_clk_freq = clocks.pll_48m_clock;
+                clocks.pll_48m_clock
             } else {
-                let apb_clk_freq = clocks.apb_clock;
+                clocks.apb_clock
             }
         }
+    }
+
+    fn recalculate(&self) -> Result<u32, ConfigError> {
+        // taken from https://github.com/apache/incubator-nuttx/blob/8267a7618629838231256edfa666e44b5313348e/arch/risc-v/src/esp32c3/esp32c3_spi.c#L496
+        let source_freq = self.clock_source_freq_hz();
 
         let reg_val: u32;
         let duty_cycle = 128;
@@ -517,7 +522,7 @@ impl Config {
         // In HW, n, h and l fields range from 1 to 64, pre ranges from 1 to 8K.
         // The value written to register is one lower than the used value.
 
-        if self.frequency > ((apb_clk_freq / 4) * 3) {
+        if self.frequency > ((source_freq / 4) * 3) {
             // Using APB frequency directly will give us the best result here.
             reg_val = 1 << 31;
         } else {
@@ -535,7 +540,7 @@ impl Config {
             let mut errval: i32;
 
             let raw_freq = self.frequency.as_hz() as i32;
-            let raw_apb_freq = apb_clk_freq.as_hz() as i32;
+            let raw_apb_freq = source_freq.as_hz() as i32;
 
             // Start at n = 2. We need to be able to set h/l so we have at least
             // one high and one low pulse.
@@ -588,17 +593,17 @@ impl Config {
     }
 
     fn validate(&self) -> Result<(), ConfigError> {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32h2)] {
-                if self.frequency < Rate::from_khz(70) || self.frequency > Rate::from_mhz(48) {
-                    return Err(ConfigError::UnsupportedFrequency);
-                }
-            } else {
-                if self.frequency < Rate::from_khz(70) || self.frequency > Rate::from_mhz(80) {
-                    return Err(ConfigError::UnsupportedFrequency);
-                }
-            }
+        let source_freq = self.clock_source_freq_hz();
+        let min_divider = 1;
+        // FIXME: while ESP32 and S2 support pre dividers as large as 8192,
+        // those values are not currently supported by the divider calculation.
+        let max_divider = 16 * 64; // n * pre
+
+        if self.frequency < source_freq / max_divider || self.frequency > source_freq / min_divider
+        {
+            return Err(ConfigError::UnsupportedFrequency);
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The actual clock value is `apb_clk/(SPI_CLKDIV_PRE + 1)/(SPI_CLKCNT_N + 1)`. The loop in question tries to brute-force a value for `SPI_CLKCNT_N`, however the `+1` is corrected later in the code, which means that the valid range for `n` in this loop is `1..=64`. However there is also an earlier check earlier, that guarantees that `n=1` would never be an optimal choice.

This also matches the behavior from `apache/incubator-nuttx` which this code was inspired by.

#### Testing
I have run this code before and after the change:

```rust
    let spi_config = spi::master::Config::default().with_frequency(Rate::from_hz(78125));
    println!("spi_config = {spi_config:?}");
```

Before this change, the values were `SPI_CLKDIV_PRE=15, SPI_CLKDIV_N=62`, after this change the values were `SPI_CLKDIV_PRE=15, SPI_CLKDIV_N=63`.