### PR TITLE
Use allocator_api2 in esp-wifi

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the async APIs to have a `_async` postfix to avoid name collisions (#2446)
 - `phy_enable_usb` is enabled by default (#2446)
 - Removed `get_` prefixes from functions (#2528)
+- Opting out of `esp-alloc` now requires implementing `esp_wifi_deallocate_internal_ram` (#3320)
 
 - Config: Crate prefixes and configuration keys are now separated by `_CONFIG_` (#2848)
 

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -53,8 +53,10 @@ default = ["builtin-scheduler", "esp-alloc"]
 
 ## Use `esp-alloc` for dynamic allocations.
 ##
-## If you opt-out you need to provide implementations for `pub extern "C" fn esp_wifi_free_internal_heap() -> usize`
-## and `pub extern "C" fn esp_wifi_allocate_from_internal_ram(size: usize) -> *mut u8`
+## If you opt-out you need to provide implementations for the following functions:
+## - `pub extern "C" fn esp_wifi_free_internal_heap() -> usize`
+## - `pub extern "C" fn esp_wifi_allocate_from_internal_ram(size: usize) -> *mut u8`
+## - `pub extern "C" fn esp_wifi_deallocate_internal_ram(ptr: *mut u8)`
 esp-alloc = ["dep:esp-alloc"]
 
 # Chip Support Feature Flags

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/esp-rs/esp-hal"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+allocator-api2 = { version = "0.2.0", default-features = false, features = ["alloc"] }
 defmt = { version = "0.3.10", optional = true }
 log = { version = "0.4.26", optional = true }
 document-features  = "0.2.11"

--- a/esp-wifi/src/compat/malloc.rs
+++ b/esp-wifi/src/compat/malloc.rs
@@ -1,5 +1,3 @@
-use core::alloc::Layout;
-
 #[no_mangle]
 pub unsafe extern "C" fn malloc(size: usize) -> *mut u8 {
     trace!("alloc {}", size);
@@ -8,7 +6,7 @@ pub unsafe extern "C" fn malloc(size: usize) -> *mut u8 {
         fn esp_wifi_allocate_from_internal_ram(size: usize) -> *mut u8;
     }
 
-    let ptr = unsafe { esp_wifi_allocate_from_internal_ram(total_size) };
+    let ptr = unsafe { esp_wifi_allocate_from_internal_ram(size) };
 
     if ptr.is_null() {
         warn!("Unable to allocate {} bytes", size);
@@ -102,13 +100,46 @@ pub extern "C" fn esp_wifi_allocate_from_internal_ram(size: usize) -> *mut u8 {
 #[doc(hidden)]
 #[no_mangle]
 pub extern "C" fn esp_wifi_deallocate_internal_ram(ptr: *mut u8) {
+    use core::alloc::GlobalAlloc;
+
     unsafe {
         let ptr = ptr.offset(-4);
         let total_size = *(ptr as *const usize);
 
         esp_alloc::HEAP.dealloc(
-            esp_alloc::MemoryCapability::Internal.into(),
+            ptr,
             core::alloc::Layout::from_size_align_unchecked(total_size, 4),
         )
     }
 }
+
+// Polyfill the InternalMemory allocator
+#[cfg(not(feature = "esp-alloc"))]
+mod esp_alloc {
+    use core::{alloc::Layout, ptr::NonNull};
+
+    use allocator_api2::alloc::{AllocError, Allocator};
+
+    /// An allocator that uses internal memory only.
+    pub struct InternalMemory;
+
+    unsafe impl Allocator for InternalMemory {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            extern "C" {
+                fn esp_wifi_allocate_from_internal_ram(size: usize) -> *mut u8;
+            }
+            let raw_ptr = unsafe { esp_wifi_allocate_from_internal_ram(layout.size()) };
+            let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
+            Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+        }
+
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
+            extern "C" {
+                fn esp_wifi_deallocate_internal_ram(ptr: *mut u8);
+            }
+            esp_wifi_deallocate_internal_ram(ptr.as_ptr());
+        }
+    }
+}
+
+pub(crate) use esp_alloc::InternalMemory;

--- a/esp-wifi/src/preempt_builtin/mod.rs
+++ b/esp-wifi/src/preempt_builtin/mod.rs
@@ -78,6 +78,7 @@ fn allocate_main_task() -> *mut Context {
         }
 
         let ptr = malloc(size_of::<Context>() as u32) as *mut Context;
+        assert!(!ptr.is_null(), "Failed to allocate main task context");
         core::ptr::write(ptr, Context::new());
         (*ptr).next = ptr;
         ctx_now.0 = ptr;
@@ -92,6 +93,7 @@ fn allocate_task() -> *mut Context {
         }
 
         let ptr = malloc(size_of::<Context>() as u32) as *mut Context;
+        assert!(!ptr.is_null(), "Failed to allocate task context");
         core::ptr::write(ptr, Context::new());
         (*ptr).next = (*ctx_now.0).next;
         (*ctx_now.0).next = ptr;

--- a/esp-wifi/src/preempt_builtin/preempt_riscv.rs
+++ b/esp-wifi/src/preempt_builtin/preempt_riscv.rs
@@ -1,120 +1,90 @@
 use esp_wifi_sys::c_types;
 
 use super::*;
-use crate::hal::interrupt::TrapFrame;
+pub use crate::hal::interrupt::TrapFrame;
 
-#[derive(Debug, Clone, Copy)]
-pub struct Context {
-    trap_frame: TrapFrame,
-    pub thread_semaphore: u32,
-    pub next: *mut Context,
-    pub allocated_stack: *const u8,
-}
-
-impl Context {
-    pub(crate) fn new() -> Self {
-        Context {
-            trap_frame: TrapFrame::default(),
-            thread_semaphore: 0,
-            next: core::ptr::null_mut(),
-            allocated_stack: core::ptr::null(),
-        }
-    }
-}
-
-pub(crate) fn task_create(
+pub(crate) fn new_task_context(
     task: extern "C" fn(*mut c_types::c_void),
     param: *mut c_types::c_void,
-    task_stack_size: usize,
-) -> *mut Context {
-    unsafe {
-        let ctx = allocate_task();
+    stack_top: *mut (),
+) -> TrapFrame {
+    let stack_top = stack_top as usize;
+    let stack_top = stack_top - (stack_top % 16);
 
-        (*ctx).trap_frame.pc = task as usize;
-        (*ctx).trap_frame.a0 = param as usize;
-
-        let stack = malloc(task_stack_size as u32);
-        (*ctx).allocated_stack = stack.cast();
-
-        // stack must be aligned by 16
-        let task_stack_ptr = stack as usize + task_stack_size;
-        let stack_ptr = task_stack_ptr - (task_stack_ptr % 0x10);
-        (*ctx).trap_frame.sp = stack_ptr;
-
-        ctx
+    TrapFrame {
+        pc: task as usize,
+        a0: param as usize,
+        sp: stack_top,
+        ..Default::default()
     }
 }
 
-pub(crate) fn restore_task_context(ctx: *mut Context, trap_frame: &mut TrapFrame) {
-    unsafe {
-        trap_frame.ra = (*ctx).trap_frame.ra;
-        trap_frame.sp = (*ctx).trap_frame.sp;
-        trap_frame.a0 = (*ctx).trap_frame.a0;
-        trap_frame.a1 = (*ctx).trap_frame.a1;
-        trap_frame.a2 = (*ctx).trap_frame.a2;
-        trap_frame.a3 = (*ctx).trap_frame.a3;
-        trap_frame.a4 = (*ctx).trap_frame.a4;
-        trap_frame.a5 = (*ctx).trap_frame.a5;
-        trap_frame.a6 = (*ctx).trap_frame.a6;
-        trap_frame.a7 = (*ctx).trap_frame.a7;
-        trap_frame.t0 = (*ctx).trap_frame.t0;
-        trap_frame.t1 = (*ctx).trap_frame.t1;
-        trap_frame.t2 = (*ctx).trap_frame.t2;
-        trap_frame.t3 = (*ctx).trap_frame.t3;
-        trap_frame.t4 = (*ctx).trap_frame.t4;
-        trap_frame.t5 = (*ctx).trap_frame.t5;
-        trap_frame.t6 = (*ctx).trap_frame.t6;
-        trap_frame.s0 = (*ctx).trap_frame.s0;
-        trap_frame.s1 = (*ctx).trap_frame.s1;
-        trap_frame.s2 = (*ctx).trap_frame.s2;
-        trap_frame.s3 = (*ctx).trap_frame.s3;
-        trap_frame.s4 = (*ctx).trap_frame.s4;
-        trap_frame.s5 = (*ctx).trap_frame.s5;
-        trap_frame.s6 = (*ctx).trap_frame.s6;
-        trap_frame.s7 = (*ctx).trap_frame.s7;
-        trap_frame.s8 = (*ctx).trap_frame.s8;
-        trap_frame.s9 = (*ctx).trap_frame.s9;
-        trap_frame.s10 = (*ctx).trap_frame.s10;
-        trap_frame.s11 = (*ctx).trap_frame.s11;
-        trap_frame.gp = (*ctx).trap_frame.gp;
-        trap_frame.tp = (*ctx).trap_frame.tp;
-        trap_frame.pc = (*ctx).trap_frame.pc;
-    }
+pub(crate) fn restore_task_context(ctx: &mut Context, trap_frame: &mut TrapFrame) {
+    trap_frame.ra = ctx.trap_frame.ra;
+    trap_frame.sp = ctx.trap_frame.sp;
+    trap_frame.a0 = ctx.trap_frame.a0;
+    trap_frame.a1 = ctx.trap_frame.a1;
+    trap_frame.a2 = ctx.trap_frame.a2;
+    trap_frame.a3 = ctx.trap_frame.a3;
+    trap_frame.a4 = ctx.trap_frame.a4;
+    trap_frame.a5 = ctx.trap_frame.a5;
+    trap_frame.a6 = ctx.trap_frame.a6;
+    trap_frame.a7 = ctx.trap_frame.a7;
+    trap_frame.t0 = ctx.trap_frame.t0;
+    trap_frame.t1 = ctx.trap_frame.t1;
+    trap_frame.t2 = ctx.trap_frame.t2;
+    trap_frame.t3 = ctx.trap_frame.t3;
+    trap_frame.t4 = ctx.trap_frame.t4;
+    trap_frame.t5 = ctx.trap_frame.t5;
+    trap_frame.t6 = ctx.trap_frame.t6;
+    trap_frame.s0 = ctx.trap_frame.s0;
+    trap_frame.s1 = ctx.trap_frame.s1;
+    trap_frame.s2 = ctx.trap_frame.s2;
+    trap_frame.s3 = ctx.trap_frame.s3;
+    trap_frame.s4 = ctx.trap_frame.s4;
+    trap_frame.s5 = ctx.trap_frame.s5;
+    trap_frame.s6 = ctx.trap_frame.s6;
+    trap_frame.s7 = ctx.trap_frame.s7;
+    trap_frame.s8 = ctx.trap_frame.s8;
+    trap_frame.s9 = ctx.trap_frame.s9;
+    trap_frame.s10 = ctx.trap_frame.s10;
+    trap_frame.s11 = ctx.trap_frame.s11;
+    trap_frame.gp = ctx.trap_frame.gp;
+    trap_frame.tp = ctx.trap_frame.tp;
+    trap_frame.pc = ctx.trap_frame.pc;
 }
 
-pub(crate) fn save_task_context(ctx: *mut Context, trap_frame: &TrapFrame) {
-    unsafe {
-        (*ctx).trap_frame.ra = trap_frame.ra;
-        (*ctx).trap_frame.sp = trap_frame.sp;
-        (*ctx).trap_frame.a0 = trap_frame.a0;
-        (*ctx).trap_frame.a1 = trap_frame.a1;
-        (*ctx).trap_frame.a2 = trap_frame.a2;
-        (*ctx).trap_frame.a3 = trap_frame.a3;
-        (*ctx).trap_frame.a4 = trap_frame.a4;
-        (*ctx).trap_frame.a5 = trap_frame.a5;
-        (*ctx).trap_frame.a6 = trap_frame.a6;
-        (*ctx).trap_frame.a7 = trap_frame.a7;
-        (*ctx).trap_frame.t0 = trap_frame.t0;
-        (*ctx).trap_frame.t1 = trap_frame.t1;
-        (*ctx).trap_frame.t2 = trap_frame.t2;
-        (*ctx).trap_frame.t3 = trap_frame.t3;
-        (*ctx).trap_frame.t4 = trap_frame.t4;
-        (*ctx).trap_frame.t5 = trap_frame.t5;
-        (*ctx).trap_frame.t6 = trap_frame.t6;
-        (*ctx).trap_frame.s0 = trap_frame.s0;
-        (*ctx).trap_frame.s1 = trap_frame.s1;
-        (*ctx).trap_frame.s2 = trap_frame.s2;
-        (*ctx).trap_frame.s3 = trap_frame.s3;
-        (*ctx).trap_frame.s4 = trap_frame.s4;
-        (*ctx).trap_frame.s5 = trap_frame.s5;
-        (*ctx).trap_frame.s6 = trap_frame.s6;
-        (*ctx).trap_frame.s7 = trap_frame.s7;
-        (*ctx).trap_frame.s8 = trap_frame.s8;
-        (*ctx).trap_frame.s9 = trap_frame.s9;
-        (*ctx).trap_frame.s10 = trap_frame.s10;
-        (*ctx).trap_frame.s11 = trap_frame.s11;
-        (*ctx).trap_frame.gp = trap_frame.gp;
-        (*ctx).trap_frame.tp = trap_frame.tp;
-        (*ctx).trap_frame.pc = trap_frame.pc;
-    }
+pub(crate) fn save_task_context(ctx: &mut Context, trap_frame: &TrapFrame) {
+    ctx.trap_frame.ra = trap_frame.ra;
+    ctx.trap_frame.sp = trap_frame.sp;
+    ctx.trap_frame.a0 = trap_frame.a0;
+    ctx.trap_frame.a1 = trap_frame.a1;
+    ctx.trap_frame.a2 = trap_frame.a2;
+    ctx.trap_frame.a3 = trap_frame.a3;
+    ctx.trap_frame.a4 = trap_frame.a4;
+    ctx.trap_frame.a5 = trap_frame.a5;
+    ctx.trap_frame.a6 = trap_frame.a6;
+    ctx.trap_frame.a7 = trap_frame.a7;
+    ctx.trap_frame.t0 = trap_frame.t0;
+    ctx.trap_frame.t1 = trap_frame.t1;
+    ctx.trap_frame.t2 = trap_frame.t2;
+    ctx.trap_frame.t3 = trap_frame.t3;
+    ctx.trap_frame.t4 = trap_frame.t4;
+    ctx.trap_frame.t5 = trap_frame.t5;
+    ctx.trap_frame.t6 = trap_frame.t6;
+    ctx.trap_frame.s0 = trap_frame.s0;
+    ctx.trap_frame.s1 = trap_frame.s1;
+    ctx.trap_frame.s2 = trap_frame.s2;
+    ctx.trap_frame.s3 = trap_frame.s3;
+    ctx.trap_frame.s4 = trap_frame.s4;
+    ctx.trap_frame.s5 = trap_frame.s5;
+    ctx.trap_frame.s6 = trap_frame.s6;
+    ctx.trap_frame.s7 = trap_frame.s7;
+    ctx.trap_frame.s8 = trap_frame.s8;
+    ctx.trap_frame.s9 = trap_frame.s9;
+    ctx.trap_frame.s10 = trap_frame.s10;
+    ctx.trap_frame.s11 = trap_frame.s11;
+    ctx.trap_frame.gp = trap_frame.gp;
+    ctx.trap_frame.tp = trap_frame.tp;
+    ctx.trap_frame.pc = trap_frame.pc;
 }

--- a/esp-wifi/src/preempt_builtin/preempt_xtensa.rs
+++ b/esp-wifi/src/preempt_builtin/preempt_xtensa.rs
@@ -1,68 +1,41 @@
 use esp_wifi_sys::c_types;
 
 use super::*;
-use crate::hal::trapframe::TrapFrame;
+pub use crate::hal::trapframe::TrapFrame;
 
-#[derive(Debug, Clone, Copy)]
-pub struct Context {
-    trap_frame: TrapFrame,
-    pub thread_semaphore: u32,
-    pub next: *mut Context,
-    pub allocated_stack: *const u8,
-}
-
-impl Context {
-    pub(crate) fn new() -> Self {
-        Context {
-            trap_frame: TrapFrame::new(),
-            thread_semaphore: 0,
-            next: core::ptr::null_mut(),
-            allocated_stack: core::ptr::null(),
-        }
-    }
-}
-
-pub(crate) fn task_create(
-    task: extern "C" fn(*mut c_types::c_void),
+pub(crate) fn new_task_context(
+    task_fn: extern "C" fn(*mut c_types::c_void),
     param: *mut c_types::c_void,
-    task_stack_size: usize,
-) -> *mut Context {
-    trace!("task_create {:?} {:?} {}", task, param, task_stack_size);
+    stack_top: *mut (),
+) -> TrapFrame {
+    // stack must be aligned by 16
+    let stack_top = stack_top as u32;
+    let stack_top = stack_top - (stack_top % 16);
+
     unsafe {
-        let ctx = allocate_task();
+        *((stack_top - 4) as *mut u32) = 0;
+        *((stack_top - 8) as *mut u32) = 0;
+        *((stack_top - 12) as *mut u32) = stack_top;
+        *((stack_top - 16) as *mut u32) = 0;
+    }
 
-        (*ctx).trap_frame.PC = task as usize as u32;
-        (*ctx).trap_frame.A6 = param as usize as u32;
+    TrapFrame {
+        PC: task_fn as usize as u32,
+        A0: 0,
+        A1: stack_top,
+        A6: param as usize as u32,
 
-        let stack = malloc(task_stack_size as u32);
-        (*ctx).allocated_stack = stack.cast();
+        // For windowed ABI set WOE and CALLINC (pretend task was 'call4'd)
+        PS: 0x00040000 | ((1 & 3) << 16),
 
-        // stack must be aligned by 16
-        let task_stack_ptr = stack as usize + task_stack_size;
-        let stack_ptr = task_stack_ptr - (task_stack_ptr % 16);
-        (*ctx).trap_frame.A1 = stack_ptr as u32;
-
-        (*ctx).trap_frame.PS = 0x00040000 | ((1 & 3) << 16); // For windowed ABI set WOE and CALLINC (pretend task was 'call4'd).
-
-        (*ctx).trap_frame.A0 = 0;
-
-        *((task_stack_ptr - 4) as *mut u32) = 0;
-        *((task_stack_ptr - 8) as *mut u32) = 0;
-        *((task_stack_ptr - 12) as *mut u32) = stack_ptr as u32;
-        *((task_stack_ptr - 16) as *mut u32) = 0;
-
-        ctx
+        ..Default::default()
     }
 }
 
-pub(crate) fn restore_task_context(ctx: *mut Context, trap_frame: &mut TrapFrame) {
-    unsafe {
-        *trap_frame = (*ctx).trap_frame;
-    }
+pub(crate) fn restore_task_context(ctx: &mut Context, trap_frame: &mut TrapFrame) {
+    *trap_frame = ctx.trap_frame;
 }
 
-pub(crate) fn save_task_context(ctx: *mut Context, trap_frame: &TrapFrame) {
-    unsafe {
-        (*ctx).trap_frame = *trap_frame;
-    }
+pub(crate) fn save_task_context(ctx: &mut Context, trap_frame: &TrapFrame) {
+    ctx.trap_frame = *trap_frame;
 }


### PR DESCRIPTION
My hope is that with this, we can stop writing C masked as Rust, and we also save 4 bytes per allocation since we have the type info when we don't have to go through `malloc`. That 4 extra bytes done for malloc is also incorrect for Rust code, if we ever use any type that needs >4 byte alignment. With this PR and the allocator API, ensuring alignment constraints is the responsibility of the allocator and is not inlined into the malloc call sites - which right now just ignore the issue and hope 4 bytes is okay.

For demonstration, I've cleaned up RawQueue and the scheduler.

Closes #3187