### PR TITLE
esp-wifi: Remove `libm` dependency

### DIFF
--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -32,7 +32,6 @@ num-traits = { version = "0.2.19", default-features = false }
 esp-wifi-sys = "0.7.1"
 embassy-sync = { version = "0.6.2", optional = true }
 embassy-net-driver = { version = "0.2.0", optional = true }
-libm = "0.2.11"
 cfg-if = "1.0.0"
 portable-atomic = { version = "1.11.0", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }

--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -299,15 +299,6 @@ pub unsafe extern "C" fn strrchr(_s: *const (), _c: u32) -> *const u8 {
     todo!("strrchr");
 }
 
-// this will result in a duplicate symbol error once `floor` is available
-// ideally we would use weak linkage but that is not stabilized
-// see https://github.com/esp-rs/esp-wifi/pull/191
-#[cfg(feature = "esp32c6")]
-#[no_mangle]
-pub unsafe extern "C" fn floor(v: f64) -> f64 {
-    libm::floor(v)
-}
-
 static PHY_CLOCK_ENABLE_REF: AtomicU32 = AtomicU32::new(0);
 
 pub(crate) unsafe fn phy_enable_clock() {


### PR DESCRIPTION
With commented code and example built for esp32c6:
```
nm wifi_embassy_dhcp | rustfilt | grep "floor"
4205db52 t compiler_builtins::math::libm::floor::floor
4205dc58 t floor
4000139c A noise_floor_auto_set
4080b412 T noise_floor_auto_set_new
400013a0 A read_hw_noisefloor
```
with that code present
```
nm wifi_embassy_dhcp | rustfilt | grep "floor"
420457f8 t floor
4000139c A noise_floor_auto_set
4080b412 T noise_floor_auto_set_new
400013a0 A read_hw_noisefloor
```

## Motivation:
It already should be in [compiler-builtins](https://github.com/rust-lang/compiler-builtins/blob/7bec089672eb5cd83d7902edd59479527bc9d8d1/src/math.rs#L53)

It can cause [compile errors](https://github.com/esp-rs/esp-hal/actions/runs/13896070905/job/38876882734?pr=3265#step:9:205)