### PR TITLE
Make `ParlIo` driver construction more consistent

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SpiDma<Async>` now uses the SPI interrupt (instead of DMA) to wait for completion (#3303)
 - I2S driver now takes `DmaDescriptor`s later in construction (#3324)
 - `gpio::interconnect` types now have a lifetime associated with them (#3302)
+- Make `ParlIo` driver construction more consistent (#3345)
 - The `critical-section` implementation is now gated behind the `critical-section-impl` feature (#3293)
 - `Trace` is no longer generic (#3305)
 - Migrate SPI slave driver to newer DMA API (#3326)

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -100,6 +100,22 @@ The affected types in the `gpio::interconnect` module are:
 +     .build(rx_descriptors);
 ```
 
+## PARL IO driver construction no longer asks for references.
+
+```diff
+ let mut parl_io_tx = parl_io
+     .tx
+     .with_config(
+-        &mut pin_conf,
+-        &mut clock_pin,
++        pin_conf,
++        clock_pin,
+         0,
+         SampleEdge::Normal,
+         BitPackOrder::Msb,
+     )?;
+```
+
 ## SPI Slave driver now uses the newer DMA APIs
 
 ```diff

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -857,7 +857,7 @@ where
     ) -> Result<ParlIoTx<'d, Dm>, Error>
     where
         P: TxPins + ConfigurePins + 'd,
-        CP: TxClkPin,
+        CP: TxClkPin + 'd,
     {
         tx_pins.configure()?;
         clk_pin.configure();
@@ -906,7 +906,7 @@ where
     ) -> Result<ParlIoRx<'d, Dm>, Error>
     where
         P: FullDuplex + RxPins + ConfigurePins + 'd,
-        CP: RxClkPin,
+        CP: RxClkPin + 'd,
     {
         let guard = GenericPeripheralGuard::new();
 
@@ -937,7 +937,7 @@ where
     ) -> Result<ParlIoRx<'d, Dm>, Error>
     where
         P: RxPins + ConfigurePins + 'd,
-        CP: RxClkPin,
+        CP: RxClkPin + 'd,
     {
         rx_pins.configure()?;
         clk_pin.configure();

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -46,8 +46,8 @@
 //! let mut parl_io_rx = parl_io
 //!     .rx
 //!     .with_config(
-//!         &mut rx_pins,
-//!         &mut rx_clk_pin,
+//!         rx_pins,
+//!         rx_clk_pin,
 //!         BitPackOrder::Msb,
 //!         Some(0xfff),
 //!     )?;
@@ -99,8 +99,8 @@
 //! let mut parl_io_tx = parl_io
 //!     .tx
 //!     .with_config(
-//!         &mut pin_conf,
-//!         &mut clock_pin,
+//!         pin_conf,
+//!         clock_pin,
 //!         0,
 //!         SampleEdge::Normal,
 //!         BitPackOrder::Msb,
@@ -849,14 +849,14 @@ where
     /// Configure TX to use the given pins and settings
     pub fn with_config<P, CP>(
         self,
-        tx_pins: &'d mut P,
-        clk_pin: &'d mut CP,
+        mut tx_pins: P,
+        mut clk_pin: CP,
         idle_value: u16,
         sample_edge: SampleEdge,
         bit_order: BitPackOrder,
     ) -> Result<ParlIoTx<'d, Dm>, Error>
     where
-        P: TxPins + ConfigurePins,
+        P: TxPins + ConfigurePins + 'd,
         CP: TxClkPin,
     {
         tx_pins.configure()?;
@@ -899,13 +899,13 @@ where
     /// Configure RX to use the given pins and settings
     pub fn with_config<P, CP>(
         self,
-        rx_pins: &'d mut P,
-        clk_pin: &'d mut CP,
+        mut rx_pins: P,
+        mut clk_pin: CP,
         bit_order: BitPackOrder,
         timeout_ticks: Option<u16>,
     ) -> Result<ParlIoRx<'d, Dm>, Error>
     where
-        P: FullDuplex + RxPins + ConfigurePins,
+        P: FullDuplex + RxPins + ConfigurePins + 'd,
         CP: RxClkPin,
     {
         let guard = GenericPeripheralGuard::new();
@@ -930,13 +930,13 @@ where
     /// Configure RX to use the given pins and settings
     pub fn with_config<P, CP>(
         self,
-        rx_pins: &'d mut P,
-        clk_pin: &'d mut CP,
+        mut rx_pins: P,
+        mut clk_pin: CP,
         bit_order: BitPackOrder,
         timeout_ticks: Option<u16>,
     ) -> Result<ParlIoRx<'d, Dm>, Error>
     where
-        P: RxPins + ConfigurePins,
+        P: RxPins + ConfigurePins + 'd,
         CP: RxClkPin,
     {
         rx_pins.configure()?;

--- a/hil-test/tests/parl_io.rs
+++ b/hil-test/tests/parl_io.rs
@@ -79,10 +79,10 @@ mod tests {
         let rx_pins = RxFourBits::new(d0_rx, d1_rx, d2_rx, d3_rx);
 
         let tx_pins = TxPinConfigWithValidPin::new(tx_pins, valid_tx);
-        let mut rx_pins = RxPinConfigWithValidPin::new(rx_pins, valid_rx, EnableMode::HighLevel);
+        let rx_pins = RxPinConfigWithValidPin::new(rx_pins, valid_rx, EnableMode::HighLevel);
 
         let clock_out_pin = ClkOutPin::new(clock_tx);
-        let mut clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
+        let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
         let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(40)).unwrap();
 
@@ -98,7 +98,7 @@ mod tests {
             .unwrap();
         let pio_rx = pio
             .rx
-            .with_config(&mut rx_pins, &mut clock_in_pin, BitPackOrder::Lsb, None)
+            .with_config(rx_pins, clock_in_pin, BitPackOrder::Lsb, None)
             .unwrap();
 
         for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -86,20 +86,14 @@ mod tests {
             NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin,
             NoPin, NoPin, NoPin, ctx.valid,
         );
-        let mut pins = TxPinConfigIncludingValidPin::new(pins);
-        let mut clock_pin = ClkOutPin::new(ctx.clock);
+        let pins = TxPinConfigIncludingValidPin::new(pins);
+        let clock_pin = ClkOutPin::new(ctx.clock);
 
         let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(10)).unwrap();
 
         let mut pio = pio
             .tx
-            .with_config(
-                &mut pins,
-                &mut clock_pin,
-                0,
-                SampleEdge::Invert,
-                BitPackOrder::Msb,
-            )
+            .with_config(pins, clock_pin, 0, SampleEdge::Invert, BitPackOrder::Msb)
             .unwrap(); // TODO: handle error
 
         // use a PCNT unit to count the negative clock edges only when valid is high
@@ -145,26 +139,20 @@ mod tests {
         );
 
         #[cfg(esp32h2)]
-        let mut pins = TxPinConfigIncludingValidPin::new(pins);
+        let pins = TxPinConfigIncludingValidPin::new(pins);
         #[cfg(esp32c6)]
-        let mut pins = TxPinConfigWithValidPin::new(pins, ctx.valid);
+        let pins = TxPinConfigWithValidPin::new(pins, ctx.valid);
 
-        let mut clock_pin = ClkOutPin::new(ctx.clock);
+        let clock_pin = ClkOutPin::new(ctx.clock);
 
         let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(10)).unwrap();
 
         let mut pio = pio
             .tx
-            .with_config(
-                &mut pins,
-                &mut clock_pin,
-                0,
-                SampleEdge::Invert,
-                BitPackOrder::Msb,
-            )
+            .with_config(pins, clock_pin, 0, SampleEdge::Invert, BitPackOrder::Msb)
             .unwrap(); // TODO: handle error
 
-        // use a PCNT unit to count the negitive clock edges only when valid is high
+        // use a PCNT unit to count the negative clock edges only when valid is high
         let clock_unit = ctx.pcnt_unit;
         clock_unit.channel0.set_edge_signal(ctx.clock_loopback);
         clock_unit.channel0.set_ctrl_signal(ctx.valid_loopback);

--- a/hil-test/tests/parl_io_tx_async.rs
+++ b/hil-test/tests/parl_io_tx_async.rs
@@ -85,8 +85,8 @@ mod tests {
             NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin,
             NoPin, NoPin, NoPin, ctx.valid,
         );
-        let mut pins = TxPinConfigIncludingValidPin::new(pins);
-        let mut clock_pin = ClkOutPin::new(ctx.clock);
+        let pins = TxPinConfigIncludingValidPin::new(pins);
+        let clock_pin = ClkOutPin::new(ctx.clock);
 
         let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(10))
             .unwrap()
@@ -94,13 +94,7 @@ mod tests {
 
         let mut pio = pio
             .tx
-            .with_config(
-                &mut pins,
-                &mut clock_pin,
-                0,
-                SampleEdge::Invert,
-                BitPackOrder::Msb,
-            )
+            .with_config(pins, clock_pin, 0, SampleEdge::Invert, BitPackOrder::Msb)
             .unwrap();
 
         // use a PCNT unit to count the negitive clock edges only when valid is high
@@ -148,11 +142,11 @@ mod tests {
         );
 
         #[cfg(esp32h2)]
-        let mut pins = TxPinConfigIncludingValidPin::new(pins);
+        let pins = TxPinConfigIncludingValidPin::new(pins);
         #[cfg(esp32c6)]
-        let mut pins = TxPinConfigWithValidPin::new(pins, ctx.valid);
+        let pins = TxPinConfigWithValidPin::new(pins, ctx.valid);
 
-        let mut clock_pin = ClkOutPin::new(ctx.clock);
+        let clock_pin = ClkOutPin::new(ctx.clock);
 
         let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(10))
             .unwrap()
@@ -160,13 +154,7 @@ mod tests {
 
         let mut pio = pio
             .tx
-            .with_config(
-                &mut pins,
-                &mut clock_pin,
-                0,
-                SampleEdge::Invert,
-                BitPackOrder::Msb,
-            )
+            .with_config(pins, clock_pin, 0, SampleEdge::Invert, BitPackOrder::Msb)
             .unwrap();
 
         // use a PCNT unit to count the negitive clock edges only when


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Some of the parl io constructors take values like so `with_config(pins, clock_pin, ...)` and others do `with_config(&mut pins, &mut clock_pin, ...)`.
I've change them all to do the former as the latter is inconvenient. See [this usage](https://github.com/liebman/esp-hub75/blob/889dc2590a7c66ee0eef3e56fb225a61366a88c8/src/parl_io.rs#L101-L144).

#### Testing
CI
