### PR TITLE
parl_io: make TxPins, RxPins & ConfigurePins public

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved DMA channel types from `esp_hal::dma::DmaChannelN`/`esp_hal::dma::XYDmaChannel` to `esp_hal::peripherals::DMA_XY` (#3372)
 - `ParlIoFullDuplex`, `ParlIoTxOnly` and `ParlIoRxOnly` have been merged into `ParlIo` (#3366)
 - All `Camera` pins are now configured using `with_*()` methods (#3237)
+- Made the `ParlIo` traits for `TxPins`, `RxPins`, `ConfigurePins` public (#3398)
 
 ### Fixed
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1528,8 +1528,9 @@ where
     _guard: GenericPeripheralGuard<{ system::Peripheral::ParlIo as u8 }>,
 }
 
-// These three traits need to be public to allow the user to create functions that
-// can take either 8 or 16 bit pins and call parl_io.tx.with_config() or parl_io.rx.with_config().
+// These three traits need to be public to allow the user to create functions
+// that can take either 8 or 16 bit pins and call parl_io.tx.with_config() or
+// parl_io.rx.with_config().
 #[doc(hidden)]
 pub trait TxPins {}
 #[doc(hidden)]

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1528,6 +1528,17 @@ where
     _guard: GenericPeripheralGuard<{ system::Peripheral::ParlIo as u8 }>,
 }
 
+// These three traits need to be public to allow the user to create functions that
+// can take either 8 or 16 bit pins and call parl_io.tx.with_config() or parl_io.rx.with_config().
+#[doc(hidden)]
+pub trait TxPins {}
+#[doc(hidden)]
+pub trait RxPins {}
+#[doc(hidden)]
+pub trait ConfigurePins {
+    fn configure(&mut self);
+}
+
 #[doc(hidden)]
 pub mod asynch {
     use core::task::Poll;
@@ -1610,19 +1621,11 @@ mod private {
 
     pub trait ContainsValidSignalPin {}
 
-    pub trait TxPins {}
-
-    pub trait RxPins {}
-
     pub trait TxClkPin {
         fn configure(&mut self);
     }
 
     pub trait RxClkPin {
-        fn configure(&mut self);
-    }
-
-    pub trait ConfigurePins {
         fn configure(&mut self);
     }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
In order for a user to treat the various TxXXXBits structs generically the following traits need to be public:
- TxPins
- RxPins
- ConfigurePins

For other chips that have some peripheral that supports parallel IO the traits are already public.
- esp32s3 lcd_cam I8080 has TxPins
- esp32 i2s_parallel has TxPins

Example use case:
```rust
pub struct Hub75<'d, DM: esp_hal::DriverMode> {
    parl_io: ParlIoTx<'d, DM>,
    tx_descriptors: &'static mut [DmaDescriptor],
}

pub trait Hub75Pins<'d, T> {
    fn convert_pins(self) -> (T, AnyPin<'d>);
}

impl<'d> Hub75<'d, esp_hal::Blocking> {
    pub fn new_async<T: TxPins + ConfigurePins + 'd>(
        parl_io: PARL_IO<'d>,
        hub75_pins: impl Hub75Pins<'d, T>,
        channel: impl DmaChannelFor<PARL_IO<'d>>,
        tx_descriptors: &'static mut [DmaDescriptor],
        frequency: Rate,
    ) -> Result<Self, Hub75Error> {
        // implementation elided for brevity
    }
}
```

#### Testing
Local Hub75 display testing
