### PR TITLE
GPIO interrupts, once more

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `esp_hal::interrupt::current_runlevel` public under the unstable feature (#3403)
 - Update `defmt` to 1.0 (#3416)
 - `spi::master::Spi::transfer` no longer returns the received data as a slice (#?)
+- esp-hal no longer clears the GPIO interrupt status bits by default. (#3408)
 
 ### Fixed
 
@@ -78,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passing an invalid seven bit I2C address is now rejected (#3343)
 - PARL_IO: Use correct max transfer size (#3346)
 - `OneShot` timer now returns an InvalidTimeout from `schedule` instead of panicking (#3433)
+- GPIO interrupt handling no longer causes infinite looping if a task at higher priority is awaiting on a pin event (#3408)
+- `esp_hal::gpio::Input::is_interrupt_set` can now return true (#3408)
 
 ### Removed
 

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -147,6 +147,36 @@ Normally you only need to configure your pin once, after which changing modes ca
 + flex.set_output_enable(true);
 ```
 
+### Interrupt handling changes
+
+The interrupt status bits are no longer cleared automatically. Depending on your use case, you will
+need to either do this yourself, or disable the pin's interrupt.
+
+If you want your interrupt to keep firing, clear the interrupt status. Keep in mind that
+this affects `is_interrupt_set`.
+
+```diff
+ #[handler]
+ pub fn interrupt_handler() {
+     critical_section::with(|cs| {
+         let pin = INPUT_PIN.borrow_ref_mut(cs).as_mut().unwrap();
++        pin.clear_interrupt();
+     });
+ }
+```
+
+If you want your interrupt to fire once per `listen` call, disable the interrupt.
+
+```diff
+ #[handler]
+ pub fn interrupt_handler() {
+     critical_section::with(|cs| {
+         let pin = INPUT_PIN.borrow_ref_mut(cs).as_mut().unwrap();
++        pin.unlisten();
+     });
+ }
+```
+
 ## I2S driver now takes `DmaDescriptor`s later in construction
 
 ```diff

--- a/esp-hal/src/gpio/asynch.rs
+++ b/esp-hal/src/gpio/asynch.rs
@@ -1,0 +1,229 @@
+use core::{
+    future::poll_fn,
+    sync::atomic::Ordering,
+    task::{Context, Poll},
+};
+
+use procmacros::ram;
+
+use crate::{
+    asynch::AtomicWaker,
+    gpio::{Event, Flex, GpioBank, Input, NUM_PINS, set_int_enable},
+};
+
+#[ram]
+pub(super) static PIN_WAKERS: [AtomicWaker; NUM_PINS] = [const { AtomicWaker::new() }; NUM_PINS];
+
+impl Flex<'_> {
+    /// Wait until the pin experiences a particular [`Event`].
+    ///
+    /// The GPIO driver will disable listening for the event once it occurs,
+    /// or if the `Future` is dropped.
+    ///
+    /// Note that calling this function will overwrite previous
+    /// [`listen`][Self::listen] operations for this pin.
+    #[inline]
+    #[instability::unstable]
+    pub async fn wait_for(&mut self, event: Event) {
+        // We construct the Future first, because its `Drop` implementation
+        // is load-bearing if `wait_for` is dropped during the initialization.
+        let future = PinFuture { pin: self };
+
+        // Make sure this pin is not being processed by an interrupt handler.
+        if future.pin.is_listening() {
+            set_int_enable(
+                future.pin.number(),
+                None, // Do not disable handling pending interrupts.
+                0,    // Disable generating new events
+                false,
+            );
+            poll_fn(|cx| {
+                if future.pin.is_interrupt_set() {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            })
+            .await;
+        }
+
+        // At this point the pin is no longer listening, we can safely
+        // do our setup.
+
+        // Mark pin as async.
+        future
+            .bank()
+            .async_operations()
+            .fetch_or(future.mask(), Ordering::Relaxed);
+
+        future.pin.listen(event);
+
+        future.await
+    }
+
+    /// Wait until the pin is high.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    #[instability::unstable]
+    pub async fn wait_for_high(&mut self) {
+        self.wait_for(Event::HighLevel).await
+    }
+
+    /// Wait until the pin is low.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    #[instability::unstable]
+    pub async fn wait_for_low(&mut self) {
+        self.wait_for(Event::LowLevel).await
+    }
+
+    /// Wait for the pin to undergo a transition from low to high.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    #[instability::unstable]
+    pub async fn wait_for_rising_edge(&mut self) {
+        self.wait_for(Event::RisingEdge).await
+    }
+
+    /// Wait for the pin to undergo a transition from high to low.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    #[instability::unstable]
+    pub async fn wait_for_falling_edge(&mut self) {
+        self.wait_for(Event::FallingEdge).await
+    }
+
+    /// Wait for the pin to undergo any transition, i.e low to high OR high
+    /// to low.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    #[instability::unstable]
+    pub async fn wait_for_any_edge(&mut self) {
+        self.wait_for(Event::AnyEdge).await
+    }
+}
+
+impl Input<'_> {
+    /// Wait until the pin experiences a particular [`Event`].
+    ///
+    /// The GPIO driver will disable listening for the event once it occurs,
+    /// or if the `Future` is dropped.
+    ///
+    /// Note that calling this function will overwrite previous
+    /// [`listen`][Self::listen] operations for this pin.
+    #[inline]
+    pub async fn wait_for(&mut self, event: Event) {
+        self.pin.wait_for(event).await
+    }
+
+    /// Wait until the pin is high.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    pub async fn wait_for_high(&mut self) {
+        self.pin.wait_for_high().await
+    }
+
+    /// Wait until the pin is low.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    pub async fn wait_for_low(&mut self) {
+        self.pin.wait_for_low().await
+    }
+
+    /// Wait for the pin to undergo a transition from low to high.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    pub async fn wait_for_rising_edge(&mut self) {
+        self.pin.wait_for_rising_edge().await
+    }
+
+    /// Wait for the pin to undergo a transition from high to low.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    pub async fn wait_for_falling_edge(&mut self) {
+        self.pin.wait_for_falling_edge().await
+    }
+
+    /// Wait for the pin to undergo any transition, i.e low to high OR high
+    /// to low.
+    ///
+    /// See [Self::wait_for] for more information.
+    #[inline]
+    pub async fn wait_for_any_edge(&mut self) {
+        self.pin.wait_for_any_edge().await
+    }
+}
+
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+struct PinFuture<'f, 'd> {
+    pin: &'f mut Flex<'d>,
+}
+
+impl PinFuture<'_, '_> {
+    fn number(&self) -> u8 {
+        self.pin.number()
+    }
+
+    fn bank(&self) -> GpioBank {
+        self.pin.pin.bank()
+    }
+
+    fn mask(&self) -> u32 {
+        self.pin.pin.mask()
+    }
+
+    fn is_done(&self) -> bool {
+        // Only the interrupt handler should clear the async bit, and only if the
+        // specific pin is handling an interrupt.
+        self.bank().async_operations().load(Ordering::Acquire) & self.mask() == 0
+    }
+}
+
+impl core::future::Future for PinFuture<'_, '_> {
+    type Output = ();
+
+    fn poll(self: core::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        PIN_WAKERS[self.number() as usize].register(cx.waker());
+
+        if self.is_done() {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl Drop for PinFuture<'_, '_> {
+    fn drop(&mut self) {
+        // If the pin isn't listening, the future has either been dropped before setup,
+        // or the interrupt has already been handled.
+        if self.pin.is_listening() {
+            // Make sure the future isn't dropped while the interrupt is being handled.
+            // This prevents tricky drop-and-relisten scenarios.
+
+            set_int_enable(
+                self.number(),
+                None, // Do not disable handling pending interrupts.
+                0,    // Disable generating new events
+                false,
+            );
+
+            while self.pin.is_interrupt_set() {}
+
+            // Unmark pin as async
+            self.bank()
+                .async_operations()
+                .fetch_and(!self.mask(), Ordering::Relaxed);
+        }
+    }
+}

--- a/esp-hal/src/gpio/asynch.rs
+++ b/esp-hal/src/gpio/asynch.rs
@@ -1,5 +1,4 @@
 use core::{
-    future::poll_fn,
     sync::atomic::Ordering,
     task::{Context, Poll},
 };
@@ -8,7 +7,7 @@ use procmacros::ram;
 
 use crate::{
     asynch::AtomicWaker,
-    gpio::{Event, Flex, GpioBank, Input, NUM_PINS, set_int_enable},
+    gpio::{Event, Flex, GpioBank, Input, NUM_PINS},
 };
 
 #[ram]
@@ -18,48 +17,43 @@ impl Flex<'_> {
     /// Wait until the pin experiences a particular [`Event`].
     ///
     /// The GPIO driver will disable listening for the event once it occurs,
-    /// or if the `Future` is dropped.
+    /// or if the `Future` is dropped - which also means this method is **not**
+    /// cancellation-safe, it will always wait for a future event.
     ///
     /// Note that calling this function will overwrite previous
     /// [`listen`][Self::listen] operations for this pin.
     #[inline]
     #[instability::unstable]
     pub async fn wait_for(&mut self, event: Event) {
-        // We construct the Future first, because its `Drop` implementation
-        // is load-bearing if `wait_for` is dropped during the initialization.
-        let future = PinFuture { pin: self };
-
         // Make sure this pin is not being processed by an interrupt handler.
-        if future.pin.is_listening() {
-            set_int_enable(
-                future.pin.number(),
-                None, // Do not disable handling pending interrupts.
-                0,    // Disable generating new events
-                false,
-            );
-            poll_fn(|cx| {
-                if future.pin.is_interrupt_set() {
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
-                } else {
-                    Poll::Ready(())
-                }
-            })
-            .await;
+        if self.is_listening() {
+            // An interrupt may happen at any point, and the interrupt handler disables the
+            // interrupt enable bit (meaning any unlisten call here might be a race
+            // condition without the critical section). On dual cores, this may happen in
+            // parallel, with the interrupt handler running on the other core.
+            // The safe way to handle this case is to take a GPIO-global
+            // critical section so that we won't run in parallel with the
+            // interrupt handler.
+            // Note that the critical section is taken inside `unlisten`.
+
+            // The pin is already listening, let's turn that off to prevent the interrupt
+            // handler from being called while we are setting up the pin.
+            self.unlisten();
+            self.clear_interrupt();
         }
 
         // At this point the pin is no longer listening, we can safely
         // do our setup.
 
         // Mark pin as async.
-        future
+        self.pin
             .bank()
             .async_operations()
-            .fetch_or(future.mask(), Ordering::Relaxed);
+            .fetch_or(self.pin.mask(), Ordering::Relaxed);
 
-        future.pin.listen(event);
+        self.listen(event);
 
-        future.await
+        PinFuture { pin: self }.await
     }
 
     /// Wait until the pin is high.
@@ -113,7 +107,8 @@ impl Input<'_> {
     /// Wait until the pin experiences a particular [`Event`].
     ///
     /// The GPIO driver will disable listening for the event once it occurs,
-    /// or if the `Future` is dropped.
+    /// or if the `Future` is dropped - which also means this method is **not**
+    /// cancellation-safe, it will always wait for a future event.
     ///
     /// Note that calling this function will overwrite previous
     /// [`listen`][Self::listen] operations for this pin.
@@ -184,7 +179,8 @@ impl PinFuture<'_, '_> {
 
     fn is_done(&self) -> bool {
         // Only the interrupt handler should clear the async bit, and only if the
-        // specific pin is handling an interrupt.
+        // specific pin is handling an interrupt. This way the user may clear the
+        // interrupt status without worrying about the async bit being cleared.
         self.bank().async_operations().load(Ordering::Acquire) & self.mask() == 0
     }
 }
@@ -192,10 +188,17 @@ impl PinFuture<'_, '_> {
 impl core::future::Future for PinFuture<'_, '_> {
     type Output = ();
 
-    fn poll(self: core::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: core::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         PIN_WAKERS[self.number() as usize].register(cx.waker());
 
         if self.is_done() {
+            self.pin.clear_interrupt();
+
+            // Forget self - we don't want to take a critical section to deconfigure the
+            // interrupt, and we don't need to - it's done by the interrupt
+            // handler.
+            #[allow(clippy::forget_non_drop)]
+            core::mem::forget(self);
             Poll::Ready(())
         } else {
             Poll::Pending
@@ -205,25 +208,16 @@ impl core::future::Future for PinFuture<'_, '_> {
 
 impl Drop for PinFuture<'_, '_> {
     fn drop(&mut self) {
-        // If the pin isn't listening, the future has either been dropped before setup,
-        // or the interrupt has already been handled.
-        if self.pin.is_listening() {
-            // Make sure the future isn't dropped while the interrupt is being handled.
-            // This prevents tricky drop-and-relisten scenarios.
+        // Resolving the Future forgets self so if this function runs, the wait is being
+        // cancelled.
 
-            set_int_enable(
-                self.number(),
-                None, // Do not disable handling pending interrupts.
-                0,    // Disable generating new events
-                false,
-            );
+        self.pin.unlisten();
+        self.pin.clear_interrupt();
 
-            while self.pin.is_interrupt_set() {}
-
-            // Unmark pin as async
-            self.bank()
-                .async_operations()
-                .fetch_and(!self.mask(), Ordering::Relaxed);
-        }
+        // Unmark pin as async so that a future listen call doesn't wake a waker for no
+        // reason.
+        self.bank()
+            .async_operations()
+            .fetch_and(!self.mask(), Ordering::Relaxed);
     }
 }

--- a/esp-hal/src/gpio/embedded_hal_impls.rs
+++ b/esp-hal/src/gpio/embedded_hal_impls.rs
@@ -1,0 +1,141 @@
+use embedded_hal::digital;
+use embedded_hal_async::digital::Wait;
+
+#[cfg(feature = "unstable")]
+use super::Flex;
+use super::{Input, Output};
+
+impl digital::ErrorType for Input<'_> {
+    type Error = core::convert::Infallible;
+}
+
+impl digital::InputPin for Input<'_> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Self::is_high(self))
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Self::is_low(self))
+    }
+}
+
+impl digital::ErrorType for Output<'_> {
+    type Error = core::convert::Infallible;
+}
+
+impl digital::OutputPin for Output<'_> {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Self::set_low(self);
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Self::set_high(self);
+        Ok(())
+    }
+}
+
+impl digital::StatefulOutputPin for Output<'_> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Self::is_set_high(self))
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Self::is_set_low(self))
+    }
+}
+
+#[instability::unstable]
+impl digital::InputPin for Flex<'_> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Self::is_high(self))
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Self::is_low(self))
+    }
+}
+
+#[instability::unstable]
+impl digital::ErrorType for Flex<'_> {
+    type Error = core::convert::Infallible;
+}
+
+#[instability::unstable]
+impl digital::OutputPin for Flex<'_> {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Self::set_low(self);
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Self::set_high(self);
+        Ok(())
+    }
+}
+
+#[instability::unstable]
+impl digital::StatefulOutputPin for super::Flex<'_> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Self::is_set_high(self))
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Self::is_set_low(self))
+    }
+}
+
+#[instability::unstable]
+impl Wait for Flex<'_> {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_high(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_low(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_rising_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_falling_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_any_edge(self).await;
+        Ok(())
+    }
+}
+
+impl Wait for Input<'_> {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_high(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_low(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_rising_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_falling_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        Self::wait_for_any_edge(self).await;
+        Ok(())
+    }
+}

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -1,0 +1,102 @@
+use portable_atomic::{AtomicPtr, Ordering};
+use procmacros::ram;
+
+use crate::{
+    gpio::{GpioBank, InterruptStatusRegisterAccess, asynch, set_int_enable},
+    interrupt::{self, DEFAULT_INTERRUPT_HANDLER, Priority},
+    peripherals::Interrupt,
+};
+
+/// Convenience constant for `Option::None` pin
+pub(super) static USER_INTERRUPT_HANDLER: CFnPtr = CFnPtr::new();
+
+pub(super) struct CFnPtr(AtomicPtr<()>);
+impl CFnPtr {
+    pub const fn new() -> Self {
+        Self(AtomicPtr::new(core::ptr::null_mut()))
+    }
+
+    pub fn store(&self, f: extern "C" fn()) {
+        self.0.store(f as *mut (), Ordering::Relaxed);
+    }
+
+    pub fn call(&self) {
+        let ptr = self.0.load(Ordering::Relaxed);
+        if !ptr.is_null() {
+            unsafe { (core::mem::transmute::<*mut (), extern "C" fn()>(ptr))() };
+        }
+    }
+}
+
+#[ram]
+pub(super) extern "C" fn user_gpio_interrupt_handler() {
+    handle_pin_interrupts(|| USER_INTERRUPT_HANDLER.call());
+}
+
+pub(crate) fn bind_default_interrupt_handler() {
+    // We first check if a handler is set in the vector table.
+    if let Some(handler) = interrupt::bound_handler(Interrupt::GPIO) {
+        let handler = handler as *const unsafe extern "C" fn();
+
+        // We only allow binding the default handler if nothing else is bound.
+        // This prevents silently overwriting RTIC's interrupt handler, if using GPIO.
+        if !core::ptr::eq(handler, DEFAULT_INTERRUPT_HANDLER.handler() as _) {
+            // The user has configured an interrupt handler they wish to use.
+            info!("Not using default GPIO interrupt handler: already bound in vector table");
+            return;
+        }
+    }
+    // The vector table doesn't contain a custom entry.Still, the
+    // peripheral interrupt may already be bound to something else.
+    if interrupt::bound_cpu_interrupt_for(crate::system::Cpu::current(), Interrupt::GPIO).is_some()
+    {
+        info!("Not using default GPIO interrupt handler: peripheral interrupt already in use");
+        return;
+    }
+
+    unsafe { interrupt::bind_interrupt(Interrupt::GPIO, default_gpio_interrupt_handler) };
+    // By default, we use lowest priority
+    unwrap!(interrupt::enable(Interrupt::GPIO, Priority::min()));
+}
+
+#[ram]
+extern "C" fn default_gpio_interrupt_handler() {
+    handle_pin_interrupts(|| ());
+}
+
+#[ram]
+fn handle_pin_interrupts(user_handler: fn()) {
+    let intrs_bank0 = InterruptStatusRegisterAccess::Bank0.interrupt_status_read();
+
+    #[cfg(gpio_bank_1)]
+    let intrs_bank1 = InterruptStatusRegisterAccess::Bank1.interrupt_status_read();
+
+    user_handler();
+
+    let banks = [
+        (GpioBank::_0, intrs_bank0),
+        #[cfg(gpio_bank_1)]
+        (GpioBank::_1, intrs_bank1),
+    ];
+
+    for (bank, intrs) in banks {
+        // Get the mask of active async pins and also unmark them in the same go.
+        let async_pins = bank.async_operations().fetch_and(!intrs, Ordering::Relaxed);
+
+        // Wake up the tasks
+        let mut intr_bits = intrs & async_pins;
+        while intr_bits != 0 {
+            let pin_pos = intr_bits.trailing_zeros();
+            intr_bits -= 1 << pin_pos;
+
+            let pin_nr = pin_pos as u8 + bank.offset();
+
+            crate::interrupt::free(|| {
+                asynch::PIN_WAKERS[pin_nr as usize].wake();
+                set_int_enable(pin_nr, Some(0), 0, false);
+            });
+        }
+
+        bank.write_interrupt_status_clear(intrs);
+    }
+}

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1520,6 +1520,13 @@ impl<'d> Flex<'d> {
         });
     }
 
+    fn unlisten_and_clear(&mut self) {
+        GPIO_LOCK.lock(|| {
+            set_int_enable(self.pin.number(), Some(0), 0, false);
+            self.clear_interrupt();
+        });
+    }
+
     /// Check if the pin is listening for interrupts.
     #[inline]
     #[instability::unstable]

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -631,7 +631,7 @@ impl<'d> Io<'d> {
     /// `None`)
     #[instability::unstable]
     pub fn set_interrupt_priority(&self, prio: Priority) {
-        unwrap!(crate::interrupt::enable(Interrupt::GPIO, prio));
+        interrupt::set_interrupt_priority(Interrupt::GPIO, prio);
     }
 
     #[cfg_attr(

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -13,7 +13,6 @@
 //! ```
 
 pub use esp_riscv_rt::TrapFrame;
-pub(crate) use esp_riscv_rt::riscv::interrupt::free;
 use riscv::register::{mcause, mtvec};
 
 #[cfg(not(plic))]

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -423,6 +423,14 @@ mod vectored {
     /// Note that interrupts still need to be enabled globally for interrupts
     /// to be serviced.
     pub fn enable(interrupt: Interrupt, level: Priority) -> Result<(), Error> {
+        enable_on_cpu(Cpu::current(), interrupt, level)
+    }
+
+    pub(crate) fn enable_on_cpu(
+        cpu: Cpu,
+        interrupt: Interrupt,
+        level: Priority,
+    ) -> Result<(), Error> {
         if matches!(level, Priority::None) {
             return Err(Error::InvalidInterruptPriority);
         }
@@ -430,7 +438,7 @@ mod vectored {
             let cpu_interrupt = core::mem::transmute::<u32, CpuInterrupt>(
                 PRIORITY_TO_INTERRUPT[(level as usize) - 1] as u32,
             );
-            map(Cpu::current(), interrupt, cpu_interrupt);
+            map(cpu, interrupt, cpu_interrupt);
             enable_cpu_interrupt(cpu_interrupt);
         }
         Ok(())

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -497,11 +497,19 @@ mod vectored {
 
     /// Enable the given peripheral interrupt
     pub fn enable(interrupt: Interrupt, level: Priority) -> Result<(), Error> {
+        enable_on_cpu(Cpu::current(), interrupt, level)
+    }
+
+    pub(crate) fn enable_on_cpu(
+        cpu: Cpu,
+        interrupt: Interrupt,
+        level: Priority,
+    ) -> Result<(), Error> {
         let cpu_interrupt =
             interrupt_level_to_cpu_interrupt(level, chip_specific::interrupt_is_edge(interrupt))?;
 
         unsafe {
-            map(Cpu::current(), interrupt, cpu_interrupt);
+            map(cpu, interrupt, cpu_interrupt);
 
             xtensa_lx::interrupt::enable_mask(
                 xtensa_lx::interrupt::get_mask() | (1 << cpu_interrupt as u32),

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -1,6 +1,7 @@
 //! Interrupt handling
 
 use xtensa_lx::interrupt;
+#[cfg(esp32)]
 pub(crate) use xtensa_lx::interrupt::free;
 use xtensa_lx_rt::exception::Context;
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -665,7 +665,7 @@ pub fn init(config: Config) -> Peripherals {
     #[cfg(esp32)]
     crate::time::time_init();
 
-    crate::gpio::bind_default_interrupt_handler();
+    crate::gpio::interrupt::bind_default_interrupt_handler();
 
     #[cfg(feature = "psram")]
     crate::psram::init_psram(config.psram);

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -113,8 +113,6 @@ pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
 pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
     match Cpu::current() {
         Cpu::AppCpu => int_enable as u8 | ((nmi_enable as u8) << 1),
-        // this should be bits 3 & 4 respectively, according to the TRM, but it doesn't seem to
-        // work. This does though.
         Cpu::ProCpu => ((int_enable as u8) << 2) | ((nmi_enable as u8) << 3),
     }
 }

--- a/hil-test/.cargo/config.toml
+++ b/hil-test/.cargo/config.toml
@@ -17,7 +17,7 @@ rustflags = [
 ]
 
 [env]
-DEFMT_LOG = "info"
+DEFMT_LOG = "info,embedded_test=warn"
 ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE="multiple-integrated"
 
 [unstable]

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -83,6 +83,16 @@ macro_rules! unconnected_pin {
     }};
 }
 
+#[macro_export]
+macro_rules! mk_static {
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write(($val));
+        x
+    }};
+}
+
 // A simple looping executor to test async code without esp-hal-embassy (which
 // needs `esp-hal/unstable`).
 #[cfg(not(feature = "embassy"))]

--- a/hil-test/tests/embassy_interrupt_executor.rs
+++ b/hil-test/tests/embassy_interrupt_executor.rs
@@ -26,16 +26,7 @@ use esp_hal::{
 #[cfg(multi_core)]
 use esp_hal_embassy::Executor;
 use esp_hal_embassy::InterruptExecutor;
-use hil_test as _;
-
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
+use hil_test::mk_static;
 
 #[embassy_executor::task]
 async fn responder_task(

--- a/hil-test/tests/embassy_interrupt_spi_dma.rs
+++ b/hil-test/tests/embassy_interrupt_spi_dma.rs
@@ -24,17 +24,8 @@ use esp_hal::{
     timer::AnyTimer,
 };
 use esp_hal_embassy::InterruptExecutor;
-use hil_test as _;
+use hil_test::mk_static;
 use portable_atomic::AtomicBool;
-
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 static STOP_INTERRUPT_TASK: AtomicBool = AtomicBool::new(false);
 static INTERRUPT_TASK_WORKING: AtomicBool = AtomicBool::new(false);

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -21,17 +21,7 @@ use esp_hal::{
 };
 #[cfg(not(feature = "esp32"))]
 use esp_hal_embassy::InterruptExecutor;
-use hil_test as _;
-
-#[cfg(not(feature = "esp32"))]
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
+use hil_test::mk_static;
 
 // List of the functions that are ACTUALLY TESTS but are called in the invokers
 mod test_helpers {

--- a/hil-test/tests/esp_wifi_init.rs
+++ b/hil-test/tests/esp_wifi_init.rs
@@ -21,17 +21,8 @@ use esp_hal::{
 };
 use esp_hal_embassy::InterruptExecutor;
 use esp_wifi::InitializationError;
-use hil_test as _;
+use hil_test::mk_static;
 use static_cell::StaticCell;
-
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[embassy_executor::task]
 async fn try_init(

--- a/hil-test/tests/gpio_custom_handler.rs
+++ b/hil-test/tests/gpio_custom_handler.rs
@@ -11,14 +11,40 @@
 #![no_std]
 #![no_main]
 
+use embassy_executor::task;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Duration, Timer};
 use esp_hal::{
-    gpio::{Flex, Input, InputConfig, InputPin, Io, Level, Output, OutputConfig, OutputPin, Pull},
+    gpio::{
+        AnyPin,
+        Flex,
+        Input,
+        InputConfig,
+        InputPin,
+        Io,
+        Level,
+        Output,
+        OutputConfig,
+        OutputPin,
+        Pin,
+        Pull,
+    },
     handler,
+    interrupt::{Priority, software::SoftwareInterruptControl},
     timer::timg::TimerGroup,
 };
+use esp_hal_embassy::InterruptExecutor;
 use hil_test as _;
 use portable_atomic::{AtomicUsize, Ordering};
+
+macro_rules! mk_static {
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write(($val));
+        x
+    }};
+}
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn GPIO() {
@@ -28,10 +54,11 @@ unsafe extern "C" fn GPIO() {
 
     let (gpio1, _) = hil_test::common_test_pins!(peripherals);
 
-    // Using flex will not mutate the pin.
+    // Using flex will reinitialize the pin, but it's okay here since we access an
+    // Input.
     let mut gpio1 = Flex::new(gpio1);
 
-    gpio1.clear_interrupt();
+    gpio1.unlisten();
 }
 
 #[handler]
@@ -64,10 +91,31 @@ async fn drive_pins(gpio1: impl InputPin, gpio2: impl OutputPin) -> usize {
     counter.load(Ordering::SeqCst)
 }
 
-#[cfg(test)]
-#[embedded_test::tests(executor = hil_test::Executor::new())]
-mod tests {
+#[task]
+async fn drive_pin(gpio: AnyPin<'static>) {
+    let mut test_gpio = Output::new(gpio, Level::Low, OutputConfig::default());
+    for _ in 0..5 {
+        test_gpio.set_high();
+        Timer::after(Duration::from_millis(25)).await;
+        test_gpio.set_low();
+        Timer::after(Duration::from_millis(25)).await;
+    }
+}
 
+#[task]
+async fn sense_pin(gpio: AnyPin<'static>, done: &'static Signal<CriticalSectionRawMutex, ()>) {
+    let mut test_gpio = Input::new(gpio, InputConfig::default().with_pull(Pull::Down));
+    test_gpio.wait_for_rising_edge().await;
+    test_gpio.wait_for_rising_edge().await;
+    test_gpio.wait_for_rising_edge().await;
+    test_gpio.wait_for_rising_edge().await;
+    test_gpio.wait_for_rising_edge().await;
+    done.signal(());
+}
+
+#[cfg(test)]
+#[embedded_test::tests(executor = hil_test::Executor::new(), default_timeout = 3)]
+mod tests {
     use super::*;
 
     #[test]
@@ -109,5 +157,37 @@ mod tests {
 
         // We expect the async API to keep working even if a user handler is set.
         assert_eq!(counter, 5);
+    }
+
+    #[test]
+    async fn task_that_runs_at_handlers_priority_is_not_locked_up() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        // Register an interrupt handler. Since we are not dealing with raw interrupts
+        // here, it's okay to do nothing. Handling async GPIO events will
+        // disable the corresponding interrupts.
+        let mut io = Io::new(peripherals.IO_MUX);
+        io.set_interrupt_handler(interrupt_handler);
+
+        let (gpio1, gpio2) = hil_test::common_test_pins!(peripherals);
+
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        esp_hal_embassy::init(timg0.timer0);
+
+        let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+        let interrupt_executor = mk_static!(
+            InterruptExecutor<1>,
+            InterruptExecutor::new(sw_ints.software_interrupt1)
+        );
+        // Run the executor at interrupt priority 1, which is the same as the default
+        // interrupt priority of the GPIO interrupt handler.
+        let interrupt_spwaner = interrupt_executor.start(Priority::Priority1);
+
+        let done = mk_static!(Signal<CriticalSectionRawMutex, ()>, Signal::new());
+
+        interrupt_spwaner.must_spawn(sense_pin(gpio1.degrade(), done));
+        interrupt_spwaner.must_spawn(drive_pin(gpio2.degrade()));
+
+        done.wait().await;
     }
 }

--- a/hil-test/tests/gpio_custom_handler.rs
+++ b/hil-test/tests/gpio_custom_handler.rs
@@ -127,14 +127,6 @@ mod tests {
         let timg0 = TimerGroup::new(peripherals.TIMG0);
         esp_hal_embassy::init(timg0.timer0);
 
-        // We need to enable the GPIO interrupt, otherwise the async Future's
-        // setup or Drop implementation hangs.
-        esp_hal::interrupt::enable(
-            esp_hal::peripherals::Interrupt::GPIO,
-            esp_hal::interrupt::Priority::Priority1,
-        )
-        .unwrap();
-
         let counter = drive_pins(gpio1, gpio2).await;
 
         // GPIO is bound to something else, so we don't expect the async API to work.

--- a/hil-test/tests/gpio_custom_handler.rs
+++ b/hil-test/tests/gpio_custom_handler.rs
@@ -173,12 +173,12 @@ mod tests {
         );
         // Run the executor at interrupt priority 1, which is the same as the default
         // interrupt priority of the GPIO interrupt handler.
-        let interrupt_spwaner = interrupt_executor.start(Priority::Priority1);
+        let interrupt_spawner = interrupt_executor.start(Priority::Priority1);
 
         let done = mk_static!(Signal<CriticalSectionRawMutex, ()>, Signal::new());
 
-        interrupt_spwaner.must_spawn(sense_pin(gpio1.degrade(), done));
-        interrupt_spwaner.must_spawn(drive_pin(gpio2.degrade()));
+        interrupt_spawner.must_spawn(sense_pin(gpio1.degrade(), done));
+        interrupt_spawner.must_spawn(drive_pin(gpio2.degrade()));
 
         done.wait().await;
     }

--- a/hil-test/tests/gpio_custom_handler.rs
+++ b/hil-test/tests/gpio_custom_handler.rs
@@ -34,17 +34,8 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_hal_embassy::InterruptExecutor;
-use hil_test as _;
+use hil_test::mk_static;
 use portable_atomic::{AtomicUsize, Ordering};
-
-macro_rules! mk_static {
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write(($val));
-        x
-    }};
-}
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn GPIO() {
@@ -116,6 +107,7 @@ async fn sense_pin(gpio: AnyPin<'static>, done: &'static Signal<CriticalSectionR
 #[cfg(test)]
 #[embedded_test::tests(executor = hil_test::Executor::new(), default_timeout = 3)]
 mod tests {
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
This PR attempts to fix #3384. To do this, the PR inserts a critical section around code that needs it (manipulating the pin register), changes interrupt handling semantics to only modify the enable bit, and cleans up code enabled by these changes. With this PR, I'm changing the GPIO interrupt handler to disable triggered interrupts by default. If the user registers a custom handler, they will be responsible for either disabling the interrupt or clearing the interrupt status, based on their use case. This is done to fix `is_interrupt_set` by default, as well as to give control to the user whether they want a pin interrupt to fire once or repeatedly.

A side-effect of this PR is that `fn is_interrupt_set` can now actually return `true`, which is nice.