### PR TITLE
Define unstable config options

### DIFF
--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -25,5 +25,6 @@ fn main() {
             stability: Stability::Unstable,
         }],
         true,
+        true,
     );
 }

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -1,5 +1,5 @@
 use esp_build::assert_unique_used_features;
-use esp_config::{generate_config, ConfigOption, Value};
+use esp_config::{generate_config, ConfigOption, Stability, Value};
 
 fn main() {
     // Ensure that only a single chip is specified:
@@ -22,6 +22,7 @@ fn main() {
             description: "The maximum number of frames that will be printed in a backtrace",
             default_value: Value::Integer(10),
             constraint: None,
+            stability: Stability::Unstable,
         }],
         true,
     );

--- a/esp-bootloader-esp-idf/build.rs
+++ b/esp-bootloader-esp-idf/build.rs
@@ -16,29 +16,42 @@ fn main() {
     println!("cargo::rustc-env=ESP_BOOTLOADER_BUILD_DATE={build_date_formatted}");
 
     // emit config
-    generate_config("esp-bootloader-esp-idf", &[
-        ConfigOption {
-            name: "mmu_page_size",
-            description: "ESP32-C2, ESP32-C6 and ESP32-H2 support configurable page sizes. This is currently only used to populate the app descriptor.",
-            default_value: Value::String(String::from("64k")),
-            constraint: Some(Validator::Enumeration(
-                vec![String::from("8k"), String::from("16k"),String::from("32k"),String::from("64k"),]
-            )),
-            stability: Stability::Unstable,
-        },
-        ConfigOption {
-            name: "esp_idf_version",
-            description: "ESP-IDF version used in the application descriptor. Currently it's not checked by the bootloader.",
-            default_value: Value::String(String::from("0.0.0")),
-            constraint: None,
-            stability: Stability::Unstable,
-        },
-        ConfigOption {
-            name: "partition-table-offset",
-            description: "The address of partition table (by default 0x8000). Allows you to move the partition table, it gives more space for the bootloader. Note that the bootloader and app will both need to be compiled with the same PARTITION_TABLE_OFFSET value.",
-            default_value: Value::Integer(0x8000),
-            constraint: Some(Validator::PositiveInteger),
-            stability: Stability::Unstable,
-        }
-    ], true);
+    generate_config(
+        "esp-bootloader-esp-idf",
+        &[
+            ConfigOption {
+                name: "mmu_page_size",
+                description: "ESP32-C2, ESP32-C6 and ESP32-H2 support configurable page sizes. \
+                This is currently only used to populate the app descriptor.",
+                default_value: Value::String(String::from("64k")),
+                constraint: Some(Validator::Enumeration(vec![
+                    String::from("8k"),
+                    String::from("16k"),
+                    String::from("32k"),
+                    String::from("64k"),
+                ])),
+                stability: Stability::Unstable,
+            },
+            ConfigOption {
+                name: "esp_idf_version",
+                description: "ESP-IDF version used in the application descriptor. Currently it's \
+                not checked by the bootloader.",
+                default_value: Value::String(String::from("0.0.0")),
+                constraint: None,
+                stability: Stability::Unstable,
+            },
+            ConfigOption {
+                name: "partition-table-offset",
+                description: "The address of partition table (by default 0x8000). Allows you to \
+                move the partition table, it gives more space for the bootloader. Note that the \
+                bootloader and app will both need to be compiled with the same |
+                PARTITION_TABLE_OFFSET value.",
+                default_value: Value::Integer(0x8000),
+                constraint: Some(Validator::PositiveInteger),
+                stability: Stability::Unstable,
+            },
+        ],
+        true,
+        true,
+    );
 }

--- a/esp-bootloader-esp-idf/build.rs
+++ b/esp-bootloader-esp-idf/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use chrono::{TimeZone, Utc};
-use esp_config::{generate_config, ConfigOption, Validator, Value};
+use esp_config::{generate_config, ConfigOption, Stability, Validator, Value};
 
 fn main() {
     let build_time = match env::var("SOURCE_DATE_EPOCH") {
@@ -23,19 +23,22 @@ fn main() {
             default_value: Value::String(String::from("64k")),
             constraint: Some(Validator::Enumeration(
                 vec![String::from("8k"), String::from("16k"),String::from("32k"),String::from("64k"),]
-            ))
+            )),
+            stability: Stability::Unstable,
         },
         ConfigOption {
             name: "esp_idf_version",
             description: "ESP-IDF version used in the application descriptor. Currently it's not checked by the bootloader.",
             default_value: Value::String(String::from("0.0.0")),
             constraint: None,
+            stability: Stability::Unstable,
         },
         ConfigOption {
             name: "partition-table-offset",
             description: "The address of partition table (by default 0x8000). Allows you to move the partition table, it gives more space for the bootloader. Note that the bootloader and app will both need to be compiled with the same PARTITION_TABLE_OFFSET value.",
             default_value: Value::Integer(0x8000),
             constraint: Some(Validator::PositiveInteger),
+            stability: Stability::Unstable,
         }
     ], true);
 }

--- a/esp-config/CHANGELOG.md
+++ b/esp-config/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `ConfigOption` struct (#3362)
+- `Stabiliy` to specify unstable options, and the version in which they became stable (#3365)
 
 ### Changed
 

--- a/esp-config/src/generate/markdown.rs
+++ b/esp-config/src/generate/markdown.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use crate::{ConfigOption, Value};
 
 pub(crate) const DOC_TABLE_HEADER: &str = r#"
-| Name | Description | Default value | Allowed value |
+| Name | Description | Default&nbsp;value | Allowed&nbsp;value |
 |------|-------------|---------------|---------------|
 "#;
 
@@ -21,8 +21,12 @@ pub(crate) fn write_doc_table_line(mut table: impl Write, name: &str, option: &C
 
     writeln!(
         table,
-        "|**{}**| <p>{}</p><p>{}</p> | {} | {}",
-        name, option.description, option.stability, option.default_value, allowed_values
+        "| {key} | <p>{description}</p><p>{stability}</p> | {default} | {allowed}",
+        description = option.description,
+        key = name,
+        stability = option.stability,
+        default = option.default_value,
+        allowed = allowed_values
     )
     .unwrap();
 }

--- a/esp-config/src/generate/markdown.rs
+++ b/esp-config/src/generate/markdown.rs
@@ -21,8 +21,8 @@ pub(crate) fn write_doc_table_line(mut table: impl Write, name: &str, option: &C
 
     writeln!(
         table,
-        "|**{}**|{}|{}|{}",
-        name, option.description, option.default_value, allowed_values
+        "|**{}**| <p>{}</p><p>{}</p> | {} | {}",
+        name, option.description, option.stability, option.default_value, allowed_values
     )
     .unwrap();
 }

--- a/esp-config/src/generate/markdown.rs
+++ b/esp-config/src/generate/markdown.rs
@@ -17,7 +17,7 @@ pub(crate) fn write_doc_table_line(mut table: impl Write, name: &str, option: &C
         .constraint
         .as_ref()
         .and_then(|validator| validator.description())
-        .unwrap_or(String::from("-"));
+        .unwrap_or_default();
 
     writeln!(
         table,

--- a/esp-config/src/generate/markdown.rs
+++ b/esp-config/src/generate/markdown.rs
@@ -4,7 +4,7 @@ use crate::{ConfigOption, Value};
 
 pub(crate) const DOC_TABLE_HEADER: &str = r#"
 | Name | Description | Default&nbsp;value | Allowed&nbsp;value |
-|------|-------------|---------------|---------------|
+|------|-------------|--------------------|--------------------|
 "#;
 
 pub(crate) const SELECTED_TABLE_HEADER: &str = r#"
@@ -21,7 +21,7 @@ pub(crate) fn write_doc_table_line(mut table: impl Write, name: &str, option: &C
 
     writeln!(
         table,
-        "| {key} | <p>{description}</p><p>{stability}</p> | {default} | {allowed}",
+        "| {key} | <p>{description}</p><p>{stability}</p> | <center>{default}</center> | <center>{allowed}</center>",
         description = option.description,
         key = name,
         stability = option.stability,

--- a/esp-config/src/generate/markdown.rs
+++ b/esp-config/src/generate/markdown.rs
@@ -21,7 +21,7 @@ pub(crate) fn write_doc_table_line(mut table: impl Write, name: &str, option: &C
 
     writeln!(
         table,
-        "| {key} | <p>{description}</p><p>{stability}</p> | <center>{default}</center> | <center>{allowed}</center>",
+        "| <p>{key}</p><p>{stability}</p> | <p>{description}</p> | <center>{default}</center> | <center>{allowed}</center>",
         description = option.description,
         key = name,
         stability = option.stability,

--- a/esp-config/src/generate/mod.rs
+++ b/esp-config/src/generate/mod.rs
@@ -79,11 +79,14 @@ pub fn generate_config(
     if emit_md_tables {
         let file_name = snake_case(crate_name);
 
-        let mut doc_table = String::from(markdown::DOC_TABLE_HEADER);
+        let mut doc_table = markdown::DOC_TABLE_HEADER.replace(
+            "{prefix}",
+            format!("{}_CONFIG_*", screaming_snake_case(crate_name)).as_str(),
+        );
         let mut selected_config = String::from(markdown::SELECTED_TABLE_HEADER);
 
         for (name, option, value) in configs.iter() {
-            markdown::write_doc_table_line(&mut doc_table, &name, option);
+            markdown::write_doc_table_line(&mut doc_table, name, option);
             markdown::write_summary_table_line(&mut selected_config, &name, value);
         }
 

--- a/esp-config/src/generate/mod.rs
+++ b/esp-config/src/generate/mod.rs
@@ -115,7 +115,7 @@ pub fn generate_config_internal<'a>(
     let prefix = format!("{}_CONFIG_", screaming_snake_case(crate_name));
 
     let mut configs = create_config(&prefix, config);
-    capture_from_env(&prefix, &mut configs, enable_unstable);
+    capture_from_env(crate_name, &prefix, &mut configs, enable_unstable);
 
     for (_, option, value) in configs.iter() {
         if let Some(ref validator) = option.constraint {
@@ -267,6 +267,7 @@ fn create_config<'a>(
 }
 
 fn capture_from_env(
+    crate_name: &str,
     prefix: &str,
     configs: &mut Vec<(String, &ConfigOption, Value)>,
     enable_unstable: bool,
@@ -300,8 +301,8 @@ fn capture_from_env(
 
     if !unstable.is_empty() {
         panic!(
-            "The following configuration options are unstable: {:?}",
-            unstable
+            "The following configuration options are unstable: {unstable:?}. You can enable it by \
+            activating the 'unstable' feature in {crate_name}."
         );
     }
 

--- a/esp-config/src/generate/mod.rs
+++ b/esp-config/src/generate/mod.rs
@@ -1,3 +1,4 @@
+use core::fmt::Display;
 use std::{collections::HashMap, env, fmt, fs, io::Write, path::PathBuf};
 
 use serde::Serialize;
@@ -199,6 +200,15 @@ pub enum Stability {
     /// Stable options contain the first version in which they were
     /// stabilized.
     Stable(&'static str),
+}
+
+impl Display for Stability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Stability::Unstable => write!(f, "⚠️ Unstable"),
+            Stability::Stable(version) => write!(f, "Stable since {version}"),
+        }
+    }
 }
 
 /// A configuration option.

--- a/esp-config/src/generate/validator.rs
+++ b/esp-config/src/generate/validator.rs
@@ -57,7 +57,14 @@ impl Validator {
             Validator::IntegerInRange(range) => {
                 Some(format!("Integer in range {}..{}", range.start, range.end))
             }
-            Validator::Enumeration(values) => Some(format!("Any of {:?}", values)),
+            Validator::Enumeration(values) => Some(format!(
+                "One of: <ul>{}</ul>",
+                values
+                    .iter()
+                    .map(|v| format!("<li>{}</li>", v))
+                    .collect::<Vec<_>>()
+                    .join("")
+            )),
             Validator::Custom(_) => None,
         }
     }

--- a/esp-config/src/generate/validator.rs
+++ b/esp-config/src/generate/validator.rs
@@ -58,7 +58,7 @@ impl Validator {
                 Some(format!("Integer in range {}..{}", range.start, range.end))
             }
             Validator::Enumeration(values) => Some(format!(
-                "One of: <ul>{}</ul>",
+                "One of: <ul style=\"display: inline-block; text-align: left\">{}</ul>",
                 values
                     .iter()
                     .map(|v| format!("<li>{}</li>", v))

--- a/esp-config/src/lib.rs
+++ b/esp-config/src/lib.rs
@@ -8,7 +8,14 @@
 #[cfg(feature = "build")]
 mod generate;
 #[cfg(feature = "build")]
-pub use generate::{generate_config, validator::Validator, value::Value, ConfigOption, Error};
+pub use generate::{
+    generate_config,
+    validator::Validator,
+    value::Value,
+    ConfigOption,
+    Error,
+    Stability,
+};
 
 /// Parse the value of an environment variable as a [bool] at compile time.
 #[macro_export]

--- a/esp-hal-embassy/build.rs
+++ b/esp-hal-embassy/build.rs
@@ -1,7 +1,7 @@
 use std::{error::Error as StdError, str::FromStr};
 
 use esp_build::assert_unique_used_features;
-use esp_config::{generate_config, ConfigOption, Error, Validator, Value};
+use esp_config::{generate_config, ConfigOption, Error, Stability, Validator, Value};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn StdError>> {
@@ -46,7 +46,8 @@ fn main() -> Result<(), Box<dyn StdError>> {
                 name: "low-power-wait",
                 description: "Enables the lower-power wait if no tasks are ready to run on the thread-mode executor. This allows the MCU to use less power if the workload allows. Recommended for battery-powered systems. May impact analog performance.",
                 default_value: Value::Bool(true),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "timer-queue",
@@ -74,13 +75,15 @@ fn main() -> Result<(), Box<dyn StdError>> {
                         "generic" => Ok(()), // allows using embassy-time without the embassy executors
                         _ => Err(Error::Validation(format!("Expected 'single-integrated', 'multiple-integrated' or 'generic', found {string}")))
                     }
-                })))
+                }))),
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "generic-queue-size",
                 description: "The capacity of the queue when the `generic` timer queue flavour is selected.",
                 default_value: Value::Integer(64),
                 constraint: Some(Validator::PositiveInteger),
+                stability: Stability::Unstable,
             },
         ],
         true,

--- a/esp-hal-embassy/build.rs
+++ b/esp-hal-embassy/build.rs
@@ -44,14 +44,22 @@ fn main() -> Result<(), Box<dyn StdError>> {
         &[
             ConfigOption {
                 name: "low-power-wait",
-                description: "Enables the lower-power wait if no tasks are ready to run on the thread-mode executor. This allows the MCU to use less power if the workload allows. Recommended for battery-powered systems. May impact analog performance.",
+                description: "Enables the lower-power wait if no tasks are ready to run on the \
+                thread-mode executor. This allows the MCU to use less power if the workload allows. \
+                Recommended for battery-powered systems. May impact analog performance.",
                 default_value: Value::Bool(true),
                 constraint: None,
                 stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "timer-queue",
-                description: "<p>The flavour of the timer queue provided by this crate. Accepts one of `single-integrated`, `multiple-integrated` or `generic`. Integrated queues require the `executors` feature to be enabled.</p><p>If you use embassy-executor, the `single-integrated` queue is recommended for ease of use, while the `multiple-integrated` queue is recommended for performance. The `multiple-integrated` option needs one timer per executor.</p><p>The `generic` queue allows using embassy-time without the embassy executors.</p>",
+                description: "<p>The flavour of the timer queue provided by this crate. Accepts \
+                one of `single-integrated`, `multiple-integrated` or `generic`. Integrated queues \
+                require the `executors` feature to be enabled.</p><p>If you use embassy-executor, \
+                the `single-integrated` queue is recommended for ease of use, while the \
+                `multiple-integrated` queue is recommended for performance. The \
+                `multiple-integrated` option needs one timer per executor.</p><p>The `generic` \
+                queue allows using embassy-time without the embassy executors.</p>",
                 default_value: Value::String(if cfg!(feature = "executors") {
                     String::from("single-integrated")
                 } else {
@@ -80,12 +88,14 @@ fn main() -> Result<(), Box<dyn StdError>> {
             },
             ConfigOption {
                 name: "generic-queue-size",
-                description: "The capacity of the queue when the `generic` timer queue flavour is selected.",
+                description: "The capacity of the queue when the `generic` timer \
+                queue flavour is selected.",
                 default_value: Value::Integer(64),
                 constraint: Some(Validator::PositiveInteger),
                 stability: Stability::Unstable,
             },
         ],
+        true,
         true,
     );
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ESP_HAL_CONFIG_CRITICAL_SECTION_IMPL` to allow opting out of the default `critical-section` implementation (#3293)
 - All peripheral singletons (`GpioPin<...>`, `SPIn`, ...) now have a lifetime, as well as `steal`, `reborrow` and `clone_unchecked` methods (#3305)
 - `i2c::master::Operation` now implements `defmt::Format` (#3348)
-- ESP32-S2: Support for light-/deep-sleep (#3341) 
-- Add DMA memcpy support to the S2 (#3352)
 - ESP32-S2: Support for light-/deep-sleep (#3341)
+- Add DMA memcpy support to the S2 (#3352)
+- Some config options can now only be set when the `unstable` feature in enabled (#3365)
 
 ### Changed
 
@@ -342,7 +342,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Camera` and `I8080` drivers' constructors now only accepts blocking-mode DMA channels. (#2519)
 - Many peripherals are now disabled by default and also get disabled when the driver is dropped (#2544)
 - Updated embassy-time to v0.4 (#2701)
-
 - Config: Crate prefixes and configuration keys are now separated by `_CONFIG_` (#2848)
 - UART: `read_byte` and `write_byte` made private. (#2915)
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `i2c::master::Operation` now implements `defmt::Format` (#3348)
 - ESP32-S2: Support for light-/deep-sleep (#3341) 
 - Add DMA memcpy support to the S2 (#3352)
+- ESP32-S2: Support for light-/deep-sleep (#3341)
 
 ### Changed
 

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -68,101 +68,125 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-link-search={}", out.display());
 
     // emit config
-    let cfg = generate_config("esp_hal", &[
-        ConfigOption {
-            name: "place-spi-driver-in-ram",
-            description: "Places the SPI driver in RAM for better performance",
-            default_value: Value::Bool(false),
-            constraint: None,
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-        ConfigOption {
-            name: "place-switch-tables-in-ram",
-            description: "Places switch-tables, some lookup tables and constants related to interrupt handling into RAM - resulting in better performance but slightly more RAM consumption.",
-            default_value: Value::Bool(true),
-            constraint: None,
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-        ConfigOption {
-            name: "place-anon-in-ram",
-            description: "Places anonymous symbols into RAM - resulting in better performance at the cost of significant more RAM consumption. Best to be combined with `place-switch-tables-in-ram`.",
-            default_value: Value::Bool(false),
-            constraint: None,
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-        // Ideally, we should be able to set any clock frequency for any chip. However, currently
-        // only the 32 and C2 implements any sort of configurability, and the rest have a fixed
-        // clock frequeny.
-        // TODO: only show this configuration for chips that have multiple valid options.
-        ConfigOption {
-            name: "xtal-frequency",
-            description: "The frequency of the crystal oscillator, in MHz. Set to `auto` to automatically detect the frequency. `auto` may not be able to identify the clock frequency in some cases. Also, configuring a specific frequency may increase performance slightly.",
-            default_value: Value::String(match device_name {
-                "esp32" | "esp32c2" => String::from("auto"),
-                // The rest has only one option
-                "esp32c3" | "esp32c6" | "esp32s2" | "esp32s3" => String::from("40"),
-                "esp32h2" => String::from("32"),
-                _ => unreachable!(),
-            }),
-            constraint:Some(Validator::Enumeration(match device_name {
-                "esp32" | "esp32c2" => vec![String::from("auto"), String::from("26"), String::from("40")],
-                // The rest has only one option
-                "esp32c3" | "esp32c6" | "esp32s2" | "esp32s3" => vec![String::from("40")],
-                "esp32h2" => vec![String::from("32")],
-                _ => unreachable!(),
-            })),
-            stability: Stability::Unstable,
-        },
-        // ideally we should only offer this for ESP32 but the config system doesn't
-        // support per target configs, yet
-        ConfigOption {
-            name: "spi-address-workaround",
-            description: "(ESP32 only) Enables a workaround for the issue where SPI in half-duplex mode incorrectly transmits the address on a single line if the data buffer is empty.",
-            default_value: Value::Bool(true),
-            constraint: None,
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-        // ideally we should only offer this for ESP32-C6/ESP32-H2 but the config system doesn't support per target configs, yet
-        ConfigOption {
-            name: "flip-link",
-            description: "(ESP32-C6/ESP32-H2 only): Move the stack to start of RAM to get zero-cost stack overflow protection.",
-            default_value: Value::Bool(false),
-            constraint: None,
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-        // ideally we should only offer this for ESP32, ESP32-S2 and `octal` only for ESP32-S3 but the config system doesn't support per target configs, yet
-        ConfigOption {
-            name: "psram-mode",
-            description: "(ESP32, ESP32-S2 and ESP32-S3 only, `octal` is only supported for ESP32-S3) SPIRAM chip mode",
-            default_value: Value::String(String::from("quad")),
-            constraint: Some(Validator::Enumeration(
-                vec![String::from("quad"), String::from("octal")]
-            )),
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-        // Rust's stack smashing protection configuration
-        ConfigOption {
-            name: "stack-guard-offset",
-            description: "The stack guard variable will be placed this many bytes from the stack's end.",
-            default_value: Value::Integer(4096),
-            constraint: None,
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-        ConfigOption {
-            name: "stack-guard-value",
-            description: "The value to be written to the stack guard variable.",
-            default_value: Value::Integer(0xDEED_BAAD),
-            constraint: None,
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-        ConfigOption {
-            name: "impl-critical-section",
-            description: "Provide a `critical-section` implementation. Note that if disabled, you will need to provide a `critical-section` implementation which is using `critical-section/restore-state-u32`.",
-            default_value: Value::Bool(true),
-            constraint: None,
-            stability: Stability::Stable("1.0.0-beta.0"),
-        },
-    ], true);
+    let cfg = generate_config(
+        "esp_hal",
+        &[
+            ConfigOption {
+                name: "place-spi-driver-in-ram",
+                description: "Places the SPI driver in RAM for better performance",
+                default_value: Value::Bool(false),
+                constraint: None,
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+            ConfigOption {
+                name: "place-switch-tables-in-ram",
+                description: "Places switch-tables, some lookup tables and constants related to \
+                interrupt handling into RAM - resulting in better performance but slightly more \
+                RAM consumption.",
+                default_value: Value::Bool(true),
+                constraint: None,
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+            ConfigOption {
+                name: "place-anon-in-ram",
+                description: "Places anonymous symbols into RAM - resulting in better performance \
+                at the cost of significant more RAM consumption. Best to be combined with \
+                `place-switch-tables-in-ram`.",
+                default_value: Value::Bool(false),
+                constraint: None,
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+            // Ideally, we should be able to set any clock frequency for any chip. However,
+            // currently only the 32 and C2 implements any sort of configurability, and
+            // the rest have a fixed clock frequeny.
+            // TODO: only show this configuration for chips that have multiple valid options.
+            ConfigOption {
+                name: "xtal-frequency",
+                description: "The frequency of the crystal oscillator, in MHz. Set to `auto` to \
+                automatically detect the frequency. `auto` may not be able to identify the clock \
+                frequency in some cases. Also, configuring a specific frequency may increase \
+                performance slightly.",
+                default_value: Value::String(match device_name {
+                    "esp32" | "esp32c2" => String::from("auto"),
+                    // The rest has only one option
+                    "esp32c3" | "esp32c6" | "esp32s2" | "esp32s3" => String::from("40"),
+                    "esp32h2" => String::from("32"),
+                    _ => unreachable!(),
+                }),
+                constraint: Some(Validator::Enumeration(match device_name {
+                    "esp32" | "esp32c2" => {
+                        vec![String::from("auto"), String::from("26"), String::from("40")]
+                    }
+                    // The rest has only one option
+                    "esp32c3" | "esp32c6" | "esp32s2" | "esp32s3" => vec![String::from("40")],
+                    "esp32h2" => vec![String::from("32")],
+                    _ => unreachable!(),
+                })),
+                stability: Stability::Unstable,
+            },
+            // ideally we should only offer this for ESP32 but the config system doesn't
+            // support per target configs, yet
+            ConfigOption {
+                name: "spi-address-workaround",
+                description: "(ESP32 only) Enables a workaround for the issue where SPI in \
+                half-duplex mode incorrectly transmits the address on a single line if the \
+                data buffer is empty.",
+                default_value: Value::Bool(true),
+                constraint: None,
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+            // ideally we should only offer this for ESP32-C6/ESP32-H2 but the config system
+            // doesn't support per target configs, yet
+            ConfigOption {
+                name: "flip-link",
+                description: "(ESP32-C6/ESP32-H2 only): Move the stack to start of RAM to get \
+                zero-cost stack overflow protection.",
+                default_value: Value::Bool(false),
+                constraint: None,
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+            // ideally we should only offer this for ESP32, ESP32-S2 and `octal` only for ESP32-S3
+            // but the config system doesn't support per target configs, yet
+            ConfigOption {
+                name: "psram-mode",
+                description: "(ESP32, ESP32-S2 and ESP32-S3 only, `octal` is only supported for \
+                ESP32-S3) SPIRAM chip mode",
+                default_value: Value::String(String::from("quad")),
+                constraint: Some(Validator::Enumeration(vec![
+                    String::from("quad"),
+                    String::from("octal"),
+                ])),
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+            // Rust's stack smashing protection configuration
+            ConfigOption {
+                name: "stack-guard-offset",
+                description: "The stack guard variable will be placed this many bytes from \
+                the stack's end.",
+                default_value: Value::Integer(4096),
+                constraint: None,
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+            ConfigOption {
+                name: "stack-guard-value",
+                description: "The value to be written to the stack guard variable.",
+                default_value: Value::Integer(0xDEED_BAAD),
+                constraint: None,
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+            ConfigOption {
+                name: "impl-critical-section",
+                description: "Provide a `critical-section` implementation. Note that if disabled, \
+                you will need to provide a `critical-section` implementation which is \
+                using `restore-state-u32`.",
+                default_value: Value::Bool(true),
+                constraint: None,
+                stability: Stability::Stable("1.0.0-beta.0"),
+            },
+        ],
+        cfg!(feature = "unstable"),
+        true,
+    );
 
     // RISC-V and Xtensa devices each require some special handling and processing
     // of linker scripts:

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use esp_build::assert_unique_used_features;
-use esp_config::{generate_config, ConfigOption, Validator, Value};
+use esp_config::{generate_config, ConfigOption, Stability, Validator, Value};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -73,19 +73,22 @@ fn main() -> Result<(), Box<dyn Error>> {
             name: "place-spi-driver-in-ram",
             description: "Places the SPI driver in RAM for better performance",
             default_value: Value::Bool(false),
-            constraint: None
+            constraint: None,
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
         ConfigOption {
             name: "place-switch-tables-in-ram",
             description: "Places switch-tables, some lookup tables and constants related to interrupt handling into RAM - resulting in better performance but slightly more RAM consumption.",
             default_value: Value::Bool(true),
-            constraint: None
+            constraint: None,
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
         ConfigOption {
             name: "place-anon-in-ram",
             description: "Places anonymous symbols into RAM - resulting in better performance at the cost of significant more RAM consumption. Best to be combined with `place-switch-tables-in-ram`.",
             default_value: Value::Bool(false),
-            constraint: None
+            constraint: None,
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
         // Ideally, we should be able to set any clock frequency for any chip. However, currently
         // only the 32 and C2 implements any sort of configurability, and the rest have a fixed
@@ -108,6 +111,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 "esp32h2" => vec![String::from("32")],
                 _ => unreachable!(),
             })),
+            stability: Stability::Unstable,
         },
         // ideally we should only offer this for ESP32 but the config system doesn't
         // support per target configs, yet
@@ -115,14 +119,16 @@ fn main() -> Result<(), Box<dyn Error>> {
             name: "spi-address-workaround",
             description: "(ESP32 only) Enables a workaround for the issue where SPI in half-duplex mode incorrectly transmits the address on a single line if the data buffer is empty.",
             default_value: Value::Bool(true),
-            constraint: None
+            constraint: None,
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
         // ideally we should only offer this for ESP32-C6/ESP32-H2 but the config system doesn't support per target configs, yet
         ConfigOption {
             name: "flip-link",
             description: "(ESP32-C6/ESP32-H2 only): Move the stack to start of RAM to get zero-cost stack overflow protection.",
             default_value: Value::Bool(false),
-            constraint: None
+            constraint: None,
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
         // ideally we should only offer this for ESP32, ESP32-S2 and `octal` only for ESP32-S3 but the config system doesn't support per target configs, yet
         ConfigOption {
@@ -132,25 +138,29 @@ fn main() -> Result<(), Box<dyn Error>> {
             constraint: Some(Validator::Enumeration(
                 vec![String::from("quad"), String::from("octal")]
             )),
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
         // Rust's stack smashing protection configuration
         ConfigOption {
             name: "stack-guard-offset",
             description: "The stack guard variable will be placed this many bytes from the stack's end.",
             default_value: Value::Integer(4096),
-            constraint: None
+            constraint: None,
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
         ConfigOption {
             name: "stack-guard-value",
             description: "The value to be written to the stack guard variable.",
             default_value: Value::Integer(0xDEED_BAAD),
-            constraint: None
+            constraint: None,
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
         ConfigOption {
             name: "impl-critical-section",
             description: "Provide a `critical-section` implementation. Note that if disabled, you will need to provide a `critical-section` implementation which is using `critical-section/restore-state-u32`.",
             default_value: Value::Bool(true),
-            constraint: None
+            constraint: None,
+            stability: Stability::Stable("1.0.0-beta.0"),
         },
     ], true);
 

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -133,7 +133,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 data buffer is empty.",
                 default_value: Value::Bool(true),
                 constraint: None,
-                stability: Stability::Stable("1.0.0-beta.0"),
+                stability: Stability::Unstable,
             },
             // ideally we should only offer this for ESP32-C6/ESP32-H2 but the config system
             // doesn't support per target configs, yet
@@ -143,7 +143,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 zero-cost stack overflow protection.",
                 default_value: Value::Bool(false),
                 constraint: None,
-                stability: Stability::Stable("1.0.0-beta.0"),
+                stability: Stability::Unstable,
             },
             // ideally we should only offer this for ESP32, ESP32-S2 and `octal` only for ESP32-S3
             // but the config system doesn't support per target configs, yet
@@ -156,7 +156,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     String::from("quad"),
                     String::from("octal"),
                 ])),
-                stability: Stability::Stable("1.0.0-beta.0"),
+                stability: Stability::Unstable,
             },
             // Rust's stack smashing protection configuration
             ConfigOption {
@@ -181,7 +181,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 using `restore-state-u32`.",
                 default_value: Value::Bool(true),
                 constraint: None,
-                stability: Stability::Stable("1.0.0-beta.0"),
+                stability: Stability::Unstable,
             },
         ],
         cfg!(feature = "unstable"),

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -146,8 +146,9 @@
 //!
 //! We've exposed some configuration options that don't fit into cargo
 //! features. These can be set via environment variables, or via cargo's `[env]`
-//! section inside `.cargo/config.toml`. Below is a table of tunable parameters
-//! for this crate:
+//! section inside `.cargo/config.toml`. Note that unstable options can only be
+//! enabled when the `unstable` feature is enabled for the crate. Below is a
+//! table of tunable parameters for this crate:
 #![doc = ""]
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_hal_config_table.md"))]
 #![doc = ""]

--- a/esp-ieee802154/build.rs
+++ b/esp-ieee802154/build.rs
@@ -17,5 +17,6 @@ fn main() {
             stability: Stability::Unstable,
         }],
         true,
+        true,
     );
 }

--- a/esp-ieee802154/build.rs
+++ b/esp-ieee802154/build.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf};
 
-use esp_config::{generate_config, ConfigOption, Validator, Value};
+use esp_config::{generate_config, ConfigOption, Stability, Validator, Value};
 
 fn main() {
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -14,6 +14,7 @@ fn main() {
             description: "Size of the RX queue in frames",
             default_value: Value::Integer(50),
             constraint: Some(Validator::PositiveInteger),
+            stability: Stability::Unstable,
         }],
         true,
     );

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -1,7 +1,7 @@
 use std::{error::Error, str::FromStr};
 
 use esp_build::assert_unique_used_features;
-use esp_config::{generate_config, ConfigOption, Validator, Value};
+use esp_config::{generate_config, ConfigOption, Stability, Validator, Value};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -103,133 +103,155 @@ fn main() -> Result<(), Box<dyn Error>> {
                 name: "rx_queue_size",
                 description: "Size of the RX queue in frames",
                 default_value: Value::Integer(5),
-                constraint: Some(Validator::PositiveInteger)
+                constraint: Some(Validator::PositiveInteger),
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "tx_queue_size",
                 description: "Size of the TX queue in frames",
                 default_value: Value::Integer(3),
-                constraint: Some(Validator::PositiveInteger)
+                constraint: Some(Validator::PositiveInteger),
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "static_rx_buf_num",
                 description: "WiFi static RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 default_value: Value::Integer(10),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "dynamic_rx_buf_num",
                 description: "WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 default_value: Value::Integer(32),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "static_tx_buf_num",
                 description: "WiFi static TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 default_value: Value::Integer(0),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "dynamic_tx_buf_num",
                 description: "WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 default_value: Value::Integer(32),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "ampdu_rx_enable",
                 description: "WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 default_value: Value::Bool(true),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "ampdu_tx_enable",
                 description: "WiFi AMPDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 default_value: Value::Bool(true),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "amsdu_tx_enable",
                 description: "WiFi AMSDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 default_value: Value::Bool(false),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "rx_ba_win",
                 description: "WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 default_value: Value::Integer(6),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "max_burst_size",
                 description: "See [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)",
                 default_value: Value::Integer(1),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "country_code",
                 description: "Country code. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
                 default_value: Value::String("CN".to_owned()),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "country_code_operating_class",
                 description: "If not 0: Operating Class table number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
                 default_value: Value::Integer(0),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "mtu",
                 description: "MTU, see [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)",
                 default_value: Value::Integer(1492),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "tick_rate_hz",
                 description: "Tick rate of the internal task scheduler in hertz",
                 default_value: Value::Integer(100),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "listen_interval",
                 description: "Interval for station to listen to beacon from AP. The unit of listen interval is one beacon interval. For example, if beacon interval is 100 ms and listen interval is 3, the interval for station to listen to beacon is 300 ms",
                 default_value: Value::Integer(3),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "beacon_timeout",
                 description: "For Station, If the station does not receive a beacon frame from the connected SoftAP during the  inactive time, disconnect from SoftAP. Default 6s. Range 6-30",
                 default_value: Value::Integer(6),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "ap_beacon_timeout",
                 description: "For SoftAP, If the SoftAP doesn't receive any data from the connected STA during inactive time, the SoftAP will force deauth the STA. Default is 300s",
                 default_value: Value::Integer(300),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "failure_retry_cnt",
                 description: "Number of connection retries station will do before moving to next AP. scan_method should be set as WIFI_ALL_CHANNEL_SCAN to use this config. Note: Enabling this may cause connection time to increase incase best AP doesn't behave properly. Defaults to 1",
                 default_value: Value::Integer(1),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "scan_method",
                 description: "0 = WIFI_FAST_SCAN, 1 = WIFI_ALL_CHANNEL_SCAN, defaults to 0",
                 default_value: Value::Integer(0),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "dump_packets",
                 description: "Dump packets via an info log statement",
                 default_value: Value::Bool(false),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
             ConfigOption {
                 name: "phy_enable_usb",
                 description: "Keeps USB running when using WiFi. This allows debugging and log messages via USB Serial JTAG. Turn off for best WiFi performance.",
                 default_value: Value::Bool(true),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
             },
         ],
         true

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -254,7 +254,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 stability: Stability::Unstable,
             },
         ],
-        true
+        true,
+        true,
     );
 
     Ok(())

--- a/hil-test/tests/flip_link.rs
+++ b/hil-test/tests/flip_link.rs
@@ -1,6 +1,7 @@
 //! Tests flip_link
 
 //% CHIPS: esp32c6 esp32h2
+//% FEATURES: unstable
 //% ENV: ESP_HAL_CONFIG_FLIP_LINK = true
 
 #![no_std]


### PR DESCRIPTION
This PR allows placing a stability tag on config options. Whether unstable options are accepted or rejected, depends on a flag passed to `generate_config`. This is hard-coded to `true` on unstable crates (i.e. everything that isn't esp-hal) and depends on the `unstable` feature in esp-hal. When the flag is disabled, specifying unstable options are a build error, similar to unknown ones.

The PR cleans up the documentation table slightly, and adds a stability note to each option. Example outupt:

![image](https://github.com/user-attachments/assets/4576dbe2-2b3b-461f-8e2b-c57ff1473d10)


Cloes #3077