### PR TITLE
Fix esp32 coex

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM` configuration option has been renamed to `ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM`. (#3402)
 - Made the `ParlIo` traits for `TxPins`, `RxPins`, `ConfigurePins` public (#3398)
 - Renamed `Flex::enable_input` to `set_input_enable` (#3387)
+- Make `esp_hal::interrupt::current_runlevel` public under the unstable feature (#3403)
 
 ### Fixed
 

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -704,7 +704,7 @@ mod classic {
     }
 
     /// Get the current run level (the level below which interrupts are masked).
-    pub(crate) fn current_runlevel() -> Priority {
+    pub fn current_runlevel() -> Priority {
         let intr = INTERRUPT_CORE0::regs();
         let prev_interrupt_priority = intr.cpu_int_thresh().read().bits().saturating_sub(1) as u8;
 
@@ -872,7 +872,7 @@ mod plic {
     }
 
     /// Get the current run level (the level below which interrupts are masked).
-    pub(crate) fn current_runlevel() -> Priority {
+    pub fn current_runlevel() -> Priority {
         let prev_interrupt_priority = PLIC_MX::regs()
             .mxint_thresh()
             .read()

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -333,7 +333,7 @@ unsafe fn core1_interrupt_peripheral() -> *const crate::pac::interrupt_core1::Re
 }
 
 /// Get the current run level (the level below which interrupts are masked).
-pub(crate) fn current_runlevel() -> Priority {
+pub fn current_runlevel() -> Priority {
     let ps: u32;
     unsafe { core::arch::asm!("rsr.ps {0}", out(reg) ps) };
 

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow `Configuration::None`, set country early, changed default power-save-mode to None (#3364)
 
 - Enterprise WPA fixed for ESP32-S2 (#3406)
+- COEX on ESP32 is now working (#3403)
 
 ### Removed
 

--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -258,7 +258,7 @@ unsafe extern "C" fn task_delete(task: *const ()) {
 
 #[ram]
 unsafe extern "C" fn is_in_isr() -> i32 {
-    crate::interrupts_disabled() as i32
+    crate::is_interrupts_disabled() as i32
 }
 
 #[ram]

--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -302,7 +302,6 @@ unsafe extern "C" fn btdm_hus_2_lpcycles(us: u32) -> u32 {
     // Converts a duration in half us into a number of low power clock cycles.
     let cycles: u64 = (us as u64) << (g_btdm_lpcycle_us_frac as u64 / g_btdm_lpcycle_us as u64);
     trace!("btdm_hus_2_lpcycles {} {}", us, cycles);
-    // probably not right ... NX returns half of the values we calculate here
 
     cycles as u32
 }

--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -258,7 +258,7 @@ unsafe extern "C" fn task_delete(task: *const ()) {
 
 #[ram]
 unsafe extern "C" fn is_in_isr() -> i32 {
-    0
+    crate::interrupts_disabled() as i32
 }
 
 #[ram]

--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -485,7 +485,19 @@ pub fn send_hci(data: &[u8]) {
                 }
 
                 PACKET_SENT.store(false, Ordering::Relaxed);
+
+                #[cfg(all(esp32, coex))]
+                ble_os_adapter_chip_specific::async_wakeup_request(
+                    ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
+                );
+
                 API_vhci_host_send_packet(packet.as_ptr(), packet.len() as u16);
+
+                #[cfg(all(esp32, coex))]
+                ble_os_adapter_chip_specific::async_wakeup_request_end(
+                    ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
+                );
+
                 trace!("sent vhci host packet");
 
                 super::dump_packet_info(packet);

--- a/esp-wifi/src/ble/os_adapter_esp32.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32.rs
@@ -558,6 +558,10 @@ pub(crate) unsafe extern "C" fn set_isr(n: i32, f: unsafe extern "C" fn(), arg: 
                 Interrupt::RWBT,
                 interrupt::Priority::Priority1
             ));
+            unwrap!(interrupt::enable(
+                Interrupt::RWBLE,
+                interrupt::Priority::Priority1
+            ));
         }
         7 => unsafe {
             ISR_INTERRUPT_7 = (f as *mut c_types::c_void, arg as *mut c_types::c_void);

--- a/esp-wifi/src/ble/os_adapter_esp32.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32.rs
@@ -406,10 +406,10 @@ pub(crate) unsafe extern "C" fn coex_bt_wakeup_request_end() {
 
     // This should really be
     // ```rust,norun
-    //#[cfg(coex)]
+    // #[cfg(coex)]
     // async_wakeup_request_end(BTDM_ASYNC_WAKEUP_REQ_COEX);
     // ```
-    // 
+    //
     // But doing the right thing here keeps BT from working.
     // In a similar scenario this function isn't called in ESP-IDF.
 }

--- a/esp-wifi/src/ble/os_adapter_esp32.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32.rs
@@ -294,12 +294,12 @@ pub(crate) fn create_ble_config() -> esp_bt_controller_config_t {
     // ideally _some_ of these values should be configurable
     esp_bt_controller_config_t {
         controller_task_stack_size: 4096,
-        controller_task_prio: 23,
+        controller_task_prio: 110,
         hci_uart_no: 1,
         hci_uart_baudrate: 921600,
         scan_duplicate_mode: 0,
         scan_duplicate_type: 0,
-        normal_adv_size: 100,
+        normal_adv_size: 200,
         mesh_adv_size: 0,
         send_adv_reserved_size: 1000,
         controller_debug_flag: 0,
@@ -309,7 +309,7 @@ pub(crate) fn create_ble_config() -> esp_bt_controller_config_t {
         bt_sco_datapath: 0,
         auto_latency: false,
         bt_legacy_auth_vs_evt: false,
-        bt_max_sync_conn: 0,
+        bt_max_sync_conn: 1,
         ble_sca: 1,
         pcm_role: 0,
         pcm_polar: 0,

--- a/esp-wifi/src/ble/os_adapter_esp32.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32.rs
@@ -290,6 +290,8 @@ static BTDM_DRAM_AVAILABLE_REGION: [btdm_dram_available_region_t; 7] = [
 ];
 
 pub(crate) fn create_ble_config() -> esp_bt_controller_config_t {
+    // keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
+    // ideally _some_ of these values should be configurable
     esp_bt_controller_config_t {
         controller_task_stack_size: 4096,
         controller_task_prio: 23,

--- a/esp-wifi/src/ble/os_adapter_esp32.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32.rs
@@ -388,7 +388,7 @@ pub(crate) unsafe extern "C" fn coex_bt_wakeup_request() -> bool {
 }
 
 pub(crate) unsafe extern "C" fn coex_bt_wakeup_request_end() {
-    warn!("coex_bt_wakeup_request_end");
+    trace!("coex_bt_wakeup_request_end");
 
     #[cfg(coex)]
     async_wakeup_request_end(BTDM_ASYNC_WAKEUP_REQ_COEX);
@@ -427,7 +427,7 @@ pub(crate) unsafe extern "C" fn coex_bt_release(event: u32) -> i32 {
 pub(crate) unsafe extern "C" fn coex_register_bt_cb_wrapper(
     callback: unsafe extern "C" fn(),
 ) -> i32 {
-    warn!("coex_register_bt_cb {:?}", callback);
+    trace!("coex_register_bt_cb {:?}", callback);
     unsafe extern "C" {
         #[cfg(coex)]
         fn coex_register_bt_cb(callback: unsafe extern "C" fn()) -> i32;
@@ -471,7 +471,7 @@ pub(crate) unsafe extern "C" fn coex_bb_reset_unlock(event: u32) {
 pub(crate) unsafe extern "C" fn coex_schm_register_btdm_callback_wrapper(
     callback: unsafe extern "C" fn(),
 ) -> i32 {
-    warn!("coex_schm_register_btdm_callback {:?}", callback);
+    trace!("coex_schm_register_btdm_callback {:?}", callback);
     unsafe extern "C" {
         #[cfg(coex)]
         fn coex_schm_register_callback(kind: u32, callback: unsafe extern "C" fn()) -> i32;
@@ -516,7 +516,7 @@ pub(crate) unsafe extern "C" fn coex_schm_curr_phase_get() -> *const () {
 
 #[allow(unused_variables)]
 pub(crate) unsafe extern "C" fn coex_wifi_channel_get(primary: *mut u8, secondary: *mut u8) -> i32 {
-    warn!("coex_wifi_channel_get");
+    trace!("coex_wifi_channel_get");
     unsafe extern "C" {
         #[cfg(coex)]
         fn coex_wifi_channel_get(primary: *mut u8, secondary: *mut u8) -> i32;
@@ -533,7 +533,7 @@ pub(crate) unsafe extern "C" fn coex_wifi_channel_get(primary: *mut u8, secondar
 pub(crate) unsafe extern "C" fn coex_register_wifi_channel_change_callback(
     callback: unsafe extern "C" fn(),
 ) -> i32 {
-    warn!("coex_register_wifi_channel_change_callback");
+    trace!("coex_register_wifi_channel_change_callback");
     unsafe extern "C" {
         #[cfg(coex)]
         fn coex_register_wifi_channel_change_callback(callback: unsafe extern "C" fn()) -> i32;

--- a/esp-wifi/src/ble/os_adapter_esp32c2.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32c2.rs
@@ -17,6 +17,8 @@ pub(crate) static mut ISR_INTERRUPT_7: (
     *mut crate::binary::c_types::c_void,
 ) = (core::ptr::null_mut(), core::ptr::null_mut());
 
+// keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
+// ideally _some_ of these values should be configurable
 pub(crate) static BLE_CONFIG: esp_bt_controller_config_t = esp_bt_controller_config_t {
     config_version: 0x20231124,
     ble_ll_resolv_list_size: 4,

--- a/esp-wifi/src/ble/os_adapter_esp32c3.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32c3.rs
@@ -251,6 +251,8 @@ unsafe extern "C" {
 }
 
 pub(crate) fn create_ble_config() -> esp_bt_controller_config_t {
+    // keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
+    // ideally _some_ of these values should be configurable
     esp_bt_controller_config_t {
         magic: 0x5a5aa5a5,
         version: 0x02404010,

--- a/esp-wifi/src/ble/os_adapter_esp32c6.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32c6.rs
@@ -17,6 +17,8 @@ pub(crate) static mut ISR_INTERRUPT_7: (
     *mut crate::binary::c_types::c_void,
 ) = (core::ptr::null_mut(), core::ptr::null_mut());
 
+// keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
+// ideally _some_ of these values should be configurable
 pub(crate) static BLE_CONFIG: esp_bt_controller_config_t = esp_bt_controller_config_t {
     config_version: 0x20240422,
     ble_ll_resolv_list_size: 4,

--- a/esp-wifi/src/ble/os_adapter_esp32h2.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32h2.rs
@@ -17,6 +17,8 @@ pub(crate) static mut ISR_INTERRUPT_3: (
     *mut crate::binary::c_types::c_void,
 ) = (core::ptr::null_mut(), core::ptr::null_mut());
 
+// keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
+// ideally _some_ of these values should be configurable
 pub(crate) static BLE_CONFIG: esp_bt_controller_config_t = esp_bt_controller_config_t {
     config_version: 0x20240422,
     ble_ll_resolv_list_size: 4,

--- a/esp-wifi/src/ble/os_adapter_esp32s3.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32s3.rs
@@ -251,6 +251,8 @@ unsafe extern "C" {
 }
 
 pub(crate) fn create_ble_config() -> esp_bt_controller_config_t {
+    // keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
+    // ideally _some_ of these values should be configurable
     esp_bt_controller_config_t {
         magic: 0x5a5aa5a5,
         version: 0x02404010,

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -205,8 +205,8 @@ pub(crate) fn sem_delete(semphr: *mut c_void) {
 }
 
 pub(crate) fn sem_take(semphr: *mut c_void, tick: u32) -> i32 {
-    // This shouldn't normally happen if we always report the correct state from `is_in_isr`.
-    // This is a last resort if we do it wrong.
+    // This shouldn't normally happen if we always report the correct state from
+    // `is_in_isr`. This is a last resort if we do it wrong.
     let tick = if tick == OSI_FUNCS_TIME_BLOCKING && crate::interrupts_disabled() {
         warn!("blocking sem_take probably called from an ISR - return early");
         1

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -206,7 +206,8 @@ pub(crate) fn sem_delete(semphr: *mut c_void) {
 
 pub(crate) fn sem_take(semphr: *mut c_void, tick: u32) -> i32 {
     // This shouldn't normally happen if we always report the correct state from
-    // `is_in_isr`. This is a last resort if we do it wrong.
+    // `is_in_isr`. This is a last resort if the driver calls this anyways.
+    // (I haven't observed this to happen)
     let tick = if tick == OSI_FUNCS_TIME_BLOCKING && crate::interrupts_disabled() {
         warn!("blocking sem_take probably called from an ISR - return early");
         1

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -208,7 +208,7 @@ pub(crate) fn sem_take(semphr: *mut c_void, tick: u32) -> i32 {
     // This shouldn't normally happen if we always report the correct state from
     // `is_in_isr`. This is a last resort if the driver calls this anyways.
     // (I haven't observed this to happen)
-    let tick = if tick == OSI_FUNCS_TIME_BLOCKING && crate::interrupts_disabled() {
+    let tick = if tick == OSI_FUNCS_TIME_BLOCKING && crate::is_interrupts_disabled() {
         warn!("blocking sem_take probably called from an ISR - return early");
         1
     } else {

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -380,7 +380,7 @@ pub fn init<'d>(
     _rng: impl EspWifiRngSource + 'd,
     _radio_clocks: RADIO_CLK<'d>,
 ) -> Result<EspWifiController<'d>, InitializationError> {
-    if crate::interrupts_disabled() {
+    if crate::is_interrupts_disabled() {
         return Err(InitializationError::InterruptsDisabled);
     }
 
@@ -474,7 +474,7 @@ pub unsafe fn deinit_unchecked() -> Result<(), InitializationError> {
 }
 
 /// Returns true if at least some interrupt levels are disabled.
-fn interrupts_disabled() -> bool {
+fn is_interrupts_disabled() -> bool {
     #[cfg(target_arch = "xtensa")]
     return hal::xtensa_lx::interrupt::get_level() != 0
         || hal::xtensa_lx::interrupt::get_mask() == 0;

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -349,6 +349,8 @@ impl private::Sealed for Trng<'_> {}
 
 /// Initialize for using WiFi and or BLE.
 ///
+/// Make sure to **not** call this function while interrupts are disabled.
+///
 /// # The `timer` argument
 ///
 /// The `timer` argument is a timer source that is used by the WiFi driver to
@@ -378,6 +380,10 @@ pub fn init<'d>(
     _rng: impl EspWifiRngSource + 'd,
     _radio_clocks: RADIO_CLK<'d>,
 ) -> Result<EspWifiController<'d>, InitializationError> {
+    if crate::interrupts_disabled() {
+        return Err(InitializationError::InterruptsDisabled);
+    }
+
     // A minimum clock of 80MHz is required to operate WiFi module.
     const MIN_CLOCK: Rate = Rate::from_mhz(80);
     let clocks = Clocks::get();
@@ -467,6 +473,16 @@ pub unsafe fn deinit_unchecked() -> Result<(), InitializationError> {
     Ok(())
 }
 
+/// Returns true if at least some interrupt levels are disabled.
+fn interrupts_disabled() -> bool {
+    #[cfg(target_arch = "xtensa")]
+    return hal::xtensa_lx::interrupt::get_level() != 0;
+
+    #[cfg(target_arch = "riscv32")]
+    return !hal::riscv::register::mstatus::read().mie()
+        || hal::interrupt::current_runlevel() >= hal::interrupt::Priority::Priority1;
+}
+
 pub(crate) mod private {
     pub trait Sealed {}
 }
@@ -474,11 +490,19 @@ pub(crate) mod private {
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// Error which can be returned during [`init`].
+#[non_exhaustive]
 pub enum InitializationError {
+    /// A general error occurred.
+    /// The internal error code is reported.
     General(i32),
+    /// An error from the WiFi driver.
     #[cfg(feature = "wifi")]
     WifiError(WifiError),
+    /// The current CPU clock frequency is too low.
     WrongClockConfig,
+    /// Tried to initialize while interrupts are disabled.
+    /// This is not supported.
+    InterruptsDisabled,
 }
 
 #[cfg(feature = "wifi")]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -476,7 +476,8 @@ pub unsafe fn deinit_unchecked() -> Result<(), InitializationError> {
 /// Returns true if at least some interrupt levels are disabled.
 fn interrupts_disabled() -> bool {
     #[cfg(target_arch = "xtensa")]
-    return hal::xtensa_lx::interrupt::get_level() != 0;
+    return hal::xtensa_lx::interrupt::get_level() != 0
+        || hal::xtensa_lx::interrupt::get_mask() == 0;
 
     #[cfg(target_arch = "riscv32")]
     return !hal::riscv::register::mstatus::read().mie()

--- a/esp-wifi/src/wifi/internal.rs
+++ b/esp-wifi/src/wifi/internal.rs
@@ -63,8 +63,7 @@ unsafe extern "C" fn semphr_give_from_isr_wrapper(
 
 #[cfg(coex)]
 unsafe extern "C" fn is_in_isr_wrapper() -> i32 {
-    // like original implementation
-    0
+    crate::interrupts_disabled() as i32
 }
 
 #[unsafe(no_mangle)]

--- a/esp-wifi/src/wifi/internal.rs
+++ b/esp-wifi/src/wifi/internal.rs
@@ -63,7 +63,7 @@ unsafe extern "C" fn semphr_give_from_isr_wrapper(
 
 #[cfg(coex)]
 unsafe extern "C" fn is_in_isr_wrapper() -> i32 {
-    crate::interrupts_disabled() as i32
+    crate::is_interrupts_disabled() as i32
 }
 
 #[unsafe(no_mangle)]

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -2608,10 +2608,16 @@ pub struct Interfaces<'d> {
 /// Create a WiFi controller and it's associated interfaces.
 ///
 /// Dropping the controller will deinitialize / stop WiFi.
+///
+/// Make sure to **not** call this function while interrupts are disabled.
 pub fn new<'d>(
     inited: &'d EspWifiController<'d>,
     _device: crate::hal::peripherals::WIFI<'d>,
 ) -> Result<(WifiController<'d>, Interfaces<'d>), WifiError> {
+    if crate::interrupts_disabled() {
+        return Err(WifiError::Unsupported);
+    }
+
     let mut controller = WifiController {
         _phantom: Default::default(),
     };

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -2614,7 +2614,7 @@ pub fn new<'d>(
     inited: &'d EspWifiController<'d>,
     _device: crate::hal::peripherals::WIFI<'d>,
 ) -> Result<(WifiController<'d>, Interfaces<'d>), WifiError> {
-    if crate::interrupts_disabled() {
+    if crate::is_interrupts_disabled() {
         return Err(WifiError::Unsupported);
     }
 

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -177,10 +177,9 @@ pub unsafe extern "C" fn is_from_isr() -> bool {
 ///   Spin lock data pointer
 ///
 /// *************************************************************************
-static mut FAKE_SPIN_LOCK: u8 = 1;
 pub unsafe extern "C" fn spin_lock_create() -> *mut crate::binary::c_types::c_void {
-    // original: return (void *)1;
-    let ptr = addr_of_mut!(FAKE_SPIN_LOCK);
+    let ptr = crate::compat::common::sem_create(1, 1);
+
     trace!("spin_lock_create {:?}", ptr);
     ptr as *mut crate::binary::c_types::c_void
 }
@@ -199,8 +198,9 @@ pub unsafe extern "C" fn spin_lock_create() -> *mut crate::binary::c_types::c_vo
 ///
 /// *************************************************************************
 pub unsafe extern "C" fn spin_lock_delete(lock: *mut crate::binary::c_types::c_void) {
-    // original: DEBUGASSERT((int)lock == 1);
     trace!("spin_lock_delete {:?}", lock);
+
+    crate::compat::common::sem_delete(lock);
 }
 
 /// **************************************************************************

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -214,6 +214,11 @@ name              = "esp_wifi_ble_controller"
 harness           = false
 required-features = ["esp-wifi", "esp-alloc"]
 
+[[test]]
+name              = "esp_wifi_init"
+harness           = false
+required-features = ["esp-wifi", "esp-alloc"]
+
 [dependencies]
 allocator-api2    = { version = "0.2.0", default-features = false, features = ["alloc"] }
 cfg-if             = "1.0.0"

--- a/hil-test/tests/esp_wifi_floats.rs
+++ b/hil-test/tests/esp_wifi_floats.rs
@@ -129,6 +129,19 @@ mod tests {
             .start_app_core(
                 unsafe { &mut *core::ptr::addr_of_mut!(APP_CORE_STACK) },
                 move || {
+                    // app core starts with interrupts disabled
+                    unsafe {
+                        esp_hal::xtensa_lx::interrupt::enable_mask(
+                            esp_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level1.mask()
+                                | esp_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2
+                                    .mask()
+                                | esp_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level3
+                                    .mask()
+                                | esp_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6
+                                    .mask(),
+                        );
+                    }
+
                     let timg0 = TimerGroup::new(peripherals.TIMG0);
                     let _init = esp_wifi::init(
                         timg0.timer1,

--- a/hil-test/tests/esp_wifi_init.rs
+++ b/hil-test/tests/esp_wifi_init.rs
@@ -1,0 +1,77 @@
+//! Test we get an error when attempting to initialize esp-wifi with interrupts
+//! disabled in common ways
+
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
+//% FEATURES: unstable esp-wifi esp-alloc esp-wifi/wifi
+
+#![no_std]
+#![no_main]
+
+use esp_hal::clock::CpuClock;
+use hil_test as _;
+
+#[cfg(test)]
+#[embedded_test::tests(default_timeout = 3)]
+mod tests {
+    use esp_hal::{peripherals::Peripherals, rng::Rng, timer::timg::TimerGroup};
+
+    use super::*;
+
+    #[init]
+    fn init() -> Peripherals {
+        esp_alloc::heap_allocator!(size: 72 * 1024);
+
+        let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+        esp_hal::init(config)
+    }
+
+    #[test]
+    fn test_init_fails_cs(peripherals: Peripherals) {
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        let init = critical_section::with(|_| {
+            esp_wifi::init(
+                timg0.timer0,
+                Rng::new(peripherals.RNG),
+                peripherals.RADIO_CLK,
+            )
+        });
+
+        assert!(matches!(
+            init,
+            Err(esp_wifi::InitializationError::InterruptsDisabled),
+        ));
+    }
+
+    #[test]
+    fn test_init_fails_interrupt_free(peripherals: Peripherals) {
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        let init = interrupt_free(|| {
+            esp_wifi::init(
+                timg0.timer0,
+                Rng::new(peripherals.RNG),
+                peripherals.RADIO_CLK,
+            )
+        });
+
+        assert!(matches!(
+            init,
+            Err(esp_wifi::InitializationError::InterruptsDisabled),
+        ));
+    }
+}
+
+#[cfg(target_arch = "riscv32")]
+fn interrupt_free<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    esp_hal::riscv::interrupt::free(f)
+}
+
+#[cfg(target_arch = "xtensa")]
+fn interrupt_free<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    esp_hal::xtensa_lx::interrupt::free(f)
+}

--- a/hil-test/tests/esp_wifi_init.rs
+++ b/hil-test/tests/esp_wifi_init.rs
@@ -2,23 +2,46 @@
 //! disabled in common ways
 
 //% CHIPS: esp32 esp32s2 esp32c2 esp32c3 esp32c6 esp32s3
-//% FEATURES: unstable esp-wifi esp-alloc esp-wifi/wifi
+//% FEATURES: unstable esp-wifi esp-alloc esp-wifi/wifi embassy
 
 #![no_std]
 #![no_main]
 
-use esp_hal::clock::CpuClock;
 #[cfg(target_arch = "riscv32")]
 use esp_hal::riscv::interrupt::free as interrupt_free;
 #[cfg(target_arch = "xtensa")]
 use esp_hal::xtensa_lx::interrupt::free as interrupt_free;
+use esp_hal::{
+    clock::CpuClock,
+    interrupt::{Priority, software::SoftwareInterruptControl},
+    peripherals::{Peripherals, RADIO_CLK, RNG, TIMG0},
+    rng::Rng,
+    timer::timg::TimerGroup,
+};
+use esp_hal_embassy::InterruptExecutor;
 use hil_test as _;
+use portable_atomic::AtomicUsize;
+use static_cell::StaticCell;
+
+static ASYNC_TEST_STATE: AtomicUsize = AtomicUsize::new(0);
+
+#[embassy_executor::task]
+async fn try_init(timer: TIMG0<'static>, rng: RNG<'static>, radio_clk: RADIO_CLK<'static>) {
+    let timg0 = TimerGroup::new(timer);
+
+    defmt::info!("before");
+    let init = esp_wifi::init(timg0.timer0, Rng::new(rng), radio_clk);
+    defmt::info!("after {}", init.is_ok());
+
+    match init {
+        Ok(_) => ASYNC_TEST_STATE.store(1, core::sync::atomic::Ordering::Relaxed),
+        Err(_) => ASYNC_TEST_STATE.store(2, core::sync::atomic::Ordering::Relaxed),
+    }
+}
 
 #[cfg(test)]
 #[embedded_test::tests(default_timeout = 3)]
 mod tests {
-    use esp_hal::{peripherals::Peripherals, rng::Rng, timer::timg::TimerGroup};
-
     use super::*;
 
     #[init]
@@ -61,5 +84,31 @@ mod tests {
             init,
             Err(esp_wifi::InitializationError::InterruptsDisabled),
         ));
+    }
+
+    #[test]
+    fn test_init_fails_in_interrupt_executor_task(peripherals: Peripherals) {
+        let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+
+        static EXECUTOR_CORE_0: StaticCell<InterruptExecutor<1>> = StaticCell::new();
+        let executor_core0 = InterruptExecutor::new(sw_ints.software_interrupt1);
+        let executor_core0 = EXECUTOR_CORE_0.init(executor_core0);
+
+        let spawner = executor_core0.start(Priority::Priority1);
+        spawner
+            .spawn(try_init(
+                peripherals.TIMG0,
+                peripherals.RNG,
+                peripherals.RADIO_CLK,
+            ))
+            .ok();
+
+        loop {
+            if ASYNC_TEST_STATE.load(core::sync::atomic::Ordering::Relaxed) != 0 {
+                break;
+            }
+        }
+
+        assert!(ASYNC_TEST_STATE.load(core::sync::atomic::Ordering::Relaxed) == 2);
     }
 }

--- a/hil-test/tests/esp_wifi_init.rs
+++ b/hil-test/tests/esp_wifi_init.rs
@@ -8,13 +8,11 @@
 #![no_main]
 
 use esp_hal::clock::CpuClock;
-use hil_test as _;
-
 #[cfg(target_arch = "riscv32")]
 use esp_hal::riscv::interrupt::free as interrupt_free;
-
 #[cfg(target_arch = "xtensa")]
 use esp_hal::xtensa_lx::interrupt::free as interrupt_free;
+use hil_test as _;
 
 #[cfg(test)]
 #[embedded_test::tests(default_timeout = 3)]

--- a/hil-test/tests/esp_wifi_init.rs
+++ b/hil-test/tests/esp_wifi_init.rs
@@ -1,7 +1,7 @@
 //! Test we get an error when attempting to initialize esp-wifi with interrupts
 //! disabled in common ways
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
+//% CHIPS: esp32 esp32s2 esp32c2 esp32c3 esp32c6 esp32s3
 //% FEATURES: unstable esp-wifi esp-alloc esp-wifi/wifi
 
 #![no_std]
@@ -9,6 +9,12 @@
 
 use esp_hal::clock::CpuClock;
 use hil_test as _;
+
+#[cfg(target_arch = "riscv32")]
+use esp_hal::riscv::interrupt::free as interrupt_free;
+
+#[cfg(target_arch = "xtensa")]
+use esp_hal::xtensa_lx::interrupt::free as interrupt_free;
 
 #[cfg(test)]
 #[embedded_test::tests(default_timeout = 3)]
@@ -58,20 +64,4 @@ mod tests {
             Err(esp_wifi::InitializationError::InterruptsDisabled),
         ));
     }
-}
-
-#[cfg(target_arch = "riscv32")]
-fn interrupt_free<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    esp_hal::riscv::interrupt::free(f)
-}
-
-#[cfg(target_arch = "xtensa")]
-fn interrupt_free<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    esp_hal::xtensa_lx::interrupt::free(f)
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This makes COEX work on ESP32. While `coex_bt_wakeup_request` and `coex_bt_wakeup_request_end`  doesn't look right it won't work with a "correct" implementation, and I don't think it was better before (and it also wasn't working)

#### Testing
Run the `wifi_coex` example
