### PR TITLE
[esp-alloc] Implement allocator_api2

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `allocator_api2` to support allocator APIs on stable Rust. (#?)
-- `AnyMemory` allocator. (#?)
+- `AnyMemory`, `InternalMemory`, `ExternalMemory` allocators. (#?)
 
 ### Changed
 

--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `allocator_api2` to support allocator APIs on stable Rust. (#?)
+- `AnyMemory` allocator. (#?)
+
 ### Changed
 
 ### Fixed

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -15,6 +15,7 @@ default-target = "riscv32imc-unknown-none-elf"
 features       = ["nightly"]
 
 [dependencies]
+allocator-api2        = { version = "0.2.0", default-features = false }
 defmt                 = { version = "0.3.10", optional = true }
 cfg-if                = "1.0.0"
 critical-section      = "1.2.0"
@@ -24,7 +25,7 @@ document-features     = "0.2.11"
 
 [features]
 default = []
-nightly = []
+nightly = ["allocator-api2/nightly"]
 
 ## Implement `defmt::Format` on certain types.
 defmt = ["dep:defmt"]

--- a/esp-alloc/src/allocators.rs
+++ b/esp-alloc/src/allocators.rs
@@ -1,6 +1,23 @@
 use core::{alloc::GlobalAlloc, ptr::NonNull};
 
 use allocator_api2::alloc::{AllocError, Allocator, Layout};
+use enumset::EnumSet;
+
+use crate::MemoryCapability;
+
+fn allocate_caps(
+    capabilities: EnumSet<MemoryCapability>,
+    layout: Layout,
+) -> Result<NonNull<[u8]>, AllocError> {
+    let raw_ptr = unsafe { crate::HEAP.alloc_caps(capabilities, layout) };
+
+    if raw_ptr.is_null() {
+        return Err(AllocError);
+    }
+
+    let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
+    Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+}
 
 use crate::EspHeap;
 
@@ -26,14 +43,33 @@ pub struct AnyMemory;
 
 unsafe impl Allocator for AnyMemory {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        let raw_ptr = unsafe { crate::HEAP.alloc(layout) };
+        allocate_caps(EnumSet::empty(), layout)
+    }
 
-        if raw_ptr.is_null() {
-            return Err(AllocError);
-        }
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        crate::HEAP.dealloc(ptr.as_ptr(), layout);
+    }
+}
 
-        let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
-        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+/// An allocator that uses internal memory only.
+pub struct InternalMemory;
+
+unsafe impl Allocator for InternalMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        allocate_caps(EnumSet::from(MemoryCapability::Internal), layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        crate::HEAP.dealloc(ptr.as_ptr(), layout);
+    }
+}
+
+/// An allocator that uses external (PSRAM) memory only.
+pub struct ExternalMemory;
+
+unsafe impl Allocator for ExternalMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        allocate_caps(EnumSet::from(MemoryCapability::External), layout)
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {

--- a/esp-alloc/src/allocators.rs
+++ b/esp-alloc/src/allocators.rs
@@ -1,0 +1,42 @@
+use core::{alloc::GlobalAlloc, ptr::NonNull};
+
+use allocator_api2::alloc::{AllocError, Allocator, Layout};
+
+use crate::EspHeap;
+
+unsafe impl Allocator for EspHeap {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let raw_ptr = unsafe { self.alloc(layout) };
+
+        if raw_ptr.is_null() {
+            return Err(AllocError);
+        }
+
+        let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        crate::HEAP.dealloc(ptr.as_ptr(), layout);
+    }
+}
+
+/// An allocator that uses all configured, available memory.
+pub struct AnyMemory;
+
+unsafe impl Allocator for AnyMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let raw_ptr = unsafe { crate::HEAP.alloc(layout) };
+
+        if raw_ptr.is_null() {
+            return Err(AllocError);
+        }
+
+        let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        crate::HEAP.dealloc(ptr.as_ptr(), layout);
+    }
+}

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -23,7 +23,15 @@
 //! }
 //! ```
 //!
+//! Alternatively, you can use the `heap_allocator!` macro to configure the
+//! global allocator with a given size:
+//!
+//! ```rust
+//! esp_alloc::heap_allocator!(size: 32 * 1024);
+//! ```
+//!
 //! # Using this with the nightly `allocator_api`-feature
+//!
 //! Sometimes you want to have more control over allocations.
 //!
 //! For that, it's convenient to use the nightly `allocator_api`-feature,
@@ -33,6 +41,7 @@
 //! flag.
 //!
 //! Create and initialize an allocator to use in single allocations:
+//!
 //! ```rust
 //! static PSRAM_ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 //!
@@ -48,16 +57,68 @@
 //! ```
 //!
 //! And then use it in an allocation:
+//!
 //! ```rust
 //! let large_buffer: Vec<u8, _> = Vec::with_capacity_in(1048576, &PSRAM_ALLOCATOR);
 //! ```
 //!
+//! Alternatively, you can use the `psram_allocator!` macro to configure the
+//! global allocator to use PSRAM:
+//!
+//! ```rust
+//! let p = esp_hal::init(esp_hal::Config::default());
+//! esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
+//! ```
+//!
+//! You can also use the `ExternalMemory` allocator to allocate PSRAM memory
+//! with the global allocator:
+//!
+//! ```rust
+//! let p = esp_hal::init(esp_hal::Config::default());
+//! esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
+//!
+//! let mut vec = Vec::<u32>::new_in(esp_alloc::ExternalMemory);
+//! ```
+//!
+//! ## `allocator_api` feature on stable Rust
+//!
+//! `esp-alloc` implements the allocator trait from [`allocator_api2`], which
+//! provides the nightly-only `allocator_api` features in stable Rust. The crate
+//! contains implementations for `Box` and `Vec`.
+//!
+//! To use the `allocator_api2` features, you need to add the crate to your
+//! `Cargo.toml`. Note that we do not enable the `alloc` feature by default, but
+//! you will need it for the `Box` and `Vec` types.
+//!
+//! ```toml
+//! allocator-api2 = { version = "0.2", features = ["alloc"] }
+//! ```
+//!
+//! With this, you can use the `Box` and `Vec` types from `allocator_api2`, with
+//! `esp-alloc` allocators:
+//!
+//! ```rust
+//! let p = esp_hal::init(esp_hal::Config::default());
+//! esp_alloc::heap_allocator!(size: 64000);
+//! esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
+//!
+//! let mut vec: Vec<u32, _> = Vec::new_in(esp_alloc::InternalMemory);
+//!
+//! vec.push(0xabcd1234);
+//! assert_eq!(vec[0], 0xabcd1234);
+//! ```
+//!
+//! # Heap stats
+//!
 //! You can also get stats about the heap usage at anytime with:
+//!
 //! ```rust
 //! let stats: HeapStats = esp_alloc::HEAP.stats();
-//! // HeapStats implements the Display and defmt::Format traits, so you can pretty-print the heap stats.
-//! println!("{}", stats);
+//! // HeapStats implements the Display and defmt::Format traits, so you can
+//! pretty-print the heap stats. println!("{}", stats);
 //! ```
+//!
+//! Example output:
 //!
 //! ```txt
 //! HEAP INFO

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -215,6 +215,7 @@ harness           = false
 required-features = ["esp-wifi", "esp-alloc"]
 
 [dependencies]
+allocator-api2    = { version = "0.2.0", default-features = false, features = ["alloc"] }
 cfg-if             = "1.0.0"
 critical-section   = "1.1.3"
 defmt              = "0.3.8"

--- a/hil-test/tests/alloc_psram.rs
+++ b/hil-test/tests/alloc_psram.rs
@@ -1,4 +1,4 @@
-//! PSRAM-related tests
+//! Allocator and PSRAM-related tests
 
 //% CHIPS(quad): esp32 esp32s2
 // The S3 dev kit in the HIL-tester has octal PSRAM.
@@ -16,6 +16,8 @@ extern crate alloc;
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
+    use esp_alloc::AnyMemory;
+
     #[init]
     fn init() {
         let p = esp_hal::init(esp_hal::Config::default());
@@ -25,6 +27,19 @@ mod tests {
     #[test]
     fn test_simple() {
         let mut vec = alloc::vec::Vec::new();
+
+        for i in 0..10000 {
+            vec.push(i);
+        }
+
+        for i in 0..10000 {
+            assert_eq!(vec[i], i);
+        }
+    }
+
+    #[test]
+    fn test_simple_with_allocator() {
+        let mut vec = allocator_api2::vec::Vec::new_in(AnyMemory);
 
         for i in 0..10000 {
             vec.push(i);

--- a/hil-test/tests/alloc_psram.rs
+++ b/hil-test/tests/alloc_psram.rs
@@ -16,13 +16,16 @@ extern crate alloc;
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
-    use esp_alloc::AnyMemory;
+    use allocator_api2::vec::Vec;
+    use esp_alloc::{AnyMemory, ExternalMemory, InternalMemory};
 
     #[init]
     fn init() {
         let p = esp_hal::init(esp_hal::Config::default());
         esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
     }
+
+    // alloc::vec::Vec tests
 
     #[test]
     fn test_simple() {
@@ -38,8 +41,25 @@ mod tests {
     }
 
     #[test]
+    fn all_psram_is_usable() {
+        let free = esp_alloc::HEAP.free();
+        defmt::info!("Free: {}", free);
+        let mut vec = alloc::vec::Vec::with_capacity(free);
+
+        for i in 0..free {
+            vec.push((i % 256) as u8);
+        }
+
+        for i in 0..free {
+            assert_eq!(vec[i], (i % 256) as u8);
+        }
+    }
+
+    // allocator_api2 tests
+
+    #[test]
     fn test_simple_with_allocator() {
-        let mut vec = allocator_api2::vec::Vec::new_in(AnyMemory);
+        let mut vec = Vec::new_in(AnyMemory);
 
         for i in 0..10000 {
             vec.push(i);
@@ -51,10 +71,42 @@ mod tests {
     }
 
     #[test]
-    fn all_psram_is_usable() {
+    #[should_panic]
+    fn internal_allocator_can_not_allocate_from_psram() {
+        let mut vec = Vec::new_in(InternalMemory);
+
+        vec.push(0);
+    }
+
+    #[test]
+    fn internal_allocator_can_allocate_memory() {
+        esp_alloc::heap_allocator!(size: 64000);
+        let mut vec: Vec<u32, _> = Vec::new_in(InternalMemory);
+
+        vec.push(0xabcd1234);
+        assert_eq!(vec[0], 0xabcd1234);
+    }
+
+    #[test]
+    fn all_psram_is_usable_with_external_mem_allocator() {
         let free = esp_alloc::HEAP.free();
         defmt::info!("Free: {}", free);
-        let mut vec = alloc::vec::Vec::with_capacity(free);
+        let mut vec = Vec::with_capacity_in(free, ExternalMemory);
+
+        for i in 0..free {
+            vec.push((i % 256) as u8);
+        }
+
+        for i in 0..free {
+            assert_eq!(vec[i], (i % 256) as u8);
+        }
+    }
+
+    #[test]
+    fn all_psram_is_usable_with_any_mem_allocator() {
+        let free = esp_alloc::HEAP.free();
+        defmt::info!("Free: {}", free);
+        let mut vec = Vec::with_capacity_in(free, AnyMemory);
 
         for i in 0..free {
             vec.push((i % 256) as u8);


### PR DESCRIPTION
Closes https://github.com/esp-rs/esp-hal/issues/2192

This PR introduces new zero-sized allocator objects to control memory allocation:

- `AnyMemory` - this just uses `HEAP.allocate` to allocate in any suitable memory
- `InternalMemory` and `ExternalMemory` using the matching MemoryCapability

These new allocators are available on stable Rust, too. On nightly, allocator_api2 falls back to the `alloc` crate, which has the same Allocator API, but provides more types compared to allocator_api2's Box and Vec.