### PR TITLE
ESP32: Enforce required pointer alignments in DMA buffers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-C6/H2: The `flip_link` feature should no longer crash (#3203)
 - SPI: `Spi::transfer_in_place_async` now stops the transfer when cancelled (#3242)
 - ESP32/ESP32-S2: Avoid running into timeouts with reads/writes larger than the FIFO (#3199)
-
+- ESP32: Enforce required pointer alignments in DMA buffers (#3296)
 - ESP32-C6: Keep ADC enabled to improve radio signal strength (#3249)
 
 ### Removed

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -201,16 +201,11 @@ impl InternalBurstConfig {
     // Size and address alignment as those come in pairs on current hardware.
     const fn min_dram_alignment(self, direction: TransferDirection) -> usize {
         if matches!(direction, TransferDirection::In) {
-            // NOTE(danielb): commenting this check is incorrect as per TRM, but works.
-            //                we'll need to restore this once peripherals can read a
-            //                different amount of data than what is configured in the
-            //                buffer.
-            // if cfg!(esp32) {
-            //     // NOTE: The size must be word-aligned.
-            //     // NOTE: The buffer address must be word-aligned
-            //     4
-            // }
-            if self.is_burst_enabled() {
+            if cfg!(esp32) {
+                // NOTE: The size must be word-aligned.
+                // NOTE: The buffer address must be word-aligned
+                4
+            } else if self.is_burst_enabled() {
                 // As described in "Accessing Internal Memory" paragraphs in the various TRMs.
                 4
             } else {

--- a/hil-test/tests/spi_full_duplex.rs
+++ b/hil-test/tests/spi_full_duplex.rs
@@ -362,9 +362,6 @@ mod tests {
         unit.channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        dma_rx_buf.set_length(TRANSFER_SIZE);
-        dma_tx_buf.set_length(TRANSFER_SIZE);
-
         // Fill the buffer where each byte has 3 pos edges.
         dma_tx_buf.as_mut_slice().fill(0b0110_1010);
 
@@ -402,9 +399,6 @@ mod tests {
             .set_edge_signal(ctx.miso_input.peripheral_input());
         unit.channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
-
-        dma_rx_buf.set_length(TRANSFER_SIZE);
-        dma_tx_buf.set_length(TRANSFER_SIZE);
 
         // Fill the buffer where each byte has 3 pos edges.
         dma_tx_buf.as_mut_slice().fill(0b0110_1010);

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -78,7 +78,7 @@ fn perform_spi_writes_are_correctly_by_pcnt(ctx: Context, mode: DataMode) {
 fn perform_spidmabus_writes_are_correctly_by_pcnt(ctx: Context, mode: DataMode) {
     const DMA_BUFFER_SIZE: usize = 4;
 
-    let (rx, rxd, buffer, descriptors) = dma_buffers!(1, DMA_BUFFER_SIZE);
+    let (rx, rxd, buffer, descriptors) = dma_buffers!(4, DMA_BUFFER_SIZE);
     let dma_rx_buf = DmaRxBuf::new(rxd, rx).unwrap();
     let dma_tx_buf = DmaTxBuf::new(descriptors, buffer).unwrap();
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Enforcing the 4-byte alignment requirement that was ignored previously.
Now that #3263 (and #2587) have landed, we can uncomment this code.

Not sure this is worth a migration guide entry.

#### Testing
HIL
