### PR TITLE
More PARL_IO HIL tests

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `Peripheral` trait and `PeripheralRef` struct have been removed (#3302, #3305)
 - Removed the inherent `degrade` method from peripheral singletons. (#3305)
+- Removed the `FullDuplex` trait from the PARL_IO driver. (#????)
 
 ## v1.0.0-beta.0
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -586,12 +586,6 @@ tx_pins!(
     P15 = PARL_TX_DATA15
 );
 
-impl FullDuplex for TxOneBit<'_> {}
-impl FullDuplex for TxTwoBits<'_> {}
-impl FullDuplex for TxFourBits<'_> {}
-impl FullDuplex for TxEightBits<'_> {}
-impl FullDuplex for TxPinConfigWithValidPin<'_, TxFourBits<'_>> {}
-
 impl NotContainsValidSignalPin for TxOneBit<'_> {}
 impl NotContainsValidSignalPin for TxTwoBits<'_> {}
 impl NotContainsValidSignalPin for TxFourBits<'_> {}
@@ -792,12 +786,6 @@ rx_pins!(
     P15 = PARL_RX_DATA15
 );
 
-impl FullDuplex for RxOneBit<'_> {}
-impl FullDuplex for RxTwoBits<'_> {}
-impl FullDuplex for RxFourBits<'_> {}
-impl FullDuplex for RxEightBits<'_> {}
-impl FullDuplex for RxPinConfigWithValidPin<'_, RxFourBits<'_>> {}
-
 impl NotContainsValidSignalPin for RxOneBit<'_> {}
 impl NotContainsValidSignalPin for RxTwoBits<'_> {}
 impl NotContainsValidSignalPin for RxFourBits<'_> {}
@@ -825,7 +813,7 @@ where
         bit_order: BitPackOrder,
     ) -> Result<ParlIoTx<'d, Dm>, Error>
     where
-        P: FullDuplex + TxPins + ConfigurePins + 'd,
+        P: TxPins + ConfigurePins + 'd,
         CP: TxClkPin + 'd,
     {
         tx_pins.configure()?;
@@ -905,7 +893,7 @@ where
         timeout_ticks: Option<u16>,
     ) -> Result<ParlIoRx<'d, Dm>, Error>
     where
-        P: FullDuplex + RxPins + ConfigurePins,
+        P: RxPins + ConfigurePins,
         CP: RxClkPin,
     {
         let guard = GenericPeripheralGuard::new();
@@ -1860,8 +1848,6 @@ pub mod asynch {
 mod private {
     use super::{BitPackOrder, Error, SampleEdge};
     use crate::peripherals::PARL_IO;
-
-    pub trait FullDuplex {}
 
     pub trait NotContainsValidSignalPin {}
 

--- a/hil-test/tests/parl_io.rs
+++ b/hil-test/tests/parl_io.rs
@@ -6,6 +6,8 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(esp32h2))]
+use esp_hal::parl_io::{RxSixteenBits, TxSixteenBits};
 use esp_hal::{
     dma::{DmaChannel0, DmaRxBuf, DmaTxBuf},
     dma_buffers,
@@ -16,11 +18,17 @@ use esp_hal::{
         EnableMode,
         ParlIoFullDuplex,
         RxClkInPin,
+        RxEightBits,
         RxFourBits,
+        RxOneBit,
         RxPinConfigWithValidPin,
+        RxTwoBits,
         SampleEdge,
+        TxEightBits,
         TxFourBits,
+        TxOneBit,
         TxPinConfigWithValidPin,
+        TxTwoBits,
     },
     peripherals::PARL_IO,
     time::Rate,
@@ -32,7 +40,9 @@ struct Context {
     dma_channel: DmaChannel0<'static>,
     clock_pin: AnyPin<'static>,
     valid_pin: AnyPin<'static>,
-    data_pins: [AnyPin<'static>; 4],
+    data_pins: [AnyPin<'static>; 8],
+    #[cfg(esp32c6)]
+    extra_data_pins: [AnyPin<'static>; 7],
 }
 
 #[cfg(test)]
@@ -51,19 +61,39 @@ mod tests {
         Context {
             parl_io,
             dma_channel,
-            clock_pin: peripherals.GPIO11.degrade(),
-            valid_pin: peripherals.GPIO10.degrade(),
+            #[cfg(esp32h2)]
+            clock_pin: peripherals.GPIO13.degrade(),
+            #[cfg(esp32h2)]
+            valid_pin: peripherals.GPIO24.degrade(),
+            #[cfg(esp32c6)]
+            clock_pin: peripherals.GPIO16.degrade(),
+            #[cfg(esp32c6)]
+            valid_pin: peripherals.GPIO17.degrade(),
             data_pins: [
-                peripherals.GPIO1.degrade(),
-                peripherals.GPIO0.degrade(),
+                peripherals.GPIO2.degrade(),
+                peripherals.GPIO4.degrade(),
+                peripherals.GPIO10.degrade(),
+                peripherals.GPIO11.degrade(),
                 peripherals.GPIO14.degrade(),
                 peripherals.GPIO23.degrade(),
+                peripherals.GPIO0.degrade(),
+                peripherals.GPIO1.degrade(),
+            ],
+            #[cfg(esp32c6)]
+            extra_data_pins: [
+                peripherals.GPIO18.degrade(),
+                peripherals.GPIO19.degrade(),
+                peripherals.GPIO20.degrade(),
+                peripherals.GPIO22.degrade(),
+                peripherals.GPIO8.degrade(),
+                peripherals.GPIO9.degrade(),
+                peripherals.GPIO15.degrade(),
             ],
         }
     }
 
     #[test]
-    fn test_parl_io_rx_can_read_tx(ctx: Context) {
+    fn test_parl_io_rx_can_read_tx_in_1_bit_mode(ctx: Context) {
         const BUFFER_SIZE: usize = 64;
 
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(BUFFER_SIZE);
@@ -72,7 +102,119 @@ mod tests {
 
         let (clock_rx, clock_tx) = ctx.clock_pin.split();
         let (valid_rx, valid_tx) = ctx.valid_pin.split();
-        let [(d0_rx, d0_tx), (d1_rx, d1_tx), (d2_rx, d2_tx), (d3_rx, d3_tx)] =
+        let [(d0_rx, d0_tx), ..] = ctx.data_pins.map(|pin| pin.split());
+
+        let tx_pins = TxOneBit::new(d0_tx);
+        let rx_pins = RxOneBit::new(d0_rx);
+
+        let tx_pins = TxPinConfigWithValidPin::new(tx_pins, valid_tx);
+        let mut rx_pins = RxPinConfigWithValidPin::new(rx_pins, valid_rx, EnableMode::HighLevel);
+
+        let clock_out_pin = ClkOutPin::new(clock_tx);
+        let mut clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
+
+        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(40)).unwrap();
+
+        let pio_tx = pio
+            .tx
+            .with_config(
+                tx_pins,
+                clock_out_pin,
+                0,
+                SampleEdge::Invert,
+                BitPackOrder::Lsb,
+            )
+            .unwrap();
+        let pio_rx = pio
+            .rx
+            .with_config(&mut rx_pins, &mut clock_in_pin, BitPackOrder::Lsb, None)
+            .unwrap();
+
+        for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
+            *b = i as u8;
+        }
+
+        let rx_transfer = pio_rx
+            .read(Some(dma_rx_buf.len()), dma_rx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
+        let tx_transfer = pio_tx
+            .write(dma_tx_buf.len(), dma_tx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
+        (_, _, dma_tx_buf) = tx_transfer.wait();
+        (_, _, dma_rx_buf) = rx_transfer.wait();
+
+        assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
+    }
+
+    #[test]
+    fn test_parl_io_rx_can_read_tx_in_2_bit_mode(ctx: Context) {
+        const BUFFER_SIZE: usize = 64;
+
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(BUFFER_SIZE);
+        let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+        let mut dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+
+        let (clock_rx, clock_tx) = ctx.clock_pin.split();
+        let (valid_rx, valid_tx) = ctx.valid_pin.split();
+        let [(d0_rx, d0_tx), (d1_rx, d1_tx), ..] = ctx.data_pins.map(|pin| pin.split());
+
+        let tx_pins = TxTwoBits::new(d0_tx, d1_tx);
+        let rx_pins = RxTwoBits::new(d0_rx, d1_rx);
+
+        let tx_pins = TxPinConfigWithValidPin::new(tx_pins, valid_tx);
+        let mut rx_pins = RxPinConfigWithValidPin::new(rx_pins, valid_rx, EnableMode::HighLevel);
+
+        let clock_out_pin = ClkOutPin::new(clock_tx);
+        let mut clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
+
+        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(40)).unwrap();
+
+        let pio_tx = pio
+            .tx
+            .with_config(
+                tx_pins,
+                clock_out_pin,
+                0,
+                SampleEdge::Invert,
+                BitPackOrder::Lsb,
+            )
+            .unwrap();
+        let pio_rx = pio
+            .rx
+            .with_config(&mut rx_pins, &mut clock_in_pin, BitPackOrder::Lsb, None)
+            .unwrap();
+
+        for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
+            *b = i as u8;
+        }
+
+        let rx_transfer = pio_rx
+            .read(Some(dma_rx_buf.len()), dma_rx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
+        let tx_transfer = pio_tx
+            .write(dma_tx_buf.len(), dma_tx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
+        (_, _, dma_tx_buf) = tx_transfer.wait();
+        (_, _, dma_rx_buf) = rx_transfer.wait();
+
+        assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
+    }
+
+    #[test]
+    fn test_parl_io_rx_can_read_tx_in_4_bit_mode(ctx: Context) {
+        const BUFFER_SIZE: usize = 64;
+
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(BUFFER_SIZE);
+        let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+        let mut dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+
+        let (clock_rx, clock_tx) = ctx.clock_pin.split();
+        let (valid_rx, valid_tx) = ctx.valid_pin.split();
+        let [(d0_rx, d0_tx), (d1_rx, d1_tx), (d2_rx, d2_tx), (d3_rx, d3_tx), ..] =
             ctx.data_pins.map(|pin| pin.split());
 
         let tx_pins = TxFourBits::new(d0_tx, d1_tx, d2_tx, d3_tx);
@@ -117,5 +259,154 @@ mod tests {
         (_, _, dma_rx_buf) = rx_transfer.wait();
 
         assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
+    }
+
+    #[test]
+    fn test_parl_io_rx_can_read_tx_in_8_bit_mode(ctx: Context) {
+        const BUFFER_SIZE: usize = 250;
+
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(BUFFER_SIZE);
+        let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+        let mut dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+
+        let (clock_rx, clock_tx) = ctx.clock_pin.split();
+        let (valid_rx, valid_tx) = ctx.valid_pin.split();
+        let [(d0_rx, d0_tx), (d1_rx, d1_tx), (d2_rx, d2_tx), (d3_rx, d3_tx), (d4_rx, d4_tx), (d5_rx, d5_tx), (d6_rx, d6_tx), (d7_rx, d7_tx)] =
+            ctx.data_pins.map(|pin| pin.split());
+
+        let tx_pins = TxEightBits::new(d0_tx, d1_tx, d2_tx, d3_tx, d4_tx, d5_tx, d6_tx, d7_tx);
+        #[cfg_attr(not(esp32h2), allow(unused_mut))]
+        let mut rx_pins = RxEightBits::new(d0_rx, d1_rx, d2_rx, d3_rx, d4_rx, d5_rx, d6_rx, d7_rx);
+
+        #[cfg(not(esp32h2))]
+        let tx_pins = TxPinConfigWithValidPin::new(tx_pins, valid_tx);
+        #[cfg(not(esp32h2))]
+        let mut rx_pins = RxPinConfigWithValidPin::new(rx_pins, valid_rx, EnableMode::HighLevel);
+
+        let clock_out_pin = ClkOutPin::new(clock_tx);
+        let mut clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
+
+        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_khz(50)).unwrap();
+
+        let pio_tx = pio
+            .tx
+            .with_config(
+                tx_pins,
+                clock_out_pin,
+                0xFFFF,
+                SampleEdge::Invert,
+                BitPackOrder::Msb,
+            )
+            .unwrap();
+        let pio_rx = pio
+            .rx
+            .with_config(&mut rx_pins, &mut clock_in_pin, BitPackOrder::Msb, None)
+            .unwrap();
+
+        for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
+            *b = i as u8;
+        }
+
+        let rx_transfer = pio_rx
+            .read(Some(dma_rx_buf.len()), dma_rx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
+        let tx_transfer = pio_tx
+            .write(dma_tx_buf.len(), dma_tx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
+        (_, _, dma_tx_buf) = tx_transfer.wait();
+        (_, _, dma_rx_buf) = rx_transfer.wait();
+
+        if cfg!(esp32h2) {
+            // skip the first few idle bytes received by the RX unit. This is needed due to
+            // the lack of an enable pin.
+            let number_of_invalid_bytes = dma_rx_buf.as_slice().partition_point(|&b| b == 0xFF);
+
+            let received_data = &dma_rx_buf.as_slice()[number_of_invalid_bytes..];
+            let successfully_transmitted_data = &dma_tx_buf.as_slice()[..received_data.len()];
+
+            // This is unfortunately a flakey test. This can be improved by dropping the
+            // frequency or (as a last resort) reducing the number here.
+            assert!(received_data.len() > 200);
+
+            assert_eq!(successfully_transmitted_data, received_data);
+        } else {
+            assert_eq!(dma_tx_buf.as_slice(), dma_rx_buf.as_slice());
+        }
+    }
+
+    #[cfg(not(esp32h2))]
+    #[test]
+    fn test_parl_io_rx_can_read_tx_in_16_bit_mode(ctx: Context) {
+        const BUFFER_SIZE: usize = 250;
+
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(BUFFER_SIZE);
+        let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+        let mut dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+
+        let (clock_rx, clock_tx) = ctx.clock_pin.split();
+        let [(d0_rx, d0_tx), (d1_rx, d1_tx), (d2_rx, d2_tx), (d3_rx, d3_tx), (d4_rx, d4_tx), (d5_rx, d5_tx), (d6_rx, d6_tx), (d7_rx, d7_tx)] =
+            ctx.data_pins.map(|pin| pin.split());
+        let [(d8_rx, d8_tx), (d9_rx, d9_tx), (d10_rx, d10_tx), (d11_rx, d11_tx), (d12_rx, d12_tx), (d13_rx, d13_tx), (d14_rx, d14_tx)] =
+            ctx.extra_data_pins.map(|pin| pin.split());
+        let (d15_rx, d15_tx) = ctx.valid_pin.split();
+
+        let tx_pins = TxSixteenBits::new(
+            d0_tx, d1_tx, d2_tx, d3_tx, d4_tx, d5_tx, d6_tx, d7_tx, d8_tx, d9_tx, d10_tx, d11_tx,
+            d12_tx, d13_tx, d14_tx, d15_tx,
+        );
+        let mut rx_pins = RxSixteenBits::new(
+            d0_rx, d1_rx, d2_rx, d3_rx, d4_rx, d5_rx, d6_rx, d7_rx, d8_rx, d9_rx, d10_rx, d11_rx,
+            d12_rx, d13_rx, d14_rx, d15_rx,
+        );
+
+        let clock_out_pin = ClkOutPin::new(clock_tx);
+        let mut clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
+
+        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_khz(50)).unwrap();
+
+        let pio_tx = pio
+            .tx
+            .with_config(
+                tx_pins,
+                clock_out_pin,
+                0xFFFF,
+                SampleEdge::Invert,
+                BitPackOrder::Msb,
+            )
+            .unwrap();
+        let pio_rx = pio
+            .rx
+            .with_config(&mut rx_pins, &mut clock_in_pin, BitPackOrder::Msb, None)
+            .unwrap();
+
+        for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
+            *b = (i | 0) as u8;
+        }
+
+        let rx_transfer = pio_rx
+            .read(Some(dma_rx_buf.len()), dma_rx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
+        let tx_transfer = pio_tx
+            .write(dma_tx_buf.len(), dma_tx_buf)
+            .map_err(|e| e.0)
+            .unwrap();
+        (_, _, dma_tx_buf) = tx_transfer.wait();
+        (_, _, dma_rx_buf) = rx_transfer.wait();
+
+        // skip the first few idle bytes received by the RX unit. This is needed due to
+        // the lack of an enable pin.
+        let number_of_invalid_bytes = dma_rx_buf.as_slice().partition_point(|&b| b == 0xFF);
+
+        let received_data = &dma_rx_buf.as_slice()[number_of_invalid_bytes..];
+        let successfully_transmitted_data = &dma_tx_buf.as_slice()[..received_data.len()];
+
+        // This is unfortunately a flakey test. This can be improved by dropping the
+        // frequency or (as a last resort) reducing the number here.
+        assert!(received_data.len() > 200);
+
+        assert_eq!(successfully_transmitted_data, received_data);
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The PR just adds more HIL tests. In particular, a test for each bus width. 1,2,4,8 and 16 bits.

I pretty much ran out of pins for the 16 bit test, I'm gonna ask that GPIO4 and GPIO5 be disconnected on the C6, they're not being used in any tests atm. This doesn't really block this PR exactly as managed to get by with the suspicious GPIOs 10 and 11.

All the tests do the same thing of setting up the TX side to speak to the RX side.

I've removed the `FullDuplex` trait as it doesn't really do anything useful in practice.
The C6's TRM says PARL_IO cannot do full duplex in 16 bit mode. However this is due to the C6 lacking the 32 GPIO pins needed (It only has 22 free pins), as supposed to some kind of hardware limitation of the PARL_IO.
Note that [esp-idf ignores this](https://docs.espressif.com/projects/esp-idf/en/v5.4.1/esp32c6/api-reference/peripherals/parlio.html#introduction) and the 16 bit test proves full duplex is fine in theory.

#### Testing
:slightly_smiling_face: 
