### PR TITLE
Change `ParlIo` driver to use a config struct

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I2S driver now takes `DmaDescriptor`s later in construction (#3324)
 - `gpio::interconnect` types now have a lifetime associated with them (#3302)
 - Make `ParlIo` driver construction more consistent (#3345)
+- `ParlIo` driver now uses a config struct (#3359)
 - The `critical-section` implementation is now gated behind the `critical-section-impl` feature (#3293)
 - `Trace` is no longer generic (#3305)
 - Migrate SPI slave driver to newer DMA API (#3326)

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -114,7 +114,9 @@ The affected types in the `gpio::interconnect` module are:
 +     .build(rx_descriptors);
 ```
 
-## PARL IO driver construction no longer asks for references.
+## PARL IO driver changes
+
+### Construction no longer asks for references
 
 ```diff
  let mut parl_io_tx = parl_io
@@ -127,6 +129,42 @@ The affected types in the `gpio::interconnect` module are:
          0,
          SampleEdge::Normal,
          BitPackOrder::Msb,
+     )?;
+```
+
+### Construction options are passed via config
+
+```diff
++let config = RxConfig::default()
++                 .with_frequency(Rate::from_mhz(20))
++                 .with_bit_order(BitPackOrder::Msb);
+
+ let mut parl_io_rx = parl_io
+     .rx
+     .with_config(
+         pin_conf,
+         clock_pin,
+-        BitPackOrder::Msb,
+-        None,
++        config,
+     )?;
+```
+
+```diff
++let config = TxConfig::default()
++                 .with_frequency(Rate::from_mhz(20))
++                 .with_sample_edge(SampleEdge::Normal)
++                 .with_bit_order(BitPackOrder::Msb);
+
+ let mut parl_io_tx = parl_io
+     .tx
+     .with_config(
+         pin_conf,
+         clock_pin,
+-        0,
+-        SampleEdge::Normal,
+-        BitPackOrder::Msb,
++        config,
      )?;
 ```
 

--- a/hil-test/tests/parl_io.rs
+++ b/hil-test/tests/parl_io.rs
@@ -18,12 +18,14 @@ use esp_hal::{
         EnableMode,
         ParlIoFullDuplex,
         RxClkInPin,
+        RxConfig,
         RxEightBits,
         RxFourBits,
         RxOneBit,
         RxPinConfigWithValidPin,
         RxTwoBits,
         SampleEdge,
+        TxConfig,
         TxEightBits,
         TxFourBits,
         TxOneBit,
@@ -113,21 +115,28 @@ mod tests {
         let clock_out_pin = ClkOutPin::new(clock_tx);
         let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
-        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(40)).unwrap();
+        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let pio_tx = pio
             .tx
             .with_config(
                 tx_pins,
                 clock_out_pin,
-                0,
-                SampleEdge::Invert,
-                BitPackOrder::Lsb,
+                TxConfig::default()
+                    .with_frequency(Rate::from_mhz(40))
+                    .with_sample_edge(SampleEdge::Invert)
+                    .with_bit_order(BitPackOrder::Lsb),
             )
             .unwrap();
         let pio_rx = pio
             .rx
-            .with_config(rx_pins, clock_in_pin, BitPackOrder::Lsb, None)
+            .with_config(
+                rx_pins,
+                clock_in_pin,
+                RxConfig::default()
+                    .with_frequency(Rate::from_mhz(40))
+                    .with_bit_order(BitPackOrder::Lsb),
+            )
             .unwrap();
 
         for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
@@ -169,21 +178,28 @@ mod tests {
         let clock_out_pin = ClkOutPin::new(clock_tx);
         let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
-        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(40)).unwrap();
+        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let pio_tx = pio
             .tx
             .with_config(
                 tx_pins,
                 clock_out_pin,
-                0,
-                SampleEdge::Invert,
-                BitPackOrder::Lsb,
+                TxConfig::default()
+                    .with_frequency(Rate::from_mhz(40))
+                    .with_sample_edge(SampleEdge::Invert)
+                    .with_bit_order(BitPackOrder::Lsb),
             )
             .unwrap();
         let pio_rx = pio
             .rx
-            .with_config(rx_pins, clock_in_pin, BitPackOrder::Lsb, None)
+            .with_config(
+                rx_pins,
+                clock_in_pin,
+                RxConfig::default()
+                    .with_frequency(Rate::from_mhz(40))
+                    .with_bit_order(BitPackOrder::Lsb),
+            )
             .unwrap();
 
         for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
@@ -226,21 +242,28 @@ mod tests {
         let clock_out_pin = ClkOutPin::new(clock_tx);
         let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
-        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(40)).unwrap();
+        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let pio_tx = pio
             .tx
             .with_config(
                 tx_pins,
                 clock_out_pin,
-                0,
-                SampleEdge::Invert,
-                BitPackOrder::Lsb,
+                TxConfig::default()
+                    .with_frequency(Rate::from_mhz(40))
+                    .with_sample_edge(SampleEdge::Invert)
+                    .with_bit_order(BitPackOrder::Lsb),
             )
             .unwrap();
         let pio_rx = pio
             .rx
-            .with_config(rx_pins, clock_in_pin, BitPackOrder::Lsb, None)
+            .with_config(
+                rx_pins,
+                clock_in_pin,
+                RxConfig::default()
+                    .with_frequency(Rate::from_mhz(40))
+                    .with_bit_order(BitPackOrder::Lsb),
+            )
             .unwrap();
 
         for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
@@ -288,21 +311,28 @@ mod tests {
         let clock_out_pin = ClkOutPin::new(clock_tx);
         let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
-        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel, Rate::from_khz(100)).unwrap();
+        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let pio_tx = pio
             .tx
             .with_config(
                 tx_pins,
                 clock_out_pin,
-                0,
-                SampleEdge::Invert,
-                BitPackOrder::Msb,
+                TxConfig::default()
+                    .with_frequency(Rate::from_khz(100))
+                    .with_sample_edge(SampleEdge::Invert)
+                    .with_bit_order(BitPackOrder::Msb),
             )
             .unwrap();
         let pio_rx = pio
             .rx
-            .with_config(rx_pins, clock_in_pin, BitPackOrder::Msb, None)
+            .with_config(
+                rx_pins,
+                clock_in_pin,
+                RxConfig::default()
+                    .with_frequency(Rate::from_khz(100))
+                    .with_bit_order(BitPackOrder::Msb),
+            )
             .unwrap();
 
         for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -20,6 +20,7 @@ use esp_hal::{
         ClkOutPin,
         ParlIoTxOnly,
         SampleEdge,
+        TxConfig,
         TxEightBits,
         TxPinConfigIncludingValidPin,
     },
@@ -89,11 +90,18 @@ mod tests {
         let pins = TxPinConfigIncludingValidPin::new(pins);
         let clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(10)).unwrap();
+        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let mut pio = pio
             .tx
-            .with_config(pins, clock_pin, 0, SampleEdge::Invert, BitPackOrder::Msb)
+            .with_config(
+                pins,
+                clock_pin,
+                TxConfig::default()
+                    .with_frequency(Rate::from_mhz(10))
+                    .with_sample_edge(SampleEdge::Invert)
+                    .with_bit_order(BitPackOrder::Msb),
+            )
             .unwrap(); // TODO: handle error
 
         // use a PCNT unit to count the negative clock edges only when valid is high
@@ -149,7 +157,14 @@ mod tests {
 
         let mut pio = pio
             .tx
-            .with_config(pins, clock_pin, 0, SampleEdge::Invert, BitPackOrder::Msb)
+            .with_config(
+                pins,
+                clock_pin,
+                TxConfig::default()
+                    .with_frequency(Rate::from_mhz(10))
+                    .with_sample_edge(SampleEdge::Invert)
+                    .with_bit_order(BitPackOrder::Msb),
+            )
             .unwrap(); // TODO: handle error
 
         // use a PCNT unit to count the negative clock edges only when valid is high

--- a/hil-test/tests/parl_io_tx_async.rs
+++ b/hil-test/tests/parl_io_tx_async.rs
@@ -20,6 +20,7 @@ use esp_hal::{
         ClkOutPin,
         ParlIoTxOnly,
         SampleEdge,
+        TxConfig,
         TxEightBits,
         TxPinConfigIncludingValidPin,
     },
@@ -88,13 +89,20 @@ mod tests {
         let pins = TxPinConfigIncludingValidPin::new(pins);
         let clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(10))
+        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel)
             .unwrap()
             .into_async();
 
         let mut pio = pio
             .tx
-            .with_config(pins, clock_pin, 0, SampleEdge::Invert, BitPackOrder::Msb)
+            .with_config(
+                pins,
+                clock_pin,
+                TxConfig::default()
+                    .with_frequency(Rate::from_mhz(10))
+                    .with_sample_edge(SampleEdge::Invert)
+                    .with_bit_order(BitPackOrder::Msb),
+            )
             .unwrap();
 
         // use a PCNT unit to count the negitive clock edges only when valid is high
@@ -148,13 +156,20 @@ mod tests {
 
         let clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel, Rate::from_mhz(10))
+        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel)
             .unwrap()
             .into_async();
 
         let mut pio = pio
             .tx
-            .with_config(pins, clock_pin, 0, SampleEdge::Invert, BitPackOrder::Msb)
+            .with_config(
+                pins,
+                clock_pin,
+                TxConfig::default()
+                    .with_frequency(Rate::from_mhz(10))
+                    .with_sample_edge(SampleEdge::Invert)
+                    .with_bit_order(BitPackOrder::Msb),
+            )
             .unwrap();
 
         // use a PCNT unit to count the negitive clock edges only when


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Refactors the PARL IO driver to use a config struct according to the latest guidelines.
This also allows changing the frequency, which is the main motive for this PR.

#### Testing
HIL & CI
