### PR TITLE
fix wifi_embassy_access_point example, use interfaces.ap instead of interfaces.sta

### DIFF
--- a/examples/src/bin/wifi_embassy_access_point.rs
+++ b/examples/src/bin/wifi_embassy_access_point.rs
@@ -72,7 +72,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let (controller, interfaces) = esp_wifi::wifi::new(&esp_wifi_ctrl, peripherals.WIFI).unwrap();
 
-    let device = interfaces.sta;
+    let device = interfaces.ap;
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-hal/issues/3319