### PR TITLE
Don't require interconnect signals to be Peripheral impls

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `rand_core` 0.9 (#3211)
 - `ESP_HAL_CONFIG_STACK_GUARD_OFFSET` and `ESP_HAL_CONFIG_STACK_GUARD_VALUE` to configure Rust's [Stack smashing protection](https://doc.rust-lang.org/rustc/exploit-mitigations.html#stack-smashing-protection) (#3203)
 - Experimental metadata in the output `.elf` (#3276)
+- `PeripheralInput::connect_input_to_peripheral` and `PeripheralOuptut::{connect_peripheral_to_output, disconnect_from_peripheral_output}` (#3302)
 
 ### Changed
 
@@ -19,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `esp_hal::i2s::master::AnyI2s` has been moved to `esp_hal::i2s::AnyI2s` (#3226)
 - `esp_hal::i2c::master::AnyI2c` has been moved to `esp_hal::i2c::AnyI2c` (#3226)
 - `SpiDmaBus` no longer adjusts the DMA buffer length for each transfer (#3263)
+
+- `gpio::interconnect` types now have a lifetime associated with them (#3302)
 
 ### Fixed
 
@@ -36,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-C6: Keep ADC enabled to improve radio signal strength (#3249)
 
 ### Removed
+
+- `gpio::{Level, NoPin, Input, Output, Flex}` no longer implement `Peripheral` (#3302)
 
 ## v1.0.0-beta.0
 

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -1,0 +1,23 @@
+# Migration Guide from v1.0.0-beta.0 to ?
+
+## GPIO changes
+
+### Interconnect types now have a lifetime
+
+The GPIO interconnect types now have a lifetime. This lifetime prevents them to be live for longer
+than the GPIO that was used to create them.
+
+The affected types in the `gpio::interconnect` module are:
+
+- `InputSignal`
+- `OutputSignal`
+- `InputConnection`
+- `OutputConnection`
+
+### Pin drivers no longer implement `Peripheral`
+
+Peripheral drivers now take `impl PeripheralInput` and `impl PeripheralOutput` directly. These
+traits are now implemented for GPIO pins (stably) and driver structs (unstably) alike.
+
+This change means it's no longer possible to pass a reference to a GPIO driver to a peripheral
+driver. For example, it's no longer possible to pass an `&mut Input` to `Spi::with_miso`.

--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -29,7 +29,7 @@ use crate::{
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaChannel(u8);
 
-impl Peripheral for AnyGdmaChannel {
+unsafe impl Peripheral for AnyGdmaChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -52,7 +52,7 @@ impl DmaChannel for AnyGdmaChannel {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaRxChannel(u8);
 
-impl Peripheral for AnyGdmaRxChannel {
+unsafe impl Peripheral for AnyGdmaRxChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -71,7 +71,7 @@ impl DmaChannelConvert<AnyGdmaRxChannel> for AnyGdmaRxChannel {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaTxChannel(u8);
 
-impl Peripheral for AnyGdmaTxChannel {
+unsafe impl Peripheral for AnyGdmaTxChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -602,7 +602,7 @@ macro_rules! impl_channel {
 
             impl $crate::private::Sealed for [<DmaChannel $num>] {}
 
-            impl Peripheral for [<DmaChannel $num>] {
+            unsafe impl Peripheral for [<DmaChannel $num>] {
                 type P = Self;
 
                 unsafe fn clone_unchecked(&self) -> Self::P {

--- a/esp-hal/src/dma/pdma/crypto.rs
+++ b/esp-hal/src/dma/pdma/crypto.rs
@@ -23,7 +23,7 @@ impl CryptoDmaRxChannel {
 
 impl crate::private::Sealed for CryptoDmaRxChannel {}
 impl DmaRxChannel for CryptoDmaRxChannel {}
-impl Peripheral for CryptoDmaRxChannel {
+unsafe impl Peripheral for CryptoDmaRxChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -44,7 +44,7 @@ impl CryptoDmaTxChannel {
 
 impl crate::private::Sealed for CryptoDmaTxChannel {}
 impl DmaTxChannel for CryptoDmaTxChannel {}
-impl Peripheral for CryptoDmaTxChannel {
+unsafe impl Peripheral for CryptoDmaTxChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -438,7 +438,7 @@ pub struct CryptoDmaChannel {}
 
 impl crate::private::Sealed for CryptoDmaChannel {}
 
-impl Peripheral for CryptoDmaChannel {
+unsafe impl Peripheral for CryptoDmaChannel {
     type P = Self;
     unsafe fn clone_unchecked(&self) -> Self::P {
         Self::steal()

--- a/esp-hal/src/dma/pdma/i2s.rs
+++ b/esp-hal/src/dma/pdma/i2s.rs
@@ -17,7 +17,7 @@ impl AnyI2sDmaRxChannel {
 
 impl crate::private::Sealed for AnyI2sDmaRxChannel {}
 impl DmaRxChannel for AnyI2sDmaRxChannel {}
-impl Peripheral for AnyI2sDmaRxChannel {
+unsafe impl Peripheral for AnyI2sDmaRxChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -38,7 +38,7 @@ impl AnyI2sDmaTxChannel {
 
 impl crate::private::Sealed for AnyI2sDmaTxChannel {}
 impl DmaTxChannel for AnyI2sDmaTxChannel {}
-impl Peripheral for AnyI2sDmaTxChannel {
+unsafe impl Peripheral for AnyI2sDmaTxChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {

--- a/esp-hal/src/dma/pdma/mod.rs
+++ b/esp-hal/src/dma/pdma/mod.rs
@@ -59,7 +59,7 @@ macro_rules! impl_pdma_channel {
 
             impl $crate::private::Sealed for [<$instance DmaChannel>] {}
 
-            impl Peripheral for [<$instance DmaChannel>] {
+            unsafe impl Peripheral for [<$instance DmaChannel>] {
                 type P = Self;
 
                 unsafe fn clone_unchecked(&self) -> Self::P {

--- a/esp-hal/src/dma/pdma/spi.rs
+++ b/esp-hal/src/dma/pdma/spi.rs
@@ -17,7 +17,7 @@ impl AnySpiDmaRxChannel {
 
 impl crate::private::Sealed for AnySpiDmaRxChannel {}
 impl DmaRxChannel for AnySpiDmaRxChannel {}
-impl Peripheral for AnySpiDmaRxChannel {
+unsafe impl Peripheral for AnySpiDmaRxChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -38,7 +38,7 @@ impl AnySpiDmaTxChannel {
 
 impl crate::private::Sealed for AnySpiDmaTxChannel {}
 impl DmaTxChannel for AnySpiDmaTxChannel {}
-impl Peripheral for AnySpiDmaTxChannel {
+unsafe impl Peripheral for AnySpiDmaTxChannel {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {

--- a/esp-hal/src/gpio/etm.rs
+++ b/esp-hal/src/gpio/etm.rs
@@ -150,7 +150,7 @@ impl<const C: u8> EventChannel<C> {
     /// Trigger at rising edge
     pub fn rising_edge<'d>(
         self,
-        pin: impl Peripheral<P = impl Into<InputSignal>> + 'd,
+        pin: impl Into<InputSignal<'d>>,
         pin_config: InputConfig,
     ) -> Event<'d> {
         self.into_event(pin, pin_config, EventKind::Rising)
@@ -159,7 +159,7 @@ impl<const C: u8> EventChannel<C> {
     /// Trigger at falling edge
     pub fn falling_edge<'d>(
         self,
-        pin: impl Peripheral<P = impl Into<InputSignal>> + 'd,
+        pin: impl Into<InputSignal<'d>>,
         pin_config: InputConfig,
     ) -> Event<'d> {
         self.into_event(pin, pin_config, EventKind::Falling)
@@ -168,7 +168,7 @@ impl<const C: u8> EventChannel<C> {
     /// Trigger at any edge
     pub fn any_edge<'d>(
         self,
-        pin: impl Peripheral<P = impl Into<InputSignal>> + 'd,
+        pin: impl Into<InputSignal<'d>>,
         pin_config: InputConfig,
     ) -> Event<'d> {
         self.into_event(pin, pin_config, EventKind::Any)
@@ -176,11 +176,11 @@ impl<const C: u8> EventChannel<C> {
 
     fn into_event<'d>(
         self,
-        pin: impl Peripheral<P = impl Into<InputSignal>> + 'd,
+        pin: impl Into<InputSignal<'d>>,
         pin_config: InputConfig,
         kind: EventKind,
     ) -> Event<'d> {
-        crate::into_mapped_ref!(pin);
+        let pin = pin.into();
 
         pin.init_input(pin_config.pull);
 
@@ -256,27 +256,19 @@ impl<const C: u8> TaskChannel<C> {
     // number is the pin-count
 
     /// Task to set a high level
-    pub fn set<'d>(
-        self,
-        pin: impl Peripheral<P = impl Into<OutputSignal>> + 'd,
-        pin_config: OutputConfig,
-    ) -> Task<'d> {
+    pub fn set<'d>(self, pin: impl Into<OutputSignal<'d>>, pin_config: OutputConfig) -> Task<'d> {
         self.into_task(pin, pin_config, TaskKind::Set)
     }
 
     /// Task to set a low level
-    pub fn clear<'d>(
-        self,
-        pin: impl Peripheral<P = impl Into<OutputSignal>> + 'd,
-        pin_config: OutputConfig,
-    ) -> Task<'d> {
+    pub fn clear<'d>(self, pin: impl Into<OutputSignal<'d>>, pin_config: OutputConfig) -> Task<'d> {
         self.into_task(pin, pin_config, TaskKind::Clear)
     }
 
     /// Task to toggle the level
     pub fn toggle<'d>(
         self,
-        pin: impl Peripheral<P = impl Into<OutputSignal>> + 'd,
+        pin: impl Into<OutputSignal<'d>>,
         pin_config: OutputConfig,
     ) -> Task<'d> {
         self.into_task(pin, pin_config, TaskKind::Toggle)
@@ -284,11 +276,11 @@ impl<const C: u8> TaskChannel<C> {
 
     fn into_task<'d>(
         self,
-        pin: impl Peripheral<P = impl Into<OutputSignal>> + 'd,
+        pin: impl Into<OutputSignal<'d>>,
         pin_config: OutputConfig,
         kind: TaskKind,
     ) -> Task<'d> {
-        crate::into_mapped_ref!(pin);
+        let pin = pin.into();
 
         pin.set_output_high(pin_config.initial_state.into());
         if pin_config.open_drain {

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -133,14 +133,14 @@ impl<'d> PeripheralOutput<'d> for Output<'d> {
 }
 
 // Placeholders
-impl PeripheralInput<'static> for NoPin {
+impl PeripheralInput<'_> for NoPin {
     fn connect_input_to_peripheral(&self, signal: gpio::InputSignal) {
         // Arbitrary choice but we need to overwrite a previous signal input
         // association.
         Level::Low.connect_input_to_peripheral(signal);
     }
 }
-impl PeripheralOutput<'static> for NoPin {
+impl PeripheralOutput<'_> for NoPin {
     fn connect_peripheral_to_output(&self, _: gpio::OutputSignal) {
         // A peripheral's outputs may be connected to any number of GPIOs.
         // Connecting to, and disconnecting from a NoPin is therefore a
@@ -155,7 +155,7 @@ impl PeripheralOutput<'static> for NoPin {
     }
 }
 
-impl PeripheralInput<'static> for Level {
+impl PeripheralInput<'_> for Level {
     fn connect_input_to_peripheral(&self, signal: gpio::InputSignal) {
         let value = match self {
             Level::High => gpio::ONE_INPUT,
@@ -165,7 +165,7 @@ impl PeripheralInput<'static> for Level {
         connect_input_signal(signal, value, false, true);
     }
 }
-impl PeripheralOutput<'static> for Level {
+impl PeripheralOutput<'_> for Level {
     fn connect_peripheral_to_output(&self, _: gpio::OutputSignal) {
         // There is no such thing as a constant-high level peripheral output,
         // the implementation just exists for convenience.
@@ -682,13 +682,13 @@ impl<'d> From<InputSignal<'d>> for InputConnection<'d> {
     }
 }
 
-impl From<Level> for InputConnection<'static> {
+impl From<Level> for InputConnection<'_> {
     fn from(level: Level) -> Self {
         Self(InputConnectionInner::Constant(level))
     }
 }
 
-impl From<NoPin> for InputConnection<'static> {
+impl From<NoPin> for InputConnection<'_> {
     fn from(_pin: NoPin) -> Self {
         Self(InputConnectionInner::Constant(Level::Low))
     }
@@ -799,13 +799,13 @@ impl<'d> From<OutputSignal<'d>> for OutputConnection<'d> {
     }
 }
 
-impl From<NoPin> for OutputConnection<'static> {
+impl From<NoPin> for OutputConnection<'_> {
     fn from(_pin: NoPin) -> Self {
         Self(OutputConnectionInner::Constant(Level::Low))
     }
 }
 
-impl From<Level> for OutputConnection<'static> {
+impl From<Level> for OutputConnection<'_> {
     fn from(level: Level) -> Self {
         Self(OutputConnectionInner::Constant(level))
     }

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -258,7 +258,7 @@ impl Clone for InputSignal {
     }
 }
 
-impl Peripheral for InputSignal {
+unsafe impl Peripheral for InputSignal {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -385,7 +385,7 @@ impl From<Flex<'static>> for OutputSignal {
     }
 }
 
-impl Peripheral for OutputSignal {
+unsafe impl Peripheral for OutputSignal {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -523,7 +523,7 @@ enum InputConnectionInner {
 #[instability::unstable]
 pub struct InputConnection(InputConnectionInner);
 
-impl Peripheral for InputConnection {
+unsafe impl Peripheral for InputConnection {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -628,7 +628,7 @@ pub struct OutputConnection(OutputConnectionInner);
 
 impl Sealed for OutputConnection {}
 
-impl Peripheral for OutputConnection {
+unsafe impl Peripheral for OutputConnection {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1146,13 +1146,6 @@ pub struct Output<'d> {
 
 impl private::Sealed for Output<'_> {}
 
-unsafe impl<'d> Peripheral for Output<'d> {
-    type P = Flex<'d>;
-    unsafe fn clone_unchecked(&self) -> Self::P {
-        self.pin.clone_unchecked()
-    }
-}
-
 impl<'d> Output<'d> {
     /// Creates a new GPIO output driver.
     ///
@@ -1361,13 +1354,6 @@ pub struct Input<'d> {
 }
 
 impl private::Sealed for Input<'_> {}
-
-unsafe impl<'d> Peripheral for Input<'d> {
-    type P = Flex<'d>;
-    unsafe fn clone_unchecked(&self) -> Self::P {
-        self.pin.clone_unchecked()
-    }
-}
 
 impl<'d> Input<'d> {
     /// Creates a new GPIO input.
@@ -1635,15 +1621,6 @@ pub struct Flex<'d> {
 }
 
 impl private::Sealed for Flex<'_> {}
-
-unsafe impl Peripheral for Flex<'_> {
-    type P = Self;
-    unsafe fn clone_unchecked(&self) -> Self::P {
-        Self {
-            pin: PeripheralRef::new(AnyPin(self.pin.number())),
-        }
-    }
-}
 
 impl<'d> Flex<'d> {
     /// Create flexible pin driver for a [Pin].

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -132,16 +132,6 @@ pub(crate) struct PinGuard {
 }
 
 impl crate::private::Sealed for PinGuard {}
-impl Peripheral for PinGuard {
-    type P = Self;
-
-    unsafe fn clone_unchecked(&self) -> Self::P {
-        Self {
-            pin: self.pin,
-            signal: self.signal,
-        }
-    }
-}
 
 impl PinGuard {
     pub(crate) fn new(mut pin: AnyPin, signal: OutputSignal) -> Self {
@@ -689,7 +679,7 @@ fn disable_usb_pads(gpionum: u8) {
     }
 }
 
-impl<const GPIONUM: u8> Peripheral for GpioPin<GPIONUM>
+unsafe impl<const GPIONUM: u8> Peripheral for GpioPin<GPIONUM>
 where
     Self: Pin,
 {
@@ -963,7 +953,7 @@ macro_rules! gpio {
                 }
             )+
 
-            impl $crate::peripheral::Peripheral for $crate::gpio::AnyPin {
+            unsafe impl $crate::peripheral::Peripheral for $crate::gpio::AnyPin {
                 type P = $crate::gpio::AnyPin;
                 unsafe fn clone_unchecked(&self) ->  Self {
                     Self(self.0)
@@ -1150,7 +1140,7 @@ pub struct Output<'d> {
 
 impl private::Sealed for Output<'_> {}
 
-impl<'d> Peripheral for Output<'d> {
+unsafe impl<'d> Peripheral for Output<'d> {
     type P = Flex<'d>;
     unsafe fn clone_unchecked(&self) -> Self::P {
         self.pin.clone_unchecked()
@@ -1361,7 +1351,7 @@ pub struct Input<'d> {
 
 impl private::Sealed for Input<'_> {}
 
-impl<'d> Peripheral for Input<'d> {
+unsafe impl<'d> Peripheral for Input<'d> {
     type P = Flex<'d>;
     unsafe fn clone_unchecked(&self) -> Self::P {
         self.pin.clone_unchecked()
@@ -1630,7 +1620,7 @@ pub struct Flex<'d> {
 
 impl private::Sealed for Flex<'_> {}
 
-impl Peripheral for Flex<'_> {
+unsafe impl Peripheral for Flex<'_> {
     type P = Self;
     unsafe fn clone_unchecked(&self) -> Self::P {
         Self {

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -50,10 +50,6 @@ impl Level {
     ) -> &'static [(AlternateFunction, OutputSignal)] {
         &[]
     }
-
-    pub(crate) fn connect_peripheral_to_output(&self, _signal: OutputSignal) {}
-
-    pub(crate) fn disconnect_from_peripheral_output(&self, _signal: OutputSignal) {}
 }
 
 /// Placeholder pin, used when no pin is required when using a peripheral.

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -7,14 +7,6 @@
 
 use super::*;
 
-unsafe impl crate::peripheral::Peripheral for Level {
-    type P = Self;
-
-    unsafe fn clone_unchecked(&self) -> Self::P {
-        *self
-    }
-}
-
 impl Level {
     pub(crate) fn pull_direction(&self, _pull: Pull) {}
 
@@ -57,14 +49,6 @@ impl Level {
 /// When used as a peripheral signal, `NoPin` is equivalent to [`Level::Low`].
 #[derive(Default, Clone, Copy)]
 pub struct NoPin;
-
-unsafe impl crate::peripheral::Peripheral for NoPin {
-    type P = Self;
-
-    unsafe fn clone_unchecked(&self) -> Self::P {
-        Self
-    }
-}
 
 impl private::Sealed for NoPin {}
 

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -8,7 +8,7 @@
 use super::*;
 use crate::gpio::interconnect::connect_input_signal;
 
-impl crate::peripheral::Peripheral for Level {
+unsafe impl crate::peripheral::Peripheral for Level {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {
@@ -72,7 +72,7 @@ impl Level {
 #[derive(Default, Clone, Copy)]
 pub struct NoPin;
 
-impl crate::peripheral::Peripheral for NoPin {
+unsafe impl crate::peripheral::Peripheral for NoPin {
     type P = Self;
 
     unsafe fn clone_unchecked(&self) -> Self::P {

--- a/esp-hal/src/gpio/placeholder.rs
+++ b/esp-hal/src/gpio/placeholder.rs
@@ -6,7 +6,6 @@
 // polluting the main module.
 
 use super::*;
-use crate::gpio::interconnect::connect_input_signal;
 
 unsafe impl crate::peripheral::Peripheral for Level {
     type P = Self;
@@ -32,15 +31,6 @@ impl Level {
 
     pub(crate) fn is_input_high(&self) -> bool {
         *self == Level::High
-    }
-
-    pub(crate) fn connect_input_to_peripheral(&self, signal: InputSignal) {
-        let value = match self {
-            Level::High => ONE_INPUT,
-            Level::Low => ZERO_INPUT,
-        };
-
-        connect_input_signal(signal, value, false, true);
     }
 
     pub(crate) fn set_to_open_drain_output(&self) {}

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -917,7 +917,7 @@ where
     /// Connect a pin to the I2C SDA signal.
     ///
     /// This will replace previous pin assignments for this signal.
-    pub fn with_sda(mut self, sda: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+    pub fn with_sda(mut self, sda: impl PeripheralOutput<'d>) -> Self {
         let info = self.driver().info;
         let input = info.sda_input;
         let output = info.sda_output;
@@ -929,7 +929,7 @@ where
     /// Connect a pin to the I2C SCL signal.
     ///
     /// This will replace previous pin assignments for this signal.
-    pub fn with_scl(mut self, scl: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+    pub fn with_scl(mut self, scl: impl PeripheralOutput<'d>) -> Self {
         let info = self.driver().info;
         let input = info.scl_input;
         let output = info.scl_output;
@@ -939,12 +939,12 @@ where
     }
 
     fn connect_pin(
-        pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        pin: impl PeripheralOutput<'d>,
         input: InputSignal,
         output: OutputSignal,
         guard: &mut PinGuard,
     ) {
-        crate::into_mapped_ref!(pin);
+        let pin = pin.into();
         // avoid the pin going low during configuration
         pin.set_output_high(true);
 
@@ -952,7 +952,7 @@ where
         pin.enable_input(true);
         pin.pull_direction(Pull::Up);
 
-        input.connect_to(pin.reborrow());
+        input.connect_to(&pin);
 
         *guard = OutputConnection::connect_with_guard(pin, output);
     }

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -403,10 +403,10 @@ where
     Dm: DriverMode,
 {
     /// Configures the I2S peripheral to use a master clock (MCLK) output pin.
-    pub fn with_mclk<P: PeripheralOutput>(self, pin: impl Peripheral<P = P> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
-        pin.set_to_push_pull_output();
-        self.i2s_tx.i2s.mclk_signal().connect_to(pin);
+    pub fn with_mclk(self, mclk: impl PeripheralOutput<'d>) -> Self {
+        let mclk = mclk.into();
+        mclk.set_to_push_pull_output();
+        self.i2s_tx.i2s.mclk_signal().connect_to(&mclk);
 
         self
     }
@@ -729,35 +729,26 @@ mod private {
             }
         }
 
-        pub fn with_bclk<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
-        where
-            P: PeripheralOutput,
-        {
-            crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output();
-            self.i2s.bclk_signal().connect_to(pin);
+        pub fn with_bclk(self, bclk: impl PeripheralOutput<'d>) -> Self {
+            let bclk = bclk.into();
+            bclk.set_to_push_pull_output();
+            self.i2s.bclk_signal().connect_to(&bclk);
 
             self
         }
 
-        pub fn with_ws<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
-        where
-            P: PeripheralOutput,
-        {
-            crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output();
-            self.i2s.ws_signal().connect_to(pin);
+        pub fn with_ws(self, ws: impl PeripheralOutput<'d>) -> Self {
+            let ws = ws.into();
+            ws.set_to_push_pull_output();
+            self.i2s.ws_signal().connect_to(&ws);
 
             self
         }
 
-        pub fn with_dout<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
-        where
-            P: PeripheralOutput,
-        {
-            crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output();
-            self.i2s.dout_signal().connect_to(pin);
+        pub fn with_dout(self, dout: impl PeripheralOutput<'d>) -> Self {
+            let dout = dout.into();
+            dout.set_to_push_pull_output();
+            self.i2s.dout_signal().connect_to(&dout);
 
             self
         }
@@ -787,35 +778,26 @@ mod private {
             }
         }
 
-        pub fn with_bclk<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
-        where
-            P: PeripheralOutput,
-        {
-            crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output();
-            self.i2s.bclk_rx_signal().connect_to(pin);
+        pub fn with_bclk(self, bclk: impl PeripheralOutput<'d>) -> Self {
+            let bclk = bclk.into();
+            bclk.set_to_push_pull_output();
+            self.i2s.bclk_rx_signal().connect_to(&bclk);
 
             self
         }
 
-        pub fn with_ws<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
-        where
-            P: PeripheralOutput,
-        {
-            crate::into_mapped_ref!(pin);
-            pin.set_to_push_pull_output();
-            self.i2s.ws_rx_signal().connect_to(pin);
+        pub fn with_ws(self, ws: impl PeripheralOutput<'d>) -> Self {
+            let ws = ws.into();
+            ws.set_to_push_pull_output();
+            self.i2s.ws_rx_signal().connect_to(&ws);
 
             self
         }
 
-        pub fn with_din<P>(self, pin: impl Peripheral<P = P> + 'd) -> Self
-        where
-            P: PeripheralInput,
-        {
-            crate::into_mapped_ref!(pin);
-            pin.init_input(crate::gpio::Pull::None);
-            self.i2s.din_signal().connect_to(pin);
+        pub fn with_din(self, din: impl PeripheralInput<'d>) -> Self {
+            let din = din.into();
+            din.init_input(crate::gpio::Pull::None);
+            self.i2s.din_signal().connect_to(&din);
 
             self
         }

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -138,39 +138,48 @@ pub trait TxPins<'d> {
 /// Represents a group of 16 output pins configured for 16-bit parallel data
 /// transmission.
 pub struct TxSixteenBits<'d> {
-    pins: [PeripheralRef<'d, OutputConnection>; 16],
+    pins: [OutputConnection<'d>; 16],
 }
 
 impl<'d> TxSixteenBits<'d> {
     #[allow(clippy::too_many_arguments)]
     /// Creates a new `TxSixteenBits` instance with the provided output pins.
     pub fn new(
-        pin_0: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_1: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_2: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_3: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_4: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_5: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_6: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_7: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_8: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_9: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_10: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_11: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_12: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_13: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_14: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_15: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        pin_0: impl PeripheralOutput<'d>,
+        pin_1: impl PeripheralOutput<'d>,
+        pin_2: impl PeripheralOutput<'d>,
+        pin_3: impl PeripheralOutput<'d>,
+        pin_4: impl PeripheralOutput<'d>,
+        pin_5: impl PeripheralOutput<'d>,
+        pin_6: impl PeripheralOutput<'d>,
+        pin_7: impl PeripheralOutput<'d>,
+        pin_8: impl PeripheralOutput<'d>,
+        pin_9: impl PeripheralOutput<'d>,
+        pin_10: impl PeripheralOutput<'d>,
+        pin_11: impl PeripheralOutput<'d>,
+        pin_12: impl PeripheralOutput<'d>,
+        pin_13: impl PeripheralOutput<'d>,
+        pin_14: impl PeripheralOutput<'d>,
+        pin_15: impl PeripheralOutput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(
-            pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7, pin_8, pin_9, pin_10, pin_11,
-            pin_12, pin_13, pin_14, pin_15
-        );
-
         Self {
             pins: [
-                pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7, pin_8, pin_9, pin_10,
-                pin_11, pin_12, pin_13, pin_14, pin_15,
+                pin_0.into(),
+                pin_1.into(),
+                pin_2.into(),
+                pin_3.into(),
+                pin_4.into(),
+                pin_5.into(),
+                pin_6.into(),
+                pin_7.into(),
+                pin_8.into(),
+                pin_9.into(),
+                pin_10.into(),
+                pin_11.into(),
+                pin_12.into(),
+                pin_13.into(),
+                pin_14.into(),
+                pin_15.into(),
             ],
         }
     }
@@ -194,26 +203,33 @@ impl<'d> TxPins<'d> for TxSixteenBits<'d> {
 /// Represents a group of 8 output pins configured for 8-bit parallel data
 /// transmission.
 pub struct TxEightBits<'d> {
-    pins: [PeripheralRef<'d, OutputConnection>; 8],
+    pins: [OutputConnection<'d>; 8],
 }
 
 impl<'d> TxEightBits<'d> {
     #[allow(clippy::too_many_arguments)]
     /// Creates a new `TxSEightBits` instance with the provided output pins.
     pub fn new(
-        pin_0: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_1: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_2: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_3: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_4: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_5: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_6: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_7: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        pin_0: impl PeripheralOutput<'d>,
+        pin_1: impl PeripheralOutput<'d>,
+        pin_2: impl PeripheralOutput<'d>,
+        pin_3: impl PeripheralOutput<'d>,
+        pin_4: impl PeripheralOutput<'d>,
+        pin_5: impl PeripheralOutput<'d>,
+        pin_6: impl PeripheralOutput<'d>,
+        pin_7: impl PeripheralOutput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7);
-
         Self {
-            pins: [pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7],
+            pins: [
+                pin_0.into(),
+                pin_1.into(),
+                pin_2.into(),
+                pin_3.into(),
+                pin_4.into(),
+                pin_5.into(),
+                pin_6.into(),
+                pin_7.into(),
+            ],
         }
     }
 }
@@ -250,13 +266,12 @@ impl<'d> I2sParallel<'d, Blocking> {
         channel: impl Peripheral<P = CH> + 'd,
         frequency: Rate,
         mut pins: impl TxPins<'d>,
-        clock_pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        clock_pin: impl PeripheralOutput<'d>,
     ) -> Self
     where
         CH: DmaChannelFor<AnyI2s>,
     {
         crate::into_mapped_ref!(i2s);
-        crate::into_mapped_ref!(clock_pin);
 
         let channel = Channel::new(channel.map(|ch| ch.degrade()));
         channel.runtime_ensure_compatible(&i2s);
@@ -266,8 +281,9 @@ impl<'d> I2sParallel<'d, Blocking> {
         // configure the I2S peripheral for parallel mode
         i2s.setup(frequency, pins.bus_width());
         // setup the clock pin
+        let clock_pin = clock_pin.into();
         clock_pin.set_to_push_pull_output();
-        i2s.ws_signal().connect_to(clock_pin);
+        i2s.ws_signal().connect_to(&clock_pin);
 
         pins.configure(i2s.reborrow());
         Self {

--- a/esp-hal/src/interrupt/software.rs
+++ b/esp-hal/src/interrupt/software.rs
@@ -139,7 +139,7 @@ impl<const NUM: u8> SoftwareInterrupt<NUM> {
     }
 }
 
-impl<const NUM: u8> crate::peripheral::Peripheral for SoftwareInterrupt<NUM> {
+unsafe impl<const NUM: u8> crate::peripheral::Peripheral for SoftwareInterrupt<NUM> {
     type P = SoftwareInterrupt<NUM>;
 
     #[inline]

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -228,44 +228,38 @@ impl<'d> Camera<'d> {
 
 impl<'d> Camera<'d> {
     /// Configures the master clock (MCLK) pin for the camera interface.
-    pub fn with_master_clock<MCLK: PeripheralOutput>(
-        self,
-        mclk: impl Peripheral<P = MCLK> + 'd,
-    ) -> Self {
-        crate::into_mapped_ref!(mclk);
-
+    pub fn with_master_clock(self, mclk: impl PeripheralOutput<'d>) -> Self {
+        let mclk = mclk.into();
         mclk.set_to_push_pull_output();
-        OutputSignal::CAM_CLK.connect_to(mclk);
+        OutputSignal::CAM_CLK.connect_to(&mclk);
 
         self
     }
 
     /// Configures the pixel clock (PCLK) pin for the camera interface.
-    pub fn with_pixel_clock<PCLK: PeripheralInput>(
-        self,
-        pclk: impl Peripheral<P = PCLK> + 'd,
-    ) -> Self {
-        crate::into_mapped_ref!(pclk);
+    pub fn with_pixel_clock(self, pclk: impl PeripheralInput<'d>) -> Self {
+        let pclk = pclk.into();
 
         pclk.init_input(Pull::None);
-        InputSignal::CAM_PCLK.connect_to(pclk);
+        InputSignal::CAM_PCLK.connect_to(&pclk);
 
         self
     }
 
     /// Configures the control pins for the camera interface (VSYNC and
     /// HENABLE).
-    pub fn with_ctrl_pins<VSYNC: PeripheralInput, HENABLE: PeripheralInput>(
+    pub fn with_ctrl_pins(
         self,
-        vsync: impl Peripheral<P = VSYNC> + 'd,
-        h_enable: impl Peripheral<P = HENABLE> + 'd,
+        vsync: impl PeripheralInput<'d>,
+        h_enable: impl PeripheralInput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(vsync, h_enable);
+        let vsync = vsync.into();
+        let h_enable = h_enable.into();
 
         vsync.init_input(Pull::None);
-        InputSignal::CAM_V_SYNC.connect_to(vsync);
+        InputSignal::CAM_V_SYNC.connect_to(&vsync);
         h_enable.init_input(Pull::None);
-        InputSignal::CAM_H_ENABLE.connect_to(h_enable);
+        InputSignal::CAM_H_ENABLE.connect_to(&h_enable);
 
         self.regs()
             .cam_ctrl1()
@@ -276,24 +270,22 @@ impl<'d> Camera<'d> {
 
     /// Configures the control pins for the camera interface (VSYNC, HSYNC, and
     /// HENABLE) with DE (data enable).
-    pub fn with_ctrl_pins_and_de<
-        VSYNC: PeripheralInput,
-        HSYNC: PeripheralInput,
-        HENABLE: PeripheralInput,
-    >(
+    pub fn with_ctrl_pins_and_de(
         self,
-        vsync: impl Peripheral<P = VSYNC> + 'd,
-        hsync: impl Peripheral<P = HSYNC> + 'd,
-        h_enable: impl Peripheral<P = HENABLE> + 'd,
+        vsync: impl PeripheralInput<'d>,
+        hsync: impl PeripheralInput<'d>,
+        h_enable: impl PeripheralInput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(vsync, hsync, h_enable);
+        let vsync = vsync.into();
+        let hsync = hsync.into();
+        let h_enable = h_enable.into();
 
         vsync.init_input(Pull::None);
-        InputSignal::CAM_V_SYNC.connect_to(vsync);
+        InputSignal::CAM_V_SYNC.connect_to(&vsync);
         hsync.init_input(Pull::None);
-        InputSignal::CAM_H_SYNC.connect_to(hsync);
+        InputSignal::CAM_H_SYNC.connect_to(&hsync);
         h_enable.init_input(Pull::None);
-        InputSignal::CAM_H_ENABLE.connect_to(h_enable);
+        InputSignal::CAM_H_ENABLE.connect_to(&h_enable);
 
         self.regs()
             .cam_ctrl1()
@@ -477,38 +469,29 @@ impl RxEightBits {
     /// Creates a new instance of `RxEightBits`, configuring the specified pins
     /// as the 8-bit data bus.
     pub fn new<'d>(
-        pin_0: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_1: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_2: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_3: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_4: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_5: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_6: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_7: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_0: impl PeripheralInput<'d>,
+        pin_1: impl PeripheralInput<'d>,
+        pin_2: impl PeripheralInput<'d>,
+        pin_3: impl PeripheralInput<'d>,
+        pin_4: impl PeripheralInput<'d>,
+        pin_5: impl PeripheralInput<'d>,
+        pin_6: impl PeripheralInput<'d>,
+        pin_7: impl PeripheralInput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(pin_0);
-        crate::into_mapped_ref!(pin_1);
-        crate::into_mapped_ref!(pin_2);
-        crate::into_mapped_ref!(pin_3);
-        crate::into_mapped_ref!(pin_4);
-        crate::into_mapped_ref!(pin_5);
-        crate::into_mapped_ref!(pin_6);
-        crate::into_mapped_ref!(pin_7);
-
         let pairs = [
-            (pin_0, InputSignal::CAM_DATA_0),
-            (pin_1, InputSignal::CAM_DATA_1),
-            (pin_2, InputSignal::CAM_DATA_2),
-            (pin_3, InputSignal::CAM_DATA_3),
-            (pin_4, InputSignal::CAM_DATA_4),
-            (pin_5, InputSignal::CAM_DATA_5),
-            (pin_6, InputSignal::CAM_DATA_6),
-            (pin_7, InputSignal::CAM_DATA_7),
+            (pin_0.into(), InputSignal::CAM_DATA_0),
+            (pin_1.into(), InputSignal::CAM_DATA_1),
+            (pin_2.into(), InputSignal::CAM_DATA_2),
+            (pin_3.into(), InputSignal::CAM_DATA_3),
+            (pin_4.into(), InputSignal::CAM_DATA_4),
+            (pin_5.into(), InputSignal::CAM_DATA_5),
+            (pin_6.into(), InputSignal::CAM_DATA_6),
+            (pin_7.into(), InputSignal::CAM_DATA_7),
         ];
 
         for (pin, signal) in pairs.into_iter() {
             pin.init_input(Pull::None);
-            signal.connect_to(pin);
+            signal.connect_to(&pin);
         }
 
         Self { _pins: () }
@@ -530,62 +513,45 @@ impl RxSixteenBits {
     /// Creates a new instance of `RxSixteenBits`, configuring the specified
     /// pins as the 16-bit data bus.
     pub fn new<'d>(
-        pin_0: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_1: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_2: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_3: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_4: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_5: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_6: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_7: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_8: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_9: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_10: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_11: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_12: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_13: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_14: impl Peripheral<P = impl PeripheralInput> + 'd,
-        pin_15: impl Peripheral<P = impl PeripheralInput> + 'd,
+        pin_0: impl PeripheralInput<'d>,
+        pin_1: impl PeripheralInput<'d>,
+        pin_2: impl PeripheralInput<'d>,
+        pin_3: impl PeripheralInput<'d>,
+        pin_4: impl PeripheralInput<'d>,
+        pin_5: impl PeripheralInput<'d>,
+        pin_6: impl PeripheralInput<'d>,
+        pin_7: impl PeripheralInput<'d>,
+        pin_8: impl PeripheralInput<'d>,
+        pin_9: impl PeripheralInput<'d>,
+        pin_10: impl PeripheralInput<'d>,
+        pin_11: impl PeripheralInput<'d>,
+        pin_12: impl PeripheralInput<'d>,
+        pin_13: impl PeripheralInput<'d>,
+        pin_14: impl PeripheralInput<'d>,
+        pin_15: impl PeripheralInput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(pin_0);
-        crate::into_mapped_ref!(pin_1);
-        crate::into_mapped_ref!(pin_2);
-        crate::into_mapped_ref!(pin_3);
-        crate::into_mapped_ref!(pin_4);
-        crate::into_mapped_ref!(pin_5);
-        crate::into_mapped_ref!(pin_6);
-        crate::into_mapped_ref!(pin_7);
-        crate::into_mapped_ref!(pin_8);
-        crate::into_mapped_ref!(pin_9);
-        crate::into_mapped_ref!(pin_10);
-        crate::into_mapped_ref!(pin_11);
-        crate::into_mapped_ref!(pin_12);
-        crate::into_mapped_ref!(pin_13);
-        crate::into_mapped_ref!(pin_14);
-        crate::into_mapped_ref!(pin_15);
-
         let pairs = [
-            (pin_0, InputSignal::CAM_DATA_0),
-            (pin_1, InputSignal::CAM_DATA_1),
-            (pin_2, InputSignal::CAM_DATA_2),
-            (pin_3, InputSignal::CAM_DATA_3),
-            (pin_4, InputSignal::CAM_DATA_4),
-            (pin_5, InputSignal::CAM_DATA_5),
-            (pin_6, InputSignal::CAM_DATA_6),
-            (pin_7, InputSignal::CAM_DATA_7),
-            (pin_8, InputSignal::CAM_DATA_8),
-            (pin_9, InputSignal::CAM_DATA_9),
-            (pin_10, InputSignal::CAM_DATA_10),
-            (pin_11, InputSignal::CAM_DATA_11),
-            (pin_12, InputSignal::CAM_DATA_12),
-            (pin_13, InputSignal::CAM_DATA_13),
-            (pin_14, InputSignal::CAM_DATA_14),
-            (pin_15, InputSignal::CAM_DATA_15),
+            (pin_0.into(), InputSignal::CAM_DATA_0),
+            (pin_1.into(), InputSignal::CAM_DATA_1),
+            (pin_2.into(), InputSignal::CAM_DATA_2),
+            (pin_3.into(), InputSignal::CAM_DATA_3),
+            (pin_4.into(), InputSignal::CAM_DATA_4),
+            (pin_5.into(), InputSignal::CAM_DATA_5),
+            (pin_6.into(), InputSignal::CAM_DATA_6),
+            (pin_7.into(), InputSignal::CAM_DATA_7),
+            (pin_8.into(), InputSignal::CAM_DATA_8),
+            (pin_9.into(), InputSignal::CAM_DATA_9),
+            (pin_10.into(), InputSignal::CAM_DATA_10),
+            (pin_11.into(), InputSignal::CAM_DATA_11),
+            (pin_12.into(), InputSignal::CAM_DATA_12),
+            (pin_13.into(), InputSignal::CAM_DATA_13),
+            (pin_14.into(), InputSignal::CAM_DATA_14),
+            (pin_15.into(), InputSignal::CAM_DATA_15),
         ];
 
         for (pin, signal) in pairs.into_iter() {
             pin.init_input(Pull::None);
-            signal.connect_to(pin);
+            signal.connect_to(&pin);
         }
 
         Self { _pins: () }

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -317,10 +317,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the VSYNC
     /// signal.
-    pub fn with_vsync<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_vsync(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_V_SYNC.connect_to(pin);
+        OutputSignal::LCD_V_SYNC.connect_to(&pin);
 
         self
     }
@@ -329,10 +329,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the HSYNC
     /// signal.
-    pub fn with_hsync<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_hsync(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_H_SYNC.connect_to(pin);
+        OutputSignal::LCD_H_SYNC.connect_to(&pin);
 
         self
     }
@@ -341,10 +341,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DE
     /// signal.
-    pub fn with_de<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_de(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_H_ENABLE.connect_to(pin);
+        OutputSignal::LCD_H_ENABLE.connect_to(&pin);
 
         self
     }
@@ -353,10 +353,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the PCLK
     /// signal.
-    pub fn with_pclk<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_pclk(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_PCLK.connect_to(pin);
+        OutputSignal::LCD_PCLK.connect_to(&pin);
 
         self
     }
@@ -365,10 +365,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_0
     /// signal.
-    pub fn with_data0<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data0(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_0.connect_to(pin);
+        OutputSignal::LCD_DATA_0.connect_to(&pin);
 
         self
     }
@@ -377,10 +377,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_1
     /// signal.
-    pub fn with_data1<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data1(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_1.connect_to(pin);
+        OutputSignal::LCD_DATA_1.connect_to(&pin);
 
         self
     }
@@ -389,10 +389,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_2
     /// signal.
-    pub fn with_data2<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data2(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_2.connect_to(pin);
+        OutputSignal::LCD_DATA_2.connect_to(&pin);
 
         self
     }
@@ -401,10 +401,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_3
     /// signal.
-    pub fn with_data3<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data3(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_3.connect_to(pin);
+        OutputSignal::LCD_DATA_3.connect_to(&pin);
 
         self
     }
@@ -413,10 +413,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_4
     /// signal.
-    pub fn with_data4<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data4(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_4.connect_to(pin);
+        OutputSignal::LCD_DATA_4.connect_to(&pin);
 
         self
     }
@@ -425,10 +425,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_5
     /// signal.
-    pub fn with_data5<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data5(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_5.connect_to(pin);
+        OutputSignal::LCD_DATA_5.connect_to(&pin);
 
         self
     }
@@ -437,10 +437,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_6
     /// signal.
-    pub fn with_data6<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data6(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_6.connect_to(pin);
+        OutputSignal::LCD_DATA_6.connect_to(&pin);
 
         self
     }
@@ -449,10 +449,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_7
     /// signal.
-    pub fn with_data7<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data7(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_7.connect_to(pin);
+        OutputSignal::LCD_DATA_7.connect_to(&pin);
 
         self
     }
@@ -461,10 +461,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_8
     /// signal.
-    pub fn with_data8<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data8(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_8.connect_to(pin);
+        OutputSignal::LCD_DATA_8.connect_to(&pin);
 
         self
     }
@@ -473,10 +473,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the DATA_9
     /// signal.
-    pub fn with_data9<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data9(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_9.connect_to(pin);
+        OutputSignal::LCD_DATA_9.connect_to(&pin);
 
         self
     }
@@ -485,10 +485,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the
     /// DATA_10 signal.
-    pub fn with_data10<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data10(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_10.connect_to(pin);
+        OutputSignal::LCD_DATA_10.connect_to(&pin);
 
         self
     }
@@ -497,10 +497,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the
     /// DATA_11 signal.
-    pub fn with_data11<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data11(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_11.connect_to(pin);
+        OutputSignal::LCD_DATA_11.connect_to(&pin);
 
         self
     }
@@ -509,10 +509,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the
     /// DATA_12 signal.
-    pub fn with_data12<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data12(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_12.connect_to(pin);
+        OutputSignal::LCD_DATA_12.connect_to(&pin);
 
         self
     }
@@ -521,10 +521,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the
     /// DATA_13 signal.
-    pub fn with_data13<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data13(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_13.connect_to(pin);
+        OutputSignal::LCD_DATA_13.connect_to(&pin);
 
         self
     }
@@ -533,10 +533,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the
     /// DATA_14 signal.
-    pub fn with_data14<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data14(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_14.connect_to(pin);
+        OutputSignal::LCD_DATA_14.connect_to(&pin);
 
         self
     }
@@ -545,10 +545,10 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the
     /// DATA_15 signal.
-    pub fn with_data15<S: PeripheralOutput>(self, pin: impl Peripheral<P = S> + 'd) -> Self {
-        crate::into_mapped_ref!(pin);
+    pub fn with_data15(self, pin: impl PeripheralOutput<'d>) -> Self {
+        let pin = pin.into();
         pin.set_to_push_pull_output();
-        OutputSignal::LCD_DATA_15.connect_to(pin);
+        OutputSignal::LCD_DATA_15.connect_to(&pin);
 
         self
     }

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -273,27 +273,28 @@ where
     }
 
     /// Associates a CS pin with the I8080 interface.
-    pub fn with_cs<CS: PeripheralOutput>(self, cs: impl Peripheral<P = CS> + 'd) -> Self {
-        crate::into_mapped_ref!(cs);
+    pub fn with_cs(self, cs: impl PeripheralOutput<'d>) -> Self {
+        let cs = cs.into();
         cs.set_to_push_pull_output();
-        OutputSignal::LCD_CS.connect_to(cs);
+        OutputSignal::LCD_CS.connect_to(&cs);
 
         self
     }
 
     /// Configures the control pins for the I8080 interface.
-    pub fn with_ctrl_pins<DC: PeripheralOutput, WRX: PeripheralOutput>(
+    pub fn with_ctrl_pins(
         self,
-        dc: impl Peripheral<P = DC> + 'd,
-        wrx: impl Peripheral<P = WRX> + 'd,
+        dc: impl PeripheralOutput<'d>,
+        wrx: impl PeripheralOutput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(dc, wrx);
+        let dc = dc.into();
+        let wrx = wrx.into();
 
         dc.set_to_push_pull_output();
-        OutputSignal::LCD_DC.connect_to(dc);
+        OutputSignal::LCD_DC.connect_to(&dc);
 
         wrx.set_to_push_pull_output();
-        OutputSignal::LCD_PCLK.connect_to(wrx);
+        OutputSignal::LCD_PCLK.connect_to(&wrx);
 
         self
     }
@@ -620,33 +621,33 @@ impl From<u16> for Command<u16> {
 /// Represents a group of 8 output pins configured for 8-bit parallel data
 /// transmission.
 pub struct TxEightBits<'d> {
-    pins: [PeripheralRef<'d, OutputConnection>; 8],
+    pins: [OutputConnection<'d>; 8],
 }
 
 impl<'d> TxEightBits<'d> {
     #[allow(clippy::too_many_arguments)]
     /// Creates a new `TxEightBits` instance with the provided output pins.
     pub fn new(
-        pin_0: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_1: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_2: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_3: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_4: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_5: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_6: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_7: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        pin_0: impl PeripheralOutput<'d>,
+        pin_1: impl PeripheralOutput<'d>,
+        pin_2: impl PeripheralOutput<'d>,
+        pin_3: impl PeripheralOutput<'d>,
+        pin_4: impl PeripheralOutput<'d>,
+        pin_5: impl PeripheralOutput<'d>,
+        pin_6: impl PeripheralOutput<'d>,
+        pin_7: impl PeripheralOutput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(pin_0);
-        crate::into_mapped_ref!(pin_1);
-        crate::into_mapped_ref!(pin_2);
-        crate::into_mapped_ref!(pin_3);
-        crate::into_mapped_ref!(pin_4);
-        crate::into_mapped_ref!(pin_5);
-        crate::into_mapped_ref!(pin_6);
-        crate::into_mapped_ref!(pin_7);
-
         Self {
-            pins: [pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7],
+            pins: [
+                pin_0.into(),
+                pin_1.into(),
+                pin_2.into(),
+                pin_3.into(),
+                pin_4.into(),
+                pin_5.into(),
+                pin_6.into(),
+                pin_7.into(),
+            ],
         }
     }
 }
@@ -664,7 +665,7 @@ impl TxPins for TxEightBits<'_> {
             OutputSignal::LCD_DATA_7,
         ];
 
-        for (pin, signal) in self.pins.iter_mut().zip(SIGNALS.into_iter()) {
+        for (pin, signal) in self.pins.iter().zip(SIGNALS.into_iter()) {
             pin.set_to_push_pull_output();
             signal.connect_to(pin);
         }
@@ -674,39 +675,48 @@ impl TxPins for TxEightBits<'_> {
 /// Represents a group of 16 output pins configured for 16-bit parallel data
 /// transmission.
 pub struct TxSixteenBits<'d> {
-    pins: [PeripheralRef<'d, OutputConnection>; 16],
+    pins: [OutputConnection<'d>; 16],
 }
 
 impl<'d> TxSixteenBits<'d> {
     #[allow(clippy::too_many_arguments)]
     /// Creates a new `TxSixteenBits` instance with the provided output pins.
     pub fn new(
-        pin_0: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_1: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_2: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_3: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_4: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_5: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_6: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_7: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_8: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_9: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_10: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_11: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_12: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_13: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_14: impl Peripheral<P = impl PeripheralOutput> + 'd,
-        pin_15: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        pin_0: impl PeripheralOutput<'d>,
+        pin_1: impl PeripheralOutput<'d>,
+        pin_2: impl PeripheralOutput<'d>,
+        pin_3: impl PeripheralOutput<'d>,
+        pin_4: impl PeripheralOutput<'d>,
+        pin_5: impl PeripheralOutput<'d>,
+        pin_6: impl PeripheralOutput<'d>,
+        pin_7: impl PeripheralOutput<'d>,
+        pin_8: impl PeripheralOutput<'d>,
+        pin_9: impl PeripheralOutput<'d>,
+        pin_10: impl PeripheralOutput<'d>,
+        pin_11: impl PeripheralOutput<'d>,
+        pin_12: impl PeripheralOutput<'d>,
+        pin_13: impl PeripheralOutput<'d>,
+        pin_14: impl PeripheralOutput<'d>,
+        pin_15: impl PeripheralOutput<'d>,
     ) -> Self {
-        crate::into_mapped_ref!(
-            pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7, pin_8, pin_9, pin_10, pin_11,
-            pin_12, pin_13, pin_14, pin_15
-        );
-
         Self {
             pins: [
-                pin_0, pin_1, pin_2, pin_3, pin_4, pin_5, pin_6, pin_7, pin_8, pin_9, pin_10,
-                pin_11, pin_12, pin_13, pin_14, pin_15,
+                pin_0.into(),
+                pin_1.into(),
+                pin_2.into(),
+                pin_3.into(),
+                pin_4.into(),
+                pin_5.into(),
+                pin_6.into(),
+                pin_7.into(),
+                pin_8.into(),
+                pin_9.into(),
+                pin_10.into(),
+                pin_11.into(),
+                pin_12.into(),
+                pin_13.into(),
+                pin_14.into(),
+                pin_15.into(),
             ],
         }
     }

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -16,7 +16,6 @@ use crate::{
         OutputSignal,
     },
     pac::ledc::RegisterBlock,
-    peripheral::{Peripheral, PeripheralRef},
     peripherals::LEDC,
 };
 
@@ -152,22 +151,18 @@ pub struct Channel<'a, S: TimerSpeed> {
     ledc: &'a RegisterBlock,
     timer: Option<&'a dyn TimerIFace<S>>,
     number: Number,
-    output_pin: PeripheralRef<'a, OutputConnection>,
+    output_pin: OutputConnection<'a>,
 }
 
 impl<'a, S: TimerSpeed> Channel<'a, S> {
     /// Return a new channel
-    pub fn new(
-        number: Number,
-        output_pin: impl Peripheral<P = impl PeripheralOutput> + 'a,
-    ) -> Self {
-        crate::into_mapped_ref!(output_pin);
+    pub fn new(number: Number, output_pin: impl PeripheralOutput<'a>) -> Self {
         let ledc = LEDC::regs();
         Channel {
             ledc,
             timer: None,
             number,
-            output_pin,
+            output_pin: output_pin.into(),
         }
     }
 }

--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -609,7 +609,7 @@ where
                 Number::Channel7 => OutputSignal::LEDC_LS_SIG7,
             };
 
-            signal.connect_to(&mut self.output_pin);
+            signal.connect_to(&self.output_pin);
         } else {
             return Err(Error::Timer);
         }

--- a/esp-hal/src/ledc/mod.rs
+++ b/esp-hal/src/ledc/mod.rs
@@ -180,7 +180,7 @@ impl<'d> Ledc<'d> {
     pub fn channel<S: TimerSpeed>(
         &self,
         number: channel::Number,
-        output_pin: impl Peripheral<P = impl PeripheralOutput> + 'd,
+        output_pin: impl PeripheralOutput<'d>,
     ) -> Channel<'d, S> {
         Channel::new(number, output_pin)
     }

--- a/esp-hal/src/macros.rs
+++ b/esp-hal/src/macros.rs
@@ -109,7 +109,7 @@ macro_rules! any_peripheral {
 
             impl $crate::private::Sealed for $name {}
 
-            impl $crate::peripheral::Peripheral for $name {
+            unsafe impl $crate::peripheral::Peripheral for $name {
                 type P = $name;
 
                 unsafe fn clone_unchecked(&self) -> Self::P {

--- a/esp-hal/src/otg_fs.rs
+++ b/esp-hal/src/otg_fs.rs
@@ -92,10 +92,10 @@ impl<'d> Usb<'d> {
 
         use crate::gpio::Level;
 
-        InputSignal::USB_OTG_IDDIG.connect_to(Level::High); // connected connector is mini-B side
-        InputSignal::USB_SRP_BVALID.connect_to(Level::High); // HIGH to force USB device mode
-        InputSignal::USB_OTG_VBUSVALID.connect_to(Level::High); // receiving a valid Vbus from device
-        InputSignal::USB_OTG_AVALID.connect_to(Level::Low);
+        InputSignal::USB_OTG_IDDIG.connect_to(&Level::High); // connected connector is mini-B side
+        InputSignal::USB_SRP_BVALID.connect_to(&Level::High); // HIGH to force USB device mode
+        InputSignal::USB_OTG_VBUSVALID.connect_to(&Level::High); // receiving a valid Vbus from device
+        InputSignal::USB_OTG_AVALID.connect_to(&Level::Low);
     }
 
     fn _disable() {

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -12,7 +12,6 @@ use core::marker::PhantomData;
 pub use crate::pac::pcnt::unit::conf0::{CTRL_MODE as CtrlMode, EDGE_MODE as EdgeMode};
 use crate::{
     gpio::{interconnect::PeripheralInput, InputSignal},
-    peripheral::Peripheral,
     peripherals::PCNT,
     system::GenericPeripheralGuard,
 };
@@ -72,7 +71,7 @@ impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
     }
 
     /// Set the control signal (pin/high/low) for this channel
-    pub fn set_ctrl_signal<P: PeripheralInput>(&self, source: impl Peripheral<P = P>) -> &Self {
+    pub fn set_ctrl_signal<'d>(&self, source: impl PeripheralInput<'d>) -> &Self {
         let signal = match UNIT {
             0 => match NUM {
                 0 => InputSignal::PCNT0_CTRL_CH0,
@@ -122,15 +121,15 @@ impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
         };
 
         if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
-            crate::into_mapped_ref!(source);
+            let source = source.into();
             source.enable_input(true);
-            signal.connect_to(source);
+            signal.connect_to(&source);
         }
         self
     }
 
     /// Set the edge signal (pin/high/low) for this channel
-    pub fn set_edge_signal<P: PeripheralInput>(&self, source: impl Peripheral<P = P>) -> &Self {
+    pub fn set_edge_signal<'d>(&self, source: impl PeripheralInput<'d>) -> &Self {
         let signal = match UNIT {
             0 => match NUM {
                 0 => InputSignal::PCNT0_SIG_CH0,
@@ -180,9 +179,9 @@ impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
         };
 
         if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
-            crate::into_mapped_ref!(source);
+            let source = source.into();
             source.enable_input(true);
-            signal.connect_to(source);
+            signal.connect_to(&source);
         }
         self
     }

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -24,6 +24,8 @@ pub struct PeripheralRef<'a, T> {
     _lifetime: PhantomData<&'a mut T>,
 }
 
+impl<'a, T> crate::private::Sealed for PeripheralRef<'a, T> {}
+
 impl<'a, T> PeripheralRef<'a, T> {
     /// Create a new exclusive reference to a peripheral
     #[inline]

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -24,7 +24,7 @@ pub struct PeripheralRef<'a, T> {
     _lifetime: PhantomData<&'a mut T>,
 }
 
-impl<'a, T> crate::private::Sealed for PeripheralRef<'a, T> {}
+impl<T> crate::private::Sealed for PeripheralRef<'_, T> {}
 
 impl<'a, T> PeripheralRef<'a, T> {
     /// Create a new exclusive reference to a peripheral

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -209,6 +209,7 @@ pub unsafe trait Peripheral: Sized {
     }
 }
 
+impl<T: Peripheral> crate::private::Sealed for &mut T {}
 unsafe impl<T: Peripheral> Peripheral for &mut T {
     type P = <T as Peripheral>::P;
 

--- a/esp-hal/src/peripheral.rs
+++ b/esp-hal/src/peripheral.rs
@@ -1,9 +1,6 @@
 //! # Exclusive peripheral access
 
-use core::{
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
-};
+use core::{marker::PhantomData, ops::Deref};
 
 /// An exclusive reference to a peripheral.
 ///
@@ -146,7 +143,16 @@ impl<T> Deref for PeripheralRef<'_, T> {
 ///
 /// `.into_ref()` on an owned `T` yields a `PeripheralRef<'static, T>`.
 /// `.into_ref()` on an `&'a mut T` yields a `PeripheralRef<'a, T>`.
-pub trait Peripheral: Sized {
+///
+/// # Safety
+///
+/// Implementing this trait is unsound on types that can be obtained again even
+/// after calling `into_ref`. For example, implementing this trait for
+/// `MutexGuard<P>` is unsound, as the guard is dropped to turn it into a
+/// `PeripheralRef<'static, P>`, which allows the `Mutex` to be immediately
+/// re-acquired, potentially resulting in multiple copies of
+/// `PeripheralRef<'static, P>`.
+pub unsafe trait Peripheral: Sized {
     /// Peripheral singleton type
     type P;
 
@@ -201,19 +207,16 @@ pub trait Peripheral: Sized {
     }
 }
 
-impl<T: DerefMut> Peripheral for T
-where
-    T::Target: Peripheral,
-{
-    type P = <T::Target as Peripheral>::P;
+unsafe impl<T: Peripheral> Peripheral for &mut T {
+    type P = <T as Peripheral>::P;
 
     #[inline]
     unsafe fn clone_unchecked(&self) -> Self::P {
-        T::Target::clone_unchecked(self)
+        T::clone_unchecked(self)
     }
 }
 
-impl<T: Peripheral> Peripheral for PeripheralRef<'_, T> {
+unsafe impl<T: Peripheral> Peripheral for PeripheralRef<'_, T> {
     type P = T::P;
 
     #[inline]
@@ -431,7 +434,7 @@ mod peripheral_macros {
                 }
             }
 
-            impl $crate::peripheral::Peripheral for $name {
+            unsafe impl $crate::peripheral::Peripheral for $name {
                 type P = $name;
 
                 #[inline]

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -138,7 +138,7 @@ impl Rng {
 
 impl Sealed for Rng {}
 
-impl Peripheral for Rng {
+unsafe impl Peripheral for Rng {
     type P = Self;
 
     #[inline]
@@ -287,7 +287,7 @@ impl rand_core09::CryptoRng for Trng<'_> {}
 
 impl Sealed for Trng<'_> {}
 
-impl Peripheral for Trng<'_> {
+unsafe impl Peripheral for Trng<'_> {
     type P = Self;
 
     #[inline]

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -127,37 +127,37 @@ impl<'d> Spi<'d, Blocking> {
 
     /// Assign the SCK (Serial Clock) pin for the SPI instance.
     #[instability::unstable]
-    pub fn with_sck(self, sclk: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
-        crate::into_mapped_ref!(sclk);
+    pub fn with_sck(self, sclk: impl PeripheralInput<'d>) -> Self {
+        let sclk = sclk.into();
         sclk.enable_input(true);
-        self.spi.info().sclk.connect_to(sclk);
+        self.spi.info().sclk.connect_to(&sclk);
         self
     }
 
     /// Assign the MOSI (Master Out Slave In) pin for the SPI instance.
     #[instability::unstable]
-    pub fn with_mosi(self, mosi: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
-        crate::into_mapped_ref!(mosi);
+    pub fn with_mosi(self, mosi: impl PeripheralInput<'d>) -> Self {
+        let mosi = mosi.into();
         mosi.enable_input(true);
-        self.spi.info().mosi.connect_to(mosi);
+        self.spi.info().mosi.connect_to(&mosi);
         self
     }
 
     /// Assign the MISO (Master In Slave Out) pin for the SPI instance.
     #[instability::unstable]
-    pub fn with_miso(self, miso: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
-        crate::into_mapped_ref!(miso);
+    pub fn with_miso(self, miso: impl PeripheralOutput<'d>) -> Self {
+        let miso = miso.into();
         miso.set_to_push_pull_output();
-        self.spi.info().miso.connect_to(miso);
+        self.spi.info().miso.connect_to(&miso);
         self
     }
 
     /// Assign the CS (Chip Select) pin for the SPI instance.
     #[instability::unstable]
-    pub fn with_cs(self, cs: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
-        crate::into_mapped_ref!(cs);
+    pub fn with_cs(self, cs: impl PeripheralInput<'d>) -> Self {
+        let cs = cs.into();
         cs.enable_input(true);
-        self.spi.info().cs.connect_to(cs);
+        self.spi.info().cs.connect_to(&cs);
         self
     }
 }

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -589,7 +589,7 @@ impl super::Timer for Alarm {
     }
 }
 
-impl Peripheral for Alarm {
+unsafe impl Peripheral for Alarm {
     type P = Self;
 
     #[inline]

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -356,7 +356,7 @@ impl super::Timer for Timer {
     }
 }
 
-impl Peripheral for Timer {
+unsafe impl Peripheral for Timer {
     type P = Self;
 
     #[inline]

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -52,7 +52,7 @@ use crate::{
     asynch::AtomicWaker,
     clock::Clocks,
     gpio::{
-        interconnect::{OutputConnection, PeripheralInput, PeripheralOutput},
+        interconnect::{PeripheralInput, PeripheralOutput},
         InputSignal,
         OutputSignal,
         PinGuard,
@@ -675,10 +675,10 @@ where
 {
     /// Configure RTS pin
     #[instability::unstable]
-    pub fn with_rts(mut self, rts: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
-        crate::into_mapped_ref!(rts);
+    pub fn with_rts(mut self, rts: impl PeripheralOutput<'d>) -> Self {
+        let rts = rts.into();
         rts.set_to_push_pull_output();
-        self.rts_pin = OutputConnection::connect_with_guard(rts, self.uart.info().rts_signal);
+        self.rts_pin = rts.connect_with_guard(self.uart.info().rts_signal);
 
         self
     }
@@ -690,12 +690,12 @@ where
     ///
     /// Disconnects the previous pin that was assigned with `with_tx`.
     #[instability::unstable]
-    pub fn with_tx(mut self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
-        crate::into_mapped_ref!(tx);
+    pub fn with_tx(mut self, tx: impl PeripheralOutput<'d>) -> Self {
+        let tx = tx.into();
         // Make sure we don't cause an unexpected low pulse on the pin.
         tx.set_output_high(true);
         tx.set_to_push_pull_output();
-        self.tx_pin = OutputConnection::connect_with_guard(tx, self.uart.info().tx_signal);
+        self.tx_pin = tx.connect_with_guard(self.uart.info().tx_signal);
 
         self
     }
@@ -1035,10 +1035,10 @@ where
     ///
     /// Sets the specified pin to input and connects it to the UART CTS signal.
     #[instability::unstable]
-    pub fn with_cts(self, cts: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
-        crate::into_mapped_ref!(cts);
+    pub fn with_cts(self, cts: impl PeripheralInput<'d>) -> Self {
+        let cts = cts.into();
         cts.init_input(Pull::None);
-        self.uart.info().cts_signal.connect_to(cts);
+        self.uart.info().cts_signal.connect_to(&cts);
 
         self
     }
@@ -1052,10 +1052,10 @@ where
     /// initially high, to avoid receiving a non-data byte caused by an
     /// initial low signal level.
     #[instability::unstable]
-    pub fn with_rx(self, rx: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
-        crate::into_mapped_ref!(rx);
+    pub fn with_rx(self, rx: impl PeripheralInput<'d>) -> Self {
+        let rx = rx.into();
         rx.init_input(Pull::Up);
-        self.uart.info().rx_signal.connect_to(rx);
+        self.uart.info().rx_signal.connect_to(&rx);
 
         self
     }
@@ -1470,7 +1470,7 @@ where
     /// configure the driver side (i.e. the TX pin), or ensure that the line is
     /// initially high, to avoid receiving a non-data byte caused by an
     /// initial low signal level.
-    pub fn with_rx(mut self, rx: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
+    pub fn with_rx(mut self, rx: impl PeripheralInput<'d>) -> Self {
         self.rx = self.rx.with_rx(rx);
         self
     }
@@ -1479,19 +1479,19 @@ where
     ///
     /// Sets the specified pin to push-pull output and connects it to the UART
     /// TX signal.
-    pub fn with_tx(mut self, tx: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+    pub fn with_tx(mut self, tx: impl PeripheralOutput<'d>) -> Self {
         self.tx = self.tx.with_tx(tx);
         self
     }
 
     /// Configure CTS pin
-    pub fn with_cts(mut self, cts: impl Peripheral<P = impl PeripheralInput> + 'd) -> Self {
+    pub fn with_cts(mut self, cts: impl PeripheralInput<'d>) -> Self {
         self.rx = self.rx.with_cts(cts);
         self
     }
 
     /// Configure RTS pin
-    pub fn with_rts(mut self, rts: impl Peripheral<P = impl PeripheralOutput> + 'd) -> Self {
+    pub fn with_rts(mut self, rts: impl PeripheralOutput<'d>) -> Self {
         self.tx = self.tx.with_rts(rts);
         self
     }

--- a/hil-test/tests/gpio.rs
+++ b/hil-test/tests/gpio.rs
@@ -51,6 +51,27 @@ pub fn interrupt_handler() {
     });
 }
 
+// Compile-time test to check that GPIOs can be passed by reference.
+fn _gpios_can_be_reused() {
+    let p = esp_hal::init(esp_hal::Config::default());
+
+    let mut gpio1 = p.GPIO1;
+
+    {
+        let _driver = Input::new(&mut gpio1, InputConfig::default().with_pull(Pull::Down));
+    }
+
+    {
+        let _driver = esp_hal::spi::master::Spi::new(p.SPI2, Default::default())
+            .unwrap()
+            .with_mosi(&mut gpio1);
+    }
+
+    {
+        let _driver = Input::new(&mut gpio1, InputConfig::default().with_pull(Pull::Down));
+    }
+}
+
 #[cfg(test)]
 #[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
 mod tests {

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -36,10 +36,10 @@ use hil_test as _;
 struct Context {
     parl_io: PARL_IO,
     dma_channel: DmaChannel0,
-    clock: OutputSignal,
-    valid: OutputSignal,
-    clock_loopback: InputSignal,
-    valid_loopback: InputSignal,
+    clock: OutputSignal<'static>,
+    valid: OutputSignal<'static>,
+    clock_loopback: InputSignal<'static>,
+    valid_loopback: InputSignal<'static>,
     pcnt_unit: Unit<'static, 0>,
 }
 

--- a/hil-test/tests/parl_io_tx_async.rs
+++ b/hil-test/tests/parl_io_tx_async.rs
@@ -36,10 +36,10 @@ use hil_test as _;
 struct Context {
     parl_io: PARL_IO,
     dma_channel: DmaChannel0,
-    clock: OutputSignal,
-    valid: OutputSignal,
-    clock_loopback: InputSignal,
-    valid_loopback: InputSignal,
+    clock: OutputSignal<'static>,
+    valid: OutputSignal<'static>,
+    clock_loopback: InputSignal<'static>,
+    valid_loopback: InputSignal<'static>,
     pcnt_unit: Unit<'static, 0>,
 }
 

--- a/hil-test/tests/spi_half_duplex_write.rs
+++ b/hil-test/tests/spi_half_duplex_write.rs
@@ -24,7 +24,7 @@ use hil_test as _;
 struct Context {
     spi: SpiDma<'static, Blocking>,
     pcnt_unit: Unit<'static, 0>,
-    pcnt_source: InputSignal,
+    pcnt_source: InputSignal<'static>,
 }
 
 fn perform_spi_writes_are_correctly_by_pcnt(ctx: Context, mode: DataMode) {

--- a/hil-test/tests/spi_half_duplex_write_psram.rs
+++ b/hil-test/tests/spi_half_duplex_write_psram.rs
@@ -43,7 +43,7 @@ macro_rules! dma_alloc_buffer {
 struct Context {
     spi: SpiDma<'static, Blocking>,
     pcnt_unit: Unit<'static, 0>,
-    pcnt_source: InputSignal,
+    pcnt_source: InputSignal<'static>,
 }
 
 #[cfg(test)]

--- a/hil-test/tests/spi_slave.rs
+++ b/hil-test/tests/spi_slave.rs
@@ -115,6 +115,11 @@ mod tests {
             }
         }
 
+        // A bit of test-specific hackery, we need to be able to work with the Input
+        // driver directly while the SPI is driving the output signal part of
+        // the GPIO. This is currently not possible to describe in safe code.
+        let miso_pin_clone = unsafe { miso_pin.clone_unchecked() };
+
         let mosi_gpio = Output::new(mosi_pin, Level::Low, OutputConfig::default());
         let cs_gpio = Output::new(cs_pin, Level::High, OutputConfig::default());
         let sclk_gpio = Output::new(sclk_pin, Level::Low, OutputConfig::default());
@@ -123,7 +128,7 @@ mod tests {
         let cs = cs_gpio.peripheral_input();
         let sclk = sclk_gpio.peripheral_input();
         let mosi = mosi_gpio.peripheral_input();
-        let miso = unsafe { miso_gpio.clone_unchecked() }.into_peripheral_output();
+        let miso = miso_pin_clone.split().1;
 
         Context {
             spi: Spi::new(peripherals.SPI2, Mode::_1)


### PR DESCRIPTION
Also includes a stop-gap workaround for the Peripheral unsoundness issue, temporarily "cherry-picking" https://github.com/embassy-rs/embassy/pull/4002. ~The end goal is to implement https://github.com/embassy-rs/embassy/pull/3999 before we go stable so that we can address #2661 in an embassy-similar way, should we want to.~ We can probably remove the whole Peripheral/PeripheralRef abstraction, as our drivers' types are not generic over the peripherals. That decision is not mine alone to make, but regardless we still want the known soundness hole patched.

The idea behind this PR is that while GPIOs are treated as peripherals, interconnect signals are no longer. So this PR removes the `impl Peripheral` part of the pin assignment functions, the `Peripheral` implementations from pin drivers as well as `Level` and `NoPin`, and probably more. This is a preparation step towards removing PeripheralRef as is currently being done in embassy, as the end result is presumed to be simpler and easier to understand.

Another part of this PR involves adding lifetimes to the interconnect types, so that they don't outlive their source object. This was an oversight (cc #2954 although that issue still stands).

`Input` and `Output` drivers can only be used as peripheral signals with the `unstable` feature. They shouldn't be needed for normal driver use cases, and passing a pre-configured pin to a driver, when that driver may change their configuration may not be what we want to stabilize.