### PR TITLE
Take AsRef/AsMut in stable drivers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `spi::master::Spi::transfer` no longer returns the received data as a slice (#3415)
 - Data transfer functions in the following modules now accept `AsRef<[u8]>` and `AsMut<[u8]>` in place of slices (#3415)
   - `spi::master::{Spi, SpiDmaBus}`
+  - `uart::{Uart, UartTx, UartRx}`
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Data transfer functions in the following modules now accept `AsRef<[u8]>` and `AsMut<[u8]>` in place of slices (#3415)
   - `spi::master::{Spi, SpiDmaBus}`
   - `uart::{Uart, UartTx, UartRx}`
+  - `i2c::master::I2c`
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made the `ParlIo` traits for `TxPins`, `RxPins`, `ConfigurePins` public (#3398)
 - Renamed `Flex::enable_input` to `set_input_enable` (#3387)
 - Make `esp_hal::interrupt::current_runlevel` public under the unstable feature (#3403)
+- `spi::master::Spi::transfer` no longer returns the received data as a slice (#3415)
+- Data transfer functions in the following modules now accept `AsRef<[u8]>` and `AsMut<[u8]>` in place of slices (#3415)
+  - `spi::master::{Spi, SpiDmaBus}`
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -292,6 +292,17 @@ The data and ctrl pins of the camera have been split out into individual `with_*
 + camera.with_data0(peripherals.GPIO11).with_data1(peripherals.GPIO9).with_dataX();
 ```
 
+## SPI changes
+
+`Spi::transfer` no longer returns the input buffer.
+
+```diff
+-let received = spi.transfer(&mut data[..]).unwrap();
+-work_with(received);
++spi.transfer(&mut data[..]).unwrap();
++work_with(&data[..]);
+```
+
 ## Configuration changes
 
 Some configuration options are now unstable and they require the `unstable` feature to be

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -60,7 +60,9 @@ mod tests {
             Err(Error::AddressInvalid(I2cAddress::SevenBit(0x80)))
         );
         assert_eq!(
-            ctx.i2c.write_read(0x80, &[0x77], &mut [0; 1]),
+            // We can even pass arrays, not just slices! That isn't meaningful for the read buffer,
+            // but it's possible.
+            ctx.i2c.write_read(0x80, [0x77], [0; 1]),
             Err(Error::AddressInvalid(I2cAddress::SevenBit(0x80)))
         );
     }


### PR DESCRIPTION
This PR implements #2785 for the stable drivers. The one change I had to make is `Spi::transfer`, where returning the slice is no longer possible - but it's also not meaningful.