### PR TITLE
esp-backtrace: allow configuring stack trace length

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The length of the stack trace can now be configured using `ESP_BACKTRACE_CONFIG_BACKTRACE_FRAMES` (#3271)
+
 ### Changed
 
 ### Fixed

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -17,11 +17,13 @@ features       = ["esp32c3", "panic-handler", "exception-handler", "println", "e
 [dependencies]
 cfg-if      = "1.0.0"
 defmt       = { version = "0.3.10", optional = true }
+esp-config  = { version = "0.3.0", path = "../esp-config" }
 esp-println = { version = "0.13.0", optional = true, default-features = false, path = "../esp-println" }
 semihosting = { version = "0.1.18", optional = true }
 
 [build-dependencies]
 esp-build = { version = "0.2.0", path = "../esp-build" }
+esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
 
 [features]
 default = ["colors"]

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -1,4 +1,5 @@
 use esp_build::assert_unique_used_features;
+use esp_config::{generate_config, Value};
 
 fn main() {
     // Ensure that only a single chip is specified:
@@ -12,4 +13,16 @@ fn main() {
     if cfg!(feature = "custom-halt") && cfg!(feature = "halt-cores") {
         panic!("Only one of `custom-halt` and `halt-cores` can be enabled");
     }
+
+    // emit config
+    generate_config(
+        "esp_backtrace",
+        &[(
+            "backtrace-frames",
+            "The maximum number of frames that will be printed in a backtrace",
+            Value::Integer(10),
+            None,
+        )],
+        true,
+    );
 }

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -9,7 +9,8 @@ use defmt as _;
 #[cfg(feature = "println")]
 use esp_println as _;
 
-const MAX_BACKTRACE_ADDRESSES: usize = 10;
+const MAX_BACKTRACE_ADDRESSES: usize =
+    esp_config::esp_config_int!(usize, "ESP_BACKTRACE_CONFIG_BACKTRACE_FRAMES");
 
 const RESET: &str = "\u{001B}[0m";
 const RED: &str = "\u{001B}[31m";


### PR DESCRIPTION
This is techincally in violation of https://github.com/esp-rs/esp-hal/issues/2509 but I see no way around that other than returning an opaque object that just allows iterating over backtraces. Might still do that, it's cleaner than an array of Options.