### PR TITLE
Tweak features and dependencies

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `IntoAnyTimer` trait has been removed (#3444)
 - The `TimerCollection` trait has been sealed and renamed to `TimeBase`. Former `IntoAnyTimer` functionality has been merged into `TimeBase`. (#3444)
 - `esp_hal_embassy::init` will panic if called multiple times (#3444)
+- The `log` feature has been replaced by `log-04`. (#3425)
 
 ### Fixed
 

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -19,20 +19,27 @@ bench = false
 test  = false
 
 [dependencies]
+cfg-if                    = "1.0.0"
 critical-section          = "1.2.0"
-defmt                     = { version = "1.0.1", optional = true }
+esp-hal                   = { version = "1.0.0-beta.0", path = "../esp-hal" }
+portable-atomic           = "1.11.0"
+static_cell               = "2.1.0"
+
+# Unstable dependencies that are not (strictly) part of the public API
 document-features         = "0.2.11"
-embassy-executor          = { version = "0.7.0", features = ["timer-item-payload-size-4"], optional = true }
 embassy-sync              = { version = "0.6.2" }
 embassy-time              = { version = "0.4.0" }
 embassy-time-driver       = { version = "0.2.0", features = [ "tick-hz-1_000_000" ] }
 embassy-time-queue-utils  = { version = "0.1.0", features = ["_generic-queue"] }
 esp-config                = { version = "0.3.0", path = "../esp-config" }
-esp-hal                   = { version = "1.0.0-beta.0", path = "../esp-hal" }
-log                       = { version = "0.4.27", optional = true }
 macros                    = { version = "0.17.0", features = ["embassy"], package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-portable-atomic           = "1.11.0"
-static_cell               = "2.1.0"
+
+# Optional dependencies that enable ecosystem support.
+embassy-executor          = { version = "0.7.0", features = ["timer-item-payload-size-4"], optional = true }
+
+# Logging interfaces, they are mutually exclusive so they need to be behind separate features.
+defmt                     = { version = "1.0.1", optional = true }
+log-04                    = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
 esp-build    = { version = "0.2.0", path = "../esp-build" }
@@ -50,12 +57,14 @@ esp32h2 = ["esp-hal/esp32h2"]
 esp32s2 = ["esp-hal/esp32s2"]
 esp32s3 = ["esp-hal/esp32s3"]
 
-## Implement `defmt::Format` on certain types.
-defmt = ["dep:defmt", "embassy-executor?/defmt", "esp-hal/defmt"]
-## Enable logging via the log crate
-log = ["dep:log"]
-## Provide `Executor` and `InterruptExecutor`
+## Enable the `Executor` and `InterruptExecutor` embassy executor implementations.
 executors = ["dep:embassy-executor", "esp-hal/__esp_hal_embassy"]
+
+#! ### Logging Feature Flags
+## Enable logging output using version 0.4 of the `log` crate.
+log-04 = ["dep:log-04"]
+## Enable logging output using `defmt` and implement `defmt::Format` on certain types.
+defmt = ["dep:defmt", "embassy-executor?/defmt", "esp-hal/defmt"]
 
 [lints.rust]
 unexpected_cfgs = "allow"

--- a/esp-hal-embassy/src/fmt.rs
+++ b/esp-hal-embassy/src/fmt.rs
@@ -5,10 +5,13 @@
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert!($($x)*);
+                } else {
+                    ::core::assert!($($x)*);
+                }
+            }
         }
     };
 }
@@ -17,10 +20,13 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert_eq!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert_eq!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert_eq!($($x)*);
+                } else {
+                    ::core::assert_eq!($($x)*);
+                }
+            }
         }
     };
 }
@@ -29,10 +35,13 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert_ne!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert_ne!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert_ne!($($x)*);
+                } else {
+                    ::core::assert_ne!($($x)*);
+                }
+            }
         }
     };
 }
@@ -41,10 +50,13 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert!($($x)*);
+                } else {
+                    ::core::debug_assert!($($x)*);
+                }
+            }
         }
     };
 }
@@ -53,10 +65,13 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert_eq!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert_eq!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert_eq!($($x)*);
+                } else {
+                    ::core::debug_assert_eq!($($x)*);
+                }
+            }
         }
     };
 }
@@ -65,10 +80,13 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert_ne!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert_ne!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert_ne!($($x)*);
+                } else {
+                    ::core::debug_assert_ne!($($x)*);
+                }
+            }
         }
     };
 }
@@ -77,10 +95,13 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::todo!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::todo!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::todo!($($x)*);
+                } else {
+                    ::core::todo!($($x)*);
+                }
+            }
         }
     };
 }
@@ -89,10 +110,13 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::unreachable!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::unreachable!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::unreachable!($($x)*);
+                } else {
+                    ::core::unreachable!($($x)*);
+                }
+            }
         }
     };
 }
@@ -101,10 +125,13 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::panic!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::panic!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::panic!($($x)*);
+                } else {
+                    ::core::panic!($($x)*);
+                }
+            }
         }
     };
 }
@@ -113,12 +140,15 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::trace!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::trace!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::trace!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -127,12 +157,15 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::debug!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::debug!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -141,12 +174,15 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::info!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::info!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::info!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -155,12 +191,15 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::warn!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::warn!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::warn!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -169,12 +208,15 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::error!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::error!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::error!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - esp-hal no longer clears the GPIO interrupt status bits by default. (#3408)
 - `spi::master::Spi::transfer` no longer returns the received data as a slice (#3417)
 - The `log` feature has been replaced by `log-04`. (#?)
+- Multiple feature flags have been replaced by `unstable`. (#?)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `log` feature has been replaced by `log-04`. (#3425)
 - Multiple feature flags have been replaced by `unstable`. (#3425)
 - The `debug` feature has been removed. (#3425)
+- The `usb_otg` and `bluetooth` features are now considered private and have been renamed accordingly. (#3425)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -57,8 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `spi::master::Spi::transfer` no longer returns the received data as a slice (#?)
 - esp-hal no longer clears the GPIO interrupt status bits by default. (#3408)
 - `spi::master::Spi::transfer` no longer returns the received data as a slice (#3417)
-- The `log` feature has been replaced by `log-04`. (#?)
-- Multiple feature flags have been replaced by `unstable`. (#?)
+- The `log` feature has been replaced by `log-04`. (#3425)
+- Multiple feature flags have been replaced by `unstable`. (#3425)
+- The `debug` feature has been removed. (#3425)
 
 ### Fixed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `defmt` to 1.0 (#3416)
 - `spi::master::Spi::transfer` no longer returns the received data as a slice (#?)
 - esp-hal no longer clears the GPIO interrupt status bits by default. (#3408)
+- `spi::master::Spi::transfer` no longer returns the received data as a slice (#3417)
+- The `log` feature has been replaced by `log-04`. (#?)
 
 ### Fixed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -113,19 +113,6 @@ __usb_otg = [
     "esp-synopsys-usb-otg/fs",
 ]
 
-## Enable debug features in the HAL (used for development).
-debug = [
-    "esp32?/impl-register-debug",
-    "esp32c2?/impl-register-debug",
-    "esp32c3?/impl-register-debug",
-    "esp32c6?/impl-register-debug",
-    "esp32h2?/impl-register-debug",
-    "esp32s2?/impl-register-debug",
-    "esp32s3?/impl-register-debug",
-]
-## Enable logging output using version 0.4 of the `log` crate.
-log-04 = ["dep:log"]
-
 # Chip Support Feature Flags
 # Target the ESP32.
 esp32   = [
@@ -173,8 +160,12 @@ esp32s3 = [
     "__usb_otg",
 ]
 
-#! ### Trait Implementation Feature Flags
-## Implement `defmt::Format` on certain types.
+
+#! ### Logging Feature Flags
+## Enable logging output using version 0.4 of the `log` crate.
+log-04 = ["dep:log"]
+
+## Enable logging output using `defmt` and implement `defmt::Format` on certain types.
 defmt = [
     "dep:defmt",
     "embassy-futures/defmt",
@@ -193,6 +184,18 @@ defmt = [
 ]
 
 #! ### PSRAM Feature Flags
+
+## Implement Debug on more types.
+debug = [
+    "esp32?/impl-register-debug",
+    "esp32c2?/impl-register-debug",
+    "esp32c3?/impl-register-debug",
+    "esp32c6?/impl-register-debug",
+    "esp32h2?/impl-register-debug",
+    "esp32s2?/impl-register-debug",
+    "esp32s3?/impl-register-debug",
+]
+
 ## Use externally connected PSRAM (`quad` by default, can be configured to `octal` via ESP_HAL_CONFIG_PSRAM_MODE)
 psram = []
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -54,7 +54,6 @@ embassy-usb-synopsys-otg = { version = "0.2.0", optional = true }
 embedded-can             = { version = "0.4.1", optional = true }
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
 nb                       = { version = "1.1.0", optional = true }
-usb-device               = { version = "0.3.2", optional = true }
 
 # Logging interfaces, they are mutually exclusive so they need to be behind separate features.
 defmt                    = { version = "1.0.1", optional = true }

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -68,9 +68,7 @@ embedded-io              = { version = "0.6.1", optional = true }
 embedded-io-async        = { version = "0.6.1", optional = true }
 rand_core-06             = { package = "rand_core", version = "0.6.4", optional = true }
 rand_core-09             = { package = "rand_core", version = "0.9.0", optional = true }
-
-# Unstable dependencies that need to be dealt with
-ufmt-write               = "0.1.0" # This should be optional, behind `ufmt_write-01`
+ufmt-write               = { version = "0.1.0", optional = true }
 
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
@@ -177,6 +175,7 @@ unstable = [
     "dep:rand_core-06",
     "dep:rand_core-09",
     "dep:nb",
+    "dep:ufmt-write",
 ]
 
 [lints.clippy]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -57,7 +57,7 @@ nb                       = { version = "1.1.0", optional = true }
 
 # Logging interfaces, they are mutually exclusive so they need to be behind separate features.
 defmt                    = { version = "1.0.1", optional = true }
-log                      = { version = "0.4.27", optional = true }
+log-04                   = { package = "log", version = "0.4.27", optional = true }
 
 # Optional dependencies that enable ecosystem support.
 # We could support individually enabling them, but there is no big downside to just
@@ -163,7 +163,7 @@ esp32s3 = [
 
 #! ### Logging Feature Flags
 ## Enable logging output using version 0.4 of the `log` crate.
-log-04 = ["dep:log"]
+log-04 = ["dep:log-04"]
 
 ## Enable logging output using `defmt` and implement `defmt::Format` on certain types.
 defmt = [

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -102,8 +102,7 @@ jiff = { version = "0.2.10", default-features = false, features = ["static"] }
 [features]
 default = []
 
-bluetooth = []
-
+__bluetooth = []
 __esp_hal_embassy = []
 __usb_otg = [
     "dep:embassy-usb-driver",

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -158,7 +158,7 @@ esp32h2 = [
 # Target the ESP32-S2.
 esp32s2 = [
     "dep:esp32s2",
-    "portable-atomic/critical-section",
+    "portable-atomic/unsafe-assume-single-core",
     "procmacros/has-ulp-core",
     "procmacros/rtc-slow",
     "xtensa-lx-rt/esp32s2",

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -70,7 +70,7 @@ rand_core-06             = { package = "rand_core", version = "0.6.4", optional 
 rand_core-09             = { package = "rand_core", version = "0.9.0", optional = true }
 
 # Unstable dependencies that need to be dealt with
-ufmt-write               = "0.1.0" # This should be optional, behind `ufmt_write01`
+ufmt-write               = "0.1.0" # This should be optional, behind `ufmt_write-01`
 
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
@@ -121,8 +121,8 @@ debug = [
     "esp32s2?/impl-register-debug",
     "esp32s3?/impl-register-debug",
 ]
-## Enable logging output using the `log` crate.
-log = ["dep:log"]
+## Enable logging output using version 0.4 of the `log` crate.
+log-04 = ["dep:log"]
 
 # Chip Support Feature Flags
 # Target the ESP32.
@@ -174,8 +174,8 @@ unstable = [
     "dep:embedded-can",
     "dep:embedded-io",
     "dep:embedded-io-async",
-    "dep:rand_core06",
-    "dep:rand_core09",
+    "dep:rand_core-06",
+    "dep:rand_core-09",
     "dep:nb",
 ]
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -102,6 +102,8 @@ jiff = { version = "0.2.10", default-features = false, features = ["static"] }
 [features]
 default = []
 
+# These features are considered private and unstable. They are not covered by
+# semver guarantees and may change or be removed without notice.
 __bluetooth = []
 __esp_hal_embassy = []
 __usb_otg = [

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -52,7 +52,7 @@ digest                   = { version = "0.10.7", default-features = false, optio
 embassy-usb-driver       = { version = "0.1.0", optional = true }
 embassy-usb-synopsys-otg = { version = "0.2.0", optional = true }
 embedded-can             = { version = "0.4.1", optional = true }
-esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
+esp-synopsys-usb-otg     = { version = "0.4.2", optional = true }
 nb                       = { version = "1.1.0", optional = true }
 
 # Logging interfaces, they are mutually exclusive so they need to be behind separate features.
@@ -104,9 +104,14 @@ default = []
 
 bluetooth = []
 
-usb-otg = ["dep:embassy-usb-driver", "dep:embassy-usb-synopsys-otg", "dep:esp-synopsys-usb-otg", "dep:usb-device"]
-
 __esp_hal_embassy = []
+__usb_otg = [
+    "dep:embassy-usb-driver",
+    "dep:embassy-usb-synopsys-otg",
+    "dep:esp-synopsys-usb-otg",
+    "esp-synopsys-usb-otg/esp32sx",
+    "esp-synopsys-usb-otg/fs",
+]
 
 ## Enable debug features in the HAL (used for development).
 debug = [
@@ -123,19 +128,50 @@ log-04 = ["dep:log"]
 
 # Chip Support Feature Flags
 # Target the ESP32.
-esp32   = ["dep:esp32", "procmacros/rtc-slow", "xtensa-lx-rt/esp32"]
+esp32   = [
+    "dep:esp32",
+    "procmacros/rtc-slow",
+    "xtensa-lx-rt/esp32",
+]
 # Target the ESP32-C2.
-esp32c2 = ["dep:esp32c2", "portable-atomic/unsafe-assume-single-core"]
+esp32c2 = [
+    "dep:esp32c2",
+    "portable-atomic/unsafe-assume-single-core",
+]
 # Target the ESP32-C3.
-esp32c3 = ["dep:esp32c3", "esp-riscv-rt/rtc-ram", "portable-atomic/unsafe-assume-single-core"]
+esp32c3 = [
+    "dep:esp32c3",
+    "esp-riscv-rt/rtc-ram",
+    "portable-atomic/unsafe-assume-single-core",
+]
 # Target the ESP32-C6.
-esp32c6 = ["dep:esp32c6", "esp-riscv-rt/rtc-ram", "procmacros/has-lp-core"]
+esp32c6 = [
+    "dep:esp32c6",
+    "esp-riscv-rt/rtc-ram",
+    "procmacros/has-lp-core",
+]
 # Target the ESP32-H2.
-esp32h2 = ["dep:esp32h2", "esp-riscv-rt/rtc-ram"]
+esp32h2 = [
+    "dep:esp32h2",
+    "esp-riscv-rt/rtc-ram",
+]
 # Target the ESP32-S2.
-esp32s2 = ["dep:esp32s2", "portable-atomic/critical-section", "procmacros/has-ulp-core", "procmacros/rtc-slow", "usb-otg", "xtensa-lx-rt/esp32s2"]
+esp32s2 = [
+    "dep:esp32s2",
+    "portable-atomic/critical-section",
+    "procmacros/has-ulp-core",
+    "procmacros/rtc-slow",
+    "xtensa-lx-rt/esp32s2",
+    "__usb_otg",
+]
 # Target the ESP32-S3.
-esp32s3 = ["dep:esp32s3", "procmacros/has-ulp-core", "procmacros/rtc-slow", "usb-otg", "xtensa-lx-rt/esp32s3"]
+esp32s3 = [
+    "dep:esp32s3",
+    "procmacros/has-ulp-core",
+    "procmacros/rtc-slow",
+    "xtensa-lx-rt/esp32s3",
+    "__usb_otg",
+]
 
 #! ### Trait Implementation Feature Flags
 ## Implement `defmt::Format` on certain types.
@@ -144,8 +180,8 @@ defmt = [
     "embassy-futures/defmt",
     "embassy-sync/defmt",
     "embedded-hal/defmt-03",
-    "embedded-io/defmt-03",
-    "embedded-io-async/defmt-03",
+    "embedded-io?/defmt-03",
+    "embedded-io-async?/defmt-03",
     "esp32?/defmt",
     "esp32c2?/defmt",
     "esp32c3?/defmt",
@@ -167,6 +203,7 @@ psram = []
 
 ## Enables APIs that are not stable and thus come with no stability guarantees.
 unstable = [
+    "dep:digest",
     "dep:embassy-embedded-hal",
     "dep:embedded-can",
     "dep:embedded-io",

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -185,17 +185,6 @@ defmt = [
 
 #! ### PSRAM Feature Flags
 
-## Implement Debug on more types.
-debug = [
-    "esp32?/impl-register-debug",
-    "esp32c2?/impl-register-debug",
-    "esp32c3?/impl-register-debug",
-    "esp32c6?/impl-register-debug",
-    "esp32h2?/impl-register-debug",
-    "esp32s2?/impl-register-debug",
-    "esp32s3?/impl-register-debug",
-]
-
 ## Use externally connected PSRAM (`quad` by default, can be configured to `octal` via ESP_HAL_CONFIG_PSRAM_MODE)
 psram = []
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -23,40 +23,54 @@ test  = false
 [dependencies]
 bitflags                 = "2.9.0"
 bytemuck                 = "1.22.0"
-bitfield                 = "0.19.0"
 cfg-if                   = "1.0.0"
 critical-section         = { version = "1.2.0", features = ["restore-state-u32"] }
-defmt                    = { version = "1.0.1", optional = true }
-delegate                 = "0.13.3"
-digest                   = { version = "0.10.7", default-features = false, optional = true }
-document-features        = "0.2.11"
-embassy-embedded-hal     = { version = "0.3.0", optional = true }
-embassy-futures          = "0.1.1"
-embassy-sync             = "0.6.2"
-embassy-usb-driver       = { version = "0.1.0", optional = true }
-embassy-usb-synopsys-otg = { version = "0.2.0", optional = true }
-embedded-can             = { version = "0.4.1", optional = true }
 embedded-hal             = "1.0.0"
 embedded-hal-async       = "1.0.0"
-embedded-io              = { version = "0.6.1", optional = true }
-embedded-io-async        = { version = "0.6.1", optional = true }
 enumset                  = "1.1.5"
+paste                    = "1.0.15"
+portable-atomic          = { version = "1.11.0", default-features = false }
+
+# Unstable dependencies that are not (strictly) part of the public API
+bitfield                 = "0.19.0"
+delegate                 = "0.13.3"
+document-features        = "0.2.11"
+embassy-futures          = "0.1.1"
+embassy-sync             = "0.6.2"
+fugit                    = "0.3.7"
+instability              = "0.3.7"
+strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
+
 esp-build                = { version = "0.2.0", path = "../esp-build" }
 esp-config               = { version = "0.3.0", path = "../esp-config" }
 esp-metadata             = { version = "0.6.0", path = "../esp-metadata", default-features = false }
-esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
-fugit                    = "0.3.7"
-instability              = "0.3.7"
-log                      = { version = "0.4.27", optional = true }
-nb                       = { version = "1.1.0", optional = true }
-paste                    = "1.0.15"
-portable-atomic          = { version = "1.11.0", default-features = false }
 procmacros               = { version = "0.17.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
+
+# Dependencies that are optional because they are used by unstable drivers.
+# They are needed when using the `unstable` feature.
+digest                   = { version = "0.10.7", default-features = false, optional = true }
+embassy-usb-driver       = { version = "0.1.0", optional = true }
+embassy-usb-synopsys-otg = { version = "0.2.0", optional = true }
+embedded-can             = { version = "0.4.1", optional = true }
+esp-synopsys-usb-otg     = { version = "0.4.2", optional = true, features = ["fs", "esp32sx"] }
+nb                       = { version = "1.1.0", optional = true }
 usb-device               = { version = "0.3.2", optional = true }
-rand_core06              = { package = "rand_core", version = "0.6.4", optional = true }
-rand_core09              = { package = "rand_core", version = "0.9.0", optional = true }
-ufmt-write               = "0.1.0"
+
+# Logging interfaces, they are mutually exclusive so they need to be behind separate features.
+defmt                    = { version = "1.0.1", optional = true }
+log                      = { version = "0.4.27", optional = true }
+
+# Optional dependencies that enable ecosystem support.
+# We could support individually enabling them, but there is no big downside to just
+# enabling them all via the `unstable` feature.
+embassy-embedded-hal     = { version = "0.3.0", optional = true }
+embedded-io              = { version = "0.6.1", optional = true }
+embedded-io-async        = { version = "0.6.1", optional = true }
+rand_core-06             = { package = "rand_core", version = "0.6.4", optional = true }
+rand_core-09             = { package = "rand_core", version = "0.9.0", optional = true }
+
+# Unstable dependencies that need to be dealt with
+ufmt-write               = "0.1.0" # This should be optional, behind `ufmt_write01`
 
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -360,9 +360,7 @@ The following dependencies are now gated behind the `unstable` feature and their
 invididual features are no longer available:
 - `digest`
 - `ufmt-write`
-- `embassy-usb-driver`
-- `embassy-usb-synopsys-otg`
-- `esp-synopsys-otg`
-- `usb-otg`
+
+The `usb_otg` and `bluetooth` features are now considered private and have been renamed accordingly.
 
 The `debug` feature has been removed. If you used it, enable `impl-register-debug` on the PAC of your device.

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -356,3 +356,4 @@ The `ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM` configuration option has been renam
 ## Changes related to cargo features
 
 The `log` feature has been replaced by `log-04`.
+`ufmt` support is now gated behind `unstable`.

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -352,3 +352,7 @@ Some configuration options are now unstable and they require the `unstable` feat
 enabled. You can learn about a particular option in the [esp-hal documentation](https://docs.espressif.com/projects/rust/esp-hal/latest/).
 
 The `ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM` configuration option has been renamed to `ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM`.
+
+## Changes related to cargo features
+
+The `log` feature has been replaced by `log-04`.

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -356,4 +356,11 @@ The `ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM` configuration option has been renam
 ## Changes related to cargo features
 
 The `log` feature has been replaced by `log-04`.
-`ufmt` support is now gated behind `unstable`.
+The following dependencies are now gated behind the `unstable` feature and their
+invididual features are no longer available:
+- `digest`
+- `ufmt-write`
+- `embassy-usb-driver`
+- `embassy-usb-synopsys-otg`
+- `esp-synopsys-otg`
+- `usb-otg`

--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -364,3 +364,5 @@ invididual features are no longer available:
 - `embassy-usb-synopsys-otg`
 - `esp-synopsys-otg`
 - `usb-otg`
+
+The `debug` feature has been removed. If you used it, enable `impl-register-debug` on the PAC of your device.

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -8,7 +8,7 @@ use std::{
     str::FromStr,
 };
 
-use esp_build::assert_unique_used_features;
+use esp_build::{assert_unique_features, assert_unique_used_features};
 use esp_config::{ConfigOption, Stability, Validator, Value, generate_config};
 use esp_metadata::{Chip, Config};
 
@@ -25,6 +25,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     assert_unique_used_features!(
         "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"
     );
+
+    // Log and defmt are mutually exclusive features. The main technical reason is
+    // that allowing both would make the exact panicking behaviour a fragile
+    // implementation detail.
+    assert_unique_features!("log-04", "defmt");
 
     // NOTE: update when adding new device support!
     // Determine the name of the configured device:

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -388,7 +388,7 @@ fn substitute_config(cfg: &HashMap<String, Value>, line: &str) -> String {
 
 #[cfg(feature = "esp32")]
 fn generate_memory_extras() -> Vec<u8> {
-    let reserve_dram = if cfg!(feature = "bluetooth") {
+    let reserve_dram = if cfg!(feature = "__bluetooth") {
         "0x10000"
     } else {
         "0x0"

--- a/esp-hal/src/fmt.rs
+++ b/esp-hal/src/fmt.rs
@@ -5,10 +5,13 @@
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert!($($x)*);
+                } else {
+                    ::core::assert!($($x)*);
+                }
+            }
         }
     };
 }
@@ -17,10 +20,13 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert_eq!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert_eq!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert_eq!($($x)*);
+                } else {
+                    ::core::assert_eq!($($x)*);
+                }
+            }
         }
     };
 }
@@ -29,10 +35,13 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert_ne!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert_ne!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert_ne!($($x)*);
+                } else {
+                    ::core::assert_ne!($($x)*);
+                }
+            }
         }
     };
 }
@@ -41,10 +50,13 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert!($($x)*);
+                } else {
+                    ::core::debug_assert!($($x)*);
+                }
+            }
         }
     };
 }
@@ -53,10 +65,13 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert_eq!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert_eq!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert_eq!($($x)*);
+                } else {
+                    ::core::debug_assert_eq!($($x)*);
+                }
+            }
         }
     };
 }
@@ -65,10 +80,13 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert_ne!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert_ne!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert_ne!($($x)*);
+                } else {
+                    ::core::debug_assert_ne!($($x)*);
+                }
+            }
         }
     };
 }
@@ -77,10 +95,13 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::todo!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::todo!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::todo!($($x)*);
+                } else {
+                    ::core::todo!($($x)*);
+                }
+            }
         }
     };
 }
@@ -89,10 +110,13 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::unreachable!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::unreachable!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::unreachable!($($x)*);
+                } else {
+                    ::core::unreachable!($($x)*);
+                }
+            }
         }
     };
 }
@@ -101,10 +125,13 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::panic!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::panic!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::panic!($($x)*);
+                } else {
+                    ::core::panic!($($x)*);
+                }
+            }
         }
     };
 }
@@ -113,12 +140,15 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::trace!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::trace!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::trace!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -127,12 +157,15 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::debug!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::debug!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -141,12 +174,15 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::info!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::info!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::info!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -155,12 +191,15 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::warn!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::warn!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::warn!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -169,12 +208,15 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::error!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::error!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::error!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }

--- a/esp-hal/src/rng.rs
+++ b/esp-hal/src/rng.rs
@@ -134,7 +134,7 @@ impl Rng {
 impl Sealed for Rng {}
 
 #[instability::unstable]
-impl rand_core06::RngCore for Rng {
+impl rand_core_06::RngCore for Rng {
     fn next_u32(&mut self) -> u32 {
         self.random()
     }
@@ -150,14 +150,14 @@ impl rand_core06::RngCore for Rng {
         self.read(dest);
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core06::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
         self.read(dest);
         Ok(())
     }
 }
 
 #[instability::unstable]
-impl rand_core09::RngCore for Rng {
+impl rand_core_09::RngCore for Rng {
     fn next_u32(&mut self) -> u32 {
         self.random()
     }
@@ -231,7 +231,7 @@ impl Drop for Trng<'_> {
 
 /// Implementing RngCore trait from rand_core for `Trng` structure
 #[instability::unstable]
-impl rand_core06::RngCore for Trng<'_> {
+impl rand_core_06::RngCore for Trng<'_> {
     fn next_u32(&mut self) -> u32 {
         self.rng.next_u32()
     }
@@ -244,13 +244,13 @@ impl rand_core06::RngCore for Trng<'_> {
         self.rng.fill_bytes(dest)
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core06::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
         self.rng.try_fill_bytes(dest)
     }
 }
 
 #[instability::unstable]
-impl rand_core09::RngCore for Trng<'_> {
+impl rand_core_09::RngCore for Trng<'_> {
     fn next_u32(&mut self) -> u32 {
         self.rng.next_u32()
     }
@@ -265,8 +265,8 @@ impl rand_core09::RngCore for Trng<'_> {
 /// Implementing a CryptoRng marker trait that indicates that the generator is
 /// cryptographically secure.
 #[instability::unstable]
-impl rand_core06::CryptoRng for Trng<'_> {}
+impl rand_core_06::CryptoRng for Trng<'_> {}
 #[instability::unstable]
-impl rand_core09::CryptoRng for Trng<'_> {}
+impl rand_core_09::CryptoRng for Trng<'_> {}
 
 impl Sealed for Trng<'_> {}

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -60,7 +60,6 @@
 use core::{borrow::Borrow, convert::Infallible, marker::PhantomData, mem::size_of};
 
 /// Re-export digest for convenience
-#[cfg(feature = "digest")]
 pub use digest::Digest;
 
 #[cfg(not(esp32))]
@@ -490,7 +489,6 @@ pub trait ShaAlgorithm: crate::private::Sealed {
     /// For example, in SHA-256, this would be 32 bytes.
     const DIGEST_LENGTH: usize;
 
-    #[cfg(feature = "digest")]
     #[doc(hidden)]
     type DigestOutputSize: digest::generic_array::ArrayLength<u8> + 'static;
 
@@ -522,15 +520,12 @@ pub trait ShaAlgorithm: crate::private::Sealed {
 /// implement digest traits if digest feature is present.
 /// Note: digest has a blanket trait implementation for [digest::Digest] for any
 /// element that implements FixedOutput + Default + Update + HashMarker
-#[cfg(feature = "digest")]
 impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> digest::HashMarker for ShaDigest<'d, A, S> {}
 
-#[cfg(feature = "digest")]
 impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> digest::OutputSizeUser for ShaDigest<'d, A, S> {
     type OutputSize = A::DigestOutputSize;
 }
 
-#[cfg(feature = "digest")]
 impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> digest::Update for ShaDigest<'d, A, S> {
     fn update(&mut self, data: &[u8]) {
         let mut remaining = data.as_ref();
@@ -540,7 +535,6 @@ impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> digest::Update for ShaDigest<'d, A
     }
 }
 
-#[cfg(feature = "digest")]
 impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> digest::FixedOutput for ShaDigest<'d, A, S> {
     fn finalize_into(mut self, out: &mut digest::Output<Self>) {
         nb::block!(self.finish(out)).unwrap();
@@ -575,7 +569,6 @@ macro_rules! impl_sha {
             #[cfg(not(esp32))]
             const MODE_AS_BITS: u8 = $mode_bits;
 
-            #[cfg(feature = "digest")]
             // We use paste to append `U` to the digest size to match a const defined in
             // digest
             type DigestOutputSize = paste::paste!(digest::consts::[< U $digest_length >]);

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -527,8 +527,7 @@ impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> digest::OutputSizeUser for ShaDige
 }
 
 impl<'d, A: ShaAlgorithm, S: Borrow<Sha<'d>>> digest::Update for ShaDigest<'d, A, S> {
-    fn update(&mut self, data: &[u8]) {
-        let mut remaining = data.as_ref();
+    fn update(&mut self, mut remaining: &[u8]) {
         while !remaining.is_empty() {
             remaining = nb::block!(Self::update(self, remaining)).unwrap();
         }

--- a/esp-ieee802154/CHANGELOG.md
+++ b/esp-ieee802154/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 - Update `defmt` to 1.0 (#3416)
+- The `log` feature has been replaced by `log-04`. (#3425)
 
 ### Fixed
 

--- a/esp-ieee802154/Cargo.toml
+++ b/esp-ieee802154/Cargo.toml
@@ -19,17 +19,23 @@ bench = false
 test  = false
 
 [dependencies]
-byte              = "0.2.7"
-critical-section  = "1.2.0"
-document-features = "0.2.11"
-esp-hal           = { version = "1.0.0-beta.0", path = "../esp-hal" }
-esp-wifi-sys      = "0.7.1"
-heapless          = "0.8.0"
-ieee802154        = "0.6.1"
 cfg-if            = "1.0.0"
+critical-section  = "1.2.0"
+esp-hal           = { version = "1.0.0-beta.0", path = "../esp-hal" }
+
+# ⚠️ Unstable dependencies that are part of the public API
+heapless          = "0.8.0"
+
+# Unstable dependencies that are not (strictly) part of the public API
+byte              = "0.2.7"
+document-features = "0.2.11"
 esp-config        = { version = "0.3.0", path = "../esp-config" }
-defmt             = { version = "1.0.1", optional = true }
-log               = { version = "0.4.27", optional = true }
+esp-wifi-sys      = "0.7.1"
+ieee802154        = "0.6.1"
+
+# Logging interfaces, they are mutually exclusive so they need to be behind separate features.
+defmt                     = { version = "1.0.1", optional = true }
+log-04                    = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
 esp-config        = { version = "0.3.0", path = "../esp-config" }
@@ -38,6 +44,12 @@ esp-config        = { version = "0.3.0", path = "../esp-config" }
 [features]
 esp32c6 = ["esp-hal/esp32c6", "esp-wifi-sys/esp32c6"]
 esp32h2 = ["esp-hal/esp32h2", "esp-wifi-sys/esp32h2"]
+
+## Enables log messages from the esp-wifi blobs.
 sys-logs = ["esp-wifi-sys/sys-logs"]
-log = ["dep:log", "esp-wifi-sys/log"]
+
+#! ### Logging Feature Flags
+## Enable logging output using version 0.4 of the `log` crate.
+log-04 = ["dep:log-04", "esp-wifi-sys/log"]
+## Enable logging output using `defmt` and implement `defmt::Format` on certain types.
 defmt = ["dep:defmt", "esp-wifi-sys/defmt"]

--- a/esp-ieee802154/src/fmt.rs
+++ b/esp-ieee802154/src/fmt.rs
@@ -7,10 +7,13 @@ use core::fmt::{Debug, Display, LowerHex};
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert!($($x)*);
+                } else {
+                    ::core::assert!($($x)*);
+                }
+            }
         }
     };
 }
@@ -19,10 +22,13 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert_eq!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert_eq!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert_eq!($($x)*);
+                } else {
+                    ::core::assert_eq!($($x)*);
+                }
+            }
         }
     };
 }
@@ -31,10 +37,13 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert_ne!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert_ne!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert_ne!($($x)*);
+                } else {
+                    ::core::assert_ne!($($x)*);
+                }
+            }
         }
     };
 }
@@ -43,10 +52,13 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert!($($x)*);
+                } else {
+                    ::core::debug_assert!($($x)*);
+                }
+            }
         }
     };
 }
@@ -55,10 +67,13 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert_eq!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert_eq!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert_eq!($($x)*);
+                } else {
+                    ::core::debug_assert_eq!($($x)*);
+                }
+            }
         }
     };
 }
@@ -67,10 +82,13 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert_ne!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert_ne!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert_ne!($($x)*);
+                } else {
+                    ::core::debug_assert_ne!($($x)*);
+                }
+            }
         }
     };
 }
@@ -79,10 +97,13 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::todo!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::todo!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::todo!($($x)*);
+                } else {
+                    ::core::todo!($($x)*);
+                }
+            }
         }
     };
 }
@@ -91,10 +112,13 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::unreachable!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::unreachable!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::unreachable!($($x)*);
+                } else {
+                    ::core::unreachable!($($x)*);
+                }
+            }
         }
     };
 }
@@ -103,10 +127,13 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::panic!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::panic!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::panic!($($x)*);
+                } else {
+                    ::core::panic!($($x)*);
+                }
+            }
         }
     };
 }
@@ -115,12 +142,15 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::trace!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::trace!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::trace!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -129,12 +159,15 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::debug!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::debug!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -143,12 +176,15 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::info!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::info!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::info!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -157,12 +193,15 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::warn!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::warn!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::warn!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -171,12 +210,15 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::error!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::error!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::error!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }

--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 - Update `defmt` to 1.0 (#3416)
+- The `log` feature has been replaced by `log-04`. (#3425)
 
 ### Fixed
 

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -66,7 +66,10 @@ no-op       = []
 #! ### Logging framework features
 ## Enables using the `log` crate for logging.
 log-04         = ["dep:log-04"]
-## Enables printing using `defmt`. defmt-encoded output can only be read using espflash.
+## Enables printing using `defmt`.
+##
+## defmt-encoded output can only be read using espflash. With esp_hal, this works out of the box.
+## Without esp_hal, you need to set the `--log-format defmt` argument for espflash.
 defmt-espflash = ["dep:defmt", "defmt?/encoding-rzcobs"]
 
 #! ### `log`-specific features

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -21,21 +21,23 @@ bench = false
 test  = false
 
 [dependencies]
+document-features = "0.2.11"
+
+# Optional dependencies
 critical-section = { version = "1.2.0", optional = true }
-defmt            = { version = "1.0.1", optional = true }
-log              = { version = "0.4.27", optional = true }
 portable-atomic  = { version = "1.11.0", optional = true, default-features = false }
+
+# Logging interfaces, they are mutually exclusive so they need to be behind separate features.
+defmt            = { version = "1.0.1", optional = true }
+log-04           = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
 esp-build = { version = "0.2.0", path = "../esp-build" }
-log       = "0.4.27"
+log-04    = { package = "log", version = "0.4.27" }
 
 [features]
 default          = ["auto", "colors", "critical-section"]
-critical-section = ["dep:critical-section"]
-log              = ["dep:log"]
 
-# You must enable exactly 1 of the below features to support the correct chip:
 esp32   = []
 esp32c2 = []
 esp32c3 = []
@@ -45,20 +47,39 @@ esp32p4 = []
 esp32s2 = []
 esp32s3 = []
 
-# You must enable exactly 1 of the below features to enable to intended
-# communication method (note that "auto" is enabled by default):
-jtag-serial = ["dep:portable-atomic"] # C3, C6, H2, P4, and S3 only!
-uart        = []
-auto        = ["dep:portable-atomic"]
+## Use a critical section around print calls. This ensures that the output is consistent.
+critical-section = ["dep:critical-section"]
 
-# Don't print anything
+#! ### Output interfaces
+#! You must enable exactly 1 of the below features to enable to intended
+#! communication method.
+
+## Automatically select the best output interface for the target.
+auto        = ["dep:portable-atomic"]
+## Use the `USB_SERIAL_JTAG` interface for printing. Available on ESP32-C3, ESP32-C6, ESP32-H2, ESP32-P4, and ESP32-S3.
+jtag-serial = ["dep:portable-atomic"]
+## Use the `UART0` peripehral for printing. Available on all devices.
+uart        = []
+## Don't print anything
 no-op       = []
 
-# Enables a `defmt` backend usable with espflash. We force rzcobs encoding to simplify implementation
+#! ### Logging framework features
+## Enables using the `log` crate for logging.
+log-04         = ["dep:log-04"]
+## Enables printing using `defmt`. defmt-encoded output can only be read using espflash.
 defmt-espflash = ["dep:defmt", "defmt?/encoding-rzcobs"]
 
-# logging sub-features
+#! ### `log`-specific features
+## Colors the message severity in the terminal.
 colors = []
+## Prints the timestamp in the log message.
+##
+## This option requires the following function to be implemented:
+## ```rust
+## extern "Rust" {
+##     fn _esp_println_timestamp() -> u64;
+## }
+## ```
 timestamp = []
 
 [lints.rust]

--- a/esp-println/README.md
+++ b/esp-println/README.md
@@ -42,7 +42,7 @@ You can now `println!("Hello world")` as usual.
 - There is one feature for each supported communication method: `uart`, `jtag-serial` and `auto`.
   - Only one of these features can be enabled at a time.
 - `no-op`: Don't print anything.
-- `log`: Enables logging using [`log` crate].
+- `log-04`: Enables logging using version 0.4 of the [`log` crate].
 - `colors`: Enable colored logging.
   - Only effective when using the `log` feature.
 - `critical-section`: Enables critical sections.
@@ -50,17 +50,10 @@ You can now `println!("Hello world")` as usual.
   of `flash` or `monitor` subcommands of `espflash` and `cargo-espflash`. Uses [rzCOBS] encoding
   and adds framing.
 
-## Default Features
-
-By default, we use the `auto`, `critial-section` and `colors` features.
-Which means that it will auto-detect if it needs to print to the UART or JTAG-Serial, use critical sections and output
-messages will be colored.
-If we want to use a communication method that is not `auto`, the default
-one, we need to [disable the default features].
-
 ## Logging
 
-With the feature `log` activated you can initialize a simple logger like this
+With the feature `log-04` activated, and version 0.4 of the `log` crate added to your dependencies,
+you can initialize a simple logger like this:
 
 ```rust
 init_logger(log::LevelFilter::Info);
@@ -97,7 +90,6 @@ https://github.com/knurling-rs/defmt?tab=readme-ov-file#msrv
 [`log` crate]: https://github.com/rust-lang/log
 [rzCOBS]: https://github.com/Dirbaio/rzcobs
 [`espflash`]: https://github.com/esp-rs/espflash
-[disable the default features]: https://doc.rust-lang.org/cargo/reference/features.html#the-default-feature
 [Implementing a Logger section log documentaion]: https://docs.rs/log/0.4.17/log/#implementing-a-logger
 [`defmt` book's setup instructions]: https://defmt.ferrous-systems.com/setup
 

--- a/esp-println/README.md
+++ b/esp-println/README.md
@@ -33,23 +33,6 @@ use esp_println::println;
 
 You can now `println!("Hello world")` as usual.
 
-# Features
-
-- There is one feature for each supported target: `esp32`, `esp32c2`,
-  `esp32c3`, `esp32c6`, `esp32h2`, `esp32s2`, and `esp32s3`.
-  - One of these features must be enabled.
-  - Only one of these features can be enabled at a time.
-- There is one feature for each supported communication method: `uart`, `jtag-serial` and `auto`.
-  - Only one of these features can be enabled at a time.
-- `no-op`: Don't print anything.
-- `log-04`: Enables logging using version 0.4 of the [`log` crate].
-- `colors`: Enable colored logging.
-  - Only effective when using the `log` feature.
-- `critical-section`: Enables critical sections.
-- `defmt-espflash`: This is intended to be used with [`espflash`], see `-L/--log-format` argument
-  of `flash` or `monitor` subcommands of `espflash` and `cargo-espflash`. Uses [rzCOBS] encoding
-  and adds framing.
-
 ## Logging
 
 With the feature `log-04` activated, and version 0.4 of the `log` crate added to your dependencies,

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -530,3 +530,31 @@ fn with<R>(f: impl FnOnce(LockToken) -> R) -> R {
     #[cfg(not(feature = "critical-section"))]
     f(unsafe { LockToken::conjure() })
 }
+
+/// A user-provided hook to supply a timestamp in milliseconds for logging.
+///
+/// When enabled via the `"timestamp"` feature, this function should be
+/// implemented to return a timestamp in milliseconds since a reference point
+/// (e.g., system boot or Unix epoch).
+///
+/// # Example
+///
+/// When using [`esp-hal`], you can define this function as follows:
+///
+/// ```rust
+/// #[no_mangle]
+/// pub extern "Rust" fn _esp_println_timestamp() -> u64 {
+///     esp_hal::time::Instant::now()
+///         .duration_since_epoch()
+///         .as_millis()
+/// }
+/// ```
+///
+/// # Notes
+///
+/// - If no implementations is provided, attempting to use this function will
+///   result in a linker error.
+#[cfg(feature = "timestamp")]
+extern "Rust" {
+    fn _esp_println_timestamp() -> u64;
+}

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -1,11 +1,13 @@
 #![doc = include_str!("../README.md")]
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![allow(rustdoc::bare_urls)]
 #![no_std]
 
 #[cfg(feature = "defmt-espflash")]
 pub mod defmt;
-#[cfg(feature = "log")]
+#[cfg(feature = "log-04")]
 pub mod logger;
 
 macro_rules! log_format {

--- a/esp-println/src/logger.rs
+++ b/esp-println/src/logger.rs
@@ -1,3 +1,5 @@
+use log_04 as log;
+
 use super::println;
 
 #[cfg(not(host_is_windows))]
@@ -117,8 +119,7 @@ fn print_log_record(record: &log::Record) {
 /// # Notes
 ///
 /// - If no implementations is provided, attempting to use this function will
-///   result in a linker
-/// error.
+///   result in a linker error.
 #[cfg(feature = "timestamp")]
 extern "Rust" {
     fn _esp_println_timestamp() -> u64;

--- a/esp-println/src/logger.rs
+++ b/esp-println/src/logger.rs
@@ -96,31 +96,3 @@ fn print_log_record(record: &log::Record) {
     #[cfg(not(feature = "timestamp"))]
     println!("{}{} - {}{}", color, record.level(), record.args(), reset);
 }
-
-/// A user-provided hook to supply a timestamp in milliseconds for logging.
-///
-/// When enabled via the `"timestamp"` feature, this function should be
-/// implemented to return a timestamp in milliseconds since a reference point
-/// (e.g., system boot or Unix epoch).
-///
-/// # Example
-///
-/// When using [`esp-hal`], you can define this function as follows:
-///
-/// ```rust
-/// #[no_mangle]
-/// pub extern "Rust" fn _esp_println_timestamp() -> u64 {
-///     esp_hal::time::Instant::now()
-///         .duration_since_epoch()
-///         .as_millis()
-/// }
-/// ```
-///
-/// # Notes
-///
-/// - If no implementations is provided, attempting to use this function will
-///   result in a linker error.
-#[cfg(feature = "timestamp")]
-extern "Rust" {
-    fn _esp_println_timestamp() -> u64;
-}

--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
+- The `low-level` feature has been removed, the gated API is always available (#3425)
 
 ### Fixed
 

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -20,28 +20,43 @@ test  = false
 
 [dependencies]
 embedded-storage = "0.3.1"
+
+# Optional dependencies
 critical-section = { version = "1.2.0", optional = true }
+
+# Unstable dependencies that are not (strictly) part of the public API
+document-features = "0.2.11"
 
 [build-dependencies]
 esp-build = { version = "0.2.0", path = "../esp-build" }
 
 [features]
-default          = ["critical-section"]
+default = ["critical-section"]
+
+## Place the flash operations in a critical section
 critical-section = ["dep:critical-section"]
 
-esp32c2       = []
-esp32c3       = []
-esp32c6       = []
-esp32h2       = []
-esp32         = []
-esp32s2       = []
-esp32s3       = []
-
-# Bytewise read emulation
+## Bytewise read emulation
 bytewise-read = []
 
-# Enable flash emulation to run tests
-emulation = []
+#! ### Chip selection
+#! One of the following features must be enabled to select the target chip:
 
-# this feature is reserved for very specific use-cases - usually you don't want to use this!
-low-level = []
+# The following trailing spaces ("## ") are important to display the feature names.
+
+## 
+esp32c2   = []
+## 
+esp32c3   = []
+## 
+esp32c6   = []
+## 
+esp32h2   = []
+## 
+esp32     = []
+## 
+esp32s2   = []
+## 
+esp32s3   = []
+## Used for testing on a host.
+emulation = []

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -1,6 +1,7 @@
+//! ## Feature Flags
+#![doc = document_features::document_features!()]
 #![cfg_attr(not(all(test, feature = "emulation")), no_std)]
 
-#[cfg(not(feature = "emulation"))]
 #[cfg_attr(feature = "esp32c2", path = "esp32c2.rs")]
 #[cfg_attr(feature = "esp32c3", path = "esp32c3.rs")]
 #[cfg_attr(feature = "esp32c6", path = "esp32c6.rs")]
@@ -8,22 +9,7 @@
 #[cfg_attr(feature = "esp32", path = "esp32.rs")]
 #[cfg_attr(feature = "esp32s2", path = "esp32s2.rs")]
 #[cfg_attr(feature = "esp32s3", path = "esp32s3.rs")]
-#[cfg_attr(
-    not(any(
-        feature = "esp32c2",
-        feature = "esp32c3",
-        feature = "esp32c6",
-        feature = "esp32",
-        feature = "esp32s2",
-        feature = "esp32s3",
-        feature = "esp32h2"
-    )),
-    path = "stub.rs"
-)]
-mod chip_specific;
-
-#[cfg(feature = "emulation")]
-#[path = "stub.rs"]
+#[cfg_attr(feature = "emulation", path = "stub.rs")]
 mod chip_specific;
 
 mod common;
@@ -31,11 +17,9 @@ mod common;
 use common::FlashSectorBuffer;
 pub use common::{FlashStorage, FlashStorageError};
 
+pub mod ll;
 mod nor_flash;
 mod storage;
-
-#[cfg(feature = "low-level")]
-pub mod ll;
 
 #[cfg(not(feature = "emulation"))]
 #[inline(always)]

--- a/esp-storage/src/ll.rs
+++ b/esp-storage/src/ll.rs
@@ -1,8 +1,11 @@
-/// Low-level API
-///
-/// This gives you access to the underlying low level functionality.
-/// These operate on raw pointers and all functions here are unsafe.
-/// No pre-conditions are checked by any of these functions.
+//! # Low-level API
+//!
+//! ⚠️ This is a low-level API and should be used with caution. ⚠️
+//!
+//! This gives you access to the underlying low level functionality.
+//! These operate on raw pointers and all functions here are unsafe.
+//! No pre-conditions are checked by any of these functions.
+
 use crate::chip_specific;
 
 /// Low-level SPI NOR Flash read

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -14,20 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The scheduler now runs at interrupt priority 1 on Xtensa chips, too. (#3164)
-
 - `esp-now` and `sniffer` are available via `Interfaces` (#3283)
-
 - Remove the `heapless` dependency (including from the public API) (#3317)
-
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 - Update `defmt` to 1.0 (#3416)
+- The `log` feature has been replaced by `log-04`. (#3425)
 
 ### Fixed
 
 - Update bt-hci version to fix serialization/deserialization of byte slices (#3340)
-
 - Allow `Configuration::None`, set country early, changed default power-save-mode to None (#3364)
-
 - Enterprise WPA fixed for ESP32-S2 (#3406)
 - COEX on ESP32 is now working (#3403)
 

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -111,7 +111,7 @@ sys-logs = ["esp-wifi-sys/sys-logs"]
 defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt", "bt-hci?/defmt", "esp-wifi-sys/defmt"]
 
 ## Enable support for the `log` crate
-log = ["dep:log", "esp-hal/log", "esp-wifi-sys/log"]
+log = ["dep:log", "esp-hal/log-04", "esp-wifi-sys/log"]
 
 ## Enable WiFi support
 wifi = ["dep:enumset", "dep:embassy-net-driver", "dep:embassy-sync"]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -15,35 +15,40 @@ bench = false
 test  = false
 
 [dependencies]
+esp-hal = { version = "1.0.0-beta.0", path = "../esp-hal", default-features = false }
+critical-section = "1.2.0"
+cfg-if = "1.0.0"
+portable-atomic = { version = "1.11.0", default-features = false }
+enumset   = { version = "1.1.5", default-features = false, optional = true }
+
+# ⚠️ Unstable dependencies
+embedded-io = { version = "0.6.1", default-features = false }
+embedded-io-async = { version = "0.6.1" }
+rand_core = "0.9.3"
+
+# Unstable dependencies that are not (strictly) part of the public API
 allocator-api2 = { version = "0.2.0", default-features = false, features = ["alloc"] }
-defmt = { version = "1.0.1", optional = true }
-log = { version = "0.4.27", optional = true }
 document-features  = "0.2.11"
 esp-alloc = { version = "0.7.0", path = "../esp-alloc", optional = true }
-esp-hal = { version = "1.0.0-beta.0", path = "../esp-hal", default-features = false }
+esp-config = { version = "0.3.0", path = "../esp-config" }
+esp-wifi-sys = "0.7.1"
+num-derive = { version = "0.4.2" }
+num-traits = { version = "0.2.19", default-features = false }
+portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
+xtensa-lx-rt = { version = "0.18.0", path = "../xtensa-lx-rt", optional = true }
+
+# Optional dependencies enabling ecosystem features
+serde = { version = "1.0.218", default-features = false, features = ["derive"], optional = true }
 smoltcp = { version = "0.12.0", default-features = false, features = [
   "medium-ethernet",
   "socket-raw",
 ], optional = true }
-critical-section = "1.2.0"
-enumset = { version = "1.1.5", default-features = false, optional = true }
-embedded-io = { version = "0.6.1", default-features = false }
-embedded-io-async = { version = "0.6.1" }
-num-derive = { version = "0.4.2" }
-num-traits = { version = "0.2.19", default-features = false }
-esp-wifi-sys = "0.7.1"
-embassy-sync = { version = "0.6.2", optional = true }
 embassy-net-driver = { version = "0.2.0", optional = true }
-cfg-if = "1.0.0"
-portable-atomic = { version = "1.11.0", default-features = false }
-portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
-rand_core           = "0.9.3"
-
 bt-hci = { version = "0.3.0", optional = true }
-esp-config = { version = "0.3.0", path = "../esp-config" }
 
-xtensa-lx-rt = { version = "0.18.0", path = "../xtensa-lx-rt", optional = true }
-serde = { version = "1.0.218", default-features = false, features = ["derive"], optional = true }
+# Logging interfaces, they are mutually exclusive so they need to be behind separate features.
+defmt            = { version = "1.0.1", optional = true }
+log-04           = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
 esp-build    = { version = "0.2.0", path = "../esp-build" }
@@ -52,14 +57,6 @@ esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
 
 [features]
 default = ["builtin-scheduler", "esp-alloc"]
-
-## Use `esp-alloc` for dynamic allocations.
-##
-## If you opt-out you need to provide implementations for the following functions:
-## - `pub extern "C" fn esp_wifi_free_internal_heap() -> usize`
-## - `pub extern "C" fn esp_wifi_allocate_from_internal_ram(size: usize) -> *mut u8`
-## - `pub extern "C" fn esp_wifi_deallocate_internal_ram(ptr: *mut u8)`
-esp-alloc = ["dep:esp-alloc"]
 
 # Chip Support Feature Flags
 # Target the ESP32-C2.
@@ -101,20 +98,24 @@ esp32s3 = [
   "xtensa-lx-rt/float-save-restore",
 ]
 
-## Enable WiFi-BLE coexistence support
-coex = []
+## Use `esp-alloc` for dynamic allocations.
+##
+## If you opt-out you need to provide implementations for the following functions:
+## - `pub extern "C" fn esp_wifi_free_internal_heap() -> usize`
+## - `pub extern "C" fn esp_wifi_allocate_from_internal_ram(size: usize) -> *mut u8`
+## - `pub extern "C" fn esp_wifi_deallocate_internal_ram(ptr: *mut u8)`
+esp-alloc = ["dep:esp-alloc"]
 
 ## Logs the WiFi logs from the driver at log level info (needs a nightly-compiler)
 sys-logs = ["esp-wifi-sys/sys-logs"]
 
-## Enable support for `defmt`
-defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt", "bt-hci?/defmt", "esp-wifi-sys/defmt"]
+## Use builtin scheduler
+builtin-scheduler = []
 
-## Enable support for the `log` crate
-log = ["dep:log", "esp-hal/log-04", "esp-wifi-sys/log"]
+#! ### Wireless Feature Flags
 
 ## Enable WiFi support
-wifi = ["dep:enumset", "dep:embassy-net-driver", "dep:embassy-sync"]
+wifi = ["dep:enumset", "dep:embassy-net-driver"]
 
 ## Enable esp-now support
 esp-now = ["wifi"]
@@ -123,19 +124,28 @@ esp-now = ["wifi"]
 sniffer = ["wifi"]
 
 ## Enable BLE support
-ble = ["esp-hal/__bluetooth", "dep:bt-hci", "dep:embassy-sync"]
+ble = ["esp-hal/__bluetooth", "dep:bt-hci"]
+
+## Enable WiFi-BLE coexistence support
+coex = []
 
 ## Enable WiFi channel state information. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv4N18wifi_init_config_t10csi_enableE)",
 csi = []
 
+#! ### Ecosystem Feature Flags
+
 ## Provide implementations of smoltcp traits
 smoltcp = ["dep:smoltcp"]
 
-## Use builtin scheduler
-builtin-scheduler = []
-
-# Implement serde Serialize / Deserialize
+## Implement serde Serialize / Deserialize
 serde = ["dep:serde", "enumset?/serde"]
+
+#! ### Logging Feature Flags
+## Enable logging output using version 0.4 of the `log` crate.
+log-04 = ["dep:log-04", "esp-hal/log-04", "esp-wifi-sys/log"]
+
+## Enable logging output using `defmt` and implement `defmt::Format` on certain types.
+defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt", "bt-hci?/defmt", "esp-wifi-sys/defmt"]
 
 [package.metadata.docs.rs]
 features = [

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -123,7 +123,7 @@ esp-now = ["wifi"]
 sniffer = ["wifi"]
 
 ## Enable BLE support
-ble = ["esp-hal/bluetooth", "dep:bt-hci", "dep:embassy-sync"]
+ble = ["esp-hal/__bluetooth", "dep:bt-hci", "dep:embassy-sync"]
 
 ## Enable WiFi channel state information. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv4N18wifi_init_config_t10csi_enableE)",
 csi = []

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -299,19 +299,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(not(any(
-    feature = "esp32",
-    feature = "esp32c2",
-    feature = "esp32c3",
-    feature = "esp32c6",
-    feature = "esp32h2",
-    feature = "esp32s2",
-    feature = "esp32s3",
-)))]
-fn main() {
-    panic!("Select a chip via it's cargo feature");
-}
-
 fn print_warning(message: impl core::fmt::Display) {
     println!("cargo:warning={message}");
 }

--- a/esp-wifi/src/fmt.rs
+++ b/esp-wifi/src/fmt.rs
@@ -5,10 +5,13 @@
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert!($($x)*);
+                } else {
+                    ::core::assert!($($x)*);
+                }
+            }
         }
     };
 }
@@ -17,10 +20,13 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert_eq!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert_eq!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert_eq!($($x)*);
+                } else {
+                    ::core::assert_eq!($($x)*);
+                }
+            }
         }
     };
 }
@@ -29,10 +35,13 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::assert_ne!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::assert_ne!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::assert_ne!($($x)*);
+                } else {
+                    ::core::assert_ne!($($x)*);
+                }
+            }
         }
     };
 }
@@ -41,10 +50,13 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert!($($x)*);
+                } else {
+                    ::core::debug_assert!($($x)*);
+                }
+            }
         }
     };
 }
@@ -53,10 +65,13 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert_eq!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert_eq!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert_eq!($($x)*);
+                } else {
+                    ::core::debug_assert_eq!($($x)*);
+                }
+            }
         }
     };
 }
@@ -65,10 +80,13 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::debug_assert_ne!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug_assert_ne!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug_assert_ne!($($x)*);
+                } else {
+                    ::core::debug_assert_ne!($($x)*);
+                }
+            }
         }
     };
 }
@@ -77,10 +95,13 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::todo!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::todo!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::todo!($($x)*);
+                } else {
+                    ::core::todo!($($x)*);
+                }
+            }
         }
     };
 }
@@ -89,10 +110,13 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::unreachable!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::unreachable!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::unreachable!($($x)*);
+                } else {
+                    ::core::unreachable!($($x)*);
+                }
+            }
         }
     };
 }
@@ -101,10 +125,13 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
-            ::core::panic!($($x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::panic!($($x)*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::panic!($($x)*);
+                } else {
+                    ::core::panic!($($x)*);
+                }
+            }
         }
     };
 }
@@ -113,12 +140,15 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::trace!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::trace!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::trace!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -127,12 +157,15 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::debug!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::debug!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::debug!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -141,12 +174,15 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::info!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::info!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::info!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -155,12 +191,15 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::warn!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::warn!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::warn!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }
@@ -169,12 +208,15 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            #[cfg(feature = "log")]
-            ::log::error!($s $(, $x)*);
-            #[cfg(feature = "defmt")]
-            ::defmt::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
-            let _ = ($( & $x ),*);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "defmt")] {
+                    ::defmt::error!($s $(, $x)*);
+                } else if #[cfg(feature = "log-04")] {
+                    ::log_04::error!($s $(, $x)*);
+                } else {
+                    let _ = ($( & $x ),*);
+                }
+            }
         }
     };
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,9 +14,9 @@ critical-section    = "1.1.3"
 embassy-executor    = { version = "0.7.0", features = ["task-arena-size-20480"] }
 embassy-futures     = "0.1.1"
 embassy-net = { version = "0.6.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
-embassy-sync        = "0.6.0"
+embassy-sync        = "0.6.2"
 embassy-time        = "0.4.0"
-embassy-usb         = { version = "0.2.0", default-features = false }
+embassy-usb         = { version = "0.4.0", default-features = false }
 embedded-hal-async  = "1.0.0"
 embedded-io         = { version = "0.6.1", default-features = false }
 embedded-io-async   = "0.6.1"
@@ -24,7 +24,7 @@ embedded-storage    = "0.3.1"
 esp-alloc           = { path = "../esp-alloc" }
 esp-backtrace       = { path = "../esp-backtrace", features = ["exception-handler", "panic-handler", "println"] }
 esp-bootloader-esp-idf = { path = "../esp-bootloader-esp-idf" }
-esp-hal             = { path = "../esp-hal", features = ["log"] }
+esp-hal             = { path = "../esp-hal", features = ["log-04"] }
 esp-hal-embassy     = { path = "../esp-hal-embassy", optional = true }
 esp-ieee802154      = { path = "../esp-ieee802154", optional = true }
 esp-println         = { path = "../esp-println", features = ["log"] }
@@ -34,7 +34,7 @@ heapless            = "0.8.0"
 hmac                = { version = "0.12.1", default-features = false }
 ieee80211           = { version = "0.4.0", default-features = false }
 ieee802154          = "0.6.1"
-log                 = "0.4.22"
+log                 = "0.4.27"
 nb                  = "1.1.0"
 sha2                = { version = "0.10.8", default-features = false }
 smoltcp             = { version = "0.12.0", default-features = false, features = [ "medium-ethernet", "socket-raw"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,9 +27,9 @@ esp-bootloader-esp-idf = { path = "../esp-bootloader-esp-idf" }
 esp-hal             = { path = "../esp-hal", features = ["log-04"] }
 esp-hal-embassy     = { path = "../esp-hal-embassy", optional = true }
 esp-ieee802154      = { path = "../esp-ieee802154", optional = true }
-esp-println         = { path = "../esp-println", features = ["log"] }
+esp-println         = { path = "../esp-println", features = ["log-04"] }
 esp-storage         = { path = "../esp-storage", optional = true }
-esp-wifi            = { path = "../esp-wifi", features = ["log"], optional = true }
+esp-wifi            = { path = "../esp-wifi", features = ["log-04"], optional = true }
 heapless            = "0.8.0"
 hmac                = { version = "0.12.1", default-features = false }
 ieee80211           = { version = "0.4.0", default-features = false }

--- a/examples/src/bin/dma_extmem2mem.rs
+++ b/examples/src/bin/dma_extmem2mem.rs
@@ -2,13 +2,13 @@
 //!
 //! If your module is octal PSRAM then you need to set `ESP_HAL_CONFIG_PSRAM_MODE` to `octal`.
 
-//% FEATURES: esp-hal/log esp-hal/psram aligned esp-hal/unstable
+//% FEATURES: esp-hal/psram aligned esp-hal/unstable
 //% CHIPS: esp32s3
 
 #![no_std]
 #![no_main]
 
-use aligned::{A64, Aligned};
+use aligned::{Aligned, A64};
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{

--- a/examples/src/bin/dma_extmem2mem.rs
+++ b/examples/src/bin/dma_extmem2mem.rs
@@ -8,7 +8,7 @@
 #![no_std]
 #![no_main]
 
-use aligned::{Aligned, A64};
+use aligned::{A64, Aligned};
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{

--- a/examples/src/bin/dma_mem2mem.rs
+++ b/examples/src/bin/dma_mem2mem.rs
@@ -1,6 +1,6 @@
 //! Uses DMA to copy memory to memory.
 
-//% FEATURES: esp-hal/log esp-hal/unstable
+//% FEATURES: esp-hal/unstable
 //% CHIPS: esp32s2 esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
 
 #![no_std]

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -15,7 +15,7 @@
 // The interrupt-executor is created in `main` and is used to spawn `high_prio`.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embassy esp-hal-embassy/log esp-hal/unstable
+//% FEATURES: embassy esp-hal-embassy/log-04 esp-hal/unstable
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -15,7 +15,7 @@
 //!
 //! If your module is octal PSRAM then you need to set `ESP_HAL_CONFIG_PSRAM_MODE` to `octal`.
 
-//% FEATURES: esp-hal/log esp-hal/psram esp-hal/unstable
+//% FEATURES: esp-hal/psram esp-hal/unstable
 //% CHIPS: esp32s3
 
 #![no_std]
@@ -27,8 +27,8 @@ use esp_hal::{
     dma::{DmaRxBuf, DmaTxBuf, ExternalBurstConfig},
     main,
     spi::{
-        Mode,
         master::{Config, Spi},
+        Mode,
     },
     time::Rate,
 };

--- a/examples/src/bin/spi_loopback_dma_psram.rs
+++ b/examples/src/bin/spi_loopback_dma_psram.rs
@@ -27,8 +27,8 @@ use esp_hal::{
     dma::{DmaRxBuf, DmaTxBuf, ExternalBurstConfig},
     main,
     spi::{
-        master::{Config, Spi},
         Mode,
+        master::{Config, Spi},
     },
     time::Rate,
 };

--- a/examples/src/bin/wifi_csi.rs
+++ b/examples/src/bin/wifi_csi.rs
@@ -4,7 +4,7 @@
 //! Set SSID and PASSWORD env variable before running this example.
 //!
 
-//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/smoltcp esp-wifi/log esp-wifi/csi esp-hal/unstable
+//% FEATURES: esp-wifi esp-wifi/wifi esp-wifi/smoltcp esp-wifi/log-04 esp-wifi/csi esp-hal/unstable
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
 
 #![no_std]

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -238,7 +238,7 @@ embedded-hal-async = "1.0.0"
 embedded-hal-nb    = "1.0.0"
 esp-alloc          = { path = "../esp-alloc", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "defmt", "semihosting"] }
-esp-hal            = { path = "../esp-hal", features = ["digest"], optional = true }
+esp-hal            = { path = "../esp-hal", optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 esp-storage        = { path = "../esp-storage", optional = true }
 esp-wifi           = { path = "../esp-wifi", optional = true }

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -17,7 +17,7 @@ esp-alloc          = { path = "../esp-alloc" }
 esp-backtrace      = { path = "../esp-backtrace", features = ["exception-handler", "panic-handler", "println"] }
 esp-hal            = { path = "../esp-hal", features = ["unstable", "log-04"] }
 esp-hal-embassy    = { path = "../esp-hal-embassy" }
-esp-println        = { path = "../esp-println", features = ["log"] }
+esp-println        = { path = "../esp-println", features = ["log-04"] }
 lis3dh-async       = "0.9.3"
 ssd1306            = "0.10.0"
 

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -15,7 +15,7 @@ embedded-graphics  = "0.8.1"
 embedded-hal-async = "1.0.0"
 esp-alloc          = { path = "../esp-alloc" }
 esp-backtrace      = { path = "../esp-backtrace", features = ["exception-handler", "panic-handler", "println"] }
-esp-hal            = { path = "../esp-hal", features = ["unstable", "log"] }
+esp-hal            = { path = "../esp-hal", features = ["unstable", "log-04"] }
 esp-hal-embassy    = { path = "../esp-hal-embassy" }
 esp-println        = { path = "../esp-println", features = ["log"] }
 lis3dh-async       = "0.9.3"

--- a/qa-test/src/bin/psram.rs
+++ b/qa-test/src/bin/psram.rs
@@ -6,7 +6,7 @@
 //! the device comes with octal-SPIRAM
 
 //% CHIPS: esp32 esp32s2 esp32s3
-//% FEATURES: esp-hal/psram esp-alloc/internal-heap-stats esp-hal/log
+//% FEATURES: esp-hal/psram esp-alloc/internal-heap-stats
 
 #![no_std]
 #![no_main]

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -115,7 +115,7 @@ impl Package {
                     features.push("__usb_otg".to_owned());
                 }
                 if config.contains("bt") {
-                    features.push("bluetooth".to_owned());
+                    features.push("__bluetooth".to_owned());
                 }
             }
             Package::EspWifi => {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -112,7 +112,7 @@ impl Package {
                     features.push("psram".to_owned())
                 }
                 if config.contains("usb0") {
-                    features.push("usb-otg".to_owned());
+                    features.push("__usb_otg".to_owned());
                 }
                 if config.contains("bt") {
                     features.push("bluetooth".to_owned());

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -157,9 +157,7 @@ impl Package {
                 features.push("auto".to_owned());
                 features.push("defmt-espflash".to_owned());
             }
-            Package::EspStorage => {
-                features.push("low-level".to_owned());
-            }
+            Package::EspStorage => {}
             Package::EspBootloaderEspIdf => {
                 features.push("defmt".to_owned());
                 features.push("validation".to_owned());


### PR DESCRIPTION
This PR draws up what I envision we should do for dependencies (#3063). Namely:

- Everything is behind `unstable`, unless needed otherwise. We can always split features out of unstable, but we can't remove them.
- usb_otg is now marked as private with two underscores (should I also change bluetooth?)
- log now has a version attached to the feature, so that we can keep supporting it even if 0.5 drops. It is API that we use, and if a project would have multiple log versions, things would likely silently fail to work as expected.
- ufmt-write is unstable for now (it was included unconditionally, but implemented unstably), although it wouldn't be terribly hard to support stably. I don't think it's likely to change in meaningful ways, given it's 5 years old.