### PR TITLE
Fix docs for real

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -43,6 +43,10 @@ jobs:
           ldproxy: false
           version: 1.85.0.0
 
+      # xtensa-toolchain installs rustup and a basic toolchain, but doesn't install rust-src
+      - name: rust-src
+        run: rustup component add rust-src --toolchain nightly
+
       # TODO: we could build this once and download onto each runner
       # Build the `xtask` package using the latest commit, and copy the
       # resulting binary to the `~/.cargo/bin/` directory. We do this to
@@ -87,7 +91,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          components: rust-src
       - name: Prepare
         run: mkdir docs && mkdir docs/esp-hal && mkdir docs/esp-wifi && mkdir docs/esp-lp-hal
       - name: Download all docs


### PR DESCRIPTION
This PR removes the previous "fix", and actually installs `rust-src` on the right toolchain. I hope this is the last place we'll be affected by the change in behavior for `rust-src` component installs :crossed_fingers:. Successful deployment here: https://github.com/esp-rs/esp-hal/actions/runs/14467240855