### PR TITLE
Mark methods as unstable to prevent unused warnings

### DIFF
--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -187,6 +187,7 @@ impl FsmTimeout {
     ///
     /// The meaning of the value and the allowed range of values is different
     /// for different chips.
+    #[instability::unstable]
     pub const fn new_const<const VALUE: u8>() -> Self {
         const {
             core::assert!(VALUE <= Self::FSM_TIMEOUT_MAX, "Invalid timeout value");
@@ -198,6 +199,7 @@ impl FsmTimeout {
     ///
     /// The meaning of the value and the allowed range of values is different
     /// for different chips.
+    #[instability::unstable]
     pub fn new(value: u8) -> Result<Self, ConfigError> {
         if value > Self::FSM_TIMEOUT_MAX {
             return Err(ConfigError::TimeoutInvalid);


### PR DESCRIPTION
This PR fixes this warning:

```
warning: associated function `new` is never used
   --> C:\_Espressif\esp-hal\esp-hal\src\i2c\master\mod.rs:203:12
    |
183 | impl FsmTimeout {
    | --------------- associated function in this implementation
...
203 |     pub fn new(value: u8) -> Result<Self, ConfigError> {
    |            ^^^
    |
    = note: `#[warn(dead_code)]` on by default
```