### PR TITLE
chore: update esp-wifi bt-hci version

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update bt-hci version to fix serialization/deserialization of byte slices
+
 ### Removed
 
 ## [0.13.0] - 2025-02-24

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -35,7 +35,7 @@ portable-atomic = { version = "1.11.0", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
 rand_core           = "0.6.4"
 
-bt-hci = { version = "0.2.1", optional = true }
+bt-hci = { version = "0.3.0", optional = true }
 esp-config = { version = "0.3.0", path = "../esp-config" }
 
 xtensa-lx-rt = { version = "0.18.0", path = "../xtensa-lx-rt", optional = true }


### PR DESCRIPTION
The new version contains some fixes to hci serialization.