### PR TITLE
Miri Experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,12 @@ jobs:
           toolchain: stable
           components: rust-src
 
+      # MIRI is only available in nightly
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: miri
+
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "ci-${{ matrix.device.soc }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude  = [
     "extras/esp-wifishark",
     "extras/ieee802154-sniffer",
     "hil-test",
+    "miri-test",
     "qa-test",
     "xtensa-lx",
     "xtensa-lx-rt",

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -461,7 +461,7 @@ mod peripheral_macros {
                 #[doc = r"Return a reference to the register block"]
                 #[inline(always)]
                 #[instability::unstable]
-                pub const fn regs<'a>() -> &'a <pac::$base as core::ops::Deref>::Target {
+                pub fn regs<'a>() -> &'a <pac::$base as core::ops::Deref>::Target {
                     unsafe { &*Self::PTR }
                 }
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -3663,7 +3663,7 @@ macro_rules! spi_instance {
                 #[inline(always)]
                 fn info(&self) -> &'static Info {
                     static INFO: Info = Info {
-                        register_block: crate::peripherals::[<SPI $num>]::regs(),
+                        register_block: crate::peripherals::[<SPI $num>]::ptr(),
                         peripheral: crate::system::Peripheral::[<Spi $num>],
                         interrupt: crate::peripherals::Interrupt::[<SPI $num>],
                         sclk: OutputSignal::$sclk,

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -780,7 +780,7 @@ macro_rules! spi_instance {
                 #[inline(always)]
                 fn info(&self) -> &'static Info {
                     static INFO: Info = Info {
-                        register_block: crate::peripherals::[<SPI $num>]::regs(),
+                        register_block: crate::peripherals::[<SPI $num>]::ptr(),
                         peripheral: crate::system::Peripheral::[<Spi $num>],
                         sclk: InputSignal::$sclk,
                         mosi: InputSignal::$mosi,

--- a/miri-test/Cargo.toml
+++ b/miri-test/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name    = "miri-test"
+version = "0.0.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+esp-hal            = { path = "../esp-hal", features = ["unstable"] }
+
+[features]
+unstable = []
+#esp32   = ["esp-hal/esp32",   ]
+esp32c2 = ["esp-hal/esp32c2", ]
+esp32c3 = ["esp-hal/esp32c3", ]
+esp32c6 = ["esp-hal/esp32c6", ]
+esp32h2 = ["esp-hal/esp32h2", ]
+#esp32s2 = ["esp-hal/esp32s2", ]
+#esp32s3 = ["esp-hal/esp32s3", ]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+debug         = 2
+debug-assertions = true
+lto           = "fat"
+codegen-units = 1
+panic = "abort"

--- a/miri-test/src/bin/duration_test.rs
+++ b/miri-test/src/bin/duration_test.rs
@@ -1,0 +1,13 @@
+#![no_std]
+#![no_main]
+
+use miri_test as _;
+
+miri_test::miri_init!();
+
+fn main() {
+    let one_hour = esp_hal::time::Duration::from_hours(1);
+
+    assert_eq!(one_hour.as_minutes(), 60);
+    assert_eq!(one_hour.as_secs(), 3600);
+}

--- a/miri-test/src/lib.rs
+++ b/miri-test/src/lib.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![allow(internal_features)]
+#![feature(core_intrinsics)]
+
+// see https://github.com/rust-lang/miri/blob/master/tests/utils/miri_extern.rs
+extern "Rust" {
+    pub fn miri_write_to_stdout(bytes: &[u8]);
+}
+
+#[panic_handler]
+fn panic<'a, 'b>(pi: &'a core::panic::PanicInfo<'b>) -> ! {
+    println!("{:?}", pi);
+    core::intrinsics::abort();
+}
+
+#[macro_export]
+macro_rules! miri_init {
+    () => {
+        #[cfg(miri)]
+        #[no_mangle]
+        fn miri_start(argc: isize, argv: *const *const u8) -> isize {
+            main();
+            0
+        }
+
+        #[cfg(not(miri))]
+        pub fn _main() {
+            main();
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {{
+        {
+            use core::fmt::Write;
+            writeln!($crate::Printer, $($arg)*).ok();
+        }
+    }};
+}
+
+pub struct Printer;
+
+impl core::fmt::Write for Printer {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        unsafe { miri_write_to_stdout(s.as_bytes()) };
+        Ok(())
+    }
+}

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -174,7 +174,8 @@ impl CargoArgsBuilder {
             args.push(format!("+{toolchain}"));
         }
 
-        args.push(self.subcommand.clone());
+        let sub_commands: Vec<String> = self.subcommand.split(' ').into_iter().map(|v| v.to_string()).collect();
+        args.extend_from_slice(&sub_commands);
 
         if let Some(ref target) = self.target {
             args.push(format!("--target={target}"));


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This isn't intended to get merged (especially not as is)! It's just for exploring and discussing if and how we could make use of MIRI

- apparently `unsafe { &*Self::PTR }` is not ok for register blocks ( https://github.com/rust-lang/rust/issues/63197#issuecomment-626653875 ) - the first commit here is just to not already fail during compilation
- We don't have MIRI for Xtensa - so just using our RV targets here
- I admit that single test added here is not useful - I can imagine MIRI could make sense to check some other things, however. Probably we would have to make use of `#[cfg(miri)]` to make interesting functions available

#### Testing
n/a

