### PR TITLE
fix doc for allocator-api2 Cargo.toml usage

### DIFF
--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -91,7 +91,7 @@
 //! you will need it for the `Box` and `Vec` types.
 //!
 //! ```toml
-//! allocator-api2 = { version = "0.2", features = ["alloc"] }
+//! allocator-api2 = { version = "0.2", default-features = false, features = ["alloc"] }
 //! ```
 //!
 //! With this, you can use the `Box` and `Vec` types from `allocator_api2`, with


### PR DESCRIPTION
#### Description
Just fix the doc for Cargo.toml usage of allocator_api2.
std is default feature
