### PR TITLE
`SpiDma<Async>` now uses the SPI interrupt (instead of DMA) to wait f…

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `esp_hal::i2s::master::AnyI2s` has been moved to `esp_hal::i2s::AnyI2s` (#3226)
 - `esp_hal::i2c::master::AnyI2c` has been moved to `esp_hal::i2c::AnyI2c` (#3226)
 - `SpiDmaBus` no longer adjusts the DMA buffer length for each transfer (#3263)
+- `SpiDma<Async>` now uses the SPI interrupt (instead of DMA) to wait for completion (#3303)
 
 ### Fixed
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -1505,13 +1505,8 @@ mod dma {
                 type Output = ();
 
                 fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-                    if self
-                        .0
-                        .interrupts()
-                        .contains(SpiInterrupt::TransferDone)
-                    {
-                        self.0
-                            .clear_interrupts(SpiInterrupt::TransferDone.into());
+                    if self.0.interrupts().contains(SpiInterrupt::TransferDone) {
+                        self.0.clear_interrupts(SpiInterrupt::TransferDone.into());
                         return Poll::Ready(());
                     }
 
@@ -3801,8 +3796,8 @@ fn handle_async<I: Instance>(instance: I) {
 
     let driver = Driver { info, state };
     if driver.interrupts().contains(SpiInterrupt::TransferDone) {
-        state.waker.wake();
         driver.enable_listen(SpiInterrupt::TransferDone.into(), false);
+        state.waker.wake();
     }
 }
 


### PR DESCRIPTION
…or completion

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The title says it all really.

#### Testing
HIL
