### PR TITLE
HD SPI: Remove restrictive three-wire check

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-C6: Keep ADC enabled to improve radio signal strength (#3249)
 - Fix off-by-one in the allowed range of the spi clock calculations (#3266)
 - Fixed an issue where inverting a pin via the interconnect matrix was ineffective (#3312)
+- The half-duplex SPI APIs should accept more valid line width combinations (#3325)
 
 ### Removed
 


### PR DESCRIPTION
This technically fixes #3308 although it's unclear to me what the hardware would do for cases like `(Command::_8Bit(0x32, DataMode::Single), Address::_24Bit(0x2C << 8, DataMode::Single), DataMode::SingleTwoDataLines)`, so they are not tested, but not rejected either in this PR. That might change either here or later if I manage to figure out a test setup.