### PR TITLE
Update embedded-test

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -253,7 +253,7 @@ digest              = { version = "0.10.7", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
 embassy-executor    = { version = "0.7.0", default-features = false }
 # Add the `embedded-test/defmt` feature for more verbose testing
-embedded-test       = { version = "0.6.0", default-features = false, features = ["embassy", "external-executor"] }
+embedded-test       = { version = "0.6.1", default-features = false, features = ["embassy", "external-executor", "semihosting"] }
 hex-literal         = "1.0.0"
 nb                  = "1.1.0"
 p192                = { version = "0.13.0", default-features = false, features = ["arithmetic"] }


### PR DESCRIPTION
0.6.1 was released a few days ago, including a breaking change (semihosting is now optional and needs to be enabled). This causes our CI to fail.