### PR TITLE
esp-storage: Remove nor-flash and storage features

### DIFF
--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- The `storage` and `nor-flash` features have been removed, the related functionality is now always available. (#3431)
+
 ## [0.5.0] - 2025-02-24
 
 ### Changed

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -26,14 +26,9 @@ critical-section = { version = "1.2.0", optional = true }
 esp-build = { version = "0.2.0", path = "../esp-build" }
 
 [features]
-default          = ["critical-section", "storage"]
+default          = ["critical-section"]
 critical-section = ["dep:critical-section"]
-# ReadStorage/Storage traits
-storage = []
-# ReadNorFlash/NorFlash traits
-nor-flash = []
-# Bytewise read emulation
-bytewise-read = []
+
 esp32c2       = []
 esp32c3       = []
 esp32c6       = []
@@ -41,6 +36,10 @@ esp32h2       = []
 esp32         = []
 esp32s2       = []
 esp32s3       = []
+
+# Bytewise read emulation
+bytewise-read = []
+
 # Enable flash emulation to run tests
 emulation = []
 

--- a/esp-storage/src/common.rs
+++ b/esp-storage/src/common.rs
@@ -87,7 +87,6 @@ impl FlashStorage {
         storage
     }
 
-    #[cfg(feature = "nor-flash")]
     #[inline(always)]
     pub(crate) fn check_alignment<const ALIGN: u32>(
         &self,

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -26,19 +26,13 @@ mod chip_specific;
 #[path = "stub.rs"]
 mod chip_specific;
 
-#[cfg(any(feature = "storage", feature = "nor-flash"))]
 mod common;
 
-#[cfg(any(feature = "storage", feature = "nor-flash"))]
 use common::FlashSectorBuffer;
-#[cfg(any(feature = "storage", feature = "nor-flash"))]
 pub use common::{FlashStorage, FlashStorageError};
 
-#[cfg(feature = "storage")]
-mod storage;
-
-#[cfg(feature = "nor-flash")]
 mod nor_flash;
+mod storage;
 
 #[cfg(feature = "low-level")]
 pub mod ll;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -158,8 +158,6 @@ impl Package {
                 features.push("defmt-espflash".to_owned());
             }
             Package::EspStorage => {
-                features.push("storage".to_owned());
-                features.push("nor-flash".to_owned());
                 features.push("low-level".to_owned());
             }
             Package::EspBootloaderEspIdf => {


### PR DESCRIPTION
I think it should be perfectly fine to have these both enabled by default. People are missing that nor-flash support needs to be enabled for sequential-storage and this is an unnecessary obstacle.