### PR TITLE
Disallow `Priority::None` for the `#[handler]` macro

### DIFF
--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Using the `#handler` macro with a priority of `None` will fail at compile time
+- Using the `#handler` macro with a priority of `None` will fail at compile time (#3304)
 
 ### Fixed
 

--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Using the `#handler` macro with a priority of `None` will fail at compile time
+
 ### Fixed
 
 ### Removed

--- a/esp-hal-procmacros/src/interrupt.rs
+++ b/esp-hal-procmacros/src/interrupt.rs
@@ -96,6 +96,15 @@ pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
     quote::quote_spanned!(original_span =>
         #f
 
+        const _: () = {
+            core::assert!(
+            match #priority {
+                #root::interrupt::Priority::None => false,
+                _ => true,
+            },
+            "Priority::None is not supported");
+        };
+
         #[allow(non_upper_case_globals)]
         #vis const #orig: #root::interrupt::InterruptHandler = #root::interrupt::InterruptHandler::new(#new, #priority);
     )


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Using s.th. like `#[handler(priority = esp_hal::interrupt::Priority::None)]` when setting an interrupt handler will always result in a runtime panic. This will prevent doing that at compile time.

The error unfortunately doesn't look great, but I don't expect a lot of users to run into it - and if they do, they can probably understand the error message.

#### Testing
Change any example using interrupts like shown above and see compilation fail
