### PR TITLE
Miniscule interrupt handler optimizations

### DIFF
--- a/esp-hal/ld/esp32/esp32.x
+++ b/esp-hal/ld/esp32/esp32.x
@@ -8,10 +8,6 @@ PROVIDE(__zero_bss = default_mem_hook);
 PROVIDE(__init_data = default_mem_hook);
 PROVIDE(__post_init = default_post_init);
 
-PROVIDE(__level_1_interrupt = handle_interrupts);
-PROVIDE(__level_2_interrupt = handle_interrupts);
-PROVIDE(__level_3_interrupt = handle_interrupts);
-
 INCLUDE exception.x
 
 /* ESP32 fixups */

--- a/esp-hal/ld/esp32s2/esp32s2.x
+++ b/esp-hal/ld/esp32s2/esp32s2.x
@@ -8,10 +8,6 @@ PROVIDE(__zero_bss = default_mem_hook);
 PROVIDE(__init_data = default_mem_hook);
 PROVIDE(__post_init = default_post_init);
 
-PROVIDE(__level_1_interrupt = handle_interrupts);
-PROVIDE(__level_2_interrupt = handle_interrupts);
-PROVIDE(__level_3_interrupt = handle_interrupts);
-
 INCLUDE exception.x
 
 /* This represents .rwtext but in .data */

--- a/esp-hal/ld/esp32s3/esp32s3.x
+++ b/esp-hal/ld/esp32s3/esp32s3.x
@@ -7,10 +7,6 @@ PROVIDE(__zero_bss = default_mem_hook);
 PROVIDE(__init_data = default_mem_hook);
 PROVIDE(__post_init = default_post_init);
 
-PROVIDE(__level_1_interrupt = handle_interrupts);
-PROVIDE(__level_2_interrupt = handle_interrupts);
-PROVIDE(__level_3_interrupt = handle_interrupts);
-
 INCLUDE exception.x
 
 SECTIONS {

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -198,13 +198,13 @@ impl InterruptStatus {
     }
 
     /// Is the given interrupt bit set
-    pub fn is_set(&self, interrupt: u16) -> bool {
-        (self.status[interrupt as usize / 32] & (1 << (interrupt as u32 % 32))) != 0
+    pub fn is_set(&self, interrupt: u8) -> bool {
+        (self.status[interrupt as usize / 32] & (1 << (interrupt % 32))) != 0
     }
 
     /// Set the given interrupt status bit
-    pub fn set(&mut self, interrupt: u16) {
-        self.status[interrupt as usize / 32] |= 1 << (interrupt as u32 % 32);
+    pub fn set(&mut self, interrupt: u8) {
+        self.status[interrupt as usize / 32] |= 1 << (interrupt % 32);
     }
 
     /// Return an iterator over the set interrupt status bits

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -85,13 +85,6 @@ mod xtensa;
 
 pub mod software;
 
-#[cfg(xtensa)]
-#[no_mangle]
-extern "C" fn EspDefaultHandler(_interrupt: crate::peripherals::Interrupt) {
-    panic!("Unhandled interrupt: {:?}", _interrupt);
-}
-
-#[cfg(riscv)]
 #[no_mangle]
 extern "C" fn EspDefaultHandler(_interrupt: crate::peripherals::Interrupt) {
     panic!("Unhandled interrupt: {:?}", _interrupt);

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -87,8 +87,8 @@ pub mod software;
 
 #[cfg(xtensa)]
 #[no_mangle]
-extern "C" fn EspDefaultHandler(_level: u32, _interrupt: crate::peripherals::Interrupt) {
-    panic!("Unhandled level {} interrupt: {:?}", _level, _interrupt);
+extern "C" fn EspDefaultHandler(_interrupt: crate::peripherals::Interrupt) {
+    panic!("Unhandled interrupt: {:?}", _interrupt);
 }
 
 #[cfg(riscv)]

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -653,7 +653,9 @@ mod classic {
     #[link_section = ".trap"]
     pub(super) unsafe extern "C" fn _handle_priority() -> u32 {
         use super::mcause;
-        let interrupt_id: usize = mcause::read().code(); // MSB is whether its exception or interrupt.
+        // Both C6 and H2 have 5 bits of code. The riscv crate masks 31 bits, which then
+        // causes a bounds check to be present.
+        let interrupt_id: usize = mcause::read().bits() & 0x1f;
         let intr = INTERRUPT_CORE0::regs();
         let interrupt_priority = intr
             .cpu_int_pri(0)

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -397,7 +397,7 @@ mod vectored {
                     ))
                 {
                     if priority_by_core(core, cpu_interrupt) == priority {
-                        res.set(interrupt_nr as u16);
+                        res.set(interrupt_nr);
                     }
                 }
             }

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -621,8 +621,9 @@ mod vectored {
                 handler(save_frame);
             }
         } else {
-            let status = if (cpu_interrupt_mask & CPU_INTERRUPT_EDGE) != 0 {
-                // Next, handle edge triggered peripheral interrupts.
+            let status = if !cfg!(esp32s3) && (cpu_interrupt_mask & CPU_INTERRUPT_EDGE) != 0 {
+                // Next, handle edge triggered peripheral interrupts. Note that on the S3 all
+                // peripheral interrupts are level-triggered.
 
                 // If the interrupt is edge triggered, we need to clear the
                 // request on the CPU's side

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -474,7 +474,7 @@ mod vectored {
                 let int_level = cpu_interrupt.level() as u8 as u32;
 
                 if int_level == level {
-                    res.set(interrupt_nr as u16);
+                    res.set(interrupt_nr);
                 }
             }
 

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -561,7 +561,7 @@ mod vectored {
     #[inline]
     fn cpu_interrupt_nr_to_cpu_interrupt_handler(
         number: u32,
-    ) -> Option<unsafe extern "C" fn(u32, save_frame: &mut Context)> {
+    ) -> Option<unsafe extern "C" fn(save_frame: &mut Context)> {
         use xtensa_lx_rt::*;
         // we're fortunate that all esp variants use the same CPU interrupt layout
         Some(match number {
@@ -576,16 +576,30 @@ mod vectored {
         })
     }
 
-    // The linker script defines `__level_1_interrupt`, `__level_2_interrupt` and
-    // `__level_3_interrupt` as `handle_interrupts`
+    #[no_mangle]
+    #[ram]
+    unsafe fn __level_1_interrupt(save_frame: &mut Context) {
+        handle_interrupts::<1>(save_frame);
+    }
 
     #[no_mangle]
     #[ram]
-    unsafe fn handle_interrupts(level: u32, save_frame: &mut Context) {
+    unsafe fn __level_2_interrupt(save_frame: &mut Context) {
+        handle_interrupts::<2>(save_frame);
+    }
+
+    #[no_mangle]
+    #[ram]
+    unsafe fn __level_3_interrupt(save_frame: &mut Context) {
+        handle_interrupts::<3>(save_frame);
+    }
+
+    #[inline(always)]
+    unsafe fn handle_interrupts<const LEVEL: u32>(save_frame: &mut Context) {
         let core = Cpu::current();
 
         let cpu_interrupt_mask =
-            interrupt::get() & interrupt::get_mask() & CPU_INTERRUPT_LEVELS[level as usize];
+            interrupt::get() & interrupt::get_mask() & CPU_INTERRUPT_LEVELS[LEVEL as usize];
 
         if cpu_interrupt_mask & CPU_INTERRUPT_INTERNAL != 0 {
             // Let's handle CPU-internal interrupts (NMI, Timer, Software, Profiling).
@@ -604,7 +618,7 @@ mod vectored {
             }
 
             if let Some(handler) = cpu_interrupt_nr_to_cpu_interrupt_handler(cpu_interrupt_nr) {
-                handler(level, save_frame);
+                handler(save_frame);
             }
         } else {
             let status = if (cpu_interrupt_mask & CPU_INTERRUPT_EDGE) != 0 {
@@ -623,32 +637,28 @@ mod vectored {
                 status(core)
             };
 
-            let configured_interrupts = configured_interrupts(core, status, level);
+            let configured_interrupts = configured_interrupts(core, status, LEVEL);
             for interrupt_nr in configured_interrupts.iterator() {
                 // Don't use `Interrupt::try_from`. It's slower and placed in flash
                 let interrupt: Interrupt = unsafe { core::mem::transmute(interrupt_nr as u16) };
-                handle_interrupt(level, interrupt, save_frame);
+
+                extern "C" {
+                    // defined in each hal
+                    fn EspDefaultHandler(interrupt: Interrupt);
+                }
+
+                let handler = pac::__INTERRUPTS[interrupt as usize]._handler;
+                if core::ptr::eq(
+                    handler as *const _,
+                    EspDefaultHandler as *const unsafe extern "C" fn(),
+                ) {
+                    EspDefaultHandler(interrupt);
+                } else {
+                    let handler: fn(&mut Context) =
+                        core::mem::transmute::<unsafe extern "C" fn(), fn(&mut Context)>(handler);
+                    handler(save_frame);
+                }
             }
-        }
-    }
-
-    #[ram]
-    unsafe fn handle_interrupt(level: u32, interrupt: Interrupt, save_frame: &mut Context) {
-        extern "C" {
-            // defined in each hal
-            fn EspDefaultHandler(level: u32, interrupt: Interrupt);
-        }
-
-        let handler = pac::__INTERRUPTS[interrupt as usize]._handler;
-        if core::ptr::eq(
-            handler as *const _,
-            EspDefaultHandler as *const unsafe extern "C" fn(),
-        ) {
-            EspDefaultHandler(level, interrupt);
-        } else {
-            let handler: fn(&mut Context) =
-                core::mem::transmute::<unsafe extern "C" fn(), fn(&mut Context)>(handler);
-            handler(save_frame);
         }
     }
 
@@ -729,25 +739,25 @@ mod raw {
 
     #[no_mangle]
     #[link_section = ".rwtext"]
-    unsafe fn __level_4_interrupt(_level: u32, save_frame: &mut Context) {
+    unsafe fn __level_4_interrupt(save_frame: &mut Context) {
         level4_interrupt(save_frame)
     }
 
     #[no_mangle]
     #[link_section = ".rwtext"]
-    unsafe fn __level_5_interrupt(_level: u32, save_frame: &mut Context) {
+    unsafe fn __level_5_interrupt(save_frame: &mut Context) {
         level5_interrupt(save_frame)
     }
 
     #[no_mangle]
     #[link_section = ".rwtext"]
-    unsafe fn __level_6_interrupt(_level: u32, save_frame: &mut Context) {
+    unsafe fn __level_6_interrupt(save_frame: &mut Context) {
         level6_interrupt(save_frame)
     }
 
     #[no_mangle]
     #[link_section = ".rwtext"]
-    unsafe fn __level_7_interrupt(_level: u32, save_frame: &mut Context) {
+    unsafe fn __level_7_interrupt(save_frame: &mut Context) {
         level7_interrupt(save_frame)
     }
 }

--- a/esp-wifi/src/preempt_builtin/timer/xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/timer/xtensa.rs
@@ -77,7 +77,7 @@ extern "C" fn timer_tick_handler(_context: &mut TrapFrame) {
 #[allow(non_snake_case)]
 #[cfg_attr(not(esp32), export_name = "Software0")]
 #[cfg_attr(esp32, export_name = "Software1")]
-fn task_switch_interrupt(_level: u32, context: &mut TrapFrame) {
+fn task_switch_interrupt(context: &mut TrapFrame) {
     let intr = SW_INTERRUPT;
     unsafe { core::arch::asm!("wsr.intclear  {0}", in(reg) intr, options(nostack)) };
 

--- a/esp-wifi/src/radio/radio_esp32.rs
+++ b/esp-wifi/src/radio/radio_esp32.rs
@@ -35,7 +35,7 @@ pub(crate) fn shutdown_radio_isr() {
 #[cfg(feature = "ble")]
 #[allow(non_snake_case)]
 #[no_mangle]
-fn Software0(_level: u32) {
+fn Software0() {
     unsafe {
         let (fnc, arg) = crate::ble::btdm::ble_os_adapter_chip_specific::ISR_INTERRUPT_7;
         trace!("interrupt Software0 {:?} {:?}", fnc, arg);

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -10,7 +10,7 @@ cfg-if             = "1.0.0"
 embassy-executor   = { version = "0.7.0", features = ["task-arena-size-12288"] }
 embassy-time       = "0.4.0"
 embassy-futures    = "0.1.1"
-embassy-sync    = "0.6.1"
+embassy-sync       = "0.6.1"
 embedded-graphics  = "0.8.1"
 embedded-hal-async = "1.0.0"
 esp-alloc          = { path = "../esp-alloc" }

--- a/qa-test/src/bin/gpio_interrupt_latency.rs
+++ b/qa-test/src/bin/gpio_interrupt_latency.rs
@@ -1,6 +1,16 @@
-//! GPIO performance test
+//! GPIO interrupt latency test.
 //!
-//! Encoder channel A: GPIO2
+//! This program outputs a square wave in the most complicated way possible: by
+//! toggling the output, and in a different task waiting for the output to be
+//! toggled. This is done to test the GPIO interrupt latency. You can measure
+//! the output frequency with a logic analyzer or an oscilloscope. The higher
+//! the frequency, the lower the interrupt latency.
+//!
+//! The async runtime introduces a constant overhead so the pulse length itself
+//! does not directly equal to the time it takes to process the interrupt.
+//!
+//! Outputs used: GPIO2, GPIO4. These are toggled one after the other, so the
+//! generated square waves are 90 degrees out of phase.
 
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
 

--- a/qa-test/src/bin/gpio_interrupt_latency.rs
+++ b/qa-test/src/bin/gpio_interrupt_latency.rs
@@ -1,0 +1,73 @@
+//! GPIO performance test
+//!
+//! Encoder channel A: GPIO2
+
+//% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use esp_backtrace as _;
+use esp_hal::{
+    clock::CpuClock,
+    gpio::{Flex, OutputConfig},
+    peripheral::Peripheral,
+    timer::timg::TimerGroup,
+};
+
+static SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+#[esp_hal_embassy::main]
+async fn main(spawner: Spawner) {
+    esp_println::logger::init_logger_from_env();
+    let p = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    let mut enc_a = Flex::new(p.GPIO2);
+    enc_a.set_as_output();
+    enc_a.apply_output_config(&OutputConfig::default());
+    enc_a.enable_input(true);
+
+    let mut enc_b = Flex::new(p.GPIO4);
+    enc_b.set_as_output();
+    enc_b.apply_output_config(&OutputConfig::default());
+    enc_b.enable_input(true);
+
+    let timg0 = TimerGroup::new(p.TIMG0);
+    esp_hal_embassy::init(timg0.timer0);
+
+    spawner.must_spawn(toggle(
+        unsafe { enc_a.clone_unchecked() },
+        unsafe { enc_b.clone_unchecked() },
+        &SIGNAL,
+    ));
+    spawner.must_spawn(wait(enc_a, enc_b, &SIGNAL));
+}
+
+#[embassy_executor::task(pool_size = 2)]
+async fn toggle(
+    mut output1: Flex<'static>,
+    mut output2: Flex<'static>,
+    signal: &'static Signal<CriticalSectionRawMutex, ()>,
+) {
+    loop {
+        output1.toggle();
+        signal.wait().await;
+        output2.toggle();
+        signal.wait().await;
+    }
+}
+
+#[embassy_executor::task(pool_size = 2)]
+async fn wait(
+    mut input1: Flex<'static>,
+    mut input2: Flex<'static>,
+    signal: &'static Signal<CriticalSectionRawMutex, ()>,
+) {
+    loop {
+        embassy_futures::select::select(input1.wait_for_any_edge(), input2.wait_for_any_edge())
+            .await;
+        signal.signal(());
+    }
+}

--- a/qa-test/src/bin/gpio_interrupt_latency.rs
+++ b/qa-test/src/bin/gpio_interrupt_latency.rs
@@ -34,12 +34,14 @@ async fn main(spawner: Spawner) {
     esp_println::logger::init_logger_from_env();
     let p = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
 
-    let mut enc_a = Flex::new(p.GPIO2);
+    let mut enc_a = Flex::new(unsafe { p.GPIO2.clone_unchecked() });
+    let enc_a_clone = Flex::new(p.GPIO2);
     enc_a.set_as_output();
     enc_a.apply_output_config(&OutputConfig::default());
     enc_a.enable_input(true);
 
-    let mut enc_b = Flex::new(p.GPIO4);
+    let mut enc_b = Flex::new(unsafe { p.GPIO4.clone_unchecked() });
+    let enc_b_clone = Flex::new(p.GPIO4);
     enc_b.set_as_output();
     enc_b.apply_output_config(&OutputConfig::default());
     enc_b.enable_input(true);
@@ -47,11 +49,7 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(p.TIMG0);
     esp_hal_embassy::init(timg0.timer0);
 
-    spawner.must_spawn(toggle(
-        unsafe { enc_a.clone_unchecked() },
-        unsafe { enc_b.clone_unchecked() },
-        &SIGNAL,
-    ));
+    spawner.must_spawn(toggle(enc_a_clone, enc_b_clone, &SIGNAL));
     spawner.must_spawn(wait(enc_a, enc_b, &SIGNAL));
 }
 

--- a/xtensa-lx-rt/src/exception/asm.rs
+++ b/xtensa-lx-rt/src/exception/asm.rs
@@ -514,17 +514,8 @@ __default_naked_exception:
 
     l32i    a6, sp, +XT_STK_EXCCAUSE  // put cause in a6 = a2 in callee
 
-    beqi    a6, 4, .Level1Interrupt   // Handle Level1 interrupt
-    mov     a7, sp                    // put address of save frame in a7=a3 in callee
+    bnei    a6, 4, .HandleException   // Handle exception elsewhere
 
-    movi    a0, (PS_INTLEVEL_EXCM | PS_WOE)
-    wsr     a0, PS
-    rsync
-
-    call4   __exception               // call handler <= actual call!
-    j       .RestoreContext
-
-.Level1Interrupt:
     movi    a0, (1 | PS_WOE)          // set PS.INTLEVEL accordingly
     wsr     a0, PS
     rsync
@@ -536,6 +527,17 @@ __default_naked_exception:
     RESTORE_CONTEXT 1
 
     rfe                               // PS.EXCM is cleared
+
+.HandleException:
+    mov     a7, sp                    // put address of save frame in a7=a3 in callee
+
+    movi    a0, (PS_INTLEVEL_EXCM | PS_WOE)
+    wsr     a0, PS
+    rsync
+
+    call4   __exception               // call handler <= actual call!
+    j       .RestoreContext
+
 .Ldefault_naked_exception_end:
     .size .Ldefault_naked_exception_start, .Ldefault_naked_exception_end
 

--- a/xtensa-lx-rt/src/exception/asm.rs
+++ b/xtensa-lx-rt/src/exception/asm.rs
@@ -195,8 +195,7 @@ global_asm!(
     wsr     a0, PS
     rsync
 
-    movi    a6, \\level                     // put interrupt level in a6 = a2 in callee
-    mov     a7, sp                         // put address of save frame in a7=a3 in callee
+    mov     a6, sp                         // put address of save frame in a6=a2 in callee
     call4   __level_\\level\\()_interrupt    // call handler <= actual call!
 
     RESTORE_CONTEXT \\level
@@ -514,9 +513,9 @@ __default_naked_exception:
     SAVE_CONTEXT 1
 
     l32i    a6, sp, +XT_STK_EXCCAUSE  // put cause in a6 = a2 in callee
-    mov     a7, sp                    // put address of save frame in a7=a3 in callee
 
     beqi    a6, 4, .Level1Interrupt   // Handle Level1 interrupt
+    mov     a7, sp                    // put address of save frame in a7=a3 in callee
 
     movi    a0, (PS_INTLEVEL_EXCM | PS_WOE)
     wsr     a0, PS
@@ -529,8 +528,8 @@ __default_naked_exception:
     movi    a0, (1 | PS_WOE)          // set PS.INTLEVEL accordingly
     wsr     a0, PS
     rsync
+    mov     a6, sp                    // put address of save frame in a6=a2 in callee
 
-    movi    a6, 1                     // put interrupt level in a6 = a2 in callee
     call4   __level_1_interrupt       // call handler <= actual call!
 
 .RestoreContext:

--- a/xtensa-lx-rt/src/exception/context.rs
+++ b/xtensa-lx-rt/src/exception/context.rs
@@ -113,19 +113,19 @@ extern "Rust" {
     fn __double_exception(cause: ExceptionCause, save_frame: &mut Context);
 
     /// This symbol will be provided by the user via `#[interrupt(1)]`
-    fn __level_1_interrupt(level: u32, save_frame: &mut Context);
+    fn __level_1_interrupt(save_frame: &mut Context);
     /// This symbol will be provided by the user via `#[interrupt(2)]`
-    fn __level_2_interrupt(level: u32, save_frame: &mut Context);
+    fn __level_2_interrupt(save_frame: &mut Context);
     /// This symbol will be provided by the user via `#[interrupt(3)]`
-    fn __level_3_interrupt(level: u32, save_frame: &mut Context);
+    fn __level_3_interrupt(save_frame: &mut Context);
     /// This symbol will be provided by the user via `#[interrupt(4)]`
-    fn __level_4_interrupt(level: u32, save_frame: &mut Context);
+    fn __level_4_interrupt(save_frame: &mut Context);
     /// This symbol will be provided by the user via `#[interrupt(5)]`
-    fn __level_5_interrupt(level: u32, save_frame: &mut Context);
+    fn __level_5_interrupt(save_frame: &mut Context);
     /// This symbol will be provided by the user via `#[interrupt(6)]`
-    fn __level_6_interrupt(level: u32, save_frame: &mut Context);
+    fn __level_6_interrupt(save_frame: &mut Context);
     /// This symbol will be provided by the user via `#[interrupt(7)]`
-    fn __level_7_interrupt(level: u32, save_frame: &mut Context);
+    fn __level_7_interrupt(save_frame: &mut Context);
 }
 
 #[no_mangle]

--- a/xtensa-lx-rt/src/lib.rs
+++ b/xtensa-lx-rt/src/lib.rs
@@ -118,24 +118,24 @@ unsafe fn reset_internal_timers() {
 // CPU Interrupts
 extern "C" {
     #[cfg(XCHAL_HAVE_TIMER0)]
-    pub fn Timer0(level: u32, save_frame: &mut crate::exception::Context);
+    pub fn Timer0(save_frame: &mut crate::exception::Context);
     #[cfg(XCHAL_HAVE_TIMER1)]
-    pub fn Timer1(level: u32, save_frame: &mut crate::exception::Context);
+    pub fn Timer1(save_frame: &mut crate::exception::Context);
     #[cfg(XCHAL_HAVE_TIMER2)]
-    pub fn Timer2(level: u32, save_frame: &mut crate::exception::Context);
+    pub fn Timer2(save_frame: &mut crate::exception::Context);
     #[cfg(XCHAL_HAVE_TIMER3)]
-    pub fn Timer3(level: u32, save_frame: &mut crate::exception::Context);
+    pub fn Timer3(save_frame: &mut crate::exception::Context);
 
     #[cfg(XCHAL_HAVE_PROFILING)]
-    pub fn Profiling(level: u32, save_frame: &mut crate::exception::Context);
+    pub fn Profiling(save_frame: &mut crate::exception::Context);
 
     #[cfg(XCHAL_HAVE_SOFTWARE0)]
-    pub fn Software0(level: u32, save_frame: &mut crate::exception::Context);
+    pub fn Software0(save_frame: &mut crate::exception::Context);
     #[cfg(XCHAL_HAVE_SOFTWARE1)]
-    pub fn Software1(level: u32, save_frame: &mut crate::exception::Context);
+    pub fn Software1(save_frame: &mut crate::exception::Context);
 
     #[cfg(XCHAL_HAVE_NMI)]
-    pub fn NMI(level: u32, save_frame: &mut crate::exception::Context);
+    pub fn NMI(save_frame: &mut crate::exception::Context);
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
I have made a small program that toggles pins and waits for them using the async API. This roundtrip indicates a rather sad performance of the APIs: on ESP32 the resulting waveform is 22kHz, on the C6 it's ~17. This PR contains a few ~1% improvements to the general interrupt handling parts.

(i.e. the result of this PR is that the square wave output of the new example goes from 22.1kHz to 22.6kHz on the ESP32)