### PR TITLE
Make sure INTERRUPT_CORE0 is referenced

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a possible crash when parsing results from a radius server (#2380)
 - Fixed `async fn WifiController::disconnect` hanging forever when awaited if not connected when called (#2392).
+- Fixed building esp-wifi without either `ble` or `wifi` enabled (#3336)
 
 ### Removed
 

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -94,6 +94,16 @@
 // toolchain doesn't know about that lint, yet)
 #![allow(unknown_lints)]
 #![allow(non_local_definitions)]
+#![cfg_attr(
+    not(any(feature = "wifi", feature = "ble")),
+    allow(
+        unused,
+        reason = "There are a number of places where code is needed for either wifi or ble,
+        and cfg-ing them out would make the code less readable just to avoid warnings in the
+        less common case. Truly unused code will be flagged by the check that enables either
+        ble or wifi."
+    )
+)]
 
 extern crate alloc;
 

--- a/esp-wifi/src/radio/radio_esp32c6.rs
+++ b/esp-wifi/src/radio/radio_esp32c6.rs
@@ -2,13 +2,11 @@
 #[allow(unused_imports)]
 use crate::{
     binary,
-    hal::{
-        interrupt,
-        peripherals::{Interrupt, INTERRUPT_CORE0},
-    },
+    hal::{interrupt, peripherals::Interrupt},
 };
 
 pub(crate) fn setup_radio_isr() {
+    use crate::hal::peripherals::INTERRUPT_CORE0;
     // make sure to disable WIFI_BB/MODEM_PERI_TIMEOUT by mapping it to CPU
     // interrupt 31 which is masked by default for some reason for this
     // interrupt, mapping it to 0 doesn't deactivate it

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -766,7 +766,21 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
 
                 Package::EspWifi => {
                     let mut features =
-                        format!("--features={chip},defmt,esp-hal/unstable,builtin-scheduler");
+                        format!("--features={chip},esp-hal/unstable,builtin-scheduler");
+
+                    lint_package(
+                        chip,
+                        &path,
+                        &[
+                            &format!("--target={}", chip.target()),
+                            "--no-default-features",
+                            &features,
+                        ],
+                        args.fix,
+                        package.build_on_host(),
+                    )?;
+
+                    features.push_str(",defmt");
 
                     if device.contains("wifi") {
                         features.push_str(",esp-now,sniffer")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -654,15 +654,15 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                         &[
                             "--no-default-features",
                             &format!("--target={}", chip.target()),
-                            &format!("--features={chip},defmt"),
                         ],
+                        &[&format!("{chip},defmt")],
                         args.fix,
                         package.build_on_host(),
                     )?;
                 }
 
                 Package::EspHal => {
-                    let mut features = format!("--features={chip},ci,unstable");
+                    let mut features = format!("{chip},ci,unstable");
 
                     // Cover all esp-hal features where a device is supported
                     if device.contains("usb0") {
@@ -680,7 +680,8 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                     lint_package(
                         chip,
                         &path,
-                        &[&format!("--target={}", chip.target()), &features],
+                        &[&format!("--target={}", chip.target())],
+                        &[&features],
                         args.fix,
                         package.build_on_host(),
                     )?;
@@ -690,10 +691,8 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                     lint_package(
                         chip,
                         &path,
-                        &[
-                            &format!("--target={}", chip.target()),
-                            &format!("--features={chip},executors,defmt,esp-hal/unstable"),
-                        ],
+                        &[&format!("--target={}", chip.target())],
+                        &[&format!("{chip},executors,defmt,esp-hal/unstable")],
                         args.fix,
                         package.build_on_host(),
                     )?;
@@ -701,11 +700,11 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
 
                 Package::EspIeee802154 => {
                     if device.contains("ieee802154") {
-                        let features = format!("--features={chip},esp-hal/unstable");
                         lint_package(
                             chip,
                             &path,
-                            &[&format!("--target={}", chip.target()), &features],
+                            &[&format!("--target={}", chip.target())],
+                            &[&format!("{chip},esp-hal/unstable")],
                             args.fix,
                             package.build_on_host(),
                         )?;
@@ -716,10 +715,8 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                         lint_package(
                             chip,
                             &path,
-                            &[
-                                &format!("--target={}", chip.lp_target().unwrap()),
-                                &format!("--features={chip},embedded-io"),
-                            ],
+                            &[&format!("--target={}", chip.lp_target().unwrap())],
+                            &[&format!("{chip},embedded-io")],
                             args.fix,
                             package.build_on_host(),
                         )?;
@@ -730,10 +727,8 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                     lint_package(
                         chip,
                         &path,
-                        &[
-                            &format!("--target={}", chip.target()),
-                            &format!("--features={chip},defmt-espflash"),
-                        ],
+                        &[&format!("--target={}", chip.target())],
+                        &[&format!("{chip},defmt-espflash")],
                         args.fix,
                         package.build_on_host(),
                     )?;
@@ -745,6 +740,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                             chip,
                             &path,
                             &[&format!("--target={}", chip.target())],
+                            &[""],
                             args.fix,
                             package.build_on_host(),
                         )?;
@@ -755,41 +751,27 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                     lint_package(
                         chip,
                         &path,
-                        &[
-                            &format!("--target={}", chip.target()),
-                            &format!("--features={chip},storage,nor-flash,low-level"),
-                        ],
+                        &[&format!("--target={}", chip.target())],
+                        &[&format!("{chip},storage,nor-flash,low-level")],
                         args.fix,
                         package.build_on_host(),
                     )?;
                 }
 
                 Package::EspWifi => {
-                    let mut features =
-                        format!("--features={chip},esp-hal/unstable,builtin-scheduler");
+                    let minimal_features = format!("{chip},esp-hal/unstable,builtin-scheduler");
+                    let mut all_features = minimal_features.clone();
 
-                    lint_package(
-                        chip,
-                        &path,
-                        &[
-                            &format!("--target={}", chip.target()),
-                            "--no-default-features",
-                            &features,
-                        ],
-                        args.fix,
-                        package.build_on_host(),
-                    )?;
-
-                    features.push_str(",defmt");
+                    all_features.push_str(",defmt");
 
                     if device.contains("wifi") {
-                        features.push_str(",esp-now,sniffer")
+                        all_features.push_str(",esp-now,sniffer")
                     }
                     if device.contains("bt") {
-                        features.push_str(",ble")
+                        all_features.push_str(",ble")
                     }
                     if device.contains("coex") {
-                        features.push_str(",coex")
+                        all_features.push_str(",coex")
                     }
                     lint_package(
                         chip,
@@ -797,8 +779,8 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                         &[
                             &format!("--target={}", chip.target()),
                             "--no-default-features",
-                            &features,
                         ],
+                        &[&minimal_features, &all_features],
                         args.fix,
                         package.build_on_host(),
                     )?;
@@ -810,6 +792,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                             chip,
                             &path,
                             &[&format!("--target={}", chip.target())],
+                            &[""],
                             args.fix,
                             package.build_on_host(),
                         )?
@@ -821,10 +804,8 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                         lint_package(
                             chip,
                             &path,
-                            &[
-                                &format!("--target={}", chip.target()),
-                                &format!("--features={chip}"),
-                            ],
+                            &[&format!("--target={}", chip.target())],
+                            &[&format!("{chip}")],
                             args.fix,
                             package.build_on_host(),
                         )?
@@ -836,7 +817,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                 Package::Examples | Package::HilTest | Package::QaTest => {}
 
                 // By default, no `clippy` arguments are required:
-                _ => lint_package(chip, &path, &[], args.fix, package.build_on_host())?,
+                _ => lint_package(chip, &path, &[], &[], args.fix, package.build_on_host())?,
             }
         }
     }
@@ -848,40 +829,50 @@ fn lint_package(
     chip: &Chip,
     path: &Path,
     args: &[&str],
+    feature_sets: &[&str],
     fix: bool,
     build_on_host: bool,
 ) -> Result<()> {
-    log::info!("Linting package: {} ({})", path.display(), chip);
+    for features in feature_sets {
+        log::info!(
+            "Linting package: {} ({}, features: {})",
+            path.display(),
+            chip,
+            features
+        );
 
-    let builder = CargoArgsBuilder::default().subcommand("clippy");
+        let builder = CargoArgsBuilder::default().subcommand("clippy");
 
-    let mut builder = if chip.is_xtensa() {
-        let builder = if build_on_host {
-            builder
+        let mut builder = if chip.is_xtensa() {
+            let builder = if build_on_host {
+                builder
+            } else {
+                builder.arg("-Zbuild-std=core,alloc")
+            };
+
+            // We only overwrite Xtensas so that externally set nightly/stable toolchains
+            // are not overwritten.
+            builder.toolchain("esp")
         } else {
-            builder.arg("-Zbuild-std=core,alloc")
+            builder
         };
 
-        // We only overwrite Xtensas so that externally set nightly/stable toolchains
-        // are not overwritten.
-        builder.toolchain("esp")
-    } else {
-        builder
-    };
+        for arg in args {
+            builder = builder.arg(arg.to_string());
+        }
 
-    for arg in args {
-        builder = builder.arg(arg.to_string());
+        builder = builder.arg(format!("--features={features}"));
+
+        let builder = if fix {
+            builder.arg("--fix").arg("--lib").arg("--allow-dirty")
+        } else {
+            builder.arg("--").arg("-D").arg("warnings").arg("--no-deps")
+        };
+
+        let cargo_args = builder.build();
+
+        xtask::cargo::run_with_env(&cargo_args, path, [("CI", "1")], false)?;
     }
-
-    let builder = if fix {
-        builder.arg("--fix").arg("--lib").arg("--allow-dirty")
-    } else {
-        builder.arg("--").arg("-D").arg("warnings").arg("--no-deps")
-    };
-
-    let cargo_args = builder.build();
-
-    xtask::cargo::run_with_env(&cargo_args, path, [("CI", "1")], false)?;
 
     Ok(())
 }


### PR DESCRIPTION
I've changed `lint_package` slightly to allow passing multiple lists of features to check, and added a radioless check for esp-wifi that discovers a compilation error. However, that check also generates about a dozen "unused" lints that would just be noisy and time consuming to resolve, so I've also added a lint-allow when linting without `ble` or `wifi`. The warnings aren't visible unless the crate is built from local sources, so it really should only affect the new lint - and maybe rust-analyzer when configured "lazily".