### PR TITLE
Fix esp-backtrace stopping at recursion

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stack traces no longer stop at recursive functions (#3270)
+
 ### Removed
 
 ## [0.15.1] - 2025-02-24

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -189,18 +189,11 @@ pub(crate) fn backtrace_internal(
         return result;
     }
 
-    let mut old_address = 0;
     while index < result.len() {
         // RA/PC
         let address = unsafe { (fp as *const u32).offset(-1).read_volatile() };
         // next FP
         fp = unsafe { (fp as *const u32).offset(-2).read_volatile() };
-
-        if old_address == address {
-            break;
-        }
-
-        old_address = address;
 
         if address == 0 {
             break;

--- a/esp-backtrace/src/xtensa.rs
+++ b/esp-backtrace/src/xtensa.rs
@@ -386,19 +386,12 @@ pub(crate) fn backtrace_internal(
         return result;
     }
 
-    let mut old_address = 0;
     while index < result.len() {
         // RA/PC
         let address = unsafe { (fp as *const u32).offset(-4).read_volatile() };
         let address = remove_window_increment(address);
         // next FP
         fp = unsafe { (fp as *const u32).offset(-3).read_volatile() };
-
-        if old_address == address {
-            break;
-        }
-
-        old_address = address;
 
         // the return address is 0 but we sanitized the address - then 0 becomes
         // 0x40000000


### PR DESCRIPTION
Previously we stopped capturing a backtrace if the PC did not change. That is not correct.