### PR TITLE
Migrate DMA memcpy driver to newer DMA API

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `critical-section` implementation is now gated behind the `critical-section-impl` feature (#3293)
 - `Trace` is no longer generic (#3305)
 - Migrate SPI slave driver to newer DMA API (#3326)
+- Migrate DMA memcpy driver to newer DMA API (#3327)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -116,3 +116,16 @@ The affected types in the `gpio::interconnect` module are:
 - let transfer = spi.read(&mut rx_buffer)?;
 + let transfer = spi.read(dma_rx_buf.len(), dma_rx_buf)?;
 ```
+
+## DMA memcpy driver now uses the newer DMA APIs
+
+```diff
+  let mut mem2mem = Mem2Mem::new(
+      peripherals.DMA_CH0,
+      dma_peripheral,
++ ).with_descriptors(
+      rx_descriptors,
+      tx_descriptors,
++     BurstConfig::default(),
+  ).unwrap();
+```

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -681,13 +681,29 @@ impl DmaRxBuf {
         descriptors: &'static mut [DmaDescriptor],
         buffer: &'static mut [u8],
     ) -> Result<Self, DmaBufError> {
+        Self::new_with_config(descriptors, buffer, BurstConfig::default())
+    }
+
+    /// Creates a new [DmaRxBuf] from some descriptors and a buffer.
+    ///
+    /// There must be enough descriptors for the provided buffer.
+    /// Depending on alignment requirements, each descriptor can handle at most
+    /// 4092 bytes worth of buffer.
+    ///
+    /// Both the descriptors and buffer must be in DMA-capable memory.
+    /// Only DRAM is supported for descriptors.
+    pub fn new_with_config(
+        descriptors: &'static mut [DmaDescriptor],
+        buffer: &'static mut [u8],
+        config: impl Into<BurstConfig>,
+    ) -> Result<Self, DmaBufError> {
         let mut buf = Self {
             descriptors: DescriptorSet::new(descriptors)?,
             buffer,
             burst: BurstConfig::default(),
         };
 
-        buf.configure(buf.burst, buf.capacity())?;
+        buf.configure(config, buf.capacity())?;
 
         Ok(buf)
     }

--- a/esp-hal/src/dma/m2m.rs
+++ b/esp-hal/src/dma/m2m.rs
@@ -363,8 +363,8 @@ pub struct SimpleMem2Mem<'d, Dm: DriverMode> {
 enum State<'d, Dm: DriverMode> {
     Idle(
         Mem2Mem<'d, Dm>,
-        &'static mut [DmaDescriptor],
-        &'static mut [DmaDescriptor],
+        &'d mut [DmaDescriptor],
+        &'d mut [DmaDescriptor],
     ),
     Active(
         Mem2MemRxTransfer<'d, Dm, DmaRxBuf>,
@@ -377,8 +377,8 @@ impl<'d, Dm: DriverMode> SimpleMem2Mem<'d, Dm> {
     /// Creates a new [SimpleMem2Mem].
     pub fn new(
         mem2mem: Mem2Mem<'d, Dm>,
-        rx_descriptors: &'static mut [DmaDescriptor],
-        tx_descriptors: &'static mut [DmaDescriptor],
+        rx_descriptors: &'d mut [DmaDescriptor],
+        tx_descriptors: &'d mut [DmaDescriptor],
         config: BurstConfig,
     ) -> Result<Self, DmaError> {
         if rx_descriptors.is_empty() || tx_descriptors.is_empty() {
@@ -412,6 +412,12 @@ impl<'d, Dm: DriverMode> SimpleMem2Mem<'d, Dm> {
             unsafe { core::slice::from_raw_parts_mut(rx_buffer.as_mut_ptr(), rx_buffer.len()) };
         let tx_buffer =
             unsafe { core::slice::from_raw_parts_mut(tx_buffer.as_ptr() as _, tx_buffer.len()) };
+        let rx_descriptors = unsafe {
+            core::slice::from_raw_parts_mut(rx_descriptors.as_mut_ptr(), rx_descriptors.len())
+        };
+        let tx_descriptors = unsafe {
+            core::slice::from_raw_parts_mut(tx_descriptors.as_mut_ptr(), tx_descriptors.len())
+        };
 
         let dma_tx_buf = unwrap!(
             DmaTxBuf::new_with_config(tx_descriptors, tx_buffer, self.config),

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2675,6 +2675,7 @@ impl<'a, I> DmaTransferRx<'a, I>
 where
     I: dma_private::DmaSupportRx,
 {
+    #[cfg_attr(esp32c2, allow(dead_code))]
     pub(crate) fn new(instance: &'a mut I) -> Self {
         Self { instance }
     }

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -7,7 +7,7 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{AnyGdmaChannel, DmaChannelConvert, DmaError, Mem2Mem},
+    dma::{AnyGdmaChannel, BurstConfig, DmaChannelConvert, DmaError, ExternalBurstConfig, Mem2Mem},
     dma_buffers,
     dma_buffers_chunk_size,
     dma_descriptors,
@@ -56,20 +56,16 @@ mod tests {
 
     #[test]
     fn test_internal_mem2mem(ctx: Context) {
-        let (mut rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(DATA_SIZE);
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(DATA_SIZE);
 
-        let mut mem2mem = Mem2Mem::new(
-            ctx.channel,
-            ctx.dma_peripheral,
-            rx_descriptors,
-            tx_descriptors,
-        )
-        .unwrap();
+        let mut mem2mem = Mem2Mem::new(ctx.channel, ctx.dma_peripheral)
+            .with_descriptors(rx_descriptors, tx_descriptors, Default::default())
+            .unwrap();
 
         for i in 0..core::mem::size_of_val(tx_buffer) {
             tx_buffer[i] = (i % 256) as u8;
         }
-        let dma_wait = mem2mem.start_transfer(&mut rx_buffer, &tx_buffer).unwrap();
+        let dma_wait = mem2mem.start_transfer(rx_buffer, tx_buffer).unwrap();
         dma_wait.wait().unwrap();
         for i in 0..core::mem::size_of_val(tx_buffer) {
             assert_eq!(rx_buffer[i], tx_buffer[i]);
@@ -80,22 +76,24 @@ mod tests {
     fn test_internal_mem2mem_chunk_size(ctx: Context) {
         const CHUNK_SIZE: usize = 2048;
 
-        let (tx_buffer, tx_descriptors, mut rx_buffer, rx_descriptors) =
+        let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) =
             dma_buffers_chunk_size!(DATA_SIZE, CHUNK_SIZE);
 
-        let mut mem2mem = Mem2Mem::new_with_chunk_size(
-            ctx.channel,
-            ctx.dma_peripheral,
-            rx_descriptors,
-            tx_descriptors,
-            CHUNK_SIZE,
-        )
-        .unwrap();
+        let mut mem2mem = Mem2Mem::new(ctx.channel, ctx.dma_peripheral)
+            .with_descriptors(
+                rx_descriptors,
+                tx_descriptors,
+                BurstConfig {
+                    external_memory: ExternalBurstConfig::Size64,
+                    internal_memory: Default::default(),
+                },
+            )
+            .unwrap();
 
         for i in 0..core::mem::size_of_val(tx_buffer) {
             tx_buffer[i] = (i % 256) as u8;
         }
-        let dma_wait = mem2mem.start_transfer(&mut rx_buffer, &tx_buffer).unwrap();
+        let dma_wait = mem2mem.start_transfer(rx_buffer, tx_buffer).unwrap();
         dma_wait.wait().unwrap();
         for i in 0..core::mem::size_of_val(tx_buffer) {
             assert_eq!(rx_buffer[i], tx_buffer[i]);
@@ -104,15 +102,11 @@ mod tests {
 
     #[test]
     fn test_mem2mem_errors_zero_tx(ctx: Context) {
-        use esp_hal::dma::CHUNK_SIZE;
-
         let (rx_descriptors, tx_descriptors) = dma_descriptors!(1024, 0);
-        match Mem2Mem::new_with_chunk_size(
-            ctx.channel,
-            ctx.dma_peripheral,
+        match Mem2Mem::new(ctx.channel, ctx.dma_peripheral).with_descriptors(
             rx_descriptors,
             tx_descriptors,
-            CHUNK_SIZE,
+            Default::default(),
         ) {
             Err(DmaError::OutOfDescriptors) => (),
             _ => panic!("Expected OutOfDescriptors"),
@@ -121,48 +115,14 @@ mod tests {
 
     #[test]
     fn test_mem2mem_errors_zero_rx(ctx: Context) {
-        use esp_hal::dma::CHUNK_SIZE;
-
         let (rx_descriptors, tx_descriptors) = dma_descriptors!(0, 1024);
-        match Mem2Mem::new_with_chunk_size(
-            ctx.channel,
-            ctx.dma_peripheral,
+        match Mem2Mem::new(ctx.channel, ctx.dma_peripheral).with_descriptors(
             rx_descriptors,
             tx_descriptors,
-            CHUNK_SIZE,
+            Default::default(),
         ) {
             Err(DmaError::OutOfDescriptors) => (),
             _ => panic!("Expected OutOfDescriptors"),
-        }
-    }
-
-    #[test]
-    fn test_mem2mem_errors_chunk_size_too_small(ctx: Context) {
-        let (rx_descriptors, tx_descriptors) = dma_descriptors!(1024, 1024);
-        match Mem2Mem::new_with_chunk_size(
-            ctx.channel,
-            ctx.dma_peripheral,
-            rx_descriptors,
-            tx_descriptors,
-            0,
-        ) {
-            Err(DmaError::InvalidChunkSize) => (),
-            _ => panic!("Expected InvalidChunkSize"),
-        }
-    }
-
-    #[test]
-    fn test_mem2mem_errors_chunk_size_too_big(ctx: Context) {
-        let (rx_descriptors, tx_descriptors) = dma_descriptors!(1024, 1024);
-        match Mem2Mem::new_with_chunk_size(
-            ctx.channel,
-            ctx.dma_peripheral,
-            rx_descriptors,
-            tx_descriptors,
-            4093,
-        ) {
-            Err(DmaError::InvalidChunkSize) => (),
-            _ => panic!("Expected InvalidChunkSize"),
         }
     }
 }

--- a/hil-test/tests/dma_mem2mem.rs
+++ b/hil-test/tests/dma_mem2mem.rs
@@ -7,9 +7,8 @@
 #![no_main]
 
 use esp_hal::{
-    dma::{AnyGdmaChannel, BurstConfig, DmaChannelConvert, DmaError, ExternalBurstConfig, Mem2Mem},
+    dma::{AnyGdmaChannel, DmaChannelConvert, DmaError, Mem2Mem},
     dma_buffers,
-    dma_buffers_chunk_size,
     dma_descriptors,
 };
 use hil_test as _;
@@ -60,34 +59,6 @@ mod tests {
 
         let mut mem2mem = Mem2Mem::new(ctx.channel, ctx.dma_peripheral)
             .with_descriptors(rx_descriptors, tx_descriptors, Default::default())
-            .unwrap();
-
-        for i in 0..core::mem::size_of_val(tx_buffer) {
-            tx_buffer[i] = (i % 256) as u8;
-        }
-        let dma_wait = mem2mem.start_transfer(rx_buffer, tx_buffer).unwrap();
-        dma_wait.wait().unwrap();
-        for i in 0..core::mem::size_of_val(tx_buffer) {
-            assert_eq!(rx_buffer[i], tx_buffer[i]);
-        }
-    }
-
-    #[test]
-    fn test_internal_mem2mem_chunk_size(ctx: Context) {
-        const CHUNK_SIZE: usize = 2048;
-
-        let (tx_buffer, tx_descriptors, rx_buffer, rx_descriptors) =
-            dma_buffers_chunk_size!(DATA_SIZE, CHUNK_SIZE);
-
-        let mut mem2mem = Mem2Mem::new(ctx.channel, ctx.dma_peripheral)
-            .with_descriptors(
-                rx_descriptors,
-                tx_descriptors,
-                BurstConfig {
-                    external_memory: ExternalBurstConfig::Size64,
-                    internal_memory: Default::default(),
-                },
-            )
             .unwrap();
 
         for i in 0..core::mem::size_of_val(tx_buffer) {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The title says it all.

A big change here: I've split the Mem2Mem driver into an RX half and a TX half. Each half could be sent to a different task.
A nice side effect of this is that the driver can now be used as a queue/channel to communicate between tasks. (Dunno if anyone would do this in practice)

I've also addressed [this comment](https://github.com/esp-rs/esp-hal/pull/2379#issuecomment-2428505541) by introducing a `SimpleMem2Mem` wrapper that provides a zero-copy API, which is what the existing code did.
It pretty much does what the solution to #3125 would do.
If you're shook by the use of `unsafe` in this implementation, just know that the existing implementation is equally unsound, it's just not as obvious :slightly_smiling_face:.

I'm happy to rename things, etc.

#### Testing
HIL
