### PR TITLE
esp-wifi: change the `PowerSaveMode` enum's default to `None`

### DIFF
--- a/esp-wifi/src/config.rs
+++ b/esp-wifi/src/config.rs
@@ -28,8 +28,8 @@ pub(crate) struct EspWifiConfig {
 #[non_exhaustive]
 #[derive(Default)]
 pub enum PowerSaveMode {
-    None,
     #[default]
+    None,
     Minimum,
     Maximum,
 }


### PR DESCRIPTION
 Fix my mess from https://github.com/esp-rs/esp-hal/pull/3364#pullrequestreview-2757491559
 