### PR TITLE
Only provide relevant config options

### DIFF
--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -23,6 +23,7 @@ fn main() {
             default_value: Value::Integer(10),
             constraint: None,
             stability: Stability::Unstable,
+            active: true,
         }],
         true,
         true,

--- a/esp-bootloader-esp-idf/build.rs
+++ b/esp-bootloader-esp-idf/build.rs
@@ -31,6 +31,7 @@ fn main() {
                     String::from("64k"),
                 ])),
                 stability: Stability::Unstable,
+                active: true, // TODO we need to know the device here
             },
             ConfigOption {
                 name: "esp_idf_version",
@@ -39,6 +40,7 @@ fn main() {
                 default_value: Value::String(String::from("0.0.0")),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "partition-table-offset",
@@ -49,6 +51,7 @@ fn main() {
                 default_value: Value::Integer(0x8000),
                 constraint: Some(Validator::PositiveInteger),
                 stability: Stability::Unstable,
+                active: true,
             },
         ],
         true,

--- a/esp-config/src/generate/mod.rs
+++ b/esp-config/src/generate/mod.rs
@@ -86,6 +86,9 @@ pub fn generate_config(
         let mut selected_config = String::from(markdown::SELECTED_TABLE_HEADER);
 
         for (name, option, value) in configs.iter() {
+            if !option.active {
+                continue;
+            }
             markdown::write_doc_table_line(&mut doc_table, name, option);
             markdown::write_summary_table_line(&mut selected_config, &name, value);
         }
@@ -237,6 +240,12 @@ pub struct ConfigOption {
 
     /// The stability of the configuration option.
     pub stability: Stability,
+
+    /// Whether the config option should be offered to the user.
+    ///
+    /// Inactive options are not included in the documentation, and accessing
+    /// them provides the default value.
+    pub active: bool,
 }
 
 impl ConfigOption {
@@ -283,6 +292,11 @@ fn capture_from_env(
                 unknown.push(var);
                 continue;
             };
+
+            if !option.active {
+                unknown.push(var);
+                continue;
+            }
 
             if !enable_unstable && !option.is_stable() {
                 unstable.push(var);
@@ -406,6 +420,7 @@ mod test {
                             default_value: Value::Integer(999),
                             constraint: None,
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "number_signed",
@@ -413,6 +428,7 @@ mod test {
                             default_value: Value::Integer(-777),
                             constraint: None,
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "string",
@@ -420,6 +436,7 @@ mod test {
                             default_value: Value::String("Demo".to_string()),
                             constraint: None,
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "bool",
@@ -427,6 +444,7 @@ mod test {
                             default_value: Value::Bool(false),
                             constraint: None,
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "number_default",
@@ -434,6 +452,7 @@ mod test {
                             default_value: Value::Integer(999),
                             constraint: None,
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "string_default",
@@ -441,6 +460,7 @@ mod test {
                             default_value: Value::String("Demo".to_string()),
                             constraint: None,
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "bool_default",
@@ -448,6 +468,7 @@ mod test {
                             default_value: Value::Bool(false),
                             constraint: None,
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                     ],
                     false,
@@ -499,6 +520,7 @@ mod test {
                             default_value: Value::Integer(-1),
                             constraint: Some(Validator::PositiveInteger),
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "negative_number",
@@ -506,6 +528,7 @@ mod test {
                             default_value: Value::Integer(1),
                             constraint: Some(Validator::NegativeInteger),
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "non_negative_number",
@@ -513,6 +536,7 @@ mod test {
                             default_value: Value::Integer(-1),
                             constraint: Some(Validator::NonNegativeInteger),
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                         ConfigOption {
                             name: "range",
@@ -520,6 +544,7 @@ mod test {
                             default_value: Value::Integer(0),
                             constraint: Some(Validator::IntegerInRange(5..10)),
                             stability: Stability::Stable("testing"),
+                            active: true,
                         },
                     ],
                     false,
@@ -547,6 +572,7 @@ mod test {
                         }
                     }))),
                     stability: Stability::Stable("testing"),
+                    active: true,
                 }],
                 false,
                 false,
@@ -566,6 +592,7 @@ mod test {
                     default_value: Value::Integer(-1),
                     constraint: Some(Validator::PositiveInteger),
                     stability: Stability::Stable("testing"),
+                    active: true,
                 }],
                 false,
                 false,
@@ -592,6 +619,7 @@ mod test {
                         }
                     }))),
                     stability: Stability::Stable("testing"),
+                    active: true,
                 }],
                 false,
                 false,
@@ -616,6 +644,7 @@ mod test {
                         default_value: Value::Integer(999),
                         constraint: None,
                         stability: Stability::Stable("testing"),
+                        active: true,
                     }],
                     false,
                     false,
@@ -636,6 +665,7 @@ mod test {
                     default_value: Value::Integer(999),
                     constraint: None,
                     stability: Stability::Stable("testing"),
+                    active: true,
                 }],
                 false,
                 false,
@@ -656,6 +686,7 @@ mod test {
                         default_value: Value::Integer(999),
                         constraint: None,
                         stability: Stability::Stable("testing"),
+                        active: true,
                     }],
                     false,
                     false,
@@ -680,6 +711,7 @@ mod test {
                         "variant-1".to_string(),
                     ])),
                     stability: Stability::Stable("testing"),
+                    active: true,
                 }],
                 false,
             );
@@ -706,6 +738,7 @@ mod test {
                     "variant-1".to_string(),
                 ])),
                 stability: Stability::Stable("testing"),
+                active: true,
             },
             ConfigOption {
                 name: "some-key2",
@@ -713,6 +746,7 @@ mod test {
                 default_value: Value::Bool(true),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
         ];
         let configs =
@@ -738,6 +772,7 @@ mod test {
     "stability": {
       "Stable": "testing"
     },
+    "active": true,
     "actual_value": {
       "String": "variant-0"
     }
@@ -750,6 +785,7 @@ mod test {
     },
     "constraint": null,
     "stability": "Unstable",
+    "active": true,
     "actual_value": {
       "Bool": true
     }
@@ -776,6 +812,31 @@ mod test {
                         "variant-1".to_string(),
                     ])),
                     stability: Stability::Unstable,
+                    active: true,
+                }],
+                false,
+            );
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn inactive_option_panics() {
+        let mut stdout = Vec::new();
+        temp_env::with_vars([("ESP_TEST_CONFIG_SOME_KEY", Some("variant-0"))], || {
+            generate_config_internal(
+                &mut stdout,
+                "esp-test",
+                &[ConfigOption {
+                    name: "some-key",
+                    description: "NA",
+                    default_value: Value::String("variant-0".to_string()),
+                    constraint: Some(Validator::Enumeration(vec![
+                        "variant-0".to_string(),
+                        "variant-1".to_string(),
+                    ])),
+                    stability: Stability::Stable("testing"),
+                    active: false,
                 }],
                 false,
             );

--- a/esp-hal-embassy/build.rs
+++ b/esp-hal-embassy/build.rs
@@ -50,6 +50,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
                 default_value: Value::Bool(true),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "timer-queue",
@@ -74,6 +75,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
                     Validator::Enumeration(vec![String::from("generic")])
                 }),
                 stability: Stability::Unstable,
+                active: cfg!(feature = "executors"),
             },
             ConfigOption {
                 name: "generic-queue-size",
@@ -82,6 +84,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
                 default_value: Value::Integer(64),
                 constraint: Some(Validator::PositiveInteger),
                 stability: Stability::Unstable,
+                active: true,
             },
         ],
         true,

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -102,8 +102,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             // Ideally, we should be able to set any clock frequency for any chip. However,
             // currently only the 32 and C2 implements any sort of configurability, and
             // the rest have a fixed clock frequeny.
-            // TODO: only show this configuration for chips that have multiple valid
-            // options.
             ConfigOption {
                 name: "xtal-frequency",
                 description: "The frequency of the crystal oscillator, in MHz. Set to `auto` to \
@@ -117,17 +115,17 @@ fn main() -> Result<(), Box<dyn Error>> {
                     "esp32h2" => String::from("32"),
                     _ => unreachable!(),
                 }),
-                constraint: Some(Validator::Enumeration(match device_name {
-                    "esp32" | "esp32c2" => {
-                        vec![String::from("auto"), String::from("26"), String::from("40")]
-                    }
+                constraint: match device_name {
+                    "esp32" | "esp32c2" => Some(Validator::Enumeration(vec![
+                        String::from("auto"),
+                        String::from("26"),
+                        String::from("40"),
+                    ])),
                     // The rest has only one option
-                    "esp32c3" | "esp32c6" | "esp32s2" | "esp32s3" => vec![String::from("40")],
-                    "esp32h2" => vec![String::from("32")],
-                    _ => unreachable!(),
-                })),
+                    _ => None,
+                },
                 stability: Stability::Unstable,
-                active: true,
+                active: ["esp32", "esp32s2"].contains(&device_name),
             },
             ConfigOption {
                 name: "spi-address-workaround",

--- a/esp-ieee802154/build.rs
+++ b/esp-ieee802154/build.rs
@@ -15,6 +15,7 @@ fn main() {
             default_value: Value::Integer(50),
             constraint: Some(Validator::PositiveInteger),
             stability: Stability::Unstable,
+            active: true,
         }],
         true,
         true,

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -105,6 +105,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(5),
                 constraint: Some(Validator::PositiveInteger),
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "tx_queue_size",
@@ -112,6 +113,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(3),
                 constraint: Some(Validator::PositiveInteger),
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "static_rx_buf_num",
@@ -119,6 +121,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(10),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "dynamic_rx_buf_num",
@@ -126,6 +129,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(32),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "static_tx_buf_num",
@@ -133,6 +137,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(0),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "dynamic_tx_buf_num",
@@ -140,6 +145,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(32),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "ampdu_rx_enable",
@@ -147,6 +153,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Bool(true),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "ampdu_tx_enable",
@@ -154,6 +161,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Bool(true),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "amsdu_tx_enable",
@@ -161,6 +169,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Bool(false),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "rx_ba_win",
@@ -168,6 +177,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(6),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "max_burst_size",
@@ -175,6 +185,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(1),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "country_code",
@@ -182,6 +193,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::String("CN".to_owned()),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "country_code_operating_class",
@@ -189,6 +201,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(0),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "mtu",
@@ -196,6 +209,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(1492),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "tick_rate_hz",
@@ -203,6 +217,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(100),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "listen_interval",
@@ -210,6 +225,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(3),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "beacon_timeout",
@@ -217,6 +233,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(6),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "ap_beacon_timeout",
@@ -224,6 +241,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(300),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "failure_retry_cnt",
@@ -231,6 +249,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(1),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "scan_method",
@@ -238,6 +257,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Integer(0),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "dump_packets",
@@ -245,6 +265,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Bool(false),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "phy_enable_usb",
@@ -252,6 +273,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 default_value: Value::Bool(true),
                 constraint: None,
                 stability: Stability::Unstable,
+                active: true,
             },
         ],
         true,


### PR DESCRIPTION
This PR gives us the option to selectively remove config options, while at the same time keeping them "known" so that we don't end up generating warnings.

The PR removes options from the documentation. See the difference below:

ESP32:

![image](https://github.com/user-attachments/assets/ad1b0a90-3480-4ca4-90bb-2e79256149f6)

ESP32C6:

![image](https://github.com/user-attachments/assets/d1a1c2fb-9f84-4f05-b375-d5ebaee24947)
