### PR TITLE
time driver: Fix panic

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a panic on very long wakeup times (#3433)
+
 ### Removed
 
 ## [0.7.0] - 2025-02-24

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Async I2C is doesn't do blocking reads anymore (#3344)
 - Passing an invalid seven bit I2C address is now rejected (#3343)
 - PARL_IO: Use correct max transfer size (#3346)
+- `OneShot` timer now returns an InvalidTimeout from `schedule` instead of panicking (#3433)
 
 ### Removed
 

--- a/hil-test/tests/embassy_timers_executors.rs
+++ b/hil-test/tests/embassy_timers_executors.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 
+use embassy_futures::select::select;
 use embassy_time::{Duration, Ticker, Timer};
 #[cfg(not(feature = "esp32"))]
 use esp_hal::{
@@ -122,6 +123,7 @@ fn set_up_embassy_with_systimer(peripherals: Peripherals) {
 #[cfg(test)]
 #[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
 mod test {
+
     use super::*;
     use crate::test_cases::*;
     #[cfg(not(feature = "esp32"))]
@@ -270,5 +272,17 @@ mod test {
         }
 
         assert!(false, "Test failed after 5 retries");
+    }
+
+    /// Test that timg0 and systimer don't have vastly different tick rates.
+    #[test]
+    async fn test_that_a_very_long_wakeup_does_not_panic(peripherals: Peripherals) {
+        set_up_embassy_with_timg0(peripherals);
+
+        select(
+            Timer::after(Duration::from_micros(u64::MAX / 2)),
+            embassy_futures::yield_now(), // we don't actually want to wait forever
+        )
+        .await;
     }
 }


### PR DESCRIPTION
Fixes #3429

This PR replaces the overflow panic in the OneShot timer scheduling with checked maths and reutrns an error if the requested duration is too long. The time driver has been updated to better deal with InvalidTimeout errors.