### PR TITLE
Replace `ParlIoFullDuplex`/`ParlIoTxOnly`/`ParlIoRxOnly` with just `P…

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate SPI slave driver to newer DMA API (#3326)
 - Migrate DMA memcpy driver to newer DMA API (#3327)
 - Moved numbered GPIO pin types from `esp_hal::gpio::GpioPin<N>` to `esp_hal::peripherals::GPION<'_>` (#3349)
+- `ParlIoFullDuplex`, `ParlIoTxOnly` and `ParlIoRxOnly` have been merged into `ParlIo` (#3366)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -116,6 +116,15 @@ The affected types in the `gpio::interconnect` module are:
 
 ## PARL IO driver changes
 
+### `ParlIoFullDuplex`, `ParlIoTxOnly` and `ParlIoRxOnly` have been merged into `ParlIo`
+
+```diff
+- let parl_io = ParlIoFullDuplex::new(peripherals.PARL_IO, dma_channel)?;
+- let parl_io = ParlIoTxOnly::new(peripherals.PARL_IO, dma_channel)?;
+- let parl_io = ParlIoRxOnly::new(peripherals.PARL_IO, dma_channel)?;
++ let parl_io = ParlIo::new(peripherals.PARL_IO, dma_channel)?;
+```
+
 ### Construction no longer asks for references
 
 ```diff

--- a/hil-test/tests/parl_io.rs
+++ b/hil-test/tests/parl_io.rs
@@ -16,7 +16,7 @@ use esp_hal::{
         BitPackOrder,
         ClkOutPin,
         EnableMode,
-        ParlIoFullDuplex,
+        ParlIo,
         RxClkInPin,
         RxConfig,
         RxEightBits,
@@ -115,7 +115,7 @@ mod tests {
         let clock_out_pin = ClkOutPin::new(clock_tx);
         let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
-        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel).unwrap();
+        let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let pio_tx = pio
             .tx
@@ -178,7 +178,7 @@ mod tests {
         let clock_out_pin = ClkOutPin::new(clock_tx);
         let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
-        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel).unwrap();
+        let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let pio_tx = pio
             .tx
@@ -242,7 +242,7 @@ mod tests {
         let clock_out_pin = ClkOutPin::new(clock_tx);
         let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
-        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel).unwrap();
+        let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let pio_tx = pio
             .tx
@@ -311,7 +311,7 @@ mod tests {
         let clock_out_pin = ClkOutPin::new(clock_tx);
         let clock_in_pin = RxClkInPin::new(clock_rx, SampleEdge::Normal);
 
-        let pio = ParlIoFullDuplex::new(ctx.parl_io, ctx.dma_channel).unwrap();
+        let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let pio_tx = pio
             .tx

--- a/hil-test/tests/parl_io_tx.rs
+++ b/hil-test/tests/parl_io_tx.rs
@@ -18,7 +18,7 @@ use esp_hal::{
     parl_io::{
         BitPackOrder,
         ClkOutPin,
-        ParlIoTxOnly,
+        ParlIo,
         SampleEdge,
         TxConfig,
         TxEightBits,
@@ -90,7 +90,7 @@ mod tests {
         let pins = TxPinConfigIncludingValidPin::new(pins);
         let clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel).unwrap();
+        let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let mut pio = pio
             .tx
@@ -153,7 +153,7 @@ mod tests {
 
         let clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel).unwrap();
+        let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
         let mut pio = pio
             .tx

--- a/hil-test/tests/parl_io_tx_async.rs
+++ b/hil-test/tests/parl_io_tx_async.rs
@@ -18,7 +18,7 @@ use esp_hal::{
     parl_io::{
         BitPackOrder,
         ClkOutPin,
-        ParlIoTxOnly,
+        ParlIo,
         SampleEdge,
         TxConfig,
         TxEightBits,
@@ -89,7 +89,7 @@ mod tests {
         let pins = TxPinConfigIncludingValidPin::new(pins);
         let clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel)
+        let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel)
             .unwrap()
             .into_async();
 
@@ -156,7 +156,7 @@ mod tests {
 
         let clock_pin = ClkOutPin::new(ctx.clock);
 
-        let pio = ParlIoTxOnly::new(ctx.parl_io, ctx.dma_channel)
+        let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel)
             .unwrap()
             .into_async();
 


### PR DESCRIPTION
…arlIo`

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Now that the `FullDuplex` trait is gone (#3339), there's no need for the `ParlIoFullDuplex`/`ParlIoTxOnly`/`ParlIoRxOnly` distinction.
We can just do `ParlIo` (which does the same thing as `ParlIoFullDuplex`).

#### Testing
HIL and CI
