### PR TITLE
Quality of life improvements

### DIFF
--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -13,6 +13,23 @@ use esp_config::{generate_config, Validator, Value};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
+    if ![
+        "xtensa-esp32-none-elf",
+        "xtensa-esp32s2-none-elf",
+        "xtensa-esp32s3-none-elf",
+        "riscv32imc-unknown-none-elf",
+        "riscv32imac-unknown-none-elf",
+    ]
+    .contains(&std::env::var("TARGET").unwrap_or_default().as_str())
+    {
+        panic!("
+        Seems you are building for an unsupported targe (e.g. the host environment).
+        Maybe you are missing the the `target` in `.cargo/config.toml` or you have configs overriding it?
+        
+        See https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
+        ");
+    }
+
     println!("cargo:rustc-check-cfg=cfg(is_debug_build)");
     if let Ok(level) = std::env::var("OPT_LEVEL") {
         if level == "0" || level == "1" {

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -9,7 +9,7 @@
 //! - CS   => GPIO5
 //!
 //! The following wiring is assumed for ESP32:
-//! - SCLK => GPIO0
+//! - SCLK => GPIO12
 //! - MISO => GPIO2
 //! - MOSI => GPIO4
 //! - IO2  => GPIO5
@@ -49,7 +49,7 @@ fn main() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let sclk = peripherals.GPIO0;
+            let sclk = peripherals.GPIO12;
             let miso = peripherals.GPIO2;
             let mosi = peripherals.GPIO4;
             let sio2 = peripherals.GPIO5;

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -9,7 +9,7 @@
 //! - CS          =>  GPIO5
 //!
 //! The following wiring is assumed for ESP32:
-//! - SCLK        =>  GPIO0
+//! - SCLK        =>  GPIO12
 //! - MISO/IO0    =>  GPIO2
 //! - MOSI/IO1    =>  GPIO4
 //! - IO2         =>  GPIO5
@@ -48,7 +48,7 @@ fn main() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let sclk = peripherals.GPIO0;
+            let sclk = peripherals.GPIO12;
             let miso = peripherals.GPIO2;
             let mosi = peripherals.GPIO4;
             let sio2 = peripherals.GPIO5;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This is really two unrelated things, but I don't think it's worth to split the PR (but can do, if requested)

We previously discovered that the QSPI related qa-tests fail on some ESP32 dev-kits because GPIO0 was used as SCLK - pretty sure we will forget about that soon - so better to change it

We had multiple issues (on GitHub and Matrix) when users accidentally tried to build for the host - lets be more helpful than what we can see in e.g. #3278 

It now looks like this
```
   Compiling esp-hal v1.0.0-beta.0 (D:\projects\esp\esp-hal\esp-hal)
error: failed to run custom build command for `esp-hal v1.0.0-beta.0 (D:\projects\esp\esp-hal\esp-hal)`

Caused by:
  process didn't exit successfully: `d:\projects\testing\failtesting\target\debug\build\esp-hal-538c4eb09c86e1cf\build-script-build` (exit code: 101)
  --- stderr
  thread 'main' panicked at D:\projects\esp\esp-hal\esp-hal\build.rs:25:9:

          Seems you are building for an unsupported targe (e.g. the host environment).
          Maybe you are missing the the `target` in `.cargo/config.toml` or you have configs overriding it?

          See https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure

  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
err process exited unsuccessfully: exit code: 101

```

I guess we can have `skip-changelog` for this

#### Testing
See above
