### PR TITLE
esp-wifi: Support calibration modes other than FULL

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- It's possible to configure the initial power-save mode
+
+- It's possible to use partial RF calibration, it's possible to use the None-calibration-schema after deep-sleep
+
 ### Changed
 
 - The scheduler now runs at interrupt priority 1 on Xtensa chips, too. (#3164)

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- It's possible to configure the initial power-save mode
-
-- It's possible to use partial RF calibration, it's possible to use the None-calibration-schema after deep-sleep
+- It's possible to use partial RF calibration, it's possible to use the None-calibration-schema after deep-sleep (#3383)
 
 ### Changed
 

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -280,18 +280,24 @@ fn main() -> Result<(), Box<dyn Error>> {
                 description: "Which power save mode to use when initializing.",
                 default_value: Value::String(String::from("none")),
                 constraint: Some(Validator::Enumeration(vec![String::from("none"), String::from("min"), String::from("max")])),
+                stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "phy_skip_calibration_after_deep_sleep",
                 description: "Use PHY_RF_CAL_NONE after deep sleep.",
                 default_value: Value::Bool(false),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
+                active: true,
             },
             ConfigOption {
                 name: "phy_full_calibration",
                 description: "Use PHY_RF_CAL_FULL instead of PHY_RF_CAL_PARTIAL.",
                 default_value: Value::Bool(true),
-                constraint: None
+                constraint: None,
+                stability: Stability::Unstable,
+                active: true,
             },
         ],
         true,

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -275,6 +275,18 @@ fn main() -> Result<(), Box<dyn Error>> {
                 stability: Stability::Unstable,
                 active: true,
             },
+            ConfigOption {
+                name: "phy_skip_calibration_after_deep_sleep",
+                description: "Use PHY_RF_CAL_NONE after deep sleep.",
+                default_value: Value::Bool(false),
+                constraint: None
+            },
+            ConfigOption {
+                name: "phy_full_calibration",
+                description: "Use PHY_RF_CAL_FULL instead of PHY_RF_CAL_PARTIAL.",
+                default_value: Value::Bool(true),
+                constraint: None
+            },
         ],
         true,
         true,

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -276,14 +276,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 active: true,
             },
             ConfigOption {
-                name: "initial_power_save_mode",
-                description: "Which power save mode to use when initializing.",
-                default_value: Value::String(String::from("none")),
-                constraint: Some(Validator::Enumeration(vec![String::from("none"), String::from("min"), String::from("max")])),
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
                 name: "phy_skip_calibration_after_deep_sleep",
                 description: "Use PHY_RF_CAL_NONE after deep sleep.",
                 default_value: Value::Bool(false),

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -276,6 +276,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                 active: true,
             },
             ConfigOption {
+                name: "initial_power_save_mode",
+                description: "Which power save mode to use when initializing.",
+                default_value: Value::String(String::from("none")),
+                constraint: Some(Validator::Enumeration(vec![String::from("none"), String::from("min"), String::from("max")])),
+            },
+            ConfigOption {
                 name: "phy_skip_calibration_after_deep_sleep",
                 description: "Use PHY_RF_CAL_NONE after deep sleep.",
                 default_value: Value::Bool(false),

--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -48,9 +48,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !G_IS_PHY_CALIBRATED {
+            if unsafe { !G_IS_PHY_CALIBRATED } {
                 super::phy_calibrate();
-                G_IS_PHY_CALIBRATED = true;
+                unsafe { G_IS_PHY_CALIBRATED = true };
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -1,6 +1,5 @@
 use portable_atomic::{AtomicU32, Ordering};
 
-use super::phy_init_data::PHY_INIT_DATA_DEFAULT;
 use crate::{
     binary::include::*,
     hal::{peripherals::LPWR, ram},
@@ -30,6 +29,10 @@ pub(crate) fn phy_mem_init() {
     }
 }
 
+pub(crate) unsafe fn bbpll_en_usb() {
+    // nothing for ESP32
+}
+
 pub(crate) unsafe fn phy_enable() {
     let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
@@ -45,22 +48,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !unsafe { G_IS_PHY_CALIBRATED } {
-                let mut cal_data: [u8; core::mem::size_of::<esp_phy_calibration_data_t>()] =
-                    [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
-
-                let init_data = &PHY_INIT_DATA_DEFAULT;
-
-                unsafe {
-                    register_chipv7_phy(
-                        init_data,
-                        &mut cal_data as *mut _
-                            as *mut crate::binary::include::esp_phy_calibration_data_t,
-                        esp_phy_calibration_mode_t_PHY_RF_CAL_FULL,
-                    );
-
-                    G_IS_PHY_CALIBRATED = true;
-                }
+            if !G_IS_PHY_CALIBRATED {
+                super::phy_calibrate();
+                G_IS_PHY_CALIBRATED = true;
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
@@ -33,9 +33,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !G_IS_PHY_CALIBRATED {
+            if unsafe { !G_IS_PHY_CALIBRATED } {
                 super::phy_calibrate();
-                G_IS_PHY_CALIBRATED = true;
+                unsafe { G_IS_PHY_CALIBRATED = true };
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
@@ -1,7 +1,6 @@
 use portable_atomic::{AtomicU32, Ordering};
 
-use super::phy_init_data::PHY_INIT_DATA_DEFAULT;
-use crate::{binary::include::*, compat::common::str_from_c};
+use crate::binary::include::*;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -22,6 +21,10 @@ pub(crate) fn phy_mem_init() {
     }
 }
 
+pub(crate) unsafe fn bbpll_en_usb() {
+    // nothing for ESP32-C2
+}
+
 pub(crate) unsafe fn phy_enable() {
     let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
@@ -30,27 +33,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !unsafe { G_IS_PHY_CALIBRATED } {
-                let mut cal_data: [u8; core::mem::size_of::<esp_phy_calibration_data_t>()] =
-                    [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
-
-                let phy_version = unsafe { get_phy_version_str() };
-                trace!("phy_version {}", unsafe { str_from_c(phy_version) });
-
-                let init_data = &PHY_INIT_DATA_DEFAULT;
-
-                // DON'T CALL `phy_bbpll_en_usb` on ESP32-C2
-
-                unsafe {
-                    register_chipv7_phy(
-                        init_data,
-                        &mut cal_data as *mut _
-                            as *mut crate::binary::include::esp_phy_calibration_data_t,
-                        esp_phy_calibration_mode_t_PHY_RF_CAL_FULL,
-                    );
-
-                    G_IS_PHY_CALIBRATED = true;
-                }
+            if !G_IS_PHY_CALIBRATED {
+                super::phy_calibrate();
+                G_IS_PHY_CALIBRATED = true;
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
@@ -58,11 +58,13 @@ pub(crate) fn phy_mem_init() {
 pub(crate) unsafe fn bbpll_en_usb() {
     #[cfg(phy_enable_usb)]
     {
-        extern "C" {
+        unsafe extern "C" {
             fn phy_bbpll_en_usb(param: bool);
         }
 
-        phy_bbpll_en_usb(true);
+        unsafe {
+            phy_bbpll_en_usb(true);
+        }
     }
 }
 
@@ -74,9 +76,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !G_IS_PHY_CALIBRATED {
+            if unsafe { !G_IS_PHY_CALIBRATED } {
                 super::phy_calibrate();
-                G_IS_PHY_CALIBRATED = true;
+                unsafe { G_IS_PHY_CALIBRATED = true };
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
@@ -24,11 +24,13 @@ pub(crate) fn phy_mem_init() {
 pub(crate) unsafe fn bbpll_en_usb() {
     #[cfg(phy_enable_usb)]
     {
-        extern "C" {
+        unsafe extern "C" {
             fn phy_bbpll_en_usb(param: bool);
         }
 
-        phy_bbpll_en_usb(true);
+        unsafe {
+            phy_bbpll_en_usb(true);
+        }
     }
 }
 
@@ -40,9 +42,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !G_IS_PHY_CALIBRATED {
+            if unsafe { !G_IS_PHY_CALIBRATED } {
                 super::phy_calibrate();
-                G_IS_PHY_CALIBRATED = true;
+                unsafe { G_IS_PHY_CALIBRATED = true };
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
@@ -1,7 +1,6 @@
 use portable_atomic::{AtomicU32, Ordering};
 
-use super::phy_init_data::PHY_INIT_DATA_DEFAULT;
-use crate::{binary::include::*, compat::common::str_from_c};
+use crate::binary::include::*;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -22,6 +21,17 @@ pub(crate) fn phy_mem_init() {
     }
 }
 
+pub(crate) unsafe fn bbpll_en_usb() {
+    #[cfg(phy_enable_usb)]
+    {
+        extern "C" {
+            fn phy_bbpll_en_usb(param: bool);
+        }
+
+        phy_bbpll_en_usb(true);
+    }
+}
+
 pub(crate) unsafe fn phy_enable() {
     let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
@@ -30,35 +40,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !unsafe { G_IS_PHY_CALIBRATED } {
-                let mut cal_data: [u8; core::mem::size_of::<esp_phy_calibration_data_t>()] =
-                    [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
-
-                let phy_version = unsafe { get_phy_version_str() };
-                trace!("phy_version {}", unsafe { str_from_c(phy_version) });
-
-                let init_data = &PHY_INIT_DATA_DEFAULT;
-
-                #[cfg(phy_enable_usb)]
-                {
-                    unsafe extern "C" {
-                        fn phy_bbpll_en_usb(param: bool);
-                    }
-
-                    unsafe {
-                        phy_bbpll_en_usb(true);
-                    }
-                }
-                unsafe {
-                    register_chipv7_phy(
-                        init_data,
-                        &mut cal_data as *mut _
-                            as *mut crate::binary::include::esp_phy_calibration_data_t,
-                        esp_phy_calibration_mode_t_PHY_RF_CAL_FULL,
-                    );
-
-                    G_IS_PHY_CALIBRATED = true;
-                }
+            if !G_IS_PHY_CALIBRATED {
+                super::phy_calibrate();
+                G_IS_PHY_CALIBRATED = true;
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32h2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32h2.rs
@@ -1,8 +1,7 @@
 // use atomic_polyfill::AtomicU32;
 use portable_atomic::{AtomicU32, Ordering};
 
-use super::phy_init_data::PHY_INIT_DATA_DEFAULT;
-use crate::{binary::include::*, compat::common::str_from_c};
+use crate::binary::include::*;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -23,6 +22,10 @@ pub(crate) fn phy_mem_init() {
     }
 }
 
+pub(crate) unsafe fn bbpll_en_usb() {
+    // nothing for ESP32-H2
+}
+
 pub(crate) unsafe fn phy_enable() {
     let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
@@ -31,35 +34,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !unsafe { G_IS_PHY_CALIBRATED } {
-                let mut cal_data: [u8; core::mem::size_of::<esp_phy_calibration_data_t>()] =
-                    [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
-
-                let phy_version = unsafe { get_phy_version_str() };
-                trace!("phy_version {}", unsafe { str_from_c(phy_version) });
-
-                let init_data = &PHY_INIT_DATA_DEFAULT;
-
-                // this would cause linker errors when the feature is activated - see https://github.com/esp-rs/esp-wifi/issues/457
-
-                // #[cfg(phy_enable_usb)]
-                // {
-                //     extern "C" {
-                //         pub fn phy_bbpll_en_usb(param: bool);
-                //     }
-
-                //     phy_bbpll_en_usb(true);
-                // }
-                unsafe {
-                    register_chipv7_phy(
-                        init_data,
-                        &mut cal_data as *mut _
-                            as *mut crate::binary::include::esp_phy_calibration_data_t,
-                        esp_phy_calibration_mode_t_PHY_RF_CAL_FULL,
-                    );
-
-                    G_IS_PHY_CALIBRATED = true;
-                }
+            if !G_IS_PHY_CALIBRATED {
+                super::phy_calibrate();
+                G_IS_PHY_CALIBRATED = true;
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32h2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32h2.rs
@@ -34,9 +34,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !G_IS_PHY_CALIBRATED {
+            if unsafe { !G_IS_PHY_CALIBRATED } {
                 super::phy_calibrate();
-                G_IS_PHY_CALIBRATED = true;
+                unsafe { G_IS_PHY_CALIBRATED = true };
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
@@ -66,9 +66,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !G_IS_PHY_CALIBRATED {
+            if unsafe { !G_IS_PHY_CALIBRATED } {
                 super::phy_calibrate();
-                G_IS_PHY_CALIBRATED = true;
+                unsafe { G_IS_PHY_CALIBRATED = true };
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
@@ -59,11 +59,13 @@ pub(crate) fn enable_wifi_power_domain() {
 pub(crate) unsafe fn bbpll_en_usb() {
     #[cfg(phy_enable_usb)]
     {
-        extern "C" {
+        unsafe extern "C" {
             fn phy_bbpll_en_usb(param: bool);
         }
 
-        phy_bbpll_en_usb(true);
+        unsafe {
+            phy_bbpll_en_usb(true);
+        }
     }
 }
 
@@ -75,9 +77,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !G_IS_PHY_CALIBRATED {
+            if unsafe { !G_IS_PHY_CALIBRATED } {
                 super::phy_calibrate();
-                G_IS_PHY_CALIBRATED = true;
+                unsafe { G_IS_PHY_CALIBRATED = true };
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
@@ -1,6 +1,5 @@
 use portable_atomic::{AtomicU32, Ordering};
 
-use super::phy_init_data::PHY_INIT_DATA_DEFAULT;
 use crate::binary::include::*;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
@@ -57,6 +56,17 @@ pub(crate) fn enable_wifi_power_domain() {
     }
 }
 
+pub(crate) unsafe fn bbpll_en_usb() {
+    #[cfg(phy_enable_usb)]
+    {
+        extern "C" {
+            fn phy_bbpll_en_usb(param: bool);
+        }
+
+        phy_bbpll_en_usb(true);
+    }
+}
+
 pub(crate) unsafe fn phy_enable() {
     let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
@@ -65,33 +75,9 @@ pub(crate) unsafe fn phy_enable() {
                 super::phy_enable_clock();
             }
 
-            if !unsafe { G_IS_PHY_CALIBRATED } {
-                let mut cal_data: [u8; core::mem::size_of::<esp_phy_calibration_data_t>()] =
-                    [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
-
-                let init_data = &PHY_INIT_DATA_DEFAULT;
-
-                #[cfg(phy_enable_usb)]
-                {
-                    unsafe extern "C" {
-                        fn phy_bbpll_en_usb(param: bool);
-                    }
-
-                    unsafe {
-                        phy_bbpll_en_usb(true);
-                    }
-                }
-
-                unsafe {
-                    register_chipv7_phy(
-                        init_data,
-                        &mut cal_data as *mut _
-                            as *mut crate::binary::include::esp_phy_calibration_data_t,
-                        esp_phy_calibration_mode_t_PHY_RF_CAL_FULL,
-                    );
-
-                    G_IS_PHY_CALIBRATED = true;
-                }
+            if !G_IS_PHY_CALIBRATED {
+                super::phy_calibrate();
+                G_IS_PHY_CALIBRATED = true;
             } else {
                 unsafe {
                     phy_wakeup_init();

--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -1,4 +1,13 @@
-use esp_wifi_sys::{c_types::c_char, include::timeval};
+use esp_wifi_sys::{
+    c_types::c_char,
+    include::{
+        esp_phy_calibration_data_t,
+        esp_phy_calibration_mode_t_PHY_RF_CAL_FULL,
+        get_phy_version_str,
+        register_chipv7_phy,
+        timeval,
+    },
+};
 use portable_atomic::{AtomicU32, Ordering};
 
 use crate::{
@@ -337,5 +346,25 @@ pub(crate) unsafe fn phy_disable_clock() {
         let radio_clocks = unsafe { RADIO_CLK::steal() };
         RadioClockController::new(radio_clocks).enable_phy(false);
         trace!("phy_disable_clock done!");
+    }
+}
+
+pub(crate) fn phy_calibrate() {
+    let mut cal_data: [u8; core::mem::size_of::<esp_phy_calibration_data_t>()] =
+        [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
+
+    let phy_version = unsafe { get_phy_version_str() };
+    trace!("phy_version {}", unsafe { str_from_c(phy_version) });
+
+    let init_data = &phy_init_data::PHY_INIT_DATA_DEFAULT;
+
+    unsafe {
+        chip_specific::bbpll_en_usb();
+
+        register_chipv7_phy(
+            init_data,
+            &mut cal_data as *mut _ as *mut crate::binary::include::esp_phy_calibration_data_t,
+            esp_phy_calibration_mode_t_PHY_RF_CAL_FULL,
+        );
     }
 }

--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -381,8 +381,7 @@ pub(crate) fn phy_calibrate() {
             }
         };
 
-        // TODO use debug
-        info!("Using calibration mode {}", calibration_mode);
+        debug!("Using calibration mode {}", calibration_mode);
 
         register_chipv7_phy(
             init_data,

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -54,7 +54,7 @@
 //!
 //! Please note that the configuration keys are usually named slightly different and not all configuration keys apply.
 //!
-//! By default the power-saving mode is [PowerSaveMode::Minimum](crate::config::PowerSaveMode::Minimum) and `ESP_WIFI_PHY_ENABLE_USB` is enabled by default.
+//! By default the power-saving mode is [PowerSaveMode::None](crate::config::PowerSaveMode::None) and `ESP_WIFI_PHY_ENABLE_USB` is enabled by default.
 //!
 //! In addition pay attention to these configuration keys:
 //! - `ESP_WIFI_RX_QUEUE_SIZE`

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -2638,14 +2638,7 @@ pub fn new<'d>(
             esp_wifi_result!(esp_wifi_set_country(&country))?;
         }
 
-        #[cfg(initial_power_save_mode_none)]
-        const INITIAL_POWER_SAVE_MODE: PowerSaveMode = PowerSaveMode::None;
-        #[cfg(initial_power_save_mode_min)]
-        const INITIAL_POWER_SAVE_MODE: PowerSaveMode = PowerSaveMode::Minimum;
-        #[cfg(initial_power_save_mode_max)]
-        const INITIAL_POWER_SAVE_MODE: PowerSaveMode = PowerSaveMode::Maximum;
-
-        controller.set_power_saving(INITIAL_POWER_SAVE_MODE)?;
+        controller.set_power_saving(PowerSaveMode::default())?;
     }
 
     Ok((

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -2638,7 +2638,14 @@ pub fn new<'d>(
             esp_wifi_result!(esp_wifi_set_country(&country))?;
         }
 
-        controller.set_power_saving(PowerSaveMode::default())?;
+        #[cfg(initial_power_save_mode_none)]
+        const INITIAL_POWER_SAVE_MODE: PowerSaveMode = PowerSaveMode::None;
+        #[cfg(initial_power_save_mode_min)]
+        const INITIAL_POWER_SAVE_MODE: PowerSaveMode = PowerSaveMode::Minimum;
+        #[cfg(initial_power_save_mode_max)]
+        const INITIAL_POWER_SAVE_MODE: PowerSaveMode = PowerSaveMode::Maximum;
+
+        controller.set_power_saving(INITIAL_POWER_SAVE_MODE)?;
     }
 
     Ok((


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
(I thought there is an issue about this but wasn't able to find it)

Until now we always did a full-calibration - now we offer some options.

Full calibration on ESP32-C6

![full_cal](https://github.com/user-attachments/assets/d7385328-32ed-4114-89ad-1d895b5b6195)


Initial partial calibration and then no-calibration after a deep-sleep

![partial-cal-no-cal](https://github.com/user-attachments/assets/f3253c63-f23e-4320-a200-88bad34061ec)

Additionally brings back a config for the initial power-save mode

There are more potential refactorings here, but I didn't want to mix functional and non-functional changes in this PR

#### Testing
Manual testing
