### PR TITLE
Add support for RMT extended memory #3182

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for RMT extended memory (#3182)
 - Support for `rand_core` 0.9 (#3211)
 - `ESP_HAL_CONFIG_STACK_GUARD_OFFSET` and `ESP_HAL_CONFIG_STACK_GUARD_VALUE` to configure Rust's [Stack smashing protection](https://doc.rust-lang.org/rustc/exploit-mitigations.html#stack-smashing-protection) (#3203)
 - Experimental metadata in the output `.elf` (#3276)

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -75,7 +75,7 @@
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! ### TX operation
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -107,7 +107,7 @@
 //! }
 //! # }
 //! ```
-//! 
+//!
 //! ### RX operation
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -216,7 +216,7 @@
 //! }
 //! # }
 //! ```
-//! 
+//!
 //! > Note: on ESP32 and ESP32-S2 you cannot specify a base frequency other than 80 MHz
 
 use core::{

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -75,7 +75,7 @@
 //! # Ok(())
 //! # }
 //! ```
-//!
+//! 
 //! ### TX operation
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -107,7 +107,7 @@
 //! }
 //! # }
 //! ```
-//!
+//! 
 //! ### RX operation
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -216,7 +216,7 @@
 //! }
 //! # }
 //! ```
-//!
+//! 
 //! > Note: on ESP32 and ESP32-S2 you cannot specify a base frequency other than 80 MHz
 
 use core::{


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Add the ability to extend RMT memory on a RMT channel

#### Description
Added changes to rmt.rs to allow the user to use extended RMT memory on a channel. This allows a user to have more pulse codes than the default of 64, 48 pulse codes depending upon the device used.
My uses case was to receive pulse codes from a weather station sensor that exceeded one RMT memory block of 64 (for ESP32).

#### Testing
Tested changes on ESP32 and ESP32S3.
