### PR TITLE
Define DRAM memory region in esp-metadata

### DIFF
--- a/esp-config/src/lib.rs
+++ b/esp-config/src/lib.rs
@@ -14,7 +14,7 @@ pub use generate::{generate_config, Error, Validator, Value};
 #[macro_export]
 macro_rules! esp_config_bool {
     ( $var:expr ) => {
-        match env!($var) {
+        match env!($var).as_bytes() {
             b"true" => true,
             b"false" => false,
             _ => ::core::panic!("boolean value must be either 'true' or 'false'"),
@@ -49,7 +49,7 @@ macro_rules! esp_config_int_parse {
         let val: $ty = match <$ty>::from_str_radix($s, 10) {
             Ok(val) => val as $ty,
             Err(_) => {
-                core::assert!(false, concat!("Unable to parse '", $s, "' as a number."));
+                core::assert!(false, "Unable to parse a config value as a number.");
                 0
             }
         };

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -39,6 +39,7 @@ embedded-io-async        = { version = "0.6.1", optional = true }
 enumset                  = "1.1.5"
 esp-build                = { version = "0.2.0", path = "../esp-build" }
 esp-config               = { version = "0.3.0", path = "../esp-config" }
+esp-metadata             = { version = "0.6.0", path = "../esp-metadata", default-features = false }
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
 fugit                    = "0.3.7"
 instability              = "0.3.7"

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -347,7 +347,7 @@ impl Clocks {
                     b"auto" => XtalClock::Other(0), // Can't be `unreachable!` due to const eval.
                     b"26" => XtalClock::_26M,
                     b"40" => XtalClock::_40M,
-                    other => XtalClock::Other(esp_config::esp_config_int_parse!(
+                    _ => XtalClock::Other(esp_config::esp_config_int_parse!(
                         u32,
                         esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY")
                     )),
@@ -401,7 +401,7 @@ impl Clocks {
                     b"auto" => XtalClock::Other(0), // Can't be `unreachable!` due to const eval.
                     b"26" => XtalClock::_26M,
                     b"40" => XtalClock::_40M,
-                    other => XtalClock::Other(esp_config::esp_config_int_parse!(
+                    _ => XtalClock::Other(esp_config::esp_config_int_parse!(
                         u32,
                         esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY")
                     )),

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -88,11 +88,11 @@ pub trait Clock {
 pub enum CpuClock {
     /// 80MHz CPU clock
     #[cfg(not(esp32h2))]
-    _80MHz  = 80,
+    _80MHz = 80,
 
     /// 96MHz CPU clock
     #[cfg(esp32h2)]
-    _96MHz  = 96,
+    _96MHz = 96,
 
     /// 120MHz CPU clock
     #[cfg(esp32c2)]
@@ -398,7 +398,10 @@ impl Clocks {
                     b"auto" => XtalClock::Other(0), // Can't be `unreachable!` due to const eval.
                     b"26" => XtalClock::_26M,
                     b"40" => XtalClock::_40M,
-                    other => XtalClock::Other(esp_config::esp_config_int_parse!(u32, other)),
+                    other => XtalClock::Other(esp_config::esp_config_int_parse!(
+                        u32,
+                        esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY")
+                    )),
                 }
             }
         }

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -343,14 +343,12 @@ impl Clocks {
             }
         } else {
             const {
-                match esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY").as_bytes() {
+                let frequency_conf = esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY");
+                match frequency_conf.as_bytes() {
                     b"auto" => XtalClock::Other(0), // Can't be `unreachable!` due to const eval.
                     b"26" => XtalClock::_26M,
                     b"40" => XtalClock::_40M,
-                    _ => XtalClock::Other(esp_config::esp_config_int_parse!(
-                        u32,
-                        esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY")
-                    )),
+                    _ => XtalClock::Other(esp_config::esp_config_int_parse!(u32, frequency_conf)),
                 }
             }
         }
@@ -397,14 +395,12 @@ impl Clocks {
             }
         } else {
             const {
-                match esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY").as_bytes() {
+                let frequency_conf = esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY");
+                match frequency_conf.as_bytes() {
                     b"auto" => XtalClock::Other(0), // Can't be `unreachable!` due to const eval.
                     b"26" => XtalClock::_26M,
                     b"40" => XtalClock::_40M,
-                    _ => XtalClock::Other(esp_config::esp_config_int_parse!(
-                        u32,
-                        esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY")
-                    )),
+                    _ => XtalClock::Other(esp_config::esp_config_int_parse!(u32, frequency_conf)),
                 }
             }
         }

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -88,11 +88,11 @@ pub trait Clock {
 pub enum CpuClock {
     /// 80MHz CPU clock
     #[cfg(not(esp32h2))]
-    _80MHz = 80,
+    _80MHz  = 80,
 
     /// 96MHz CPU clock
     #[cfg(esp32h2)]
-    _96MHz = 96,
+    _96MHz  = 96,
 
     /// 120MHz CPU clock
     #[cfg(esp32c2)]
@@ -347,7 +347,10 @@ impl Clocks {
                     b"auto" => XtalClock::Other(0), // Can't be `unreachable!` due to const eval.
                     b"26" => XtalClock::_26M,
                     b"40" => XtalClock::_40M,
-                    other => XtalClock::Other(esp_config::esp_config_int_parse!(u32, other)),
+                    other => XtalClock::Other(esp_config::esp_config_int_parse!(
+                        u32,
+                        esp_config::esp_config_str!("ESP_HAL_CONFIG_XTAL_FREQUENCY")
+                    )),
                 }
             }
         }

--- a/esp-hal/src/soc/esp32/mod.rs
+++ b/esp-hal/src/soc/esp32/mod.rs
@@ -48,10 +48,6 @@ pub(crate) mod constants {
     pub const RMT_RAM_START: usize = 0x3ff56800;
     /// The size (number of pulse codes) of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 64;
-    /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: usize = 0x3FFA_E000;
-    /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: usize = 0x4000_0000;
     /// A reference clock tick of 1 MHz.
     pub const REF_TICK: Rate = Rate::from_mhz(1);
 }

--- a/esp-hal/src/soc/esp32c2/mod.rs
+++ b/esp-hal/src/soc/esp32c2/mod.rs
@@ -38,11 +38,6 @@ pub(crate) mod registers {
 pub(crate) mod constants {
     use crate::time::Rate;
 
-    /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: usize = 0x3FCA_0000;
-    /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: usize = 0x3FCE_0000;
-
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17500);
 }

--- a/esp-hal/src/soc/esp32c3/mod.rs
+++ b/esp-hal/src/soc/esp32c3/mod.rs
@@ -56,11 +56,6 @@ pub(crate) mod constants {
     /// RMT Clock source frequency.
     pub const RMT_CLOCK_SRC_FREQ: Rate = Rate::from_mhz(80);
 
-    /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: usize = 0x3FC8_0000;
-    /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: usize = 0x3FCE_0000;
-
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17500);
 }

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -64,11 +64,6 @@ pub(crate) mod constants {
     /// The clock frequency for the Parallel IO peripheral in Hertz.
     pub const PARL_IO_SCLK: u32 = 240_000_000;
 
-    /// The lower address boundary for system DRAM.
-    pub const SOC_DRAM_LOW: usize = 0x4080_0000;
-    /// The upper address boundary for system DRAM.
-    pub const SOC_DRAM_HIGH: usize = 0x4088_0000;
-
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17_500);
 }

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -64,11 +64,6 @@ pub(crate) mod constants {
     /// Hertz.
     pub const PARL_IO_SCLK: u32 = 96_000_000;
 
-    /// Start address of the system's DRAM (low range).
-    pub const SOC_DRAM_LOW: usize = 0x4080_0000;
-    /// End address of the system's DRAM (high range).
-    pub const SOC_DRAM_HIGH: usize = 0x4085_0000;
-
     /// RC FAST Clock value (Hertz).
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17500);
 }

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -52,10 +52,6 @@ pub(crate) mod constants {
     pub const RMT_RAM_START: usize = 0x3f416400;
     /// The size (number of pulse codes) of each RMT channel's dedicated RAM.
     pub const RMT_CHANNEL_RAM_SIZE: usize = 64;
-    /// Start address of the system's DRAM (low range).
-    pub const SOC_DRAM_LOW: usize = 0x3FFB_0000;
-    /// End address of the system's DRAM (high range).
-    pub const SOC_DRAM_HIGH: usize = 0x4000_0000;
     /// Reference clock tick frequency, set to 1 MHz.
     pub const REF_TICK: Rate = Rate::from_mhz(1);
 }

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -59,11 +59,6 @@ pub(crate) mod constants {
     /// RMT Clock source frequency.
     pub const RMT_CLOCK_SRC_FREQ: Rate = Rate::from_mhz(80);
 
-    /// The lower bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_LOW: usize = 0x3FC8_8000;
-    /// The upper bound of the system's DRAM (Data RAM) address space.
-    pub const SOC_DRAM_HIGH: usize = 0x3FD0_0000;
-
     /// A reference clock tick of 1 MHz.
     pub const RC_FAST_CLK: Rate = Rate::from_khz(17500);
 }

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -39,10 +39,10 @@ pub(crate) fn psram_range() -> Range<usize> {
 }
 
 /// The lower bound of the system's DRAM (Data RAM) address space.
-const SOC_DRAM_LOW: usize = esp_config::esp_config_int!(usize, "REGION-DRAM-START");
+const SOC_DRAM_LOW: usize = esp_metadata::memory_region_start!("DRAM");
 
 /// The upper bound of the system's DRAM (Data RAM) address space.
-const SOC_DRAM_HIGH: usize = esp_config::esp_config_int!(usize, "REGION-DRAM-END");
+const SOC_DRAM_HIGH: usize = esp_metadata::memory_region_end!("DRAM");
 
 const DRAM: Range<usize> = SOC_DRAM_LOW..SOC_DRAM_HIGH;
 

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -38,7 +38,13 @@ pub(crate) fn psram_range() -> Range<usize> {
     }
 }
 
-const DRAM: Range<usize> = self::constants::SOC_DRAM_LOW..self::constants::SOC_DRAM_HIGH;
+/// The lower bound of the system's DRAM (Data RAM) address space.
+const SOC_DRAM_LOW: usize = esp_config::esp_config_int!(usize, "REGION-DRAM-START");
+
+/// The upper bound of the system's DRAM (Data RAM) address space.
+const SOC_DRAM_HIGH: usize = esp_config::esp_config_int!(usize, "REGION-DRAM-END");
+
+const DRAM: Range<usize> = SOC_DRAM_LOW..SOC_DRAM_HIGH;
 
 #[cfg(feature = "psram")]
 pub struct MappedPsram {

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add ability to define memory regions, have DRAM defined there (#3300)
 
+- Provide macros to get the start/end of a memory region, make it possible to use the macros in a no-std project (#3300)
+
 ### Changed
 
 ### Fixed

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add ability to define memory regions, have DRAM defined there (#3300)
+
 ### Changed
 
 ### Fixed

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -9,8 +9,13 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [dependencies]
-anyhow     = "1.0.95"
+anyhow     = { version = "1.0.95", optional = true }
 clap       = { version = "4.5.26", features = ["derive"], optional = true }
-basic-toml = "0.1.9"
-serde      = { version = "1.0.217", features = ["derive"] }
-strum      = { version = "0.26.3", features = ["derive"] }
+basic-toml = { version = "0.1.9", optional = true }
+serde      = { version = "1.0.217", features = ["derive"], optional = true }
+strum      = { version = "0.26.3", features = ["derive"], optional = true }
+
+[features]
+default = ["build"]
+build = ["dep:anyhow", "dep:basic-toml", "dep:serde", "dep:strum"]
+clap = ["dep:clap"]

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -76,3 +76,5 @@ symbols = [
     "pm_support_touch_sensor_wakeup",
     "ulp_supported",
 ]
+
+memory = [{ name = "dram", start = 0x3FFA_E000, end = 0x4000_0000 }]

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -52,3 +52,5 @@ symbols = [
     "uart_support_wakeup_int",
     "gpio_support_deepsleep_wakeup",
 ]
+
+memory = [{ name = "dram", start = 0x3FCA_0000, end = 0x3FCE_0000 }]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -66,3 +66,5 @@ symbols = [
     "uart_support_wakeup_int",
     "gpio_support_deepsleep_wakeup",
 ]
+
+memory = [{ name = "dram", start = 0x3FC8_0000, end = 0x3FCE_0000 }]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -98,3 +98,5 @@ symbols = [
     "uart_support_wakeup_int",
     "pm_support_ext1_wakeup",
 ]
+
+memory = [{ name = "dram", start = 0x4080_0000, end = 0x4088_0000 }]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -77,3 +77,5 @@ symbols = [
     "rom_crc_be",
     "rom_md5_bsd",
 ]
+
+memory = [{ name = "dram", start = 0x4080_0000, end = 0x4085_0000 }]

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -100,3 +100,5 @@ symbols = [
     "gpio_bank_1",
     "spi_octal",
 ]
+
+memory = [{ name = "dram", start = 0x4FF0_0000, end = 0x4FFC_0000 }]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -78,3 +78,5 @@ symbols = [
     # Other capabilities
     "psram_dma",
 ]
+
+memory = [{ name = "dram", start = 0x3FFB_0000, end = 0x4000_0000 }]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -95,3 +95,5 @@ symbols = [
     # Other capabilities
     "psram_dma",
 ]
+
+memory = [{ name = "dram", start = 0x3FC8_8000, end = 0x3FD0_0000 }]

--- a/esp-metadata/src/generate_cfg.rs
+++ b/esp-metadata/src/generate_cfg.rs
@@ -1,0 +1,280 @@
+use std::sync::OnceLock;
+
+use anyhow::{bail, Result};
+use strum::IntoEnumIterator;
+
+macro_rules! include_toml {
+    ($type:ty, $file:expr) => {{
+        static LOADED_TOML: OnceLock<$type> = OnceLock::new();
+        LOADED_TOML.get_or_init(|| basic_toml::from_str(include_str!($file)).unwrap())
+    }};
+}
+
+/// Supported device architectures.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Deserialize,
+    serde::Serialize,
+    strum::Display,
+    strum::EnumIter,
+    strum::EnumString,
+    strum::AsRefStr,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum Arch {
+    /// RISC-V architecture
+    RiscV,
+    /// Xtensa architecture
+    Xtensa,
+}
+
+/// Device core count.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Deserialize,
+    serde::Serialize,
+    strum::Display,
+    strum::EnumIter,
+    strum::EnumString,
+    strum::AsRefStr,
+)]
+pub enum Cores {
+    /// Single CPU core
+    #[serde(rename = "single_core")]
+    #[strum(serialize = "single_core")]
+    Single,
+    /// Two or more CPU cores
+    #[serde(rename = "multi_core")]
+    #[strum(serialize = "multi_core")]
+    Multi,
+}
+
+/// Supported devices.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Deserialize,
+    serde::Serialize,
+    strum::Display,
+    strum::EnumIter,
+    strum::EnumString,
+    strum::AsRefStr,
+)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum Chip {
+    /// ESP32
+    Esp32,
+    /// ESP32-C2, ESP8684
+    Esp32c2,
+    /// ESP32-C3, ESP8685
+    Esp32c3,
+    /// ESP32-C6
+    Esp32c6,
+    /// ESP32-H2
+    Esp32h2,
+    /// ESP32-S2
+    Esp32s2,
+    /// ESP32-S3
+    Esp32s3,
+}
+
+impl Chip {
+    pub fn target(&self) -> &str {
+        use Chip::*;
+
+        match self {
+            Esp32 => "xtensa-esp32-none-elf",
+            Esp32c2 | Esp32c3 => "riscv32imc-unknown-none-elf",
+            Esp32c6 | Esp32h2 => "riscv32imac-unknown-none-elf",
+            Esp32s2 => "xtensa-esp32s2-none-elf",
+            Esp32s3 => "xtensa-esp32s3-none-elf",
+        }
+    }
+
+    pub fn has_lp_core(&self) -> bool {
+        use Chip::*;
+
+        matches!(self, Esp32c6 | Esp32s2 | Esp32s3)
+    }
+
+    pub fn lp_target(&self) -> Result<&str> {
+        use Chip::*;
+
+        match self {
+            Esp32c6 => Ok("riscv32imac-unknown-none-elf"),
+            Esp32s2 | Esp32s3 => Ok("riscv32imc-unknown-none-elf"),
+            _ => bail!("Chip does not contain an LP core: '{}'", self),
+        }
+    }
+
+    pub fn pretty_name(&self) -> &str {
+        match self {
+            Chip::Esp32 => "ESP32",
+            Chip::Esp32c2 => "ESP32-C2",
+            Chip::Esp32c3 => "ESP32-C3",
+            Chip::Esp32c6 => "ESP32-C6",
+            Chip::Esp32h2 => "ESP32-H2",
+            Chip::Esp32s2 => "ESP32-S2",
+            Chip::Esp32s3 => "ESP32-S3",
+        }
+    }
+
+    pub fn is_xtensa(&self) -> bool {
+        matches!(self, Chip::Esp32 | Chip::Esp32s2 | Chip::Esp32s3)
+    }
+
+    pub fn is_riscv(&self) -> bool {
+        !self.is_xtensa()
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct MemoryRegion {
+    name: String,
+    start: u32,
+    end: u32,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+struct Device {
+    pub name: String,
+    pub arch: Arch,
+    pub cores: Cores,
+    pub peripherals: Vec<String>,
+    pub symbols: Vec<String>,
+    pub memory: Vec<MemoryRegion>,
+}
+
+/// Device configuration file format.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Config {
+    device: Device,
+}
+
+impl Config {
+    /// The configuration for the specified chip.
+    pub fn for_chip(chip: &Chip) -> &Self {
+        match chip {
+            Chip::Esp32 => include_toml!(Config, "../devices/esp32.toml"),
+            Chip::Esp32c2 => include_toml!(Config, "../devices/esp32c2.toml"),
+            Chip::Esp32c3 => include_toml!(Config, "../devices/esp32c3.toml"),
+            Chip::Esp32c6 => include_toml!(Config, "../devices/esp32c6.toml"),
+            Chip::Esp32h2 => include_toml!(Config, "../devices/esp32h2.toml"),
+            Chip::Esp32s2 => include_toml!(Config, "../devices/esp32s2.toml"),
+            Chip::Esp32s3 => include_toml!(Config, "../devices/esp32s3.toml"),
+        }
+    }
+
+    /// The name of the device.
+    pub fn name(&self) -> String {
+        self.device.name.clone()
+    }
+
+    /// The CPU architecture of the device.
+    pub fn arch(&self) -> Arch {
+        self.device.arch
+    }
+
+    /// The core count of the device.
+    pub fn cores(&self) -> Cores {
+        self.device.cores
+    }
+
+    /// The peripherals of the device.
+    pub fn peripherals(&self) -> &[String] {
+        &self.device.peripherals
+    }
+
+    /// User-defined symbols for the device.
+    pub fn symbols(&self) -> &[String] {
+        &self.device.symbols
+    }
+
+    /// Memory regions.
+    ///
+    /// Will be available as env-variables `REGION-<NAME>-START` /
+    /// `REGION-<NAME>-END`
+    pub fn memory(&self) -> &[MemoryRegion] {
+        &self.device.memory
+    }
+
+    /// All configuration values for the device.
+    pub fn all(&self) -> impl Iterator<Item = &str> + '_ {
+        [
+            self.device.name.as_str(),
+            self.device.arch.as_ref(),
+            self.device.cores.as_ref(),
+        ]
+        .into_iter()
+        .chain(self.device.peripherals.iter().map(|s| s.as_str()))
+        .chain(self.device.symbols.iter().map(|s| s.as_str()))
+    }
+
+    /// Does the configuration contain `item`?
+    pub fn contains(&self, item: &str) -> bool {
+        self.all().any(|i| i == item)
+    }
+
+    /// Define all symbols for a given configuration.
+    pub fn define_symbols(&self) {
+        define_all_possible_symbols();
+        // Define all necessary configuration symbols for the configured device:
+        for symbol in self.all() {
+            println!("cargo:rustc-cfg={symbol}");
+        }
+
+        // Define env-vars for all memory regions
+        for memory in self.memory() {
+            println!("cargo:rustc-cfg=has_{}_region", memory.name.to_lowercase());
+
+            println!(
+                "cargo::rustc-env=ESP_METADATA_REGION_{}_START={}",
+                memory.name.to_uppercase(),
+                memory.start
+            );
+            println!(
+                "cargo::rustc-env=ESP_METADATA_REGION_{}_END={}",
+                memory.name.to_uppercase(),
+                memory.end
+            );
+        }
+    }
+}
+
+/// Defines all possible symbols that _could_ be output from this crate
+/// regardless of the chosen configuration.
+///
+/// This is required to avoid triggering the unexpected-cfgs lint.
+fn define_all_possible_symbols() {
+    // Used by our documentation builds to prevent the huge red warning banner.
+    println!("cargo:rustc-check-cfg=cfg(not_really_docsrs)");
+
+    for chip in Chip::iter() {
+        let config = Config::for_chip(&chip);
+        for symbol in config.all() {
+            // https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-check-cfg
+            println!("cargo:rustc-check-cfg=cfg({})", symbol);
+        }
+    }
+}

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -152,12 +152,20 @@ impl Chip {
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct MemoryRegion {
+    name: String,
+    start: u32,
+    end: u32,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 struct Device {
     pub name: String,
     pub arch: Arch,
     pub cores: Cores,
     pub peripherals: Vec<String>,
     pub symbols: Vec<String>,
+    pub memory: Vec<MemoryRegion>,
 }
 
 /// Device configuration file format.
@@ -205,6 +213,14 @@ impl Config {
         &self.device.symbols
     }
 
+    /// Memory regions.
+    ///
+    /// Will be available as env-variables `REGION-<NAME>-START` /
+    /// `REGION-<NAME>-END`
+    pub fn memory(&self) -> &[MemoryRegion] {
+        &self.device.memory
+    }
+
     /// All configuration values for the device.
     pub fn all(&self) -> impl Iterator<Item = &str> + '_ {
         [
@@ -228,6 +244,22 @@ impl Config {
         // Define all necessary configuration symbols for the configured device:
         for symbol in self.all() {
             println!("cargo:rustc-cfg={symbol}");
+        }
+
+        // Define env-vars for all memory regions
+        for memory in self.memory() {
+            println!("cargo:rustc-cfg=has_{}_region", memory.name.to_lowercase());
+
+            println!(
+                "cargo::rustc-env=REGION-{}-START={}",
+                memory.name.to_uppercase(),
+                memory.start
+            );
+            println!(
+                "cargo::rustc-env=REGION-{}-END={}",
+                memory.name.to_uppercase(),
+                memory.end
+            );
         }
     }
 }

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -1,282 +1,48 @@
 //! Metadata for Espressif devices, primarily intended for use in build scripts.
+#![cfg_attr(not(feature = "build"), no_std)]
 
-use std::sync::OnceLock;
+#[cfg(feature = "build")]
+mod generate_cfg;
 
-use anyhow::{bail, Result};
-use strum::IntoEnumIterator;
+#[cfg(feature = "build")]
+pub use generate_cfg::*;
 
-macro_rules! include_toml {
-    ($type:ty, $file:expr) => {{
-        static LOADED_TOML: OnceLock<$type> = OnceLock::new();
-        LOADED_TOML.get_or_init(|| basic_toml::from_str(include_str!($file)).unwrap())
-    }};
-}
-
-/// Supported device architectures.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    serde::Deserialize,
-    serde::Serialize,
-    strum::Display,
-    strum::EnumIter,
-    strum::EnumString,
-    strum::AsRefStr,
-)]
-#[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
-pub enum Arch {
-    /// RISC-V architecture
-    RiscV,
-    /// Xtensa architecture
-    Xtensa,
-}
-
-/// Device core count.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    serde::Deserialize,
-    serde::Serialize,
-    strum::Display,
-    strum::EnumIter,
-    strum::EnumString,
-    strum::AsRefStr,
-)]
-pub enum Cores {
-    /// Single CPU core
-    #[serde(rename = "single_core")]
-    #[strum(serialize = "single_core")]
-    Single,
-    /// Two or more CPU cores
-    #[serde(rename = "multi_core")]
-    #[strum(serialize = "multi_core")]
-    Multi,
-}
-
-/// Supported devices.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    serde::Deserialize,
-    serde::Serialize,
-    strum::Display,
-    strum::EnumIter,
-    strum::EnumString,
-    strum::AsRefStr,
-)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[serde(rename_all = "kebab-case")]
-#[strum(serialize_all = "kebab-case")]
-pub enum Chip {
-    /// ESP32
-    Esp32,
-    /// ESP32-C2, ESP8684
-    Esp32c2,
-    /// ESP32-C3, ESP8685
-    Esp32c3,
-    /// ESP32-C6
-    Esp32c6,
-    /// ESP32-H2
-    Esp32h2,
-    /// ESP32-S2
-    Esp32s2,
-    /// ESP32-S3
-    Esp32s3,
-}
-
-impl Chip {
-    pub fn target(&self) -> &str {
-        use Chip::*;
-
-        match self {
-            Esp32 => "xtensa-esp32-none-elf",
-            Esp32c2 | Esp32c3 => "riscv32imc-unknown-none-elf",
-            Esp32c6 | Esp32h2 => "riscv32imac-unknown-none-elf",
-            Esp32s2 => "xtensa-esp32s2-none-elf",
-            Esp32s3 => "xtensa-esp32s3-none-elf",
-        }
-    }
-
-    pub fn has_lp_core(&self) -> bool {
-        use Chip::*;
-
-        matches!(self, Esp32c6 | Esp32s2 | Esp32s3)
-    }
-
-    pub fn lp_target(&self) -> Result<&str> {
-        use Chip::*;
-
-        match self {
-            Esp32c6 => Ok("riscv32imac-unknown-none-elf"),
-            Esp32s2 | Esp32s3 => Ok("riscv32imc-unknown-none-elf"),
-            _ => bail!("Chip does not contain an LP core: '{}'", self),
-        }
-    }
-
-    pub fn pretty_name(&self) -> &str {
-        match self {
-            Chip::Esp32 => "ESP32",
-            Chip::Esp32c2 => "ESP32-C2",
-            Chip::Esp32c3 => "ESP32-C3",
-            Chip::Esp32c6 => "ESP32-C6",
-            Chip::Esp32h2 => "ESP32-H2",
-            Chip::Esp32s2 => "ESP32-S2",
-            Chip::Esp32s3 => "ESP32-S3",
-        }
-    }
-
-    pub fn is_xtensa(&self) -> bool {
-        matches!(self, Chip::Esp32 | Chip::Esp32s2 | Chip::Esp32s3)
-    }
-
-    pub fn is_riscv(&self) -> bool {
-        !self.is_xtensa()
-    }
-}
-
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct MemoryRegion {
-    name: String,
-    start: u32,
-    end: u32,
-}
-
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-struct Device {
-    pub name: String,
-    pub arch: Arch,
-    pub cores: Cores,
-    pub peripherals: Vec<String>,
-    pub symbols: Vec<String>,
-    pub memory: Vec<MemoryRegion>,
-}
-
-/// Device configuration file format.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct Config {
-    device: Device,
-}
-
-impl Config {
-    /// The configuration for the specified chip.
-    pub fn for_chip(chip: &Chip) -> &Self {
-        match chip {
-            Chip::Esp32 => include_toml!(Config, "../devices/esp32.toml"),
-            Chip::Esp32c2 => include_toml!(Config, "../devices/esp32c2.toml"),
-            Chip::Esp32c3 => include_toml!(Config, "../devices/esp32c3.toml"),
-            Chip::Esp32c6 => include_toml!(Config, "../devices/esp32c6.toml"),
-            Chip::Esp32h2 => include_toml!(Config, "../devices/esp32h2.toml"),
-            Chip::Esp32s2 => include_toml!(Config, "../devices/esp32s2.toml"),
-            Chip::Esp32s3 => include_toml!(Config, "../devices/esp32s3.toml"),
-        }
-    }
-
-    /// The name of the device.
-    pub fn name(&self) -> String {
-        self.device.name.clone()
-    }
-
-    /// The CPU architecture of the device.
-    pub fn arch(&self) -> Arch {
-        self.device.arch
-    }
-
-    /// The core count of the device.
-    pub fn cores(&self) -> Cores {
-        self.device.cores
-    }
-
-    /// The peripherals of the device.
-    pub fn peripherals(&self) -> &[String] {
-        &self.device.peripherals
-    }
-
-    /// User-defined symbols for the device.
-    pub fn symbols(&self) -> &[String] {
-        &self.device.symbols
-    }
-
-    /// Memory regions.
-    ///
-    /// Will be available as env-variables `REGION-<NAME>-START` /
-    /// `REGION-<NAME>-END`
-    pub fn memory(&self) -> &[MemoryRegion] {
-        &self.device.memory
-    }
-
-    /// All configuration values for the device.
-    pub fn all(&self) -> impl Iterator<Item = &str> + '_ {
-        [
-            self.device.name.as_str(),
-            self.device.arch.as_ref(),
-            self.device.cores.as_ref(),
-        ]
-        .into_iter()
-        .chain(self.device.peripherals.iter().map(|s| s.as_str()))
-        .chain(self.device.symbols.iter().map(|s| s.as_str()))
-    }
-
-    /// Does the configuration contain `item`?
-    pub fn contains(&self, item: &str) -> bool {
-        self.all().any(|i| i == item)
-    }
-
-    /// Define all symbols for a given configuration.
-    pub fn define_symbols(&self) {
-        define_all_possible_symbols();
-        // Define all necessary configuration symbols for the configured device:
-        for symbol in self.all() {
-            println!("cargo:rustc-cfg={symbol}");
-        }
-
-        // Define env-vars for all memory regions
-        for memory in self.memory() {
-            println!("cargo:rustc-cfg=has_{}_region", memory.name.to_lowercase());
-
-            println!(
-                "cargo::rustc-env=REGION-{}-START={}",
-                memory.name.to_uppercase(),
-                memory.start
-            );
-            println!(
-                "cargo::rustc-env=REGION-{}-END={}",
-                memory.name.to_uppercase(),
-                memory.end
-            );
-        }
-    }
-}
-
-/// Defines all possible symbols that _could_ be output from this crate
-/// regardless of the chosen configuration.
+/// Macro to get the start of the given memory region.
 ///
-/// This is required to avoid triggering the unexpected-cfgs lint.
-fn define_all_possible_symbols() {
-    // Used by our documentation builds to prevent the huge red warning banner.
-    println!("cargo:rustc-check-cfg=cfg(not_really_docsrs)");
-
-    for chip in Chip::iter() {
-        let config = Config::for_chip(&chip);
-        for symbol in config.all() {
-            // https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-check-cfg
-            println!("cargo:rustc-check-cfg=cfg({})", symbol);
+/// ```rust,no-run
+/// const DRAM_START: usize = esp_metadata::memory_region_start("DRAM");
+/// ```
+#[macro_export]
+macro_rules! memory_region_start {
+    ( $var:expr ) => {
+        const {
+            match usize::from_str_radix(env!(concat!("ESP_METADATA_REGION_", $var, "_START")), 10) {
+                Ok(val) => val,
+                Err(_) => {
+                    core::assert!(false, "Unable to parse memory region.");
+                    0
+                }
+            }
         }
-    }
+    };
+}
+
+/// Macro to get the end of the given memory region.
+///
+/// ```rust,no-run
+/// const DRAM_END: usize = esp_metadata::memory_region_end("DRAM");
+/// ```
+#[macro_export]
+macro_rules! memory_region_end {
+    ( $var:expr ) => {
+        const {
+            match usize::from_str_radix(env!(concat!("ESP_METADATA_REGION_", $var, "_END")), 10) {
+                Ok(val) => val,
+                Err(_) => {
+                    core::assert!(false, "Unable to parse memory region.");
+                    0
+                }
+            }
+        }
+    };
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This is (hopefully) the less controversial part of #2672 and a good thing on its own. For now, it only defines the DRAM memory region, but more memory regions can (and should) be added as needed.

`skip-changelog` for the changes in `esp-hal` which are not user facing

#### Testing
CI
