### PR TITLE
Thwart potential infinite loop in I2C fifo read

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-C6: Keep ADC enabled to improve radio signal strength (#3249)
 - Fix off-by-one in the allowed range of the spi clock calculations (#3266)
 - Fixed an issue where inverting a pin via the interconnect matrix was ineffective (#3312)
+- Fixed I2C getting in an infinite loop if rx fifo receives less data than expected (#3314)
 
 ### Removed
 


### PR DESCRIPTION
If there is no more fifo data to receive but the I2C bus is no longer busy, then we throw an error as we did not get all of the expected data in read_all_from_fifo_blocking.

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [n/a] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [n/a] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Problem described:  https://github.com/esp-rs/esp-hal/issues/3314

#### Testing
The infinite loop no longer occurred- instead, the error was reported.
