### PR TITLE
UART: Adding HW and SW flow control config option

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented `embedded_io::WriteReady` for `Uart` and `UartTx` (#3423)
 - ESP32-H2: Support for ADC calibration (#3414)
 - Added `UartInterrupt::RxTimeout` support (#3493)
+- UART: Added HW and SW flow control config option (#3435)
 
 ### Changed
 

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2900,7 +2900,6 @@ impl Info {
             .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8 + 1) });
     }
 
-    #[cfg(feature = "unstable")]
     fn change_flow_control(&self, sw_flow_ctrl: SwFlowControl, hw_flow_ctrl: HwFlowControl) {
         // set SW flow control
         match sw_flow_ctrl {

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -2972,7 +2972,7 @@ impl Info {
             RtsConfig::Enabled(threshold) => self.set_rts(true, Some(threshold)),
             RtsConfig::Disabled => self.set_rts(false, None),
         }
-        
+
         #[cfg(any(esp32c6, esp32h2))]
         sync_regs(self.regs());
     }

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -219,6 +219,44 @@ pub enum StopBits {
     _2,
 }
 
+/// Software flow control settings.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
+pub enum SwFlowControl {
+    #[default]
+    /// Disables software flow control.
+    Disabled,
+    /// Enables software flow control with configured parameters
+    Enabled {
+        /// Xon flow control char.
+        xon_char: u8,
+        /// Xoff flow control char.
+        xoff_char: u8,
+        /// If the software flow control is enabled and the data amount in rxfifo is less than xon_thrd, an xon_char will be sent.
+        xon_threshold: u8,
+        /// If the software flow control is enabled and the data amount in rxfifo is more than xoff_thrd, an xoff_char will be sent
+        xoff_threshold: u8,
+    },
+}
+
+/// Hardware flow control configuration.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
+pub enum HwFlowControl {
+    /// Enables RTS flow control with a configurable FIFO threshold.
+    Rts(u8),
+    /// Enables CTS flow control.
+    Cts,
+    /// Enables both RTS and CTS flow control. RTS uses a configurable
+    /// threshold.
+    Full(u8),
+    #[default]
+    /// Disables hardware flow control.
+    Disabled,
+}
+
 /// Defines how strictly the requested baud rate must be met.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -252,6 +290,12 @@ pub struct Config {
     parity: Parity,
     /// Number of stop bits in each frame (1, 1.5, or 2 bits).
     stop_bits: StopBits,
+    /// Software flow control.
+    #[builder_lite(unstable)]
+    sw_flow_ctrl: SwFlowControl,
+    /// Hardware flow control.
+    #[builder_lite(unstable)]
+    hw_flow_ctrl: HwFlowControl,
     /// Clock source used by the UART peripheral.
     #[builder_lite(unstable)]
     clock_source: ClockSource,
@@ -271,6 +315,8 @@ impl Default for Config {
             data_bits: Default::default(),
             parity: Default::default(),
             stop_bits: Default::default(),
+            sw_flow_ctrl: Default::default(),
+            hw_flow_ctrl: Default::default(),
             clock_source: Default::default(),
         }
     }
@@ -2513,6 +2559,7 @@ impl Info {
         self.change_data_bits(config.data_bits);
         self.change_parity(config.parity);
         self.change_stop_bits(config.stop_bits);
+        self.change_flow_control(config.sw_flow_ctrl, config.hw_flow_ctrl);
 
         Ok(())
     }
@@ -2849,6 +2896,116 @@ impl Info {
         self.regs()
             .conf0()
             .modify(|_, w| unsafe { w.stop_bit_num().bits(stop_bits as u8 + 1) });
+    }
+
+    #[cfg(feature = "unstable")]
+    fn change_flow_control(&self, sw_flow_ctrl: SwFlowControl, hw_flow_ctrl: HwFlowControl) {
+        // set SW flow control
+        match sw_flow_ctrl {
+            SwFlowControl::Enabled {
+                xon_char,
+                xoff_char,
+                xon_threshold,
+                xoff_threshold,
+            } => {
+                cfg_if::cfg_if! {
+                    if #[cfg(any(esp32c6, esp32h2))] {
+                        self.regs().swfc_conf0().modify(|_, w| w.xonoff_del().set_bit());
+                        self.regs().swfc_conf0().modify(|_, w| w.sw_flow_con_en().set_bit());
+                        self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold) });
+                        self.regs().swfc_conf1().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold) });
+                        self.regs().swfc_conf0().modify(|_, w| unsafe { w.xon_char().bits(xon_char) });
+                        self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_char().bits(xoff_char) });
+                    } else if #[cfg(esp32)]{
+                        self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit());
+                        self.regs().flow_conf().modify(|_, w| unsafe { w.sw_flow_con_en().set_bit() });
+                        self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold) });
+                        self.regs().swfc_conf().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold) });
+                        self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_char().bits(xon_char) });
+                        self.regs().swfc_conf().modify(|_, w| unsafe { w.xoff_char().bits(xoff_char) });
+                    } else {
+                        self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit());
+                        self.regs().flow_conf().modify(|_, w| unsafe { w.sw_flow_con_en().set_bit() });
+                        self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold) });
+                        self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold) });
+                        self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_char().bits(xon_char) });
+                        self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_char().bits(xoff_char) });
+                    }
+                }
+                #[cfg(any(esp32c6, esp32h2))]
+                sync_regs(self.regs());
+            }
+            SwFlowControl::Disabled => {
+                cfg_if::cfg_if! {
+                    if #[cfg(any(esp32c6, esp32h2))] {
+                        let reg = self.regs().swfc_conf0();
+                    } else {
+                        let reg = self.regs().flow_conf();
+                    }
+                }
+
+                reg.modify(|_, w| w.sw_flow_con_en().clear_bit() );
+                reg.modify(|_, w| w.xonoff_del().clear_bit() );
+
+                #[cfg(any(esp32c6, esp32h2))]
+                sync_regs(self.regs());
+            }
+        }
+
+        // set HW flow control
+        match hw_flow_ctrl {
+            HwFlowControl::Disabled => {
+                self.set_rts(false, None);
+                self.set_cts(false);
+            }
+        
+            HwFlowControl::Cts => {
+                self.set_rts(false, None);
+                self.set_cts(true);
+            }
+        
+            HwFlowControl::Rts(threshold) => {
+                self.set_rts(true, Some(threshold));
+                self.set_cts(false);
+            }
+        
+            HwFlowControl::Full(rts_threshold) => {
+                self.set_rts(true, Some(rts_threshold));
+                self.set_cts(true);
+            }
+        }
+    }
+
+    fn set_cts(&self, enable: bool) {
+        self.regs().conf0().modify(|_, w| {
+            w.tx_flow_en().bit(enable)
+        });
+    }
+    
+    fn set_rts(&self, enable: bool, threshold: Option<u8>) {
+        if let Some(threshold) = threshold {
+            cfg_if::cfg_if! {
+                if #[cfg(esp32)] {
+                    self.regs().conf1().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
+                } else if #[cfg(any(esp32c6, esp32h2))] {
+                    self.regs().hwfc_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
+                } else {
+                    self.regs().mem_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
+                }
+            }
+        }
+    
+        cfg_if::cfg_if! {
+            if #[cfg(any(esp32c6, esp32h2))] {
+                self.regs().hwfc_conf().modify(|_, w| {
+                    w.rx_flow_en().bit(enable)
+                });
+            } else {
+                self.regs().conf1().modify(|_, w| {
+                    w.rx_flow_en().bit(enable)
+                });
+            }
+        }
     }
 
     fn rxfifo_reset(&self) {

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -233,9 +233,11 @@ pub enum SwFlowControl {
         xon_char: u8,
         /// Xoff flow control char.
         xoff_char: u8,
-        /// If the software flow control is enabled and the data amount in rxfifo is less than xon_thrd, an xon_char will be sent.
+        /// If the software flow control is enabled and the data amount in
+        /// rxfifo is less than xon_thrd, an xon_char will be sent.
         xon_threshold: u8,
-        /// If the software flow control is enabled and the data amount in rxfifo is more than xoff_thrd, an xoff_char will be sent
+        /// If the software flow control is enabled and the data amount in
+        /// rxfifo is more than xoff_thrd, an xoff_char will be sent
         xoff_threshold: u8,
     },
 }
@@ -2918,16 +2920,16 @@ impl Info {
                         self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_char().bits(xoff_char) });
                     } else if #[cfg(esp32)]{
                         self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit());
-                        self.regs().flow_conf().modify(|_, w| unsafe { w.sw_flow_con_en().set_bit() });
+                        self.regs().flow_conf().modify(|_, w| w.sw_flow_con_en().set_bit());
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold) });
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold) });
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_char().bits(xon_char) });
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xoff_char().bits(xoff_char) });
                     } else {
                         self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit());
-                        self.regs().flow_conf().modify(|_, w| unsafe { w.sw_flow_con_en().set_bit() });
-                        self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold) });
-                        self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold) });
+                        self.regs().flow_conf().modify(|_, w| w.sw_flow_con_en().set_bit());
+                        self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold as u16) });
+                        self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold as u16) });
                         self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_char().bits(xon_char) });
                         self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_char().bits(xoff_char) });
                     }
@@ -2944,8 +2946,8 @@ impl Info {
                     }
                 }
 
-                reg.modify(|_, w| w.sw_flow_con_en().clear_bit() );
-                reg.modify(|_, w| w.xonoff_del().clear_bit() );
+                reg.modify(|_, w| w.sw_flow_con_en().clear_bit());
+                reg.modify(|_, w| w.xonoff_del().clear_bit());
 
                 #[cfg(any(esp32c6, esp32h2))]
                 sync_regs(self.regs());
@@ -2958,17 +2960,17 @@ impl Info {
                 self.set_rts(false, None);
                 self.set_cts(false);
             }
-        
+
             HwFlowControl::Cts => {
                 self.set_rts(false, None);
                 self.set_cts(true);
             }
-        
+
             HwFlowControl::Rts(threshold) => {
                 self.set_rts(true, Some(threshold));
                 self.set_cts(false);
             }
-        
+
             HwFlowControl::Full(rts_threshold) => {
                 self.set_rts(true, Some(rts_threshold));
                 self.set_cts(true);
@@ -2977,11 +2979,11 @@ impl Info {
     }
 
     fn set_cts(&self, enable: bool) {
-        self.regs().conf0().modify(|_, w| {
-            w.tx_flow_en().bit(enable)
-        });
+        self.regs()
+            .conf0()
+            .modify(|_, w| w.tx_flow_en().bit(enable));
     }
-    
+
     fn set_rts(&self, enable: bool, threshold: Option<u8>) {
         if let Some(threshold) = threshold {
             cfg_if::cfg_if! {
@@ -2990,11 +2992,11 @@ impl Info {
                 } else if #[cfg(any(esp32c6, esp32h2))] {
                     self.regs().hwfc_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
                 } else {
-                    self.regs().mem_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
+                    self.regs().mem_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold as u16) });
                 }
             }
         }
-    
+
         cfg_if::cfg_if! {
             if #[cfg(any(esp32c6, esp32h2))] {
                 self.regs().hwfc_conf().modify(|_, w| {

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -132,8 +132,6 @@ mod tests {
         ))
         .unwrap();
 
-        rts_input.set_input_enable(true);
-
         let data: [u8; 10] = [0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9];
 
         // This will make RTS pin go high, as we write more than the RTS threshold.

--- a/hil-test/tests/uart.rs
+++ b/hil-test/tests/uart.rs
@@ -136,6 +136,8 @@ mod tests {
 
         // This will make RTS pin go high, as we write more than the RTS threshold.
         uart.write(&data).unwrap();
+        // Required, otherwise we'll run into a timing issue and won't be able to
+        // determine that the RTS is at a high level.
         ctx.delay.delay_millis(1);
 
         // RTS pin should go high when the threshold is exceeded.


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-hal/issues/2644

#### Description
Inspired by [IDF implementation](https://github.com/espressif/esp-idf/blob/master/components/hal/esp32c6/include/hal/uart_ll.h#L772-L831) of this functionality for different chips

#### Testing
Not sure how to (and whether to) add a proper HIL test here 🤔 . 
I'm open to suggestions. [IDF test](https://github.com/espressif/esp-idf/blob/master/components/esp_driver_uart/test_apps/uart/main/test_uart.c#L259-L269) seems kind of inefficient to me since it only sets the HW Flow Control and then reads the register being set, nothing ACTUALLY testing the functionality 
