### PR TITLE
Add all SPI signals to Info struct

### DIFF
--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2730,27 +2730,35 @@ pub struct Info {
     pub sio3_input: Option<InputSignal>,
 
     /// SIO4 output signal for OPI mode.
+    #[cfg(any(esp32s2, esp32s3))]
     pub sio4_output: Option<OutputSignal>,
 
     /// SIO4 input signal for OPI mode.
+    #[cfg(any(esp32s2, esp32s3))]
     pub sio4_input: Option<InputSignal>,
 
     /// SIO5 output signal for OPI mode.
+    #[cfg(any(esp32s2, esp32s3))]
     pub sio5_output: Option<OutputSignal>,
 
     /// SIO5 input signal for OPI mode.
+    #[cfg(any(esp32s2, esp32s3))]
     pub sio5_input: Option<InputSignal>,
 
     /// SIO6 output signal for OPI mode.
+    #[cfg(any(esp32s2, esp32s3))]
     pub sio6_output: Option<OutputSignal>,
 
     /// SIO6 input signal for OPI mode.
+    #[cfg(any(esp32s2, esp32s3))]
     pub sio6_input: Option<InputSignal>,
 
     /// SIO7 output signal for OPI mode.
+    #[cfg(any(esp32s2, esp32s3))]
     pub sio7_output: Option<OutputSignal>,
 
     /// SIO7 input signal for OPI mode.
+    #[cfg(any(esp32s2, esp32s3))]
     pub sio7_input: Option<InputSignal>,
 }
 
@@ -3718,13 +3726,21 @@ macro_rules! spi_instance {
                         sio2_input: $crate::if_set!($(Some(InputSignal::$sio2))?, None),
                         sio3_output: $crate::if_set!($(Some(OutputSignal::$sio3))?, None),
                         sio3_input: $crate::if_set!($(Some(InputSignal::$sio3))?, None),
+                        #[cfg(any(esp32s2, esp32s3))]
                         sio4_output: $crate::if_set!($($(Some(OutputSignal::$sio4))?)?, None),
+                        #[cfg(any(esp32s2, esp32s3))]
                         sio4_input: $crate::if_set!($($(Some(InputSignal::$sio4))?)?, None),
+                        #[cfg(any(esp32s2, esp32s3))]
                         sio5_output: $crate::if_set!($($(Some(OutputSignal::$sio5))?)?, None),
+                        #[cfg(any(esp32s2, esp32s3))]
                         sio5_input: $crate::if_set!($($(Some(InputSignal::$sio5))?)?, None),
+                        #[cfg(any(esp32s2, esp32s3))]
                         sio6_output: $crate::if_set!($($(Some(OutputSignal::$sio6))?)?, None),
+                        #[cfg(any(esp32s2, esp32s3))]
                         sio6_input: $crate::if_set!($($(Some(InputSignal::$sio6))?)?, None),
+                        #[cfg(any(esp32s2, esp32s3))]
                         sio7_output: $crate::if_set!($($(Some(OutputSignal::$sio7))?)?, None),
+                        #[cfg(any(esp32s2, esp32s3))]
                         sio7_input: $crate::if_set!($($(Some(InputSignal::$sio7))?)?, None),
                     };
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2730,35 +2730,35 @@ pub struct Info {
     pub sio3_input: Option<InputSignal>,
 
     /// SIO4 output signal for OPI mode.
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(spi_octal)]
     pub sio4_output: Option<OutputSignal>,
 
     /// SIO4 input signal for OPI mode.
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(spi_octal)]
     pub sio4_input: Option<InputSignal>,
 
     /// SIO5 output signal for OPI mode.
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(spi_octal)]
     pub sio5_output: Option<OutputSignal>,
 
     /// SIO5 input signal for OPI mode.
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(spi_octal)]
     pub sio5_input: Option<InputSignal>,
 
     /// SIO6 output signal for OPI mode.
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(spi_octal)]
     pub sio6_output: Option<OutputSignal>,
 
     /// SIO6 input signal for OPI mode.
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(spi_octal)]
     pub sio6_input: Option<InputSignal>,
 
     /// SIO7 output signal for OPI mode.
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(spi_octal)]
     pub sio7_output: Option<OutputSignal>,
 
     /// SIO7 input signal for OPI mode.
-    #[cfg(any(esp32s2, esp32s3))]
+    #[cfg(spi_octal)]
     pub sio7_input: Option<InputSignal>,
 }
 
@@ -3726,21 +3726,21 @@ macro_rules! spi_instance {
                         sio2_input: $crate::if_set!($(Some(InputSignal::$sio2))?, None),
                         sio3_output: $crate::if_set!($(Some(OutputSignal::$sio3))?, None),
                         sio3_input: $crate::if_set!($(Some(InputSignal::$sio3))?, None),
-                        #[cfg(any(esp32s2, esp32s3))]
+                        #[cfg(spi_octal)]
                         sio4_output: $crate::if_set!($($(Some(OutputSignal::$sio4))?)?, None),
-                        #[cfg(any(esp32s2, esp32s3))]
+                        #[cfg(spi_octal)]
                         sio4_input: $crate::if_set!($($(Some(InputSignal::$sio4))?)?, None),
-                        #[cfg(any(esp32s2, esp32s3))]
+                        #[cfg(spi_octal)]
                         sio5_output: $crate::if_set!($($(Some(OutputSignal::$sio5))?)?, None),
-                        #[cfg(any(esp32s2, esp32s3))]
+                        #[cfg(spi_octal)]
                         sio5_input: $crate::if_set!($($(Some(InputSignal::$sio5))?)?, None),
-                        #[cfg(any(esp32s2, esp32s3))]
+                        #[cfg(spi_octal)]
                         sio6_output: $crate::if_set!($($(Some(OutputSignal::$sio6))?)?, None),
-                        #[cfg(any(esp32s2, esp32s3))]
+                        #[cfg(spi_octal)]
                         sio6_input: $crate::if_set!($($(Some(InputSignal::$sio6))?)?, None),
-                        #[cfg(any(esp32s2, esp32s3))]
+                        #[cfg(spi_octal)]
                         sio7_output: $crate::if_set!($($(Some(OutputSignal::$sio7))?)?, None),
-                        #[cfg(any(esp32s2, esp32s3))]
+                        #[cfg(spi_octal)]
                         sio7_input: $crate::if_set!($($(Some(InputSignal::$sio7))?)?, None),
                     };
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -680,7 +680,7 @@ impl<'d> Spi<'d, Blocking> {
 
         let mosi_pin = PinGuard::new_unconnected(spi.info().mosi);
         let sclk_pin = PinGuard::new_unconnected(spi.info().sclk);
-        let cs_pin = PinGuard::new_unconnected(spi.info().cs);
+        let cs_pin = PinGuard::new_unconnected(spi.info().cs[0]);
         let sio1_pin = PinGuard::new_unconnected(spi.info().sio1_output);
         let sio2_pin = spi.info().sio2_output.map(PinGuard::new_unconnected);
         let sio3_pin = spi.info().sio3_output.map(PinGuard::new_unconnected);
@@ -1021,7 +1021,7 @@ where
     pub fn with_cs(mut self, cs: impl PeripheralOutput<'d>) -> Self {
         let cs = cs.into();
         cs.set_to_push_pull_output();
-        self.pins.cs_pin = cs.connect_with_guard(self.driver().info.cs);
+        self.pins.cs_pin = cs.connect_with_guard(self.driver().info.cs[0]);
 
         self
     }
@@ -2708,8 +2708,8 @@ pub struct Info {
     /// MISO signal.
     pub miso: InputSignal,
 
-    /// Chip select signal.
-    pub cs: OutputSignal,
+    /// Chip select signals.
+    pub cs: &'static [OutputSignal],
 
     /// SIO0 (MOSI) input signal for half-duplex mode.
     pub sio0_input: InputSignal,
@@ -2728,6 +2728,30 @@ pub struct Info {
 
     /// SIO3 input signal for QSPI mode.
     pub sio3_input: Option<InputSignal>,
+
+    /// SIO4 output signal for OPI mode.
+    pub sio4_output: Option<OutputSignal>,
+
+    /// SIO4 input signal for OPI mode.
+    pub sio4_input: Option<InputSignal>,
+
+    /// SIO5 output signal for OPI mode.
+    pub sio5_output: Option<OutputSignal>,
+
+    /// SIO5 input signal for OPI mode.
+    pub sio5_input: Option<InputSignal>,
+
+    /// SIO6 output signal for OPI mode.
+    pub sio6_output: Option<OutputSignal>,
+
+    /// SIO6 input signal for OPI mode.
+    pub sio6_input: Option<InputSignal>,
+
+    /// SIO7 output signal for OPI mode.
+    pub sio7_output: Option<OutputSignal>,
+
+    /// SIO7 input signal for OPI mode.
+    pub sio7_input: Option<InputSignal>,
 }
 
 struct DmaDriver {
@@ -3675,7 +3699,7 @@ unsafe impl Sync for Info {}
 // hardware fully. The master module should extend it with the master specific
 // details.
 macro_rules! spi_instance {
-    ($num:literal, $sclk:ident, $mosi:ident, $miso:ident, $cs:ident $(, $sio2:ident, $sio3:ident)?) => {
+    ($num:literal, $sclk:ident, $mosi:ident, $miso:ident, [$($cs:ident),+] $(, $sio2:ident, $sio3:ident $(, $sio4:ident, $sio5:ident, $sio6:ident, $sio7:ident)?)?) => {
         paste::paste! {
             impl PeripheralInstance for crate::peripherals::[<SPI $num>]<'_> {
                 #[inline(always)]
@@ -3687,13 +3711,21 @@ macro_rules! spi_instance {
                         sclk: OutputSignal::$sclk,
                         mosi: OutputSignal::$mosi,
                         miso: InputSignal::$miso,
-                        cs: OutputSignal::$cs,
+                        cs: &[$(OutputSignal::$cs),+],
                         sio0_input: InputSignal::$mosi,
                         sio1_output: OutputSignal::$miso,
                         sio2_output: $crate::if_set!($(Some(OutputSignal::$sio2))?, None),
                         sio2_input: $crate::if_set!($(Some(InputSignal::$sio2))?, None),
                         sio3_output: $crate::if_set!($(Some(OutputSignal::$sio3))?, None),
                         sio3_input: $crate::if_set!($(Some(InputSignal::$sio3))?, None),
+                        sio4_output: $crate::if_set!($($(Some(OutputSignal::$sio4))?)?, None),
+                        sio4_input: $crate::if_set!($($(Some(InputSignal::$sio4))?)?, None),
+                        sio5_output: $crate::if_set!($($(Some(OutputSignal::$sio5))?)?, None),
+                        sio5_input: $crate::if_set!($($(Some(InputSignal::$sio5))?)?, None),
+                        sio6_output: $crate::if_set!($($(Some(OutputSignal::$sio6))?)?, None),
+                        sio6_input: $crate::if_set!($($(Some(InputSignal::$sio6))?)?, None),
+                        sio7_output: $crate::if_set!($($(Some(OutputSignal::$sio7))?)?, None),
+                        sio7_input: $crate::if_set!($($(Some(InputSignal::$sio7))?)?, None),
                     };
 
                     &INFO
@@ -3712,22 +3744,22 @@ macro_rules! spi_instance {
 #[cfg(spi2)]
 cfg_if::cfg_if! {
     if #[cfg(esp32)] {
-        spi_instance!(2, HSPICLK, HSPID, HSPIQ, HSPICS0, HSPIWP, HSPIHD);
+        spi_instance!(2, HSPICLK, HSPID, HSPIQ, [HSPICS0, HSPICS1, HSPICS2], HSPIWP, HSPIHD);
     } else if #[cfg(any(esp32s2, esp32s3))] {
-        spi_instance!(2, FSPICLK, FSPID, FSPIQ, FSPICS0, FSPIWP, FSPIHD);
+        spi_instance!(2, FSPICLK, FSPID, FSPIQ, [FSPICS0, FSPICS1, FSPICS2, FSPICS3, FSPICS4, FSPICS5], FSPIWP, FSPIHD, FSPIIO4, FSPIIO5, FSPIIO6, FSPIIO7);
     } else {
-        spi_instance!(2, FSPICLK_MUX, FSPID, FSPIQ, FSPICS0, FSPIWP, FSPIHD);
+        spi_instance!(2, FSPICLK_MUX, FSPID, FSPIQ, [FSPICS0, FSPICS1, FSPICS2, FSPICS3, FSPICS4, FSPICS5], FSPIWP, FSPIHD);
     }
 }
 
 #[cfg(spi3)]
 cfg_if::cfg_if! {
     if #[cfg(esp32)] {
-        spi_instance!(3, VSPICLK, VSPID, VSPIQ, VSPICS0, VSPIWP, VSPIHD);
+        spi_instance!(3, VSPICLK, VSPID, VSPIQ, [VSPICS0, VSPICS1, VSPICS2], VSPIWP, VSPIHD);
     } else if #[cfg(esp32s3)] {
-        spi_instance!(3, SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0, SPI3_WP, SPI3_HD);
+        spi_instance!(3, SPI3_CLK, SPI3_D, SPI3_Q, [SPI3_CS0, SPI3_CS1, SPI3_CS2], SPI3_WP, SPI3_HD);
     } else {
-        spi_instance!(3, SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0);
+        spi_instance!(3, SPI3_CLK, SPI3_D, SPI3_Q, [SPI3_CS0, SPI3_CS1, SPI3_CS2]);
     }
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Expose all the SPI signals. Particularly the OPI and CS signals.

This is as much as I can do until the GPIO matrix PRs are done.

#### Testing
CI
