### PR TITLE
Provide config information in machine readable format

### DIFF
--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -10,10 +10,12 @@ license       = "MIT OR Apache-2.0"
 
 [dependencies]
 document-features = "0.2.10"
+serde = { version = "1.0.197", features = ["derive"], optional = true }
+serde_json = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 temp-env = "0.3.6"
 
 [features]
 ## Enable the generation and parsing of a config
-build = []
+build = ["dep:serde","dep:serde_json"]

--- a/esp-config/src/generate.rs
+++ b/esp-config/src/generate.rs
@@ -174,7 +174,7 @@ fn serialize_custom<S>(
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str("Unknown")
+    serializer.serialize_str("Custom")
 }
 
 impl Validator {

--- a/esp-config/src/generate.rs
+++ b/esp-config/src/generate.rs
@@ -423,14 +423,16 @@ fn write_config_json(
         })
     }
 
-    let json = serde_json::to_string(&to_write).unwrap();
-
-    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    let out_file = out_dir
-        .join(format!("{crate_name}_config_data.json"))
-        .display()
-        .to_string();
-    fs::write(out_file, json).unwrap();
+    #[cfg(not(test))]
+    {
+        let json = serde_json::to_string(&to_write).unwrap();
+        let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        let out_file = out_dir
+            .join(format!("{crate_name}_config_data.json"))
+            .display()
+            .to_string();
+        fs::write(out_file, json).unwrap();
+    }
 }
 
 // A work-around for https://github.com/rust-lang/cargo/issues/10358


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
In preparation of https://github.com/esp-rs/esp-generate/issues/12

This serializes the config as JSON (in addition to the MD files generated).

`skip-changelog` since it's not user facing

#### Testing
Have a look for `*_config_data.json` files in the target directory
