### PR TITLE
Fix I2C HIL tests

### DIFF
--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -188,15 +188,8 @@ mod tests {
     // This is still an issue on ESP32-S2
     #[cfg(not(esp32s2))]
     #[test]
-    async fn async_test_timeout_when_scl_kept_low(_ctx: Context) {
-        let mut i2c = I2c::new(
-            unsafe { esp_hal::peripherals::I2C0::steal() },
-            Config::default(),
-        )
-        .unwrap()
-        .with_sda(unsafe { esp_hal::peripherals::GPIO4::steal() })
-        .with_scl(unsafe { esp_hal::peripherals::GPIO5::steal() })
-        .into_async();
+    async fn async_test_timeout_when_scl_kept_low(ctx: Context) {
+        let mut i2c = ctx.i2c.into_async();
 
         esp_hal::gpio::InputSignal::I2CEXT0_SCL.connect_to(&esp_hal::gpio::Level::Low);
 


### PR DESCRIPTION
https://docs.espressif.com/projects/esp-idf/en/v5.2.3/esp32c2/api-guides/jtag-debugging/configure-other-jtag.html

Also, the hardcoded `GPIO4` and `GPIO5` are only correct for `i2c` communication for a minority of chips, so they were not working correctly. 

Now the esp32c2 will not fail